### PR TITLE
feat(fleet): enforce rental rules at booking time + surface in renter UI (#65)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,5 +1,6 @@
 import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
+import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
 import { createBookingSchema } from '@kuruma/shared/validators/booking'
 import { Hono } from 'hono'
 import type { BookingRepository, VehicleRepository } from '../repositories/types'
@@ -95,15 +96,48 @@ export function createBookingRoutes(
       return c.json({ success: false, error: { renterId: ['Renter ID is required'] } }, 400)
     }
 
+    const startAt = new Date(result.data.startAt)
     const endAt = new Date(result.data.endAt)
     const defaultBufferMs = 60 * 60 * 1000 // 60 minutes default
     const effectiveEndAt = new Date(endAt.getTime() + defaultBufferMs)
+
+    // Issue #65: per-vehicle rental rules (min/max duration, advance booking
+    // window). Looked up here because the rules live on the vehicle and the
+    // server clock is the authoritative "now". We only enforce when the
+    // vehicle is actually present in the repo — production bookings always
+    // carry a real FK, so in practice this runs on every booking.
+    if (vehicleRepo) {
+      const vehicle = await vehicleRepo.findById(result.data.vehicleId)
+      if (vehicle) {
+        const check = checkRentalRules(
+          {
+            minRentalHours: vehicle.minRentalHours,
+            maxRentalHours: vehicle.maxRentalHours,
+            advanceBookingHours: vehicle.advanceBookingHours,
+          },
+          startAt,
+          endAt,
+          new Date(),
+        )
+        if (!check.ok) {
+          return c.json(
+            {
+              success: false,
+              error: 'Booking violates a rental rule on this vehicle',
+              code: check.code,
+              details: { required: check.required, actual: check.actual },
+            },
+            400,
+          )
+        }
+      }
+    }
 
     try {
       const booking = await repo.create({
         renterId,
         vehicleId: result.data.vehicleId,
-        startAt: new Date(result.data.startAt),
+        startAt,
         endAt,
         effectiveEndAt,
         status: 'CONFIRMED',

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -226,9 +226,12 @@ describe('Booking Routes', () => {
         fuelType: 'Gasoline',
         status: 'AVAILABLE',
         bufferMinutes: 60,
-        minRentalHours: 4,
-        maxRentalHours: 168,
-        advanceBookingHours: 24,
+        // No rental rules — this test verifies expand projection, not
+        // rental-rules enforcement. Keep them null so the 24h booking from
+        // validBookingInput doesn't flirt with the advance-booking boundary.
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
       })
 
       const allVehicles = await vehicleRepo.findAll()
@@ -345,6 +348,116 @@ describe('Booking Routes', () => {
 
       const res = await createBooking()
       expect(res.status).toBe(201)
+    })
+
+    // Issue #65: per-vehicle rental rules. Shared helper logic is unit-tested
+    // in packages/shared/tests/lib/rental-rules.test.ts — these tests verify
+    // the API route wires the helper correctly and returns the structured
+    // error envelope the web client depends on.
+    describe('rental rules enforcement', () => {
+      async function seedVehicleWithRules(rules: {
+        minRentalHours?: number | null
+        maxRentalHours?: number | null
+        advanceBookingHours?: number | null
+      }) {
+        const vehicle = await vehicleRepo.create({
+          name: 'Toyota Alphard',
+          description: null,
+          photos: [],
+          seats: 7,
+          transmission: 'AUTO',
+          fuelType: 'Hybrid',
+          status: 'AVAILABLE',
+          bufferMinutes: 60,
+          minRentalHours: rules.minRentalHours ?? null,
+          maxRentalHours: rules.maxRentalHours ?? null,
+          advanceBookingHours: rules.advanceBookingHours ?? null,
+          dailyRateJpy: 18000,
+          hourlyRateJpy: 2500,
+        })
+        return vehicle.id
+      }
+
+      it('rejects a 2h booking on a vehicle with min 6h', async () => {
+        const vehicleId = await seedVehicleWithRules({ minRentalHours: 6 })
+
+        const res = await createBooking({
+          ...validBookingInput(),
+          vehicleId,
+          startAt: futureDate(48),
+          endAt: futureDate(50),
+        })
+
+        expect(res.status).toBe(400)
+        const body = await res.json()
+        expect(body.success).toBe(false)
+        expect(body.code).toBe('RENTAL_RULE_MIN_DURATION')
+        expect(body.details).toMatchObject({ required: 6 })
+      })
+
+      it('rejects a 100h booking on a vehicle with max 72h', async () => {
+        const vehicleId = await seedVehicleWithRules({ maxRentalHours: 72 })
+
+        const res = await createBooking({
+          ...validBookingInput(),
+          vehicleId,
+          startAt: futureDate(48),
+          endAt: futureDate(148),
+        })
+
+        expect(res.status).toBe(400)
+        const body = await res.json()
+        expect(body.success).toBe(false)
+        expect(body.code).toBe('RENTAL_RULE_MAX_DURATION')
+        expect(body.details).toMatchObject({ required: 72 })
+      })
+
+      it('rejects a same-day booking on a vehicle requiring 24h advance', async () => {
+        const vehicleId = await seedVehicleWithRules({ advanceBookingHours: 24 })
+
+        const res = await createBooking({
+          ...validBookingInput(),
+          vehicleId,
+          startAt: futureDate(2),
+          endAt: futureDate(26),
+        })
+
+        expect(res.status).toBe(400)
+        const body = await res.json()
+        expect(body.success).toBe(false)
+        expect(body.code).toBe('RENTAL_RULE_ADVANCE_BOOKING')
+        expect(body.details).toMatchObject({ required: 24 })
+      })
+
+      it('accepts a compliant booking on a vehicle with all three rules', async () => {
+        const vehicleId = await seedVehicleWithRules({
+          minRentalHours: 6,
+          maxRentalHours: 240,
+          advanceBookingHours: 24,
+        })
+
+        const res = await createBooking({
+          ...validBookingInput(),
+          vehicleId,
+          startAt: futureDate(48),
+          endAt: futureDate(96),
+        })
+
+        expect(res.status).toBe(201)
+      })
+
+      it('accepts a booking on a vehicle with no rules set', async () => {
+        const vehicleId = await seedVehicleWithRules({})
+
+        const res = await createBooking({
+          ...validBookingInput(),
+          vehicleId,
+          startAt: futureDate(2),
+          endAt: futureDate(3),
+        })
+
+        expect(res.status).toBe(201)
+      })
     })
   })
 

--- a/packages/shared/src/lib/rental-rules.ts
+++ b/packages/shared/src/lib/rental-rules.ts
@@ -1,0 +1,74 @@
+// Per-vehicle rental rules. The owner declares these on each vehicle (#50);
+// this helper enforces them at booking time and is also called client-side
+// so the time picker can disable submit with a translated hint before the
+// request even leaves the browser. Both callers must agree, so this is the
+// single source of truth for "does this time range satisfy this vehicle's
+// rules" — don't duplicate the math anywhere else.
+
+export type RentalRuleCode =
+  | 'RENTAL_RULE_ADVANCE_BOOKING'
+  | 'RENTAL_RULE_MIN_DURATION'
+  | 'RENTAL_RULE_MAX_DURATION'
+
+export type RentalRulesResult =
+  | { ok: true }
+  | {
+      ok: false
+      code: RentalRuleCode
+      // Hours the rule requires (e.g. min=4, max=72, advance=24).
+      required: number
+      // Hours actually present in the booking (duration or advance offset).
+      actual: number
+    }
+
+export interface RentalRules {
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
+}
+
+const HOURS_MS = 60 * 60 * 1000
+
+export function checkRentalRules(
+  rules: RentalRules,
+  startAt: Date,
+  endAt: Date,
+  now: Date,
+): RentalRulesResult {
+  const hoursUntilStart = (startAt.getTime() - now.getTime()) / HOURS_MS
+  const durationHours = (endAt.getTime() - startAt.getTime()) / HOURS_MS
+
+  // Order matters: advance-booking failures are the hardest to fix (renter
+  // must move the start date) so we surface them first. Min/max duration
+  // are reported after — those are fixable by extending or shortening the
+  // return time. If both advance and duration fail we still only report
+  // one code (the API error shape is a single code + details).
+  if (rules.advanceBookingHours != null && hoursUntilStart < rules.advanceBookingHours) {
+    return {
+      ok: false,
+      code: 'RENTAL_RULE_ADVANCE_BOOKING',
+      required: rules.advanceBookingHours,
+      actual: hoursUntilStart,
+    }
+  }
+
+  if (rules.minRentalHours != null && durationHours < rules.minRentalHours) {
+    return {
+      ok: false,
+      code: 'RENTAL_RULE_MIN_DURATION',
+      required: rules.minRentalHours,
+      actual: durationHours,
+    }
+  }
+
+  if (rules.maxRentalHours != null && durationHours > rules.maxRentalHours) {
+    return {
+      ok: false,
+      code: 'RENTAL_RULE_MAX_DURATION',
+      required: rules.maxRentalHours,
+      actual: durationHours,
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/shared/tests/lib/rental-rules.test.ts
+++ b/packages/shared/tests/lib/rental-rules.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { checkRentalRules } from '../../src/lib/rental-rules'
+
+// Helpers. Durations are always expressed in hours from a fixed "now" so tests
+// read like the booking flow: "the renter is at now, wants to pick up in N
+// hours and return M hours later."
+const NOW = new Date('2026-04-11T12:00:00Z')
+const hoursFromNow = (h: number) => new Date(NOW.getTime() + h * 60 * 60 * 1000)
+
+const noRules = {
+  minRentalHours: null,
+  maxRentalHours: null,
+  advanceBookingHours: null,
+}
+
+describe('checkRentalRules', () => {
+  describe('when no rules are set', () => {
+    it('allows any booking', () => {
+      const result = checkRentalRules(noRules, hoursFromNow(1), hoursFromNow(2), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('allows a very short booking', () => {
+      const result = checkRentalRules(
+        noRules,
+        hoursFromNow(1),
+        new Date(NOW.getTime() + 30 * 60 * 1000),
+        NOW,
+      )
+      expect(result.ok).toBe(true)
+    })
+
+    it('allows a very long booking', () => {
+      const result = checkRentalRules(noRules, hoursFromNow(1), hoursFromNow(1000), NOW)
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe('minRentalHours', () => {
+    const rules = { minRentalHours: 4, maxRentalHours: null, advanceBookingHours: null }
+
+    it('rejects a 2-hour booking when minimum is 4', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(26), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.code).toBe('RENTAL_RULE_MIN_DURATION')
+        expect(result.required).toBe(4)
+        expect(result.actual).toBe(2)
+      }
+    })
+
+    it('accepts a booking that exactly meets the minimum', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(28), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts a booking longer than the minimum', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(72), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects a booking 1 minute short of the minimum', () => {
+      // 4h minus 1 minute = 3h59m, which is below 4h.
+      const start = hoursFromNow(24)
+      const end = new Date(start.getTime() + (4 * 60 - 1) * 60 * 1000)
+      const result = checkRentalRules(rules, start, end, NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.code).toBe('RENTAL_RULE_MIN_DURATION')
+    })
+  })
+
+  describe('maxRentalHours', () => {
+    const rules = { minRentalHours: null, maxRentalHours: 72, advanceBookingHours: null }
+
+    it('rejects a 100-hour booking when maximum is 72', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(124), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.code).toBe('RENTAL_RULE_MAX_DURATION')
+        expect(result.required).toBe(72)
+        expect(result.actual).toBe(100)
+      }
+    })
+
+    it('accepts a booking that exactly hits the maximum', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(96), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts a booking shorter than the maximum', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(48), NOW)
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe('advanceBookingHours', () => {
+    const rules = { minRentalHours: null, maxRentalHours: null, advanceBookingHours: 24 }
+
+    it('rejects a booking starting in 2 hours when 24 hours advance is required', () => {
+      const result = checkRentalRules(rules, hoursFromNow(2), hoursFromNow(10), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.code).toBe('RENTAL_RULE_ADVANCE_BOOKING')
+        expect(result.required).toBe(24)
+        expect(result.actual).toBe(2)
+      }
+    })
+
+    it('accepts a booking starting exactly at the advance window', () => {
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(48), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts a booking well beyond the advance window', () => {
+      const result = checkRentalRules(rules, hoursFromNow(168), hoursFromNow(192), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects a booking starting in the past', () => {
+      const result = checkRentalRules(rules, hoursFromNow(-1), hoursFromNow(10), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.code).toBe('RENTAL_RULE_ADVANCE_BOOKING')
+    })
+  })
+
+  describe('precedence when multiple rules are violated', () => {
+    // When a booking violates several rules we return a single code. The
+    // order matters because the API surfaces only one message — advance
+    // booking is the most disruptive to change (push the start date out),
+    // so it's reported first. Min/max are duration tweaks, reported after.
+    const rules = { minRentalHours: 4, maxRentalHours: 72, advanceBookingHours: 24 }
+
+    it('reports advance booking failure before min duration failure', () => {
+      // Start in 2h (violates advance=24), duration 1h (violates min=4).
+      const result = checkRentalRules(rules, hoursFromNow(2), hoursFromNow(3), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.code).toBe('RENTAL_RULE_ADVANCE_BOOKING')
+    })
+
+    it('reports min duration failure before max duration failure', () => {
+      // Start in 48h (passes advance=24). Duration 0 hours impossible; use
+      // a malformed but structurally valid case: min=4/max=72, duration 2h.
+      // Only min is violated here, but this test documents that min beats
+      // max when both would be flagged (physically impossible since min<max,
+      // but we want the precedence order documented).
+      const result = checkRentalRules(rules, hoursFromNow(48), hoursFromNow(50), NOW)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.code).toBe('RENTAL_RULE_MIN_DURATION')
+    })
+  })
+
+  describe('all rules set and all satisfied', () => {
+    it('accepts a Honda N-BOX booking: 4h minimum, 72h max, no advance, 24h duration', () => {
+      const rules = { minRentalHours: 4, maxRentalHours: 72, advanceBookingHours: null }
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(48), NOW)
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts a Toyota Alphard booking: 6h min, 240h max, 24h advance, 48h duration', () => {
+      const rules = { minRentalHours: 6, maxRentalHours: 240, advanceBookingHours: 24 }
+      const result = checkRentalRules(rules, hoursFromNow(24), hoursFromNow(72), NOW)
+      expect(result.ok).toBe(true)
+    })
+  })
+})

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -73,7 +73,22 @@
       "photos": "Photos",
       "description": "About this vehicle",
       "notFound": "Vehicle not found",
-      "notFoundDescription": "The vehicle you are looking for does not exist or has been removed."
+      "notFoundDescription": "The vehicle you are looking for does not exist or has been removed.",
+      "rentalRules": {
+        "heading": "Rental rules",
+        "hours": "{count, plural, one {# hour} other {# hours}}",
+        "days": "{count, plural, one {# day} other {# days}}",
+        "minDuration": "Minimum rental: {duration}",
+        "maxDuration": "Maximum rental: {duration}",
+        "advanceBooking": "Book at least {duration} in advance"
+      }
+    },
+    "card": {
+      "rentalRule": {
+        "advance": "{duration} advance",
+        "min": "Min {duration}",
+        "max": "Max {duration}"
+      }
     },
     "filters": {
       "from": "From",
@@ -230,7 +245,12 @@
       "vehicleInfo": "Vehicle details",
       "seats": "{count} seats",
       "auto": "Auto",
-      "manual": "Manual"
+      "manual": "Manual",
+      "rentalRuleViolation": {
+        "advance": "This car must be booked at least {duration} in advance.",
+        "min": "This car requires a minimum rental of {duration}.",
+        "max": "This car allows a maximum rental of {duration}."
+      }
     },
     "confirmation": {
       "title": "Booking confirmed",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -73,7 +73,22 @@
       "photos": "写真",
       "description": "この車について",
       "notFound": "車両が見つかりません",
-      "notFoundDescription": "お探しの車両は存在しないか、削除されました。"
+      "notFoundDescription": "お探しの車両は存在しないか、削除されました。",
+      "rentalRules": {
+        "heading": "レンタルルール",
+        "hours": "{count, plural, other {#時間}}",
+        "days": "{count, plural, other {#日}}",
+        "minDuration": "最短レンタル：{duration}",
+        "maxDuration": "最長レンタル：{duration}",
+        "advanceBooking": "{duration}前までに予約してください"
+      }
+    },
+    "card": {
+      "rentalRule": {
+        "advance": "{duration}前に予約",
+        "min": "最短{duration}",
+        "max": "最長{duration}"
+      }
     },
     "filters": {
       "from": "開始日",
@@ -230,7 +245,12 @@
       "vehicleInfo": "車両情報",
       "seats": "{count}席",
       "auto": "オートマ",
-      "manual": "マニュアル"
+      "manual": "マニュアル",
+      "rentalRuleViolation": {
+        "advance": "この車両は{duration}前までに予約する必要があります。",
+        "min": "この車両は最短{duration}のレンタルが必要です。",
+        "max": "この車両は最長{duration}までレンタルできます。"
+      }
     },
     "confirmation": {
       "title": "予約が確定しました",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -73,7 +73,22 @@
       "photos": "照片",
       "description": "关于此车",
       "notFound": "车辆未找到",
-      "notFoundDescription": "您查找的车辆不存在或已被删除。"
+      "notFoundDescription": "您查找的车辆不存在或已被删除。",
+      "rentalRules": {
+        "heading": "租赁规则",
+        "hours": "{count, plural, other {# 小时}}",
+        "days": "{count, plural, other {# 天}}",
+        "minDuration": "最短租赁：{duration}",
+        "maxDuration": "最长租赁：{duration}",
+        "advanceBooking": "请至少提前 {duration} 预订"
+      }
+    },
+    "card": {
+      "rentalRule": {
+        "advance": "需提前 {duration}",
+        "min": "最短 {duration}",
+        "max": "最长 {duration}"
+      }
     },
     "filters": {
       "from": "从",
@@ -230,7 +245,12 @@
       "vehicleInfo": "车辆信息",
       "seats": "{count}座",
       "auto": "自动挡",
-      "manual": "手动挡"
+      "manual": "手动挡",
+      "rentalRuleViolation": {
+        "advance": "此车辆须至少提前 {duration} 预订。",
+        "min": "此车辆最短租赁时长为 {duration}。",
+        "max": "此车辆最长租赁时长为 {duration}。"
+      }
     },
     "confirmation": {
       "title": "预订已确认",

--- a/packages/web/src/app/[locale]/bookings/new/BookingForm.tsx
+++ b/packages/web/src/app/[locale]/bookings/new/BookingForm.tsx
@@ -5,10 +5,12 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useRouter } from '@/i18n/routing'
-import { createBooking } from '@/lib/bookings'
+import { type RentalRuleFailure, createBooking } from '@/lib/bookings'
+import { formatDurationHours } from '@/lib/rental-rules-format'
+import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
 import { Car, Fuel, Settings2, Users, XCircle } from 'lucide-react'
 import { useTranslations } from 'next-intl'
-import { useActionState, useEffect, useState } from 'react'
+import { useActionState, useEffect, useMemo, useState } from 'react'
 
 interface VehicleInfo {
   id: string
@@ -17,6 +19,9 @@ interface VehicleInfo {
   seats: number
   transmission: string
   fuelType: string | null
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
 }
 
 interface BookingFormProps {
@@ -28,6 +33,7 @@ interface FormState {
   success?: boolean
   error?: string
   bookingId?: string
+  rentalRule?: RentalRuleFailure
 }
 
 async function bookingAction(_prevState: FormState, formData: FormData): Promise<FormState> {
@@ -41,6 +47,7 @@ async function bookingAction(_prevState: FormState, formData: FormData): Promise
 
 export function BookingForm({ vehicle, isAuthenticated }: BookingFormProps) {
   const t = useTranslations('bookings.new')
+  const durationT = useTranslations('vehicles.detail.rentalRules')
   const router = useRouter()
   const [startAt, setStartAt] = useState('')
   const [endAt, setEndAt] = useState('')
@@ -49,6 +56,64 @@ export function BookingForm({ vehicle, isAuthenticated }: BookingFormProps) {
   const hasDates = startAt !== '' && endAt !== ''
   const primaryPhoto = vehicle.photos?.[0]
   const transmissionLabel = vehicle.transmission === 'AUTO' ? t('auto') : t('manual')
+
+  // Issue #65: inline rental-rules check. Uses the same helper the API
+  // calls, with the client clock as `now` — good enough for a hint, not
+  // authoritative (the server always re-checks). Recomputed on every
+  // keystroke so the submit button flips the moment a rule is satisfied
+  // or violated.
+  const localRuleCheck = useMemo(() => {
+    if (!hasDates) return null
+    const start = new Date(startAt)
+    const end = new Date(endAt)
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null
+    if (end <= start) return null
+    return checkRentalRules(
+      {
+        minRentalHours: vehicle.minRentalHours,
+        maxRentalHours: vehicle.maxRentalHours,
+        advanceBookingHours: vehicle.advanceBookingHours,
+      },
+      start,
+      end,
+      new Date(),
+    )
+  }, [
+    hasDates,
+    startAt,
+    endAt,
+    vehicle.minRentalHours,
+    vehicle.maxRentalHours,
+    vehicle.advanceBookingHours,
+  ])
+
+  const unitT = (key: string, values: { count: number }) => durationT(key, values)
+
+  function getRentalRuleMessage(code: RentalRuleFailure['code'], requiredHours: number): string {
+    const duration = formatDurationHours(requiredHours, unitT)
+    if (code === 'RENTAL_RULE_ADVANCE_BOOKING') {
+      return t('rentalRuleViolation.advance', { duration })
+    }
+    if (code === 'RENTAL_RULE_MIN_DURATION') {
+      return t('rentalRuleViolation.min', { duration })
+    }
+    return t('rentalRuleViolation.max', { duration })
+  }
+
+  // Priority: server-returned rental-rule error (stale state after submit)
+  // is ignored if the user has since typed new dates and the local check
+  // is clean. Otherwise prefer the local check so the message updates as
+  // they adjust the picker.
+  const activeRuleFailure =
+    localRuleCheck && !localRuleCheck.ok
+      ? { code: localRuleCheck.code, required: localRuleCheck.required }
+      : state.rentalRule
+        ? { code: state.rentalRule.code, required: state.rentalRule.required }
+        : null
+
+  const rentalRuleMessage = activeRuleFailure
+    ? getRentalRuleMessage(activeRuleFailure.code, activeRuleFailure.required)
+    : null
 
   // Redirect to confirmation page on success
   useEffect(() => {
@@ -127,8 +192,19 @@ export function BookingForm({ vehicle, isAuthenticated }: BookingFormProps) {
         {/* Availability status */}
         {!hasDates && <p className="text-sm text-muted-foreground">{t('selectDates')}</p>}
 
-        {/* Error message */}
-        {state.error && (
+        {/* Rental rule violation — inline hint (#65). Takes precedence
+            over the generic server error so the renter sees the specific
+            reason their dates are rejected. */}
+        {rentalRuleMessage && (
+          <div className="flex items-center gap-2 text-sm text-destructive" role="alert">
+            <XCircle className="size-4 shrink-0" />
+            {rentalRuleMessage}
+          </div>
+        )}
+
+        {/* Generic server error — only shown when we don't have a more
+            specific rental-rule message to display. */}
+        {state.error && !rentalRuleMessage && (
           <div className="flex items-center gap-2 text-sm text-destructive" role="alert">
             <XCircle className="size-4 shrink-0" />
             {state.error}
@@ -139,7 +215,7 @@ export function BookingForm({ vehicle, isAuthenticated }: BookingFormProps) {
         <Button
           type="submit"
           className="w-full"
-          disabled={!hasDates || !isAuthenticated || isPending}
+          disabled={!hasDates || !isAuthenticated || isPending || rentalRuleMessage !== null}
         >
           {isPending ? t('submitting') : t('confirmBooking')}
         </Button>

--- a/packages/web/src/app/[locale]/bookings/new/page.tsx
+++ b/packages/web/src/app/[locale]/bookings/new/page.tsx
@@ -35,6 +35,12 @@ export default async function NewBookingPage({ searchParams }: NewBookingPagePro
             seats: vehicle.seats,
             transmission: vehicle.transmission,
             fuelType: vehicle.fuelType,
+            // Issue #65: per-vehicle rental rules. Forwarded so the form's
+            // inline validation can disable submit before the renter hits
+            // the API wall.
+            minRentalHours: vehicle.minRentalHours,
+            maxRentalHours: vehicle.maxRentalHours,
+            advanceBookingHours: vehicle.advanceBookingHours,
           }}
           isAuthenticated={isAuthenticated}
         />

--- a/packages/web/src/app/[locale]/vehicles/[id]/page.tsx
+++ b/packages/web/src/app/[locale]/vehicles/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { RentalRulesCard } from '@/components/vehicles/RentalRulesCard'
 import { Link } from '@/i18n/routing'
 import { cn } from '@/lib/utils'
 import { getVehicleById } from '@/lib/vehicles'
@@ -113,6 +114,18 @@ export default async function VehicleDetailPage({ params }: VehicleDetailPagePro
                 </div>
               </CardContent>
             </Card>
+
+            {/* Rental rules (#65) — rendered only when the vehicle has at
+                least one rule set. The same helper powers the booking
+                form's inline validation so renters see the same numbers
+                before and during booking. */}
+            <RentalRulesCard
+              rules={{
+                minRentalHours: vehicle.minRentalHours,
+                maxRentalHours: vehicle.maxRentalHours,
+                advanceBookingHours: vehicle.advanceBookingHours,
+              }}
+            />
 
             {/* Book CTA */}
             <Link

--- a/packages/web/src/app/[locale]/vehicles/page.tsx
+++ b/packages/web/src/app/[locale]/vehicles/page.tsx
@@ -1,4 +1,5 @@
 import { ActiveFilters } from '@/components/vehicles/ActiveFilters'
+import { RentalRulesBadge } from '@/components/vehicles/RentalRulesBadge'
 import { Link } from '@/i18n/routing'
 import { getAvailableVehicles } from '@/lib/vehicles'
 import { Car, Fuel, Settings2, Users } from 'lucide-react'
@@ -54,7 +55,18 @@ export default async function VehiclesPage({
                   )}
                 </div>
                 <div className="p-5">
-                  <h2 className="text-lg font-semibold">{vehicle.name}</h2>
+                  <div className="flex items-start justify-between gap-2">
+                    <h2 className="text-lg font-semibold">{vehicle.name}</h2>
+                    {/* Rental-rules hint (#65). Only shows when at least one
+                        rule is set — most cars won't have any. */}
+                    <RentalRulesBadge
+                      rules={{
+                        minRentalHours: vehicle.minRentalHours,
+                        maxRentalHours: vehicle.maxRentalHours,
+                        advanceBookingHours: vehicle.advanceBookingHours,
+                      }}
+                    />
+                  </div>
                   {vehicle.description && (
                     <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
                       {vehicle.description}

--- a/packages/web/src/components/vehicles/RentalRulesBadge.tsx
+++ b/packages/web/src/components/vehicles/RentalRulesBadge.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import {
+  type DisplayRentalRules,
+  formatDurationHours,
+  pickPrimaryRentalRule,
+} from '@/lib/rental-rules-format'
+import { Clock } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+interface RentalRulesBadgeProps {
+  rules: DisplayRentalRules
+}
+
+/**
+ * Compact badge shown on the renter vehicle list card (#65) when a car has
+ * at least one rental rule set. Dumping all three rules clutters the card,
+ * so we pick the single "most likely to surprise" rule via
+ * `pickPrimaryRentalRule` — the rest are still visible on the detail page.
+ * Renders nothing when no rules are set (most cars won't have any).
+ */
+export function RentalRulesBadge({ rules }: RentalRulesBadgeProps) {
+  // Pull duration keys from the detail namespace so there's one source of
+  // truth for "4 hours" / "3 days" formatting between badge, card, and
+  // booking form.
+  const detailT = useTranslations('vehicles.detail.rentalRules')
+  const cardT = useTranslations('vehicles.card.rentalRule')
+
+  const primary = pickPrimaryRentalRule(rules)
+  if (!primary) return null
+
+  const unitT = (key: string, values: { count: number }) => detailT(key, values)
+  const duration = formatDurationHours(primary.hours, unitT)
+  const text = cardT(primary.code, { duration })
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      <Clock className="size-3" />
+      {text}
+    </span>
+  )
+}

--- a/packages/web/src/components/vehicles/RentalRulesCard.tsx
+++ b/packages/web/src/components/vehicles/RentalRulesCard.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  type DisplayRentalRules,
+  formatDurationHours,
+  hasAnyRentalRule,
+} from '@/lib/rental-rules-format'
+import { Clock } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+interface RentalRulesCardProps {
+  rules: DisplayRentalRules
+}
+
+/**
+ * Per-vehicle rental rules surfaced to renters on the vehicle detail page
+ * (#65). Renders nothing when the owner hasn't set any rules — a car with
+ * no restrictions shouldn't show an empty "no rules" card that reads like
+ * an error. The rules themselves are enforced by the API on POST /bookings
+ * via the shared `checkRentalRules` helper, so what you see here matches
+ * exactly what the server will allow.
+ */
+export function RentalRulesCard({ rules }: RentalRulesCardProps) {
+  const t = useTranslations('vehicles.detail.rentalRules')
+
+  if (!hasAnyRentalRule(rules)) return null
+
+  const unitT = (key: string, values: { count: number }) => t(key, values)
+
+  const lines: { key: string; text: string }[] = []
+
+  if (rules.minRentalHours != null) {
+    lines.push({
+      key: 'min',
+      text: t('minDuration', { duration: formatDurationHours(rules.minRentalHours, unitT) }),
+    })
+  }
+  if (rules.maxRentalHours != null) {
+    lines.push({
+      key: 'max',
+      text: t('maxDuration', { duration: formatDurationHours(rules.maxRentalHours, unitT) }),
+    })
+  }
+  if (rules.advanceBookingHours != null) {
+    lines.push({
+      key: 'advance',
+      text: t('advanceBooking', {
+        duration: formatDurationHours(rules.advanceBookingHours, unitT),
+      }),
+    })
+  }
+
+  return (
+    <Card>
+      <CardContent className="pt-2">
+        <h2 className="text-lg font-medium mb-4">{t('heading')}</h2>
+        <ul className="space-y-2">
+          {lines.map((line) => (
+            <li key={line.key} className="flex items-start gap-2.5 text-sm">
+              <Clock className="size-4 text-muted-foreground mt-0.5 shrink-0" />
+              <span>{line.text}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/web/src/lib/bookings.ts
+++ b/packages/web/src/lib/bookings.ts
@@ -10,7 +10,18 @@ interface CreateBookingInput {
   notes?: string
 }
 
-type CreateBookingResult = { success: true; bookingId: string } | { success: false; error: string }
+// Structured rental-rule failure surfaced from the API. The form needs the
+// exact `code` + `required` hours so it can render the same translated
+// message as the inline client-side check (#65).
+export type RentalRuleFailure = {
+  code: 'RENTAL_RULE_ADVANCE_BOOKING' | 'RENTAL_RULE_MIN_DURATION' | 'RENTAL_RULE_MAX_DURATION'
+  required: number
+  actual: number
+}
+
+type CreateBookingResult =
+  | { success: true; bookingId: string }
+  | { success: false; error: string; rentalRule?: RentalRuleFailure }
 
 interface ApiResponse<T> {
   success: boolean
@@ -78,13 +89,39 @@ export async function createBooking(input: CreateBookingInput): Promise<CreateBo
       ...(input.notes ? { notes: input.notes } : {}),
     }),
   })
-  const json: ApiResponse<{ id: string }> = await res.json()
+  // Parse as unknown so we can detect rental-rule error envelopes without
+  // pretending every non-success response has the same shape.
+  const json: {
+    success: boolean
+    data?: { id: string }
+    error?: string
+    code?: string
+    details?: { required?: number; actual?: number }
+  } = await res.json()
 
-  if (!json.success || !json.data) {
-    return { success: false, error: 'Failed to create booking.' }
+  if (json.success && json.data) {
+    return { success: true, bookingId: json.data.id }
   }
 
-  return { success: true, bookingId: json.data.id }
+  // Rental-rule rejections carry a known code so the client can translate.
+  // Everything else gets a generic error string.
+  if (
+    json.code === 'RENTAL_RULE_ADVANCE_BOOKING' ||
+    json.code === 'RENTAL_RULE_MIN_DURATION' ||
+    json.code === 'RENTAL_RULE_MAX_DURATION'
+  ) {
+    return {
+      success: false,
+      error: json.error ?? 'Booking violates a rental rule',
+      rentalRule: {
+        code: json.code,
+        required: json.details?.required ?? 0,
+        actual: json.details?.actual ?? 0,
+      },
+    }
+  }
+
+  return { success: false, error: 'Failed to create booking.' }
 }
 
 export type BookingWithVehicle = {

--- a/packages/web/src/lib/rental-rules-format.ts
+++ b/packages/web/src/lib/rental-rules-format.ts
@@ -1,0 +1,63 @@
+// Display helpers for per-vehicle rental rules (#65). The owner types values
+// in hours but renters read durations in the chunks that feel natural: a
+// 72h max becomes "3 days," a 4h minimum stays "4 hours." The unit switch
+// lives here so it's consistent across the detail page, the list card
+// badge, and the booking form's inline validation.
+
+type TranslateWithCount = (key: string, values: { count: number }) => string
+
+/**
+ * Turn a raw hours value into a localized duration string, using days when
+ * the value is a clean multiple of 24 and >= 24h. Anything else stays in
+ * hours (e.g. 36h → "36 hours" — don't guess "1.5 days" and confuse anyone).
+ *
+ * Requires two translation keys on the caller's namespace: `hours` and
+ * `days`, each an ICU plural message like "{count, plural, one {# hour}
+ * other {# hours}}".
+ */
+export function formatDurationHours(hours: number, t: TranslateWithCount): string {
+  if (hours >= 24 && hours % 24 === 0) {
+    return t('days', { count: hours / 24 })
+  }
+  return t('hours', { count: hours })
+}
+
+export interface DisplayRentalRules {
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
+}
+
+/**
+ * True when at least one rule is set. Used to decide whether to render the
+ * rental-rules block at all on the detail page, and whether to show the
+ * compact badge on the list card.
+ */
+export function hasAnyRentalRule(rules: DisplayRentalRules): boolean {
+  return (
+    rules.minRentalHours != null ||
+    rules.maxRentalHours != null ||
+    rules.advanceBookingHours != null
+  )
+}
+
+/**
+ * Pick the single "most likely to surprise a renter" rule for the compact
+ * list-card badge. Precedence mirrors the API enforcement order so the
+ * badge matches the error the renter would hit: advance booking first
+ * (can't be fixed by tweaking duration), then min, then max.
+ */
+export function pickPrimaryRentalRule(
+  rules: DisplayRentalRules,
+): { code: 'advance' | 'min' | 'max'; hours: number } | null {
+  if (rules.advanceBookingHours != null) {
+    return { code: 'advance', hours: rules.advanceBookingHours }
+  }
+  if (rules.minRentalHours != null) {
+    return { code: 'min', hours: rules.minRentalHours }
+  }
+  if (rules.maxRentalHours != null) {
+    return { code: 'max', hours: rules.maxRentalHours }
+  }
+  return null
+}

--- a/packages/web/tests/components/bookings/BookingForm-rental-rules.test.tsx
+++ b/packages/web/tests/components/bookings/BookingForm-rental-rules.test.tsx
@@ -1,0 +1,170 @@
+// Issue #65: inline rental-rules validation on the booking form. The form
+// calls the same @kuruma/shared helper as the API, so a violation should
+// disable the submit button and show the matching translated hint *before*
+// the renter ever hits the server.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) => (key: string, values?: Record<string, string | number>) => {
+      const count = Number(values?.count ?? 0)
+      const duration = String(values?.duration ?? '')
+      if (namespace === 'bookings.new') {
+        const messages: Record<string, string> = {
+          vehicleInfo: 'Vehicle details',
+          pickupDate: 'Pickup date and time',
+          returnDate: 'Return date and time',
+          selectDates: 'Select dates to check availability',
+          confirmBooking: 'Confirm booking',
+          submitting: 'Booking...',
+          auto: 'Auto',
+          manual: 'Manual',
+          'rentalRuleViolation.advance': `This car must be booked at least ${duration} in advance.`,
+          'rentalRuleViolation.min': `This car requires a minimum rental of ${duration}.`,
+          'rentalRuleViolation.max': `This car allows a maximum rental of ${duration}.`,
+        }
+        if (key === 'seats') return `${count} seats`
+        return messages[key] ?? key
+      }
+      if (namespace === 'vehicles.detail.rentalRules') {
+        if (key === 'hours') return count === 1 ? `${count} hour` : `${count} hours`
+        if (key === 'days') return count === 1 ? `${count} day` : `${count} days`
+      }
+      return key
+    },
+}))
+
+vi.mock('@/i18n/routing', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/bookings', () => ({
+  createBooking: vi.fn().mockResolvedValue({ success: true, bookingId: 'b1' }),
+}))
+
+import { BookingForm } from '@/app/[locale]/bookings/new/BookingForm'
+
+// Future-dated ISO strings with second precision, formatted for
+// <input type="datetime-local"> (no Z, no milliseconds).
+function datetimeLocal(hoursFromNow: number): string {
+  const d = new Date(Date.now() + hoursFromNow * 60 * 60 * 1000)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function makeVehicle(
+  rules: {
+    minRentalHours?: number | null
+    maxRentalHours?: number | null
+    advanceBookingHours?: number | null
+  } = {},
+) {
+  return {
+    id: 'v1',
+    name: 'Toyota Alphard',
+    photos: [],
+    seats: 7,
+    transmission: 'AUTO',
+    fuelType: 'Hybrid',
+    minRentalHours: rules.minRentalHours ?? null,
+    maxRentalHours: rules.maxRentalHours ?? null,
+    advanceBookingHours: rules.advanceBookingHours ?? null,
+  }
+}
+
+describe('BookingForm rental-rules validation', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows no rental-rule message when no rules are set', async () => {
+    const user = userEvent.setup()
+    render(<BookingForm vehicle={makeVehicle()} isAuthenticated={true} />)
+
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(48))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(50))
+
+    expect(screen.queryByText(/This car/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm booking' })).toBeEnabled()
+  })
+
+  it('disables submit and shows min-duration message when duration is below minimum', async () => {
+    const user = userEvent.setup()
+    render(<BookingForm vehicle={makeVehicle({ minRentalHours: 6 })} isAuthenticated={true} />)
+
+    // 2h duration on a vehicle that requires min 6h.
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(48))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(50))
+
+    expect(screen.getByText('This car requires a minimum rental of 6 hours.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm booking' })).toBeDisabled()
+  })
+
+  it('disables submit and shows max-duration message when duration is above maximum', async () => {
+    const user = userEvent.setup()
+    render(<BookingForm vehicle={makeVehicle({ maxRentalHours: 72 })} isAuthenticated={true} />)
+
+    // 100h duration on a vehicle that allows max 72h (3 days).
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(48))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(148))
+
+    expect(screen.getByText('This car allows a maximum rental of 3 days.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm booking' })).toBeDisabled()
+  })
+
+  it('disables submit and shows advance-booking message when start is too soon', async () => {
+    const user = userEvent.setup()
+    render(
+      <BookingForm vehicle={makeVehicle({ advanceBookingHours: 24 })} isAuthenticated={true} />,
+    )
+
+    // Start in 2h on a vehicle requiring 24h advance.
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(2))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(10))
+
+    expect(
+      screen.getByText('This car must be booked at least 1 day in advance.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm booking' })).toBeDisabled()
+  })
+
+  it('enables submit when dates satisfy all rules', async () => {
+    const user = userEvent.setup()
+    render(
+      <BookingForm
+        vehicle={makeVehicle({ minRentalHours: 6, maxRentalHours: 240, advanceBookingHours: 24 })}
+        isAuthenticated={true}
+      />,
+    )
+
+    // Start in 48h, 48h duration — satisfies all three rules.
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(48))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(96))
+
+    expect(screen.queryByText(/This car/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm booking' })).toBeEnabled()
+  })
+
+  it('flips to advance-booking message when only that rule fails among several', async () => {
+    // Min=4 OK (duration 8h), max=72 OK, advance=24 violated (start in 2h).
+    // The precedence test from the shared lib is already covered; here we
+    // just confirm the form surfaces the right message for this combo.
+    const user = userEvent.setup()
+    render(
+      <BookingForm
+        vehicle={makeVehicle({ minRentalHours: 4, maxRentalHours: 72, advanceBookingHours: 24 })}
+        isAuthenticated={true}
+      />,
+    )
+
+    await user.type(screen.getByLabelText('Pickup date and time'), datetimeLocal(2))
+    await user.type(screen.getByLabelText('Return date and time'), datetimeLocal(10))
+
+    expect(
+      screen.getByText('This car must be booked at least 1 day in advance.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/components/vehicles/RentalRulesBadge.test.tsx
+++ b/packages/web/tests/components/vehicles/RentalRulesBadge.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The badge reads from two nested namespaces. Mock useTranslations so each
+// namespace returns its own table and we catch key-name drift the same
+// way the real next-intl would at runtime.
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) => (key: string, values?: Record<string, string | number>) => {
+      const count = Number(values?.count ?? 0)
+      const duration = String(values?.duration ?? '')
+      if (namespace === 'vehicles.detail.rentalRules') {
+        if (key === 'hours') return count === 1 ? `${count} hour` : `${count} hours`
+        if (key === 'days') return count === 1 ? `${count} day` : `${count} days`
+      }
+      if (namespace === 'vehicles.card.rentalRule') {
+        if (key === 'advance') return `${duration} advance`
+        if (key === 'min') return `Min ${duration}`
+        if (key === 'max') return `Max ${duration}`
+      }
+      return key
+    },
+}))
+
+import { RentalRulesBadge } from '@/components/vehicles/RentalRulesBadge'
+
+describe('RentalRulesBadge', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing when no rules are set', () => {
+    const { container } = render(
+      <RentalRulesBadge
+        rules={{
+          minRentalHours: null,
+          maxRentalHours: null,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('prefers the advance-booking rule when all three are set', () => {
+    render(
+      <RentalRulesBadge
+        rules={{
+          minRentalHours: 4,
+          maxRentalHours: 72,
+          advanceBookingHours: 24,
+        }}
+      />,
+    )
+    expect(screen.getByText('1 day advance')).toBeInTheDocument()
+  })
+
+  it('falls back to min when advance is null', () => {
+    render(
+      <RentalRulesBadge
+        rules={{
+          minRentalHours: 4,
+          maxRentalHours: 72,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+    expect(screen.getByText('Min 4 hours')).toBeInTheDocument()
+  })
+
+  it('falls back to max when only max is set', () => {
+    render(
+      <RentalRulesBadge
+        rules={{
+          minRentalHours: null,
+          maxRentalHours: 120,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+    expect(screen.getByText('Max 5 days')).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/components/vehicles/RentalRulesCard.test.tsx
+++ b/packages/web/tests/components/vehicles/RentalRulesCard.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The card uses next-intl with ICU parameters. Mock the hook so tests
+// don't need a full IntlProvider, and keep the messages close to the real
+// en.json so we catch key-name drift.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    const count = Number(values?.count ?? 0)
+    const duration = String(values?.duration ?? '')
+    const messages: Record<string, string> = {
+      heading: 'Rental rules',
+      minDuration: `Minimum rental: ${duration}`,
+      maxDuration: `Maximum rental: ${duration}`,
+      advanceBooking: `Book at least ${duration} in advance`,
+      hours: count === 1 ? `${count} hour` : `${count} hours`,
+      days: count === 1 ? `${count} day` : `${count} days`,
+    }
+    return messages[key] ?? key
+  },
+}))
+
+import { RentalRulesCard } from '@/components/vehicles/RentalRulesCard'
+
+describe('RentalRulesCard', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing when all three rules are null', () => {
+    const { container } = render(
+      <RentalRulesCard
+        rules={{
+          minRentalHours: null,
+          maxRentalHours: null,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+    // Entire component tree is empty — no heading, no card chrome.
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders only the minimum rule line when only min is set', () => {
+    render(
+      <RentalRulesCard
+        rules={{
+          minRentalHours: 4,
+          maxRentalHours: null,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Rental rules')).toBeInTheDocument()
+    expect(screen.getByText('Minimum rental: 4 hours')).toBeInTheDocument()
+    expect(screen.queryByText(/Maximum rental/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Book at least/)).not.toBeInTheDocument()
+  })
+
+  it('formats 72 hours as "3 days" on the maximum line', () => {
+    render(
+      <RentalRulesCard
+        rules={{
+          minRentalHours: null,
+          maxRentalHours: 72,
+          advanceBookingHours: null,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Maximum rental: 3 days')).toBeInTheDocument()
+  })
+
+  it('formats 24 hours as "1 day" on the advance-booking line', () => {
+    render(
+      <RentalRulesCard
+        rules={{
+          minRentalHours: null,
+          maxRentalHours: null,
+          advanceBookingHours: 24,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Book at least 1 day in advance')).toBeInTheDocument()
+  })
+
+  it('renders all three rule lines when all three are set (Alphard case)', () => {
+    render(
+      <RentalRulesCard
+        rules={{
+          minRentalHours: 6,
+          maxRentalHours: 240,
+          advanceBookingHours: 24,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Rental rules')).toBeInTheDocument()
+    expect(screen.getByText('Minimum rental: 6 hours')).toBeInTheDocument()
+    expect(screen.getByText('Maximum rental: 10 days')).toBeInTheDocument()
+    expect(screen.getByText('Book at least 1 day in advance')).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/lib/rental-rules-format.test.ts
+++ b/packages/web/tests/lib/rental-rules-format.test.ts
@@ -1,0 +1,130 @@
+import {
+  formatDurationHours,
+  hasAnyRentalRule,
+  pickPrimaryRentalRule,
+} from '@/lib/rental-rules-format'
+import { describe, expect, it } from 'vitest'
+
+// The translate function under test: mimics next-intl's ICU plural
+// behaviour for the two keys this helper uses.
+const t = (key: string, values: { count: number }) => {
+  const { count } = values
+  if (key === 'hours') return count === 1 ? `${count} hour` : `${count} hours`
+  if (key === 'days') return count === 1 ? `${count} day` : `${count} days`
+  return key
+}
+
+describe('formatDurationHours', () => {
+  it('formats 1 hour with singular unit', () => {
+    expect(formatDurationHours(1, t)).toBe('1 hour')
+  })
+
+  it('formats 4 hours as plural hours', () => {
+    expect(formatDurationHours(4, t)).toBe('4 hours')
+  })
+
+  it('formats 24 hours as "1 day", not "24 hours"', () => {
+    expect(formatDurationHours(24, t)).toBe('1 day')
+  })
+
+  it('formats 72 hours as "3 days"', () => {
+    expect(formatDurationHours(72, t)).toBe('3 days')
+  })
+
+  it('formats 240 hours as "10 days"', () => {
+    expect(formatDurationHours(240, t)).toBe('10 days')
+  })
+
+  it('keeps 36 hours in hours (not a clean day multiple)', () => {
+    // Guessing "1.5 days" would confuse — stay honest and show hours.
+    expect(formatDurationHours(36, t)).toBe('36 hours')
+  })
+
+  it('keeps 23 hours in hours', () => {
+    expect(formatDurationHours(23, t)).toBe('23 hours')
+  })
+})
+
+describe('hasAnyRentalRule', () => {
+  it('returns false when all three are null', () => {
+    expect(
+      hasAnyRentalRule({
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when only min is set', () => {
+    expect(
+      hasAnyRentalRule({
+        minRentalHours: 4,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when only max is set', () => {
+    expect(
+      hasAnyRentalRule({
+        minRentalHours: null,
+        maxRentalHours: 72,
+        advanceBookingHours: null,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when only advance is set', () => {
+    expect(
+      hasAnyRentalRule({
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: 24,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('pickPrimaryRentalRule', () => {
+  it('returns null when no rules are set', () => {
+    expect(
+      pickPrimaryRentalRule({
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('prefers advance over min over max', () => {
+    expect(
+      pickPrimaryRentalRule({
+        minRentalHours: 4,
+        maxRentalHours: 72,
+        advanceBookingHours: 24,
+      }),
+    ).toEqual({ code: 'advance', hours: 24 })
+  })
+
+  it('prefers min over max when advance is unset', () => {
+    expect(
+      pickPrimaryRentalRule({
+        minRentalHours: 4,
+        maxRentalHours: 72,
+        advanceBookingHours: null,
+      }),
+    ).toEqual({ code: 'min', hours: 4 })
+  })
+
+  it('falls back to max when it is the only rule', () => {
+    expect(
+      pickPrimaryRentalRule({
+        minRentalHours: null,
+        maxRentalHours: 72,
+        advanceBookingHours: null,
+      }),
+    ).toEqual({ code: 'max', hours: 72 })
+  })
+})


### PR DESCRIPTION
Closes #65. Follow-up to #50 (which let the owner *declare* rental rules but enforced nothing and showed them nowhere).

## Summary

- **Shared helper** — `packages/shared/src/lib/rental-rules.ts` exposes a pure `checkRentalRules(rules, startAt, endAt, now)`. Single source of truth: the API and the booking form both call it, so they can never disagree about whether a given time range is allowed.
- **API enforcement** — `POST /bookings` looks up the vehicle, runs the check using server-side `new Date()`, and rejects violating bookings with a structured 400: `{ success: false, error, code, details: { required, actual } }`. Codes: `RENTAL_RULE_ADVANCE_BOOKING` / `RENTAL_RULE_MIN_DURATION` / `RENTAL_RULE_MAX_DURATION`.
- **Renter vehicle detail page** — new `<RentalRulesCard>` renders a "Rental rules" block listing only the rules the owner set. Renders nothing when no rules exist so an unrestricted car doesn't show an empty card.
- **Renter vehicle list card** — new `<RentalRulesBadge>` shows a compact hint like `1 day advance`, `Min 4 hours`, or `Max 5 days`. Picks the most disruptive rule (advance > min > max) via `pickPrimaryRentalRule` so the renter sees what's most likely to surprise them before clicking in.
- **Booking form inline validation** — the time picker calls `checkRentalRules` on every keystroke with the client clock as `now`, disables submit when violated, and surfaces the matching translated hint. If the server still rejects due to clock skew, the same error code maps to the same message so the renter never sees two different explanations for the same failure.
- **Duration formatting** — `formatDurationHours` renders clean day multiples (24, 72, 240) as `1 day` / `3 days` / `10 days`, everything else in hours. Owner types hours, renter reads days where natural. Used consistently across card, badge, and inline hint.
- **i18n** — EN / JA / ZH keys for heading, duration plurals (ICU `plural` syntax), badge labels, and all three inline violation messages.

Explicitly out of scope per the issue: blackout dates, day-of-week rules, seasonal pricing. No schema change.

## Test plan

- [x] `bun run --filter @kuruma/shared test` — 98/98 (+18 rental-rules helper tests covering boundary values, precedence order, and Alphard / kei happy paths)
- [x] `bun run --filter @kuruma/api test` — 87/87 (+5 route tests: min/max/advance rejection with exact code + details shape, compliant booking accepted, no-rules vehicle accepted)
- [x] `bun run --filter @kuruma/web test` — 193/193 (+30: 15 format helper tests, 5 `RentalRulesCard`, 4 `RentalRulesBadge`, 6 `BookingForm` inline validation)
- [x] `bunx biome check` — clean
- [x] `bunx tsc --noEmit` on shared / api / web — clean
- [x] `bun run db:verify` — no schema drift (no schema change in this slice)
- [ ] Manual: seed DB, open Alphard detail page, verify rental rules block shows "Minimum rental: 6 hours / Maximum rental: 10 days / Book at least 1 day in advance"
- [ ] Manual: pick 2h duration on Alphard booking form, verify submit disabled and inline hint shows
- [ ] Manual: pick 48h+48h duration, verify submit enabled and booking succeeds

## Notes for reviewers

- The API route makes rule enforcement conditional on `vehicleRepo` being provided and the vehicle being found. In production both are always true (DB repo + FK constraint), so the skip path exists only to keep legacy in-memory tests using fake vehicle IDs passing. Real bookings always check.
- The shared helper returns one code at a time (precedence: advance > min > max) to match the single-message API envelope. If a booking violates several rules, the renter is pointed at the most disruptive one to fix first.
- `36 hours` is intentionally not formatted as `1.5 days` — the helper only switches to days on clean multiples of 24. Half-day formatting would confuse more than it helps.