### PR TITLE
test(web): fix env var pollution in api-client tests

### DIFF
--- a/packages/web/tests/lib/api-client.test.ts
+++ b/packages/web/tests/lib/api-client.test.ts
@@ -1,31 +1,33 @@
 import { getApiBaseUrl } from '@/lib/api-client'
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 describe('getApiBaseUrl', () => {
+  let originalUrl: string | undefined
+
+  beforeEach(() => {
+    originalUrl = process.env.NEXT_PUBLIC_API_URL
+  })
+
+  afterEach(() => {
+    if (originalUrl === undefined) {
+      Reflect.deleteProperty(process.env, 'NEXT_PUBLIC_API_URL')
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalUrl
+    }
+  })
+
   test('returns NEXT_PUBLIC_API_URL when set', () => {
-    const original = process.env.NEXT_PUBLIC_API_URL
     process.env.NEXT_PUBLIC_API_URL = 'https://api.kuruma.example.com'
-
     expect(getApiBaseUrl()).toBe('https://api.kuruma.example.com')
-
-    process.env.NEXT_PUBLIC_API_URL = original
   })
 
   test('returns localhost fallback when env var is not set', () => {
-    const original = process.env.NEXT_PUBLIC_API_URL
     Reflect.deleteProperty(process.env, 'NEXT_PUBLIC_API_URL')
-
     expect(getApiBaseUrl()).toBe('http://localhost:8787')
-
-    process.env.NEXT_PUBLIC_API_URL = original
   })
 
   test('strips trailing slash from URL', () => {
-    const original = process.env.NEXT_PUBLIC_API_URL
     process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com/'
-
     expect(getApiBaseUrl()).toBe('https://api.example.com')
-
-    process.env.NEXT_PUBLIC_API_URL = original
   })
 })


### PR DESCRIPTION
## Summary

- Replace manual save/restore of `process.env` with `beforeEach`/`afterEach`
- Prevents env leakage if assertion throws before restore

## Test plan

- [x] 216/216 web tests pass

Closes #116