### PR TITLE
fix(ci): remove paths-ignore so db-drift is non-bypassable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 
 jobs:
   test-and-build:


### PR DESCRIPTION
## Summary
- Removes workflow-level `paths-ignore` from CI triggers
- `db-drift` now runs on every push/PR, matching its "non-bypassable" designation
- `test-and-build` also runs on docs-only PRs (~2 min cost, acceptable trade-off)

## Context
The `paths-ignore` added in PR #85 skipped `**.md` and `docs/**` at the workflow level, which inadvertently applied to both `test-and-build` AND `db-drift`. The `db-drift` job exists specifically because of two past incidents (issue #27) where schema changes shipped without migrations. It should never be skippable.

## Test plan
- [ ] CI runs on this PR (proves the trigger works without paths-ignore)
- [ ] db-drift job appears and runs

Closes #85 scope gap.