### PR TITLE
feat(api): persist DM threads via Drizzle repos (#28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,12 @@ jobs:
         # journal entries match on-disk .sql files, and DB migration count
         # matches the journal. See scripts/db-verify.ts.
         run: bun run db:verify
+
+      - name: Run repository integration tests against fresh Postgres
+        # Exercises the Drizzle repos that talk to real tables. Right now
+        # only the messaging repo tests run here (issue #28); the other
+        # integration test files under packages/api/tests/integration/ still
+        # go through the neon-http driver and can't connect to a local
+        # postgres — issue #29 tracks migrating them. As more repo tests
+        # land, expand the `test:integration` script to include them.
+        run: bun run --filter @kuruma/api test:integration

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260410.1",
+        "postgres": "^3.4.8",
         "vitest": "^2",
         "wrangler": "^4.80.0",
       },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,6 +10,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260410.1",
+    "postgres": "^3.4.8",
     "vitest": "^2",
     "wrangler": "^4.80.0"
   }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,7 +3,9 @@ import { Hono } from 'hono'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
+  DrizzleMessageRepository,
   DrizzleStatsRepository,
+  DrizzleThreadRepository,
   DrizzleVehicleRepository,
 } from './repositories/drizzle'
 import {
@@ -56,8 +58,8 @@ export function createApp(overrides?: {
     bookingRepo = new DrizzleBookingRepository(db)
     availabilityRepo = new DrizzleAvailabilityRepository(db)
     statsRepo = new DrizzleStatsRepository(db)
-    threadRepo = new InMemoryThreadRepository()
-    messageRepo = new InMemoryMessageRepository(threadRepo as InMemoryThreadRepository)
+    threadRepo = new DrizzleThreadRepository(db)
+    messageRepo = new DrizzleMessageRepository(db)
   } else {
     vehicleRepo = new InMemoryVehicleRepository()
     bookingRepo = new InMemoryBookingRepository()

--- a/packages/api/src/repositories/drizzle.ts
+++ b/packages/api/src/repositories/drizzle.ts
@@ -1,16 +1,25 @@
 import type { getDb } from '@kuruma/shared/db'
-import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
-import { and, count, eq, sql } from 'drizzle-orm'
-import type { Booking, Vehicle } from '../stores'
+import {
+  bookings,
+  messages,
+  threadParticipants,
+  threads,
+  users,
+  vehicles,
+} from '@kuruma/shared/db/schema'
+import { and, asc, count, eq, inArray, sql } from 'drizzle-orm'
+import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 import type {
   AvailabilityRepository,
   BookingRepository,
   DashboardStats,
+  MessageRepository,
   StatsRepository,
+  ThreadRepository,
   VehicleRepository,
 } from './types'
 
-type Db = ReturnType<typeof getDb>
+export type Db = ReturnType<typeof getDb>
 
 const vehicleColumns = {
   id: vehicles.id,
@@ -274,5 +283,247 @@ export class DrizzleStatsRepository implements StatsRepository {
       totalCustomers: customerCount[0]?.count ?? 0,
       unreadMessages: 0,
     }
+  }
+}
+
+// Explicit column lists. Following the pattern in DrizzleVehicleRepository
+// (and the rule from issue #19 — never SELECT *) so adding a column to the
+// schema can never silently leak into API responses.
+const threadColumns = {
+  id: threads.id,
+  bookingId: threads.bookingId,
+  createdAt: threads.createdAt,
+  updatedAt: threads.updatedAt,
+}
+
+const participantColumns = {
+  id: threadParticipants.id,
+  threadId: threadParticipants.threadId,
+  userId: threadParticipants.userId,
+  unreadCount: threadParticipants.unreadCount,
+}
+
+const messageColumns = {
+  id: messages.id,
+  threadId: messages.threadId,
+  senderId: messages.senderId,
+  content: messages.content,
+  sourceLanguage: messages.sourceLanguage,
+  translations: messages.translations,
+  createdAt: messages.createdAt,
+}
+
+// `messages.translations` is a nullable text column with a default of '{}'.
+// The shared `Message` type declares it as `string` (non-null), so we
+// normalise NULL → '{}' at the boundary rather than leak the DB nuance.
+function normaliseMessage(row: {
+  id: string
+  threadId: string
+  senderId: string
+  content: string
+  sourceLanguage: string | null
+  translations: string | null
+  createdAt: Date
+}): Message {
+  return {
+    id: row.id,
+    threadId: row.threadId,
+    senderId: row.senderId,
+    content: row.content,
+    sourceLanguage: row.sourceLanguage,
+    translations: row.translations ?? '{}',
+    createdAt: row.createdAt,
+  }
+}
+
+export class DrizzleThreadRepository implements ThreadRepository {
+  constructor(private readonly db: Db) {}
+
+  async findAll(
+    userId: string,
+  ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>> {
+    // Step 1: which threads does this user participate in?
+    const myParticipations = await this.db
+      .select({ threadId: threadParticipants.threadId })
+      .from(threadParticipants)
+      .where(eq(threadParticipants.userId, userId))
+
+    const threadIds = [...new Set(myParticipations.map((p) => p.threadId))]
+    if (threadIds.length === 0) return []
+
+    // Step 2: fetch the threads themselves.
+    const threadRows = (await this.db
+      .select(threadColumns)
+      .from(threads)
+      .where(inArray(threads.id, threadIds))) as Thread[]
+
+    // Step 3: fetch all participants for those threads in one round-trip.
+    const participantRows = (await this.db
+      .select(participantColumns)
+      .from(threadParticipants)
+      .where(inArray(threadParticipants.threadId, threadIds))) as ThreadParticipant[]
+
+    // Step 4: fetch only the latest message per thread. The DISTINCT ON
+    // pattern keeps this O(threads) instead of O(messages) — important once
+    // any single conversation grows beyond a few dozen messages.
+    const lastMessageRows = await this.db.execute<{
+      id: string
+      threadId: string
+      senderId: string
+      content: string
+      sourceLanguage: string | null
+      translations: string | null
+      createdAt: Date
+    }>(sql`
+      SELECT DISTINCT ON ("threadId")
+        "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "createdAt"
+      FROM "messages"
+      WHERE "threadId" IN (${sql.join(
+        threadIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})
+      ORDER BY "threadId", "createdAt" DESC
+    `)
+
+    // postgres-js returns rows on the result directly; neon-http wraps in {rows}.
+    // Coerce both shapes into a single array.
+    const lastMessageList = (
+      Array.isArray(lastMessageRows)
+        ? lastMessageRows
+        : ((lastMessageRows as { rows?: unknown[] }).rows ?? [])
+    ) as Array<{
+      id: string
+      threadId: string
+      senderId: string
+      content: string
+      sourceLanguage: string | null
+      translations: string | null
+      createdAt: Date
+    }>
+
+    const lastMessageByThreadId = new Map<string, Message>()
+    for (const row of lastMessageList) {
+      lastMessageByThreadId.set(row.threadId, normaliseMessage(row))
+    }
+
+    return threadRows.map((thread) => ({
+      ...thread,
+      participants: participantRows.filter((p) => p.threadId === thread.id),
+      lastMessage: lastMessageByThreadId.get(thread.id) ?? null,
+    }))
+  }
+
+  async findById(
+    id: string,
+  ): Promise<(Thread & { participants: ThreadParticipant[]; messages: Message[] }) | undefined> {
+    const [thread] = (await this.db
+      .select(threadColumns)
+      .from(threads)
+      .where(eq(threads.id, id))) as Thread[]
+
+    if (!thread) return undefined
+
+    const [participantRows, messageRows] = await Promise.all([
+      this.db
+        .select(participantColumns)
+        .from(threadParticipants)
+        .where(eq(threadParticipants.threadId, id)),
+      this.db
+        .select(messageColumns)
+        .from(messages)
+        .where(eq(messages.threadId, id))
+        .orderBy(asc(messages.createdAt)),
+    ])
+
+    return {
+      ...thread,
+      participants: participantRows as ThreadParticipant[],
+      messages: (messageRows as Array<Parameters<typeof normaliseMessage>[0]>).map(
+        normaliseMessage,
+      ),
+    }
+  }
+
+  async create(bookingId: string | null, participantIds: string[]): Promise<Thread> {
+    // Two-statement sequence: insert the thread row, then insert all
+    // participants in one batch. Cleaner than a transaction for this case;
+    // if the participant insert fails, the thread row is orphaned but
+    // harmless and can be GC'd later. (postgres-js + neon-http both support
+    // .transaction() but the behaviour differs slightly across drivers and
+    // we don't need atomicity here for correctness.)
+    const [insertedThread] = (await this.db
+      .insert(threads)
+      .values({ bookingId })
+      .returning(threadColumns)) as Thread[]
+
+    if (!insertedThread) {
+      throw new Error('Failed to insert thread')
+    }
+
+    if (participantIds.length > 0) {
+      await this.db.insert(threadParticipants).values(
+        participantIds.map((userId) => ({
+          threadId: insertedThread.id,
+          userId,
+          unreadCount: 0,
+        })),
+      )
+    }
+
+    return insertedThread
+  }
+
+  async markAsRead(threadId: string, userId: string): Promise<void> {
+    // Single UPDATE — no read-modify-write, no race window.
+    await this.db
+      .update(threadParticipants)
+      .set({ unreadCount: 0 })
+      .where(and(eq(threadParticipants.threadId, threadId), eq(threadParticipants.userId, userId)))
+  }
+}
+
+export class DrizzleMessageRepository implements MessageRepository {
+  constructor(private readonly db: Db) {}
+
+  async create(threadId: string, senderId: string, content: string): Promise<Message> {
+    // Insert the message AND atomically bump every other participant's
+    // unread count in a single round-trip pair. The unread bump uses a
+    // SQL arithmetic expression (`unreadCount + 1`) so concurrent inserts
+    // can never lose an increment — this is the Check-Then-Act race fix
+    // called out in the issue.
+    const [inserted] = (await this.db
+      .insert(messages)
+      .values({ threadId, senderId, content })
+      .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
+
+    if (!inserted) {
+      throw new Error('Failed to insert message')
+    }
+
+    await this.db
+      .update(threadParticipants)
+      .set({ unreadCount: sql`${threadParticipants.unreadCount} + 1` })
+      .where(
+        and(
+          eq(threadParticipants.threadId, threadId),
+          sql`${threadParticipants.userId} <> ${senderId}`,
+        ),
+      )
+
+    // Touch the parent thread's updatedAt so findAll can sort by recency
+    // later if/when needed. Cheap and keeps invariants honest.
+    await this.db.update(threads).set({ updatedAt: sql`now()` }).where(eq(threads.id, threadId))
+
+    return normaliseMessage(inserted)
+  }
+
+  async findByThreadId(threadId: string): Promise<Message[]> {
+    const rows = (await this.db
+      .select(messageColumns)
+      .from(messages)
+      .where(eq(messages.threadId, threadId))
+      .orderBy(asc(messages.createdAt))) as Array<Parameters<typeof normaliseMessage>[0]>
+
+    return rows.map(normaliseMessage)
   }
 }

--- a/packages/api/tests/integration/messages.test.ts
+++ b/packages/api/tests/integration/messages.test.ts
@@ -1,0 +1,302 @@
+// Integration tests for DrizzleThreadRepository + DrizzleMessageRepository
+// against a real Postgres (issue #28).
+//
+// Run locally:
+//   docker run -d --rm --name kuruma-test-pg \
+//     -e POSTGRES_USER=kuruma -e POSTGRES_PASSWORD=kuruma -e POSTGRES_DB=kuruma_test \
+//     -p 5432:5432 postgres:16
+//   DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test bun run db:migrate
+//   cd packages/api && bunx vitest run --config vitest.integration.config.ts
+//
+// CI runs the same flow in the `db-drift` job (see .github/workflows/ci.yml).
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { DrizzleMessageRepository, DrizzleThreadRepository } from '../../src/repositories/drizzle'
+import type { Db } from '../../src/repositories/drizzle'
+import { cleanupMessaging, createTestUsers, testDb } from './messaging-setup'
+
+const threadRepo = new DrizzleThreadRepository(testDb as unknown as Db)
+const messageRepo = new DrizzleMessageRepository(testDb as unknown as Db)
+
+const createdUserIds: string[] = []
+
+afterEach(async () => {
+  await cleanupMessaging(createdUserIds)
+  createdUserIds.length = 0
+})
+
+describe('DrizzleThreadRepository', () => {
+  describe('create', () => {
+    it('creates a thread with two participants and returns it', async () => {
+      const [u1, u2] = await createTestUsers(2)
+      createdUserIds.push(u1!, u2!)
+
+      const thread = await threadRepo.create(null, [u1!, u2!])
+
+      expect(thread.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+      expect(thread.bookingId).toBeNull()
+      expect(thread.createdAt).toBeInstanceOf(Date)
+      expect(thread.updatedAt).toBeInstanceOf(Date)
+    })
+
+    it('persists participants with unreadCount=0', async () => {
+      const [u1, u2] = await createTestUsers(2)
+      createdUserIds.push(u1!, u2!)
+
+      const thread = await threadRepo.create(null, [u1!, u2!])
+      const fetched = await threadRepo.findById(thread.id)
+
+      expect(fetched).toBeDefined()
+      expect(fetched!.participants).toHaveLength(2)
+      const participantUserIds = fetched!.participants.map((p) => p.userId).sort()
+      expect(participantUserIds).toEqual([u1, u2].sort())
+      for (const p of fetched!.participants) {
+        expect(p.unreadCount).toBe(0)
+      }
+    })
+
+    it('supports a null bookingId (standalone thread)', async () => {
+      const [u1, u2] = await createTestUsers(2)
+      createdUserIds.push(u1!, u2!)
+
+      const thread = await threadRepo.create(null, [u1!, u2!])
+
+      expect(thread.bookingId).toBeNull()
+    })
+  })
+
+  describe('findAll', () => {
+    it('returns only threads the user participates in', async () => {
+      const [alice, bob, carol] = await createTestUsers(3)
+      createdUserIds.push(alice!, bob!, carol!)
+
+      // Thread 1: alice + bob
+      await threadRepo.create(null, [alice!, bob!])
+      // Thread 2: bob + carol (alice is NOT a participant)
+      await threadRepo.create(null, [bob!, carol!])
+
+      const aliceThreads = await threadRepo.findAll(alice!)
+      const bobThreads = await threadRepo.findAll(bob!)
+      const carolThreads = await threadRepo.findAll(carol!)
+
+      expect(aliceThreads).toHaveLength(1)
+      expect(bobThreads).toHaveLength(2)
+      expect(carolThreads).toHaveLength(1)
+    })
+
+    it('includes participants and the most recent message per thread', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      await messageRepo.create(thread.id, alice!, 'first')
+      await new Promise((r) => setTimeout(r, 5)) // ensure ordering
+      await messageRepo.create(thread.id, bob!, 'second')
+
+      const threads = await threadRepo.findAll(alice!)
+      expect(threads).toHaveLength(1)
+      const t = threads[0]!
+      expect(t.participants).toHaveLength(2)
+      expect(t.lastMessage).not.toBeNull()
+      expect(t.lastMessage!.content).toBe('second')
+    })
+
+    it('returns empty array when user has no threads', async () => {
+      const [loner] = await createTestUsers(1)
+      createdUserIds.push(loner!)
+
+      const result = await threadRepo.findAll(loner!)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('findById', () => {
+    it('returns thread with participants and ordered messages', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      await messageRepo.create(thread.id, alice!, 'one')
+      await new Promise((r) => setTimeout(r, 5))
+      await messageRepo.create(thread.id, bob!, 'two')
+      await new Promise((r) => setTimeout(r, 5))
+      await messageRepo.create(thread.id, alice!, 'three')
+
+      const found = await threadRepo.findById(thread.id)
+
+      expect(found).toBeDefined()
+      expect(found!.id).toBe(thread.id)
+      expect(found!.participants).toHaveLength(2)
+      expect(found!.messages).toHaveLength(3)
+      expect(found!.messages.map((m) => m.content)).toEqual(['one', 'two', 'three'])
+    })
+
+    it('returns undefined for nonexistent thread id', async () => {
+      const found = await threadRepo.findById('00000000-0000-0000-0000-000000000000')
+      expect(found).toBeUndefined()
+    })
+  })
+
+  describe('markAsRead', () => {
+    it('zeroes the unread count for the given user only', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      // Alice sends two messages → bob's unreadCount becomes 2
+      await messageRepo.create(thread.id, alice!, 'hi')
+      await messageRepo.create(thread.id, alice!, 'you there?')
+
+      const beforeBob = await threadRepo.findAll(bob!)
+      const bobBefore = beforeBob[0]!.participants.find((p) => p.userId === bob)!
+      expect(bobBefore.unreadCount).toBe(2)
+
+      await threadRepo.markAsRead(thread.id, bob!)
+
+      const afterBob = await threadRepo.findAll(bob!)
+      const bobAfter = afterBob[0]!.participants.find((p) => p.userId === bob)!
+      const aliceAfter = afterBob[0]!.participants.find((p) => p.userId === alice)!
+      expect(bobAfter.unreadCount).toBe(0)
+      // Alice's count must NOT have been touched.
+      expect(aliceAfter.unreadCount).toBe(0)
+    })
+
+    it('is a no-op for a user who is not a participant', async () => {
+      const [alice, bob, eve] = await createTestUsers(3)
+      createdUserIds.push(alice!, bob!, eve!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      await messageRepo.create(thread.id, alice!, 'hi')
+
+      // eve is not in the thread; should not throw, should not affect anything.
+      await expect(threadRepo.markAsRead(thread.id, eve!)).resolves.toBeUndefined()
+
+      const after = await threadRepo.findAll(bob!)
+      const bobAfter = after[0]!.participants.find((p) => p.userId === bob)!
+      expect(bobAfter.unreadCount).toBe(1)
+    })
+  })
+})
+
+describe('DrizzleMessageRepository', () => {
+  describe('create', () => {
+    it('inserts a message and returns it with generated fields', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      const message = await messageRepo.create(thread.id, alice!, 'hello world')
+
+      expect(message.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+      expect(message.threadId).toBe(thread.id)
+      expect(message.senderId).toBe(alice)
+      expect(message.content).toBe('hello world')
+      expect(message.sourceLanguage).toBeNull()
+      expect(message.translations).toBe('{}')
+      expect(message.createdAt).toBeInstanceOf(Date)
+    })
+
+    it('atomically increments unreadCount for every participant except the sender', async () => {
+      // Regression for the Check-Then-Act race anti-pattern called out in the
+      // issue. The repo must use a single arithmetic UPDATE on the participants
+      // row, not a read-modify-write that races with concurrent inserts.
+      const [alice, bob, carol] = await createTestUsers(3)
+      createdUserIds.push(alice!, bob!, carol!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!, carol!])
+
+      // Alice sends 5 messages serially.
+      for (let i = 0; i < 5; i++) {
+        await messageRepo.create(thread.id, alice!, `msg ${i}`)
+      }
+
+      const found = await threadRepo.findById(thread.id)
+      const aliceP = found!.participants.find((p) => p.userId === alice)!
+      const bobP = found!.participants.find((p) => p.userId === bob)!
+      const carolP = found!.participants.find((p) => p.userId === carol)!
+
+      // Sender's count must not move.
+      expect(aliceP.unreadCount).toBe(0)
+      // Every other participant gains exactly one per message.
+      expect(bobP.unreadCount).toBe(5)
+      expect(carolP.unreadCount).toBe(5)
+    })
+
+    it('handles concurrent message inserts without losing any unread increments', async () => {
+      // Stronger race-condition test. With a read-modify-write, parallel
+      // inserts would interleave their reads and clobber each other's writes,
+      // leaving the final unreadCount lower than the message count. With an
+      // atomic SQL `unreadCount = unreadCount + 1`, the final count must
+      // equal the number of messages sent by other users.
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+
+      const N = 10
+      await Promise.all(
+        Array.from({ length: N }, (_, i) => messageRepo.create(thread.id, alice!, `parallel ${i}`)),
+      )
+
+      const found = await threadRepo.findById(thread.id)
+      const bobP = found!.participants.find((p) => p.userId === bob)!
+      expect(bobP.unreadCount).toBe(N)
+      expect(found!.messages).toHaveLength(N)
+    })
+  })
+
+  describe('findByThreadId', () => {
+    it('returns messages in chronological order', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      await messageRepo.create(thread.id, alice!, 'first')
+      await new Promise((r) => setTimeout(r, 5))
+      await messageRepo.create(thread.id, bob!, 'second')
+      await new Promise((r) => setTimeout(r, 5))
+      await messageRepo.create(thread.id, alice!, 'third')
+
+      const messages = await messageRepo.findByThreadId(thread.id)
+      expect(messages.map((m) => m.content)).toEqual(['first', 'second', 'third'])
+    })
+
+    it('returns empty array for thread with no messages', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(null, [alice!, bob!])
+      const messages = await messageRepo.findByThreadId(thread.id)
+      expect(messages).toEqual([])
+    })
+  })
+})
+
+describe('persistence across repo instances (the whole point of #28)', () => {
+  it('messages survive when a fresh repo is constructed against the same DB', async () => {
+    const [alice, bob] = await createTestUsers(2)
+    createdUserIds.push(alice!, bob!)
+
+    const repoA = new DrizzleThreadRepository(testDb as unknown as Db)
+    const messageRepoA = new DrizzleMessageRepository(testDb as unknown as Db)
+
+    const thread = await repoA.create(null, [alice!, bob!])
+    await messageRepoA.create(thread.id, alice!, 'before restart')
+
+    // Simulate Worker cold-start: throw away the repo handles, build new ones.
+    const repoB = new DrizzleThreadRepository(testDb as unknown as Db)
+
+    const found = await repoB.findById(thread.id)
+    expect(found).toBeDefined()
+    expect(found!.messages).toHaveLength(1)
+    expect(found!.messages[0]!.content).toBe('before restart')
+  })
+})
+
+// Type-only export so the test file is self-contained even before the impl exists.
+beforeAll(() => {
+  // Smoke check that the test runner can resolve the repos. Forces the
+  // import-time error if the symbols don't exist yet (RED phase).
+  expect(typeof DrizzleThreadRepository).toBe('function')
+  expect(typeof DrizzleMessageRepository).toBe('function')
+})

--- a/packages/api/tests/integration/messaging-setup.ts
+++ b/packages/api/tests/integration/messaging-setup.ts
@@ -1,0 +1,84 @@
+// Standalone Postgres test client for the messaging integration tests.
+//
+// The production code in `packages/shared/src/db/index.ts` uses
+// `@neondatabase/serverless` (HTTP). That driver only speaks Neon's HTTPS
+// wire protocol and cannot connect to a vanilla Postgres on localhost, so
+// it is unusable for tests against the docker `postgres:16` container that
+// CI's `db-drift` job spins up. We use `postgres-js` here instead — same
+// `drizzle-orm` query API surface as neon-http, but speaks raw Postgres TCP.
+//
+// The repo classes in `src/repositories/drizzle.ts` are typed against the
+// neon-http return type. At runtime drizzle's select/insert/update/delete
+// API is identical across drivers, so we cast the postgres-js drizzle
+// instance to the same type when constructing the repos under test.
+//
+// Existing integration tests under `tests/integration/` (vehicles, bookings,
+// availability) still go through `getDb()` and remain unrunnable until
+// issue #29 migrates them to the same pattern. Out of scope for #28.
+
+import * as schema from '@kuruma/shared/db/schema'
+import { messages, threadParticipants, threads, users } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+
+const TEST_DATABASE_URL = process.env.DATABASE_URL
+
+if (!TEST_DATABASE_URL) {
+  throw new Error(
+    'DATABASE_URL is required for integration tests. ' +
+      'CI sets this via the postgres service container; locally run ' +
+      '`docker run -d --rm --name kuruma-test-pg -e POSTGRES_USER=kuruma ' +
+      '-e POSTGRES_PASSWORD=kuruma -e POSTGRES_DB=kuruma_test -p 5432:5432 postgres:16` ' +
+      'and `DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test bun run db:migrate` first.',
+  )
+}
+
+// Single client per process; vitest reuses the module across files.
+const client = postgres(TEST_DATABASE_URL, { max: 4 })
+
+export const testDb = drizzle(client, { schema })
+
+/**
+ * Create real users for FK satisfaction. `thread_participants.userId` and
+ * `messages.senderId` both have FKs into `users`. Returns ids in insert
+ * order so callers can pin participantIds in tests.
+ */
+export async function createTestUsers(count: number): Promise<string[]> {
+  const seed = crypto.randomUUID()
+  const rows = Array.from({ length: count }, (_, i) => ({
+    name: `Test User ${i}`,
+    email: `test-${seed}-${i}@example.com`,
+  }))
+  const inserted = await testDb.insert(users).values(rows).returning({ id: users.id })
+  return inserted.map((r) => r.id)
+}
+
+/**
+ * Tear down the messaging tables for the given user ids. Cascades from
+ * `threads` clean up `thread_participants` and `messages`.
+ */
+export async function cleanupMessaging(userIds: string[]): Promise<void> {
+  if (userIds.length === 0) return
+
+  // Delete threads where any participant is one of our test users.
+  // We don't have a direct query helper, so do it in two passes:
+  // 1. Find threadIds touched by these users via participants.
+  // 2. Delete the threads (cascade removes participants + messages).
+  const participantRows = await testDb
+    .select({ threadId: threadParticipants.threadId })
+    .from(threadParticipants)
+    .where(inArray(threadParticipants.userId, userIds))
+
+  const threadIds = [...new Set(participantRows.map((r) => r.threadId))]
+  if (threadIds.length > 0) {
+    await testDb.delete(threads).where(inArray(threads.id, threadIds))
+  }
+
+  // Also clear any messages directly authored by these users that somehow
+  // escaped (e.g. orphan inserts in failing tests).
+  await testDb.delete(messages).where(inArray(messages.senderId, userIds))
+
+  // Finally drop the users themselves.
+  await testDb.delete(users).where(inArray(users.id, userIds))
+}


### PR DESCRIPTION
## Summary

Closes #28. The DM threads feature shipped with the schema and in-memory repos but no Drizzle implementation, so `packages/api/src/index.ts` hardcoded the in-memory variants even when `DATABASE_URL` was set. On Cloudflare Workers that meant every cold start dropped the conversation history. This PR wires real persistence into the production code path.

## What changed

**Repos** (`packages/api/src/repositories/drizzle.ts`)
- `DrizzleThreadRepository` — `findAll`, `findById`, `create`, `markAsRead`. Explicit column lists (issue #19), `inArray` batching for the per-user thread fetch, single SQL `DISTINCT ON` query to pull the most-recent message per thread in O(threads) instead of O(messages).
- `DrizzleMessageRepository` — `create`, `findByThreadId`. Insert + atomic unread bump issued back-to-back. The bump uses a SQL arithmetic expression (`unreadCount = unreadCount + 1`) so concurrent inserts can never lose an increment — fixes the **Check-Then-Act race** the issue called out.
- `markAsRead` is a single `UPDATE` — no read-modify-write window.
- `messages.translations` is nullable in the schema but `string` in the shared `Message` type; the repo normalises NULL → `'{}'` at the boundary instead of leaking the DB nuance.

**Wiring** (`packages/api/src/index.ts:53-60`)
- Constructs the Drizzle repos when `DATABASE_URL` is set. InMemory variants stay for unit tests + DB-less local dev.

**Integration tests** (`packages/api/tests/integration/messages.test.ts` — 16 tests)
- Covers create / findAll / findById / markAsRead / message ordering / persistence-across-fresh-repo-instances.
- Includes a `Promise.all` concurrent-insert test that proves the unread bump is atomic. With a read-modify-write impl this test would deterministically fail (parallel reads clobber each other's writes); with the SQL arithmetic update the final unread count equals the message count exactly.
- Also includes a "no-op for non-participant" test for `markAsRead` and a "Worker cold start" test that throws away the repo handles, builds new ones, and verifies the data is still there.

**Test setup** (`packages/api/tests/integration/messaging-setup.ts`)
- Standalone postgres-js Drizzle client. Production uses `@neondatabase/serverless` (Worker HTTPS), but neon-http can't connect to a vanilla local Postgres, so the tests use a postgres-js client and cast to the same `Db` type at the repo boundary. The runtime API surface is identical between drivers.
- The existing `tests/integration/{vehicles,bookings,availability}.test.ts` files still go through `getDb()` / neon-http and remain unrunnable until #29 migrates them. Out of scope here — flagged in the setup file's comment.

**CI** (`.github/workflows/ci.yml`)
- New `test:integration` script in `packages/api`, scoped to `messages.test.ts`.
- New step in the `db-drift` job runs `bun run --filter @kuruma/api test:integration` after `db:verify`. The Postgres service container with applied migrations is already there, so this is essentially free and avoids the "tests nobody runs" trap you flagged.

**Deps**
- `postgres@^3.4.8` as a devDependency on `packages/api` for the test client.

## Test plan

- [x] `bun run db:verify` — clean (9 migrations, no drift)
- [x] `bun run lint` — clean
- [x] `bun run --filter @kuruma/api typecheck` — clean
- [x] `bun run test` — 213 tests pass (135 web + 78 api unit)
- [x] `DATABASE_URL=... bun run --filter @kuruma/api test:integration` — 16/16 against postgres:16 docker
- [x] `bun run --filter @kuruma/web build` — Next.js build green
- [x] `bun run --filter @kuruma/api build` — wrangler dry-run green
- [ ] CI `db-drift` job: should now run migrations + db:verify + the new integration tests against the fresh Postgres service container

## Notes for follow-up

- **#29** is now partially unblocked. The pattern in `messaging-setup.ts` (postgres-js Drizzle client + cast at repo boundary) is the migration path for the other broken integration test files.
- **End-to-end manual verify** (issue acceptance criterion): start the API with a real `DATABASE_URL`, send a message via `POST /threads/:id/messages`, restart the Worker, fetch the thread, confirm the message is still there. I can't do this in my worktree without your DATABASE_URL — flagging so you can spot-check before merge if you want.