### PR TITLE
fix(web): eliminate hydration mismatch in BusinessSidebar (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Airbnb-style car rental platform for a Japan-based company (Osaka) serving inter
 
 - **`noUncheckedIndexedAccess` is on.** Array indexing like `segments[1]` returns `T | undefined`. Always guard with a variable check before returning.
 
+- **Active-link className conditionals are a hydration trap (issue #25).** When a `'use client'` nav component computes a conditional className from `usePathname()` (e.g. `cn('base', isActive ? 'on' : 'off')`), Next.js 16 + Turbopack can produce a server/client className mismatch on the rendered `<a>`. The visible symptom is a hydration error pointing at the `<Link>` line with a className diff. Fix pattern:
+  1. Make the className a single static string (no `cn()` conditional).
+  2. Express active state via `aria-current="page"` and Tailwind `aria-[current=page]:*` variants.
+  3. Defer the active calculation behind a `mounted` flag (`const [mounted,setMounted]=useState(false); useEffect(()=>setMounted(true),[])`) so the SSR pass and the first client render emit identical DOM, and only after hydration does any item gain `aria-current`. The 1-frame flicker is invisible and the mismatch becomes structurally impossible.
+  See `packages/web/src/components/nav/BusinessSidebar.tsx` for the canonical pattern.
+
 ## Biome Linter
 
 - Biome auto-sorts imports and reformats on save/check. If you write a file and it gets reformatted, re-read before editing again or the Edit tool will fail on stale `old_string`.

--- a/packages/web/src/components/nav/BusinessSidebar.tsx
+++ b/packages/web/src/components/nav/BusinessSidebar.tsx
@@ -2,9 +2,9 @@
 
 import { useLayoutPreference } from '@/components/providers/LayoutPreferenceProvider'
 import { Link, usePathname } from '@/i18n/routing'
-import { cn } from '@/lib/utils'
 import { Calendar, Car, LayoutDashboard, MessageSquare, Users } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
 
 const SIDEBAR_ITEMS = [
   { href: '/dashboard', icon: LayoutDashboard, labelKey: 'dashboard' },
@@ -14,10 +14,34 @@ const SIDEBAR_ITEMS = [
   { href: '/manage/messages', icon: MessageSquare, labelKey: 'messages' },
 ] as const
 
+// Single static className string used for every link. Active state is driven
+// by the `aria-current="page"` attribute and the `aria-[current=page]:*`
+// Tailwind variants below. This keeps the className byte-for-byte identical
+// between server and client renders, eliminating the hydration mismatch that
+// occurred when the active/inactive branches produced different strings.
+const LINK_CLASSNAME =
+  'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ' +
+  'text-sidebar-foreground hover:bg-sidebar-accent/50 ' +
+  'aria-[current=page]:bg-sidebar-accent aria-[current=page]:text-sidebar-accent-foreground ' +
+  'aria-[current=page]:hover:bg-sidebar-accent'
+
 export function BusinessSidebar() {
   const t = useTranslations('nav')
   const pathname = usePathname()
   const { preference } = useLayoutPreference()
+
+  // Defer the active-state computation until after the client has hydrated.
+  // The very first client render must produce the same DOM as the SSR pass,
+  // so on the initial render we report `mounted=false` and emit no
+  // `aria-current` attribute. After hydration completes, the effect flips
+  // `mounted` to true and React re-renders to highlight the matching item.
+  // The cost is a single frame where no item is highlighted; the benefit is
+  // an absolute guarantee that this component cannot trigger a hydration
+  // mismatch from a divergent `usePathname()` value.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   if (preference === 'topnav') return null
 
@@ -28,17 +52,13 @@ export function BusinessSidebar() {
     >
       <nav className="flex flex-col gap-1 p-3">
         {SIDEBAR_ITEMS.map(({ href, icon: Icon, labelKey }) => {
-          const isActive = pathname === href || pathname.startsWith(`${href}/`)
+          const isActive = mounted && (pathname === href || pathname.startsWith(`${href}/`))
           return (
             <Link
               key={href}
               href={href}
-              className={cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                  : 'text-sidebar-foreground hover:bg-sidebar-accent/50',
-              )}
+              aria-current={isActive ? 'page' : undefined}
+              className={LINK_CLASSNAME}
             >
               <Icon className="size-5" />
               {t(labelKey)}

--- a/packages/web/tests/components/nav/BusinessSidebar.test.tsx
+++ b/packages/web/tests/components/nav/BusinessSidebar.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let mockPathname = '/manage/vehicles'
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({
+    href,
+    children,
+    className,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className} {...rest}>
+      {children}
+    </a>
+  ),
+  usePathname: () => mockPathname,
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      dashboard: 'Dashboard',
+      bookings: 'Bookings',
+      fleet: 'Fleet',
+      customers: 'Customers',
+      messages: 'Messages',
+    }
+    return messages[key] ?? key
+  },
+}))
+
+vi.mock('@/components/providers/LayoutPreferenceProvider', () => ({
+  useLayoutPreference: () => ({ preference: 'sidebar', toggle: () => {} }),
+}))
+
+import { BusinessSidebar } from '@/components/nav/BusinessSidebar'
+
+describe('BusinessSidebar', () => {
+  beforeEach(() => {
+    mockPathname = '/manage/vehicles'
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders all sidebar items with labels', () => {
+    render(<BusinessSidebar />)
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Bookings')).toBeInTheDocument()
+    expect(screen.getByText('Fleet')).toBeInTheDocument()
+    expect(screen.getByText('Customers')).toBeInTheDocument()
+    expect(screen.getByText('Messages')).toBeInTheDocument()
+  })
+
+  it('emits a static className string for every link (no conditional active-state classes in the string)', () => {
+    // Regression for #25: the original implementation composed className via
+    // `cn('base', isActive ? 'activeClasses' : 'inactiveClasses')`. That
+    // produced two different classNames depending on `isActive`, and the
+    // active/inactive branch drove a server/client hydration mismatch when
+    // `usePathname()` returned a subtly different value across render passes.
+    //
+    // The fix: render a single static className string on every link and
+    // express the active state via an `aria-current` attribute instead. CSS
+    // (`aria-[current=page]:*` utilities) handles the visual styling.
+    render(<BusinessSidebar />)
+    const links = screen.getAllByRole('link')
+    expect(links.length).toBeGreaterThan(0)
+
+    const classNames = links.map((link) => link.getAttribute('class'))
+    // Every link must share the exact same className string.
+    const unique = new Set(classNames)
+    expect(unique.size).toBe(1)
+  })
+
+  it('marks the current route with aria-current="page"', () => {
+    mockPathname = '/manage/vehicles'
+    render(<BusinessSidebar />)
+
+    const fleetLink = screen.getByRole('link', { name: /Fleet/i })
+    expect(fleetLink).toHaveAttribute('aria-current', 'page')
+
+    // Siblings must NOT be marked current.
+    const dashboardLink = screen.getByRole('link', { name: /Dashboard/i })
+    expect(dashboardLink).not.toHaveAttribute('aria-current')
+  })
+
+  it('matches nested routes (e.g. /manage/bookings/123 highlights Bookings)', () => {
+    mockPathname = '/manage/bookings/abc-123'
+    render(<BusinessSidebar />)
+
+    const bookingsLink = screen.getByRole('link', { name: /Bookings/i })
+    expect(bookingsLink).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('renders deterministically across repeated renders (hydration-safety smoke test)', () => {
+    mockPathname = '/manage/vehicles'
+
+    const { container: c1, unmount: u1 } = render(<BusinessSidebar />)
+    const html1 = c1.innerHTML
+    u1()
+
+    const { container: c2, unmount: u2 } = render(<BusinessSidebar />)
+    const html2 = c2.innerHTML
+    u2()
+
+    expect(html1).toBe(html2)
+  })
+})


### PR DESCRIPTION
## Summary

- Fix the hydration mismatch error overlay shown on `/manage/vehicles` (issue #25)
- Active sidebar links no longer compute their className conditionally; they share a single static string and express the active state via `aria-current="page"` + Tailwind `aria-[current=page]:*` variants
- The active calculation is deferred behind a `mounted` flag so the SSR pass and the first client hydration pass emit byte-for-byte identical DOM — the mismatch becomes structurally impossible
- Adds a 5-test vitest suite for `BusinessSidebar` (renders all items, every link emits the same className, the matching item gets `aria-current="page"`, nested routes match, repeated renders are deterministic)
- Documents the gotcha in `CLAUDE.md` so the next session doesn't reinvent the same conditional-className mistake

## Why this approach

A static className string cannot drift between server and client, regardless of what `usePathname()` returns. Even if the underlying cause is `usePathname()` divergence (which I suspected during investigation), the `mounted` guard makes the second render the *only* render where `aria-current` becomes truthy, so any divergence is invisible to React's hydration check. Cost is one frame of unhighlighted sidebar; benefit is an absolute guarantee of hydration safety.

## Test plan

- [x] `bun run --filter @kuruma/web test` — 135 / 135 pass (5 new tests for BusinessSidebar)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean
- [x] `bun run build` — Next.js build green
- [x] `bun run build:worker` — opennextjs-cloudflare worker build green
- [ ] Manual: visit `/en/manage/vehicles` while signed in as a business user; confirm dev overlay shows zero hydration errors and the matching item highlights after first paint

Closes #25