### PR TITLE
refactor(api): replace positional params with object in updateStatus/cancel

### DIFF
--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -74,13 +74,12 @@ export class DrizzleBookingRepository implements BookingRepository {
 
   async updateStatus(
     id: string,
-    expectedStatus: Booking['status'],
-    newStatus: Booking['status'],
+    transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined> {
     const [updated] = await this.db
       .update(bookings)
-      .set({ status: newStatus, updatedAt: sql`now()` })
-      .where(and(eq(bookings.id, id), eq(bookings.status, expectedStatus)))
+      .set({ status: transition.to, updatedAt: sql`now()` })
+      .where(and(eq(bookings.id, id), eq(bookings.status, transition.from)))
       .returning()
 
     return (updated as Booking) ?? undefined
@@ -88,19 +87,17 @@ export class DrizzleBookingRepository implements BookingRepository {
 
   async cancel(
     id: string,
-    expectedStatus: Booking['status'],
-    cancellationFee: number,
-    cancelledAt: Date,
+    opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined> {
     const [cancelled] = await this.db
       .update(bookings)
       .set({
         status: 'CANCELLED',
-        cancellationFee,
-        cancelledAt,
+        cancellationFee: opts.fee,
+        cancelledAt: opts.cancelledAt,
         updatedAt: sql`now()`,
       })
-      .where(and(eq(bookings.id, id), eq(bookings.status, expectedStatus)))
+      .where(and(eq(bookings.id, id), eq(bookings.status, opts.from)))
       .returning()
 
     return (cancelled as Booking) ?? undefined

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -91,15 +91,14 @@ export class InMemoryBookingRepository implements BookingRepository {
 
   async updateStatus(
     id: string,
-    expectedStatus: Booking['status'],
-    newStatus: Booking['status'],
+    transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
-    if (!existing || existing.status !== expectedStatus) return undefined
+    if (!existing || existing.status !== transition.from) return undefined
 
     const updated: Booking = {
       ...existing,
-      status: newStatus,
+      status: transition.to,
       updatedAt: new Date(),
     }
     this.store.set(updated.id, updated)
@@ -108,18 +107,16 @@ export class InMemoryBookingRepository implements BookingRepository {
 
   async cancel(
     id: string,
-    expectedStatus: Booking['status'],
-    cancellationFee: number,
-    cancelledAt: Date,
+    opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
-    if (!existing || existing.status !== expectedStatus) return undefined
+    if (!existing || existing.status !== opts.from) return undefined
 
     const cancelled: Booking = {
       ...existing,
       status: 'CANCELLED',
-      cancellationFee,
-      cancelledAt,
+      cancellationFee: opts.fee,
+      cancelledAt: opts.cancelledAt,
       updatedAt: new Date(),
     }
     this.store.set(cancelled.id, cancelled)

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -43,14 +43,11 @@ export interface BookingRepository {
   create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking>
   updateStatus(
     id: string,
-    expectedStatus: Booking['status'],
-    newStatus: Booking['status'],
+    transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined>
   cancel(
     id: string,
-    expectedStatus: Booking['status'],
-    cancellationFee: number,
-    cancelledAt: Date,
+    opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined>
 }
 

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -197,11 +197,10 @@ export class BookingService {
       }
     }
 
-    const updated = await this.bookingRepo.updateStatus(
-      booking.id,
-      booking.status,
-      newStatus as Booking['status'],
-    )
+    const updated = await this.bookingRepo.updateStatus(booking.id, {
+      from: booking.status,
+      to: newStatus as Booking['status'],
+    })
     if (!updated) {
       return {
         ok: false,
@@ -229,12 +228,11 @@ export class BookingService {
     const now = new Date()
     const cancellation = calculateCancellationFee(booking.startAt, now, booking.totalPrice ?? 0)
 
-    const updated = await this.bookingRepo.cancel(
-      booking.id,
-      booking.status,
-      cancellation.feeAmount,
-      now,
-    )
+    const updated = await this.bookingRepo.cancel(booking.id, {
+      from: booking.status,
+      fee: cancellation.feeAmount,
+      cancelledAt: now,
+    })
     if (!updated) {
       return {
         ok: false,

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -213,7 +213,7 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(created.id)
 
-    const updated = await bookingRepo.updateStatus(created.id, 'ACTIVE')
+    const updated = await bookingRepo.updateStatus(created.id, { from: 'CONFIRMED', to: 'ACTIVE' })
 
     expect(updated).toBeDefined()
     expect(updated!.id).toBe(created.id)

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -172,22 +172,22 @@ describe('GET /vehicles/:id/detail', () => {
     const b1 = await seedBooking(vehicle.id, pastDate(72), pastDate(48), {
       totalPrice: 5000,
     })
-    await bookingRepo.updateStatus(b1.id, 'CONFIRMED', 'ACTIVE')
-    await bookingRepo.updateStatus(b1.id, 'ACTIVE', 'COMPLETED')
+    await bookingRepo.updateStatus(b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     // Completed booking 10 days ago
     const b2 = await seedBooking(vehicle.id, pastDate(240), pastDate(216), {
       totalPrice: 8000,
     })
-    await bookingRepo.updateStatus(b2.id, 'CONFIRMED', 'ACTIVE')
-    await bookingRepo.updateStatus(b2.id, 'ACTIVE', 'COMPLETED')
+    await bookingRepo.updateStatus(b2.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(b2.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     // Completed booking 60 days ago
     const b3 = await seedBooking(vehicle.id, pastDate(1440), pastDate(1416), {
       totalPrice: 12000,
     })
-    await bookingRepo.updateStatus(b3.id, 'CONFIRMED', 'ACTIVE')
-    await bookingRepo.updateStatus(b3.id, 'ACTIVE', 'COMPLETED')
+    await bookingRepo.updateStatus(b3.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(b3.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()
@@ -203,8 +203,8 @@ describe('GET /vehicles/:id/detail', () => {
     const b1 = await seedBooking(vehicle.id, pastDate(72), pastDate(48), {
       totalPrice: null,
     })
-    await bookingRepo.updateStatus(b1.id, 'CONFIRMED', 'ACTIVE')
-    await bookingRepo.updateStatus(b1.id, 'ACTIVE', 'COMPLETED')
+    await bookingRepo.updateStatus(b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()
@@ -233,8 +233,8 @@ describe('GET /vehicles/:id/detail', () => {
     const b = await seedBooking(vehicle.id, pastDate(48), pastDate(24), {
       totalPrice: 5000,
     })
-    await bookingRepo.updateStatus(b.id, 'CONFIRMED', 'ACTIVE')
-    await bookingRepo.updateStatus(b.id, 'ACTIVE', 'COMPLETED')
+    await bookingRepo.updateStatus(b.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(b.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()


### PR DESCRIPTION
## Summary
- Replace `updateStatus(id, expectedStatus, newStatus)` with `updateStatus(id, { from, to })`
- Replace `cancel(id, expectedStatus, fee, date)` with `cancel(id, { from, fee, cancelledAt })`
- Self-documenting params that TypeScript can distinguish — impossible to silently swap

## Changed files
- `types.ts` — interface
- `drizzle/booking.ts` + `in-memory/booking.ts` — implementations
- `services/booking.ts` — caller
- `tests/routes/vehicle-detail.test.ts` — 8 call sites
- `tests/integration/bookings.test.ts` — 1 call site (was also broken with old 2-arg form)

## Test plan
- [x] 477 tests pass (shared 124 + api 137 + web 216)
- [x] tsc clean
- [x] Biome lint clean
- [x] Pre-commit hooks pass

Closes #130