### PR TITLE
feat(api): cursor-based pagination for GET /bookings

### DIFF
--- a/docs/2026-04-08-lessons-learned.md
+++ b/docs/2026-04-08-lessons-learned.md
@@ -289,3 +289,15 @@ The in-memory repo used `...data` spread and kept all fields, so every route-lev
 **Rule:** When a unique/exclusion constraint in the DB enforces a business rule, don't pre-check in application code. Attempt the write and handle the constraint violation gracefully. This is optimistic concurrency control — it eliminates both the race window and the extra round-trip.
 
 **The general pattern:** check-then-act is only safe when you can hold a lock between the check and the act. HTTP requests can't hold locks. The DB constraint IS the lock.
+
+---
+
+## 19. Unbounded List Endpoints Are Time Bombs (issue #91)
+
+**Symptom:** None yet — this is a latent problem. GET /bookings returns all rows. At 200 bookings/month, after 1 year that's 2400+ rows serialized on every request.
+
+**Root cause:** List endpoints had no pagination. Nobody notices gradual degradation — 50ms at launch, 200ms at 6 months, 800ms at 1 year.
+
+**Fix:** Added cursor-based pagination to GET /bookings using `createdAt + id` keyset. The service overfetches by 1 row to detect hasMore and computes `nextCursor`. Vehicles (bounded at 40-50) and threads (placeholder, unused) left unpaginated.
+
+**Rule:** If data grows with time or user activity, paginate from day one. If bounded by business constraint, pagination is optional. Use cursor (keyset) over offset — offset is O(n) at depth, cursor is O(1).

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -1,5 +1,5 @@
 import { bookings } from '@kuruma/shared/db/schema'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, desc, eq, lt, or, sql } from 'drizzle-orm'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
 import { type Db, bookingColumns } from './shared'
@@ -27,10 +27,36 @@ export class DrizzleBookingRepository implements BookingRepository {
       )
     }
 
-    const query = this.db.select(bookingColumns).from(bookings)
+    // Cursor-based pagination: skip past the cursor position
+    if (filters?.cursor) {
+      const sep = filters.cursor.indexOf('_')
+      const cursorTime = filters.cursor.slice(0, sep)
+      const cursorId = filters.cursor.slice(sep + 1)
+      conditions.push(
+        or(
+          lt(bookings.createdAt, sql`${cursorTime}::timestamptz`),
+          and(
+            eq(bookings.createdAt, sql`${cursorTime}::timestamptz`),
+            lt(bookings.id, cursorId),
+          ),
+        )!,
+      )
+    }
 
-    const rows = conditions.length > 0 ? await query.where(and(...conditions)) : await query
+    let query = this.db
+      .select(bookingColumns)
+      .from(bookings)
+      .orderBy(desc(bookings.createdAt), desc(bookings.id))
 
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions)) as typeof query
+    }
+
+    if (filters?.limit) {
+      query = query.limit(filters.limit) as typeof query
+    }
+
+    const rows = await query
     return rows as Booking[]
   }
 

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -47,6 +47,30 @@ export class InMemoryBookingRepository implements BookingRepository {
       results = results.filter((b) => b.startAt < to && b.effectiveEndAt > from)
     }
 
+    // Sort by createdAt DESC, id DESC (matches Drizzle ORDER BY)
+    results.sort((a, b) => {
+      const timeDiff = b.createdAt.getTime() - a.createdAt.getTime()
+      if (timeDiff !== 0) return timeDiff
+      return b.id < a.id ? -1 : 1
+    })
+
+    // Cursor: skip past the cursor position
+    if (filters?.cursor) {
+      const sep = filters.cursor.indexOf('_')
+      const cursorTime = new Date(filters.cursor.slice(0, sep))
+      const cursorId = filters.cursor.slice(sep + 1)
+      results = results.filter((b) => {
+        if (b.createdAt.getTime() < cursorTime.getTime()) return true
+        if (b.createdAt.getTime() === cursorTime.getTime() && b.id < cursorId) return true
+        return false
+      })
+    }
+
+    // Apply limit
+    if (filters?.limit) {
+      results = results.slice(0, filters.limit)
+    }
+
     return results
   }
 

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -34,6 +34,8 @@ export interface BookingFilters {
   renterId?: string
   from?: Date
   to?: Date
+  limit?: number
+  cursor?: string
 }
 
 export interface BookingRepository {

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -12,11 +12,20 @@ export function createBookingRoutes(service: BookingService): Hono {
     const vehicleIdFilter = c.req.query('vehicleId')
     const renterIdFilter = c.req.query('renterId')
     const expand = c.req.query('expand')
+    const limitParam = c.req.query('limit')
+    const cursor = c.req.query('cursor')
 
     const dateRange = parseDateRange(c, false)
     if (!dateRange.ok) return dateRange.response
 
-    const filters: BookingFilters = {}
+    // Validate limit: 1–100, default 20
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : 20
+    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+      return fail(c, 'limit must be between 1 and 100', 400)
+    }
+
+    const filters: BookingFilters = { limit }
+    if (cursor) filters.cursor = cursor
     if (statusFilter) filters.status = statusFilter
     if (vehicleIdFilter) filters.vehicleId = vehicleIdFilter
     if (renterIdFilter) filters.renterId = renterIdFilter
@@ -25,15 +34,13 @@ export function createBookingRoutes(service: BookingService): Hono {
       filters.to = dateRange.to
     }
 
-    const active = Object.keys(filters).length > 0 ? filters : undefined
-
     if (expand === 'vehicle') {
-      const expanded = await service.findAllWithVehicles(active)
-      return ok(c, expanded)
+      const result = await service.findAllWithVehiclesPaginated(filters)
+      return ok(c, result.data, 200, { nextCursor: result.nextCursor })
     }
 
-    const results = await service.findAll(active)
-    return ok(c, results)
+    const result = await service.findAllPaginated(filters)
+    return ok(c, result.data, 200, { nextCursor: result.nextCursor })
   })
 
   bookings.get('/bookings/:id', async (c) => {

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -2,7 +2,7 @@ import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
-import type { BookingRepository, VehicleRepository } from '../repositories/types'
+import type { BookingFilters, BookingRepository, VehicleRepository } from '../repositories/types'
 import type { Booking } from '../stores'
 
 const DEFAULT_BUFFER_MS = 60 * 60 * 1000 // 60 minutes
@@ -46,27 +46,31 @@ export class BookingService {
     private readonly vehicleRepo?: VehicleRepository,
   ) {}
 
-  async findAll(filters?: {
-    status?: string
-    vehicleId?: string
-    renterId?: string
-    from?: Date
-    to?: Date
-  }): Promise<Booking[]> {
+  async findAll(filters?: BookingFilters): Promise<Booking[]> {
     return this.bookingRepo.findAll(filters)
   }
 
-  async findAllWithVehicles(filters?: {
-    status?: string
-    vehicleId?: string
-    renterId?: string
-    from?: Date
-    to?: Date
-  }): Promise<(Booking & { vehicle?: { name: string; photos: string[] } | undefined })[]> {
-    const results = await this.bookingRepo.findAll(filters)
-    if (!this.vehicleRepo) return results
+  async findAllPaginated(
+    filters: BookingFilters,
+  ): Promise<{ data: Booking[]; nextCursor: string | null }> {
+    const limit = filters.limit ?? 20
+    // Overfetch by 1 to detect if more pages exist
+    const rows = await this.bookingRepo.findAll({ ...filters, limit: limit + 1 })
+    const hasMore = rows.length > limit
+    const data = hasMore ? rows.slice(0, limit) : rows
+    const last = data[data.length - 1]
+    const nextCursor = hasMore && last ? `${last.createdAt.toISOString()}_${last.id}` : null
+    return { data, nextCursor }
+  }
 
-    const vehicleIds = [...new Set(results.map((b) => b.vehicleId))]
+  async findAllWithVehiclesPaginated(filters: BookingFilters): Promise<{
+    data: (Booking & { vehicle?: { name: string; photos: string[] } | undefined })[]
+    nextCursor: string | null
+  }> {
+    const { data, nextCursor } = await this.findAllPaginated(filters)
+    if (!this.vehicleRepo) return { data, nextCursor }
+
+    const vehicleIds = [...new Set(data.map((b) => b.vehicleId))]
     const vehicleMap = new Map<string, { name: string; photos: string[] }>()
 
     await Promise.all(
@@ -78,10 +82,13 @@ export class BookingService {
       }),
     )
 
-    return results.map((booking) => ({
-      ...booking,
-      vehicle: vehicleMap.get(booking.vehicleId),
-    }))
+    return {
+      data: data.map((booking) => ({
+        ...booking,
+        vehicle: vehicleMap.get(booking.vehicleId),
+      })),
+      nextCursor,
+    }
   }
 
   async findById(id: string): Promise<Booking | undefined> {

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -48,7 +48,7 @@ describe('Booking Routes', () => {
       expect(res.status).toBe(200)
 
       const body = await res.json()
-      expect(body).toEqual({ success: true, data: [] })
+      expect(body).toEqual({ success: true, data: [], nextCursor: null })
     })
 
     it('returns created bookings', async () => {
@@ -264,6 +264,115 @@ describe('Booking Routes', () => {
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(1)
       expect(body.data[0].vehicle).toBeUndefined()
+    })
+  })
+
+  describe('GET /bookings — cursor pagination', () => {
+    async function createNBookings(n: number) {
+      const ids: string[] = []
+      for (let i = 0; i < n; i++) {
+        const res = await app.request('/bookings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            vehicleId: `v-page-${i}`,
+            renterId: 'user1',
+            startAt: futureDate(24),
+            endAt: futureDate(48),
+            source: 'DIRECT',
+          }),
+        })
+        const body = await res.json()
+        ids.push(body.data.id)
+      }
+      return ids
+    }
+
+    it('returns at most limit items and a nextCursor when more exist', async () => {
+      await createNBookings(5)
+
+      const res = await app.request('/bookings?limit=2')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(2)
+      expect(body.nextCursor).toBeDefined()
+      expect(typeof body.nextCursor).toBe('string')
+    })
+
+    it('returns nextCursor null when no more results', async () => {
+      await createNBookings(2)
+
+      const res = await app.request('/bookings?limit=10')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(2)
+      expect(body.nextCursor).toBeNull()
+    })
+
+    it('pages through all results using nextCursor', async () => {
+      await createNBookings(5)
+
+      // Page 1
+      const res1 = await app.request('/bookings?limit=2')
+      const body1 = await res1.json()
+      expect(body1.data).toHaveLength(2)
+      expect(body1.nextCursor).toBeDefined()
+
+      // Page 2
+      const res2 = await app.request(`/bookings?limit=2&cursor=${body1.nextCursor}`)
+      const body2 = await res2.json()
+      expect(body2.data).toHaveLength(2)
+      expect(body2.nextCursor).toBeDefined()
+
+      // Page 3 (last item)
+      const res3 = await app.request(`/bookings?limit=2&cursor=${body2.nextCursor}`)
+      const body3 = await res3.json()
+      expect(body3.data).toHaveLength(1)
+      expect(body3.nextCursor).toBeNull()
+
+      // No duplicates across pages
+      const allIds = [
+        ...body1.data.map((b: { id: string }) => b.id),
+        ...body2.data.map((b: { id: string }) => b.id),
+        ...body3.data.map((b: { id: string }) => b.id),
+      ]
+      expect(new Set(allIds).size).toBe(5)
+    })
+
+    it('combines pagination with status filter', async () => {
+      await createNBookings(3)
+      // Cancel the first one
+      const allRes = await app.request('/bookings')
+      const allBody = await allRes.json()
+      const firstId = allBody.data[0].id
+      await app.request(`/bookings/${firstId}/cancel`, { method: 'POST' })
+
+      const res = await app.request('/bookings?status=CONFIRMED&limit=10')
+      const body = await res.json()
+
+      expect(body.data).toHaveLength(2)
+      expect(body.data.every((b: { status: string }) => b.status === 'CONFIRMED')).toBe(true)
+      expect(body.nextCursor).toBeNull()
+    })
+
+    it('defaults to 20 items when no limit specified', async () => {
+      const res = await app.request('/bookings')
+      const body = await res.json()
+
+      // Existing behavior: returns all (empty here), with nextCursor null
+      expect(body.nextCursor).toBeNull()
+    })
+
+    it('rejects limit > 100', async () => {
+      const res = await app.request('/bookings?limit=200')
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects limit < 1', async () => {
+      const res = await app.request('/bookings?limit=0')
+      expect(res.status).toBe(400)
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `limit` (1-100, default 20) and `cursor` query params to GET /bookings
- Uses `createdAt + id` keyset pagination — O(1) at any depth
- Service overfetches by 1 row to compute `nextCursor` in response
- All existing filters (status, vehicleId, renterId, date range) work alongside pagination

## Test plan

- [x] 7 new pagination tests (limit, cursor traversal, filter combo, validation)
- [x] All 50 booking route tests pass
- [x] Full suite green
- [x] Lint + typecheck clean

Closes #91