### PR TITLE
perf(web): cache user role in JWT with 5-minute refresh interval

### DIFF
--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -26,16 +26,24 @@ function getAuthResult(): NextAuthResult {
       callbacks: {
         async jwt({ token, user }) {
           if (user) {
+            // First sign-in: populate role from the user object
             token.role = (user as { role?: string }).role ?? 'RENTER'
+            token.roleRefreshedAt = Date.now()
           } else if (token.sub) {
-            const db = getDb()
-            const [dbUser] = await db
-              .select({ role: users.role })
-              .from(users)
-              .where(eq(users.id, token.sub))
-              .limit(1)
-            if (dbUser) {
-              token.role = dbUser.role
+            // Subsequent refreshes: re-fetch role from DB at most every 5 minutes
+            const ROLE_REFRESH_MS = 5 * 60 * 1000
+            const lastRefresh = (token.roleRefreshedAt as number) ?? 0
+            if (!token.role || Date.now() - lastRefresh > ROLE_REFRESH_MS) {
+              const db = getDb()
+              const [dbUser] = await db
+                .select({ role: users.role })
+                .from(users)
+                .where(eq(users.id, token.sub))
+                .limit(1)
+              if (dbUser) {
+                token.role = dbUser.role
+              }
+              token.roleRefreshedAt = Date.now()
             }
           }
           return token


### PR DESCRIPTION
## Summary

- Role cached in JWT token with `roleRefreshedAt` timestamp
- DB query only fires if role is missing or >5 minutes stale
- Reduces DB load from once-per-request to once-per-5-minutes per user

## Test plan

- [x] `tsc --noEmit` passes
- [x] Role still populated on first sign-in (from user object)
- [x] Role refresh still works (just throttled to 5min intervals)

Closes #113