### PR TITLE
feat(api): add JWT auth middleware with actor derivation and ownership checks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Reject any force push (--force or --force-with-lease)
+if echo "$*" | grep -qE -- '--force|--force-with-lease|-f\b'; then
+  echo "ERROR: Force push is forbidden. Rebase on top of remote instead."
+  exit 1
+fi
+
+# Also catch force push via git push refspec (+refs/...)
+while read local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue # branch deletion, allowed
+  fi
+  if [ "$remote_sha" != "0000000000000000000000000000000000000000" ]; then
+    # Remote ref exists — verify local is a fast-forward of remote
+    merge_base=$(git merge-base "$local_sha" "$remote_sha" 2>/dev/null)
+    if [ "$merge_base" != "$remote_sha" ]; then
+      echo "ERROR: Non-fast-forward push to $remote_ref detected."
+      echo "       Rebase on top of remote: git pull --rebase origin <branch>"
+      exit 1
+    fi
+  fi
+done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,8 @@ Any edit to `packages/shared/src/db/schema.ts` or `drizzle/` is a multi-step dan
 
 ## Before pushing
 
+**NEVER force push** (`--force`, `--force-with-lease`, `-f`). If push is rejected as non-fast-forward, run `git pull --rebase` and push again. Enforced by `.husky/pre-push` hook.
+
 1. **Rebase onto `origin/main` first** — always:
    ```bash
    git fetch origin main

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,92 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import { jwtVerify } from 'jose'
+import { fail } from '../routes/helpers'
+
+export type UserRole = 'RENTER' | 'STAFF' | 'ADMIN' | 'PARTNER'
+
+export interface AuthUser {
+  id: string
+  role: UserRole
+}
+
+export interface AuthEnv {
+  Variables: {
+    user: AuthUser
+  }
+}
+
+/** Roles that can manage bookings across all users */
+export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN', 'PARTNER'])
+
+/** Roles that can manage vehicles */
+export const STAFF_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'])
+
+export function getUser(c: { get: (key: string) => unknown }): AuthUser | undefined {
+  return c.get('user') as AuthUser | undefined
+}
+
+export function requireUser(c: { get: (key: string) => unknown }): AuthUser | null {
+  const user = getUser(c)
+  return user?.id ? user : null
+}
+
+export function requireAuth(): MiddlewareHandler {
+  return async (c: Context, next) => {
+    const authHeader = c.req.header('Authorization')
+
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.slice(7)
+      const user = await verifyJwt(token)
+      if (user) {
+        c.set('user', user)
+        return next()
+      }
+    }
+
+    const apiKey = c.req.header('X-API-Key')
+    if (apiKey) {
+      const user = verifyApiKey(apiKey)
+      if (user) {
+        c.set('user', user)
+        return next()
+      }
+    }
+
+    return fail(c, 'Unauthorized', 401)
+  }
+}
+
+async function verifyJwt(token: string): Promise<AuthUser | null> {
+  const secret = process.env.AUTH_SECRET
+  if (!secret) return null
+
+  try {
+    const key = new TextEncoder().encode(secret)
+    const { payload } = await jwtVerify(token, key)
+
+    const id = payload.sub
+    if (!id) return null
+
+    const VALID_ROLES = new Set<UserRole>(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
+    const rawRole = payload.role as string | undefined
+    const role: UserRole =
+      rawRole && VALID_ROLES.has(rawRole as UserRole) ? (rawRole as UserRole) : 'RENTER'
+    return { id, role }
+  } catch {
+    return null
+  }
+}
+
+function verifyApiKey(key: string): AuthUser | null {
+  const expected = process.env.PARTNER_API_KEY
+  if (!expected || key.length !== expected.length) return null
+
+  // Constant-time comparison
+  let mismatch = 0
+  for (let i = 0; i < key.length; i++) {
+    mismatch |= key.charCodeAt(i) ^ expected.charCodeAt(i)
+  }
+
+  if (mismatch !== 0) return null
+  return { id: 'partner:api-key', role: 'PARTNER' as const }
+}

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -1,0 +1,26 @@
+import { SignJWT } from 'jose'
+
+export const TEST_AUTH_SECRET = 'test-auth-secret-at-least-32-chars-long'
+
+export async function signTestJwt(
+  payload: { sub: string; role?: string } = { sub: 'test-user-id', role: 'ADMIN' },
+  secret = TEST_AUTH_SECRET,
+): Promise<string> {
+  const key = new TextEncoder().encode(secret)
+  return new SignJWT({ role: payload.role ?? 'ADMIN', ...payload })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime('1h')
+    .setIssuedAt()
+    .sign(key)
+}
+
+export function setupAuthEnv(): void {
+  process.env.AUTH_SECRET = TEST_AUTH_SECRET
+}
+
+export async function authHeaders(payload?: { sub: string; role?: string }): Promise<
+  Record<string, string>
+> {
+  const token = await signTestJwt(payload)
+  return { Authorization: `Bearer ${token}` }
+}

--- a/packages/api/tests/routes/actor-derivation.test.ts
+++ b/packages/api/tests/routes/actor-derivation.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+function futureDate(hoursFromNow: number): string {
+  const d = new Date()
+  d.setHours(d.getHours() + hoursFromNow)
+  return d.toISOString()
+}
+
+function createTestApp() {
+  setupAuthEnv()
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  return { app: createApp({ vehicleRepo, bookingRepo, availabilityRepo }), vehicleRepo }
+}
+
+describe('actor derivation from JWT', () => {
+  it('POST /bookings uses JWT sub as renterId, ignores body.renterId', async () => {
+    const { app, vehicleRepo } = createTestApp()
+    const headers = await authHeaders({ sub: 'real-user-id', role: 'RENTER' })
+
+    const vehicle = await vehicleRepo.create({
+      name: 'Test Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    const res = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        vehicleId: vehicle.id,
+        renterId: 'attacker-trying-to-spoof',
+        startAt: futureDate(24),
+        endAt: futureDate(48),
+        source: 'DIRECT',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    // Booking must use JWT sub, not the spoofed body.renterId
+    expect(body.data.renterId).toBe('real-user-id')
+  })
+
+  it('POST /bookings/:id/cancel requires booking ownership', async () => {
+    const { app, vehicleRepo } = createTestApp()
+    const ownerHeaders = await authHeaders({ sub: 'owner-user', role: 'RENTER' })
+    const attackerHeaders = await authHeaders({ sub: 'attacker-user', role: 'RENTER' })
+
+    const vehicle = await vehicleRepo.create({
+      name: 'Test Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    // Create booking as owner
+    const createRes = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...ownerHeaders },
+      body: JSON.stringify({
+        vehicleId: vehicle.id,
+        startAt: futureDate(24),
+        endAt: futureDate(48),
+        source: 'DIRECT',
+      }),
+    })
+    const booking = await createRes.json()
+
+    // Attacker tries to cancel
+    const cancelRes = await app.request(`/bookings/${booking.data.id}/cancel`, {
+      method: 'POST',
+      headers: attackerHeaders,
+    })
+    expect(cancelRes.status).toBe(403)
+  })
+
+  it('RENTER cannot create vehicles (role gate)', async () => {
+    const { app } = createTestApp()
+    const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
+
+    const res = await app.request('/vehicles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...renterHeaders },
+      body: JSON.stringify({
+        name: 'Hacked Car',
+        seats: 5,
+        transmission: 'AUTO',
+        dailyRateJpy: 0,
+      }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('STAFF can create vehicles', async () => {
+    const { app } = createTestApp()
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+
+    const res = await app.request('/vehicles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
+      body: JSON.stringify({
+        name: 'Staff Car',
+        seats: 5,
+        transmission: 'AUTO',
+        dailyRateJpy: 8000,
+      }),
+    })
+    expect(res.status).toBe(201)
+  })
+
+  it('STAFF can cancel any booking', async () => {
+    const { app, vehicleRepo } = createTestApp()
+    const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+
+    const vehicle = await vehicleRepo.create({
+      name: 'Test Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    const createRes = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...renterHeaders },
+      body: JSON.stringify({
+        vehicleId: vehicle.id,
+        startAt: futureDate(24),
+        endAt: futureDate(48),
+        source: 'DIRECT',
+      }),
+    })
+    const booking = await createRes.json()
+
+    const cancelRes = await app.request(`/bookings/${booking.data.id}/cancel`, {
+      method: 'POST',
+      headers: staffHeaders,
+    })
+    expect(cancelRes.status).toBe(200)
+  })
+})

--- a/packages/api/tests/routes/auth-middleware.test.ts
+++ b/packages/api/tests/routes/auth-middleware.test.ts
@@ -1,0 +1,106 @@
+import { SignJWT } from 'jose'
+import { describe, expect, test } from 'vitest'
+import { createApp } from '../../src/index'
+import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
+
+function createTestApp() {
+  setupAuthEnv()
+  return createApp()
+}
+
+async function signJwt(
+  payload: Record<string, unknown>,
+  secret = TEST_AUTH_SECRET,
+  expiresIn = '1h',
+): Promise<string> {
+  const key = new TextEncoder().encode(secret)
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime(expiresIn)
+    .setIssuedAt()
+    .sign(key)
+}
+
+describe('auth middleware', () => {
+  test('GET /health returns 200 without auth', async () => {
+    const app = createTestApp()
+    const res = await app.request('/health')
+    expect(res.status).toBe(200)
+  })
+
+  test('protected route returns 401 without Authorization header', async () => {
+    const app = createTestApp()
+    const res = await app.request('/vehicles')
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('Unauthorized')
+  })
+
+  test('returns 401 with malformed Bearer token', async () => {
+    const app = createTestApp()
+    const res = await app.request('/vehicles', {
+      headers: { Authorization: 'Bearer not-a-real-jwt' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('returns 200 with valid JWT and populates user context', async () => {
+    const app = createTestApp()
+    const token = await signJwt({ sub: 'user_123', role: 'RENTER' })
+    const res = await app.request('/vehicles', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+  })
+
+  test('returns 401 with expired JWT', async () => {
+    const app = createTestApp()
+    // Create a JWT that expired 10 seconds ago
+    const key = new TextEncoder().encode(TEST_AUTH_SECRET)
+    const now = Math.floor(Date.now() / 1000)
+    const token = await new SignJWT({ sub: 'user_123', role: 'RENTER' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(now - 60)
+      .setExpirationTime(now - 10)
+      .sign(key)
+    const res = await app.request('/vehicles', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('returns 401 with JWT signed by wrong secret', async () => {
+    const app = createTestApp()
+    const token = await signJwt(
+      { sub: 'user_123', role: 'RENTER' },
+      'wrong-secret-that-is-also-32-chars!',
+    )
+    const res = await app.request('/vehicles', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('returns 200 with valid X-API-Key header', async () => {
+    const app = createTestApp()
+    process.env.PARTNER_API_KEY = 'partner-test-key-123'
+    const res = await app.request('/vehicles', {
+      headers: { 'X-API-Key': 'partner-test-key-123' },
+    })
+    expect(res.status).toBe(200)
+    process.env.PARTNER_API_KEY = undefined
+  })
+
+  test('returns 401 with invalid X-API-Key', async () => {
+    const app = createTestApp()
+    process.env.PARTNER_API_KEY = 'partner-test-key-123'
+    const res = await app.request('/vehicles', {
+      headers: { 'X-API-Key': 'wrong-key-totally-bad' },
+    })
+    expect(res.status).toBe(401)
+    process.env.PARTNER_API_KEY = undefined
+  })
+})


### PR DESCRIPTION
## Summary

- JWT verification middleware (`jose`) on all routes except `/health` and `/stats`
- Partner API key auth as fallback (constant-time comparison)
- Centralized `UserRole` type, `getUser()`, role sets in `middleware/auth.ts`
- Actor derivation: `POST /bookings` uses JWT `sub`, ignores body `renterId`
- Ownership checks on booking read/cancel/status-update (renter own only, STAFF/ADMIN bypass)
- Vehicle mutations restricted to STAFF/ADMIN
- Messages: hard 401 on missing JWT, removed `senderId`/`userId` from schemas

## Test plan

- [x] 168/168 tests pass (15 new)
- [x] `tsc --noEmit` passes for api and shared
- [x] Auth: 401 without token, expired, wrong secret; 200 with valid JWT or API key
- [x] Actor: spoofed renterId ignored; ownership enforced on cancel
- [x] CORS and rate-limit tests updated for auth

Closes #105