### PR TITLE
fix(api): add global error handler to prevent stack trace leaks

### DIFF
--- a/packages/api/src/error-handlers.ts
+++ b/packages/api/src/error-handlers.ts
@@ -1,0 +1,11 @@
+import type { Hono } from 'hono'
+
+export function setupGlobalHandlers(app: Hono): void {
+  app.onError((_err, c) => {
+    return c.json({ success: false, error: 'Internal server error' }, 500)
+  })
+
+  app.notFound((c) => {
+    return c.json({ success: false, error: 'Not found' }, 404)
+  })
+}

--- a/packages/api/src/error-handlers.ts
+++ b/packages/api/src/error-handlers.ts
@@ -1,7 +1,15 @@
 import type { Hono } from 'hono'
 
 export function setupGlobalHandlers(app: Hono): void {
-  app.onError((_err, c) => {
+  app.onError((err, c) => {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        message: err.message,
+        path: c.req.path,
+        method: c.req.method,
+      }),
+    )
     return c.json({ success: false, error: 'Internal server error' }, 500)
   })
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,7 @@
 import { getDb } from '@kuruma/shared/db'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { setupGlobalHandlers } from './error-handlers'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -94,6 +95,9 @@ export function createApp(overrides?: {
   }
 
   const app = new Hono()
+
+  // Global error handlers — prevent stack traces leaking to clients.
+  setupGlobalHandlers(app)
 
   // CORS. Browser calls from the web package (localhost:3001 in dev, the
   // deployed origin in prod) are same-intent but cross-origin, so without

--- a/packages/api/tests/routes/error-handler.test.ts
+++ b/packages/api/tests/routes/error-handler.test.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+// Minimal app that mounts the global handlers the same way createApp does.
+// We add a throwing route to trigger onError.
+function createTestApp(setupHandlers: (app: Hono) => void): Hono {
+  const app = new Hono()
+  setupHandlers(app)
+  app.get('/throw', () => {
+    throw new Error('kaboom')
+  })
+  return app
+}
+
+describe('Global error handlers', () => {
+  // We'll import the setup function once it exists
+  let setupGlobalHandlers: (app: Hono) => void
+
+  it('onError returns { success: false } with 500 and no stack trace', async () => {
+    const { setupGlobalHandlers: setup } = await import('../../src/error-handlers')
+    setupGlobalHandlers = setup
+
+    const app = createTestApp(setupGlobalHandlers)
+    const res = await app.request('/throw')
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Internal server error')
+    expect(body).not.toHaveProperty('stack')
+    expect(JSON.stringify(body)).not.toContain('kaboom')
+  })
+
+  it('notFound returns { success: false } with 404', async () => {
+    const { setupGlobalHandlers: setup } = await import('../../src/error-handlers')
+
+    const app = createTestApp(setup)
+    const res = await app.request('/nonexistent')
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Not found')
+  })
+})


### PR DESCRIPTION
## Summary

Uncaught exceptions now return `{ success: false, error: 'Internal server error' }` with structured JSON logging. Unknown routes return 404 JSON instead of HTML.

- New `error-handlers.ts` with `setupGlobalHandlers(app)`
- Wired into `createApp()` before CORS middleware
- 2 new tests (500 shape + no leak, 404 shape)
- **Named pattern:** Catch and Ignore (fixed — errors are now logged)

Closes #115