### PR TITLE
fix(api): enable CORS so web client can reach Worker (#46)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,6 @@
 import { getDb } from '@kuruma/shared/db'
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -73,6 +74,25 @@ export function createApp(overrides?: {
   }
 
   const app = new Hono()
+
+  // CORS. Browser calls from the web package (localhost:3001 in dev, the
+  // deployed origin in prod) are same-intent but cross-origin, so without
+  // this middleware every fetch rejects and the UI hangs on loading states.
+  // Origins come from WEB_ORIGIN (comma-separated) so staging and prod can
+  // diverge from dev without code changes; the dev defaults cover the
+  // common local setup. 3rd-party API callers (Trip.com) hit the Worker
+  // server-to-server and do not need CORS.
+  const allowedOrigins = resolveAllowedOrigins(process.env.WEB_ORIGIN)
+  app.use(
+    '*',
+    cors({
+      origin: allowedOrigins,
+      allowMethods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'Authorization'],
+      maxAge: 86400,
+    }),
+  )
+
   app.route('/', health)
   app.route('/', createVehicleRoutes(vehicleRepo))
   app.route('/', createBookingRoutes(bookingRepo, vehicleRepo))
@@ -81,6 +101,20 @@ export function createApp(overrides?: {
   app.route('/', createMessageRoutes(threadRepo, messageRepo))
 
   return app
+}
+
+const DEV_WEB_ORIGINS = ['http://localhost:3001', 'http://127.0.0.1:3001']
+
+function resolveAllowedOrigins(envValue: string | undefined): string[] {
+  const fromEnv = (envValue ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+
+  // Always include the dev origins so `bun run dev` + `bun run dev:api`
+  // works out of the box. Deduped because the user may also list them in
+  // WEB_ORIGIN explicitly.
+  return [...new Set([...DEV_WEB_ORIGINS, ...fromEnv])]
 }
 
 export default createApp()

--- a/packages/api/tests/routes/cors.test.ts
+++ b/packages/api/tests/routes/cors.test.ts
@@ -1,0 +1,59 @@
+// Regression test for issue #46. Without CORS middleware the browser
+// fetch from the web dev server (http://localhost:3001) to the Worker
+// (http://localhost:8787) rejects, and the fleet page hangs on skeleton
+// loaders forever. See packages/api/src/index.ts for the middleware.
+
+import { describe, expect, it } from 'vitest'
+import app from '../../src/index'
+
+describe('CORS middleware', () => {
+  it('emits Access-Control-Allow-Origin for the web dev origin on a simple GET', async () => {
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://localhost:3001' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3001')
+  })
+
+  it('accepts 127.0.0.1:3001 as an alias for the dev origin', async () => {
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://127.0.0.1:3001' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://127.0.0.1:3001')
+  })
+
+  it('answers OPTIONS preflight with the allowed methods and headers', async () => {
+    const res = await app.request('/vehicles', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:3001',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Content-Type',
+      },
+    })
+
+    // hono/cors answers preflight with 204
+    expect([200, 204]).toContain(res.status)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3001')
+    const allowedMethods = res.headers.get('Access-Control-Allow-Methods') ?? ''
+    expect(allowedMethods).toContain('GET')
+    expect(allowedMethods).toContain('POST')
+    expect(allowedMethods).toContain('PATCH')
+    expect(allowedMethods).toContain('DELETE')
+  })
+
+  it('does NOT echo disallowed origins', async () => {
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://evil.example.com' },
+    })
+
+    // Same-site GETs that are not in the allowlist still succeed — CORS is
+    // enforced by the browser, not the server — but the server must NOT
+    // echo the rogue origin back. The header must be absent (or falsy).
+    const acao = res.headers.get('Access-Control-Allow-Origin')
+    expect(acao).not.toBe('http://evil.example.com')
+  })
+})

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -112,6 +112,8 @@
       "title": "Fleet",
       "subtitle": "Manage your vehicles",
       "empty": "No vehicles added yet",
+      "loadError": "Couldn't load your fleet",
+      "retry": "Try again",
       "addVehicle": "Add vehicle",
       "editVehicle": "Edit vehicle",
       "retireVehicle": "Retire vehicle",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -112,6 +112,8 @@
       "title": "車両管理",
       "subtitle": "車両の管理",
       "empty": "車両はまだ追加されていません",
+      "loadError": "車両情報を読み込めませんでした",
+      "retry": "再試行",
       "addVehicle": "車両を追加",
       "editVehicle": "車両を編集",
       "retireVehicle": "車両を廃止",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -112,6 +112,8 @@
       "title": "车队管理",
       "subtitle": "管理您的车辆",
       "empty": "尚未添加车辆",
+      "loadError": "无法加载车队信息",
+      "retry": "重试",
       "addVehicle": "添加车辆",
       "editVehicle": "编辑车辆",
       "retireVehicle": "停用车辆",

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -16,7 +16,7 @@ import {
 import type { VehicleData } from '@/lib/vehicle-api'
 import { fetchVehicles } from '@/lib/vehicle-api'
 import { useQuery } from '@tanstack/react-query'
-import { Car, Plus } from 'lucide-react'
+import { AlertCircle, Car, Plus } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useMemo, useState } from 'react'
 
@@ -34,7 +34,13 @@ export function VehicleList() {
   const [retiringVehicle, setRetiringVehicle] = useState<VehicleData | null>(null)
   const [showAddDialog, setShowAddDialog] = useState(false)
 
-  const { data: vehicles, isLoading } = useQuery({
+  const {
+    data: vehicles,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ['vehicles'],
     queryFn: () => fetchVehicles(),
   })
@@ -83,7 +89,20 @@ export function VehicleList() {
           </div>
         )}
 
-        {!isLoading && displayed.length > 0 && (
+        {!isLoading && isError && (
+          <div className="border border-destructive/30 bg-destructive/5 rounded-xl p-6 text-center">
+            <AlertCircle className="size-8 text-destructive mx-auto mb-3" />
+            <p className="text-sm font-medium text-foreground">{t('loadError')}</p>
+            <p className="mt-1 text-xs text-muted-foreground break-words">
+              {error instanceof Error ? error.message : String(error)}
+            </p>
+            <Button variant="outline" size="sm" className="mt-4" onClick={() => refetch()}>
+              {t('retry')}
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && displayed.length > 0 && (
           <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
             {displayed.map((vehicle) => (
               <FleetVehicleCard
@@ -96,7 +115,7 @@ export function VehicleList() {
           </div>
         )}
 
-        {!isLoading && displayed.length === 0 && (
+        {!isLoading && !isError && displayed.length === 0 && (
           <div className="text-center py-20">
             <Car className="size-12 text-muted-foreground/30 mx-auto mb-4" />
             <p className="text-lg text-muted-foreground">{t('empty')}</p>


### PR DESCRIPTION
## Summary

Fleet page hangs on skeleton loaders on a fresh local dev start because the Hono Worker has no CORS middleware, so every browser fetch from \`http://localhost:3001\` to \`http://localhost:8787\` is blocked. React Query defaults to 3 retries + exponential backoff, which is why it looks like an infinite loading state instead of an error.

Closes #46.

## What changed

- **\`packages/api/src/index.ts\`** — mount \`hono/cors\` as the first middleware. Allowed origins come from \`WEB_ORIGIN\` (comma-separated) so staging/prod can diverge from dev, plus unconditional dev defaults (\`http://localhost:3001\`, \`http://127.0.0.1:3001\`) so \`bun run dev\` + \`bun run dev:api\` works out of the box. 3rd-party callers (Trip.com) hit the Worker server-to-server and don't go through CORS.
- **\`packages/api/tests/routes/cors.test.ts\`** (new, 4 tests) — dev origin echoed, 127.0.0.1 alias works, OPTIONS preflight responds with GET/POST/PATCH/DELETE allowed, rogue origins are not echoed.
- **\`packages/web/src/components/vehicles/VehicleList.tsx\`** — add an \`isError\` branch. Today, when the query eventually gives up, \`vehicles\` is \`undefined\`, \`displayed = []\`, and the "no vehicles added yet" empty state renders — hiding the real error. Now it shows a real error card with the message and a retry button. Same treatment for future regressions will prevent this category of issue from silently masking itself.
- **\`packages/web/messages/{en,ja,zh}.json\`** — \`business.vehicles.loadError\` + \`retry\` strings for the new error state.

## Test plan

- [x] \`bun run test\` — 135 web + 82 api pass (4 new CORS tests)
- [x] \`bun run lint\` — clean
- [x] \`bun run --filter @kuruma/api typecheck\` — clean
- [x] \`bun run --filter @kuruma/web typecheck\` — clean
- [x] \`bun run --filter @kuruma/web build\` — Next.js build green
- [x] \`bun run --filter @kuruma/api build\` — wrangler dry-run green
- [ ] Manual verify: restart your \`dev:api\` process after merge, reload \`/en/manage/vehicles\` — cars should render

## Notes

- If you deploy to staging/prod, set \`WEB_ORIGIN\` on the Worker to the deployed web origin (e.g. \`https://kuruma-rental.pages.dev\`) — the dev defaults don't cover prod.
- This fix is a blocker for the Phase 1 fleet-management redesign work. I'll follow up in the main thread with the UX proposal + issue breakdown once this merges.