### PR TITLE
fix(api): batch vehicle lookup to fix N+1 query

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,5 +1,5 @@
 import { vehicles } from '@kuruma/shared/db/schema'
-import { eq, sql } from 'drizzle-orm'
+import { eq, inArray, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
 import type { VehicleRepository } from '../types'
 import { type Db, vehicleColumns } from './shared'
@@ -21,6 +21,15 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     const [row] = await this.db.select(vehicleColumns).from(vehicles).where(eq(vehicles.id, id))
 
     return (row as Vehicle) ?? undefined
+  }
+
+  async findByIds(ids: string[]): Promise<Vehicle[]> {
+    if (ids.length === 0) return []
+    const rows = await this.db
+      .select(vehicleColumns)
+      .from(vehicles)
+      .where(inArray(vehicles.id, ids))
+    return rows as Vehicle[]
   }
 
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -18,6 +18,13 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     return this.store.get(id)
   }
 
+  async findByIds(ids: string[]): Promise<Vehicle[]> {
+    return ids.flatMap((id) => {
+      const v = this.store.get(id)
+      return v ? [v] : []
+    })
+  }
+
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {
     const now = new Date()
     const vehicle: Vehicle = {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -11,6 +11,7 @@ import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../st
 export interface VehicleRepository {
   findAll(filters?: { status?: string }): Promise<Vehicle[]>
   findById(id: string): Promise<Vehicle | undefined>
+  findByIds(ids: string[]): Promise<Vehicle[]>
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>
   update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -71,7 +71,7 @@ export class BookingService {
     if (!this.vehicleRepo) return { data, nextCursor }
 
     const vehicleIds = [...new Set(data.map((b) => b.vehicleId))]
-    const vehicleList = await this.vehicleRepo!.findByIds(vehicleIds)
+    const vehicleList = await this.vehicleRepo.findByIds(vehicleIds)
     const vehicleMap = new Map(vehicleList.map((v) => [v.id, { name: v.name, photos: v.photos }]))
 
     return {

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -71,16 +71,8 @@ export class BookingService {
     if (!this.vehicleRepo) return { data, nextCursor }
 
     const vehicleIds = [...new Set(data.map((b) => b.vehicleId))]
-    const vehicleMap = new Map<string, { name: string; photos: string[] }>()
-
-    await Promise.all(
-      vehicleIds.map(async (vid) => {
-        const vehicle = await this.vehicleRepo!.findById(vid)
-        if (vehicle) {
-          vehicleMap.set(vid, { name: vehicle.name, photos: vehicle.photos })
-        }
-      }),
-    )
+    const vehicleList = await this.vehicleRepo!.findByIds(vehicleIds)
+    const vehicleMap = new Map(vehicleList.map((v) => [v.id, { name: v.name, photos: v.photos }]))
 
     return {
       data: data.map((booking) => ({

--- a/packages/api/tests/repositories/vehicle.test.ts
+++ b/packages/api/tests/repositories/vehicle.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
+import type { Vehicle } from '../../src/stores'
+
+function vehicleInput(overrides?: Partial<Vehicle>) {
+  return {
+    name: 'Test Car',
+    description: 'A test vehicle',
+    photos: ['photo.jpg'],
+    seats: 4,
+    transmission: 'AUTOMATIC' as const,
+    fuelType: 'GASOLINE' as const,
+    status: 'ACTIVE' as const,
+    bufferMinutes: 60,
+    minRentalHours: 1,
+    maxRentalHours: 168,
+    advanceBookingHours: 24,
+    dailyRateJpy: 5000,
+    hourlyRateJpy: 1000,
+    ...overrides,
+  }
+}
+
+describe('VehicleRepository.findByIds', () => {
+  let repo: InMemoryVehicleRepository
+
+  beforeEach(() => {
+    repo = new InMemoryVehicleRepository()
+  })
+
+  it('returns empty array for empty input', async () => {
+    const result = await repo.findByIds([])
+    expect(result).toEqual([])
+  })
+
+  it('returns matching vehicles for given IDs', async () => {
+    const v1 = await repo.create(vehicleInput({ name: 'Car A' }))
+    const v2 = await repo.create(vehicleInput({ name: 'Car B' }))
+    await repo.create(vehicleInput({ name: 'Car C' }))
+
+    const result = await repo.findByIds([v1.id, v2.id])
+
+    expect(result).toHaveLength(2)
+    const names = result.map((v) => v.name).sort()
+    expect(names).toEqual(['Car A', 'Car B'])
+  })
+
+  it('skips IDs that do not exist', async () => {
+    const v1 = await repo.create(vehicleInput({ name: 'Car A' }))
+
+    const result = await repo.findByIds([v1.id, 'nonexistent-id'])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe('Car A')
+  })
+})


### PR DESCRIPTION
## Summary
- Added `findByIds(ids: string[])` to `VehicleRepository` interface
- Drizzle impl uses `WHERE id IN (...)` -- single round-trip instead of N
- InMemory impl uses `flatMap` over store
- `BookingService.findAllWithVehiclesPaginated` now calls `findByIds` instead of `Promise.all(ids.map(findById))`

## What changed
- `packages/api/src/repositories/types.ts` -- new interface method
- `packages/api/src/repositories/drizzle/vehicle.ts` -- Drizzle `inArray` impl
- `packages/api/src/repositories/in-memory/vehicle.ts` -- InMemory impl
- `packages/api/src/services/booking.ts` -- replaced N+1 loop with batch call

## Test plan
- [x] New unit tests for `findByIds` (empty, multiple, missing IDs)
- [x] Existing `?expand=vehicle` test passes unchanged
- [x] Full API suite: 151 tests pass
- [x] TypeScript strict mode clean
- [x] Biome lint clean

Closes #134