### PR TITLE
perf(web): replace raw img tags with next/image

### DIFF
--- a/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import type { VehicleDetailData } from '@/lib/vehicle-api'
 import { ArrowLeft, Calendar, Car, Clock, Fuel, Settings2, Users } from 'lucide-react'
 import type { getTranslations } from 'next-intl/server'
+import Image from 'next/image'
 import type { ComponentType } from 'react'
 import { UtilizationChart } from './UtilizationChart'
 
@@ -198,14 +199,29 @@ function PhotoGallery({
     <section aria-label={placeholder}>
       {primaryPhoto ? (
         <div className="space-y-3">
-          <div className="aspect-[16/9] overflow-hidden rounded-xl bg-muted">
-            <img src={primaryPhoto} alt={name} className="w-full h-full object-cover" />
+          <div className="relative aspect-[16/9] overflow-hidden rounded-xl bg-muted">
+            <Image
+              src={primaryPhoto}
+              alt={name}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 66vw"
+            />
           </div>
           {photos.length > 1 && (
             <div className="grid grid-cols-4 gap-3">
               {photos.slice(1, 5).map((photo) => (
-                <div key={photo} className="aspect-[4/3] overflow-hidden rounded-lg bg-muted">
-                  <img src={photo} alt={name} className="w-full h-full object-cover" />
+                <div
+                  key={photo}
+                  className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted"
+                >
+                  <Image
+                    src={photo}
+                    alt={name}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 25vw, 16vw"
+                  />
                 </div>
               ))}
             </div>

--- a/packages/web/src/app/[locale]/bookings/new/BookingForm.tsx
+++ b/packages/web/src/app/[locale]/bookings/new/BookingForm.tsx
@@ -10,6 +10,7 @@ import { formatDurationHours } from '@/lib/rental-rules-format'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
 import { Car, Fuel, Settings2, Users, XCircle } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import Image from 'next/image'
 import { useActionState, useEffect, useMemo, useState } from 'react'
 
 interface VehicleInfo {
@@ -130,8 +131,14 @@ export function BookingForm({ vehicle, isAuthenticated }: BookingFormProps) {
           <h2 className="text-lg font-medium mb-4">{t('vehicleInfo')}</h2>
           <div className="flex gap-4">
             {primaryPhoto ? (
-              <div className="w-32 h-24 overflow-hidden rounded-lg bg-muted shrink-0">
-                <img src={primaryPhoto} alt={vehicle.name} className="w-full h-full object-cover" />
+              <div className="relative w-32 h-24 overflow-hidden rounded-lg bg-muted shrink-0">
+                <Image
+                  src={primaryPhoto}
+                  alt={vehicle.name}
+                  fill
+                  className="object-cover"
+                  sizes="128px"
+                />
               </div>
             ) : (
               <div className="w-32 h-24 overflow-hidden rounded-lg bg-muted flex items-center justify-center shrink-0">

--- a/packages/web/src/components/vehicles/FleetVehicleCard.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleCard.tsx
@@ -7,6 +7,7 @@ import { formatVehicleRate } from '@/lib/format'
 import type { VehicleData } from '@/lib/vehicle-api'
 import { Car, Fuel, Pencil, Settings2, Trash2, Users } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import Image from 'next/image'
 
 interface FleetVehicleCardProps {
   vehicle: VehicleData
@@ -24,9 +25,15 @@ export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCard
 
   return (
     <Card>
-      <div className="aspect-[4/3] overflow-hidden bg-muted">
+      <div className="relative aspect-[4/3] overflow-hidden bg-muted">
         {photo ? (
-          <img src={photo} alt={vehicle.name} className="w-full h-full object-cover" />
+          <Image
+            src={photo}
+            alt={vehicle.name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 33vw"
+          />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
             <Car className="size-12 text-muted-foreground/30" />

--- a/packages/web/src/components/vehicles/FleetVehicleRow.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleRow.tsx
@@ -12,6 +12,7 @@ import { formatVehicleRate } from '@/lib/format'
 import type { FleetBookingSummaryData, FleetVehicleOverviewData } from '@/lib/vehicle-api'
 import { Car, MoreHorizontal } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import Image from 'next/image'
 
 interface FleetVehicleRowProps {
   overview: FleetVehicleOverviewData
@@ -81,9 +82,9 @@ export function FleetVehicleRow({ overview, onEdit, onRetire }: FleetVehicleRowP
   return (
     <div className="flex items-center gap-4 rounded-lg border bg-card p-3">
       {/* Thumbnail: 80x60 per issue spec */}
-      <div className="flex-shrink-0 h-[60px] w-[80px] overflow-hidden rounded bg-muted">
+      <div className="relative flex-shrink-0 h-[60px] w-[80px] overflow-hidden rounded bg-muted">
         {photo ? (
-          <img src={photo} alt={overview.name} className="h-full w-full object-cover" />
+          <Image src={photo} alt={overview.name} fill className="object-cover" sizes="80px" />
         ) : (
           <div
             data-testid="fleet-row-thumbnail-placeholder"


### PR DESCRIPTION
## Summary
Replace all 5 raw `<img>` tags with `next/image` for lazy loading, responsive sizes, and format optimization.

## What changed
- `FleetVehicleCard.tsx` -- card thumbnail (sizes: 33vw desktop)
- `FleetVehicleRow.tsx` -- row thumbnail (sizes: 80px fixed)
- `BookingForm.tsx` -- vehicle preview (sizes: 128px fixed)
- `VehicleDetail.tsx` -- hero image (66vw) + gallery thumbnails (16vw)

All use `relative` parent + `fill` + `object-cover` pattern with `sizes` hints for correct srcset generation.

## Test plan
- [x] TypeScript strict mode clean
- [x] Biome lint clean
- [x] `remotePatterns` already configured for `images.unsplash.com`
- [ ] Visual check: vehicle cards, rows, detail page, booking form

Closes #143