### PR TITLE
fix(validators): add cross-field validation to updateVehicleSchema

### DIFF
--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -261,6 +261,22 @@ describe('Vehicle CRUD Routes', () => {
       ])
     })
 
+    it('rejects update where minRentalHours exceeds maxRentalHours', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minRentalHours: 10, maxRentalHours: 5 }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error.maxRentalHours[0]).toContain('greater than or equal')
+    })
+
     it('rejects invalid update data', async () => {
       const createRes = await createVehicle()
       const created = await createRes.json()

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -53,7 +53,17 @@ export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) =
   }
 })
 
-export const updateVehicleSchema = vehicleObjectSchema.partial()
+export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((data, ctx) => {
+  const min = data.minRentalHours
+  const max = data.maxRentalHours
+  if (min != null && max != null && min > max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['maxRentalHours'],
+      message: 'Maximum rental hours must be greater than or equal to minimum',
+    })
+  }
+})
 
 // Issue #51: inline status toggle. Kept as its own tiny schema so the
 // fleet list can bind a one-field mutation without sending the full


### PR DESCRIPTION
## Summary
- `updateVehicleSchema.partial()` dropped the `superRefine` from `createVehicleSchema`
- A PATCH with `minRentalHours: 10, maxRentalHours: 5` was silently accepted
- Added `superRefine` that validates `min <= max` when both fields are present

## What changed
- `packages/shared/src/validators/vehicle.ts` -- added `superRefine` to `updateVehicleSchema`
- `packages/api/tests/routes/vehicles.test.ts` -- added test for the invalid update

## Test plan
- [x] New test: PATCH with min > max returns 400
- [x] Full API suite: 159 tests pass
- [x] Both packages typecheck clean
- [x] Biome lint clean

Closes #141