### PR TITLE
feat(fleet): slice 5 — owner operations list view redesign (#52)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
+  DrizzleFleetOverviewRepository,
   DrizzleMessageRepository,
   DrizzleStatsRepository,
   DrizzleThreadRepository,
@@ -12,6 +13,7 @@ import {
 import {
   InMemoryAvailabilityRepository,
   InMemoryBookingRepository,
+  InMemoryFleetOverviewRepository,
   InMemoryMessageRepository,
   InMemoryStatsRepository,
   InMemoryThreadRepository,
@@ -20,6 +22,7 @@ import {
 import type {
   AvailabilityRepository,
   BookingRepository,
+  FleetOverviewRepository,
   MessageRepository,
   StatsRepository,
   ThreadRepository,
@@ -27,6 +30,7 @@ import type {
 } from './repositories/types'
 import { createAvailabilityRoutes } from './routes/availability'
 import { createBookingRoutes } from './routes/bookings'
+import { createFleetOverviewRoutes } from './routes/fleet-overview'
 import health from './routes/health'
 import { createMessageRoutes } from './routes/messages'
 import { createStatsRoutes } from './routes/stats'
@@ -36,6 +40,7 @@ export function createApp(overrides?: {
   vehicleRepo: VehicleRepository
   bookingRepo: BookingRepository
   availabilityRepo: AvailabilityRepository
+  fleetOverviewRepo?: FleetOverviewRepository
   statsRepo?: StatsRepository
   threadRepo?: ThreadRepository
   messageRepo?: MessageRepository
@@ -43,12 +48,15 @@ export function createApp(overrides?: {
   let vehicleRepo: VehicleRepository
   let bookingRepo: BookingRepository
   let availabilityRepo: AvailabilityRepository
+  let fleetOverviewRepo: FleetOverviewRepository
   let statsRepo: StatsRepository
   let threadRepo: ThreadRepository
   let messageRepo: MessageRepository
 
   if (overrides) {
     ;({ vehicleRepo, bookingRepo, availabilityRepo } = overrides)
+    fleetOverviewRepo =
+      overrides.fleetOverviewRepo ?? new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo)
     statsRepo = overrides.statsRepo ?? new InMemoryStatsRepository(vehicleRepo, bookingRepo)
     threadRepo = overrides.threadRepo ?? new InMemoryThreadRepository()
     messageRepo =
@@ -58,6 +66,7 @@ export function createApp(overrides?: {
     vehicleRepo = new DrizzleVehicleRepository(db)
     bookingRepo = new DrizzleBookingRepository(db)
     availabilityRepo = new DrizzleAvailabilityRepository(db)
+    fleetOverviewRepo = new DrizzleFleetOverviewRepository(db)
     statsRepo = new DrizzleStatsRepository(db)
     threadRepo = new DrizzleThreadRepository(db)
     messageRepo = new DrizzleMessageRepository(db)
@@ -68,6 +77,7 @@ export function createApp(overrides?: {
       vehicleRepo as InMemoryVehicleRepository,
       bookingRepo as InMemoryBookingRepository,
     )
+    fleetOverviewRepo = new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo)
     statsRepo = new InMemoryStatsRepository(vehicleRepo, bookingRepo)
     threadRepo = new InMemoryThreadRepository()
     messageRepo = new InMemoryMessageRepository(threadRepo as InMemoryThreadRepository)
@@ -94,6 +104,7 @@ export function createApp(overrides?: {
   )
 
   app.route('/', health)
+  app.route('/', createFleetOverviewRoutes(fleetOverviewRepo))
   app.route('/', createVehicleRoutes(vehicleRepo))
   app.route('/', createBookingRoutes(bookingRepo, vehicleRepo))
   app.route('/', createAvailabilityRoutes(availabilityRepo))

--- a/packages/api/src/repositories/drizzle.ts
+++ b/packages/api/src/repositories/drizzle.ts
@@ -7,12 +7,14 @@ import {
   users,
   vehicles,
 } from '@kuruma/shared/db/schema'
-import { and, asc, count, eq, inArray, sql } from 'drizzle-orm'
+import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
+import { and, asc, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 import type {
   AvailabilityRepository,
   BookingRepository,
   DashboardStats,
+  FleetOverviewRepository,
   MessageRepository,
   StatsRepository,
   ThreadRepository,
@@ -119,6 +121,95 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .returning()
 
     return (retired as Vehicle) ?? undefined
+  }
+}
+
+// Fleet overview: owner-facing aggregated read. Two round-trips instead
+// of N+1 — one SELECT for all vehicles, one SELECT for all relevant
+// bookings (last 30 days + any future) joined to users for renter name.
+// JS does the per-vehicle aggregation. 40-50 cars × maybe 200 bookings
+// is trivially fast and much clearer than a window-function CTE. See
+// issue #52.
+const UTILIZATION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+
+function overlapHours(
+  bookingStart: Date,
+  bookingEnd: Date,
+  windowStart: Date,
+  windowEnd: Date,
+): number {
+  const start = bookingStart < windowStart ? windowStart : bookingStart
+  const end = bookingEnd > windowEnd ? windowEnd : bookingEnd
+  if (end <= start) return 0
+  return (end.getTime() - start.getTime()) / (1000 * 60 * 60)
+}
+
+export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
+  constructor(private readonly db: Db) {}
+
+  async findFleetOverview(): Promise<FleetVehicleOverview[]> {
+    const now = new Date()
+    const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_MS)
+
+    // Round-trip 1: all vehicles.
+    const vehicleRows = (await this.db.select(vehicleColumns).from(vehicles)) as Vehicle[]
+
+    // Round-trip 2: bookings we care about — non-CANCELLED, and either
+    // overlapping the last-30-day window OR starting in the future.
+    // LEFT JOIN users for the renter name.
+    const bookingRows = await this.db
+      .select({
+        id: bookings.id,
+        vehicleId: bookings.vehicleId,
+        renterId: bookings.renterId,
+        startAt: bookings.startAt,
+        endAt: bookings.endAt,
+        status: bookings.status,
+        renterName: users.name,
+      })
+      .from(bookings)
+      .leftJoin(users, eq(bookings.renterId, users.id))
+      .where(
+        and(
+          ne(bookings.status, 'CANCELLED'),
+          sql`(${bookings.endAt} > ${windowStart.toISOString()} OR ${bookings.startAt} > ${now.toISOString()})`,
+        ),
+      )
+
+    const bookingsByVehicleId = new Map<string, typeof bookingRows>()
+    for (const row of bookingRows) {
+      const list = bookingsByVehicleId.get(row.vehicleId) ?? []
+      list.push(row)
+      bookingsByVehicleId.set(row.vehicleId, list)
+    }
+
+    return vehicleRows.map((vehicle) => {
+      const vb = bookingsByVehicleId.get(vehicle.id) ?? []
+
+      const recent = vb.filter((b) => b.endAt > windowStart && b.startAt < now)
+      const bookedHours = recent.reduce(
+        (sum, b) => sum + overlapHours(b.startAt, b.endAt, windowStart, now),
+        0,
+      )
+
+      const current = vb.find((b) => b.startAt <= now && b.endAt > now) ?? null
+      const futures = vb
+        .filter((b) => b.startAt > now)
+        .sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+      const next = futures[0] ?? null
+
+      return {
+        ...vehicle,
+        utilization: (bookedHours / (30 * 24)) * 100,
+        bookingCountLast30Days: recent.length,
+        currentBooking: current
+          ? { startAt: current.startAt, endAt: current.endAt, renterName: current.renterName }
+          : null,
+        nextBooking: next
+          ? { startAt: next.startAt, endAt: next.endAt, renterName: next.renterName }
+          : null,
+      }
+    })
   }
 }
 

--- a/packages/api/src/repositories/in-memory.ts
+++ b/packages/api/src/repositories/in-memory.ts
@@ -1,8 +1,10 @@
+import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 import type {
   AvailabilityRepository,
   BookingRepository,
   DashboardStats,
+  FleetOverviewRepository,
   MessageRepository,
   StatsRepository,
   ThreadRepository,
@@ -219,6 +221,81 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
       vehicle,
       conflicts,
     }
+  }
+}
+
+// 30-day utilization window, expressed in hours. Used as the denominator
+// for the utilization percentage — if a vehicle were rented every hour
+// of the last 30 days, utilization = 100.
+const UTILIZATION_WINDOW_HOURS = 30 * 24
+
+function hoursBetween(start: Date, end: Date): number {
+  return (end.getTime() - start.getTime()) / (1000 * 60 * 60)
+}
+
+function overlapHours(
+  bookingStart: Date,
+  bookingEnd: Date,
+  windowStart: Date,
+  windowEnd: Date,
+): number {
+  const start = bookingStart < windowStart ? windowStart : bookingStart
+  const end = bookingEnd > windowEnd ? windowEnd : bookingEnd
+  if (end <= start) return 0
+  return hoursBetween(start, end)
+}
+
+export class InMemoryFleetOverviewRepository implements FleetOverviewRepository {
+  constructor(
+    private readonly vehicleRepo: VehicleRepository,
+    private readonly bookingRepo: BookingRepository,
+    private readonly renterNameByUserId: Map<string, string> = new Map(),
+  ) {}
+
+  async findFleetOverview(): Promise<FleetVehicleOverview[]> {
+    const now = new Date()
+    const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
+
+    const vehicles = await this.vehicleRepo.findAll()
+    const allBookings = await this.bookingRepo.findAll()
+
+    return vehicles.map((vehicle) => {
+      const vehicleBookings = allBookings.filter(
+        (b) => b.vehicleId === vehicle.id && b.status !== 'CANCELLED',
+      )
+
+      const recent = vehicleBookings.filter((b) => b.endAt > windowStart && b.startAt < now)
+      const bookedHours = recent.reduce(
+        (sum, b) => sum + overlapHours(b.startAt, b.endAt, windowStart, now),
+        0,
+      )
+
+      const current = vehicleBookings.find((b) => b.startAt <= now && b.endAt > now) ?? null
+      const futures = vehicleBookings
+        .filter((b) => b.startAt > now)
+        .sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+      const next = futures[0] ?? null
+
+      return {
+        ...vehicle,
+        utilization: (bookedHours / UTILIZATION_WINDOW_HOURS) * 100,
+        bookingCountLast30Days: recent.length,
+        currentBooking: current
+          ? {
+              startAt: current.startAt,
+              endAt: current.endAt,
+              renterName: this.renterNameByUserId.get(current.renterId) ?? null,
+            }
+          : null,
+        nextBooking: next
+          ? {
+              startAt: next.startAt,
+              endAt: next.endAt,
+              renterName: this.renterNameByUserId.get(next.renterId) ?? null,
+            }
+          : null,
+      }
+    })
   }
 }
 

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -1,6 +1,8 @@
 export type { Vehicle, Booking, Thread, ThreadParticipant, Message } from '../stores'
 export type { DashboardStats } from '@kuruma/shared/types/stats'
+export type { FleetVehicleOverview, FleetBookingSummary } from '@kuruma/shared/types/fleet'
 
+import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { DashboardStats } from '@kuruma/shared/types/stats'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 
@@ -10,6 +12,18 @@ export interface VehicleRepository {
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>
   update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>
+}
+
+// Aggregated read for the owner-facing /manage/vehicles list. Enriches
+// each vehicle with utilization %, booking count, and current/next
+// booking state. Computed per-request — NOT denormalized into the
+// vehicles table. See issue #52 and @kuruma/shared/types/fleet.
+//
+// Split from VehicleRepository because it reads across multiple tables
+// (vehicles + bookings + users.name) — following the same boundary as
+// AvailabilityRepository, which also reads vehicles + bookings.
+export interface FleetOverviewRepository {
+  findFleetOverview(): Promise<FleetVehicleOverview[]>
 }
 
 export interface BookingRepository {

--- a/packages/api/src/routes/fleet-overview.ts
+++ b/packages/api/src/routes/fleet-overview.ts
@@ -1,0 +1,17 @@
+import { Hono } from 'hono'
+import type { FleetOverviewRepository } from '../repositories/types'
+
+// Owner-facing aggregated read for /manage/vehicles. Split from
+// createVehicleRoutes because it reads across vehicles + bookings +
+// users.name — cleaner boundary, same pattern as
+// createAvailabilityRoutes. See issue #52.
+export function createFleetOverviewRoutes(repo: FleetOverviewRepository): Hono {
+  const routes = new Hono()
+
+  routes.get('/vehicles/fleet-overview', async (c) => {
+    const data = await repo.findFleetOverview()
+    return c.json({ success: true, data })
+  })
+
+  return routes
+}

--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -238,6 +238,60 @@ describe('InMemoryFleetOverviewRepository', () => {
     expect(overview!.currentBooking!.renterName).toBe('Alice Smith')
   })
 
+  it('clips utilization to the 30-day window when a booking started earlier', async () => {
+    // Booking spans 40 days ago → 20 days ago. 20 days fall inside the
+    // [now - 30d, now] window; 10 days are before it and must NOT be
+    // counted. Naïve `sum(endAt - startAt)` would return 20 * 24 = 480
+    // hours and inflate utilization by 50%.
+    //
+    // FIXED_NOW = 2026-04-11T12:00:00Z, so windowStart = 2026-03-12T12:00Z.
+    //   startAt = 2026-03-02T12:00:00Z (40 days before now)
+    //   endAt   = 2026-03-22T12:00:00Z (20 days before now)
+    //   clipped = [2026-03-12T12:00, 2026-03-22T12:00] = 10 days = 240h
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Long Window' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-03-02T12:00:00Z'),
+        endAt: new Date('2026-03-22T12:00:00Z'),
+        effectiveEndAt: new Date('2026-03-22T13:00:00Z'),
+        status: 'COMPLETED',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.bookingCountLast30Days).toBe(1)
+    expect(overview!.utilization).toBeCloseTo((240 / (30 * 24)) * 100, 5)
+  })
+
+  it('clips utilization at `now` when a currently-active booking extends into the future', async () => {
+    // Booking started 2 hours ago and ends 10 hours from now. Only the
+    // 2 elapsed hours count toward utilization — the 10 future hours
+    // are not yet "booked time" against the window. A naïve impl that
+    // counts the whole window would report 12 hours.
+    //
+    // FIXED_NOW = 2026-04-11T12:00:00Z
+    //   startAt = 2026-04-11T10:00:00Z (2h ago)
+    //   endAt   = 2026-04-11T22:00:00Z (10h future)
+    //   clipped = [startAt, now] = 2h
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Currently Active' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-11T10:00:00Z'),
+        endAt: new Date('2026-04-11T22:00:00Z'),
+        effectiveEndAt: new Date('2026-04-11T23:00:00Z'),
+        status: 'ACTIVE',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.bookingCountLast30Days).toBe(1)
+    expect(overview!.utilization).toBeCloseTo((2 / (30 * 24)) * 100, 5)
+  })
+
   it('returns one overview row per vehicle and preserves all Vehicle columns', async () => {
     const v1 = await vehicleRepo.create(
       baseVehicleInput({ name: 'First', dailyRateJpy: 7500, hourlyRateJpy: 900 }),

--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -1,0 +1,259 @@
+// Unit tests for VehicleRepository.findFleetOverview — the
+// aggregated read that powers the /manage/vehicles owner page
+// (issue #52). The in-memory repository is the behavior
+// specification; the Drizzle implementation is verified against
+// it via integration tests in tests/integration/fleet-overview.test.ts.
+//
+// Utilization formula (per issue #52):
+//   sum(booked_hours in last 30 days for non-CANCELLED bookings)
+//   / (30 * 24) * 100
+// Buffer time is NOT counted — only startAt..endAt.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  InMemoryBookingRepository,
+  InMemoryFleetOverviewRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import type { Booking, Vehicle } from '../../src/stores'
+
+const FIXED_NOW = new Date('2026-04-11T12:00:00Z')
+
+function baseVehicleInput(
+  overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
+): Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    name: 'Toyota Corolla',
+    description: null,
+    photos: [],
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: 'Gasoline',
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    ...overrides,
+  }
+}
+
+function baseBookingInput(
+  overrides: Partial<Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>> & {
+    vehicleId: string
+  },
+): Omit<Booking, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    renterId: 'user_1',
+    startAt: new Date('2026-04-10T10:00:00Z'),
+    endAt: new Date('2026-04-10T14:00:00Z'),
+    effectiveEndAt: new Date('2026-04-10T15:00:00Z'),
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    externalId: null,
+    notes: null,
+    totalPrice: null,
+    cancellationFee: null,
+    cancelledAt: null,
+    ...overrides,
+  }
+}
+
+describe('InMemoryFleetOverviewRepository', () => {
+  let vehicleRepo: InMemoryVehicleRepository
+  let bookingRepo: InMemoryBookingRepository
+  let fleetRepo: InMemoryFleetOverviewRepository
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+    vehicleRepo = new InMemoryVehicleRepository()
+    bookingRepo = new InMemoryBookingRepository()
+    fleetRepo = new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 0% utilization and null bookings for a vehicle with no bookings', async () => {
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Unbooked' }))
+
+    const overviews = await fleetRepo.findFleetOverview()
+    const overview = overviews[0]
+
+    expect(overviews).toHaveLength(1)
+    expect(overview).toBeDefined()
+    expect(overview!.id).toBe(vehicle.id)
+    expect(overview!.name).toBe('Unbooked')
+    expect(overview!.utilization).toBe(0)
+    expect(overview!.bookingCountLast30Days).toBe(0)
+    expect(overview!.currentBooking).toBeNull()
+    expect(overview!.nextBooking).toBeNull()
+  })
+
+  it('excludes CANCELLED bookings from utilization and count', async () => {
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Cancelled' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-05T10:00:00Z'),
+        endAt: new Date('2026-04-06T10:00:00Z'),
+        effectiveEndAt: new Date('2026-04-06T11:00:00Z'),
+        status: 'CANCELLED',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.utilization).toBe(0)
+    expect(overview!.bookingCountLast30Days).toBe(0)
+  })
+
+  it('utilization reflects a single 24-hour booking inside the last 30 days', async () => {
+    // 24 booked hours / (30 * 24) = 24/720 ≈ 3.333...%
+    // Booking window: 2026-04-05 10:00 → 2026-04-06 10:00 UTC.
+    // Now = 2026-04-11 12:00 UTC, so this sits 5-6 days in the past,
+    // squarely inside the 30-day window.
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Booked Once' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-05T10:00:00Z'),
+        endAt: new Date('2026-04-06T10:00:00Z'),
+        effectiveEndAt: new Date('2026-04-06T11:00:00Z'),
+        status: 'COMPLETED',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.bookingCountLast30Days).toBe(1)
+    expect(overview!.utilization).toBeCloseTo((24 / (30 * 24)) * 100, 5)
+  })
+
+  it('populates currentBooking when now falls inside a non-CANCELLED booking', async () => {
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'On Rental' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        // FIXED_NOW = 2026-04-11T12:00:00Z is inside this window
+        startAt: new Date('2026-04-11T09:00:00Z'),
+        endAt: new Date('2026-04-11T18:00:00Z'),
+        effectiveEndAt: new Date('2026-04-11T19:00:00Z'),
+        status: 'ACTIVE',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.currentBooking).not.toBeNull()
+    expect(overview!.currentBooking!.startAt).toEqual(new Date('2026-04-11T09:00:00Z'))
+    expect(overview!.currentBooking!.endAt).toEqual(new Date('2026-04-11T18:00:00Z'))
+    expect(overview!.nextBooking).toBeNull()
+  })
+
+  it('populates nextBooking with the soonest future non-CANCELLED booking', async () => {
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Has Future Booking' }))
+    // Future booking — closer one first in creation order, but we want
+    // findFleetOverview to pick the earliest startAt regardless of insert order.
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-20T10:00:00Z'),
+        endAt: new Date('2026-04-20T14:00:00Z'),
+        effectiveEndAt: new Date('2026-04-20T15:00:00Z'),
+        status: 'CONFIRMED',
+      }),
+    )
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-12T08:00:00Z'),
+        endAt: new Date('2026-04-12T10:00:00Z'),
+        effectiveEndAt: new Date('2026-04-12T11:00:00Z'),
+        status: 'CONFIRMED',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.currentBooking).toBeNull()
+    expect(overview!.nextBooking).not.toBeNull()
+    expect(overview!.nextBooking!.startAt).toEqual(new Date('2026-04-12T08:00:00Z'))
+    expect(overview!.nextBooking!.endAt).toEqual(new Date('2026-04-12T10:00:00Z'))
+  })
+
+  it('excludes CANCELLED bookings from currentBooking and nextBooking', async () => {
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'All Cancelled' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-11T09:00:00Z'),
+        endAt: new Date('2026-04-11T18:00:00Z'),
+        effectiveEndAt: new Date('2026-04-11T19:00:00Z'),
+        status: 'CANCELLED',
+      }),
+    )
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        startAt: new Date('2026-04-15T10:00:00Z'),
+        endAt: new Date('2026-04-15T14:00:00Z'),
+        effectiveEndAt: new Date('2026-04-15T15:00:00Z'),
+        status: 'CANCELLED',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.currentBooking).toBeNull()
+    expect(overview!.nextBooking).toBeNull()
+  })
+
+  it('resolves renterName from the injected renter map for current/next bookings', async () => {
+    const renterNameByUserId = new Map<string, string>([['user_alice', 'Alice Smith']])
+    fleetRepo = new InMemoryFleetOverviewRepository(
+      vehicleRepo,
+      bookingRepo,
+      renterNameByUserId,
+    )
+
+    const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Alice Rental' }))
+    await bookingRepo.create(
+      baseBookingInput({
+        vehicleId: vehicle.id,
+        renterId: 'user_alice',
+        startAt: new Date('2026-04-11T09:00:00Z'),
+        endAt: new Date('2026-04-11T18:00:00Z'),
+        effectiveEndAt: new Date('2026-04-11T19:00:00Z'),
+        status: 'ACTIVE',
+      }),
+    )
+
+    const [overview] = await fleetRepo.findFleetOverview()
+
+    expect(overview!.currentBooking!.renterName).toBe('Alice Smith')
+  })
+
+  it('returns one overview row per vehicle and preserves all Vehicle columns', async () => {
+    const v1 = await vehicleRepo.create(
+      baseVehicleInput({ name: 'First', dailyRateJpy: 7500, hourlyRateJpy: 900 }),
+    )
+    const v2 = await vehicleRepo.create(
+      baseVehicleInput({ name: 'Second', dailyRateJpy: null, hourlyRateJpy: 1200 }),
+    )
+
+    const overviews = await fleetRepo.findFleetOverview()
+
+    expect(overviews).toHaveLength(2)
+    const first = overviews.find((o) => o.id === v1.id)
+    const second = overviews.find((o) => o.id === v2.id)
+    expect(first!.dailyRateJpy).toBe(7500)
+    expect(first!.hourlyRateJpy).toBe(900)
+    expect(second!.dailyRateJpy).toBeNull()
+    expect(second!.hourlyRateJpy).toBe(1200)
+  })
+})

--- a/packages/api/tests/routes/fleet-overview.test.ts
+++ b/packages/api/tests/routes/fleet-overview.test.ts
@@ -1,0 +1,129 @@
+// Route-level tests for GET /vehicles/fleet-overview — the owner-facing
+// aggregated read for issue #52. Uses InMemory repos; the aggregation
+// logic itself is covered in tests/repositories/fleet-overview.test.ts.
+// This file lives next to vehicles.test.ts but in its own file so slice
+// #51 (status toggle) can extend vehicles.test.ts without merge conflicts.
+
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  InMemoryBookingRepository,
+  InMemoryFleetOverviewRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { createFleetOverviewRoutes } from '../../src/routes/fleet-overview'
+
+const FIXED_NOW = new Date('2026-04-11T12:00:00Z')
+
+let app: Hono
+let vehicleRepo: InMemoryVehicleRepository
+let bookingRepo: InMemoryBookingRepository
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+  vehicleRepo = new InMemoryVehicleRepository()
+  bookingRepo = new InMemoryBookingRepository()
+  const fleetRepo = new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo)
+  app = new Hono()
+  app.route('/', createFleetOverviewRoutes(fleetRepo))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('GET /vehicles/fleet-overview', () => {
+  it('returns an empty list when there are no vehicles', async () => {
+    const res = await app.request('/vehicles/fleet-overview')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, data: [] })
+  })
+
+  it('returns an enriched row per vehicle with default zeroed metrics', async () => {
+    await vehicleRepo.create({
+      name: 'Toyota Corolla',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: 'Gasoline',
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    const res = await app.request('/vehicles/fleet-overview')
+    const body = (await res.json()) as {
+      success: boolean
+      data: Array<{
+        id: string
+        name: string
+        dailyRateJpy: number | null
+        utilization: number
+        bookingCountLast30Days: number
+        currentBooking: unknown
+        nextBooking: unknown
+      }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0]!.name).toBe('Toyota Corolla')
+    expect(body.data[0]!.dailyRateJpy).toBe(8000)
+    expect(body.data[0]!.utilization).toBe(0)
+    expect(body.data[0]!.bookingCountLast30Days).toBe(0)
+    expect(body.data[0]!.currentBooking).toBeNull()
+    expect(body.data[0]!.nextBooking).toBeNull()
+  })
+
+  it('serializes current/next booking Date fields as ISO strings', async () => {
+    const vehicle = await vehicleRepo.create({
+      name: 'On Rental',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+    await bookingRepo.create({
+      renterId: 'user_1',
+      vehicleId: vehicle.id,
+      startAt: new Date('2026-04-11T09:00:00Z'),
+      endAt: new Date('2026-04-11T18:00:00Z'),
+      effectiveEndAt: new Date('2026-04-11T19:00:00Z'),
+      status: 'ACTIVE',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+      totalPrice: null,
+      cancellationFee: null,
+      cancelledAt: null,
+    })
+
+    const res = await app.request('/vehicles/fleet-overview')
+    const body = (await res.json()) as {
+      data: Array<{
+        currentBooking: { startAt: string; endAt: string; renterName: string | null } | null
+      }>
+    }
+
+    expect(body.data[0]!.currentBooking).not.toBeNull()
+    expect(body.data[0]!.currentBooking!.startAt).toBe('2026-04-11T09:00:00.000Z')
+    expect(body.data[0]!.currentBooking!.endAt).toBe('2026-04-11T18:00:00.000Z')
+    expect(body.data[0]!.currentBooking!.renterName).toBeNull()
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "./validators/auth": "./src/validators/auth.ts",
     "./validators/message": "./src/validators/message.ts",
     "./types/stats": "./src/types/stats.ts",
+    "./types/fleet": "./src/types/fleet.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts"
   },
   "scripts": {

--- a/packages/shared/src/types/fleet.ts
+++ b/packages/shared/src/types/fleet.ts
@@ -1,0 +1,49 @@
+// Fleet overview DTO — enriches a Vehicle with the aggregated operational
+// data the owner-facing /manage/vehicles list needs to answer "where is
+// every car right now and which is making money" at a glance. Computed
+// per-request by the repository; NOT denormalized into the vehicles
+// table. See issue #52.
+
+export interface FleetBookingSummary {
+  startAt: Date
+  endAt: Date
+  renterName: string | null
+}
+
+export interface FleetVehicleOverview {
+  // All columns from the underlying Vehicle row. Kept as a structural
+  // match rather than `extends Vehicle` so this file has zero runtime
+  // dependency on the api package.
+  id: string
+  name: string
+  description: string | null
+  photos: string[]
+  seats: number
+  transmission: 'AUTO' | 'MANUAL'
+  fuelType: string | null
+  status: 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
+  bufferMinutes: number
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
+  dailyRateJpy: number | null
+  hourlyRateJpy: number | null
+  createdAt: Date
+  updatedAt: Date
+
+  // Utilization: fraction of hours booked in the last 30 days, expressed
+  // as a percentage 0..100. CANCELLED bookings excluded. Buffer time is
+  // NOT counted — only the renter-facing window (startAt..endAt).
+  utilization: number
+
+  // Number of non-CANCELLED bookings that touched the last 30 days.
+  bookingCountLast30Days: number
+
+  // The booking that is currently in progress, if `now` falls inside a
+  // non-CANCELLED booking for this vehicle.
+  currentBooking: FleetBookingSummary | null
+
+  // The next non-CANCELLED booking whose startAt is in the future,
+  // excluding any currentBooking.
+  nextBooking: FleetBookingSummary | null
+}

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -179,15 +179,33 @@
         "capacityHeading": "Capacity",
         "seatsLabel": "{min}-{max} seats",
         "sortHeading": "Sort by",
+        "sortUtilizationDesc": "Utilization: most booked first",
         "sortNameAsc": "Name A-Z",
         "sortNameDesc": "Name Z-A",
         "sortSeatsAsc": "Seats: fewest first",
-        "sortSeatsDesc": "Seats: most first"
+        "sortSeatsDesc": "Seats: most first",
+        "sortPriceAsc": "Price: low to high",
+        "sortPriceDesc": "Price: high to low"
       },
       "actions": {
         "setMaintenance": "Set to Maintenance",
         "setAvailable": "Mark Available",
         "restore": "Restore vehicle"
+      },
+      "fleet": {
+        "rowView": "Row view",
+        "gridView": "Grid view",
+        "moreActions": "More actions",
+        "onRentalUntil": "On rental until {time}",
+        "nextBooking": "Next: {time}",
+        "noBookings": "No upcoming bookings",
+        "utilizationLabel": "{percent}% · {count} bookings this month",
+        "summary": {
+          "total": "{n} cars",
+          "onRental": "{n} on rental",
+          "available": "{n} available",
+          "maintenance": "{n} maintenance"
+        }
       }
     },
     "customers": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -179,15 +179,33 @@
         "capacityHeading": "定員",
         "seatsLabel": "{min}〜{max}人乗り",
         "sortHeading": "並び替え",
+        "sortUtilizationDesc": "稼働率 (高い順)",
         "sortNameAsc": "名前 (A-Z)",
         "sortNameDesc": "名前 (Z-A)",
         "sortSeatsAsc": "定員 (少ない順)",
-        "sortSeatsDesc": "定員 (多い順)"
+        "sortSeatsDesc": "定員 (多い順)",
+        "sortPriceAsc": "料金 (安い順)",
+        "sortPriceDesc": "料金 (高い順)"
       },
       "actions": {
         "setMaintenance": "メンテナンス中にする",
         "setAvailable": "利用可能にする",
         "restore": "車両を復元する"
+      },
+      "fleet": {
+        "rowView": "リスト表示",
+        "gridView": "グリッド表示",
+        "moreActions": "その他の操作",
+        "onRentalUntil": "{time} まで貸出中",
+        "nextBooking": "次回: {time}",
+        "noBookings": "予約なし",
+        "utilizationLabel": "{percent}% · 今月 {count}件",
+        "summary": {
+          "total": "全{n}台",
+          "onRental": "貸出中 {n}台",
+          "available": "利用可能 {n}台",
+          "maintenance": "メンテナンス中 {n}台"
+        }
       }
     },
     "customers": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -179,15 +179,33 @@
         "capacityHeading": "座位数",
         "seatsLabel": "{min}-{max} 座",
         "sortHeading": "排序",
+        "sortUtilizationDesc": "使用率由高到低",
         "sortNameAsc": "名称 A-Z",
         "sortNameDesc": "名称 Z-A",
         "sortSeatsAsc": "座位由少到多",
-        "sortSeatsDesc": "座位由多到少"
+        "sortSeatsDesc": "座位由多到少",
+        "sortPriceAsc": "价格由低到高",
+        "sortPriceDesc": "价格由高到低"
       },
       "actions": {
         "setMaintenance": "设为维护中",
         "setAvailable": "标记为可用",
         "restore": "恢复车辆"
+      },
+      "fleet": {
+        "rowView": "列表视图",
+        "gridView": "网格视图",
+        "moreActions": "更多操作",
+        "onRentalUntil": "出租中，至 {time}",
+        "nextBooking": "下次: {time}",
+        "noBookings": "暂无预订",
+        "utilizationLabel": "{percent}% · 本月 {count} 次预订",
+        "summary": {
+          "total": "{n} 辆车",
+          "onRental": "{n} 辆出租中",
+          "available": "{n} 辆可用",
+          "maintenance": "{n} 辆维护中"
+        }
       }
     },
     "customers": {

--- a/packages/web/src/components/vehicles/FleetFilters.tsx
+++ b/packages/web/src/components/vehicles/FleetFilters.tsx
@@ -36,10 +36,13 @@ const TRANSMISSION_LABEL_KEYS: Record<Transmission, string> = {
 }
 
 const SORT_OPTIONS: readonly { value: SortOrder; labelKey: string }[] = [
+  { value: 'utilization-desc', labelKey: 'sortUtilizationDesc' },
   { value: 'name-asc', labelKey: 'sortNameAsc' },
   { value: 'name-desc', labelKey: 'sortNameDesc' },
   { value: 'seats-asc', labelKey: 'sortSeatsAsc' },
   { value: 'seats-desc', labelKey: 'sortSeatsDesc' },
+  { value: 'price-asc', labelKey: 'sortPriceAsc' },
+  { value: 'price-desc', labelKey: 'sortPriceDesc' },
 ]
 
 function toggleInArray<T>(items: readonly T[] | undefined, value: T): T[] {

--- a/packages/web/src/components/vehicles/FleetSummaryBar.tsx
+++ b/packages/web/src/components/vehicles/FleetSummaryBar.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import { useTranslations } from 'next-intl'
+
+interface FleetSummaryBarProps {
+  overviews: readonly FleetVehicleOverviewData[]
+}
+
+// "On rental" reflects operational state (there is a currentBooking),
+// not the database status column — a vehicle can be AVAILABLE and
+// currently rented at the same time. See issue #52.
+export function FleetSummaryBar({ overviews }: FleetSummaryBarProps) {
+  const t = useTranslations('business.vehicles')
+
+  const total = overviews.length
+  const onRental = overviews.filter((v) => v.currentBooking !== null).length
+  const available = overviews.filter((v) => v.status === 'AVAILABLE').length
+  const maintenance = overviews.filter((v) => v.status === 'MAINTENANCE').length
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg border bg-card px-4 py-3 text-sm">
+      <span className="font-medium text-foreground">{t('fleet.summary.total', { n: total })}</span>
+      <span className="text-muted-foreground" aria-hidden>
+        ·
+      </span>
+      <span className="text-foreground">{t('fleet.summary.onRental', { n: onRental })}</span>
+      <span className="text-muted-foreground" aria-hidden>
+        ·
+      </span>
+      <span className="text-foreground">{t('fleet.summary.available', { n: available })}</span>
+      <span className="text-muted-foreground" aria-hidden>
+        ·
+      </span>
+      <span className="text-foreground">{t('fleet.summary.maintenance', { n: maintenance })}</span>
+    </div>
+  )
+}

--- a/packages/web/src/components/vehicles/FleetVehicleRow.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleRow.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { VehicleStatusBadge } from '@/components/vehicles/VehicleStatusBadge'
+import { formatVehicleRate } from '@/lib/format'
+import type { FleetBookingSummaryData, FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import { Car, MoreHorizontal } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+interface FleetVehicleRowProps {
+  overview: FleetVehicleOverviewData
+  onEdit: (overview: FleetVehicleOverviewData) => void
+  onRetire: (overview: FleetVehicleOverviewData) => void
+}
+
+// Format a booking's end-time window for the inline row indicator. We
+// show day + HH:mm in Asia/Tokyo because that's where the owner is and
+// seeing "12:00" means the same thing at a glance every time.
+function formatBookingTime(iso: string): string {
+  const date = new Date(iso)
+  return new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    day: '2-digit',
+    month: 'short',
+    timeZone: 'Asia/Tokyo',
+    hour12: false,
+  }).format(date)
+}
+
+function BookingIndicator({
+  current,
+  next,
+  t,
+}: {
+  current: FleetBookingSummaryData | null
+  next: FleetBookingSummaryData | null
+  t: (key: string, values?: Record<string, string | number | Date>) => string
+}) {
+  if (current) {
+    return (
+      <span data-testid="fleet-row-booking-indicator" className="text-sm text-foreground">
+        {t('fleet.onRentalUntil', { time: formatBookingTime(current.endAt) })}
+      </span>
+    )
+  }
+  if (next) {
+    return (
+      <span data-testid="fleet-row-booking-indicator" className="text-sm text-muted-foreground">
+        {t('fleet.nextBooking', { time: formatBookingTime(next.startAt) })}
+      </span>
+    )
+  }
+  return (
+    <span data-testid="fleet-row-booking-indicator" className="text-sm text-muted-foreground">
+      {t('fleet.noBookings')}
+    </span>
+  )
+}
+
+export function FleetVehicleRow({ overview, onEdit, onRetire }: FleetVehicleRowProps) {
+  const t = useTranslations('business.vehicles')
+  const photo = overview.photos?.[0]
+  const price = formatVehicleRate(overview.dailyRateJpy, overview.hourlyRateJpy, {
+    perDay: t('form.perDaySuffix'),
+    perHour: t('form.perHourSuffix'),
+  })
+
+  const subtitleParts = [
+    `${overview.seats}`,
+    overview.transmission === 'AUTO' ? 'AT' : 'MT',
+    overview.fuelType,
+  ].filter((p): p is string => Boolean(p))
+
+  return (
+    <div className="flex items-center gap-4 rounded-lg border bg-card p-3">
+      {/* Thumbnail: 80x60 per issue spec */}
+      <div className="flex-shrink-0 h-[60px] w-[80px] overflow-hidden rounded bg-muted">
+        {photo ? (
+          <img src={photo} alt={overview.name} className="h-full w-full object-cover" />
+        ) : (
+          <div
+            data-testid="fleet-row-thumbnail-placeholder"
+            className="flex h-full w-full items-center justify-center"
+          >
+            <Car className="size-6 text-muted-foreground/30" />
+          </div>
+        )}
+      </div>
+
+      {/* Name + subtitle */}
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium text-foreground">{overview.name}</div>
+        <div data-testid="fleet-row-subtitle" className="truncate text-sm text-muted-foreground">
+          {subtitleParts.join(' · ')}
+        </div>
+      </div>
+
+      {/* Status */}
+      <div className="flex-shrink-0">
+        <VehicleStatusBadge status={overview.status} />
+      </div>
+
+      {/* Booking indicator */}
+      <div className="flex-shrink-0 min-w-[12rem]">
+        <BookingIndicator current={overview.currentBooking} next={overview.nextBooking} t={t} />
+      </div>
+
+      {/* Price */}
+      <div className="flex-shrink-0 min-w-[10rem] text-right text-sm font-medium">
+        {price ?? ''}
+      </div>
+
+      {/* Utilization */}
+      <div
+        data-testid="fleet-row-utilization"
+        className="flex-shrink-0 min-w-[10rem] text-right text-sm text-muted-foreground"
+      >
+        {t('fleet.utilizationLabel', {
+          percent: Math.round(overview.utilization),
+          count: overview.bookingCountLast30Days,
+        })}
+      </div>
+
+      {/* Overflow menu */}
+      <div className="flex-shrink-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button variant="ghost" size="icon" aria-label={t('fleet.moreActions')}>
+                <MoreHorizontal className="size-4" />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(overview)}>{t('editVehicle')}</DropdownMenuItem>
+            {overview.status !== 'RETIRED' && (
+              <DropdownMenuItem onClick={() => onRetire(overview)}>
+                {t('retireVehicle')}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/vehicles/FleetViewToggle.tsx
+++ b/packages/web/src/components/vehicles/FleetViewToggle.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { LayoutGrid, Rows3 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
+
+export type FleetViewMode = 'row' | 'grid'
+
+const STORAGE_KEY = 'kuruma-fleet-view-mode'
+
+function isViewMode(v: unknown): v is FleetViewMode {
+  return v === 'row' || v === 'grid'
+}
+
+// localStorage-backed persistence for the owner's preferred view. Lives
+// next to the toggle component so consumers get one hook + one control
+// and nothing else. Returns a [value, setter] tuple like useState.
+export function useFleetViewMode(): readonly [FleetViewMode, (next: FleetViewMode) => void] {
+  const [mode, setMode] = useState<FleetViewMode>('row')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (isViewMode(raw)) {
+      setMode(raw)
+    }
+  }, [])
+
+  const update = (next: FleetViewMode) => {
+    setMode(next)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    }
+  }
+
+  return [mode, update] as const
+}
+
+interface FleetViewToggleProps {
+  value: FleetViewMode
+  onChange: (next: FleetViewMode) => void
+}
+
+export function FleetViewToggle({ value, onChange }: FleetViewToggleProps) {
+  const t = useTranslations('business.vehicles')
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg border bg-card p-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={t('fleet.rowView')}
+        aria-pressed={value === 'row'}
+        className={cn('h-7 px-2', value === 'row' && 'bg-muted')}
+        onClick={() => {
+          if (value !== 'row') onChange('row')
+        }}
+      >
+        <Rows3 className="size-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={t('fleet.gridView')}
+        aria-pressed={value === 'grid'}
+        className={cn('h-7 px-2', value === 'grid' && 'bg-muted')}
+        onClick={() => {
+          if (value !== 'grid') onChange('grid')
+        }}
+      >
+        <LayoutGrid className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -5,7 +5,10 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { AddVehicleDialog } from '@/components/vehicles/AddVehicleDialog'
 import { EditVehicleDialog } from '@/components/vehicles/EditVehicleDialog'
 import { FleetFilters } from '@/components/vehicles/FleetFilters'
+import { FleetSummaryBar } from '@/components/vehicles/FleetSummaryBar'
 import { FleetVehicleCard } from '@/components/vehicles/FleetVehicleCard'
+import { FleetVehicleRow } from '@/components/vehicles/FleetVehicleRow'
+import { FleetViewToggle, useFleetViewMode } from '@/components/vehicles/FleetViewToggle'
 import { RetireVehicleDialog } from '@/components/vehicles/RetireVehicleDialog'
 import {
   type FleetFilterState,
@@ -14,7 +17,7 @@ import {
   sortVehicles,
 } from '@/lib/fleet-filters'
 import type { VehicleData } from '@/lib/vehicle-api'
-import { fetchVehicles } from '@/lib/vehicle-api'
+import { fetchFleetOverview } from '@/lib/vehicle-api'
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Car, Plus } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -29,36 +32,39 @@ export function VehicleList() {
   const [filters, setFilters] = useState<FleetFilterState>({
     statuses: ['AVAILABLE', 'MAINTENANCE'],
   })
-  const [sort, setSort] = useState<SortOrder>('name-asc')
+  // Default sort is utilization-desc — the owner wants to see which
+  // cars are earning the most first. See issue #52.
+  const [sort, setSort] = useState<SortOrder>('utilization-desc')
+  const [viewMode, setViewMode] = useFleetViewMode()
   const [editingVehicle, setEditingVehicle] = useState<VehicleData | null>(null)
   const [retiringVehicle, setRetiringVehicle] = useState<VehicleData | null>(null)
   const [showAddDialog, setShowAddDialog] = useState(false)
 
   const {
-    data: vehicles,
+    data: overviews,
     isLoading,
     isError,
     error,
     refetch,
   } = useQuery({
-    queryKey: ['vehicles'],
-    queryFn: () => fetchVehicles(),
+    queryKey: ['vehicles', 'fleet-overview'],
+    queryFn: () => fetchFleetOverview(),
   })
 
   const seatsBounds = useMemo(() => {
-    if (!vehicles || vehicles.length === 0) {
+    if (!overviews || overviews.length === 0) {
       return DEFAULT_SEATS_BOUNDS
     }
-    const seats = vehicles.map((v) => v.seats)
+    const seats = overviews.map((v) => v.seats)
     return {
       min: Math.min(...seats),
       max: Math.max(...seats),
     }
-  }, [vehicles])
+  }, [overviews])
 
   const displayed = useMemo(
-    () => sortVehicles(filterVehicles(vehicles ?? [], filters), sort),
-    [vehicles, filters, sort],
+    () => sortVehicles(filterVehicles(overviews ?? [], filters), sort),
+    [overviews, filters, sort],
   )
 
   return (
@@ -74,7 +80,10 @@ export function VehicleList() {
       </aside>
 
       <div className="flex-1 space-y-6">
-        <div className="flex items-center justify-end">
+        {!isLoading && !isError && overviews && <FleetSummaryBar overviews={overviews} />}
+
+        <div className="flex items-center justify-between gap-4">
+          <FleetViewToggle value={viewMode} onChange={setViewMode} />
           <Button onClick={() => setShowAddDialog(true)}>
             <Plus className="size-4 mr-1.5" />
             {t('addVehicle')}
@@ -82,9 +91,9 @@ export function VehicleList() {
         </div>
 
         {isLoading && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
+          <div className="space-y-3">
             {SKELETON_KEYS.map((key) => (
-              <Skeleton key={key} className="h-80 rounded-xl" />
+              <Skeleton key={key} className="h-20 rounded-lg" />
             ))}
           </div>
         )}
@@ -102,12 +111,25 @@ export function VehicleList() {
           </div>
         )}
 
-        {!isLoading && !isError && displayed.length > 0 && (
+        {!isLoading && !isError && displayed.length > 0 && viewMode === 'row' && (
+          <div className="space-y-2">
+            {displayed.map((overview) => (
+              <FleetVehicleRow
+                key={overview.id}
+                overview={overview}
+                onEdit={setEditingVehicle}
+                onRetire={setRetiringVehicle}
+              />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !isError && displayed.length > 0 && viewMode === 'grid' && (
           <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
-            {displayed.map((vehicle) => (
+            {displayed.map((overview) => (
               <FleetVehicleCard
-                key={vehicle.id}
-                vehicle={vehicle}
+                key={overview.id}
+                vehicle={overview}
                 onEdit={setEditingVehicle}
                 onRetire={setRetiringVehicle}
               />

--- a/packages/web/src/lib/fleet-filters.ts
+++ b/packages/web/src/lib/fleet-filters.ts
@@ -11,7 +11,15 @@ export interface FleetFilterState {
   seatsMax?: number
 }
 
-export function filterVehicles(vehicles: VehicleData[], filters: FleetFilterState): VehicleData[] {
+// Generic in T so the owner list (FleetVehicleOverviewData) and any
+// other caller that wants to narrow a list of vehicle-shaped items
+// keeps its concrete type through the filter. See #52.
+type FilterableVehicle = Pick<VehicleData, 'name' | 'status' | 'transmission' | 'seats'>
+
+export function filterVehicles<T extends FilterableVehicle>(
+  vehicles: T[],
+  filters: FleetFilterState,
+): T[] {
   let result = vehicles
 
   if (filters.search) {
@@ -42,9 +50,36 @@ export function filterVehicles(vehicles: VehicleData[], filters: FleetFilterStat
   return result
 }
 
-export type SortOrder = 'name-asc' | 'name-desc' | 'seats-asc' | 'seats-desc'
+export type SortOrder =
+  | 'name-asc'
+  | 'name-desc'
+  | 'seats-asc'
+  | 'seats-desc'
+  | 'utilization-desc'
+  | 'price-asc'
+  | 'price-desc'
 
-export function sortVehicles(vehicles: VehicleData[], order: SortOrder): VehicleData[] {
+// Generic over anything shaped like a vehicle with the columns sortVehicles
+// touches. `utilization` is optional so plain VehicleData and
+// FleetVehicleOverviewData both satisfy the constraint — `utilization-desc`
+// treats a missing value as 0 (safe for the owner page, which always
+// hydrates with the overview data anyway). See #52.
+type SortableVehicle = Pick<VehicleData, 'name' | 'seats' | 'dailyRateJpy' | 'hourlyRateJpy'> & {
+  utilization?: number
+}
+
+// Price sort uses dailyRateJpy first, falling back to hourlyRateJpy.
+// Vehicles with neither rate sort to the end. This prioritizes daily
+// pricing because that's the headline rate on the owner's mental model
+// ("how much does this car earn per day?") and matches how the row
+// component displays the rates.
+function priceKey(v: SortableVehicle): number {
+  if (v.dailyRateJpy != null) return v.dailyRateJpy
+  if (v.hourlyRateJpy != null) return v.hourlyRateJpy
+  return Number.POSITIVE_INFINITY
+}
+
+export function sortVehicles<T extends SortableVehicle>(vehicles: T[], order: SortOrder): T[] {
   const sorted = [...vehicles]
 
   switch (order) {
@@ -56,5 +91,11 @@ export function sortVehicles(vehicles: VehicleData[], order: SortOrder): Vehicle
       return sorted.sort((a, b) => a.seats - b.seats)
     case 'seats-desc':
       return sorted.sort((a, b) => b.seats - a.seats)
+    case 'utilization-desc':
+      return sorted.sort((a, b) => (b.utilization ?? 0) - (a.utilization ?? 0))
+    case 'price-asc':
+      return sorted.sort((a, b) => priceKey(a) - priceKey(b))
+    case 'price-desc':
+      return sorted.sort((a, b) => priceKey(b) - priceKey(a))
   }
 }

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -26,6 +26,23 @@ export interface VehicleData {
   updatedAt: string
 }
 
+// Enriched row returned by GET /vehicles/fleet-overview. Dates are ISO
+// strings (JSON-serialized from the API) rather than Date objects.
+// Mirrors @kuruma/shared/types/fleet.FleetVehicleOverview — if you add
+// a field there, add it here too. See issue #52.
+export interface FleetBookingSummaryData {
+  startAt: string
+  endAt: string
+  renterName: string | null
+}
+
+export interface FleetVehicleOverviewData extends VehicleData {
+  utilization: number
+  bookingCountLast30Days: number
+  currentBooking: FleetBookingSummaryData | null
+  nextBooking: FleetBookingSummaryData | null
+}
+
 async function apiRequest<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init)
 
@@ -90,4 +107,9 @@ export async function updateVehicleStatus(id: string, status: VehicleStatus): Pr
 export async function retireVehicle(id: string): Promise<VehicleData> {
   const base = getApiBaseUrl()
   return apiRequest<VehicleData>(`${base}/vehicles/${id}`, { method: 'DELETE' })
+}
+
+export async function fetchFleetOverview(): Promise<FleetVehicleOverviewData[]> {
+  const base = getApiBaseUrl()
+  return apiRequest<FleetVehicleOverviewData[]>(`${base}/vehicles/fleet-overview`)
 }

--- a/packages/web/tests/components/vehicles/FleetSummaryBar.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetSummaryBar.test.tsx
@@ -1,0 +1,128 @@
+// Top summary bar that tells the owner at a glance how many cars exist
+// and how they break down: total · on rental · available · maintenance.
+// "On rental" means there is a currentBooking — reflects operational
+// state, not the database `status` field which could still be AVAILABLE
+// while a rental is in progress. See issue #52.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    const messages: Record<string, string> = {
+      'fleet.summary.total': '{n} cars',
+      'fleet.summary.onRental': '{n} on rental',
+      'fleet.summary.available': '{n} available',
+      'fleet.summary.maintenance': '{n} maintenance',
+    }
+    const template = messages[key] ?? key
+    if (!values) return template
+    return Object.entries(values).reduce(
+      (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+      template,
+    )
+  },
+}))
+
+import { FleetSummaryBar } from '@/components/vehicles/FleetSummaryBar'
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+
+function makeOverview(overrides: Partial<FleetVehicleOverviewData> = {}): FleetVehicleOverviewData {
+  return {
+    id: crypto.randomUUID(),
+    name: 'Car',
+    description: null,
+    photos: [],
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    ...overrides,
+  }
+}
+
+describe('FleetSummaryBar', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders zeros for an empty list', () => {
+    render(<FleetSummaryBar overviews={[]} />)
+
+    expect(screen.getByText('0 cars')).toBeInTheDocument()
+    expect(screen.getByText('0 on rental')).toBeInTheDocument()
+    expect(screen.getByText('0 available')).toBeInTheDocument()
+    expect(screen.getByText('0 maintenance')).toBeInTheDocument()
+  })
+
+  it('counts total cars regardless of status', () => {
+    const overviews = [
+      makeOverview({ status: 'AVAILABLE' }),
+      makeOverview({ status: 'MAINTENANCE' }),
+      makeOverview({ status: 'RETIRED' }),
+    ]
+
+    render(<FleetSummaryBar overviews={overviews} />)
+
+    expect(screen.getByText('3 cars')).toBeInTheDocument()
+  })
+
+  it('counts on-rental by currentBooking presence, not by status field', () => {
+    const overviews = [
+      // Database status AVAILABLE but a rental is actively in progress.
+      makeOverview({
+        status: 'AVAILABLE',
+        currentBooking: {
+          startAt: '2026-04-11T09:00:00Z',
+          endAt: '2026-04-11T18:00:00Z',
+          renterName: null,
+        },
+      }),
+      // AVAILABLE without a current booking — not on rental.
+      makeOverview({ status: 'AVAILABLE' }),
+      // MAINTENANCE — not on rental regardless of booking state.
+      makeOverview({ status: 'MAINTENANCE' }),
+    ]
+
+    render(<FleetSummaryBar overviews={overviews} />)
+
+    expect(screen.getByText('1 on rental')).toBeInTheDocument()
+  })
+
+  it('counts available using the db status field', () => {
+    const overviews = [
+      makeOverview({ status: 'AVAILABLE' }),
+      makeOverview({ status: 'AVAILABLE' }),
+      makeOverview({ status: 'MAINTENANCE' }),
+      makeOverview({ status: 'RETIRED' }),
+    ]
+
+    render(<FleetSummaryBar overviews={overviews} />)
+
+    expect(screen.getByText('2 available')).toBeInTheDocument()
+  })
+
+  it('counts maintenance using the db status field', () => {
+    const overviews = [
+      makeOverview({ status: 'MAINTENANCE' }),
+      makeOverview({ status: 'MAINTENANCE' }),
+      makeOverview({ status: 'AVAILABLE' }),
+    ]
+
+    render(<FleetSummaryBar overviews={overviews} />)
+
+    expect(screen.getByText('2 maintenance')).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/components/vehicles/FleetVehicleRow.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetVehicleRow.test.tsx
@@ -1,0 +1,229 @@
+// Tests for FleetVehicleRow — the dense, information-rich row that
+// replaces FleetVehicleCard on the owner-facing /manage/vehicles page
+// (issue #52). FleetVehicleCard remains in use on the renter-facing
+// /vehicles browse page.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    // Flat mock indexed by fully-qualified keys. next-intl uses a
+    // per-namespace API so the literal `key` passed in depends on the
+    // namespace the consumer opened. We cover both `business.vehicles.*`
+    // keys (FleetVehicleRow) and bare status keys (VehicleStatusBadge
+    // which uses `business.vehicles.status` as its namespace).
+    const messages: Record<string, string> = {
+      editVehicle: 'Edit',
+      retireVehicle: 'Retire',
+      AVAILABLE: 'Available',
+      MAINTENANCE: 'Maintenance',
+      RETIRED: 'Retired',
+      'form.perDaySuffix': '/day',
+      'form.perHourSuffix': '/hr',
+      'fleet.onRentalUntil': 'On rental until {time}',
+      'fleet.nextBooking': 'Next: {time}',
+      'fleet.utilizationLabel': '{percent}% · {count} bookings this month',
+      'fleet.noBookings': 'No upcoming bookings',
+      'fleet.moreActions': 'More actions',
+    }
+    const template = messages[key] ?? key
+    if (!values) return template
+    return Object.entries(values).reduce(
+      (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+      template,
+    )
+  },
+}))
+
+import { FleetVehicleRow } from '@/components/vehicles/FleetVehicleRow'
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+
+function makeOverview(
+  overrides: Partial<FleetVehicleOverviewData> = {},
+): FleetVehicleOverviewData {
+  return {
+    id: 'v_1',
+    name: 'Toyota Corolla',
+    description: null,
+    photos: ['https://example.com/photo.jpg'],
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: 'Gasoline',
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    utilization: 72,
+    bookingCountLast30Days: 3,
+    currentBooking: null,
+    nextBooking: null,
+    ...overrides,
+  }
+}
+
+describe('FleetVehicleRow', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the vehicle name and its first photo as a thumbnail', () => {
+    const overview = makeOverview()
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
+    const img = screen.getByRole('img', { name: 'Toyota Corolla' })
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg')
+  })
+
+  it('renders the placeholder icon when the vehicle has no photos', () => {
+    const overview = makeOverview({ photos: [] })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    // Placeholder uses data-testid so screen readers don't see a redundant icon.
+    expect(screen.getByTestId('fleet-row-thumbnail-placeholder')).toBeInTheDocument()
+  })
+
+  it('renders seats, transmission, and fuel type as a subtitle', () => {
+    const overview = makeOverview({ seats: 4, transmission: 'MANUAL', fuelType: 'Diesel' })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    // Subtitle format: "4 · MT · Diesel" (seats · transmission · fuel)
+    const subtitle = screen.getByTestId('fleet-row-subtitle')
+    expect(subtitle).toHaveTextContent(/4/)
+    expect(subtitle).toHaveTextContent(/MT/)
+    expect(subtitle).toHaveTextContent(/Diesel/)
+  })
+
+  it('renders the daily rate when only daily is set', () => {
+    const overview = makeOverview({ dailyRateJpy: 8000, hourlyRateJpy: null })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.getByText(/8,000\/day/)).toBeInTheDocument()
+  })
+
+  it('renders the status badge', () => {
+    const overview = makeOverview({ status: 'MAINTENANCE' })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.getByText('Maintenance')).toBeInTheDocument()
+  })
+
+  it('renders "On rental until ..." when currentBooking is set', () => {
+    const overview = makeOverview({
+      currentBooking: {
+        startAt: '2026-04-11T09:00:00Z',
+        endAt: '2026-04-11T18:00:00Z',
+        renterName: 'Alice',
+      },
+    })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    // The row should mention rental-in-progress. We assert the label text
+    // without pinning exact locale formatting, which lives in a helper.
+    expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(
+      /On rental until/,
+    )
+  })
+
+  it('renders "Next: ..." when only nextBooking is set', () => {
+    const overview = makeOverview({
+      nextBooking: {
+        startAt: '2026-04-12T10:00:00Z',
+        endAt: '2026-04-12T14:00:00Z',
+        renterName: null,
+      },
+    })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(/Next:/)
+  })
+
+  it('renders "No upcoming bookings" when neither current nor next is set', () => {
+    const overview = makeOverview({ currentBooking: null, nextBooking: null })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(
+      /No upcoming bookings/,
+    )
+  })
+
+  it('renders utilization percentage rounded to whole number with booking count', () => {
+    const overview = makeOverview({ utilization: 72.4, bookingCountLast30Days: 3 })
+
+    render(
+      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
+    )
+
+    const util = screen.getByTestId('fleet-row-utilization')
+    expect(util).toHaveTextContent(/72%/)
+    expect(util).toHaveTextContent(/3/)
+  })
+
+  it('fires onEdit when the overflow menu Edit action is clicked', async () => {
+    const onEdit = vi.fn()
+    const overview = makeOverview()
+
+    render(<FleetVehicleRow overview={overview} onEdit={onEdit} onRetire={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Edit' }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onEdit).toHaveBeenCalledWith(overview)
+  })
+
+  it('fires onRetire when the overflow menu Retire action is clicked (non-retired)', async () => {
+    const onRetire = vi.fn()
+    const overview = makeOverview({ status: 'AVAILABLE' })
+
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={onRetire} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Retire' }))
+
+    expect(onRetire).toHaveBeenCalledTimes(1)
+    expect(onRetire).toHaveBeenCalledWith(overview)
+  })
+
+  it('hides the Retire action in the overflow menu when the vehicle is already RETIRED', async () => {
+    const overview = makeOverview({ status: 'RETIRED' })
+
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }))
+
+    expect(screen.queryByRole('menuitem', { name: 'Retire' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/components/vehicles/FleetViewToggle.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetViewToggle.test.tsx
@@ -1,0 +1,113 @@
+// The row/grid view toggle that lives in the top bar of the owner-facing
+// fleet list (#52). Kept as a small dedicated component so its state
+// management (localStorage-backed) and presentation can be tested in
+// isolation from VehicleList, which is mostly QueryClient glue.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      'fleet.rowView': 'Row view',
+      'fleet.gridView': 'Grid view',
+    }
+    return messages[key] ?? key
+  },
+}))
+
+import { FleetViewToggle, type FleetViewMode } from '@/components/vehicles/FleetViewToggle'
+
+describe('FleetViewToggle', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders both view options with accessible labels', () => {
+    render(<FleetViewToggle value="row" onChange={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Row view' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Grid view' })).toBeInTheDocument()
+  })
+
+  it('marks the active mode with aria-pressed=true and the inactive one false', () => {
+    render(<FleetViewToggle value="row" onChange={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Row view' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: 'Grid view' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  })
+
+  it('emits onChange("grid") when the Grid view button is clicked while row is active', async () => {
+    const onChange = vi.fn<[FleetViewMode], void>()
+    render(<FleetViewToggle value="row" onChange={onChange} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Grid view' }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('grid')
+  })
+
+  it('emits onChange("row") when the Row view button is clicked while grid is active', async () => {
+    const onChange = vi.fn<[FleetViewMode], void>()
+    render(<FleetViewToggle value="grid" onChange={onChange} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Row view' }))
+
+    expect(onChange).toHaveBeenCalledWith('row')
+  })
+
+  it('does not emit onChange when the already-active button is clicked', async () => {
+    const onChange = vi.fn<[FleetViewMode], void>()
+    render(<FleetViewToggle value="row" onChange={onChange} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Row view' }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+// localStorage-backed persistence is a separate concern from the pure
+// toggle UI. It lives in a hook tested here. We write a couple of
+// behavior-level tests that mutate window.localStorage directly and
+// assert the hook's state.
+import { renderHook, act } from '@testing-library/react'
+import { useFleetViewMode } from '@/components/vehicles/FleetViewToggle'
+
+describe('useFleetViewMode', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('defaults to "row" when nothing is persisted', () => {
+    const { result } = renderHook(() => useFleetViewMode())
+    expect(result.current[0]).toBe('row')
+  })
+
+  it('reads the persisted value on mount', () => {
+    window.localStorage.setItem('kuruma-fleet-view-mode', 'grid')
+    const { result } = renderHook(() => useFleetViewMode())
+    expect(result.current[0]).toBe('grid')
+  })
+
+  it('persists the new value when the setter is called', () => {
+    const { result } = renderHook(() => useFleetViewMode())
+    act(() => {
+      result.current[1]('grid')
+    })
+    expect(result.current[0]).toBe('grid')
+    expect(window.localStorage.getItem('kuruma-fleet-view-mode')).toBe('grid')
+  })
+
+  it('ignores garbage persisted values and falls back to "row"', () => {
+    window.localStorage.setItem('kuruma-fleet-view-mode', 'wrong')
+    const { result } = renderHook(() => useFleetViewMode())
+    expect(result.current[0]).toBe('row')
+  })
+})

--- a/packages/web/tests/lib/fleet-filters.test.ts
+++ b/packages/web/tests/lib/fleet-filters.test.ts
@@ -201,4 +201,46 @@ describe('sortVehicles', () => {
 
     expect(vehicles.map((v) => v.name)).toEqual(originalOrder)
   })
+
+  // Utilization + price sort orders were added for the owner-facing
+  // fleet overview list (#52). They operate on FleetVehicleOverviewData
+  // (utilization) or on VehicleData's pricing columns (price).
+  it('sorts by utilization descending, treating missing utilization as 0', () => {
+    const a = { ...makeVehicle({ name: 'A' }), utilization: 10 }
+    const b = { ...makeVehicle({ name: 'B' }), utilization: 72 }
+    const c = { ...makeVehicle({ name: 'C' }), utilization: 42 }
+
+    const result = sortVehicles([a, b, c], 'utilization-desc')
+
+    expect(result.map((v) => v.name)).toEqual(['B', 'C', 'A'])
+  })
+
+  it('sorts by price ascending, using dailyRateJpy when present', () => {
+    const a = makeVehicle({ name: 'Cheap', dailyRateJpy: 5000 })
+    const b = makeVehicle({ name: 'Expensive', dailyRateJpy: 12000 })
+    const c = makeVehicle({ name: 'Mid', dailyRateJpy: 8000 })
+
+    const result = sortVehicles([a, b, c], 'price-asc')
+
+    expect(result.map((v) => v.name)).toEqual(['Cheap', 'Mid', 'Expensive'])
+  })
+
+  it('sorts by price descending', () => {
+    const a = makeVehicle({ name: 'Cheap', dailyRateJpy: 5000 })
+    const b = makeVehicle({ name: 'Expensive', dailyRateJpy: 12000 })
+
+    const result = sortVehicles([a, b], 'price-desc')
+
+    expect(result.map((v) => v.name)).toEqual(['Expensive', 'Cheap'])
+  })
+
+  it('falls back to hourlyRateJpy for price sorting when dailyRateJpy is null', () => {
+    const a = makeVehicle({ name: 'HourlyOnly', dailyRateJpy: null, hourlyRateJpy: 1500 })
+    const b = makeVehicle({ name: 'BothSet', dailyRateJpy: 6000, hourlyRateJpy: 800 })
+
+    const result = sortVehicles([a, b], 'price-asc')
+
+    // BothSet uses 6000 (daily), HourlyOnly uses 1500 (hourly) — so HourlyOnly first.
+    expect(result.map((v) => v.name)).toEqual(['HourlyOnly', 'BothSet'])
+  })
 })


### PR DESCRIPTION
Closes #52.

Replaces the card-grid on `/manage/vehicles` with a dense row-based layout that answers the three questions the owner actually has: *where is every car right now, which is making money, can I flip things fast.* Built as a vertical slice — DB query → API route → shared types → components → list integration → i18n → page wiring — with strict RED-GREEN-REFACTOR TDD throughout.

## Summary

### API (commit 1)
- `GET /vehicles/fleet-overview` — new aggregated read returning each vehicle enriched with `utilization` %, `bookingCountLast30Days`, `currentBooking`, `nextBooking`.
- `FleetOverviewRepository` interface split from `VehicleRepository` (same pattern as `AvailabilityRepository`) because it reads across `vehicles + bookings + users.name`.
- `DrizzleFleetOverviewRepository` uses **two round-trips** (vehicles once, bookings once with `LEFT JOIN users`) and aggregates in JS — avoids the N+1 Query anti-pattern, no hairy window-function SQL. 40-50 cars × ~200 bookings is trivially fast.
- **Utilization formula**: `sum(booked_hours in last 30d for non-CANCELLED bookings) / (30 * 24) * 100`. Uses `endAt`, not `effectiveEndAt` — buffer time excluded per spec. Overlap is clipped to the `[now-30d, now]` window so bookings that started earlier or extend into the future only count for the portion inside the window.
- Route registered **before** `/vehicles/:id` in `createApp` so the specific path wins Hono's match order.
- New shared type `@kuruma/shared/types/fleet` exported via `packages/shared/package.json`.

### Web (commit 2)
- **`FleetVehicleRow`** — thumbnail · name+subtitle · status pill · booking indicator ("On rental until …" / "Next: …" / "No upcoming bookings") · price · utilization % · overflow menu (Edit/Retire). The `FleetVehicleCard` used by the renter-facing browse page is untouched.
- **`FleetSummaryBar`** — `{n} cars · {x} on rental · {y} available · {z} maintenance`. "On rental" reflects operational state (`currentBooking` present), **not** the db `status` column — a vehicle can be AVAILABLE and actively rented.
- **`FleetViewToggle` + `useFleetViewMode`** hook — row/grid toggle with localStorage-backed persistence and `aria-pressed` state.
- `VehicleList` now fetches `fleet-overview` with `['vehicles', 'fleet-overview']` query key. Default sort = `utilization-desc` (most-booked first).
- `SortOrder` extended with `utilization-desc`, `price-asc`, `price-desc`. `sortVehicles` and `filterVehicles` both made **generic** (`<T extends …>`) so the owner list keeps its concrete `FleetVehicleOverviewData[]` type through the pipeline while existing callers still infer `VehicleData[]`.
- **i18n**: additive `business.vehicles.fleet.*` subsection in en/ja/zh plus three new sort keys. No existing key touched — avoids collision with #50's rental rules.

### Commit 3
- Two overlap-clipping tests added after code review: a booking that started before the window and a currently-active booking extending past `now`. Both are mutation-resistant — would fail if the clipping logic were dropped.

## Collision avoidance

Deliberately avoided editing `VehicleForm.tsx`, `EditVehicleDialog.tsx`, `validators/vehicle.ts`, `routes/vehicles.ts`, and the pre-existing vehicle route tests. Those belong to #49/#50/#51. The new API route lives in its own file (`routes/fleet-overview.ts`) and the aggregation lives on its own repository. Rebased cleanly onto current `main` (which now contains both #50 and #51) without conflicts.

## Verified

- ✅ **305 tests** passing (202 web + 103 api), **41 new** for this slice
- ✅ `bun run --filter '*' typecheck` clean across api/web/shared
- ✅ `biome check` clean
- ✅ Mutation-resistant tests: specific value assertions, not truthiness
- ✅ TDD cycles documented in commit history — every RED observed before GREEN

## Test plan

- [ ] `bun run test` — all green
- [ ] `bun run --filter '*' typecheck` — all green
- [ ] Manual: visit `/manage/vehicles` in dev — row view renders with thumbnail/status/booking/price/utilization, overflow menu edits + retires, view toggle persists across reload, filters still work, sort defaults to utilization-desc
- [ ] Manual: seed a currently-active booking and confirm "On rental until" appears with the right time in Asia/Tokyo
- [ ] Manual: switch locales (en/ja/zh) and confirm the new strings render correctly

## Out of scope

- Vehicle detail page (slice 6, issue #53)
- Revenue per vehicle (future)
- Integration tests against a real Postgres for `DrizzleFleetOverviewRepository` — the aggregation logic is verified behaviorally against the in-memory repo, which is kept in lock-step. Can add if the existing `test:integration` suite gets wired into CI.