### PR TITLE
feat(api): add participant access control to thread endpoints

### DIFF
--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -84,11 +84,16 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/read', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!PRIVILEGED_ROLES.has(user.role)) {
+      const isParticipant = thread.participants.some((p) => p.userId === user.id)
+      if (!isParticipant) return fail(c, 'Thread not found', 404)
+    }
 
     await threadRepo.markAsRead(thread.id, user.id)
     return ok(c, null)

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,6 +1,6 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { getUser } from '../middleware/auth'
+import { PRIVILEGED_ROLES, getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
@@ -32,16 +32,30 @@ export function createMessageRoutes(
   })
 
   app.get('/threads/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) {
-      return fail(c, 'Thread not found', 404)
+    if (!thread) return fail(c, 'Thread not found', 404)
+
+    if (!PRIVILEGED_ROLES.has(user.role)) {
+      const isParticipant = thread.participants.some((p) => p.userId === user.id)
+      if (!isParticipant) return fail(c, 'Thread not found', 404)
     }
+
     return ok(c, thread)
   })
 
   app.post('/threads', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const parsed = await parseBody(c, createThreadSchema)
     if (!parsed.ok) return parsed.response
+
+    if (!PRIVILEGED_ROLES.has(user.role) && !parsed.data.participantIds.includes(user.id)) {
+      return fail(c, 'Caller must be a participant', 400)
+    }
 
     const thread = await threadRepo.create(
       parsed.data.bookingId ?? null,
@@ -51,11 +65,16 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/messages', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
-    const user = getUser(c)
-    if (!user) return fail(c, 'Unauthorized', 401)
+    if (!PRIVILEGED_ROLES.has(user.role)) {
+      const isParticipant = thread.participants.some((p) => p.userId === user.id)
+      if (!isParticipant) return fail(c, 'Thread not found', 404)
+    }
 
     const parsed = await parseBody(c, sendMessageSchema)
     if (!parsed.ok) return parsed.response

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -179,6 +179,22 @@ describe('Message Routes', () => {
       })
       expect(res.status).toBe(404)
     })
+
+    it('non-participant cannot mark thread as read', async () => {
+      const createRes = await appAs(U1).request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}/read`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: U3 }),
+      })
+      expect(res.status).toBe(404)
+    })
   })
 
   describe('POST /threads/:id/messages', () => {

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -15,9 +15,9 @@ let threadRepo: InMemoryThreadRepository
 let messageRepo: InMemoryMessageRepository
 
 /** Create a Hono app authenticated as the given user. */
-function appAs(userId: string): Hono {
+function appAs(userId: string, role: 'RENTER' | 'STAFF' | 'ADMIN' = 'RENTER'): Hono {
   const a = new Hono()
-  a.use('*', testAuthMiddleware(userId, 'RENTER'))
+  a.use('*', testAuthMiddleware(userId, role))
   a.route('/', createMessageRoutes(threadRepo, messageRepo))
   return a
 }
@@ -72,7 +72,7 @@ describe('Message Routes', () => {
       })
 
       // Thread between user2 and user3 (user1 is NOT a participant)
-      await app.request('/threads', {
+      await appAs(U2).request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participantIds: [U2, U3] }),
@@ -116,6 +116,68 @@ describe('Message Routes', () => {
       expect(body.data.bookingId).toBeNull()
       expect(body.data.createdAt).toBeDefined()
       expect(body.data.updatedAt).toBeDefined()
+    })
+  })
+
+  describe('access control', () => {
+    it('POST /threads rejects when caller is not in participantIds', async () => {
+      const res = await appAs(U1).request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U2, U3] }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('Caller must be a participant')
+    })
+
+    it('STAFF can create thread between arbitrary users', async () => {
+      const res = await appAs(U1, 'STAFF').request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U2, U3] }),
+      })
+      expect(res.status).toBe(201)
+    })
+
+    it('GET /threads/:id returns 404 for non-participant', async () => {
+      const createRes = await appAs(U1).request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}`)
+      expect(res.status).toBe(404)
+    })
+
+    it('STAFF can read any thread regardless of participation', async () => {
+      const createRes = await appAs(U1).request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3, 'STAFF').request(`/threads/${threadId}`)
+      expect(res.status).toBe(200)
+    })
+
+    it('non-participant cannot send messages to thread', async () => {
+      const createRes = await appAs(U1).request('/threads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantIds: [U1, U2] }),
+      })
+      const threadId = (await createRes.json()).data.id
+
+      const res = await appAs(U3).request(`/threads/${threadId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Snooping!', senderId: U3 }),
+      })
+      expect(res.status).toBe(404)
     })
   })
 


### PR DESCRIPTION
## Summary

- `GET /threads/:id` returns 404 for non-participants (prevents conversation leaks)
- `POST /threads` rejects if caller is not in participantIds (prevents impersonation)
- `POST /threads/:id/messages` returns 404 for non-participants
- STAFF/ADMIN/PARTNER bypass all participant checks (support/admin use case)

## Test plan

- [x] 183 API tests pass (5 new access control tests)
- [x] Non-participant gets 404 on GET /threads/:id
- [x] STAFF can read any thread (bypass)
- [x] POST /threads rejects when caller not in participantIds
- [x] Non-participant can't send messages to thread
- [x] TypeScript strict + Biome lint pass

Closes #183