### PR TITLE
chore(ci): add typecheck step and docs-only skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   test-and-build:
@@ -21,6 +27,9 @@ jobs:
 
       - name: Lint
         run: bun run lint
+
+      - name: Typecheck
+        run: bun run --filter '*' typecheck
 
       - name: Test (all packages)
         run: bun run test


### PR DESCRIPTION
## Summary

Two additive improvements to `.github/workflows/ci.yml`:

- **Typecheck step** added to `test-and-build` between Lint and Test. Runs `bun run --filter '*' typecheck` (tsc --noEmit across all packages). Catches type regressions — critical now that #81 enabled `exactOptionalPropertyTypes`.
- **`paths-ignore`** added for `**.md` and `docs/**` on both push and PR triggers. Docs-only changes skip the full lint+test+build suite.

No existing checks removed. `db-drift` job is completely unchanged.

## Test plan

- [x] YAML is valid (ruby YAML.load_file)
- [ ] CI runs successfully on this PR branch (proves the new typecheck step passes)
- [ ] `db-drift` job still runs and passes

Closes #82