### PR TITLE
fix(db): correct JPY currency handling and unify formatJpy()

### DIFF
--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -122,8 +122,8 @@ export const bookings = pgTable('bookings', {
   source: bookingSourceEnum('source').notNull().default('DIRECT'),
   externalId: text('externalId'),
   notes: text('notes'),
-  totalPrice: integer('totalPrice'), // cents, nullable for legacy bookings
-  cancellationFee: integer('cancellationFee'), // cents, set on cancellation
+  totalPrice: integer('totalPrice'), // whole JPY, nullable for legacy bookings
+  cancellationFee: integer('cancellationFee'), // whole JPY, set on cancellation
   cancelledAt: timestamp('cancelledAt', { withTimezone: true, mode: 'date' }),
   idempotencyKey: text('idempotencyKey'),
   createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/tests/lib/cancellation-policy.test.ts
+++ b/packages/shared/tests/lib/cancellation-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { calculateCancellationFee } from '../../src/lib/cancellation-policy'
 
 describe('calculateCancellationFee', () => {
-  const totalPrice = 10000 // ¥10,000 in cents
+  const totalPrice = 10000 // ¥10,000
 
   test('72h+ before pickup → FREE tier, 0% fee', () => {
     const pickupAt = new Date('2026-05-10T10:00:00Z')

--- a/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Link } from '@/i18n/routing'
+import { formatJpy } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import type { VehicleDetailData } from '@/lib/vehicle-api'
 import { ArrowLeft, Calendar, Car, Clock, Fuel, Settings2, Users } from 'lucide-react'
@@ -14,10 +15,6 @@ type Translator = Awaited<ReturnType<typeof getTranslations>>
 interface VehicleDetailProps {
   vehicle: VehicleDetailData
   t: Translator
-}
-
-function formatJpy(amount: number): string {
-  return `\u00a5${amount.toLocaleString('en-US')}`
 }
 
 function formatDateRange(startAt: string, endAt: string): string {

--- a/packages/web/src/components/landing/FeaturedVehicles.tsx
+++ b/packages/web/src/components/landing/FeaturedVehicles.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from '@/components/ui/button'
 import { Link } from '@/i18n/routing'
+import { formatJpy } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import { ArrowRight, Star, Users } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -87,9 +88,7 @@ export function FeaturedVehicles() {
                 <p className="text-sm text-muted-foreground mt-0.5">{vehicle.type}</p>
                 <div className="flex items-center justify-between mt-3">
                   <p className="text-sm">
-                    <span className="font-semibold">
-                      {t('currency', { price: vehicle.price.toLocaleString() })}
-                    </span>
+                    <span className="font-semibold">{formatJpy(vehicle.price)}</span>
                     <span className="text-muted-foreground"> / {t('perDay')}</span>
                   </p>
                   <div className="flex items-center gap-1 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Fix schema comments on `totalPrice` and `cancellationFee` from "cents" to "whole JPY"
- Fix misleading test comment in cancellation-policy tests
- Remove duplicate local `formatJpy` in VehicleDetail, replace ad-hoc `toLocaleString` in FeaturedVehicles — both now use shared `formatJpy()` from `lib/format`

## Test plan
- [x] All 124 shared package tests pass
- [x] Biome lint + tsc pass (pre-commit hooks)
- [x] No logic changes to pricing — comments and import consolidation only

Closes #145
Closes #160