### PR TITLE
chore(shared): add canonical ApiResponse<T> discriminated union type

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "./validators/auth": "./src/validators/auth.ts",
     "./validators/message": "./src/validators/message.ts",
     "./types/stats": "./src/types/stats.ts",
+    "./types/api-response": "./src/types/api-response.ts",
     "./types/fleet": "./src/types/fleet.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts"
   },

--- a/packages/shared/src/types/api-response.ts
+++ b/packages/shared/src/types/api-response.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical API response shape used by all Hono routes and consumed
+ * by all web-side fetchers. Discriminated union on `success`:
+ *
+ * - success=true  -> `data: T` is guaranteed
+ * - success=false -> `error: string` is guaranteed
+ *
+ * Consumer migration tracked in the feature-modules PR-2/PR-3 plan.
+ */
+export type ApiResponse<T> =
+  | { success: true; data: T }
+  | {
+      success: false
+      error: string
+      code?: string
+      details?: Record<string, string[]>
+    }

--- a/packages/shared/tests/types/api-response.test.ts
+++ b/packages/shared/tests/types/api-response.test.ts
@@ -1,0 +1,55 @@
+import type { ApiResponse } from '@kuruma/shared/types/api-response'
+import { describe, expect, it } from 'vitest'
+
+describe('ApiResponse<T>', () => {
+  it('narrows to data on success', () => {
+    const response: ApiResponse<{ id: string }> = {
+      success: true,
+      data: { id: 'abc' },
+    }
+
+    if (response.success) {
+      // TypeScript narrows: response.data is { id: string }, not optional
+      expect(response.data.id).toBe('abc')
+    }
+  })
+
+  it('narrows to error on failure', () => {
+    const response: ApiResponse<{ id: string }> = {
+      success: false,
+      error: 'Not found',
+    }
+
+    if (!response.success) {
+      // TypeScript narrows: response.error is string, guaranteed
+      expect(response.error).toBe('Not found')
+    }
+  })
+
+  it('allows optional code and details on failure', () => {
+    const response: ApiResponse<never> = {
+      success: false,
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: { email: ['Invalid email format'] },
+    }
+
+    if (!response.success) {
+      expect(response.code).toBe('VALIDATION_ERROR')
+      expect(response.details?.email).toEqual(['Invalid email format'])
+    }
+  })
+
+  it('forbids data on failure branch', () => {
+    // This test verifies the discriminated union is correct at the type level.
+    // If someone tried to access .data on the failure branch, TypeScript
+    // would error. We verify the runtime shape instead:
+    const response: ApiResponse<string> = { success: false, error: 'bad' }
+    expect('data' in response).toBe(false)
+  })
+
+  it('forbids error on success branch', () => {
+    const response: ApiResponse<string> = { success: true, data: 'ok' }
+    expect('error' in response).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `ApiResponse<T>` discriminated union type to `@kuruma/shared/types/api-response`:

```typescript
export type ApiResponse<T> =
  | { success: true; data: T }
  | { success: false; error: string; code?: string; details?: Record<string, string[]> }
```

Four duplicate definitions currently exist across `packages/web/src/lib/` (calendar.ts, vehicles.ts, vehicle-api.ts, bookings.ts). Consumer migration happens in PR-2/PR-3 of the feature-modules initiative — this PR only adds the shared type + tests.

## Test plan

- [x] 5 new tests exercising discriminated union narrowing
- [x] Existing tests unchanged (shared/api/web all green)
- [x] tsc --noEmit clean across all packages
- [ ] CI green

Closes #95