### PR TITLE
refactor(shared): type VALID_BOOKING_TRANSITIONS with BookingStatus enum

### DIFF
--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -1,4 +1,4 @@
-import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
+import { type BookingStatus, VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
@@ -188,14 +188,13 @@ export class BookingService {
     }
   }
 
-  async updateStatus(bookingId: string, newStatus: string): Promise<StatusTransitionResult> {
+  async updateStatus(bookingId: string, newStatus: BookingStatus): Promise<StatusTransitionResult> {
     const booking = await this.bookingRepo.findById(bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
     }
 
-    const allowedTransitions =
-      VALID_BOOKING_TRANSITIONS[booking.status as keyof typeof VALID_BOOKING_TRANSITIONS] ?? []
+    const allowedTransitions = VALID_BOOKING_TRANSITIONS[booking.status] ?? []
     if (!allowedTransitions.includes(newStatus)) {
       return {
         ok: false,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -172,7 +172,9 @@ export const messages = pgTable('messages', {
   createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
 })
 
-export const VALID_BOOKING_TRANSITIONS: Record<string, string[]> = {
+export type BookingStatus = (typeof bookingStatusEnum.enumValues)[number]
+
+export const VALID_BOOKING_TRANSITIONS: Record<BookingStatus, BookingStatus[]> = {
   CONFIRMED: ['ACTIVE', 'CANCELLED'],
   ACTIVE: ['COMPLETED', 'CANCELLED'],
   COMPLETED: [],


### PR DESCRIPTION
## Summary
- Extract `BookingStatus` type from `bookingStatusEnum`
- Change `VALID_BOOKING_TRANSITIONS` from `Record<string, string[]>` to `Record<BookingStatus, BookingStatus[]>`
- Remove unsafe `as keyof typeof` cast in `BookingService.updateStatus`
- Type `newStatus` param as `BookingStatus` instead of `string`

## What changed
- `packages/shared/src/db/schema.ts` — new `BookingStatus` type, typed transitions map
- `packages/api/src/services/booking.ts` — import `BookingStatus`, remove cast, type param

## Test plan
- [x] All transition tests pass (existing coverage is comprehensive)
- [x] TypeScript strict mode clean (both packages)
- [x] Biome lint clean

Closes #142