### PR TITLE
refactor(shared): extract cancellation policy magic numbers to config

### DIFF
--- a/packages/shared/src/lib/cancellation-policy.ts
+++ b/packages/shared/src/lib/cancellation-policy.ts
@@ -1,9 +1,23 @@
+export type CancellationTier = 'FREE' | 'LOW' | 'MEDIUM' | 'FULL'
+
 export interface CancellationResult {
-  tier: 'FREE' | 'LOW' | 'MEDIUM' | 'FULL'
+  tier: CancellationTier
   feePercentage: number
   feeAmount: number
   refundAmount: number
 }
+
+/** Tiered cancellation: 72h free / 48h 30% / 24h 70% / same-day 100% */
+const CANCELLATION_TIERS: ReadonlyArray<{
+  tier: CancellationTier
+  minHours: number
+  feePercentage: number
+}> = [
+  { tier: 'FREE', minHours: 72, feePercentage: 0 },
+  { tier: 'LOW', minHours: 48, feePercentage: 0.3 },
+  { tier: 'MEDIUM', minHours: 24, feePercentage: 0.7 },
+  { tier: 'FULL', minHours: 0, feePercentage: 1 },
+] as const
 
 const HOURS_MS = 60 * 60 * 1000
 
@@ -14,25 +28,17 @@ export function calculateCancellationFee(
 ): CancellationResult {
   const hoursUntilPickup = (pickupAt.getTime() - now.getTime()) / HOURS_MS
 
-  let tier: CancellationResult['tier']
-  let feePercentage: number
+  const matched =
+    CANCELLATION_TIERS.find((t) => hoursUntilPickup >= t.minHours) ??
+    CANCELLATION_TIERS[CANCELLATION_TIERS.length - 1]!
 
-  if (hoursUntilPickup >= 72) {
-    tier = 'FREE'
-    feePercentage = 0
-  } else if (hoursUntilPickup >= 48) {
-    tier = 'LOW'
-    feePercentage = 0.3
-  } else if (hoursUntilPickup >= 24) {
-    tier = 'MEDIUM'
-    feePercentage = 0.7
-  } else {
-    tier = 'FULL'
-    feePercentage = 1
-  }
-
-  const feeAmount = Math.round(totalPrice * feePercentage)
+  const feeAmount = Math.round(totalPrice * matched.feePercentage)
   const refundAmount = totalPrice - feeAmount
 
-  return { tier, feePercentage, feeAmount, refundAmount }
+  return {
+    tier: matched.tier,
+    feePercentage: matched.feePercentage,
+    feeAmount,
+    refundAmount,
+  }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded 72/48/24 hour thresholds with `CANCELLATION_TIERS` config array
- Extract `CancellationTier` type
- Business rule changes now require editing one data structure

## Test plan

- [x] 128/128 shared tests pass

Closes #117