### PR TITLE
fix(api): gate CORS dev origins behind NODE_ENV

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -152,10 +152,10 @@ function resolveAllowedOrigins(envValue: string | undefined): string[] {
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
 
-  // Always include the dev origins so `bun run dev` + `bun run dev:api`
-  // works out of the box. Deduped because the user may also list them in
-  // WEB_ORIGIN explicitly.
-  return [...new Set([...DEV_WEB_ORIGINS, ...fromEnv])]
+  // Only include dev origins outside production so `bun run dev` works
+  // out of the box without leaking localhost to prod.
+  const devOrigins = process.env.NODE_ENV === 'production' ? [] : DEV_WEB_ORIGINS
+  return [...new Set([...devOrigins, ...fromEnv])]
 }
 
 export default createApp()

--- a/packages/api/tests/routes/cors-env.test.ts
+++ b/packages/api/tests/routes/cors-env.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+
+describe('CORS env gating', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('rejects dev origins when NODE_ENV is production', async () => {
+    process.env.NODE_ENV = 'production'
+    const app = createApp()
+
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://localhost:3001' },
+    })
+
+    expect(res.status).toBe(200)
+    const acao = res.headers.get('Access-Control-Allow-Origin')
+    expect(acao).not.toBe('http://localhost:3001')
+  })
+
+  it('rejects 127.0.0.1 dev origin when NODE_ENV is production', async () => {
+    process.env.NODE_ENV = 'production'
+    const app = createApp()
+
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://127.0.0.1:3001' },
+    })
+
+    const acao = res.headers.get('Access-Control-Allow-Origin')
+    expect(acao).not.toBe('http://127.0.0.1:3001')
+  })
+
+  it('allows dev origins when NODE_ENV is not production', async () => {
+    process.env.NODE_ENV = 'development'
+    const app = createApp()
+
+    const res = await app.request('/health', {
+      headers: { Origin: 'http://localhost:3001' },
+    })
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3001')
+  })
+
+  it('allows configured WEB_ORIGIN in production', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.WEB_ORIGIN = 'https://kuruma.example.com'
+    const app = createApp()
+
+    const res = await app.request('/health', {
+      headers: { Origin: 'https://kuruma.example.com' },
+    })
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://kuruma.example.com')
+    process.env.WEB_ORIGIN = undefined
+  })
+})


### PR DESCRIPTION
## Summary
- Dev origins (`localhost:3001`, `127.0.0.1:3001`) were unconditionally included in CORS allowed origins, even in production
- Now gated behind `NODE_ENV !== 'production'` so they only apply in dev/test

## Test plan
- [x] New test: dev origins rejected when `NODE_ENV=production`
- [x] New test: dev origins allowed when `NODE_ENV=development`
- [x] New test: `WEB_ORIGIN` env var works in production
- [x] Existing CORS tests still pass (150/150 all API tests green)

Closes #139