### PR TITLE
fix(api): wrap thread/message repo operations in transactions

### DIFF
--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -8,35 +8,31 @@ export class DrizzleMessageRepository implements MessageRepository {
   constructor(private readonly db: Db) {}
 
   async create(threadId: string, senderId: string, content: string): Promise<Message> {
-    // Insert the message AND atomically bump every other participant's
-    // unread count in a single round-trip pair. The unread bump uses a
-    // SQL arithmetic expression (`unreadCount + 1`) so concurrent inserts
-    // can never lose an increment -- this is the Check-Then-Act race fix
-    // called out in the issue.
-    const [inserted] = (await this.db
-      .insert(messages)
-      .values({ threadId, senderId, content })
-      .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
+    return this.db.transaction(async (tx) => {
+      const [inserted] = (await tx
+        .insert(messages)
+        .values({ threadId, senderId, content })
+        .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
 
-    if (!inserted) {
-      throw new Error('Failed to insert message')
-    }
+      if (!inserted) {
+        throw new Error('Failed to insert message')
+      }
 
-    await this.db
-      .update(threadParticipants)
-      .set({ unreadCount: sql`${threadParticipants.unreadCount} + 1` })
-      .where(
-        and(
-          eq(threadParticipants.threadId, threadId),
-          sql`${threadParticipants.userId} <> ${senderId}`,
-        ),
-      )
+      // Atomic bump -- SQL arithmetic prevents lost increments under concurrency
+      await tx
+        .update(threadParticipants)
+        .set({ unreadCount: sql`${threadParticipants.unreadCount} + 1` })
+        .where(
+          and(
+            eq(threadParticipants.threadId, threadId),
+            sql`${threadParticipants.userId} <> ${senderId}`,
+          ),
+        )
 
-    // Touch the parent thread's updatedAt so findAll can sort by recency
-    // later if/when needed. Cheap and keeps invariants honest.
-    await this.db.update(threads).set({ updatedAt: sql`now()` }).where(eq(threads.id, threadId))
+      await tx.update(threads).set({ updatedAt: sql`now()` }).where(eq(threads.id, threadId))
 
-    return normaliseMessage(inserted)
+      return normaliseMessage(inserted)
+    })
   }
 
   async findByThreadId(threadId: string): Promise<Message[]> {

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -106,32 +106,28 @@ export class DrizzleThreadRepository implements ThreadRepository {
   }
 
   async create(bookingId: string | null, participantIds: string[]): Promise<Thread> {
-    // Two-statement sequence: insert the thread row, then insert all
-    // participants in one batch. Cleaner than a transaction for this case;
-    // if the participant insert fails, the thread row is orphaned but
-    // harmless and can be GC'd later. (postgres-js + neon-http both support
-    // .transaction() but the behaviour differs slightly across drivers and
-    // we don't need atomicity here for correctness.)
-    const [insertedThread] = (await this.db
-      .insert(threads)
-      .values({ bookingId })
-      .returning(threadColumns)).map(toThread)
+    return this.db.transaction(async (tx) => {
+      const [insertedThread] = (await tx
+        .insert(threads)
+        .values({ bookingId })
+        .returning(threadColumns)).map(toThread)
 
-    if (!insertedThread) {
-      throw new Error('Failed to insert thread')
-    }
+      if (!insertedThread) {
+        throw new Error('Failed to insert thread')
+      }
 
-    if (participantIds.length > 0) {
-      await this.db.insert(threadParticipants).values(
-        participantIds.map((userId) => ({
-          threadId: insertedThread.id,
-          userId,
-          unreadCount: 0,
-        })),
-      )
-    }
+      if (participantIds.length > 0) {
+        await tx.insert(threadParticipants).values(
+          participantIds.map((userId) => ({
+            threadId: insertedThread.id,
+            userId,
+            unreadCount: 0,
+          })),
+        )
+      }
 
-    return insertedThread
+      return insertedThread
+    })
   }
 
   async markAsRead(threadId: string, userId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Thread `create()`: insert thread + participants now atomic via `db.transaction()`
- Message `create()`: insert message + bump unread + touch thread now atomic
- Prevents orphaned threads and drifting unread counts

## Test plan

- [x] All 8 message route tests pass
- [x] 163 tests pass (9 auth failures pre-existing)

Closes #110