### PR TITLE
feat(api): wire JWT auth middleware into all protected routes

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import { getDb } from '@kuruma/shared/db'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { setupGlobalHandlers } from './error-handlers'
+import { requireAuth } from './middleware/auth'
 import { structuredLogger } from './middleware/logger'
 import { requestId } from './middleware/request-id'
 import {
@@ -137,7 +138,15 @@ export function createApp(overrides?: {
     )
   }
 
+  // Public routes (no auth required)
   app.route('/', health)
+
+  // Auth middleware on all protected paths
+  app.use('/vehicles/*', requireAuth())
+  app.use('/bookings/*', requireAuth())
+  app.use('/availability/*', requireAuth())
+  app.use('/threads/*', requireAuth())
+
   const bookingService = new BookingService(bookingRepo, vehicleRepo)
 
   app.route('/', createFleetOverviewRoutes(fleetOverviewRepo))

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -111,7 +111,7 @@ export function createBookingRoutes(service: BookingService): Hono {
     // Ownership: RENTER can only cancel own bookings; STAFF/ADMIN/PARTNER bypass
     if (!PRIVILEGED_ROLES.has(user.role)) {
       const booking = await service.findById(c.req.param('id'))
-      if (booking && booking.renterId !== user.id) {
+      if (!booking || booking.renterId !== user.id) {
         return fail(c, 'Forbidden', 403)
       }
     }

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,5 +1,6 @@
 import { createBookingSchema, updateBookingStatusSchema } from '@kuruma/shared/validators/booking'
 import { Hono } from 'hono'
+import { PRIVILEGED_ROLES, STAFF_ROLES, getUser } from '../middleware/auth'
 import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
 import { fail, ok, parseDateRange } from './helpers'
@@ -52,6 +53,9 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.post('/bookings', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const body = await c.req.json()
     const result = createBookingSchema.safeParse(body)
 
@@ -59,14 +63,10 @@ export function createBookingRoutes(service: BookingService): Hono {
       return fail(c, result.error.flatten().fieldErrors, 400)
     }
 
-    const renterId = body.renterId as string | undefined
-    if (!renterId) {
-      return fail(c, { renterId: ['Renter ID is required'] }, 400)
-    }
-
+    // Actor derivation: renterId comes from JWT, never from body
     const createResult = await service.create({
       vehicleId: result.data.vehicleId,
-      renterId,
+      renterId: user.id,
       startAt: new Date(result.data.startAt),
       endAt: new Date(result.data.endAt),
       source: result.data.source,
@@ -86,6 +86,10 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.patch('/bookings/:id/status', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const body = await c.req.json()
     const parsed = updateBookingStatusSchema.safeParse(body)
     if (!parsed.success) {
@@ -101,6 +105,17 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.post('/bookings/:id/cancel', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
+    // Ownership: RENTER can only cancel own bookings; STAFF/ADMIN/PARTNER bypass
+    if (!PRIVILEGED_ROLES.has(user.role)) {
+      const booking = await service.findById(c.req.param('id'))
+      if (booking && booking.renterId !== user.id) {
+        return fail(c, 'Forbidden', 403)
+      }
+    }
+
     const result = await service.cancel(c.req.param('id'))
     if (!result.ok) {
       return fail(c, result.error, result.status)

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,8 +1,4 @@
-import {
-  createThreadSchema,
-  markReadSchema,
-  sendMessageSchema,
-} from '@kuruma/shared/validators/message'
+import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
 import { getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
@@ -16,11 +12,7 @@ export function createMessageRoutes(
 
   app.get('/threads', async (c) => {
     const user = getUser(c)
-    // Use JWT sub as userId; fall back to query param for backward compat
-    const userId = user?.id ?? c.req.query('userId')
-    if (!userId) {
-      return fail(c, 'userId query parameter is required', 400)
-    }
+    if (!user) return fail(c, 'Unauthorized', 401)
 
     const limitParam = c.req.query('limit')
     const offsetParam = c.req.query('offset')
@@ -34,7 +26,7 @@ export function createMessageRoutes(
       return fail(c, 'offset must be a non-negative integer', 400)
     }
 
-    const all = await threadRepo.findAll(userId)
+    const all = await threadRepo.findAll(user.id)
     const page = all.slice(offset, offset + limit)
     return ok(c, page, 200, { total: all.length, limit, offset })
   })
@@ -63,12 +55,12 @@ export function createMessageRoutes(
     if (!thread) return fail(c, 'Thread not found', 404)
 
     const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const parsed = await parseBody(c, sendMessageSchema)
     if (!parsed.ok) return parsed.response
 
-    // Actor derivation: use JWT sub as senderId when available
-    const senderId = user?.id ?? parsed.data.senderId
-    const message = await messageRepo.create(thread.id, senderId, parsed.data.content)
+    const message = await messageRepo.create(thread.id, user.id, parsed.data.content)
     return ok(c, message, 201)
   })
 
@@ -77,12 +69,9 @@ export function createMessageRoutes(
     if (!thread) return fail(c, 'Thread not found', 404)
 
     const user = getUser(c)
-    const parsed = await parseBody(c, markReadSchema)
-    if (!parsed.ok) return parsed.response
+    if (!user) return fail(c, 'Unauthorized', 401)
 
-    // Actor derivation: use JWT sub as userId when available
-    const userId = user?.id ?? parsed.data.userId
-    await threadRepo.markAsRead(thread.id, userId)
+    await threadRepo.markAsRead(thread.id, user.id)
     return ok(c, null)
   })
 

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -4,6 +4,7 @@ import {
   sendMessageSchema,
 } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
+import { getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
@@ -14,7 +15,9 @@ export function createMessageRoutes(
   const app = new Hono()
 
   app.get('/threads', async (c) => {
-    const userId = c.req.query('userId')
+    const user = getUser(c)
+    // Use JWT sub as userId; fall back to query param for backward compat
+    const userId = user?.id ?? c.req.query('userId')
     if (!userId) {
       return fail(c, 'userId query parameter is required', 400)
     }
@@ -59,10 +62,13 @@ export function createMessageRoutes(
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
+    const user = getUser(c)
     const parsed = await parseBody(c, sendMessageSchema)
     if (!parsed.ok) return parsed.response
 
-    const message = await messageRepo.create(thread.id, parsed.data.senderId, parsed.data.content)
+    // Actor derivation: use JWT sub as senderId when available
+    const senderId = user?.id ?? parsed.data.senderId
+    const message = await messageRepo.create(thread.id, senderId, parsed.data.content)
     return ok(c, message, 201)
   })
 
@@ -70,10 +76,13 @@ export function createMessageRoutes(
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
+    const user = getUser(c)
     const parsed = await parseBody(c, markReadSchema)
     if (!parsed.ok) return parsed.response
 
-    await threadRepo.markAsRead(thread.id, parsed.data.userId)
+    // Actor derivation: use JWT sub as userId when available
+    const userId = user?.id ?? parsed.data.userId
+    await threadRepo.markAsRead(thread.id, userId)
     return ok(c, null)
   })
 

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -4,6 +4,7 @@ import {
   updateVehicleStatusSchema,
 } from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
+import { STAFF_ROLES, getUser } from '../middleware/auth'
 import type { Vehicle, VehicleRepository } from '../repositories/types'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
@@ -38,6 +39,10 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.post('/vehicles', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const parsed = await parseBody(c, createVehicleSchema)
     if (!parsed.ok) return parsed.response
 
@@ -61,6 +66,10 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.patch('/vehicles/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)
@@ -106,6 +115,10 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.patch('/vehicles/:id/status', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)
@@ -119,6 +132,10 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.delete('/vehicles/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -1,6 +1,17 @@
+import type { MiddlewareHandler } from 'hono'
 import { SignJWT } from 'jose'
+import type { UserRole } from '../../src/middleware/auth'
 
 export const TEST_AUTH_SECRET = 'test-auth-secret-at-least-32-chars-long'
+
+/** Middleware that sets a fake authenticated user for unit tests that
+ *  mount route handlers directly (without the full createApp() + JWT flow). */
+export function testAuthMiddleware(id = 'test-user', role: UserRole = 'ADMIN'): MiddlewareHandler {
+  return async (c, next) => {
+    c.set('user', { id, role })
+    return next()
+  }
+}
 
 export async function signTestJwt(
   payload: { sub: string; role?: string } = { sub: 'test-user-id', role: 'ADMIN' },

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -6,9 +6,11 @@ import {
 } from '../../src/repositories/in-memory'
 import { createBookingRoutes } from '../../src/routes/bookings'
 import { BookingService } from '../../src/services/booking'
+import { testAuthMiddleware } from '../helpers/auth'
 
 let app: Hono
 let vehicleRepo: InMemoryVehicleRepository
+let bookingRepo: InMemoryBookingRepository
 
 function futureDate(hoursFromNow: number): string {
   return new Date(Date.now() + hoursFromNow * 60 * 60 * 1000).toISOString()
@@ -40,9 +42,11 @@ async function createBooking(input = validBookingInput()) {
 describe('Booking Routes', () => {
   beforeEach(() => {
     vehicleRepo = new InMemoryVehicleRepository()
-    const repo = new InMemoryBookingRepository()
-    const service = new BookingService(repo, vehicleRepo)
+    bookingRepo = new InMemoryBookingRepository()
+    const service = new BookingService(bookingRepo, vehicleRepo)
     app = new Hono()
+    // ADMIN with USER1 identity — mirrors pre-auth test data
+    app.use('*', testAuthMiddleware(USER1, 'ADMIN'))
     app.route('/', createBookingRoutes(service))
   })
 
@@ -107,11 +111,19 @@ describe('Booking Routes', () => {
     })
 
     it('filters by renterId', async () => {
+      // Create one booking via route (gets USER1 from JWT context)
       await createBooking()
-      await createBooking({
-        ...validBookingInput(),
-        renterId: USER2,
+      // Create second booking directly in repo with USER2 (bypasses JWT)
+      await bookingRepo.create({
         vehicleId: V2,
+        renterId: USER2,
+        startAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        endAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        effectiveEndAt: new Date(Date.now() + 49 * 60 * 60 * 1000),
+        status: 'CONFIRMED',
+        source: 'DIRECT',
+        externalId: null,
+        notes: null,
       })
 
       const res = await app.request(`/bookings?renterId=${USER1}`)

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -5,26 +5,35 @@ import {
   InMemoryThreadRepository,
 } from '../../src/repositories/in-memory'
 import { createMessageRoutes } from '../../src/routes/messages'
+import { testAuthMiddleware } from '../helpers/auth'
 
 const U1 = '00000000-0000-4000-8000-0000000000a1'
 const U2 = '00000000-0000-4000-8000-0000000000a2'
 const U3 = '00000000-0000-4000-8000-0000000000a3'
 
-let app: Hono
 let threadRepo: InMemoryThreadRepository
 let messageRepo: InMemoryMessageRepository
 
+/** Create a Hono app authenticated as the given user. */
+function appAs(userId: string): Hono {
+  const a = new Hono()
+  a.use('*', testAuthMiddleware(userId, 'RENTER'))
+  a.route('/', createMessageRoutes(threadRepo, messageRepo))
+  return a
+}
+
 describe('Message Routes', () => {
+  let app: Hono
+
   beforeEach(() => {
     threadRepo = new InMemoryThreadRepository()
     messageRepo = new InMemoryMessageRepository(threadRepo)
-    app = new Hono()
-    app.route('/', createMessageRoutes(threadRepo, messageRepo))
+    app = appAs(U1)
   })
 
   describe('GET /threads', () => {
     it('returns empty list when no threads exist for user', async () => {
-      const res = await app.request(`/threads?userId=${U1}`)
+      const res = await app.request('/threads')
 
       expect(res.status).toBe(200)
 
@@ -41,7 +50,7 @@ describe('Message Routes', () => {
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
-      const res = await app.request(`/threads?userId=${U1}`)
+      const res = await app.request('/threads')
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -70,19 +79,19 @@ describe('Message Routes', () => {
       })
 
       // user1 should only see 1 thread
-      const res1 = await app.request(`/threads?userId=${U1}`)
+      const res1 = await appAs(U1).request('/threads')
       const body1 = await res1.json()
       expect(body1.success).toBe(true)
       expect(body1.data).toHaveLength(1)
 
       // user2 should see both threads
-      const res2 = await app.request(`/threads?userId=${U2}`)
+      const res2 = await appAs(U2).request('/threads')
       const body2 = await res2.json()
       expect(body2.success).toBe(true)
       expect(body2.data).toHaveLength(2)
 
       // user3 should see only 1 thread
-      const res3 = await app.request(`/threads?userId=${U3}`)
+      const res3 = await appAs(U3).request('/threads')
       const body3 = await res3.json()
       expect(body3.success).toBe(true)
       expect(body3.data).toHaveLength(1)
@@ -121,6 +130,7 @@ describe('Message Routes', () => {
       const created = await createRes.json()
       const threadId = created.data.id
 
+      // senderId derived from JWT (U1), body.senderId ignored
       const res = await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -150,13 +160,14 @@ describe('Message Routes', () => {
       const created = await createRes.json()
       const threadId = created.data.id
 
-      // Send two messages
-      await app.request(`/threads/${threadId}/messages`, {
+      // U1 sends a message
+      await appAs(U1).request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
-      await app.request(`/threads/${threadId}/messages`, {
+      // U2 replies
+      await appAs(U2).request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: 'Hi there!', senderId: U2 }),
@@ -200,19 +211,19 @@ describe('Message Routes', () => {
       const threadId = created.data.id
 
       // user1 sends two messages (user2 gets unread incremented)
-      await app.request(`/threads/${threadId}/messages`, {
+      await appAs(U1).request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
-      await app.request(`/threads/${threadId}/messages`, {
+      await appAs(U1).request(`/threads/${threadId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: 'Are you there?', senderId: U1 }),
       })
 
       // Verify user2 has unread messages via thread list
-      const beforeRes = await app.request(`/threads?userId=${U2}`)
+      const beforeRes = await appAs(U2).request('/threads')
       const beforeBody = await beforeRes.json()
       const user2Participant = beforeBody.data[0].participants.find(
         (p: { userId: string }) => p.userId === U2,
@@ -220,7 +231,7 @@ describe('Message Routes', () => {
       expect(user2Participant.unreadCount).toBe(2)
 
       // user2 marks as read
-      const readRes = await app.request(`/threads/${threadId}/read`, {
+      const readRes = await appAs(U2).request(`/threads/${threadId}/read`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: U2 }),
@@ -231,7 +242,7 @@ describe('Message Routes', () => {
       expect(readBody.success).toBe(true)
 
       // Verify unread count is now 0
-      const afterRes = await app.request(`/threads?userId=${U2}`)
+      const afterRes = await appAs(U2).request('/threads')
       const afterBody = await afterRes.json()
       const user2After = afterBody.data[0].participants.find(
         (p: { userId: string }) => p.userId === U2,

--- a/packages/api/tests/routes/rate-limit.test.ts
+++ b/packages/api/tests/routes/rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 describe('rate limiting wiring', () => {
   it('app starts without rate limit binding (local dev)', async () => {
@@ -9,9 +10,11 @@ describe('rate limiting wiring', () => {
   })
 
   it('all endpoints respond when no rate limit binding is present', async () => {
+    setupAuthEnv()
     const app = createApp()
+    const headers = await authHeaders()
 
-    const vehicles = await app.request('/vehicles')
+    const vehicles = await app.request('/vehicles', { headers })
     expect(vehicles.status).toBe(200)
 
     const health = await app.request('/health')

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -6,8 +6,10 @@ import {
   InMemoryStatsRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 function createTestApp() {
+  setupAuthEnv()
   const vehicleRepo = new InMemoryVehicleRepository()
   const bookingRepo = new InMemoryBookingRepository()
   const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
@@ -56,10 +58,11 @@ const BOOKING_FIELDS = [
 describe('API responses contain only expected fields', () => {
   it('GET /vehicles returns vehicles with exact field set', async () => {
     const app = createTestApp()
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
 
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -69,7 +72,7 @@ describe('API responses contain only expected fields', () => {
       }),
     })
 
-    const res = await app.request('/vehicles')
+    const res = await app.request('/vehicles', { headers: staffHeaders })
     const body = await res.json()
     const vehicle = body.data[0]
 
@@ -82,10 +85,11 @@ describe('API responses contain only expected fields', () => {
 
   it('GET /vehicles/:id returns vehicle with exact field set', async () => {
     const app = createTestApp()
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
 
     const createRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -96,7 +100,7 @@ describe('API responses contain only expected fields', () => {
     })
     const created = await createRes.json()
 
-    const res = await app.request(`/vehicles/${created.data.id}`)
+    const res = await app.request(`/vehicles/${created.data.id}`, { headers: staffHeaders })
     const body = await res.json()
 
     for (const field of VEHICLE_FIELDS) {
@@ -107,11 +111,13 @@ describe('API responses contain only expected fields', () => {
 
   it('GET /bookings returns bookings with exact field set', async () => {
     const app = createTestApp()
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+    const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
 
-    // Create a vehicle first
+    // Create a vehicle first (STAFF)
     const vRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -122,11 +128,11 @@ describe('API responses contain only expected fields', () => {
     })
     const vehicle = await vRes.json()
 
+    // Create a booking (RENTER — renterId derived from JWT sub)
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...renterHeaders },
       body: JSON.stringify({
-        renterId: 'user-1',
         vehicleId: vehicle.data.id,
         startAt: '2026-05-01T10:00:00Z',
         endAt: '2026-05-03T10:00:00Z',
@@ -134,7 +140,7 @@ describe('API responses contain only expected fields', () => {
       }),
     })
 
-    const res = await app.request('/bookings')
+    const res = await app.request('/bookings', { headers: staffHeaders })
     const body = await res.json()
     const booking = body.data[0]
 

--- a/packages/api/tests/routes/stats.test.ts
+++ b/packages/api/tests/routes/stats.test.ts
@@ -6,10 +6,12 @@ import {
   InMemoryStatsRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 const TEST_API_KEY = 'test-stats-key'
 
 function createTestApp() {
+  setupAuthEnv()
   const vehicleRepo = new InMemoryVehicleRepository()
   const bookingRepo = new InMemoryBookingRepository()
   const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
@@ -72,11 +74,13 @@ describe('GET /stats', () => {
 
   it('returns correct counts after creating vehicles and bookings', async () => {
     const { app } = createTestApp()
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+    const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
 
     // Create 3 vehicles (2 AVAILABLE, 1 will be soft-deleted)
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Toyota Prius',
         description: 'Hybrid',
@@ -88,7 +92,7 @@ describe('GET /stats', () => {
     })
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Honda Fit',
         description: 'Compact',
@@ -100,7 +104,7 @@ describe('GET /stats', () => {
     })
     const maintenanceRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...staffHeaders },
       body: JSON.stringify({
         name: 'Suzuki Swift',
         description: 'Under repair',
@@ -113,10 +117,11 @@ describe('GET /stats', () => {
     const maintenanceBody = await maintenanceRes.json()
     await app.request(`/vehicles/${maintenanceBody.data.id}`, {
       method: 'DELETE',
+      headers: staffHeaders,
     })
 
     // Create 2 bookings
-    const vehiclesRes = await app.request('/vehicles')
+    const vehiclesRes = await app.request('/vehicles', { headers: staffHeaders })
     const vehiclesBody = await vehiclesRes.json()
     const availableVehicle = vehiclesBody.data.find(
       (v: { status: string }) => v.status === 'AVAILABLE',
@@ -124,9 +129,8 @@ describe('GET /stats', () => {
 
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...renterHeaders },
       body: JSON.stringify({
-        renterId: 'user-1',
         vehicleId: availableVehicle.id,
         startAt: '2026-05-01T10:00:00Z',
         endAt: '2026-05-03T10:00:00Z',
@@ -135,9 +139,8 @@ describe('GET /stats', () => {
     })
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...renterHeaders },
       body: JSON.stringify({
-        renterId: 'user-2',
         vehicleId: availableVehicle.id,
         startAt: '2026-06-01T10:00:00Z',
         endAt: '2026-06-03T10:00:00Z',

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
 import { createVehicleRoutes } from '../../src/routes/vehicles'
+import { testAuthMiddleware } from '../helpers/auth'
 
 let app: Hono
 
@@ -29,6 +30,7 @@ describe('Vehicle CRUD Routes', () => {
   beforeEach(() => {
     const repo = new InMemoryVehicleRepository()
     app = new Hono()
+    app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
     app.route('/', createVehicleRoutes(repo))
   })
 


### PR DESCRIPTION
## Summary

- Apply `requireAuth()` path middleware for `/vehicles/*`, `/bookings/*`, `/availability/*`, `/threads/*`
- Actor derivation: `POST /bookings` uses JWT `sub` as `renterId`, body field ignored
- Role gates: vehicle mutations (`POST`/`PATCH`/`DELETE`) require `STAFF`/`ADMIN`
- Role gates: booking status updates require `STAFF`/`ADMIN`
- Ownership enforcement: `RENTER` can only cancel own bookings (403)
- Actor derivation for messages: `senderId`/`userId` from JWT unconditionally (no body fallback)
- Cancel ownership returns uniform 403 for both not-found and not-owned (no info leak)

## Follow-up issues needed

- Scope `GET /bookings` to caller's own bookings for non-privileged roles
- Add participant check on `GET /threads/:id`
- Validate caller is a participant on `POST /threads`
- Consider role gate on `/vehicles/fleet-overview` (staff-only dashboard data)

## Test plan

- [x] All 178 API tests pass (9 previously-failing auth tests now green)
- [x] Auth middleware tests: missing header, malformed token, expired JWT, wrong secret, valid JWT, API key
- [x] Actor derivation tests: spoofed renterId ignored, ownership on cancel, role gates on vehicles
- [x] Existing unit tests updated with `testAuthMiddleware` helper
- [x] Multi-user message tests use per-user `appAs()` pattern
- [x] TypeScript strict mode passes
- [x] Biome lint passes

Closes #87