### PR TITLE
fix(api): add optimistic locking to booking status transitions

### DIFF
--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -62,11 +62,15 @@ export class DrizzleBookingRepository implements BookingRepository {
     return inserted as Booking
   }
 
-  async updateStatus(id: string, status: string): Promise<Booking | undefined> {
+  async updateStatus(
+    id: string,
+    expectedStatus: Booking['status'],
+    newStatus: Booking['status'],
+  ): Promise<Booking | undefined> {
     const [updated] = await this.db
       .update(bookings)
-      .set({ status: status as Booking['status'], updatedAt: sql`now()` })
-      .where(eq(bookings.id, id))
+      .set({ status: newStatus, updatedAt: sql`now()` })
+      .where(and(eq(bookings.id, id), eq(bookings.status, expectedStatus)))
       .returning()
 
     return (updated as Booking) ?? undefined
@@ -74,6 +78,7 @@ export class DrizzleBookingRepository implements BookingRepository {
 
   async cancel(
     id: string,
+    expectedStatus: Booking['status'],
     cancellationFee: number,
     cancelledAt: Date,
   ): Promise<Booking | undefined> {
@@ -85,7 +90,7 @@ export class DrizzleBookingRepository implements BookingRepository {
         cancelledAt,
         updatedAt: sql`now()`,
       })
-      .where(eq(bookings.id, id))
+      .where(and(eq(bookings.id, id), eq(bookings.status, expectedStatus)))
       .returning()
 
     return (cancelled as Booking) ?? undefined

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -82,13 +82,17 @@ export class InMemoryBookingRepository implements BookingRepository {
     return booking
   }
 
-  async updateStatus(id: string, status: string): Promise<Booking | undefined> {
+  async updateStatus(
+    id: string,
+    expectedStatus: Booking['status'],
+    newStatus: Booking['status'],
+  ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
-    if (!existing) return undefined
+    if (!existing || existing.status !== expectedStatus) return undefined
 
     const updated: Booking = {
       ...existing,
-      status: status as Booking['status'],
+      status: newStatus,
       updatedAt: new Date(),
     }
     this.store.set(updated.id, updated)
@@ -97,11 +101,12 @@ export class InMemoryBookingRepository implements BookingRepository {
 
   async cancel(
     id: string,
+    expectedStatus: Booking['status'],
     cancellationFee: number,
     cancelledAt: Date,
   ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
-    if (!existing) return undefined
+    if (!existing || existing.status !== expectedStatus) return undefined
 
     const cancelled: Booking = {
       ...existing,

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -40,8 +40,17 @@ export interface BookingRepository {
   findAll(filters?: BookingFilters): Promise<Booking[]>
   findById(id: string): Promise<Booking | undefined>
   create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking>
-  updateStatus(id: string, status: string): Promise<Booking | undefined>
-  cancel(id: string, cancellationFee: number, cancelledAt: Date): Promise<Booking | undefined>
+  updateStatus(
+    id: string,
+    expectedStatus: Booking['status'],
+    newStatus: Booking['status'],
+  ): Promise<Booking | undefined>
+  cancel(
+    id: string,
+    expectedStatus: Booking['status'],
+    cancellationFee: number,
+    cancelledAt: Date,
+  ): Promise<Booking | undefined>
 }
 
 export interface StatsRepository {

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -29,7 +29,7 @@ export type CreateBookingResult =
 
 export type StatusTransitionResult =
   | { ok: true; booking: Booking }
-  | { ok: false; status: 404 | 400; error: string }
+  | { ok: false; status: 400 | 404 | 409; error: string }
 
 export type CancelResult =
   | {
@@ -187,9 +187,17 @@ export class BookingService {
       }
     }
 
-    const updated = await this.bookingRepo.updateStatus(booking.id, newStatus)
+    const updated = await this.bookingRepo.updateStatus(
+      booking.id,
+      booking.status,
+      newStatus as Booking['status'],
+    )
     if (!updated) {
-      return { ok: false, status: 404 as const, error: 'Booking disappeared during status update' }
+      return {
+        ok: false,
+        status: 409,
+        error: 'Booking status was modified by another request. Please retry.',
+      }
     }
     return { ok: true, booking: updated }
   }
@@ -211,9 +219,18 @@ export class BookingService {
     const now = new Date()
     const cancellation = calculateCancellationFee(booking.startAt, now, booking.totalPrice ?? 0)
 
-    const updated = await this.bookingRepo.cancel(booking.id, cancellation.feeAmount, now)
+    const updated = await this.bookingRepo.cancel(
+      booking.id,
+      booking.status,
+      cancellation.feeAmount,
+      now,
+    )
     if (!updated) {
-      return { ok: false, status: 404 as const, error: 'Booking disappeared during cancellation' }
+      return {
+        ok: false,
+        status: 409,
+        error: 'Booking status was modified by another request. Please retry.',
+      }
     }
     return { ok: true, booking: updated, cancellation }
   }


### PR DESCRIPTION
## Summary

- Adds `WHERE status = $expectedStatus` to `updateStatus()` and `cancel()` queries (optimistic concurrency control)
- Returns 409 Conflict when another request modified the booking status between read and write
- Narrows params from `string` to `Booking['status']` for compile-time safety
- Mirrors the guard in both Drizzle and in-memory repositories

## Test plan

- [x] 133 existing tests pass
- [x] `tsc --noEmit` passes for api and web
- [x] Biome lint + module boundary checks pass

Closes #104