### PR TITLE
refactor(api): accept optional now param for testable date logic

### DIFF
--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -88,7 +88,7 @@ export class BookingService {
     return this.bookingRepo.findById(id)
   }
 
-  async create(input: CreateBookingInput): Promise<CreateBookingResult> {
+  async create(input: CreateBookingInput, now: Date = new Date()): Promise<CreateBookingResult> {
     // Idempotency: if a key was provided, check for an existing booking first.
     if (input.idempotencyKey) {
       const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
@@ -114,7 +114,7 @@ export class BookingService {
           },
           input.startAt,
           input.endAt,
-          new Date(),
+          now,
         )
         if (!check.ok) {
           return {
@@ -218,7 +218,7 @@ export class BookingService {
     return { ok: true, booking: updated }
   }
 
-  async cancel(bookingId: string): Promise<CancelResult> {
+  async cancel(bookingId: string, now: Date = new Date()): Promise<CancelResult> {
     const booking = await this.bookingRepo.findById(bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
@@ -232,7 +232,6 @@ export class BookingService {
       }
     }
 
-    const now = new Date()
     const cancellation = calculateCancellationFee(booking.startAt, now, booking.totalPrice ?? 0)
 
     const updated = await this.bookingRepo.cancel(booking.id, {


### PR DESCRIPTION
## Summary
- Add optional `now: Date` param to `BookingService.create()` and `cancel()`
- Defaults to `new Date()` — no behavior change for callers
- Removes impure `new Date()` from business logic, enabling deterministic testing without fake timers

## Test plan
- [x] All 53 booking route tests pass
- [x] tsc --noEmit passes
- [x] Biome lint clean
- [x] No API contract change (routes don't pass `now`)

Closes #147