### PR TITLE
perf(db): add index on bookings.status

### DIFF
--- a/drizzle/0014_add-bookings-status-index.sql
+++ b/drizzle/0014_add-bookings-status-index.sql
@@ -1,0 +1,4 @@
+-- bookings.status is filtered in nearly every booking query (dashboard,
+-- fleet overview, status transitions). Without an index, every query is
+-- a sequential scan. See issue #140.
+CREATE INDEX IF NOT EXISTS idx_bookings_status ON bookings (status);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1776016154850,
       "tag": "0013_thread-participant-unique",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776017978486,
+      "tag": "0014_add-bookings-status-index",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `idx_bookings_status` index on `bookings.status` column
- Every booking query (dashboard, fleet overview, transitions) filters by status — this was a sequential scan

## Test plan
- [x] Migration applies cleanly (`db:migrate`)
- [x] `db:verify` passes (15 migrations, all synced)
- [x] Index confirmed in `pg_indexes`
- [x] All 28 integration tests pass
- [x] 163/163 unit tests pass (9 pre-existing auth failures unrelated)

Closes #140