### PR TITLE
chore(shared): add missing export paths for rental-rules, booking, vehicle

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,10 @@
     "./types/fleet": "./src/types/fleet.ts",
     "./types/vehicle-detail": "./src/types/vehicle-detail.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
-    "./lib/pricing": "./src/lib/pricing.ts"
+    "./lib/pricing": "./src/lib/pricing.ts",
+    "./lib/rental-rules": "./src/lib/rental-rules.ts",
+    "./validators/booking": "./src/validators/booking.ts",
+    "./validators/vehicle": "./src/validators/vehicle.ts"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Adds three missing `exports` entries to `packages/shared/package.json`:
  - `./lib/rental-rules`
  - `./validators/booking`
  - `./validators/vehicle`

## Context
These modules are actively imported by `@kuruma/api` but had no explicit export path. Bun workspace mode resolves them via filesystem fallback, but stricter bundlers (or a future non-workspace consumer like a standalone deploy) would fail.

Found during code review of PRs #77-#96.

## Test plan
- [ ] `bun run --filter @kuruma/shared typecheck` passes
- [ ] CI passes (lint, typecheck, test, build)

Note: `@kuruma/api` has two pre-existing `exactOptionalPropertyTypes` errors unrelated to this change (tracked separately).