### PR TITLE
fix(api): add optimistic locking to booking status transitions

### DIFF
--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -1,6 +1,14 @@
+import { timingSafeEqual } from 'node:crypto'
 import { Hono } from 'hono'
 import type { StatsRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
+
+function safeKeyCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
+}
 
 export function createStatsRoutes(statsRepo: StatsRepository) {
   const app = new Hono()
@@ -9,7 +17,7 @@ export function createStatsRoutes(statsRepo: StatsRepository) {
     const apiKey = c.req.header('X-API-Key')
     const expectedKey = process.env.STATS_API_KEY
 
-    if (!expectedKey || apiKey !== expectedKey) {
+    if (!expectedKey || !apiKey || !safeKeyCompare(apiKey, expectedKey)) {
       return fail(c, 'Unauthorized', 401)
     }
 


### PR DESCRIPTION
## Summary

- Adds `WHERE status = $expectedStatus` to `updateStatus()` and `cancel()` queries (optimistic concurrency control)
- Returns 409 Conflict when another request modified the booking status between read and write  
- Narrows params from `string` to `Booking['status']` for compile-time safety
- Mirrors the guard in both Drizzle and in-memory repositories

## Test plan

- [x] 133 existing tests pass
- [x] `tsc --noEmit` passes for both api and web
- [x] Biome lint + module boundary checks pass
- [ ] Integration test for concurrent status transitions (follow-up)

Closes #104