### PR TITLE
refactor(web): deduplicate ApiResponse types

### DIFF
--- a/packages/web/src/lib/bookings.ts
+++ b/packages/web/src/lib/bookings.ts
@@ -2,6 +2,7 @@
 
 import { auth } from '@/auth'
 import { getApiBaseUrl } from '@/lib/api-client'
+import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
 interface CreateBookingInput {
   vehicleId: string
@@ -23,12 +24,6 @@ type CreateBookingResult =
   | { success: true; bookingId: string }
   | { success: false; error: string; rentalRule?: RentalRuleFailure }
 
-interface ApiResponse<T> {
-  success: boolean
-  data?: T
-  error?: string
-}
-
 export async function checkAvailability(
   vehicleId: string,
   startAt: Date,
@@ -42,7 +37,7 @@ export async function checkAvailability(
   )
   const json: ApiResponse<{ available: boolean }> = await res.json()
 
-  if (!json.success || !json.data) return false
+  if (!json.success) return false
 
   return json.data.available
 }
@@ -158,7 +153,7 @@ export async function getBookingsByRenterId(userId: string): Promise<BookingWith
   const res = await fetch(`${base}/bookings?renterId=${encodeURIComponent(userId)}&expand=vehicle`)
   const json: ApiResponse<BookingWithVehicleResponse[]> = await res.json()
 
-  if (!json.success || !json.data) return []
+  if (!json.success) return []
 
   return json.data.map((booking) => ({
     id: booking.id,
@@ -192,7 +187,7 @@ export async function getBookingById(id: string): Promise<Booking | null> {
   const res = await fetch(`${base}/bookings/${encodeURIComponent(id)}`)
   const json: ApiResponse<Booking> = await res.json()
 
-  if (!json.success || !json.data) return null
+  if (!json.success) return null
 
   return json.data
 }

--- a/packages/web/src/lib/calendar.ts
+++ b/packages/web/src/lib/calendar.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/lib/api-client'
+import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
 export interface CalendarBooking {
   id: string
@@ -12,12 +13,6 @@ export interface CalendarBooking {
   notes: string | null
 }
 
-interface ApiResponse<T> {
-  success: boolean
-  data: T
-  error?: string
-}
-
 export async function fetchCalendarBookings(from: string, to: string): Promise<CalendarBooking[]> {
   const base = getApiBaseUrl()
   const params = new URLSearchParams({ from, to })
@@ -28,7 +23,7 @@ export async function fetchCalendarBookings(from: string, to: string): Promise<C
   }
 
   const body: ApiResponse<CalendarBooking[]> = await res.json()
-  if (!body.success || !Array.isArray(body.data)) {
+  if (!body.success) {
     throw new Error(body.error ?? 'Invalid bookings response')
   }
 

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -1,11 +1,6 @@
 import { getApiBaseUrl } from '@/lib/api-client'
+import type { ApiResponse } from '@kuruma/shared/types/api-response'
 import type { CreateVehicleInput, VehicleStatus } from '@kuruma/shared/validators/vehicle'
-
-interface ApiResponse<T> {
-  success: boolean
-  data: T
-  error?: string
-}
 
 export interface VehicleData {
   id: string
@@ -45,13 +40,15 @@ export interface FleetVehicleOverviewData extends VehicleData {
 
 async function apiRequest<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init)
+  const body: ApiResponse<T> = await res.json().catch(() => ({
+    success: false as const,
+    error: 'Unknown error',
+  }))
 
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: 'Unknown error' }))
-    throw new Error((body as ApiResponse<never>).error ?? `HTTP ${res.status}`)
+  if (!body.success) {
+    throw new Error(body.error ?? `HTTP ${res.status}`)
   }
 
-  const body: ApiResponse<T> = await res.json()
   return body.data
 }
 

--- a/packages/web/src/lib/vehicles.ts
+++ b/packages/web/src/lib/vehicles.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/lib/api-client'
+import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
 interface Vehicle {
   id: string
@@ -17,12 +18,6 @@ interface Vehicle {
   updatedAt: string
 }
 
-interface ApiResponse<T> {
-  success: boolean
-  data?: T
-  error?: string
-}
-
 export async function getAvailableVehicles(from?: string, to?: string): Promise<Vehicle[]> {
   const base = getApiBaseUrl()
 
@@ -34,7 +29,7 @@ export async function getAvailableVehicles(from?: string, to?: string): Promise<
   const res = await fetch(url)
   const json: ApiResponse<Vehicle[]> = await res.json()
 
-  if (!json.success || !json.data) return []
+  if (!json.success) return []
 
   return json.data
 }
@@ -44,7 +39,7 @@ export async function getVehicleById(id: string): Promise<Vehicle | null> {
   const res = await fetch(`${base}/vehicles/${encodeURIComponent(id)}`)
   const json: ApiResponse<Vehicle> = await res.json()
 
-  if (!json.success || !json.data) return null
+  if (!json.success) return null
 
   return json.data
 }


### PR DESCRIPTION
## Summary

- Replaced 4 duplicate `ApiResponse<T>` definitions with import from `@kuruma/shared/types/api-response`
- Removed redundant `!json.data` guards — discriminated union guarantees `data` when `success: true`
- Fixed `vehicle-api.ts` `apiRequest` helper to use proper type narrowing

## Test plan

- [x] All 486 tests pass (124 + 146 + 216)
- [x] Typecheck clean across all packages
- [x] Lint clean

Closes #92