### PR TITLE
chore: enable exactOptionalPropertyTypes + forceConsistentCasingInFileNames

### DIFF
--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -4,7 +4,7 @@ import {
   updateVehicleStatusSchema,
 } from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
-import type { VehicleRepository } from '../repositories/types'
+import type { Vehicle, VehicleRepository } from '../repositories/types'
 
 export function createVehicleRoutes(repo: VehicleRepository): Hono {
   const vehicles = new Hono()
@@ -63,16 +63,23 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
       return c.json({ success: false, error: result.error.flatten().fieldErrors }, 400)
     }
 
-    const updated = await repo.update(existing.id, {
-      ...result.data,
-      description: result.data.description ?? existing.description,
-      fuelType: result.data.fuelType ?? existing.fuelType,
-      minRentalHours: result.data.minRentalHours ?? existing.minRentalHours,
-      maxRentalHours: result.data.maxRentalHours ?? existing.maxRentalHours,
-      advanceBookingHours: result.data.advanceBookingHours ?? existing.advanceBookingHours,
-      dailyRateJpy: result.data.dailyRateJpy ?? existing.dailyRateJpy,
-      hourlyRateJpy: result.data.hourlyRateJpy ?? existing.hourlyRateJpy,
-    })
+    // Strip keys the partial schema left as `undefined` — Partial<Vehicle>
+    // under exactOptionalPropertyTypes forbids explicit undefined values.
+    const updated = await repo.update(
+      existing.id,
+      Object.fromEntries(
+        Object.entries({
+          ...result.data,
+          description: result.data.description ?? existing.description,
+          fuelType: result.data.fuelType ?? existing.fuelType,
+          minRentalHours: result.data.minRentalHours ?? existing.minRentalHours,
+          maxRentalHours: result.data.maxRentalHours ?? existing.maxRentalHours,
+          advanceBookingHours: result.data.advanceBookingHours ?? existing.advanceBookingHours,
+          dailyRateJpy: result.data.dailyRateJpy ?? existing.dailyRateJpy,
+          hourlyRateJpy: result.data.hourlyRateJpy ?? existing.hourlyRateJpy,
+        }).filter(([, v]) => v !== undefined),
+      ) as Partial<Vehicle>,
+    )
 
     return c.json({ success: true, data: updated })
   })

--- a/packages/web/src/components/vehicles/ActiveFilters.tsx
+++ b/packages/web/src/components/vehicles/ActiveFilters.tsx
@@ -2,8 +2,8 @@ import { Calendar } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 interface ActiveFiltersProps {
-  readonly from?: string
-  readonly to?: string
+  readonly from?: string | undefined
+  readonly to?: string | undefined
 }
 
 export function ActiveFilters({ from, to }: ActiveFiltersProps) {

--- a/packages/web/src/components/vehicles/EditVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/EditVehicleDialog.tsx
@@ -57,11 +57,11 @@ export function EditVehicleDialog({ vehicle, onOpenChange }: EditVehicleDialogPr
             isSubmitting={isSubmitting}
             defaultValues={{
               name: vehicle.name,
-              description: vehicle.description ?? undefined,
-              photos: vehicle.photos,
+              ...(vehicle.description != null && { description: vehicle.description }),
+              photos: vehicle.photos ?? [],
               seats: vehicle.seats,
               transmission: vehicle.transmission,
-              fuelType: vehicle.fuelType ?? undefined,
+              ...(vehicle.fuelType != null && { fuelType: vehicle.fuelType }),
               bufferMinutes: vehicle.bufferMinutes,
               // Issue #60: the rate inputs were added in #48 but this
               // whitelist forgot to forward them, so the edit form

--- a/packages/web/src/lib/fleet-filters.ts
+++ b/packages/web/src/lib/fleet-filters.ts
@@ -4,7 +4,7 @@ export type VehicleStatus = VehicleData['status']
 export type Transmission = VehicleData['transmission']
 
 export interface FleetFilterState {
-  search?: string
+  search?: string | undefined
   statuses?: VehicleStatus[]
   transmissions?: Transmission[]
   seatsMin?: number

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,8 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary

- Enables `exactOptionalPropertyTypes` and `forceConsistentCasingInFileNames` in `tsconfig.base.json`, completing the strict TS config mandated by project rules
- Fixes all 5 type errors (across 4 source files) surfaced by the new flag -- all optional-prop type mismatches, zero behavior changes

## Files changed

| File | Fix |
|------|-----|
| `tsconfig.base.json` | Added `exactOptionalPropertyTypes: true`, `forceConsistentCasingInFileNames: true` |
| `packages/api/src/routes/vehicles.ts` | Strip `undefined` entries from partial update object before passing to `repo.update()` |
| `packages/web/src/components/vehicles/ActiveFilters.tsx` | Widen `from`/`to` props to `string \| undefined` |
| `packages/web/src/components/vehicles/EditVehicleDialog.tsx` | Use conditional spread for nullable fields, fallback `[]` for photos |
| `packages/web/src/lib/fleet-filters.ts` | Widen `search` to `string \| undefined` in `FleetFilterState` |

## Verification

| Gate | Result |
|------|--------|
| `tsc --noEmit` (shared) | 0 errors |
| `tsc --noEmit` (api) | 0 errors |
| `tsc --noEmit` (web) | 0 errors |
| Tests (shared) | 7 files / 104 tests passed |
| Tests (api) | 10 files / 108 tests passed |
| Tests (web) | 29 files / 216 tests passed |
| `bun run --filter @kuruma/web build` | exit 0 |
| `bunx biome check .` | No errors |

Closes #78

Generated with [Claude Code](https://claude.com/claude-code)