### PR TITLE
fix(api): auto-filter RETIRED vehicles from public queries

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,18 +1,23 @@
 import { vehicles } from '@kuruma/shared/db/schema'
-import { eq, inArray, sql } from 'drizzle-orm'
+import { eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
-import type { VehicleRepository } from '../types'
+import type { VehicleFilters, VehicleRepository } from '../types'
 import { type Db, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: { status?: string }): Promise<Vehicle[]> {
+  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
     const query = this.db.select(vehicleColumns).from(vehicles)
 
-    const rows = filters?.status
-      ? await query.where(eq(vehicles.status, filters.status as Vehicle['status']))
-      : await query
+    if (filters?.status) {
+      const rows = await query.where(eq(vehicles.status, filters.status as Vehicle['status']))
+      return rows.map(toVehicle)
+    }
+
+    const rows = filters?.includeRetired
+      ? await query
+      : await query.where(ne(vehicles.status, 'RETIRED'))
 
     return rows.map(toVehicle)
   }

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -1,5 +1,5 @@
 import type { Vehicle } from '../../stores'
-import type { VehicleRepository } from '../types'
+import type { VehicleFilters, VehicleRepository } from '../types'
 
 export class InMemoryVehicleRepository implements VehicleRepository {
   private readonly store: Map<string, Vehicle>
@@ -8,10 +8,11 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: { status?: string }): Promise<Vehicle[]> {
-    const vehicles = [...this.store.values()]
-    if (!filters?.status) return vehicles
-    return vehicles.filter((v) => v.status === filters.status)
+  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
+    const all = [...this.store.values()]
+    if (filters?.status) return all.filter((v) => v.status === filters.status)
+    if (filters?.includeRetired) return all
+    return all.filter((v) => v.status !== 'RETIRED')
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -8,8 +8,13 @@ import type { DashboardStats } from '@kuruma/shared/types/stats'
 import type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 import type { Booking, Message, Thread, ThreadParticipant, Vehicle } from '../stores'
 
+export interface VehicleFilters {
+  status?: string
+  includeRetired?: boolean
+}
+
 export interface VehicleRepository {
-  findAll(filters?: { status?: string }): Promise<Vehicle[]>
+  findAll(filters?: VehicleFilters): Promise<Vehicle[]>
   findById(id: string): Promise<Vehicle | undefined>
   findByIds(ids: string[]): Promise<Vehicle[]>
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -58,7 +58,7 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data[1].name).toBe('Honda Civic')
     })
 
-    it('returns all vehicles when no status filter is provided', async () => {
+    it('excludes RETIRED vehicles by default', async () => {
       await createVehicle()
       const createRes = await createVehicle({
         ...validVehicleInput(),
@@ -66,18 +66,27 @@ describe('Vehicle CRUD Routes', () => {
       })
       const created = await createRes.json()
 
-      // Soft-delete the second vehicle to make it RETIRED
       await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
 
       const res = await app.request('/vehicles')
       const body = await res.json()
 
       expect(body.success).toBe(true)
-      expect(body.data).toHaveLength(2)
-      expect(body.data.map((v: { name: string }) => v.name)).toEqual([
-        'Toyota Corolla',
-        'Retired Car',
-      ])
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].name).toBe('Toyota Corolla')
+    })
+
+    it('returns RETIRED vehicles when filtered by status=RETIRED', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
+
+      const res = await app.request('/vehicles?status=RETIRED')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].status).toBe('RETIRED')
     })
 
     it('filters by explicit status query param', async () => {


### PR DESCRIPTION
## Summary

- `findAll()` now excludes RETIRED vehicles by default
- Explicit `?status=RETIRED` still returns them
- Added `VehicleFilters` interface with `includeRetired` flag
- Updated tests: verify exclusion by default + explicit filter access

## Test plan

- [x] 163 tests pass (9 auth failures are pre-existing from #165 missing jose dep)
- [x] New test: `excludes RETIRED vehicles by default`
- [x] New test: `returns RETIRED when filtered by status=RETIRED`

Closes #112