### PR TITLE
refactor(api): deduplicate inline type definitions

### DIFF
--- a/packages/api/src/repositories/drizzle.ts
+++ b/packages/api/src/repositories/drizzle.ts
@@ -12,6 +12,7 @@ import { and, asc, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 import type {
   AvailabilityRepository,
+  BookingFilters,
   BookingRepository,
   DashboardStats,
   FleetOverviewRepository,
@@ -274,13 +275,7 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
 export class DrizzleBookingRepository implements BookingRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: {
-    status?: string
-    vehicleId?: string
-    renterId?: string
-    from?: Date
-    to?: Date
-  }): Promise<Booking[]> {
+  async findAll(filters?: BookingFilters): Promise<Booking[]> {
     const conditions = []
 
     if (filters?.status) {
@@ -408,10 +403,9 @@ const messageColumns = {
   createdAt: messages.createdAt,
 }
 
-// `messages.translations` is a nullable text column with a default of '{}'.
-// The shared `Message` type declares it as `string` (non-null), so we
-// normalise NULL → '{}' at the boundary rather than leak the DB nuance.
-function normaliseMessage(row: {
+// Raw row shape returned by message queries. Extracted because it appears in
+// normaliseMessage, the DISTINCT ON raw-SQL result, and the neon-http coercion.
+type RawMessageRow = {
   id: string
   threadId: string
   senderId: string
@@ -419,7 +413,12 @@ function normaliseMessage(row: {
   sourceLanguage: string | null
   translations: string | null
   createdAt: Date
-}): Message {
+}
+
+// `messages.translations` is a nullable text column with a default of '{}'.
+// The shared `Message` type declares it as `string` (non-null), so we
+// normalise NULL → '{}' at the boundary rather than leak the DB nuance.
+function normaliseMessage(row: RawMessageRow): Message {
   return {
     id: row.id,
     threadId: row.threadId,
@@ -461,15 +460,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
     // Step 4: fetch only the latest message per thread. The DISTINCT ON
     // pattern keeps this O(threads) instead of O(messages) — important once
     // any single conversation grows beyond a few dozen messages.
-    const lastMessageRows = await this.db.execute<{
-      id: string
-      threadId: string
-      senderId: string
-      content: string
-      sourceLanguage: string | null
-      translations: string | null
-      createdAt: Date
-    }>(sql`
+    const lastMessageRows = await this.db.execute<RawMessageRow>(sql`
       SELECT DISTINCT ON ("threadId")
         "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "createdAt"
       FROM "messages"
@@ -486,15 +477,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
       Array.isArray(lastMessageRows)
         ? lastMessageRows
         : ((lastMessageRows as { rows?: unknown[] }).rows ?? [])
-    ) as Array<{
-      id: string
-      threadId: string
-      senderId: string
-      content: string
-      sourceLanguage: string | null
-      translations: string | null
-      createdAt: Date
-    }>
+    ) as Array<RawMessageRow>
 
     const lastMessageByThreadId = new Map<string, Message>()
     for (const row of lastMessageList) {

--- a/packages/api/src/repositories/in-memory.ts
+++ b/packages/api/src/repositories/in-memory.ts
@@ -2,6 +2,7 @@ import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 import type {
   AvailabilityRepository,
+  BookingFilters,
   BookingRepository,
   DashboardStats,
   FleetOverviewRepository,
@@ -78,13 +79,7 @@ export class InMemoryBookingRepository implements BookingRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: {
-    status?: string
-    vehicleId?: string
-    renterId?: string
-    from?: Date
-    to?: Date
-  }): Promise<Booking[]> {
+  async findAll(filters?: BookingFilters): Promise<Booking[]> {
     let results = [...this.store.values()]
 
     if (filters?.status) {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -28,14 +28,16 @@ export interface FleetOverviewRepository {
   findFleetOverview(): Promise<FleetVehicleOverview[]>
 }
 
+export interface BookingFilters {
+  status?: string
+  vehicleId?: string
+  renterId?: string
+  from?: Date
+  to?: Date
+}
+
 export interface BookingRepository {
-  findAll(filters?: {
-    status?: string
-    vehicleId?: string
-    renterId?: string
-    from?: Date
-    to?: Date
-  }): Promise<Booking[]>
+  findAll(filters?: BookingFilters): Promise<Booking[]>
   findById(id: string): Promise<Booking | undefined>
   create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking>
   updateStatus(id: string, status: string): Promise<Booking | undefined>

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,5 +1,6 @@
 import { createBookingSchema } from '@kuruma/shared/validators/booking'
 import { Hono } from 'hono'
+import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
 import { fail, ok, parseDateRange } from './helpers'
 
@@ -15,13 +16,7 @@ export function createBookingRoutes(service: BookingService): Hono {
     const dateRange = parseDateRange(c, false)
     if (!dateRange.ok) return dateRange.response
 
-    const filters: {
-      status?: string
-      vehicleId?: string
-      renterId?: string
-      from?: Date
-      to?: Date
-    } = {}
+    const filters: BookingFilters = {}
     if (statusFilter) filters.status = statusFilter
     if (vehicleIdFilter) filters.vehicleId = vehicleIdFilter
     if (renterIdFilter) filters.renterId = renterIdFilter


### PR DESCRIPTION
## Summary
- Extract `RawMessageRow` type alias in `drizzle.ts` — 3 identical 8-field inline shapes replaced by 1 named type
- Extract `BookingFilters` interface in `repositories/types.ts` — reused across routes, drizzle repo, and in-memory repo instead of 4 inline copies
- Net: -26 lines of duplicated type definitions

## Files changed
- `packages/api/src/repositories/types.ts` — new `BookingFilters` interface
- `packages/api/src/repositories/drizzle.ts` — `RawMessageRow` type + `BookingFilters` import
- `packages/api/src/repositories/in-memory.ts` — `BookingFilters` import
- `packages/api/src/routes/bookings.ts` — `BookingFilters` import

## Test plan
- [x] `tsc --noEmit` clean
- [x] 109/109 API tests passing (no behavioral changes)

Closes #97