### PR TITLE
fix(validators): tighten booking status to z.enum, IDs to z.uuid

### DIFF
--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -14,10 +14,15 @@ function futureDate(hoursFromNow: number): string {
   return new Date(Date.now() + hoursFromNow * 60 * 60 * 1000).toISOString()
 }
 
+const V1 = '00000000-0000-4000-8000-000000000001'
+const V2 = '00000000-0000-4000-8000-000000000002'
+const USER1 = '00000000-0000-4000-8000-0000000000a1'
+const USER2 = '00000000-0000-4000-8000-0000000000a2'
+
 function validBookingInput() {
   return {
-    vehicleId: 'v1',
-    renterId: 'user1',
+    vehicleId: V1,
+    renterId: USER1,
     startAt: futureDate(24),
     endAt: futureDate(48),
     source: 'DIRECT' as const,
@@ -55,7 +60,7 @@ describe('Booking Routes', () => {
       await createBooking()
       await createBooking({
         ...validBookingInput(),
-        vehicleId: 'v2',
+        vehicleId: V2,
       })
 
       const res = await app.request('/bookings')
@@ -90,31 +95,31 @@ describe('Booking Routes', () => {
       await createBooking()
       await createBooking({
         ...validBookingInput(),
-        vehicleId: 'v2',
+        vehicleId: V2,
       })
 
-      const res = await app.request('/bookings?vehicleId=v1')
+      const res = await app.request(`/bookings?vehicleId=${V1}`)
       const body = await res.json()
 
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(1)
-      expect(body.data[0].vehicleId).toBe('v1')
+      expect(body.data[0].vehicleId).toBe(V1)
     })
 
     it('filters by renterId', async () => {
       await createBooking()
       await createBooking({
         ...validBookingInput(),
-        renterId: 'user2',
-        vehicleId: 'v2',
+        renterId: USER2,
+        vehicleId: V2,
       })
 
-      const res = await app.request('/bookings?renterId=user1')
+      const res = await app.request(`/bookings?renterId=${USER1}`)
       const body = await res.json()
 
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(1)
-      expect(body.data[0].renterId).toBe('user1')
+      expect(body.data[0].renterId).toBe(USER1)
     })
 
     it('filters by renterId returning empty when no match', async () => {
@@ -164,7 +169,7 @@ describe('Booking Routes', () => {
       await createBooking()
       await createBooking({
         ...validBookingInput(),
-        vehicleId: 'v2',
+        vehicleId: V2,
       })
 
       // Cancel one
@@ -275,8 +280,8 @@ describe('Booking Routes', () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            vehicleId: `v-page-${i}`,
-            renterId: 'user1',
+            vehicleId: `00000000-0000-4000-8000-00000000${String(i).padStart(4, '0')}`,
+            renterId: USER1,
             startAt: futureDate(24),
             endAt: futureDate(48),
             source: 'DIRECT',
@@ -385,8 +390,8 @@ describe('Booking Routes', () => {
 
       const body = await res.json()
       expect(body.success).toBe(true)
-      expect(body.data.vehicleId).toBe('v1')
-      expect(body.data.renterId).toBe('user1')
+      expect(body.data.vehicleId).toBe(V1)
+      expect(body.data.renterId).toBe(USER1)
       expect(body.data.status).toBe('CONFIRMED')
       expect(body.data.source).toBe('DIRECT')
       expect(body.data.externalId).toBeNull()
@@ -401,7 +406,7 @@ describe('Booking Routes', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          renterId: 'user1',
+          renterId: USER1,
           startAt: futureDate(24),
           endAt: futureDate(48),
         }),
@@ -412,6 +417,33 @@ describe('Booking Routes', () => {
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBeDefined()
+    })
+
+    it('rejects non-UUID vehicleId with 400', async () => {
+      const res = await createBooking({
+        ...validBookingInput(),
+        vehicleId: 'not-a-uuid',
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error.vehicleId[0]).toContain('UUID')
+    })
+
+    it('rejects invalid status string in PATCH /bookings/:id/status', async () => {
+      const createRes = await createBooking()
+      const created = await createRes.json()
+
+      const res = await app.request(`/bookings/${created.data.id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'BANANA' }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
     })
 
     it('rejects endAt before startAt and returns 400', async () => {
@@ -448,7 +480,7 @@ describe('Booking Routes', () => {
       const first = await createBooking()
       expect(first.status).toBe(201)
 
-      const res = await createBooking({ ...validBookingInput(), vehicleId: 'v2' })
+      const res = await createBooking({ ...validBookingInput(), vehicleId: V2 })
       expect(res.status).toBe(201)
     })
 
@@ -592,7 +624,7 @@ describe('Booking Routes', () => {
         const first = await createBooking({
           ...validBookingInput(),
           idempotencyKey: crypto.randomUUID(),
-          vehicleId: 'v1',
+          vehicleId: V1,
         })
         expect(first.status).toBe(201)
         const firstBody = await first.json()
@@ -600,7 +632,7 @@ describe('Booking Routes', () => {
         const second = await createBooking({
           ...validBookingInput(),
           idempotencyKey: crypto.randomUUID(),
-          vehicleId: 'v2',
+          vehicleId: V2,
         })
         expect(second.status).toBe(201)
         const secondBody = await second.json()
@@ -624,7 +656,7 @@ describe('Booking Routes', () => {
         // then both attempt create. Second one hits the unique constraint.
         const [r1, r2] = await Promise.all([
           createBooking(input),
-          createBooking({ ...input, vehicleId: 'v2' }),
+          createBooking({ ...input, vehicleId: V2 }),
         ])
 
         const statuses = [r1.status, r2.status].sort()
@@ -676,7 +708,7 @@ describe('Booking Routes', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             vehicleId,
-            renterId: 'user1',
+            renterId: USER1,
             startAt: futureDate(48),
             endAt: futureDate(72),
             source: 'DIRECT',
@@ -721,7 +753,7 @@ describe('Booking Routes', () => {
       const body = await res.json()
       expect(body.success).toBe(true)
       expect(body.data.id).toBe(created.data.id)
-      expect(body.data.vehicleId).toBe('v1')
+      expect(body.data.vehicleId).toBe(V1)
     })
 
     it('returns 404 for nonexistent booking', async () => {

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -6,6 +6,10 @@ import {
 } from '../../src/repositories/in-memory'
 import { createMessageRoutes } from '../../src/routes/messages'
 
+const U1 = '00000000-0000-4000-8000-0000000000a1'
+const U2 = '00000000-0000-4000-8000-0000000000a2'
+const U3 = '00000000-0000-4000-8000-0000000000a3'
+
 let app: Hono
 let threadRepo: InMemoryThreadRepository
 let messageRepo: InMemoryMessageRepository
@@ -20,7 +24,7 @@ describe('Message Routes', () => {
 
   describe('GET /threads', () => {
     it('returns empty list when no threads exist for user', async () => {
-      const res = await app.request('/threads?userId=user1')
+      const res = await app.request(`/threads?userId=${U1}`)
 
       expect(res.status).toBe(200)
 
@@ -33,18 +37,18 @@ describe('Message Routes', () => {
       await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user1', 'user2'] }),
+        body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
-      const res = await app.request('/threads?userId=user1')
+      const res = await app.request(`/threads?userId=${U1}`)
       const body = await res.json()
 
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(1)
       expect(body.data[0].participants).toHaveLength(2)
       expect(body.data[0].participants.map((p: { userId: string }) => p.userId).sort()).toEqual([
-        'user1',
-        'user2',
+        U1,
+        U2,
       ])
       expect(body.data[0].lastMessage).toBeNull()
     })
@@ -54,30 +58,30 @@ describe('Message Routes', () => {
       await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user1', 'user2'] }),
+        body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
       // Thread between user2 and user3 (user1 is NOT a participant)
       await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user2', 'user3'] }),
+        body: JSON.stringify({ participantIds: [U2, U3] }),
       })
 
       // user1 should only see 1 thread
-      const res1 = await app.request('/threads?userId=user1')
+      const res1 = await app.request(`/threads?userId=${U1}`)
       const body1 = await res1.json()
       expect(body1.success).toBe(true)
       expect(body1.data).toHaveLength(1)
 
       // user2 should see both threads
-      const res2 = await app.request('/threads?userId=user2')
+      const res2 = await app.request(`/threads?userId=${U2}`)
       const body2 = await res2.json()
       expect(body2.success).toBe(true)
       expect(body2.data).toHaveLength(2)
 
       // user3 should see only 1 thread
-      const res3 = await app.request('/threads?userId=user3')
+      const res3 = await app.request(`/threads?userId=${U3}`)
       const body3 = await res3.json()
       expect(body3.success).toBe(true)
       expect(body3.data).toHaveLength(1)
@@ -90,7 +94,7 @@ describe('Message Routes', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          participantIds: ['user1', 'user2'],
+          participantIds: [U1, U2],
         }),
       })
 
@@ -111,7 +115,7 @@ describe('Message Routes', () => {
       const createRes = await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user1', 'user2'] }),
+        body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
       const threadId = created.data.id
@@ -119,7 +123,7 @@ describe('Message Routes', () => {
       const res = await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: 'Hello!', senderId: 'user1' }),
+        body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
 
       expect(res.status).toBe(201)
@@ -127,7 +131,7 @@ describe('Message Routes', () => {
       const body = await res.json()
       expect(body.success).toBe(true)
       expect(body.data.threadId).toBe(threadId)
-      expect(body.data.senderId).toBe('user1')
+      expect(body.data.senderId).toBe(U1)
       expect(body.data.content).toBe('Hello!')
       expect(body.data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
       expect(body.data.createdAt).toBeDefined()
@@ -140,7 +144,7 @@ describe('Message Routes', () => {
       const createRes = await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user1', 'user2'] }),
+        body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
       const threadId = created.data.id
@@ -149,12 +153,12 @@ describe('Message Routes', () => {
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: 'Hello!', senderId: 'user1' }),
+        body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: 'Hi there!', senderId: 'user2' }),
+        body: JSON.stringify({ content: 'Hi there!', senderId: U2 }),
       })
 
       const res = await app.request(`/threads/${threadId}`)
@@ -167,9 +171,9 @@ describe('Message Routes', () => {
       expect(body.data.participants).toHaveLength(2)
       expect(body.data.messages).toHaveLength(2)
       expect(body.data.messages[0].content).toBe('Hello!')
-      expect(body.data.messages[0].senderId).toBe('user1')
+      expect(body.data.messages[0].senderId).toBe(U1)
       expect(body.data.messages[1].content).toBe('Hi there!')
-      expect(body.data.messages[1].senderId).toBe('user2')
+      expect(body.data.messages[1].senderId).toBe(U2)
     })
 
     it('returns 404 for nonexistent thread', async () => {
@@ -189,7 +193,7 @@ describe('Message Routes', () => {
       const createRes = await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: ['user1', 'user2'] }),
+        body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
       const threadId = created.data.id
@@ -198,19 +202,19 @@ describe('Message Routes', () => {
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: 'Hello!', senderId: 'user1' }),
+        body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: 'Are you there?', senderId: 'user1' }),
+        body: JSON.stringify({ content: 'Are you there?', senderId: U1 }),
       })
 
       // Verify user2 has unread messages via thread list
-      const beforeRes = await app.request('/threads?userId=user2')
+      const beforeRes = await app.request(`/threads?userId=${U2}`)
       const beforeBody = await beforeRes.json()
       const user2Participant = beforeBody.data[0].participants.find(
-        (p: { userId: string }) => p.userId === 'user2',
+        (p: { userId: string }) => p.userId === U2,
       )
       expect(user2Participant.unreadCount).toBe(2)
 
@@ -218,7 +222,7 @@ describe('Message Routes', () => {
       const readRes = await app.request(`/threads/${threadId}/read`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: 'user2' }),
+        body: JSON.stringify({ userId: U2 }),
       })
 
       expect(readRes.status).toBe(200)
@@ -226,10 +230,10 @@ describe('Message Routes', () => {
       expect(readBody.success).toBe(true)
 
       // Verify unread count is now 0
-      const afterRes = await app.request('/threads?userId=user2')
+      const afterRes = await app.request(`/threads?userId=${U2}`)
       const afterBody = await afterRes.json()
       const user2After = afterBody.data[0].participants.find(
-        (p: { userId: string }) => p.userId === 'user2',
+        (p: { userId: string }) => p.userId === U2,
       )
       expect(user2After.unreadCount).toBe(0)
     })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,7 +9,7 @@ export {
 } from './validators/vehicle'
 export {
   createBookingSchema,
-  cancelBookingSchema,
+  updateBookingStatusSchema,
   type CreateBookingInput,
-  type CancelBookingInput,
+  type UpdateBookingStatusInput,
 } from './validators/booking'

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 // dropped by Zod, and the server writes its own computed value.
 export const createBookingSchema = z
   .object({
-    vehicleId: z.string().min(1, 'Vehicle ID is required'),
+    vehicleId: z.string().uuid('Vehicle ID must be a valid UUID'),
     startAt: z.string().datetime({ message: 'Must be ISO datetime' }),
     endAt: z.string().datetime({ message: 'Must be ISO datetime' }),
     notes: z.string().optional(),
@@ -20,12 +20,10 @@ export const createBookingSchema = z
   })
 
 export const updateBookingStatusSchema = z.object({
-  status: z.string().min(1, 'Status is required'),
-})
-
-export const cancelBookingSchema = z.object({
-  reason: z.string().optional(),
+  status: z.enum(['CONFIRMED', 'ACTIVE', 'COMPLETED', 'CANCELLED'], {
+    message: 'Status must be CONFIRMED, ACTIVE, COMPLETED, or CANCELLED',
+  }),
 })
 
 export type CreateBookingInput = z.infer<typeof createBookingSchema>
-export type CancelBookingInput = z.infer<typeof cancelBookingSchema>
+export type UpdateBookingStatusInput = z.infer<typeof updateBookingStatusSchema>

--- a/packages/shared/src/validators/message.ts
+++ b/packages/shared/src/validators/message.ts
@@ -1,17 +1,19 @@
 import { z } from 'zod'
 
 export const createThreadSchema = z.object({
-  bookingId: z.string().optional(),
-  participantIds: z.array(z.string().min(1)).min(1, 'At least one participant required'),
+  bookingId: z.string().uuid('Must be a valid UUID').optional(),
+  participantIds: z
+    .array(z.string().uuid('Each participant ID must be a valid UUID'))
+    .min(1, 'At least one participant required'),
 })
 
 export const sendMessageSchema = z.object({
-  senderId: z.string().min(1, 'senderId is required'),
+  senderId: z.string().uuid('senderId must be a valid UUID'),
   content: z.string().trim().min(1, 'Message cannot be empty').max(5000),
 })
 
 export const markReadSchema = z.object({
-  userId: z.string().min(1, 'userId is required'),
+  userId: z.string().uuid('userId must be a valid UUID'),
 })
 
 export type CreateThreadInput = z.infer<typeof createThreadSchema>

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { cancelBookingSchema, createBookingSchema } from '../../src/validators/booking'
+import { createBookingSchema, updateBookingStatusSchema } from '../../src/validators/booking'
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
 
 describe('createBookingSchema', () => {
   const validInput = {
-    vehicleId: 'vehicle-123',
+    vehicleId: VALID_UUID,
     startAt: '2026-04-10T09:00:00Z',
     endAt: '2026-04-10T17:00:00Z',
   }
@@ -12,7 +14,7 @@ describe('createBookingSchema', () => {
     const result = createBookingSchema.safeParse(validInput)
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.source).toBe('DIRECT') // default
+      expect(result.data.source).toBe('DIRECT')
     }
   })
 
@@ -24,6 +26,11 @@ describe('createBookingSchema', () => {
       externalId: 'TC-12345',
     })
     expect(result.success).toBe(true)
+  })
+
+  it('rejects non-UUID vehicleId', () => {
+    const result = createBookingSchema.safeParse({ ...validInput, vehicleId: 'vehicle-123' })
+    expect(result.success).toBe(false)
   })
 
   it('rejects missing vehicleId', () => {
@@ -52,17 +59,29 @@ describe('createBookingSchema', () => {
   })
 })
 
-describe('cancelBookingSchema', () => {
-  it('accepts empty object', () => {
-    const result = cancelBookingSchema.safeParse({})
-    expect(result.success).toBe(true)
-  })
-
-  it('accepts reason', () => {
-    const result = cancelBookingSchema.safeParse({ reason: 'Flight cancelled' })
+describe('updateBookingStatusSchema', () => {
+  it('accepts valid status', () => {
+    const result = updateBookingStatusSchema.safeParse({ status: 'ACTIVE' })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.reason).toBe('Flight cancelled')
+      expect(result.data.status).toBe('ACTIVE')
     }
+  })
+
+  it('accepts all valid statuses', () => {
+    for (const status of ['CONFIRMED', 'ACTIVE', 'COMPLETED', 'CANCELLED']) {
+      const result = updateBookingStatusSchema.safeParse({ status })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid status', () => {
+    const result = updateBookingStatusSchema.safeParse({ status: 'BANANA' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty status', () => {
+    const result = updateBookingStatusSchema.safeParse({ status: '' })
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/shared/tests/validators/message.test.ts
+++ b/packages/shared/tests/validators/message.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { createThreadSchema, markReadSchema, sendMessageSchema } from '../../src/validators/message'
 
+const UUID1 = '550e8400-e29b-41d4-a716-446655440001'
+const UUID2 = '550e8400-e29b-41d4-a716-446655440002'
+const UUID_BOOKING = '550e8400-e29b-41d4-a716-446655440099'
+
 describe('createThreadSchema', () => {
-  const validInput = {
-    participantIds: ['user-1', 'user-2'],
-  }
+  const validInput = { participantIds: [UUID1, UUID2] }
 
   it('accepts valid input with participantIds only', () => {
     const result = createThreadSchema.safeParse(validInput)
@@ -12,14 +14,21 @@ describe('createThreadSchema', () => {
   })
 
   it('accepts valid input with bookingId', () => {
-    const result = createThreadSchema.safeParse({
-      ...validInput,
-      bookingId: 'booking-1',
-    })
+    const result = createThreadSchema.safeParse({ ...validInput, bookingId: UUID_BOOKING })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.bookingId).toBe('booking-1')
+      expect(result.data.bookingId).toBe(UUID_BOOKING)
     }
+  })
+
+  it('rejects non-UUID bookingId', () => {
+    const result = createThreadSchema.safeParse({ ...validInput, bookingId: 'booking-1' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-UUID participantIds', () => {
+    const result = createThreadSchema.safeParse({ participantIds: ['not-a-uuid'] })
+    expect(result.success).toBe(false)
   })
 
   it('rejects missing participantIds', () => {
@@ -29,11 +38,6 @@ describe('createThreadSchema', () => {
 
   it('rejects empty participantIds array', () => {
     const result = createThreadSchema.safeParse({ participantIds: [] })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects participantIds with empty string', () => {
-    const result = createThreadSchema.safeParse({ participantIds: [''] })
     expect(result.success).toBe(false)
   })
 
@@ -47,24 +51,24 @@ describe('createThreadSchema', () => {
 })
 
 describe('sendMessageSchema', () => {
-  const valid = { senderId: 'user-1', content: 'Hello!' }
+  const valid = { senderId: UUID1, content: 'Hello!' }
 
   it('accepts valid input', () => {
     const result = sendMessageSchema.safeParse(valid)
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.senderId).toBe('user-1')
+      expect(result.data.senderId).toBe(UUID1)
       expect(result.data.content).toBe('Hello!')
     }
   })
 
-  it('rejects missing senderId', () => {
-    const result = sendMessageSchema.safeParse({ content: 'Hello!' })
+  it('rejects non-UUID senderId', () => {
+    const result = sendMessageSchema.safeParse({ senderId: 'user-1', content: 'Hello!' })
     expect(result.success).toBe(false)
   })
 
-  it('rejects empty senderId', () => {
-    const result = sendMessageSchema.safeParse({ senderId: '', content: 'Hello!' })
+  it('rejects missing senderId', () => {
+    const result = sendMessageSchema.safeParse({ content: 'Hello!' })
     expect(result.success).toBe(false)
   })
 
@@ -97,27 +101,27 @@ describe('sendMessageSchema', () => {
   })
 
   it('rejects missing content', () => {
-    const result = sendMessageSchema.safeParse({ senderId: 'user-1' })
+    const result = sendMessageSchema.safeParse({ senderId: UUID1 })
     expect(result.success).toBe(false)
   })
 })
 
 describe('markReadSchema', () => {
-  it('accepts valid userId', () => {
-    const result = markReadSchema.safeParse({ userId: 'user-1' })
+  it('accepts valid UUID userId', () => {
+    const result = markReadSchema.safeParse({ userId: UUID1 })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.userId).toBe('user-1')
+      expect(result.data.userId).toBe(UUID1)
     }
+  })
+
+  it('rejects non-UUID userId', () => {
+    const result = markReadSchema.safeParse({ userId: 'user-1' })
+    expect(result.success).toBe(false)
   })
 
   it('rejects missing userId', () => {
     const result = markReadSchema.safeParse({})
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects empty userId', () => {
-    const result = markReadSchema.safeParse({ userId: '' })
     expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- `updateBookingStatusSchema`: accepts only valid enum values, not arbitrary strings
- ID fields (`vehicleId`, `senderId`, `userId`, `participantIds`, `bookingId`): require UUID format
- Removed dead `cancelBookingSchema` (no DB column, never used by API)
- Updated all test fixtures to use valid UUIDs

Closes #136

## Test plan
- [x] 502 tests pass across all packages
- [x] Lint + typecheck + pre-commit hooks pass