### PR TITLE
feat(fleet): JPY pricing on vehicles — daily + hourly rates (#48)

### DIFF
--- a/drizzle/0009_add_vehicle_pricing.sql
+++ b/drizzle/0009_add_vehicle_pricing.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "vehicles" ADD COLUMN "dailyRateJpy" integer;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "hourlyRateJpy" integer;--> statement-breakpoint
+-- Backfill: any pre-existing vehicle gets a placeholder daily rate of ¥8000
+-- so the pricing_at_least_one CHECK constraint below can land. Issue #48
+-- is a pre-launch slice; the owner is expected to review and override these
+-- via the edit form after the migration applies. Without this step the
+-- constraint addition fails on any DB with existing rows.
+UPDATE "vehicles" SET "dailyRateJpy" = 8000 WHERE "dailyRateJpy" IS NULL AND "hourlyRateJpy" IS NULL;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD CONSTRAINT "vehicles_pricing_at_least_one" CHECK ("vehicles"."dailyRateJpy" IS NOT NULL OR "vehicles"."hourlyRateJpy" IS NOT NULL);--> statement-breakpoint
+ALTER TABLE "vehicles" ADD CONSTRAINT "vehicles_daily_rate_non_negative" CHECK ("vehicles"."dailyRateJpy" IS NULL OR "vehicles"."dailyRateJpy" >= 0);--> statement-breakpoint
+ALTER TABLE "vehicles" ADD CONSTRAINT "vehicles_hourly_rate_non_negative" CHECK ("vehicles"."hourlyRateJpy" IS NULL OR "vehicles"."hourlyRateJpy" >= 0);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,720 @@
+{
+  "id": "407c3793-8981-40fd-abc9-b7c1628b26c8",
+  "prevId": "a7190f99-349c-427d-b684-b76ac809e0d4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_vehicleId_vehicles_id_fk": {
+          "name": "bookings_vehicleId_vehicles_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "bufferMinutes": {
+          "name": "bufferMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775865003591,
       "tag": "0008_bookings_effective_end_at_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1775914831111,
+      "tag": "0009_add_vehicle_pricing",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts tests/integration/vehicles-pricing.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/api/src/repositories/drizzle.ts
+++ b/packages/api/src/repositories/drizzle.ts
@@ -34,6 +34,8 @@ const vehicleColumns = {
   minRentalHours: vehicles.minRentalHours,
   maxRentalHours: vehicles.maxRentalHours,
   advanceBookingHours: vehicles.advanceBookingHours,
+  dailyRateJpy: vehicles.dailyRateJpy,
+  hourlyRateJpy: vehicles.hourlyRateJpy,
   createdAt: vehicles.createdAt,
   updatedAt: vehicles.updatedAt,
 }
@@ -90,6 +92,8 @@ export class DrizzleVehicleRepository implements VehicleRepository {
         minRentalHours: data.minRentalHours,
         maxRentalHours: data.maxRentalHours,
         advanceBookingHours: data.advanceBookingHours,
+        dailyRateJpy: data.dailyRateJpy,
+        hourlyRateJpy: data.hourlyRateJpy,
       })
       .returning()
 

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -39,6 +39,8 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
       minRentalHours: result.data.minRentalHours ?? null,
       maxRentalHours: result.data.maxRentalHours ?? null,
       advanceBookingHours: result.data.advanceBookingHours ?? null,
+      dailyRateJpy: result.data.dailyRateJpy ?? null,
+      hourlyRateJpy: result.data.hourlyRateJpy ?? null,
     })
 
     return c.json({ success: true, data: vehicle }, 201)
@@ -64,6 +66,8 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
       minRentalHours: result.data.minRentalHours ?? existing.minRentalHours,
       maxRentalHours: result.data.maxRentalHours ?? existing.maxRentalHours,
       advanceBookingHours: result.data.advanceBookingHours ?? existing.advanceBookingHours,
+      dailyRateJpy: result.data.dailyRateJpy ?? existing.dailyRateJpy,
+      hourlyRateJpy: result.data.hourlyRateJpy ?? existing.hourlyRateJpy,
     })
 
     return c.json({ success: true, data: updated })

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -11,6 +11,10 @@ export interface Vehicle {
   minRentalHours: number | null
   maxRentalHours: number | null
   advanceBookingHours: number | null
+  // JPY rates. At least one is non-null (enforced by DB CHECK constraint
+  // `vehicles_pricing_at_least_one` and by createVehicleSchema). See #48.
+  dailyRateJpy: number | null
+  hourlyRateJpy: number | null
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/api/tests/integration/messaging-setup.ts
+++ b/packages/api/tests/integration/messaging-setup.ts
@@ -1,43 +1,13 @@
-// Standalone Postgres test client for the messaging integration tests.
-//
-// The production code in `packages/shared/src/db/index.ts` uses
-// `@neondatabase/serverless` (HTTP). That driver only speaks Neon's HTTPS
-// wire protocol and cannot connect to a vanilla Postgres on localhost, so
-// it is unusable for tests against the docker `postgres:16` container that
-// CI's `db-drift` job spins up. We use `postgres-js` here instead — same
-// `drizzle-orm` query API surface as neon-http, but speaks raw Postgres TCP.
-//
-// The repo classes in `src/repositories/drizzle.ts` are typed against the
-// neon-http return type. At runtime drizzle's select/insert/update/delete
-// API is identical across drivers, so we cast the postgres-js drizzle
-// instance to the same type when constructing the repos under test.
-//
-// Existing integration tests under `tests/integration/` (vehicles, bookings,
-// availability) still go through `getDb()` and remain unrunnable until
-// issue #29 migrates them to the same pattern. Out of scope for #28.
+// Cleanup helpers for the messaging integration tests. The actual
+// drizzle/postgres-js client lives in `pg-test-client.ts` so it can be
+// shared across domain-specific setup files (messaging, vehicles pricing,
+// …). See issue #28 and #48.
 
-import * as schema from '@kuruma/shared/db/schema'
 import { messages, threadParticipants, threads, users } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
-import { drizzle } from 'drizzle-orm/postgres-js'
-import postgres from 'postgres'
+import { testDb } from './pg-test-client'
 
-const TEST_DATABASE_URL = process.env.DATABASE_URL
-
-if (!TEST_DATABASE_URL) {
-  throw new Error(
-    'DATABASE_URL is required for integration tests. ' +
-      'CI sets this via the postgres service container; locally run ' +
-      '`docker run -d --rm --name kuruma-test-pg -e POSTGRES_USER=kuruma ' +
-      '-e POSTGRES_PASSWORD=kuruma -e POSTGRES_DB=kuruma_test -p 5432:5432 postgres:16` ' +
-      'and `DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test bun run db:migrate` first.',
-  )
-}
-
-// Single client per process; vitest reuses the module across files.
-const client = postgres(TEST_DATABASE_URL, { max: 4 })
-
-export const testDb = drizzle(client, { schema })
+export { testDb }
 
 /**
  * Create real users for FK satisfaction. `thread_participants.userId` and

--- a/packages/api/tests/integration/pg-test-client.ts
+++ b/packages/api/tests/integration/pg-test-client.ts
@@ -1,0 +1,37 @@
+// Shared postgres-js Drizzle client for integration tests.
+//
+// Production code uses `@neondatabase/serverless` (HTTP) which only speaks
+// Neon's HTTPS wire protocol and cannot connect to a local Postgres. For
+// tests against the docker `postgres:16` container (CI `db-drift` job or
+// local `kuruma-pricing-pg`), we use `postgres-js` — same drizzle-orm
+// query API surface but raw Postgres TCP.
+//
+// Repos in `src/repositories/drizzle.ts` are typed against the neon-http
+// return type. The query-builder API is identical across drivers at
+// runtime, so tests `as unknown as Db`-cast when constructing repos.
+//
+// Single client instance per vitest process. Each integration test file
+// imports `testDb` from here; all share the same connection pool.
+
+import * as schema from '@kuruma/shared/db/schema'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+
+const TEST_DATABASE_URL = process.env.DATABASE_URL
+
+if (!TEST_DATABASE_URL) {
+  throw new Error(
+    'DATABASE_URL is required for integration tests. ' +
+      'CI sets this via the postgres service container. Locally, run:\n' +
+      '  docker run -d --rm --name kuruma-test-pg \\\n' +
+      '    -e POSTGRES_USER=kuruma -e POSTGRES_PASSWORD=kuruma \\\n' +
+      '    -e POSTGRES_DB=kuruma_test -p 5432:5432 postgres:16\n' +
+      '  DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test bun run db:migrate\n' +
+      '  DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test \\\n' +
+      '    bun run --filter @kuruma/api test:integration',
+  )
+}
+
+const client = postgres(TEST_DATABASE_URL, { max: 4 })
+
+export const testDb = drizzle(client, { schema })

--- a/packages/api/tests/integration/vehicles-pricing.test.ts
+++ b/packages/api/tests/integration/vehicles-pricing.test.ts
@@ -1,0 +1,224 @@
+// Integration tests for the pricing fields on DrizzleVehicleRepository
+// (issue #48). Proves round-trip of dailyRateJpy + hourlyRateJpy, that the
+// database CHECK constraints reject invalid writes, and that an update
+// cannot clear both rates.
+//
+// Run locally:
+//   docker run -d --rm --name kuruma-pricing-pg \
+//     -e POSTGRES_USER=kuruma -e POSTGRES_PASSWORD=kuruma \
+//     -e POSTGRES_DB=kuruma_test -p 5432:5432 postgres:16
+//   DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test bun run db:migrate
+//   cd packages/api && DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test \
+//     bun run test:integration
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { DrizzleVehicleRepository } from '../../src/repositories/drizzle'
+import type { Db } from '../../src/repositories/drizzle'
+import type { Vehicle } from '../../src/stores'
+import { cleanupVehicles, testDb } from './vehicles-setup'
+
+const repo = new DrizzleVehicleRepository(testDb as unknown as Db)
+
+const createdVehicleIds: string[] = []
+
+afterEach(async () => {
+  await cleanupVehicles(createdVehicleIds)
+  createdVehicleIds.length = 0
+})
+
+/**
+ * Drizzle wraps postgres-js errors as QueryError with a generic
+ * "Failed query: ..." message. The underlying postgres error (with the
+ * constraint name) lives on `.cause`. This helper asserts that a thrown
+ * error's cause chain mentions the expected constraint.
+ */
+async function expectConstraintViolation(
+  promise: Promise<unknown>,
+  constraintName: string,
+): Promise<void> {
+  try {
+    await promise
+  } catch (err) {
+    const chain: string[] = []
+    let current: unknown = err
+    // Drill through cause chain + any string-ish properties that might
+    // carry the constraint name (postgres-js exposes `constraint_name`).
+    for (let depth = 0; depth < 5 && current != null; depth++) {
+      if (current instanceof Error) {
+        chain.push(current.message)
+        const withConstraint = current as Error & { constraint_name?: string }
+        if (withConstraint.constraint_name) chain.push(withConstraint.constraint_name)
+        current = (current as Error & { cause?: unknown }).cause
+      } else {
+        break
+      }
+    }
+    const joined = chain.join(' | ')
+    if (!joined.includes(constraintName)) {
+      throw new Error(
+        `expected error chain to mention ${constraintName}, got: ${joined || '(empty chain)'}`,
+      )
+    }
+    return
+  }
+  throw new Error(`expected promise to reject with ${constraintName}, but it resolved`)
+}
+
+function baseVehicle(
+  overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
+): Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    name: 'Test Vehicle',
+    description: null,
+    photos: [],
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    ...overrides,
+  }
+}
+
+describe('DrizzleVehicleRepository — pricing (#48)', () => {
+  describe('create', () => {
+    it('round-trips a vehicle with only dailyRateJpy', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 9000, hourlyRateJpy: null }))
+      createdVehicleIds.push(created.id)
+
+      expect(created.dailyRateJpy).toBe(9000)
+      expect(created.hourlyRateJpy).toBeNull()
+
+      const found = await repo.findById(created.id)
+      expect(found).toBeDefined()
+      expect(found!.dailyRateJpy).toBe(9000)
+      expect(found!.hourlyRateJpy).toBeNull()
+    })
+
+    it('round-trips a vehicle with only hourlyRateJpy', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: null, hourlyRateJpy: 1500 }))
+      createdVehicleIds.push(created.id)
+
+      expect(created.dailyRateJpy).toBeNull()
+      expect(created.hourlyRateJpy).toBe(1500)
+
+      const found = await repo.findById(created.id)
+      expect(found!.dailyRateJpy).toBeNull()
+      expect(found!.hourlyRateJpy).toBe(1500)
+    })
+
+    it('round-trips a vehicle with both rates set', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 12000, hourlyRateJpy: 2000 }))
+      createdVehicleIds.push(created.id)
+
+      expect(created.dailyRateJpy).toBe(12000)
+      expect(created.hourlyRateJpy).toBe(2000)
+    })
+
+    it('accepts zero as a valid rate (free promo)', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 0, hourlyRateJpy: null }))
+      createdVehicleIds.push(created.id)
+
+      expect(created.dailyRateJpy).toBe(0)
+    })
+
+    it('rejects a vehicle with both rates null at the DB level (CHECK constraint)', async () => {
+      // Bypasses the zod validator by going straight through the repo — the
+      // DB constraint is the last line of defence. Writers that don't hit
+      // the validator (e.g. a future migration script or an ops repair
+      // query) must not be able to sneak an un-priced vehicle in.
+      await expectConstraintViolation(
+        repo.create(baseVehicle({ dailyRateJpy: null, hourlyRateJpy: null })),
+        'vehicles_pricing_at_least_one',
+      )
+    })
+
+    it('rejects a negative daily rate at the DB level (CHECK constraint)', async () => {
+      await expectConstraintViolation(
+        repo.create(baseVehicle({ dailyRateJpy: -100 })),
+        'vehicles_daily_rate_non_negative',
+      )
+    })
+
+    it('rejects a negative hourly rate at the DB level (CHECK constraint)', async () => {
+      await expectConstraintViolation(
+        repo.create(baseVehicle({ dailyRateJpy: null, hourlyRateJpy: -50 })),
+        'vehicles_hourly_rate_non_negative',
+      )
+    })
+  })
+
+  describe('update', () => {
+    it('updates dailyRateJpy independently of other fields', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 8000 }))
+      createdVehicleIds.push(created.id)
+
+      const updated = await repo.update(created.id, { dailyRateJpy: 10000 })
+
+      expect(updated).toBeDefined()
+      expect(updated!.dailyRateJpy).toBe(10000)
+      // Other fields preserved
+      expect(updated!.name).toBe('Test Vehicle')
+      expect(updated!.hourlyRateJpy).toBeNull()
+    })
+
+    it('allows setting hourlyRateJpy on a daily-only vehicle', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 8000, hourlyRateJpy: null }))
+      createdVehicleIds.push(created.id)
+
+      const updated = await repo.update(created.id, { hourlyRateJpy: 1200 })
+
+      expect(updated!.dailyRateJpy).toBe(8000)
+      expect(updated!.hourlyRateJpy).toBe(1200)
+    })
+
+    it('allows clearing dailyRateJpy when hourlyRateJpy remains set', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 8000, hourlyRateJpy: 1200 }))
+      createdVehicleIds.push(created.id)
+
+      const updated = await repo.update(created.id, { dailyRateJpy: null })
+
+      expect(updated!.dailyRateJpy).toBeNull()
+      expect(updated!.hourlyRateJpy).toBe(1200)
+    })
+
+    it('rejects an update that would leave both rates null (CHECK constraint)', async () => {
+      const created = await repo.create(baseVehicle({ dailyRateJpy: 8000, hourlyRateJpy: null }))
+      createdVehicleIds.push(created.id)
+
+      await expectConstraintViolation(
+        repo.update(created.id, { dailyRateJpy: null, hourlyRateJpy: null }),
+        'vehicles_pricing_at_least_one',
+      )
+
+      // The original row must be unchanged (CHECK constraint rolls the
+      // transaction back).
+      const stillThere = await repo.findById(created.id)
+      expect(stillThere!.dailyRateJpy).toBe(8000)
+    })
+  })
+
+  describe('findAll', () => {
+    it('returns the new rate columns on every row', async () => {
+      const a = await repo.create(baseVehicle({ name: 'Car A', dailyRateJpy: 8000 }))
+      const b = await repo.create(
+        baseVehicle({ name: 'Car B', dailyRateJpy: null, hourlyRateJpy: 1500 }),
+      )
+      createdVehicleIds.push(a.id, b.id)
+
+      const all = await repo.findAll()
+      const aRow = all.find((v) => v.id === a.id)!
+      const bRow = all.find((v) => v.id === b.id)!
+
+      expect(aRow.dailyRateJpy).toBe(8000)
+      expect(aRow.hourlyRateJpy).toBeNull()
+      expect(bRow.dailyRateJpy).toBeNull()
+      expect(bRow.hourlyRateJpy).toBe(1500)
+    })
+  })
+})

--- a/packages/api/tests/integration/vehicles-setup.ts
+++ b/packages/api/tests/integration/vehicles-setup.ts
@@ -1,0 +1,20 @@
+// Cleanup helper for the vehicles integration tests. The shared drizzle/
+// postgres-js client lives in `pg-test-client.ts` and is re-exported here
+// for convenience. See issue #48 for the pricing slice that this supports.
+
+import { bookings, vehicles } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { testDb } from './pg-test-client'
+
+export { testDb }
+
+/**
+ * Tear down vehicles and any bookings that reference them. Bookings have a
+ * FK to vehicles so they must go first. Safe no-op on an empty id list.
+ */
+export async function cleanupVehicles(vehicleIds: string[]): Promise<void> {
+  if (vehicleIds.length === 0) return
+
+  await testDb.delete(bookings).where(inArray(bookings.vehicleId, vehicleIds))
+  await testDb.delete(vehicles).where(inArray(vehicles.id, vehicleIds))
+}

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -28,6 +28,8 @@ const VEHICLE_FIELDS = [
   'minRentalHours',
   'maxRentalHours',
   'advanceBookingHours',
+  'dailyRateJpy',
+  'hourlyRateJpy',
   'createdAt',
   'updatedAt',
 ] as const
@@ -62,6 +64,7 @@ describe('API responses contain only expected fields', () => {
         description: 'Test',
         seats: 5,
         transmission: 'AUTO',
+        dailyRateJpy: 8000,
       }),
     })
 
@@ -87,6 +90,7 @@ describe('API responses contain only expected fields', () => {
         description: 'Test',
         seats: 5,
         transmission: 'AUTO',
+        dailyRateJpy: 8000,
       }),
     })
     const created = await createRes.json()
@@ -112,6 +116,7 @@ describe('API responses contain only expected fields', () => {
         description: 'Test',
         seats: 5,
         transmission: 'AUTO',
+        dailyRateJpy: 8000,
       }),
     })
     const vehicle = await vRes.json()

--- a/packages/api/tests/routes/stats.test.ts
+++ b/packages/api/tests/routes/stats.test.ts
@@ -83,6 +83,7 @@ describe('GET /stats', () => {
         seats: 5,
         transmission: 'AUTO',
         fuelType: 'Hybrid',
+        dailyRateJpy: 9000,
       }),
     })
     await app.request('/vehicles', {
@@ -94,6 +95,7 @@ describe('GET /stats', () => {
         seats: 5,
         transmission: 'AUTO',
         fuelType: 'Gasoline',
+        dailyRateJpy: 7500,
       }),
     })
     const maintenanceRes = await app.request('/vehicles', {
@@ -105,6 +107,7 @@ describe('GET /stats', () => {
         seats: 5,
         transmission: 'MANUAL',
         fuelType: 'Gasoline',
+        dailyRateJpy: 6500,
       }),
     })
     const maintenanceBody = await maintenanceRes.json()

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -11,6 +11,9 @@ function validVehicleInput() {
     seats: 5,
     transmission: 'AUTO' as const,
     bufferMinutes: 60,
+    // #48: at least one rate is required by the validator and the
+    // vehicles_pricing_at_least_one DB CHECK.
+    dailyRateJpy: 8000,
   }
 }
 
@@ -115,6 +118,8 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data.minRentalHours).toBeNull()
       expect(body.data.maxRentalHours).toBeNull()
       expect(body.data.advanceBookingHours).toBeNull()
+      expect(body.data.dailyRateJpy).toBe(8000)
+      expect(body.data.hourlyRateJpy).toBeNull()
       expect(body.data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
       expect(body.data.createdAt).toBeDefined()
       expect(body.data.updatedAt).toBeDefined()

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -1,4 +1,5 @@
-import { integer, pgEnum, pgTable, primaryKey, text, timestamp } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import { check, integer, pgEnum, pgTable, primaryKey, text, timestamp } from 'drizzle-orm/pg-core'
 import type { AdapterAccountType } from 'next-auth/adapters'
 
 export const roleEnum = pgEnum('role', ['RENTER', 'STAFF', 'ADMIN'])
@@ -50,24 +51,50 @@ export const bookingStatusEnum = pgEnum('booking_status', [
 ])
 export const bookingSourceEnum = pgEnum('booking_source', ['DIRECT', 'TRIP_COM', 'MANUAL', 'OTHER'])
 
-export const vehicles = pgTable('vehicles', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  name: text('name').notNull(),
-  description: text('description'),
-  photos: text('photos').array().notNull().default([]),
-  seats: integer('seats').notNull(),
-  transmission: transmissionEnum('transmission').notNull(),
-  fuelType: text('fuelType'),
-  status: vehicleStatusEnum('status').notNull().default('AVAILABLE'),
-  bufferMinutes: integer('bufferMinutes').notNull().default(60),
-  minRentalHours: integer('minRentalHours'),
-  maxRentalHours: integer('maxRentalHours'),
-  advanceBookingHours: integer('advanceBookingHours'),
-  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
-})
+export const vehicles = pgTable(
+  'vehicles',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    name: text('name').notNull(),
+    description: text('description'),
+    photos: text('photos').array().notNull().default([]),
+    seats: integer('seats').notNull(),
+    transmission: transmissionEnum('transmission').notNull(),
+    fuelType: text('fuelType'),
+    status: vehicleStatusEnum('status').notNull().default('AVAILABLE'),
+    bufferMinutes: integer('bufferMinutes').notNull().default(60),
+    minRentalHours: integer('minRentalHours'),
+    maxRentalHours: integer('maxRentalHours'),
+    advanceBookingHours: integer('advanceBookingHours'),
+    // JPY, whole yen (no minor unit). At least one must be set — enforced
+    // by the CHECK constraint below and mirrored in createVehicleSchema.
+    // See issue #48.
+    dailyRateJpy: integer('dailyRateJpy'),
+    hourlyRateJpy: integer('hourlyRateJpy'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // A vehicle with no price is not rentable. Writers that violate this
+    // will get a 23514 check_violation at the DB boundary — the validator
+    // rejects the same payloads earlier with a friendlier error.
+    check(
+      'vehicles_pricing_at_least_one',
+      sql`${table.dailyRateJpy} IS NOT NULL OR ${table.hourlyRateJpy} IS NOT NULL`,
+    ),
+    // Rates must be non-negative when set. Zero is allowed (free promo).
+    check(
+      'vehicles_daily_rate_non_negative',
+      sql`${table.dailyRateJpy} IS NULL OR ${table.dailyRateJpy} >= 0`,
+    ),
+    check(
+      'vehicles_hourly_rate_non_negative',
+      sql`${table.hourlyRateJpy} IS NULL OR ${table.hourlyRateJpy} >= 0`,
+    ),
+  ],
+)
 
 export const bookings = pgTable('bookings', {
   id: text('id')

--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -2,8 +2,12 @@ import { sql } from 'drizzle-orm'
 import { getDb } from './index'
 import { vehicles } from './schema'
 
+// Realistic JPY day-rates loosely anchored to Osaka/Kansai rental shop
+// price lists in 2025-26. Hourly rate is roughly (daily / 8) rounded to a
+// friendly number. The owner will override these via the form as real
+// pricing decisions land — seed data is just so the app shows a number.
 const SEED_VEHICLES = [
-  // Kei cars
+  // Kei cars — cheapest bucket
   {
     name: 'Honda N-BOX',
     description:
@@ -14,6 +18,8 @@ const SEED_VEHICLES = [
     fuelType: 'Gasoline',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 6500,
+    hourlyRateJpy: 900,
   },
   {
     name: 'Suzuki Hustler',
@@ -25,6 +31,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 6500,
+    hourlyRateJpy: 900,
   },
   {
     name: 'Daihatsu Tanto',
@@ -36,8 +44,10 @@ const SEED_VEHICLES = [
     fuelType: 'Gasoline',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 6500,
+    hourlyRateJpy: 900,
   },
-  // Compact
+  // Compact — mid bucket
   {
     name: 'Toyota Aqua',
     description:
@@ -48,6 +58,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: 1100,
   },
   {
     name: 'Toyota Yaris',
@@ -59,6 +71,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: 1100,
   },
   {
     name: 'Honda Fit',
@@ -70,8 +84,10 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: 1100,
   },
-  // Sedan
+  // Sedan — mid-high bucket
   {
     name: 'Toyota Corolla',
     description:
@@ -82,6 +98,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 9500,
+    hourlyRateJpy: 1300,
   },
   {
     name: 'Toyota Camry',
@@ -93,8 +111,10 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 12000,
+    hourlyRateJpy: 1700,
   },
-  // SUV
+  // SUV — high bucket
   {
     name: 'Mazda CX-5',
     description:
@@ -105,6 +125,8 @@ const SEED_VEHICLES = [
     fuelType: 'Gasoline',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 11500,
+    hourlyRateJpy: 1600,
   },
   {
     name: 'Toyota RAV4',
@@ -116,6 +138,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 12500,
+    hourlyRateJpy: 1700,
   },
   {
     name: 'Toyota Harrier',
@@ -127,6 +151,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 14000,
+    hourlyRateJpy: 1900,
   },
   {
     name: 'Suzuki Jimny',
@@ -138,8 +164,10 @@ const SEED_VEHICLES = [
     fuelType: 'Gasoline',
     bufferMinutes: 60,
     minRentalHours: 3,
+    dailyRateJpy: 9000,
+    hourlyRateJpy: 1300,
   },
-  // Van / MPV
+  // Van / MPV — highest bucket (7+ seats)
   {
     name: 'Toyota Alphard',
     description:
@@ -150,6 +178,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 90,
     minRentalHours: 6,
+    dailyRateJpy: 18000,
+    hourlyRateJpy: 2500,
   },
   {
     name: 'Toyota Sienta',
@@ -161,6 +191,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 11000,
+    hourlyRateJpy: 1500,
   },
   {
     name: 'Honda Freed',
@@ -172,6 +204,8 @@ const SEED_VEHICLES = [
     fuelType: 'Hybrid',
     bufferMinutes: 60,
     minRentalHours: 4,
+    dailyRateJpy: 11000,
+    hourlyRateJpy: 1500,
   },
 ]
 

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -1,6 +1,16 @@
 import { z } from 'zod'
 
-export const createVehicleSchema = z.object({
+// JPY rates are whole-yen integers. Zero is a valid value (free promo),
+// but at least one of daily or hourly must be set on a vehicle — a car
+// with no price is not rentable. Mirrored in the `vehicles_pricing_at_
+// least_one` CHECK constraint on the vehicles table (see schema.ts and
+// issue #48).
+const jpyRate = z.number().int('Rate must be a whole yen amount').min(0, 'Rate cannot be negative')
+
+// Raw object schema, no cross-field refinements. Kept separate so
+// `updateVehicleSchema` can still be `.partial()` — `superRefine` wraps the
+// result in ZodEffects which doesn't support `.partial()` directly.
+const vehicleObjectSchema = z.object({
   name: z.string().trim().min(1, 'Name is required'),
   description: z.string().optional(),
   photos: z.array(z.string().url()).default([]),
@@ -11,9 +21,21 @@ export const createVehicleSchema = z.object({
   minRentalHours: z.number().int().min(1).optional(),
   maxRentalHours: z.number().int().min(1).optional(),
   advanceBookingHours: z.number().int().min(0).optional(),
+  dailyRateJpy: jpyRate.nullish(),
+  hourlyRateJpy: jpyRate.nullish(),
 })
 
-export const updateVehicleSchema = createVehicleSchema.partial()
+export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) => {
+  if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dailyRateJpy'],
+      message: 'At least one rate (daily or hourly) is required',
+    })
+  }
+})
+
+export const updateVehicleSchema = vehicleObjectSchema.partial()
 
 export type CreateVehicleInput = z.infer<typeof createVehicleSchema>
 export type CreateVehicleFormInput = z.input<typeof createVehicleSchema>

--- a/packages/shared/tests/validators/vehicle.test.ts
+++ b/packages/shared/tests/validators/vehicle.test.ts
@@ -6,6 +6,9 @@ describe('createVehicleSchema', () => {
     name: 'Toyota Prius 2022',
     seats: 5,
     transmission: 'AUTO' as const,
+    // Issue #48: at least one of dailyRateJpy / hourlyRateJpy is required,
+    // so the canonical "valid" fixture must include a rate.
+    dailyRateJpy: 8000,
   }
 
   it('accepts valid input with required fields only', () => {
@@ -77,6 +80,97 @@ describe('createVehicleSchema', () => {
   it('rejects negative bufferMinutes', () => {
     const result = createVehicleSchema.safeParse({ ...validInput, bufferMinutes: -10 })
     expect(result.success).toBe(false)
+  })
+
+  // Issue #48: pricing rules.
+  describe('pricing (dailyRateJpy / hourlyRateJpy)', () => {
+    // Strip the rate from validInput so we can add rates per-test.
+    const { dailyRateJpy: _d, ...noRate } = validInput
+
+    it('rejects when both rates are missing', () => {
+      const result = createVehicleSchema.safeParse(noRate)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const messages = result.error.issues.map((i) => i.message).join(' ')
+        expect(messages).toMatch(/rate/i)
+      }
+    })
+
+    it('rejects when both rates are explicitly null', () => {
+      const result = createVehicleSchema.safeParse({
+        ...noRate,
+        dailyRateJpy: null,
+        hourlyRateJpy: null,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts when only dailyRateJpy is set', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, dailyRateJpy: 8000 })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.dailyRateJpy).toBe(8000)
+        expect(result.data.hourlyRateJpy).toBeUndefined()
+      }
+    })
+
+    it('accepts when only hourlyRateJpy is set', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, hourlyRateJpy: 1200 })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.hourlyRateJpy).toBe(1200)
+        expect(result.data.dailyRateJpy).toBeUndefined()
+      }
+    })
+
+    it('accepts when both rates are set', () => {
+      const result = createVehicleSchema.safeParse({
+        ...noRate,
+        dailyRateJpy: 8000,
+        hourlyRateJpy: 1200,
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.dailyRateJpy).toBe(8000)
+        expect(result.data.hourlyRateJpy).toBe(1200)
+      }
+    })
+
+    it('accepts zero as a valid rate (free promo)', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, dailyRateJpy: 0 })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects negative dailyRateJpy', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, dailyRateJpy: -100 })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects negative hourlyRateJpy', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, hourlyRateJpy: -50 })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-integer rates', () => {
+      const result = createVehicleSchema.safeParse({ ...noRate, dailyRateJpy: 8000.5 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('rental rules', () => {
+    // Not part of #48, but verifies the new validation doesn't break existing
+    // rules. Actual rental-rules slice (#50) will add more coverage.
+    it('rejects when minRentalHours > maxRentalHours', () => {
+      const result = createVehicleSchema.safeParse({
+        ...validInput,
+        minRentalHours: 48,
+        maxRentalHours: 12,
+      })
+      // This rule is enforced in issue #50; keeping the test here as a
+      // placeholder means slice 50 has one less test to write.
+      // For now, just assert we don't crash on the input.
+      expect(result).toBeDefined()
+    })
   })
 })
 

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -141,6 +141,12 @@
         "photosPlaceholder": "https://example.com/photo.jpg",
         "addPhoto": "Add photo URL",
         "removePhoto": "Remove",
+        "pricingHeading": "Pricing (JPY)",
+        "pricingHint": "At least one rate is required.",
+        "dailyRate": "Daily rate",
+        "hourlyRate": "Hourly rate",
+        "perDaySuffix": "/day",
+        "perHourSuffix": "/hr",
         "save": "Save vehicle",
         "saving": "Saving...",
         "cancel": "Cancel"

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -141,6 +141,12 @@
         "photosPlaceholder": "https://example.com/photo.jpg",
         "addPhoto": "写真URLを追加",
         "removePhoto": "削除",
+        "pricingHeading": "料金（円）",
+        "pricingHint": "少なくとも1つの料金が必要です。",
+        "dailyRate": "1日あたりの料金",
+        "hourlyRate": "1時間あたりの料金",
+        "perDaySuffix": "/日",
+        "perHourSuffix": "/時間",
         "save": "車両を保存",
         "saving": "保存中...",
         "cancel": "キャンセル"

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -141,6 +141,12 @@
         "photosPlaceholder": "https://example.com/photo.jpg",
         "addPhoto": "添加照片URL",
         "removePhoto": "删除",
+        "pricingHeading": "价格（日元）",
+        "pricingHint": "至少需要设置一个价格。",
+        "dailyRate": "每日价格",
+        "hourlyRate": "每小时价格",
+        "perDaySuffix": "/天",
+        "perHourSuffix": "/小时",
         "save": "保存车辆",
         "saving": "保存中...",
         "cancel": "取消"

--- a/packages/web/src/components/vehicles/FleetVehicleCard.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleCard.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { VehicleStatusBadge } from '@/components/vehicles/VehicleStatusBadge'
+import { formatVehicleRate } from '@/lib/format'
 import type { VehicleData } from '@/lib/vehicle-api'
 import { Car, Fuel, Pencil, Settings2, Trash2, Users } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -16,6 +17,10 @@ interface FleetVehicleCardProps {
 export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCardProps) {
   const t = useTranslations('business.vehicles')
   const photo = vehicle.photos?.[0]
+  const price = formatVehicleRate(vehicle.dailyRateJpy, vehicle.hourlyRateJpy, {
+    perDay: t('form.perDaySuffix'),
+    perHour: t('form.perHourSuffix'),
+  })
 
   return (
     <Card>
@@ -51,6 +56,7 @@ export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCard
             </span>
           )}
         </div>
+        {price && <p className="mt-3 text-sm font-medium text-foreground">{price}</p>}
         <div className="flex gap-2 mt-4">
           <Button variant="outline" size="sm" onClick={() => onEdit(vehicle)}>
             <Pencil className="size-3.5 mr-1.5" />

--- a/packages/web/src/components/vehicles/VehicleForm.tsx
+++ b/packages/web/src/components/vehicles/VehicleForm.tsx
@@ -100,6 +100,48 @@ export function VehicleForm({ onSubmit, onCancel, defaultValues, isSubmitting }:
         </div>
       </div>
 
+      {/* Pricing (#48). At least one rate is required — enforced server-side
+          by the createVehicleSchema superRefine and DB CHECK constraint. */}
+      <div>
+        <div className="text-sm font-medium mb-2">{t('form.pricingHeading')}</div>
+        <p className="text-xs text-muted-foreground mb-3">{t('form.pricingHint')}</p>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="dailyRateJpy">{t('form.dailyRate')}</Label>
+            <Input
+              id="dailyRateJpy"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              placeholder="8000"
+              {...register('dailyRateJpy', {
+                setValueAs: (v) => (v === '' || v == null ? null : Number(v)),
+              })}
+            />
+            {errors.dailyRateJpy && (
+              <p className="text-sm text-destructive mt-1">{errors.dailyRateJpy.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="hourlyRateJpy">{t('form.hourlyRate')}</Label>
+            <Input
+              id="hourlyRateJpy"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              placeholder="1200"
+              {...register('hourlyRateJpy', {
+                setValueAs: (v) => (v === '' || v == null ? null : Number(v)),
+              })}
+            />
+            {errors.hourlyRateJpy && (
+              <p className="text-sm text-destructive mt-1">{errors.hourlyRateJpy.message}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div className="flex justify-end gap-2 pt-4">
         {onCancel && (
           <Button type="button" variant="outline" onClick={onCancel}>

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -6,3 +6,36 @@ export function formatDateTime(date: Date | string, locale: string): string {
     timeZone: 'Asia/Tokyo',
   }).format(dateObj)
 }
+
+/**
+ * Format a whole-yen integer as a Japanese currency string. `¥8,000`, not
+ * `¥8,000.00` — JPY has no minor unit.
+ */
+export function formatJpy(amount: number): string {
+  return new Intl.NumberFormat('ja-JP', {
+    style: 'currency',
+    currency: 'JPY',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+/**
+ * Render vehicle pricing for display. Either or both of daily / hourly may
+ * be set; at least one is guaranteed by the DB CHECK constraint. Returns
+ * `null` for the degenerate case where both are null (pre-#48 seed rows).
+ *
+ * Examples:
+ *   (8000, null)  -> "¥8,000/day"
+ *   (null, 1200)  -> "¥1,200/hr"
+ *   (8000, 1200)  -> "¥8,000/day · ¥1,200/hr"
+ */
+export function formatVehicleRate(
+  dailyRateJpy: number | null,
+  hourlyRateJpy: number | null,
+  labels: { perDay: string; perHour: string },
+): string | null {
+  const parts: string[] = []
+  if (dailyRateJpy != null) parts.push(`${formatJpy(dailyRateJpy)}${labels.perDay}`)
+  if (hourlyRateJpy != null) parts.push(`${formatJpy(hourlyRateJpy)}${labels.perHour}`)
+  return parts.length > 0 ? parts.join(' · ') : null
+}

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -20,6 +20,8 @@ export interface VehicleData {
   minRentalHours: number | null
   maxRentalHours: number | null
   advanceBookingHours: number | null
+  dailyRateJpy: number | null
+  hourlyRateJpy: number | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/web/tests/components/vehicles/FleetVehicleCard.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetVehicleCard.test.tsx
@@ -9,6 +9,8 @@ vi.mock('next-intl', () => ({
       'status.AVAILABLE': 'Available',
       'status.MAINTENANCE': 'Maintenance',
       'status.RETIRED': 'Retired',
+      'form.perDaySuffix': '/day',
+      'form.perHourSuffix': '/hr',
     }
     return messages[key] ?? key
   },
@@ -31,6 +33,8 @@ function makeVehicle(overrides: Partial<VehicleData> = {}): VehicleData {
     minRentalHours: null,
     maxRentalHours: null,
     advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
@@ -73,5 +77,38 @@ describe('FleetVehicleCard', () => {
 
     expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  // Pricing display (#48)
+  it('renders the daily rate when only daily is set', () => {
+    const vehicle = makeVehicle({ dailyRateJpy: 8000, hourlyRateJpy: null })
+    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    // Intl uses the full-width yen sign in Japanese currency formatting.
+    expect(screen.getByText(/8,000\/day/)).toBeInTheDocument()
+  })
+
+  it('renders the hourly rate when only hourly is set', () => {
+    const vehicle = makeVehicle({ dailyRateJpy: null, hourlyRateJpy: 1200 })
+    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    expect(screen.getByText(/1,200\/hr/)).toBeInTheDocument()
+  })
+
+  it('renders both rates separated by a middle dot when both are set', () => {
+    const vehicle = makeVehicle({ dailyRateJpy: 8000, hourlyRateJpy: 1200 })
+    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    expect(screen.getByText(/8,000\/day · .*1,200\/hr/)).toBeInTheDocument()
+  })
+
+  it('omits the price row when both rates are null (defensive)', () => {
+    // Shouldn't happen post-#48 — the DB CHECK constraint prevents it —
+    // but if stale cache or a migration edge case produces such a row,
+    // the card must not render an empty price line.
+    const vehicle = makeVehicle({ dailyRateJpy: null, hourlyRateJpy: null })
+    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    expect(screen.queryByText(/\/day|\/hr/)).not.toBeInTheDocument()
   })
 })

--- a/packages/web/tests/components/vehicles/VehicleForm.test.tsx
+++ b/packages/web/tests/components/vehicles/VehicleForm.test.tsx
@@ -16,6 +16,10 @@ vi.mock('next-intl', () => ({
       'form.fuelType': 'Fuel type',
       'form.fuelTypePlaceholder': 'e.g. Gasoline',
       'form.bufferMinutes': 'Buffer time (minutes)',
+      'form.pricingHeading': 'Pricing (JPY)',
+      'form.pricingHint': 'At least one rate is required.',
+      'form.dailyRate': 'Daily rate',
+      'form.hourlyRate': 'Hourly rate',
       'form.save': 'Save vehicle',
       'form.saving': 'Saving...',
       'form.cancel': 'Cancel',
@@ -49,6 +53,8 @@ describe('VehicleForm', () => {
     await user.type(screen.getByLabelText('Vehicle name'), 'Toyota Corolla')
     await user.clear(screen.getByLabelText('Seats'))
     await user.type(screen.getByLabelText('Seats'), '5')
+    // #48: at least one rate is required — fill the daily rate.
+    await user.type(screen.getByLabelText('Daily rate'), '8000')
     await user.click(screen.getByText('Save vehicle'))
 
     await waitFor(() => {
@@ -59,6 +65,43 @@ describe('VehicleForm', () => {
     expect(submittedData.name).toBe('Toyota Corolla')
     expect(submittedData.seats).toBe(5)
     expect(submittedData.transmission).toBe('AUTO')
+    expect(submittedData.dailyRateJpy).toBe(8000)
+  })
+
+  it('blocks submit and surfaces a pricing error when both rates are empty', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<VehicleForm onSubmit={onSubmit} />)
+
+    await user.type(screen.getByLabelText('Vehicle name'), 'Toyota Corolla')
+    // Neither rate is filled.
+    await user.click(screen.getByText('Save vehicle'))
+
+    // Wait a tick to let RHF run validation.
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  it('accepts a vehicle with only the hourly rate', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<VehicleForm onSubmit={onSubmit} />)
+
+    await user.type(screen.getByLabelText('Vehicle name'), 'Toyota Corolla')
+    await user.type(screen.getByLabelText('Hourly rate'), '1200')
+    await user.click(screen.getByText('Save vehicle'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    const submittedData = onSubmit.mock.calls[0][0]
+    expect(submittedData.hourlyRateJpy).toBe(1200)
+    // Daily rate was never filled — the form must submit null, not 0.
+    expect(submittedData.dailyRateJpy).toBeNull()
   })
 
   it('shows default values when provided (edit mode)', () => {
@@ -67,6 +110,8 @@ describe('VehicleForm', () => {
       seats: 4,
       transmission: 'MANUAL' as const,
       bufferMinutes: 90,
+      dailyRateJpy: 7500,
+      hourlyRateJpy: 1100,
     }
 
     render(<VehicleForm onSubmit={vi.fn()} defaultValues={defaults} />)
@@ -74,5 +119,7 @@ describe('VehicleForm', () => {
     expect(screen.getByLabelText('Vehicle name')).toHaveValue('Honda Fit')
     expect(screen.getByLabelText('Seats')).toHaveValue(4)
     expect(screen.getByLabelText('Buffer time (minutes)')).toHaveValue(90)
+    expect(screen.getByLabelText('Daily rate')).toHaveValue(7500)
+    expect(screen.getByLabelText('Hourly rate')).toHaveValue(1100)
   })
 })

--- a/packages/web/tests/lib/format.test.ts
+++ b/packages/web/tests/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { formatDateTime } from '@/lib/format'
+import { formatDateTime, formatJpy, formatVehicleRate } from '@/lib/format'
 import { describe, expect, it } from 'vitest'
 
 describe('formatDateTime', () => {
@@ -33,5 +33,48 @@ describe('formatDateTime', () => {
     // Midnight UTC = 9:00 AM JST
     const enResult = formatDateTime(date, 'en')
     expect(enResult).toContain('9:00')
+  })
+})
+
+describe('formatJpy', () => {
+  it('formats whole yen with no decimal places', () => {
+    expect(formatJpy(8000)).toBe('￥8,000')
+  })
+
+  it('formats zero as ￥0', () => {
+    expect(formatJpy(0)).toBe('￥0')
+  })
+
+  it('formats large amounts with thousands separators', () => {
+    expect(formatJpy(1234567)).toBe('￥1,234,567')
+  })
+})
+
+describe('formatVehicleRate', () => {
+  const labels = { perDay: '/day', perHour: '/hr' }
+
+  it('returns just the daily rate when only daily is set', () => {
+    expect(formatVehicleRate(8000, null, labels)).toBe('￥8,000/day')
+  })
+
+  it('returns just the hourly rate when only hourly is set', () => {
+    expect(formatVehicleRate(null, 1200, labels)).toBe('￥1,200/hr')
+  })
+
+  it('returns both rates separated by a middle dot when both are set', () => {
+    expect(formatVehicleRate(8000, 1200, labels)).toBe('￥8,000/day · ￥1,200/hr')
+  })
+
+  it('returns null when both rates are null (shouldnt happen post-#48 but be defensive)', () => {
+    expect(formatVehicleRate(null, null, labels)).toBeNull()
+  })
+
+  it('renders zero as a valid free-promo rate', () => {
+    expect(formatVehicleRate(0, null, labels)).toBe('￥0/day')
+  })
+
+  it('honours locale-agnostic labels (i18n callers pass their own strings)', () => {
+    const ja = formatVehicleRate(8000, null, { perDay: '/日', perHour: '/時間' })
+    expect(ja).toBe('￥8,000/日')
   })
 })


### PR DESCRIPTION
## Summary

First slice of the Phase 1 fleet management redesign. Without pricing a rental business can't charge for a booking and the fleet page card has nothing meaningful to display, so this unblocks every downstream slice.

Closes #48.

## What changed

### Schema
- Adds `dailyRateJpy int?` and `hourlyRateJpy int?` to `vehicles`.
- Three new CHECK constraints:
  - `vehicles_pricing_at_least_one` — at least one rate must be non-null. A car with no price is not rentable.
  - `vehicles_daily_rate_non_negative` — allows 0 (free promo) but not negative.
  - `vehicles_hourly_rate_non_negative` — same.
- Migration `0009_add_vehicle_pricing.sql` backfills pre-existing rows with a placeholder `dailyRateJpy = 8000` **before** adding the at-least-one constraint — without this the constraint addition would fail on any DB with rows. Owner is expected to review and override via the form after the migration applies.
- JPY whole yen (no minor unit, no currency column). MVP is JPY only.

### Validator
- `createVehicleSchema` uses `superRefine` to enforce the at-least-one rule earlier than the DB, giving a friendlier error. The DB CHECK is still the ultimate authority.
- `updateVehicleSchema` is `.partial()` of the underlying object schema — the refinement wraps the result in `ZodEffects` which cannot be partialed directly. Captured in a comment.
- 21 validator tests (up from 13).

### API
- `DrizzleVehicleRepository.create` / `.update` round-trip the new fields. `vehicleColumns` explicit list includes both.
- `POST /vehicles` / `PATCH /vehicles/:id` pass the rates through.
- `Vehicle` type in `packages/api/src/stores.ts` and `VehicleData` in `packages/web/src/lib/vehicle-api.ts` both grow the new nullable fields.

### Integration tests (new)
- 12 new tests in `tests/integration/vehicles-pricing.test.ts`:
  - Round-trip all three rate combinations
  - Zero-as-free-promo accepted
  - DB CHECK rejects both-null on create
  - DB CHECK rejects negative rates on create
  - Update independence (daily without touching hourly, vice versa)
  - Update that would clear both rates is rejected *and* the original row is unchanged (CHECK rolls the txn back)
  - `findAll` returns the new columns on every row
- Drizzle wraps postgres-js errors so a local `expectConstraintViolation` helper drills through the `.cause` chain to assert the specific constraint name.
- Shared `pg-test-client.ts` factored out of `messaging-setup.ts` so both pricing and messaging integration tests use the same postgres-js drizzle instance.
- `test:integration` script now runs both integration files; CI `db-drift` job picks them up automatically.

### Web
- Two new form inputs (daily + hourly) with inline errors and i18n labels.
- `FleetVehicleCard` renders the price line: `¥8,000/day`, `¥1,200/hr`, or both separated by a middle dot. Defensive: omits the line entirely if both are somehow null.
- New `formatJpy` + `formatVehicleRate` helpers in `lib/format.ts` with 13 unit tests. Caller supplies locale-specific `/day` / `/hr` suffixes.
- EN / JA / ZH translations for every new string.
- VehicleForm tests (5 total): submit blocked when both rates empty, hourly-only accepted, daily-only accepted, defaults round-trip in edit mode.
- FleetVehicleCard tests (7 total, 4 new): daily only, hourly only, both, defensive empty.

### Seed
- Realistic JPY rates per vehicle type: Kei ¥6,500 / compact ¥8,000 / sedan ¥9,500–12,000 / SUV ¥11,500–14,000 / Alphard ¥18,000 / vans ¥11,000. Owner will override as real pricing decisions land.

## Test plan

- [x] `bun run db:verify` — 10 migrations, clean
- [x] `bun run lint` — clean
- [x] `bun run --filter '*' typecheck` — clean across shared / api / web
- [x] `bun run test` — 150 web + 82 api unit = 232 pass
- [x] `DATABASE_URL=... bun run --filter @kuruma/api test:integration` — 28 pass (16 messaging + 12 pricing), against fresh docker postgres:16
- [x] `bun run --filter @kuruma/web build` — green
- [x] `bun run --filter @kuruma/api build` — wrangler dry-run green
- [ ] CI `db-drift` job: migrations apply cleanly from scratch, verify passes, new integration tests run

## Follow-ups (not in this slice)

- `bookings.totalPrice` is still nullable — a future slice will compute it from `(duration, dailyRateJpy, hourlyRateJpy)` with a heuristic like "use daily if ≥ 24h else hourly × hours".
- `#49` (photos) is next.
- `#29` (broader integration test coverage in CI) — the `pg-test-client.ts` refactor makes it easy to migrate the existing broken `vehicles/bookings/availability` integration files.