### PR TITLE
fix(api): thread IDOR, fleet-overview role gate, type-safe role validation

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import type { Context, MiddlewareHandler } from 'hono'
 import { jwtVerify } from 'jose'
 import { fail } from '../routes/helpers'
@@ -17,8 +18,19 @@ export interface AuthEnv {
 
 const ALL_ROLES: ReadonlySet<string> = new Set<string>(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
 
-function isValidRole(value: string): value is UserRole {
+export function isValidRole(value: string): value is UserRole {
   return ALL_ROLES.has(value)
+}
+
+function isAuthUser(v: unknown): v is AuthUser {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'id' in v &&
+    typeof (v as AuthUser).id === 'string' &&
+    'role' in v &&
+    isValidRole((v as AuthUser).role)
+  )
 }
 
 /** Roles that can manage bookings across all users */
@@ -28,12 +40,16 @@ export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'
 export const STAFF_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'])
 
 export function getUser(c: { get: (key: string) => unknown }): AuthUser | undefined {
-  return c.get('user') as AuthUser | undefined
+  const raw = c.get('user')
+  return isAuthUser(raw) ? raw : undefined
 }
 
-export function requireUser(c: { get: (key: string) => unknown }): AuthUser | null {
+/** Assert the user is present. Throws if middleware didn't set it —
+ *  safe to call in any route registered after requireAuth(). */
+export function requireUser(c: { get: (key: string) => unknown }): AuthUser {
   const user = getUser(c)
-  return user?.id ? user : null
+  if (!user) throw new Error('requireUser: no authenticated user in context')
+  return user
 }
 
 export function requireAuth(): MiddlewareHandler {
@@ -83,14 +99,11 @@ async function verifyJwt(token: string): Promise<AuthUser | null> {
 
 function verifyApiKey(key: string): AuthUser | null {
   const expected = process.env.PARTNER_API_KEY
-  if (!expected || key.length !== expected.length) return null
+  if (!expected) return null
 
-  // Constant-time comparison
-  let mismatch = 0
-  for (let i = 0; i < key.length; i++) {
-    mismatch |= key.charCodeAt(i) ^ expected.charCodeAt(i)
-  }
+  const a = Buffer.from(key)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null
 
-  if (mismatch !== 0) return null
   return { id: 'partner:api-key', role: 'PARTNER' }
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -15,6 +15,12 @@ export interface AuthEnv {
   }
 }
 
+const ALL_ROLES: ReadonlySet<string> = new Set<string>(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
+
+function isValidRole(value: string): value is UserRole {
+  return ALL_ROLES.has(value)
+}
+
 /** Roles that can manage bookings across all users */
 export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN', 'PARTNER'])
 
@@ -67,10 +73,8 @@ async function verifyJwt(token: string): Promise<AuthUser | null> {
     const id = payload.sub
     if (!id) return null
 
-    const VALID_ROLES = new Set<UserRole>(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
-    const rawRole = payload.role as string | undefined
-    const role: UserRole =
-      rawRole && VALID_ROLES.has(rawRole as UserRole) ? (rawRole as UserRole) : 'RENTER'
+    const rawRole = typeof payload.role === 'string' ? payload.role : undefined
+    const role: UserRole = rawRole && isValidRole(rawRole) ? rawRole : 'RENTER'
     return { id, role }
   } catch {
     return null
@@ -88,5 +92,5 @@ function verifyApiKey(key: string): AuthUser | null {
   }
 
   if (mismatch !== 0) return null
-  return { id: 'partner:api-key', role: 'PARTNER' as const }
+  return { id: 'partner:api-key', role: 'PARTNER' }
 }

--- a/packages/api/src/routes/fleet-overview.ts
+++ b/packages/api/src/routes/fleet-overview.ts
@@ -1,11 +1,16 @@
 import { Hono } from 'hono'
+import { STAFF_ROLES, getUser } from '../middleware/auth'
 import type { FleetOverviewRepository } from '../repositories/types'
-import { ok } from './helpers'
+import { fail, ok } from './helpers'
 
 export function createFleetOverviewRoutes(repo: FleetOverviewRepository): Hono {
   const routes = new Hono()
 
   routes.get('/vehicles/fleet-overview', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const data = await repo.findFleetOverview()
     return ok(c, data)
   })

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,8 +1,12 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { getUser } from '../middleware/auth'
+import { PRIVILEGED_ROLES, getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
+
+function isParticipant(participants: ReadonlyArray<{ userId: string }>, userId: string): boolean {
+  return participants.some((p) => p.userId === userId)
+}
 
 export function createMessageRoutes(
   threadRepo: ThreadRepository,
@@ -32,30 +36,44 @@ export function createMessageRoutes(
   })
 
   app.get('/threads/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) {
+    if (!thread) return fail(c, 'Thread not found', 404)
+
+    if (!PRIVILEGED_ROLES.has(user.role) && !isParticipant(thread.participants, user.id)) {
       return fail(c, 'Thread not found', 404)
     }
     return ok(c, thread)
   })
 
   app.post('/threads', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const parsed = await parseBody(c, createThreadSchema)
     if (!parsed.ok) return parsed.response
 
-    const thread = await threadRepo.create(
-      parsed.data.bookingId ?? null,
-      parsed.data.participantIds,
-    )
+    // Ensure the creator is always a participant
+    const participantIds = parsed.data.participantIds.includes(user.id)
+      ? parsed.data.participantIds
+      : [user.id, ...parsed.data.participantIds]
+
+    const thread = await threadRepo.create(parsed.data.bookingId ?? null, participantIds)
     return ok(c, thread, 201)
   })
 
   app.post('/threads/:id/messages', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!PRIVILEGED_ROLES.has(user.role) && !isParticipant(thread.participants, user.id)) {
+      return fail(c, 'Thread not found', 404)
+    }
 
     const parsed = await parseBody(c, sendMessageSchema)
     if (!parsed.ok) return parsed.response
@@ -65,11 +83,15 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/read', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!isParticipant(thread.participants, user.id)) {
+      return fail(c, 'Thread not found', 404)
+    }
 
     await threadRepo.markAsRead(thread.id, user.id)
     return ok(c, null)

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,6 +1,6 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { PRIVILEGED_ROLES, getUser } from '../middleware/auth'
+import { PRIVILEGED_ROLES, requireUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
@@ -15,8 +15,7 @@ export function createMessageRoutes(
   const app = new Hono()
 
   app.get('/threads', async (c) => {
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    const user = requireUser(c)
 
     const limitParam = c.req.query('limit')
     const offsetParam = c.req.query('offset')
@@ -36,8 +35,7 @@ export function createMessageRoutes(
   })
 
   app.get('/threads/:id', async (c) => {
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    const user = requireUser(c)
 
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
@@ -49,8 +47,7 @@ export function createMessageRoutes(
   })
 
   app.post('/threads', async (c) => {
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    const user = requireUser(c)
 
     const parsed = await parseBody(c, createThreadSchema)
     if (!parsed.ok) return parsed.response
@@ -65,8 +62,7 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/messages', async (c) => {
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    const user = requireUser(c)
 
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
@@ -83,8 +79,7 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/read', async (c) => {
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    const user = requireUser(c)
 
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -295,5 +295,38 @@ describe('Message Routes', () => {
       const body = await res.json()
       expect(body.data).toHaveLength(1)
     })
+
+    it('STAFF can read a thread they are not a participant of', async () => {
+      const createRes = await app.request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      // U3 as STAFF (not a participant) should bypass the check
+      const staffApp = new Hono()
+      staffApp.use('*', testAuthMiddleware(U3, 'STAFF'))
+      staffApp.route('/', createMessageRoutes(threadRepo, messageRepo))
+
+      const res = await staffApp.request(`/threads/${threadId}`)
+      expect(res.status).toBe(200)
+    })
+
+    it('non-participant cannot mark-as-read (returns 404)', async () => {
+      const createRes = await app.request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}/read`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      expect(res.status).toBe(404)
+    })
   })
 })

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -71,8 +71,9 @@ describe('Message Routes', () => {
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
-      // Thread between user2 and user3 (user1 is NOT a participant)
-      await app.request('/threads', {
+      // Thread between user2 and user3 (user1 is NOT a participant).
+      // Use appAs(U2) so U1 isn't auto-added as creator.
+      await appAs(U2).request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participantIds: [U2, U3] }),
@@ -248,6 +249,51 @@ describe('Message Routes', () => {
         (p: { userId: string }) => p.userId === U2,
       )
       expect(user2After.unreadCount).toBe(0)
+    })
+  })
+
+  describe('thread ownership checks', () => {
+    it('non-participant RENTER cannot read a thread (returns 404)', async () => {
+      const createRes = await app.request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}`)
+      expect(res.status).toBe(404)
+    })
+
+    it('non-participant RENTER cannot send messages to a thread', async () => {
+      const createRes = await app.request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Snooping!' }),
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('POST /threads always includes creator as participant', async () => {
+      // U1 creates a thread listing only U2
+      const createRes = await app.request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U2] }),
+      })
+      expect((await createRes.json()).success).toBe(true)
+
+      // U1 should see it (auto-added as participant)
+      const res = await app.request('/threads')
+      const body = await res.json()
+      expect(body.data).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Thread IDOR fix: `GET/POST /threads/:id` verify caller is a participant (404 for outsiders)
- `POST /threads` auto-injects creator into `participantIds`
- Fleet-overview requires STAFF/ADMIN role (business-internal data)
- Replace `as UserRole` cast chain with `isValidRole()` type guard
- Move `VALID_ROLES` to module-level `ALL_ROLES` (avoid per-request allocation)

## Test plan

- [x] Non-participant RENTER gets 404 on thread read
- [x] Non-participant RENTER gets 404 on thread message send
- [x] Creator auto-added to thread participants
- [x] 165 route tests pass, types clean
- [x] Pre-existing fleet-overview fake timer failures unaffected

Refs #76