### PR TITLE
fix(api): catch idempotency key unique constraint race, return 200

### DIFF
--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Postgres error codes used in constraint-violation handling.
+ * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+export const PG_ERROR = {
+  EXCLUSION_VIOLATION: '23P01',
+  UNIQUE_VIOLATION: '23505',
+} as const
+
+/** Extract the Postgres error code from an unknown thrown value, or null. */
+export function pgErrorCode(err: unknown): string | null {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: unknown }).code
+    return typeof code === 'string' ? code : null
+  }
+  return null
+}

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -1,3 +1,4 @@
+import { PG_ERROR } from '../../pg-errors'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
 
@@ -96,7 +97,7 @@ export class InMemoryBookingRepository implements BookingRepository {
           data.startAt < existing.effectiveEndAt && existing.startAt < data.effectiveEndAt
         if (overlaps) {
           const err = new Error('bookings_no_overlap violation') as Error & { code: string }
-          err.code = '23P01'
+          err.code = PG_ERROR.EXCLUSION_VIOLATION
           throw err
         }
       }
@@ -107,7 +108,7 @@ export class InMemoryBookingRepository implements BookingRepository {
       for (const existing of this.store.values()) {
         if (existing.idempotencyKey === data.idempotencyKey) {
           const err = new Error('unique_idempotency_key violation') as Error & { code: string }
-          err.code = '23505'
+          err.code = PG_ERROR.UNIQUE_VIOLATION
           throw err
         }
       }

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -102,6 +102,17 @@ export class InMemoryBookingRepository implements BookingRepository {
       }
     }
 
+    // Mirror the DB-level partial unique index on idempotencyKey
+    if (data.idempotencyKey) {
+      for (const existing of this.store.values()) {
+        if (existing.idempotencyKey === data.idempotencyKey) {
+          const err = new Error('unique_idempotency_key violation') as Error & { code: string }
+          err.code = '23505'
+          throw err
+        }
+      }
+    }
+
     const now = new Date()
     const booking: Booking = {
       ...data,

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -2,6 +2,7 @@ import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
+import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { BookingFilters, BookingRepository, VehicleRepository } from '../repositories/types'
 import type { Booking } from '../stores'
 
@@ -172,11 +173,10 @@ export class BookingService {
 
       return { ok: true, booking }
     } catch (err) {
-      const code =
-        err && typeof err === 'object' && 'code' in err ? (err as { code: unknown }).code : null
+      const code = pgErrorCode(err)
 
       // Overlap exclusion constraint
-      if (code === '23P01') {
+      if (code === PG_ERROR.EXCLUSION_VIOLATION) {
         return {
           ok: false,
           status: 409,
@@ -185,7 +185,7 @@ export class BookingService {
       }
 
       // Idempotency key unique constraint race: re-fetch and return existing
-      if (code === '23505' && input.idempotencyKey) {
+      if (code === PG_ERROR.UNIQUE_VIOLATION && input.idempotencyKey) {
         const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
         if (existing) {
           return { ok: true, booking: existing, status: 200 }

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -172,18 +172,26 @@ export class BookingService {
 
       return { ok: true, booking }
     } catch (err) {
-      if (
-        err &&
-        typeof err === 'object' &&
-        'code' in err &&
-        (err as { code: unknown }).code === '23P01'
-      ) {
+      const code =
+        err && typeof err === 'object' && 'code' in err ? (err as { code: unknown }).code : null
+
+      // Overlap exclusion constraint
+      if (code === '23P01') {
         return {
           ok: false,
           status: 409,
           error: 'Vehicle is already booked for the requested time range',
         }
       }
+
+      // Idempotency key unique constraint race: re-fetch and return existing
+      if (code === '23505' && input.idempotencyKey) {
+        const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
+        if (existing) {
+          return { ok: true, booking: existing, status: 200 }
+        }
+      }
+
       throw err
     }
   }

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -615,6 +615,25 @@ describe('Booking Routes', () => {
         const body = await res.json()
         expect(body.data.idempotencyKey).toBeNull()
       })
+
+      it('returns 200 when concurrent duplicate key hits unique constraint', async () => {
+        const idempotencyKey = crypto.randomUUID()
+        const input = { ...validBookingInput(), idempotencyKey }
+
+        // Simulate race: both requests pass findByIdempotencyKey check,
+        // then both attempt create. Second one hits the unique constraint.
+        const [r1, r2] = await Promise.all([
+          createBooking(input),
+          createBooking({ ...input, vehicleId: 'v2' }),
+        ])
+
+        const statuses = [r1.status, r2.status].sort()
+        expect(statuses).toEqual([200, 201])
+
+        const b1 = await r1.json()
+        const b2 = await r2.json()
+        expect(b1.data.id).toBe(b2.data.id)
+      })
     })
 
     // Issue #74: server-side pricing. Clients must not be able to propose a


### PR DESCRIPTION
## Summary
- Catch Postgres `23505` (unique violation) on idempotency key during concurrent duplicate POSTs
- Re-fetch the winning booking and return it as 200 instead of crashing with 500
- Mirror the unique constraint in `InMemoryBookingRepository` so unit tests exercise the race path

## Test plan
- [x] New test: concurrent duplicate key returns [200, 201], same booking ID
- [x] 489 tests pass (shared 124 + api 149 + web 216)
- [x] tsc clean, biome clean, all pre-commit hooks pass

Closes #146