### PR TITLE
perf(api): fix N+1 query in findAllWithVehicles

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,5 +1,5 @@
 import { vehicles } from '@kuruma/shared/db/schema'
-import { eq, sql } from 'drizzle-orm'
+import { eq, inArray, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
 import type { VehicleRepository } from '../types'
 import { type Db, vehicleColumns } from './shared'
@@ -21,6 +21,15 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     const [row] = await this.db.select(vehicleColumns).from(vehicles).where(eq(vehicles.id, id))
 
     return (row as Vehicle) ?? undefined
+  }
+
+  async findByIds(ids: string[]): Promise<Vehicle[]> {
+    if (ids.length === 0) return []
+    const rows = await this.db
+      .select(vehicleColumns)
+      .from(vehicles)
+      .where(inArray(vehicles.id, ids))
+    return rows as Vehicle[]
   }
 
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -18,6 +18,13 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     return this.store.get(id)
   }
 
+  async findByIds(ids: string[]): Promise<Vehicle[]> {
+    return ids.flatMap((id) => {
+      const v = this.store.get(id)
+      return v ? [v] : []
+    })
+  }
+
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {
     const now = new Date()
     const vehicle: Vehicle = {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -11,6 +11,7 @@ import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../st
 export interface VehicleRepository {
   findAll(filters?: { status?: string }): Promise<Vehicle[]>
   findById(id: string): Promise<Vehicle | undefined>
+  findByIds(ids: string[]): Promise<Vehicle[]>
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>
   update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -71,16 +71,8 @@ export class BookingService {
     if (!this.vehicleRepo) return { data, nextCursor }
 
     const vehicleIds = [...new Set(data.map((b) => b.vehicleId))]
-    const vehicleMap = new Map<string, { name: string; photos: string[] }>()
-
-    await Promise.all(
-      vehicleIds.map(async (vid) => {
-        const vehicle = await this.vehicleRepo!.findById(vid)
-        if (vehicle) {
-          vehicleMap.set(vid, { name: vehicle.name, photos: vehicle.photos })
-        }
-      }),
-    )
+    const vehicles = await this.vehicleRepo.findByIds(vehicleIds)
+    const vehicleMap = new Map(vehicles.map((v) => [v.id, { name: v.name, photos: v.photos }]))
 
     return {
       data: data.map((booking) => ({

--- a/packages/api/tests/repositories/vehicle.test.ts
+++ b/packages/api/tests/repositories/vehicle.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory/vehicle'
+
+const vehicleData = {
+  name: 'Test Car',
+  description: 'A test vehicle',
+  photos: ['photo.jpg'],
+  seats: 5,
+  transmission: 'AUTO' as const,
+  fuelType: 'Gasoline',
+  status: 'AVAILABLE' as const,
+  bufferMinutes: 60,
+  minRentalHours: null,
+  maxRentalHours: null,
+  advanceBookingHours: null,
+  dailyRateJpy: 10000,
+  hourlyRateJpy: null,
+}
+
+describe('VehicleRepository.findByIds', () => {
+  it('returns vehicles matching the given IDs', async () => {
+    const repo = new InMemoryVehicleRepository()
+    const v1 = await repo.create({ ...vehicleData, name: 'Car A' })
+    const v2 = await repo.create({ ...vehicleData, name: 'Car B' })
+    await repo.create({ ...vehicleData, name: 'Car C' })
+
+    const result = await repo.findByIds([v1.id, v2.id])
+
+    expect(result).toHaveLength(2)
+    expect(result.map((v) => v.name).sort()).toEqual(['Car A', 'Car B'])
+  })
+
+  it('returns empty array for empty input', async () => {
+    const repo = new InMemoryVehicleRepository()
+    const result = await repo.findByIds([])
+    expect(result).toEqual([])
+  })
+
+  it('skips IDs that do not exist', async () => {
+    const repo = new InMemoryVehicleRepository()
+    const v1 = await repo.create(vehicleData)
+
+    const result = await repo.findByIds([v1.id, 'nonexistent-id'])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe(v1.id)
+  })
+})


### PR DESCRIPTION
## Summary
- Replace N individual `findById` calls with single `findByIds(ids)` batch query
- `GET /bookings?expand=vehicle` was firing 1 SELECT per distinct vehicle — now fires 1 total

## What changed
- **`repositories/types.ts`** — add `findByIds(ids: string[]): Promise<Vehicle[]>` to `VehicleRepository`
- **`repositories/drizzle/vehicle.ts`** — implement with `WHERE id IN (...)` via `inArray()`
- **`repositories/in-memory/vehicle.ts`** — implement with Map lookup
- **`services/booking.ts`** — replace `Promise.all(ids.map(findById))` with `findByIds(ids)`
- **`tests/repositories/vehicle.test.ts`** — 3 tests for findByIds (match, empty, missing IDs)

## Test plan
- [x] 3 new findByIds unit tests pass
- [x] Existing `expand=vehicle` route test still passes (behavioral — doesn't care about internal query count)
- [x] Full suite: 151 tests green
- [x] TypeScript strict mode clean

Closes #134