### PR TITLE
feat(api): add idempotencyKey to prevent duplicate bookings

### DIFF
--- a/drizzle/0011_add-idempotency-key.sql
+++ b/drizzle/0011_add-idempotency-key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "bookings" ADD COLUMN "idempotencyKey" text;

--- a/drizzle/0012_idempotency-unique-index.sql
+++ b/drizzle/0012_idempotency-unique-index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "bookings_idempotency_key_unique" ON "bookings" ("idempotencyKey") WHERE "idempotencyKey" IS NOT NULL;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,726 @@
+{
+  "id": "d5468c41-973d-4e59-8e5a-271ca7963afc",
+  "prevId": "29a176b6-5ef6-407f-80da-d813b72154d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_vehicleId_vehicles_id_fk": {
+          "name": "bookings_vehicleId_vehicles_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "bufferMinutes": {
+          "name": "bufferMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,726 @@
+{
+  "id": "29b5ff44-5e68-47db-8a93-30a8749f52e5",
+  "prevId": "d5468c41-973d-4e59-8e5a-271ca7963afc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "bookings_vehicleId_vehicles_id_fk": {
+          "name": "bookings_vehicleId_vehicles_id_fk",
+          "tableFrom": "bookings",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "tableTo": "vehicles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "tableTo": "threads",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "tableTo": "threads",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "tableTo": "bookings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "bufferMinutes": {
+          "name": "bufferMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1776007624986,
       "tag": "0010_add-fk-indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776013170170,
+      "tag": "0011_add-idempotency-key",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776013177988,
+      "tag": "0012_idempotency-unique-index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -40,6 +40,15 @@ export class DrizzleBookingRepository implements BookingRepository {
     return (row as Booking) ?? undefined
   }
 
+  async findByIdempotencyKey(key: string): Promise<Booking | undefined> {
+    const [row] = await this.db
+      .select(bookingColumns)
+      .from(bookings)
+      .where(eq(bookings.idempotencyKey, key))
+
+    return (row as Booking) ?? undefined
+  }
+
   async create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
     const [inserted] = await this.db
       .insert(bookings)
@@ -56,6 +65,7 @@ export class DrizzleBookingRepository implements BookingRepository {
         totalPrice: data.totalPrice,
         cancellationFee: data.cancellationFee,
         cancelledAt: data.cancelledAt,
+        idempotencyKey: data.idempotencyKey,
       })
       .returning()
 

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -43,6 +43,7 @@ export const bookingColumns = {
   totalPrice: bookings.totalPrice,
   cancellationFee: bookings.cancellationFee,
   cancelledAt: bookings.cancelledAt,
+  idempotencyKey: bookings.idempotencyKey,
   createdAt: bookings.createdAt,
   updatedAt: bookings.updatedAt,
 }

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -54,6 +54,13 @@ export class InMemoryBookingRepository implements BookingRepository {
     return this.store.get(id)
   }
 
+  async findByIdempotencyKey(key: string): Promise<Booking | undefined> {
+    for (const booking of this.store.values()) {
+      if (booking.idempotencyKey === key) return booking
+    }
+    return undefined
+  }
+
   async create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
     // Mirror the DB-level `bookings_no_overlap` exclusion constraint so in-memory
     // tests exercise the same conflict behavior as real Postgres.

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -39,6 +39,7 @@ export interface BookingFilters {
 export interface BookingRepository {
   findAll(filters?: BookingFilters): Promise<Booking[]>
   findById(id: string): Promise<Booking | undefined>
+  findByIdempotencyKey(key: string): Promise<Booking | undefined>
   create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking>
   updateStatus(
     id: string,

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -65,6 +65,7 @@ export function createBookingRoutes(service: BookingService): Hono {
       source: result.data.source,
       externalId: result.data.externalId ?? null,
       notes: result.data.notes ?? null,
+      idempotencyKey: result.data.idempotencyKey ?? null,
     })
 
     if (!createResult.ok) {
@@ -74,7 +75,7 @@ export function createBookingRoutes(service: BookingService): Hono {
       })
     }
 
-    return ok(c, createResult.booking, 201)
+    return ok(c, createResult.booking, createResult.status ?? 201)
   })
 
   bookings.patch('/bookings/:id/status', async (c) => {

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -15,10 +15,11 @@ export interface CreateBookingInput {
   source: Booking['source']
   externalId?: string | null
   notes?: string | null
+  idempotencyKey?: string | null
 }
 
 export type CreateBookingResult =
-  | { ok: true; booking: Booking }
+  | { ok: true; booking: Booking; status?: 200 | 201 }
   | {
       ok: false
       status: 400 | 409
@@ -88,6 +89,13 @@ export class BookingService {
   }
 
   async create(input: CreateBookingInput): Promise<CreateBookingResult> {
+    if (input.idempotencyKey) {
+      const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
+      if (existing) {
+        return { ok: true, booking: existing, status: 200 }
+      }
+    }
+
     const effectiveEndAt = new Date(input.endAt.getTime() + DEFAULT_BUFFER_MS)
 
     // Issue #65: rental rules + Issue #74: server-side pricing.
@@ -151,6 +159,7 @@ export class BookingService {
         totalPrice,
         cancellationFee: null,
         cancelledAt: null,
+        idempotencyKey: input.idempotencyKey ?? null,
       })
 
       return { ok: true, booking }

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -33,6 +33,7 @@ export interface Booking {
   totalPrice: number | null
   cancellationFee: number | null
   cancelledAt: Date | null
+  idempotencyKey: string | null
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -241,6 +241,7 @@ describe('DrizzleBookingRepository', () => {
       totalPrice: 15000,
       cancellationFee: null,
       cancelledAt: null,
+      idempotencyKey: null,
     })
     createdBookingIds.push(booking.id)
 

--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -57,6 +57,7 @@ function baseBookingInput(
     totalPrice: null,
     cancellationFee: null,
     cancelledAt: null,
+    idempotencyKey: null,
     ...overrides,
   }
 }

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -784,4 +784,48 @@ describe('Booking Routes', () => {
       expect(body.cancellation.refundAmount).toBe(0)
     })
   })
+
+  describe('Idempotency', () => {
+    it('returns 200 with same booking when duplicate idempotencyKey sent', async () => {
+      const idempotencyKey = crypto.randomUUID()
+      const input = { ...validBookingInput(), idempotencyKey }
+
+      const res1 = await createBooking(input)
+      expect(res1.status).toBe(201)
+      const body1 = await res1.json()
+
+      const res2 = await createBooking(input)
+      expect(res2.status).toBe(200)
+      const body2 = await res2.json()
+
+      expect(body2.data.id).toBe(body1.data.id)
+    })
+
+    it('creates separate bookings for different idempotencyKeys', async () => {
+      const input1 = { ...validBookingInput(), idempotencyKey: crypto.randomUUID() }
+      const input2 = {
+        ...validBookingInput(),
+        vehicleId: 'v2',
+        idempotencyKey: crypto.randomUUID(),
+      }
+
+      const res1 = await createBooking(input1)
+      const res2 = await createBooking(input2)
+
+      expect(res1.status).toBe(201)
+      expect(res2.status).toBe(201)
+
+      const body1 = await res1.json()
+      const body2 = await res2.json()
+      expect(body1.data.id).not.toBe(body2.data.id)
+    })
+
+    it('creates booking without idempotencyKey (backward compat)', async () => {
+      const res = await createBooking(validBookingInput())
+      expect(res.status).toBe(201)
+
+      const body = await res.json()
+      expect(body.data.idempotencyKey).toBeNull()
+    })
+  })
 })

--- a/packages/api/tests/routes/fleet-overview.test.ts
+++ b/packages/api/tests/routes/fleet-overview.test.ts
@@ -112,6 +112,7 @@ describe('GET /vehicles/fleet-overview', () => {
       totalPrice: null,
       cancellationFee: null,
       cancelledAt: null,
+      idempotencyKey: null,
     })
 
     const res = await app.request('/vehicles/fleet-overview')

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -48,6 +48,7 @@ const BOOKING_FIELDS = [
   'totalPrice',
   'cancellationFee',
   'cancelledAt',
+  'idempotencyKey',
   'createdAt',
   'updatedAt',
 ] as const

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -72,6 +72,7 @@ async function seedBooking(
     totalPrice: overrides?.totalPrice ?? null,
     cancellationFee: null,
     cancelledAt: null,
+    idempotencyKey: null,
   })
 }
 

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -116,6 +116,7 @@ export const bookings = pgTable('bookings', {
   totalPrice: integer('totalPrice'), // cents, nullable for legacy bookings
   cancellationFee: integer('cancellationFee'), // cents, set on cancellation
   cancelledAt: timestamp('cancelledAt', { withTimezone: true, mode: 'date' }),
+  idempotencyKey: text('idempotencyKey'),
   createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -12,6 +12,7 @@ export const createBookingSchema = z
     notes: z.string().optional(),
     source: z.enum(['DIRECT', 'TRIP_COM', 'MANUAL', 'OTHER']).default('DIRECT'),
     externalId: z.string().optional(),
+    idempotencyKey: z.string().uuid('Must be a valid UUID').optional(),
   })
   .refine((data) => new Date(data.endAt) > new Date(data.startAt), {
     message: 'End time must be after start time',

--- a/packages/web/src/lib/bookings.ts
+++ b/packages/web/src/lib/bookings.ts
@@ -83,6 +83,7 @@ export async function createBooking(input: CreateBookingInput): Promise<CreateBo
       startAt: input.startAt,
       endAt: input.endAt,
       source: 'DIRECT',
+      idempotencyKey: crypto.randomUUID(),
       ...(input.notes ? { notes: input.notes } : {}),
     }),
   })


### PR DESCRIPTION
## Summary
- Client sends UUID `idempotencyKey` with booking creation requests
- Server returns existing booking (200) on duplicate key, creates new (201) otherwise
- Nullable column + partial unique index -- backward compatible
- Re-implementation of closed PR #123 against the new per-domain repo structure

## Changes
- **Schema**: `idempotencyKey` text column on bookings (migrations 0011 + 0012)
- **Repo**: `findByIdempotencyKey()` on Drizzle and InMemory implementations
- **Service**: idempotency check before create in `BookingService`
- **Validator**: `idempotencyKey: z.string().uuid().optional()`
- **Web**: auto-generates UUID per booking request
- **Tests**: 3 new idempotency tests

## Test plan
- [x] 476 tests pass (1 pre-existing failure: vehicle-detail revenue)
- [x] `bun run lint` + `tsc --noEmit` + `db:verify` all pass
- [x] Pre-commit hooks pass