### PR TITLE
fix(validators): add cross-field validation to updateVehicleSchema

### DIFF
--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -68,6 +68,16 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
       dailyRateJpy: parsed.data.dailyRateJpy ?? existing.dailyRateJpy,
       hourlyRateJpy: parsed.data.hourlyRateJpy ?? existing.hourlyRateJpy,
     }
+    const mergedMin = changes.minRentalHours
+    const mergedMax = changes.maxRentalHours
+    if (mergedMin != null && mergedMax != null && mergedMin > mergedMax) {
+      return fail(
+        c,
+        { maxRentalHours: ['Maximum rental hours must be greater than or equal to minimum'] },
+        400,
+      )
+    }
+
     const updated = await repo.update(existing.id, stripUndefined(changes) as Partial<Vehicle>)
 
     return ok(c, updated)

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -56,18 +56,27 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
     const parsed = await parseBody(c, updateVehicleSchema)
     if (!parsed.ok) return parsed.response
 
-    // Strip keys the partial schema left as `undefined` — Partial<Vehicle>
-    // under exactOptionalPropertyTypes forbids explicit undefined values.
+    // Merge patch with existing: use patch value if key was sent (even null),
+    // otherwise keep existing. `??` would swallow explicit nulls.
+    const d = parsed.data
+    const merge = <T>(key: string, fallback: T): T =>
+      key in d ? ((d as Record<string, unknown>)[key] as T) : fallback
+
     const changes = {
-      ...parsed.data,
-      description: parsed.data.description ?? existing.description,
-      fuelType: parsed.data.fuelType ?? existing.fuelType,
-      minRentalHours: parsed.data.minRentalHours ?? existing.minRentalHours,
-      maxRentalHours: parsed.data.maxRentalHours ?? existing.maxRentalHours,
-      advanceBookingHours: parsed.data.advanceBookingHours ?? existing.advanceBookingHours,
-      dailyRateJpy: parsed.data.dailyRateJpy ?? existing.dailyRateJpy,
-      hourlyRateJpy: parsed.data.hourlyRateJpy ?? existing.hourlyRateJpy,
+      ...d,
+      description: merge('description', existing.description),
+      fuelType: merge('fuelType', existing.fuelType),
+      minRentalHours: merge('minRentalHours', existing.minRentalHours),
+      maxRentalHours: merge('maxRentalHours', existing.maxRentalHours),
+      advanceBookingHours: merge('advanceBookingHours', existing.advanceBookingHours),
+      dailyRateJpy: merge('dailyRateJpy', existing.dailyRateJpy),
+      hourlyRateJpy: merge('hourlyRateJpy', existing.hourlyRateJpy),
     }
+
+    if (changes.dailyRateJpy == null && changes.hourlyRateJpy == null) {
+      return fail(c, 'At least one rate (daily or hourly) is required', 400)
+    }
+
     const mergedMin = changes.minRentalHours
     const mergedMax = changes.maxRentalHours
     if (mergedMin != null && mergedMax != null && mergedMin > mergedMax) {

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -270,6 +270,22 @@ describe('Vehicle CRUD Routes', () => {
       ])
     })
 
+    it('rejects update where minRentalHours exceeds maxRentalHours', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minRentalHours: 10, maxRentalHours: 5 }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error.maxRentalHours[0]).toContain('greater than or equal')
+    })
+
     it('rejects invalid update data', async () => {
       const createRes = await createVehicle()
       const created = await createRes.json()

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -286,6 +286,62 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.error.maxRentalHours[0]).toContain('greater than or equal')
     })
 
+    it('rejects PATCH with only minRentalHours exceeding existing maxRentalHours', async () => {
+      const createRes = await createVehicle({
+        ...validVehicleInput(),
+        minRentalHours: 2,
+        maxRentalHours: 10,
+      })
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minRentalHours: 20 }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error.maxRentalHours[0]).toContain('greater than or equal')
+    })
+
+    it('accepts PATCH with only maxRentalHours still valid against existing min', async () => {
+      const createRes = await createVehicle({
+        ...validVehicleInput(),
+        minRentalHours: 2,
+        maxRentalHours: 10,
+      })
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ maxRentalHours: 15 }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.maxRentalHours).toBe(15)
+      expect(body.data.minRentalHours).toBe(2)
+    })
+
+    it('accepts PATCH with equal minRentalHours and maxRentalHours', async () => {
+      const createRes = await createVehicle()
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minRentalHours: 5, maxRentalHours: 5 }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.minRentalHours).toBe(5)
+      expect(body.data.maxRentalHours).toBe(5)
+    })
+
     it('rejects invalid update data', async () => {
       const createRes = await createVehicle()
       const created = await createRes.json()

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -342,6 +342,47 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data.maxRentalHours).toBe(5)
     })
 
+    it('rejects PATCH that nullifies the only rate on a vehicle', async () => {
+      // Vehicle created with only dailyRateJpy — nullifying it leaves no rate.
+      const createRes = await createVehicle({
+        ...validVehicleInput(),
+        dailyRateJpy: 8000,
+        hourlyRateJpy: null,
+      })
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dailyRateJpy: null }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toMatch(/rate/i)
+    })
+
+    it('allows nullifying one rate when the other remains set', async () => {
+      const createRes = await createVehicle({
+        ...validVehicleInput(),
+        dailyRateJpy: 8000,
+        hourlyRateJpy: 1200,
+      })
+      const created = await createRes.json()
+
+      const res = await app.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dailyRateJpy: null }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.dailyRateJpy).toBeNull()
+      expect(body.data.hourlyRateJpy).toBe(1200)
+    })
+
     it('rejects invalid update data', async () => {
       const createRes = await createVehicle()
       const created = await createRes.json()

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -53,7 +53,29 @@ export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) =
   }
 })
 
-export const updateVehicleSchema = vehicleObjectSchema.partial()
+export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((data, ctx) => {
+  // Only check when both rate keys are present in the patch — a patch with
+  // just { name: "..." } shouldn't trigger the pricing rule.
+  if ('dailyRateJpy' in data && 'hourlyRateJpy' in data) {
+    if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dailyRateJpy'],
+        message: 'At least one rate (daily or hourly) is required',
+      })
+    }
+  }
+
+  const min = data.minRentalHours
+  const max = data.maxRentalHours
+  if (min != null && max != null && min > max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['maxRentalHours'],
+      message: 'Maximum rental hours must be greater than or equal to minimum',
+    })
+  }
+})
 
 // Issue #51: inline status toggle. Kept as its own tiny schema so the
 // fleet list can bind a one-field mutation without sending the full

--- a/packages/shared/tests/validators/vehicle.test.ts
+++ b/packages/shared/tests/validators/vehicle.test.ts
@@ -247,6 +247,57 @@ describe('updateVehicleSchema', () => {
     const result = updateVehicleSchema.safeParse({})
     expect(result.success).toBe(true)
   })
+
+  it('rejects when both rates are explicitly set to null', () => {
+    const result = updateVehicleSchema.safeParse({
+      dailyRateJpy: null,
+      hourlyRateJpy: null,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(' ')
+      expect(messages).toMatch(/rate/i)
+    }
+  })
+
+  it('allows setting one rate to null when the other is set', () => {
+    const result = updateVehicleSchema.safeParse({
+      dailyRateJpy: null,
+      hourlyRateJpy: 1200,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('allows setting a single rate without the other', () => {
+    const result = updateVehicleSchema.safeParse({ dailyRateJpy: 8000 })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects when minRentalHours > maxRentalHours', () => {
+    const result = updateVehicleSchema.safeParse({
+      minRentalHours: 10,
+      maxRentalHours: 5,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(' ')
+      expect(messages).toMatch(/minimum/i)
+      expect(messages).toMatch(/maximum/i)
+    }
+  })
+
+  it('accepts when minRentalHours <= maxRentalHours', () => {
+    const result = updateVehicleSchema.safeParse({
+      minRentalHours: 4,
+      maxRentalHours: 72,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('allows updating minRentalHours alone', () => {
+    const result = updateVehicleSchema.safeParse({ minRentalHours: 4 })
+    expect(result.success).toBe(true)
+  })
 })
 
 describe('updateVehicleStatusSchema', () => {


### PR DESCRIPTION
## Summary
- `updateVehicleSchema.partial()` dropped `superRefine` from `createVehicleSchema`, allowing PATCH to persist `minRentalHours > maxRentalHours`
- Added `superRefine` to update schema for when both fields are in payload
- Added post-merge route guard for single-field PATCHes against existing values
- Fixed merge helper to use `in` check instead of `??` (preserves explicit `null`)
- Added pricing guard preventing nullification of both rates

## Test plan
- [x] PATCH with both min > max -> 400
- [x] PATCH with only min exceeding existing max -> 400
- [x] PATCH with valid single-field update -> 200
- [x] PATCH with equal min and max -> 200
- [x] PATCH nullifying only rate -> 400
- [x] PATCH nullifying one of two rates -> 200
- [x] Shared validator unit tests (3 cases)
- [x] 30 vehicle route tests pass
- [x] Both packages typecheck clean

Closes #141