### PR TITLE
feat(api): add structured logging and request correlation IDs

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,8 @@ import { getDb } from '@kuruma/shared/db'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { setupGlobalHandlers } from './error-handlers'
+import { structuredLogger } from './middleware/logger'
+import { requestId } from './middleware/request-id'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -99,6 +101,11 @@ export function createApp(overrides?: {
 
   // Global error handlers — prevent stack traces leaking to clients.
   setupGlobalHandlers(app)
+
+  // Request ID + structured logging — must be before all other middleware
+  // so every request gets a correlation ID and timing.
+  app.use('*', requestId())
+  app.use('*', structuredLogger())
 
   // CORS. Browser calls from the web package (localhost:3001 in dev, the
   // deployed origin in prod) are same-intent but cross-origin, so without

--- a/packages/api/src/middleware/logger.ts
+++ b/packages/api/src/middleware/logger.ts
@@ -1,0 +1,25 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Structured JSON logger. Logs method, path, status, duration, and
+ * request ID for every request. Integrates with CF Workers logging.
+ */
+export function structuredLogger(): MiddlewareHandler {
+  return async (c, next) => {
+    const start = Date.now()
+    await next()
+    const duration = Date.now() - start
+    const requestId = (c.get('requestId') as string) ?? '-'
+
+    const entry = {
+      level: c.res.status >= 500 ? 'error' : c.res.status >= 400 ? 'warn' : 'info',
+      method: c.req.method,
+      path: c.req.path,
+      status: c.res.status,
+      duration,
+      requestId,
+    }
+
+    console.log(JSON.stringify(entry))
+  }
+}

--- a/packages/api/src/middleware/request-id.ts
+++ b/packages/api/src/middleware/request-id.ts
@@ -1,0 +1,14 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Generates a unique request ID and attaches it to the context.
+ * Also sets the X-Request-Id response header for client correlation.
+ */
+export function requestId(): MiddlewareHandler {
+  return async (c, next) => {
+    const id = c.req.header('X-Request-Id') ?? crypto.randomUUID()
+    c.set('requestId', id)
+    c.header('X-Request-Id', id)
+    await next()
+  }
+}


### PR DESCRIPTION
## Summary

- `requestId()` middleware: UUID per request, `X-Request-Id` response header
- `structuredLogger()` middleware: JSON log entry per request (method, path, status, duration, requestId)
- Wired in `index.ts` before CORS so all requests are traced

## Test plan

- [x] 163 tests pass (9 auth failures pre-existing)
- [x] Log output visible in test runs as JSON lines

Closes #114