### PR TITLE
chore(web): fix pre-existing biome errors in fleet test files

### DIFF
--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -215,11 +215,7 @@ describe('InMemoryFleetOverviewRepository', () => {
 
   it('resolves renterName from the injected renter map for current/next bookings', async () => {
     const renterNameByUserId = new Map<string, string>([['user_alice', 'Alice Smith']])
-    fleetRepo = new InMemoryFleetOverviewRepository(
-      vehicleRepo,
-      bookingRepo,
-      renterNameByUserId,
-    )
+    fleetRepo = new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo, renterNameByUserId)
 
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Alice Rental' }))
     await bookingRepo.create(

--- a/packages/web/tests/components/vehicles/FleetVehicleRow.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetVehicleRow.test.tsx
@@ -40,9 +40,7 @@ vi.mock('next-intl', () => ({
 import { FleetVehicleRow } from '@/components/vehicles/FleetVehicleRow'
 import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
 
-function makeOverview(
-  overrides: Partial<FleetVehicleOverviewData> = {},
-): FleetVehicleOverviewData {
+function makeOverview(overrides: Partial<FleetVehicleOverviewData> = {}): FleetVehicleOverviewData {
   return {
     id: 'v_1',
     name: 'Toyota Corolla',
@@ -76,9 +74,7 @@ describe('FleetVehicleRow', () => {
   it('renders the vehicle name and its first photo as a thumbnail', () => {
     const overview = makeOverview()
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText('Toyota Corolla')).toBeInTheDocument()
     const img = screen.getByRole('img', { name: 'Toyota Corolla' })
@@ -88,9 +84,7 @@ describe('FleetVehicleRow', () => {
   it('renders the placeholder icon when the vehicle has no photos', () => {
     const overview = makeOverview({ photos: [] })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
     // Placeholder uses data-testid so screen readers don't see a redundant icon.
@@ -100,9 +94,7 @@ describe('FleetVehicleRow', () => {
   it('renders seats, transmission, and fuel type as a subtitle', () => {
     const overview = makeOverview({ seats: 4, transmission: 'MANUAL', fuelType: 'Diesel' })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     // Subtitle format: "4 · MT · Diesel" (seats · transmission · fuel)
     const subtitle = screen.getByTestId('fleet-row-subtitle')
@@ -114,9 +106,7 @@ describe('FleetVehicleRow', () => {
   it('renders the daily rate when only daily is set', () => {
     const overview = makeOverview({ dailyRateJpy: 8000, hourlyRateJpy: null })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText(/8,000\/day/)).toBeInTheDocument()
   })
@@ -124,9 +114,7 @@ describe('FleetVehicleRow', () => {
   it('renders the status badge', () => {
     const overview = makeOverview({ status: 'MAINTENANCE' })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByText('Maintenance')).toBeInTheDocument()
   })
@@ -140,15 +128,11 @@ describe('FleetVehicleRow', () => {
       },
     })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     // The row should mention rental-in-progress. We assert the label text
     // without pinning exact locale formatting, which lives in a helper.
-    expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(
-      /On rental until/,
-    )
+    expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(/On rental until/)
   })
 
   it('renders "Next: ..." when only nextBooking is set', () => {
@@ -160,9 +144,7 @@ describe('FleetVehicleRow', () => {
       },
     })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(/Next:/)
   })
@@ -170,9 +152,7 @@ describe('FleetVehicleRow', () => {
   it('renders "No upcoming bookings" when neither current nor next is set', () => {
     const overview = makeOverview({ currentBooking: null, nextBooking: null })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     expect(screen.getByTestId('fleet-row-booking-indicator')).toHaveTextContent(
       /No upcoming bookings/,
@@ -182,9 +162,7 @@ describe('FleetVehicleRow', () => {
   it('renders utilization percentage rounded to whole number with booking count', () => {
     const overview = makeOverview({ utilization: 72.4, bookingCountLast30Days: 3 })
 
-    render(
-      <FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />,
-    )
+    render(<FleetVehicleRow overview={overview} onEdit={vi.fn()} onRetire={vi.fn()} />)
 
     const util = screen.getByTestId('fleet-row-utilization')
     expect(util).toHaveTextContent(/72%/)

--- a/packages/web/tests/components/vehicles/FleetViewToggle.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetViewToggle.test.tsx
@@ -17,7 +17,7 @@ vi.mock('next-intl', () => ({
   },
 }))
 
-import { FleetViewToggle, type FleetViewMode } from '@/components/vehicles/FleetViewToggle'
+import { type FleetViewMode, FleetViewToggle } from '@/components/vehicles/FleetViewToggle'
 
 describe('FleetViewToggle', () => {
   afterEach(() => {
@@ -34,10 +34,7 @@ describe('FleetViewToggle', () => {
   it('marks the active mode with aria-pressed=true and the inactive one false', () => {
     render(<FleetViewToggle value="row" onChange={vi.fn()} />)
 
-    expect(screen.getByRole('button', { name: 'Row view' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
+    expect(screen.getByRole('button', { name: 'Row view' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: 'Grid view' })).toHaveAttribute(
       'aria-pressed',
       'false',
@@ -73,12 +70,12 @@ describe('FleetViewToggle', () => {
   })
 })
 
+import { useFleetViewMode } from '@/components/vehicles/FleetViewToggle'
 // localStorage-backed persistence is a separate concern from the pure
 // toggle UI. It lives in a hook tested here. We write a couple of
 // behavior-level tests that mutate window.localStorage directly and
 // assert the hook's state.
-import { renderHook, act } from '@testing-library/react'
-import { useFleetViewMode } from '@/components/vehicles/FleetViewToggle'
+import { act, renderHook } from '@testing-library/react'
 
 describe('useFleetViewMode', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Three pre-existing biome errors in two fleet test files, all mechanical autofixes from `biome check --write`:

- `FleetViewToggle.test.tsx` — `organizeImports` (import sort order) + `format` (whitespace)
- `FleetVehicleRow.test.tsx` — `format` (collapsing multiline `render(<X />)` calls to one line)

No assertion text, JSX props, or test logic was touched. These landed on main via #52 (commit `154e5e3`) and were missed by that PR's lint gate.

## Verification

| Gate | Result |
|------|--------|
| `bunx biome check ./packages/web/src ./packages/web/tests` | clean (133 files, no fixes) |
| `bun run --filter @kuruma/web test` | 31 files / 232 tests passed (matches baseline) |
| `bunx tsc --noEmit` (packages/web) | zero output |

## Out of scope

Any other biome findings in the tree are follow-up work, not this PR. The `--write` was scoped to only the two affected files.

Closes #71