### PR TITLE
refactor(api): replace type assertions with mapper functions

### DIFF
--- a/packages/api/src/repositories/drizzle/availability.ts
+++ b/packages/api/src/repositories/drizzle/availability.ts
@@ -2,7 +2,7 @@ import { bookings, vehicles } from '@kuruma/shared/db/schema'
 import { and, eq, sql } from 'drizzle-orm'
 import type { Booking, Vehicle } from '../../stores'
 import type { AvailabilityRepository } from '../types'
-import { type Db, bookingColumns, vehicleColumns } from './shared'
+import { type Db, bookingColumns, toBooking, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleAvailabilityRepository implements AvailabilityRepository {
   constructor(private readonly db: Db) {}
@@ -25,7 +25,7 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
           )`,
         ),
       )
-    return rows as Vehicle[]
+    return rows.map(toVehicle)
   }
 
   async checkVehicleAvailability(
@@ -56,8 +56,8 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
 
     return {
       available: conflicts.length === 0,
-      vehicle: vehicle as Vehicle,
-      conflicts: conflicts as Booking[],
+      vehicle: toVehicle(vehicle),
+      conflicts: conflicts.map(toBooking),
     }
   }
 }

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -2,7 +2,7 @@ import { bookings } from '@kuruma/shared/db/schema'
 import { and, desc, eq, lt, or, sql } from 'drizzle-orm'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
-import { type Db, bookingColumns } from './shared'
+import { type Db, bookingColumns, toBooking } from './shared'
 
 export class DrizzleBookingRepository implements BookingRepository {
   constructor(private readonly db: Db) {}
@@ -57,13 +57,13 @@ export class DrizzleBookingRepository implements BookingRepository {
     }
 
     const rows = await query
-    return rows as Booking[]
+    return rows.map(toBooking)
   }
 
   async findById(id: string): Promise<Booking | undefined> {
     const [row] = await this.db.select(bookingColumns).from(bookings).where(eq(bookings.id, id))
 
-    return (row as Booking) ?? undefined
+    return row ? toBooking(row) : undefined
   }
 
   async findByIdempotencyKey(key: string): Promise<Booking | undefined> {
@@ -72,7 +72,7 @@ export class DrizzleBookingRepository implements BookingRepository {
       .from(bookings)
       .where(eq(bookings.idempotencyKey, key))
 
-    return (row as Booking) ?? undefined
+    return row ? toBooking(row) : undefined
   }
 
   async create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
@@ -95,7 +95,8 @@ export class DrizzleBookingRepository implements BookingRepository {
       })
       .returning()
 
-    return inserted as Booking
+    if (!inserted) throw new Error('Failed to insert booking')
+    return toBooking(inserted)
   }
 
   async updateStatus(
@@ -108,7 +109,7 @@ export class DrizzleBookingRepository implements BookingRepository {
       .where(and(eq(bookings.id, id), eq(bookings.status, transition.from)))
       .returning()
 
-    return (updated as Booking) ?? undefined
+    return updated ? toBooking(updated) : undefined
   }
 
   async cancel(
@@ -126,6 +127,6 @@ export class DrizzleBookingRepository implements BookingRepository {
       .where(and(eq(bookings.id, id), eq(bookings.status, opts.from)))
       .returning()
 
-    return (cancelled as Booking) ?? undefined
+    return cancelled ? toBooking(cancelled) : undefined
   }
 }

--- a/packages/api/src/repositories/drizzle/fleet-overview.ts
+++ b/packages/api/src/repositories/drizzle/fleet-overview.ts
@@ -4,7 +4,7 @@ import { and, ne, sql } from 'drizzle-orm'
 import { eq } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
 import type { FleetOverviewRepository } from '../types'
-import { type Db, vehicleColumns } from './shared'
+import { type Db, toVehicle, vehicleColumns } from './shared'
 
 // Fleet overview: owner-facing aggregated read. Two round-trips instead
 // of N+1 -- one SELECT for all vehicles, one SELECT for all relevant
@@ -34,7 +34,7 @@ export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_MS)
 
     // Round-trip 1: all vehicles.
-    const vehicleRows = (await this.db.select(vehicleColumns).from(vehicles)) as Vehicle[]
+    const vehicleRows = (await this.db.select(vehicleColumns).from(vehicles)).map(toVehicle)
 
     // Round-trip 2: bookings we care about -- non-CANCELLED, and either
     // overlapping the last-30-day window OR starting in the future.

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -6,7 +6,7 @@ import {
   threads,
   vehicles,
 } from '@kuruma/shared/db/schema'
-import type { Message } from '../../stores'
+import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../../stores'
 
 export type Db = ReturnType<typeof getDb>
 
@@ -73,6 +73,75 @@ export const messageColumns = {
   sourceLanguage: messages.sourceLanguage,
   translations: messages.translations,
   createdAt: messages.createdAt,
+}
+
+// --- Row-to-domain mappers ---
+// Drizzle infers wider types than our domain interfaces (e.g. `string`
+// instead of `'AUTO' | 'MANUAL'`). These mappers verify every field at
+// the boundary. If a schema column is added to the domain type, the
+// mapper fails to compile — unlike `as Type` which silently allows it.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle row types vary
+type AnyRow = Record<string, any>
+
+export function toVehicle(r: AnyRow): Vehicle {
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    photos: r.photos,
+    seats: r.seats,
+    transmission: r.transmission,
+    fuelType: r.fuelType,
+    status: r.status,
+    bufferMinutes: r.bufferMinutes,
+    minRentalHours: r.minRentalHours,
+    maxRentalHours: r.maxRentalHours,
+    advanceBookingHours: r.advanceBookingHours,
+    dailyRateJpy: r.dailyRateJpy,
+    hourlyRateJpy: r.hourlyRateJpy,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }
+}
+
+export function toBooking(r: AnyRow): Booking {
+  return {
+    id: r.id,
+    renterId: r.renterId,
+    vehicleId: r.vehicleId,
+    startAt: r.startAt,
+    endAt: r.endAt,
+    effectiveEndAt: r.effectiveEndAt,
+    status: r.status,
+    source: r.source,
+    externalId: r.externalId,
+    notes: r.notes,
+    totalPrice: r.totalPrice,
+    cancellationFee: r.cancellationFee,
+    cancelledAt: r.cancelledAt,
+    idempotencyKey: r.idempotencyKey,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }
+}
+
+export function toThread(r: AnyRow): Thread {
+  return {
+    id: r.id,
+    bookingId: r.bookingId,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }
+}
+
+export function toThreadParticipant(r: AnyRow): ThreadParticipant {
+  return {
+    id: r.id,
+    threadId: r.threadId,
+    userId: r.userId,
+    unreadCount: r.unreadCount,
+  }
 }
 
 // Raw row shape returned by message queries. Extracted because it appears in

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -9,6 +9,8 @@ import {
   normaliseMessage,
   participantColumns,
   threadColumns,
+  toThread,
+  toThreadParticipant,
 } from './shared'
 
 export class DrizzleThreadRepository implements ThreadRepository {
@@ -30,13 +32,13 @@ export class DrizzleThreadRepository implements ThreadRepository {
     const threadRows = (await this.db
       .select(threadColumns)
       .from(threads)
-      .where(inArray(threads.id, threadIds))) as Thread[]
+      .where(inArray(threads.id, threadIds))).map(toThread)
 
     // Step 3: fetch all participants for those threads in one round-trip.
     const participantRows = (await this.db
       .select(participantColumns)
       .from(threadParticipants)
-      .where(inArray(threadParticipants.threadId, threadIds))) as ThreadParticipant[]
+      .where(inArray(threadParticipants.threadId, threadIds))).map(toThreadParticipant)
 
     // Step 4: fetch only the latest message per thread. The DISTINCT ON
     // pattern keeps this O(threads) instead of O(messages) -- important once
@@ -78,7 +80,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
     const [thread] = (await this.db
       .select(threadColumns)
       .from(threads)
-      .where(eq(threads.id, id))) as Thread[]
+      .where(eq(threads.id, id))).map(toThread)
 
     if (!thread) return undefined
 
@@ -96,7 +98,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
 
     return {
       ...thread,
-      participants: participantRows as ThreadParticipant[],
+      participants: participantRows.map(toThreadParticipant),
       messages: (messageRows as Array<Parameters<typeof normaliseMessage>[0]>).map(
         normaliseMessage,
       ),
@@ -113,7 +115,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
     const [insertedThread] = (await this.db
       .insert(threads)
       .values({ bookingId })
-      .returning(threadColumns)) as Thread[]
+      .returning(threadColumns)).map(toThread)
 
     if (!insertedThread) {
       throw new Error('Failed to insert thread')

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -2,7 +2,7 @@ import { vehicles } from '@kuruma/shared/db/schema'
 import { eq, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
 import type { VehicleRepository } from '../types'
-import { type Db, vehicleColumns } from './shared'
+import { type Db, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
   constructor(private readonly db: Db) {}
@@ -14,13 +14,13 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       ? await query.where(eq(vehicles.status, filters.status as Vehicle['status']))
       : await query
 
-    return rows as Vehicle[]
+    return rows.map(toVehicle)
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {
     const [row] = await this.db.select(vehicleColumns).from(vehicles).where(eq(vehicles.id, id))
 
-    return (row as Vehicle) ?? undefined
+    return row ? toVehicle(row) : undefined
   }
 
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {
@@ -43,7 +43,8 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       })
       .returning()
 
-    return inserted as Vehicle
+    if (!inserted) throw new Error('Failed to insert vehicle')
+    return toVehicle(inserted)
   }
 
   async update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined> {
@@ -54,7 +55,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .where(eq(vehicles.id, id))
       .returning()
 
-    return (updated as Vehicle) ?? undefined
+    return updated ? toVehicle(updated) : undefined
   }
 
   async softDelete(id: string): Promise<Vehicle | undefined> {
@@ -64,6 +65,6 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .where(eq(vehicles.id, id))
       .returning()
 
-    return (retired as Vehicle) ?? undefined
+    return retired ? toVehicle(retired) : undefined
   }
 }


### PR DESCRIPTION
## Summary

- Added `toVehicle`, `toBooking`, `toThread`, `toThreadParticipant` mapper functions in `shared.ts`
- Replaced 20 scattered `as Type` assertions across 5 Drizzle repo files
- Each mapper explicitly maps every field — compiler catches missing fields on domain type changes
- Kept 2 input-narrowing casts (`filters.status as Vehicle['status']`) which are correct

## Test plan

- [x] All 488 tests pass (124 + 148 + 216)
- [x] Typecheck clean
- [x] Lint clean

Closes #93