### PR TITLE
fix(validators): add cross-field validation to updateVehicleSchema

### DIFF
--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -53,7 +53,32 @@ export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) =
   }
 })
 
-export const updateVehicleSchema = vehicleObjectSchema.partial()
+export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((data, ctx) => {
+  // Only reject when both rates are explicitly present and both null.
+  // A partial update sending only one rate is fine — the other stays unchanged in DB.
+  if (
+    'dailyRateJpy' in data &&
+    'hourlyRateJpy' in data &&
+    data.dailyRateJpy == null &&
+    data.hourlyRateJpy == null
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dailyRateJpy'],
+      message: 'At least one rate (daily or hourly) is required',
+    })
+  }
+
+  const min = data.minRentalHours
+  const max = data.maxRentalHours
+  if (min != null && max != null && min > max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['maxRentalHours'],
+      message: 'Maximum rental hours must be greater than or equal to minimum',
+    })
+  }
+})
 
 // Issue #51: inline status toggle. Kept as its own tiny schema so the
 // fleet list can bind a one-field mutation without sending the full

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -29,19 +29,13 @@ const vehicleObjectSchema = z.object({
   hourlyRateJpy: jpyRate.nullish(),
 })
 
-export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) => {
-  if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['dailyRateJpy'],
-      message: 'At least one rate (daily or hourly) is required',
-    })
-  }
-
-  // Issue #50: if both rental bounds are set, min must be <= max. Otherwise
-  // the owner could create a vehicle nobody can book ("min 10h, max 5h").
-  // Enforced here rather than on the column so each field can still be
-  // optional independently.
+// Issue #50: shared cross-field check — if both rental bounds are present,
+// min must be <= max. Enforced in the validator (not the column) so each
+// field can still be optional independently.
+function rejectMinExceedsMax(
+  data: { minRentalHours?: number | null | undefined; maxRentalHours?: number | null | undefined },
+  ctx: z.RefinementCtx,
+): void {
   const min = data.minRentalHours
   const max = data.maxRentalHours
   if (min != null && max != null && min > max) {
@@ -51,6 +45,17 @@ export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) =
       message: 'Maximum rental hours must be greater than or equal to minimum',
     })
   }
+}
+
+export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) => {
+  if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dailyRateJpy'],
+      message: 'At least one rate (daily or hourly) is required',
+    })
+  }
+  rejectMinExceedsMax(data, ctx)
 })
 
 export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((data, ctx) => {
@@ -68,16 +73,7 @@ export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((da
       message: 'At least one rate (daily or hourly) is required',
     })
   }
-
-  const min = data.minRentalHours
-  const max = data.maxRentalHours
-  if (min != null && max != null && min > max) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['maxRentalHours'],
-      message: 'Maximum rental hours must be greater than or equal to minimum',
-    })
-  }
+  rejectMinExceedsMax(data, ctx)
 })
 
 // Issue #51: inline status toggle. Kept as its own tiny schema so the

--- a/packages/shared/tests/validators/vehicle.test.ts
+++ b/packages/shared/tests/validators/vehicle.test.ts
@@ -247,6 +247,48 @@ describe('updateVehicleSchema', () => {
     const result = updateVehicleSchema.safeParse({})
     expect(result.success).toBe(true)
   })
+
+  it('rejects when both rates are explicitly set to null', () => {
+    const result = updateVehicleSchema.safeParse({
+      dailyRateJpy: null,
+      hourlyRateJpy: null,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(' ')
+      expect(messages).toMatch(/rate/i)
+    }
+  })
+
+  it('rejects when minRentalHours > maxRentalHours', () => {
+    const result = updateVehicleSchema.safeParse({
+      minRentalHours: 10,
+      maxRentalHours: 5,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths.some((p) => p.includes('maxRentalHours'))).toBe(true)
+    }
+  })
+
+  it('allows setting one rate to null (other rate not in payload)', () => {
+    const result = updateVehicleSchema.safeParse({ dailyRateJpy: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('allows setting one rate when other is null', () => {
+    const result = updateVehicleSchema.safeParse({
+      dailyRateJpy: null,
+      hourlyRateJpy: 1200,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('allows min without max in partial update', () => {
+    const result = updateVehicleSchema.safeParse({ minRentalHours: 4 })
+    expect(result.success).toBe(true)
+  })
 })
 
 describe('updateVehicleStatusSchema', () => {


### PR DESCRIPTION
## Summary
- `updateVehicleSchema = vehicleObjectSchema.partial()` dropped both `superRefine` checks from `createVehicleSchema`
- A PATCH setting both rates to null passed validation, making a vehicle unrentable
- A PATCH with `minRentalHours > maxRentalHours` silently persisted an impossible booking window
- Added `superRefine` to update schema that checks cross-field constraints only when both fields are present

## Test plan
- [x] 5 new tests: rejects both-rates-null, rejects min > max, allows single-rate null, allows one-rate-with-other-null, allows min-only partial
- [x] All 41 vehicle validator tests pass
- [x] tsc --noEmit passes all three packages
- [x] Biome lint clean

Closes #141