### PR TITLE
feat(api): add pagination to vehicles and threads list endpoints

### DIFF
--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -19,8 +19,21 @@ export function createMessageRoutes(
       return fail(c, 'userId query parameter is required', 400)
     }
 
-    const threads = await threadRepo.findAll(userId)
-    return ok(c, threads)
+    const limitParam = c.req.query('limit')
+    const offsetParam = c.req.query('offset')
+
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : 25
+    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+      return fail(c, 'limit must be between 1 and 100', 400)
+    }
+    const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
+    if (Number.isNaN(offset) || offset < 0) {
+      return fail(c, 'offset must be a non-negative integer', 400)
+    }
+
+    const all = await threadRepo.findAll(userId)
+    const page = all.slice(offset, offset + limit)
+    return ok(c, page, 200, { total: all.length, limit, offset })
   })
 
   app.get('/threads/:id', async (c) => {

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -12,8 +12,21 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
 
   vehicles.get('/vehicles', async (c) => {
     const status = c.req.query('status')
-    const filtered = status ? await repo.findAll({ status }) : await repo.findAll()
-    return ok(c, filtered)
+    const limitParam = c.req.query('limit')
+    const offsetParam = c.req.query('offset')
+
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : 50
+    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+      return fail(c, 'limit must be between 1 and 100', 400)
+    }
+    const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
+    if (Number.isNaN(offset) || offset < 0) {
+      return fail(c, 'offset must be a non-negative integer', 400)
+    }
+
+    const all = status ? await repo.findAll({ status }) : await repo.findAll()
+    const page = all.slice(offset, offset + limit)
+    return ok(c, page, 200, { total: all.length, limit, offset })
   })
 
   vehicles.get('/vehicles/:id', async (c) => {

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -29,7 +29,8 @@ describe('Message Routes', () => {
       expect(res.status).toBe(200)
 
       const body = await res.json()
-      expect(body).toEqual({ success: true, data: [] })
+      expect(body.success).toBe(true)
+      expect(body.data).toEqual([])
     })
 
     it('returns created thread with participant info', async () => {

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -39,7 +39,8 @@ describe('Vehicle CRUD Routes', () => {
       expect(res.status).toBe(200)
 
       const body = await res.json()
-      expect(body).toEqual({ success: true, data: [] })
+      expect(body.success).toBe(true)
+      expect(body.data).toEqual([])
     })
 
     it('returns created vehicles', async () => {


### PR DESCRIPTION
## Summary

- `GET /vehicles`: `?limit=` (default 50) and `?offset=` (default 0)
- `GET /threads`: `?limit=` (default 25) and `?offset=` (default 0)
- Response includes `total`, `limit`, `offset` metadata
- Bookings already had cursor pagination; availability bounded by date range

## Test plan

- [x] 26 vehicle tests pass
- [x] 8 message tests pass
- [x] 163 total tests pass (9 auth failures pre-existing)

Closes #107