### PR TITLE
feat(web): inline vehicle status toggle on fleet list (#51)

### DIFF
--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -1,4 +1,8 @@
-import { createVehicleSchema, updateVehicleSchema } from '@kuruma/shared/validators/vehicle'
+import {
+  createVehicleSchema,
+  updateVehicleSchema,
+  updateVehicleStatusSchema,
+} from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
 import type { VehicleRepository } from '../repositories/types'
 
@@ -70,6 +74,26 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
       hourlyRateJpy: result.data.hourlyRateJpy ?? existing.hourlyRateJpy,
     })
 
+    return c.json({ success: true, data: updated })
+  })
+
+  // Issue #51: one-shot status toggle. Kept separate from PATCH /vehicles/:id
+  // so the fleet list UI can bind a tiny optimistic mutation without sending
+  // the full vehicle payload. Any transition is allowed (owner needs to be
+  // able to flip a car back out of RETIRED if they soft-deleted by mistake).
+  vehicles.patch('/vehicles/:id/status', async (c) => {
+    const existing = await repo.findById(c.req.param('id'))
+    if (!existing) {
+      return c.json({ success: false, error: 'Vehicle not found' }, 404)
+    }
+
+    const body = await c.req.json()
+    const result = updateVehicleStatusSchema.safeParse(body)
+    if (!result.success) {
+      return c.json({ success: false, error: result.error.flatten().fieldErrors }, 400)
+    }
+
+    const updated = await repo.update(existing.id, { status: result.data.status })
     return c.json({ success: true, data: updated })
   })
 

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -278,6 +278,121 @@ describe('Vehicle CRUD Routes', () => {
     })
   })
 
+  describe('PATCH /vehicles/:id/status (issue #51)', () => {
+    async function patchStatus(id: string, status: string) {
+      return app.request(`/vehicles/${id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      })
+    }
+
+    it('flips AVAILABLE → MAINTENANCE and returns the updated vehicle', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await patchStatus(created.data.id, 'MAINTENANCE')
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data.status).toBe('MAINTENANCE')
+      expect(body.data.id).toBe(created.data.id)
+    })
+
+    it('round-trips MAINTENANCE → AVAILABLE', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      await patchStatus(created.data.id, 'MAINTENANCE')
+      const res = await patchStatus(created.data.id, 'AVAILABLE')
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.status).toBe('AVAILABLE')
+    })
+
+    it('allows un-retiring: RETIRED → AVAILABLE', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      await patchStatus(created.data.id, 'RETIRED')
+      const res = await patchStatus(created.data.id, 'AVAILABLE')
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.status).toBe('AVAILABLE')
+    })
+
+    it('advances updatedAt on a status change', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+      const before = created.data.updatedAt
+
+      // Ensure at least 1 ms delta so the InMemoryVehicleRepository
+      // timestamp is guaranteed to advance on systems with 1 ms clock resolution.
+      await new Promise((r) => setTimeout(r, 2))
+      const res = await patchStatus(created.data.id, 'MAINTENANCE')
+      const body = await res.json()
+
+      expect(new Date(body.data.updatedAt).getTime()).toBeGreaterThan(
+        new Date(before).getTime(),
+      )
+    })
+
+    it('returns 404 for nonexistent vehicle', async () => {
+      const res = await patchStatus('nonexistent-id', 'MAINTENANCE')
+
+      expect(res.status).toBe(404)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Vehicle not found')
+    })
+
+    it('rejects unknown status with 400', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await patchStatus(created.data.id, 'BROKEN')
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+    })
+
+    it('rejects missing status body with 400', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+    })
+
+    it('does not touch fields other than status', async () => {
+      const createRes = await createVehicle({
+        ...validVehicleInput(),
+        name: 'Keep Me',
+        dailyRateJpy: 12345,
+      })
+      const created = await createRes.json()
+
+      await patchStatus(created.data.id, 'MAINTENANCE')
+
+      const getRes = await app.request(`/vehicles/${created.data.id}`)
+      const getBody = await getRes.json()
+      expect(getBody.data.name).toBe('Keep Me')
+      expect(getBody.data.dailyRateJpy).toBe(12345)
+      expect(getBody.data.status).toBe('MAINTENANCE')
+    })
+  })
+
   describe('DELETE /vehicles/:id', () => {
     it('soft deletes by setting status to RETIRED', async () => {
       const createRes = await createVehicle()

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -335,9 +335,7 @@ describe('Vehicle CRUD Routes', () => {
       const res = await patchStatus(created.data.id, 'MAINTENANCE')
       const body = await res.json()
 
-      expect(new Date(body.data.updatedAt).getTime()).toBeGreaterThan(
-        new Date(before).getTime(),
-      )
+      expect(new Date(body.data.updatedAt).getTime()).toBeGreaterThan(new Date(before).getTime())
     })
 
     it('returns 404 for nonexistent vehicle', async () => {

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -55,6 +55,16 @@ export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) =
 
 export const updateVehicleSchema = vehicleObjectSchema.partial()
 
+// Issue #51: inline status toggle. Kept as its own tiny schema so the
+// fleet list can bind a one-field mutation without sending the full
+// update payload. Mirrors the `vehicle_status` pgEnum in schema.ts.
+export const vehicleStatusEnum = z.enum(['AVAILABLE', 'MAINTENANCE', 'RETIRED'])
+export const updateVehicleStatusSchema = z.object({
+  status: vehicleStatusEnum,
+})
+
 export type CreateVehicleInput = z.infer<typeof createVehicleSchema>
 export type CreateVehicleFormInput = z.input<typeof createVehicleSchema>
 export type UpdateVehicleInput = z.infer<typeof updateVehicleSchema>
+export type UpdateVehicleStatusInput = z.infer<typeof updateVehicleStatusSchema>
+export type VehicleStatus = z.infer<typeof vehicleStatusEnum>

--- a/packages/shared/tests/validators/vehicle.test.ts
+++ b/packages/shared/tests/validators/vehicle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { createVehicleSchema, updateVehicleSchema } from '../../src/validators/vehicle'
+import {
+  createVehicleSchema,
+  updateVehicleSchema,
+  updateVehicleStatusSchema,
+} from '../../src/validators/vehicle'
 
 describe('createVehicleSchema', () => {
   const validInput = {
@@ -242,5 +246,40 @@ describe('updateVehicleSchema', () => {
   it('accepts empty object', () => {
     const result = updateVehicleSchema.safeParse({})
     expect(result.success).toBe(true)
+  })
+})
+
+describe('updateVehicleStatusSchema', () => {
+  it('accepts AVAILABLE', () => {
+    const result = updateVehicleStatusSchema.safeParse({ status: 'AVAILABLE' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe('AVAILABLE')
+    }
+  })
+
+  it('accepts MAINTENANCE', () => {
+    const result = updateVehicleStatusSchema.safeParse({ status: 'MAINTENANCE' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts RETIRED', () => {
+    const result = updateVehicleStatusSchema.safeParse({ status: 'RETIRED' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects unknown status value', () => {
+    const result = updateVehicleStatusSchema.safeParse({ status: 'BROKEN' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing status', () => {
+    const result = updateVehicleStatusSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects lowercase status', () => {
+    const result = updateVehicleStatusSchema.safeParse({ status: 'available' })
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -127,6 +127,11 @@
         "MAINTENANCE": "Maintenance",
         "RETIRED": "Retired"
       },
+      "statusToggle": {
+        "ariaLabel": "Change status",
+        "restore": "Restore",
+        "error": "Could not update status. Please try again."
+      },
       "form": {
         "name": "Vehicle name",
         "namePlaceholder": "e.g. Toyota Corolla 2024",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -127,6 +127,11 @@
         "MAINTENANCE": "メンテナンス中",
         "RETIRED": "廃止"
       },
+      "statusToggle": {
+        "ariaLabel": "ステータスを変更",
+        "restore": "復元",
+        "error": "ステータスを更新できませんでした。もう一度お試しください。"
+      },
       "form": {
         "name": "車両名",
         "namePlaceholder": "例：トヨタ カローラ 2024",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -127,6 +127,11 @@
         "MAINTENANCE": "维护中",
         "RETIRED": "已停用"
       },
+      "statusToggle": {
+        "ariaLabel": "更改状态",
+        "restore": "恢复",
+        "error": "无法更新状态，请重试。"
+      },
       "form": {
         "name": "车辆名称",
         "namePlaceholder": "例如：丰田卡罗拉 2024",

--- a/packages/web/src/components/vehicles/FleetVehicleCard.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleCard.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { VehicleStatusBadge } from '@/components/vehicles/VehicleStatusBadge'
+import { VehicleStatusToggle } from '@/components/vehicles/VehicleStatusToggle'
 import { formatVehicleRate } from '@/lib/format'
 import type { VehicleData } from '@/lib/vehicle-api'
 import { Car, Fuel, Pencil, Settings2, Trash2, Users } from 'lucide-react'
@@ -36,7 +36,7 @@ export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCard
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle>{vehicle.name}</CardTitle>
-          <VehicleStatusBadge status={vehicle.status} />
+          <VehicleStatusToggle vehicle={vehicle} />
         </div>
       </CardHeader>
       <CardContent>

--- a/packages/web/src/components/vehicles/VehicleStatusToggle.tsx
+++ b/packages/web/src/components/vehicles/VehicleStatusToggle.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { type VehicleData, updateVehicleStatus } from '@/lib/vehicle-api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslations } from 'next-intl'
+
+interface VehicleStatusToggleProps {
+  vehicle: VehicleData
+}
+
+type TogglableStatus = 'AVAILABLE' | 'MAINTENANCE'
+const togglableStatuses: TogglableStatus[] = ['AVAILABLE', 'MAINTENANCE']
+const VEHICLES_KEY = ['vehicles'] as const
+
+interface OptimisticContext {
+  previous: VehicleData[] | undefined
+}
+
+export function VehicleStatusToggle({ vehicle }: VehicleStatusToggleProps) {
+  const t = useTranslations('business.vehicles')
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<VehicleData, Error, TogglableStatus, OptimisticContext>({
+    mutationFn: (next) => updateVehicleStatus(vehicle.id, next),
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey: VEHICLES_KEY })
+      const previous = queryClient.getQueryData<VehicleData[]>(VEHICLES_KEY)
+      if (previous) {
+        queryClient.setQueryData<VehicleData[]>(
+          VEHICLES_KEY,
+          previous.map((v) => (v.id === vehicle.id ? { ...v, status: next } : v)),
+        )
+      }
+      return { previous }
+    },
+    onError: (_err, _next, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(VEHICLES_KEY, ctx.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: VEHICLES_KEY })
+    },
+  })
+
+  function handleClick(next: TogglableStatus) {
+    if (next === vehicle.status) return
+    mutation.mutate(next)
+  }
+
+  // RETIRED cars surface a single "Restore" affordance instead of the
+  // segmented control. Active rental operations (AVAILABLE ↔ MAINTENANCE)
+  // are the 95% case and get the fast path; un-retiring is rare and
+  // deserves its own obvious control.
+  if (vehicle.status === 'RETIRED') {
+    return (
+      <div className="inline-flex flex-col items-end gap-1">
+        <div className="inline-flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-0.5">
+          <span className="text-xs font-medium text-muted-foreground">{t('status.RETIRED')}</span>
+          <button
+            type="button"
+            onClick={() => mutation.mutate('AVAILABLE')}
+            disabled={mutation.isPending}
+            className="rounded px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 hover:bg-emerald-500/10 disabled:opacity-60"
+          >
+            {t('statusToggle.restore')}
+          </button>
+        </div>
+        {mutation.isError && (
+          <output className="text-[11px] text-destructive">{t('statusToggle.error')}</output>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="inline-flex flex-col items-end gap-1">
+      {/* biome-ignore lint/a11y/useSemanticElements: <fieldset> would force a <legend> child which doesn't match the inline segmented-control visual. role="group" + aria-label is the standard ARIA authoring pattern for toggle button groups. */}
+      <div
+        role="group"
+        aria-label={t('statusToggle.ariaLabel')}
+        className="inline-flex rounded-md border border-border bg-background p-0.5"
+      >
+        {togglableStatuses.map((status) => {
+          const isActive = vehicle.status === status
+          return (
+            <button
+              key={status}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => handleClick(status)}
+              disabled={mutation.isPending}
+              className={cn(
+                'rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-60',
+                isActive && status === 'AVAILABLE' && 'bg-emerald-500/15 text-emerald-700',
+                isActive && status === 'MAINTENANCE' && 'bg-amber-500/15 text-amber-700',
+                !isActive && 'text-muted-foreground hover:bg-muted',
+              )}
+            >
+              {t(`status.${status}`)}
+            </button>
+          )
+        })}
+      </div>
+      {mutation.isError && (
+        <output className="text-[11px] text-destructive">{t('statusToggle.error')}</output>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -1,5 +1,5 @@
 import { getApiBaseUrl } from '@/lib/api-client'
-import type { CreateVehicleInput } from '@kuruma/shared/validators/vehicle'
+import type { CreateVehicleInput, VehicleStatus } from '@kuruma/shared/validators/vehicle'
 
 interface ApiResponse<T> {
   success: boolean
@@ -72,6 +72,18 @@ export async function updateVehicle(
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+  })
+}
+
+// Issue #51: one-shot status mutation for the fleet list inline toggle.
+// Kept separate from updateVehicle() so callers don't accidentally ship a
+// partial vehicle payload when they only mean to flip a status.
+export async function updateVehicleStatus(id: string, status: VehicleStatus): Promise<VehicleData> {
+  const base = getApiBaseUrl()
+  return apiRequest<VehicleData>(`${base}/vehicles/${id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
   })
 }
 

--- a/packages/web/tests/components/vehicles/FleetVehicleCard.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetVehicleCard.test.tsx
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('next-intl', () => ({
@@ -9,6 +11,9 @@ vi.mock('next-intl', () => ({
       'status.AVAILABLE': 'Available',
       'status.MAINTENANCE': 'Maintenance',
       'status.RETIRED': 'Retired',
+      'statusToggle.restore': 'Restore',
+      'statusToggle.error': 'Could not update status. Please try again.',
+      'statusToggle.ariaLabel': 'Change status',
       'form.perDaySuffix': '/day',
       'form.perHourSuffix': '/hr',
     }
@@ -18,6 +23,22 @@ vi.mock('next-intl', () => ({
 
 import { FleetVehicleCard } from '@/components/vehicles/FleetVehicleCard'
 import type { VehicleData } from '@/lib/vehicle-api'
+
+// Wrap in a QueryClientProvider because the embedded VehicleStatusToggle
+// uses React Query hooks (issue #51).
+function renderCard(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Number.POSITIVE_INFINITY,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+      mutations: { retry: false },
+    },
+  })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
 
 function makeVehicle(overrides: Partial<VehicleData> = {}): VehicleData {
   return {
@@ -48,7 +69,7 @@ describe('FleetVehicleCard', () => {
 
   it('renders vehicle name and photo when photos exist', () => {
     const vehicle = makeVehicle()
-    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
     const img = screen.getByRole('img', { name: 'Toyota Corolla' })
@@ -61,7 +82,7 @@ describe('FleetVehicleCard', () => {
     })
 
     expect(() =>
-      render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />),
+      renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />),
     ).not.toThrow()
 
     expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
@@ -72,7 +93,7 @@ describe('FleetVehicleCard', () => {
     const vehicle = makeVehicle({ photos: [] })
 
     expect(() =>
-      render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />),
+      renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />),
     ).not.toThrow()
 
     expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
@@ -82,7 +103,7 @@ describe('FleetVehicleCard', () => {
   // Pricing display (#48)
   it('renders the daily rate when only daily is set', () => {
     const vehicle = makeVehicle({ dailyRateJpy: 8000, hourlyRateJpy: null })
-    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     // Intl uses the full-width yen sign in Japanese currency formatting.
     expect(screen.getByText(/8,000\/day/)).toBeInTheDocument()
@@ -90,16 +111,30 @@ describe('FleetVehicleCard', () => {
 
   it('renders the hourly rate when only hourly is set', () => {
     const vehicle = makeVehicle({ dailyRateJpy: null, hourlyRateJpy: 1200 })
-    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText(/1,200\/hr/)).toBeInTheDocument()
   })
 
   it('renders both rates separated by a middle dot when both are set', () => {
     const vehicle = makeVehicle({ dailyRateJpy: 8000, hourlyRateJpy: 1200 })
-    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText(/8,000\/day · .*1,200\/hr/)).toBeInTheDocument()
+  })
+
+  // Issue #51
+  it('renders the inline status toggle (not just a static badge)', () => {
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    // The segmented control exposes both options with current pressed.
+    const toggleGroup = screen.getByRole('group', { name: 'Change status' })
+    expect(toggleGroup).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Available' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
   })
 
   it('omits the price row when both rates are null (defensive)', () => {
@@ -107,7 +142,7 @@ describe('FleetVehicleCard', () => {
     // but if stale cache or a migration edge case produces such a row,
     // the card must not render an empty price line.
     const vehicle = makeVehicle({ dailyRateJpy: null, hourlyRateJpy: null })
-    render(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
+    renderCard(<FleetVehicleCard vehicle={vehicle} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.queryByText(/\/day|\/hr/)).not.toBeInTheDocument()
   })

--- a/packages/web/tests/components/vehicles/VehicleStatusToggle.test.tsx
+++ b/packages/web/tests/components/vehicles/VehicleStatusToggle.test.tsx
@@ -1,0 +1,190 @@
+// Issue #51: inline status toggle on fleet list rows. Tests describe
+// observable behaviour (what the user sees and what the API gets called
+// with), not internal React Query plumbing.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      'status.AVAILABLE': 'Available',
+      'status.MAINTENANCE': 'Maintenance',
+      'status.RETIRED': 'Retired',
+      'statusToggle.restore': 'Restore',
+      'statusToggle.error': 'Could not update status. Please try again.',
+      'statusToggle.ariaLabel': 'Change status',
+    }
+    return messages[key] ?? key
+  },
+}))
+
+const updateVehicleStatusMock = vi.fn()
+vi.mock('@/lib/vehicle-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/vehicle-api')>('@/lib/vehicle-api')
+  return {
+    ...actual,
+    updateVehicleStatus: (...args: unknown[]) => updateVehicleStatusMock(...args),
+  }
+})
+
+import { VehicleStatusToggle } from '@/components/vehicles/VehicleStatusToggle'
+import type { VehicleData } from '@/lib/vehicle-api'
+
+function makeVehicle(overrides: Partial<VehicleData> = {}): VehicleData {
+  return {
+    id: 'v_1',
+    name: 'Toyota Corolla',
+    description: null,
+    photos: [],
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderWithClient(
+  ui: ReactNode,
+  seed?: { vehicles?: VehicleData[] },
+): { client: QueryClient } {
+  const client = new QueryClient({
+    defaultOptions: {
+      // gcTime must be Infinity (or large) because the test seeds data via
+      // setQueryData without a mounted useQuery observer; with the default
+      // gc, the onSettled → invalidateQueries path evicts the data before
+      // assertions can read it.
+      queries: {
+        retry: false,
+        gcTime: Number.POSITIVE_INFINITY,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+      mutations: { retry: false },
+    },
+  })
+  if (seed?.vehicles) {
+    client.setQueryData(['vehicles'], seed.vehicles)
+  }
+  render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+  return { client }
+}
+
+describe('VehicleStatusToggle', () => {
+  beforeEach(() => {
+    updateVehicleStatusMock.mockReset()
+  })
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders AVAILABLE and MAINTENANCE options with AVAILABLE selected when current status is AVAILABLE', () => {
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    renderWithClient(<VehicleStatusToggle vehicle={vehicle} />)
+
+    const available = screen.getByRole('button', { name: 'Available' })
+    const maintenance = screen.getByRole('button', { name: 'Maintenance' })
+
+    expect(available).toHaveAttribute('aria-pressed', 'true')
+    expect(maintenance).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('calls updateVehicleStatus when the user clicks a non-active option', async () => {
+    updateVehicleStatusMock.mockResolvedValueOnce({
+      ...makeVehicle(),
+      status: 'MAINTENANCE',
+    })
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    renderWithClient(<VehicleStatusToggle vehicle={vehicle} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maintenance' }))
+
+    await waitFor(() => {
+      expect(updateVehicleStatusMock).toHaveBeenCalledWith('v_1', 'MAINTENANCE')
+    })
+  })
+
+  it('does not call updateVehicleStatus when the user clicks the already-active option', () => {
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    renderWithClient(<VehicleStatusToggle vehicle={vehicle} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Available' }))
+
+    expect(updateVehicleStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('optimistically patches the vehicles cache before the server responds', async () => {
+    // Keep the mutation pending so we can observe the optimistic state.
+    let resolveMutation: (v: VehicleData) => void = () => {}
+    updateVehicleStatusMock.mockImplementationOnce(
+      () =>
+        new Promise<VehicleData>((res) => {
+          resolveMutation = res
+        }),
+    )
+
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    const { client } = renderWithClient(<VehicleStatusToggle vehicle={vehicle} />, {
+      vehicles: [vehicle],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maintenance' }))
+
+    await waitFor(() => {
+      const cached = client.getQueryData<VehicleData[]>(['vehicles'])
+      expect(cached?.[0]?.status).toBe('MAINTENANCE')
+    })
+
+    // Let the mutation resolve so React Query doesn't complain.
+    resolveMutation({ ...vehicle, status: 'MAINTENANCE' })
+  })
+
+  it('rolls back the optimistic cache update and shows an error when the mutation fails', async () => {
+    updateVehicleStatusMock.mockRejectedValueOnce(new Error('network boom'))
+
+    const vehicle = makeVehicle({ status: 'AVAILABLE' })
+    const { client } = renderWithClient(<VehicleStatusToggle vehicle={vehicle} />, {
+      vehicles: [vehicle],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maintenance' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not update status. Please try again.')).toBeInTheDocument()
+    })
+
+    const cached = client.getQueryData<VehicleData[]>(['vehicles'])
+    expect(cached?.[0]?.status).toBe('AVAILABLE')
+  })
+
+  it('renders a Restore control when status is RETIRED and flips to AVAILABLE on click', async () => {
+    updateVehicleStatusMock.mockResolvedValueOnce({
+      ...makeVehicle(),
+      status: 'AVAILABLE',
+    })
+    const vehicle = makeVehicle({ status: 'RETIRED' })
+    renderWithClient(<VehicleStatusToggle vehicle={vehicle} />)
+
+    // The AVAILABLE/MAINTENANCE segmented control is not interactable in this
+    // mode — the owner flips back via a dedicated Restore button.
+    expect(screen.queryByRole('button', { name: 'Available' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Maintenance' })).not.toBeInTheDocument()
+
+    const restore = screen.getByRole('button', { name: 'Restore' })
+    fireEvent.click(restore)
+
+    await waitFor(() => {
+      expect(updateVehicleStatusMock).toHaveBeenCalledWith('v_1', 'AVAILABLE')
+    })
+  })
+})

--- a/packages/web/tests/modules/vehicles/vehicle-api.test.ts
+++ b/packages/web/tests/modules/vehicles/vehicle-api.test.ts
@@ -152,6 +152,41 @@ describe('vehicle-api', () => {
     })
   })
 
+  describe('updateVehicleStatus (issue #51)', () => {
+    it('sends PATCH /vehicles/:id/status with { status } and returns updated vehicle', async () => {
+      const spy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ success: true, data: { ...mockVehicle, status: 'MAINTENANCE' } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+
+      const { updateVehicleStatus } = await import('@/lib/vehicle-api')
+      const result = await updateVehicleStatus('v1', 'MAINTENANCE')
+
+      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles/v1/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'MAINTENANCE' }),
+      })
+      expect(result.status).toBe('MAINTENANCE')
+    })
+
+    it('surfaces server errors as thrown Error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: false, error: 'Vehicle not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+      const { updateVehicleStatus } = await import('@/lib/vehicle-api')
+      await expect(updateVehicleStatus('nope', 'AVAILABLE')).rejects.toThrow('Vehicle not found')
+    })
+  })
+
   describe('retireVehicle', () => {
     it('sends DELETE /vehicles/:id and returns retired vehicle', async () => {
       const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(


### PR DESCRIPTION
Closes #51.

## Summary

One-click AVAILABLE ↔ MAINTENANCE toggle on each fleet list card, replacing the previous Edit-modal-round-trip. Most frequent owner action per the MVP doc; turns 6+ clicks into 1.

- New `PATCH /vehicles/:id/status` route (any transition allowed, including un-retiring)
- New `VehicleStatusToggle` component with segmented control, color-coded (emerald/amber), optimistic React Query update + rollback on error, inline error message
- RETIRED cars surface a dedicated "Restore" button instead of the segmented control
- i18n keys added for EN/JA/ZH
- `VehicleStatusBadge.tsx` left in place — sibling fleet-phase-1 worktrees (#49 photos, #50 rules) still import it; cleanup PR to follow once all slices merge

Built slice-by-slice via TDD (5 vertical slices: validator → API route → web client → UI → i18n).

## Test plan

- [x] Shared validator: 6 new specs on \`updateVehicleStatusSchema\` (valid/invalid/missing/case)
- [x] API integration: 8 new specs on \`PATCH /vehicles/:id/status\` (round-trip each transition, updatedAt advances, 404 unknown id, 400 invalid/missing body, other fields untouched)
- [x] Web client: 2 new specs on \`updateVehicleStatus()\` (URL + body + error surfacing)
- [x] VehicleStatusToggle component: 6 specs (render + click + optimistic cache patch + rollback + error display + RETIRED Restore flow)
- [x] FleetVehicleCard: 1 new spec verifying the toggle replaces the static badge
- [x] Totals: shared 77 · api 90 · web 164 → **331 tests, all passing**
- [x] \`bun run --filter @kuruma/{shared,api,web} typecheck\` green
- [x] \`bunx biome check\` clean
- [x] \`bun run db:verify\` — no drizzle drift