### PR TITLE
feat(api): wire auth middleware, actor derivation, role gates, and ownership checks

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import { getDb } from '@kuruma/shared/db'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { setupGlobalHandlers } from './error-handlers'
+import { requireAuth } from './middleware/auth'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -131,6 +132,11 @@ export function createApp(overrides?: {
   }
 
   app.route('/', health)
+
+  // Auth middleware: everything below this point requires a valid JWT or API key.
+  // Health check is mounted above so it stays public.
+  app.use('*', requireAuth())
+
   const bookingService = new BookingService(bookingRepo, vehicleRepo)
 
   app.route('/', createFleetOverviewRoutes(fleetOverviewRepo))

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -21,13 +21,11 @@ export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'
 /** Roles that can manage vehicles */
 export const STAFF_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'])
 
+/** All valid roles for JWT parsing */
+const VALID_ROLES: ReadonlySet<UserRole> = new Set(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
+
 export function getUser(c: { get: (key: string) => unknown }): AuthUser | undefined {
   return c.get('user') as AuthUser | undefined
-}
-
-export function requireUser(c: { get: (key: string) => unknown }): AuthUser | null {
-  const user = getUser(c)
-  return user?.id ? user : null
 }
 
 export function requireAuth(): MiddlewareHandler {
@@ -67,7 +65,6 @@ async function verifyJwt(token: string): Promise<AuthUser | null> {
     const id = payload.sub
     if (!id) return null
 
-    const VALID_ROLES = new Set<UserRole>(['RENTER', 'STAFF', 'ADMIN', 'PARTNER'])
     const rawRole = payload.role as string | undefined
     const role: UserRole =
       rawRole && VALID_ROLES.has(rawRole as UserRole) ? (rawRole as UserRole) : 'RENTER'

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,5 +1,6 @@
 import { createBookingSchema, updateBookingStatusSchema } from '@kuruma/shared/validators/booking'
 import { Hono } from 'hono'
+import { PRIVILEGED_ROLES, getUser } from '../middleware/auth'
 import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
 import { fail, ok, parseDateRange } from './helpers'
@@ -8,6 +9,9 @@ export function createBookingRoutes(service: BookingService): Hono {
   const bookings = new Hono()
 
   bookings.get('/bookings', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const statusFilter = c.req.query('status')
     const vehicleIdFilter = c.req.query('vehicleId')
     const renterIdFilter = c.req.query('renterId')
@@ -24,11 +28,14 @@ export function createBookingRoutes(service: BookingService): Hono {
       return fail(c, 'limit must be between 1 and 100', 400)
     }
 
+    // Non-privileged users can only see their own bookings
+    const effectiveRenterId = PRIVILEGED_ROLES.has(user.role) ? renterIdFilter : user.id
+
     const filters: BookingFilters = { limit }
     if (cursor) filters.cursor = cursor
     if (statusFilter) filters.status = statusFilter
     if (vehicleIdFilter) filters.vehicleId = vehicleIdFilter
-    if (renterIdFilter) filters.renterId = renterIdFilter
+    if (effectiveRenterId) filters.renterId = effectiveRenterId
     if (dateRange.from && dateRange.to) {
       filters.from = dateRange.from
       filters.to = dateRange.to
@@ -52,6 +59,9 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.post('/bookings', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const body = await c.req.json()
     const result = createBookingSchema.safeParse(body)
 
@@ -59,10 +69,8 @@ export function createBookingRoutes(service: BookingService): Hono {
       return fail(c, result.error.flatten().fieldErrors, 400)
     }
 
-    const renterId = body.renterId as string | undefined
-    if (!renterId) {
-      return fail(c, { renterId: ['Renter ID is required'] }, 400)
-    }
+    // Actor derivation: always use JWT sub, never trust body.renterId
+    const renterId = user.id
 
     const createResult = await service.create({
       vehicleId: result.data.vehicleId,
@@ -101,6 +109,16 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.post('/bookings/:id/cancel', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
+    // Ownership check: only the booking owner or privileged roles can cancel
+    const booking = await service.findById(c.req.param('id'))
+    if (!booking) return fail(c, 'Booking not found', 404)
+    if (booking.renterId !== user.id && !PRIVILEGED_ROLES.has(user.role)) {
+      return fail(c, 'Forbidden', 403)
+    }
+
     const result = await service.cancel(c.req.param('id'))
     if (!result.ok) {
       return fail(c, result.error, result.status)

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -51,8 +51,14 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.get('/bookings/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const booking = await service.findById(c.req.param('id'))
-    if (!booking) {
+    if (!booking) return fail(c, 'Booking not found', 404)
+
+    // Ownership check: non-privileged users can only see their own bookings
+    if (booking.renterId !== user.id && !PRIVILEGED_ROLES.has(user.role)) {
       return fail(c, 'Booking not found', 404)
     }
     return ok(c, booking)
@@ -94,6 +100,9 @@ export function createBookingRoutes(service: BookingService): Hono {
   })
 
   bookings.patch('/bookings/:id/status', async (c) => {
+    const user = getUser(c)
+    if (!user || !PRIVILEGED_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const body = await c.req.json()
     const parsed = updateBookingStatusSchema.safeParse(body)
     if (!parsed.success) {
@@ -112,14 +121,7 @@ export function createBookingRoutes(service: BookingService): Hono {
     const user = getUser(c)
     if (!user) return fail(c, 'Unauthorized', 401)
 
-    // Ownership check: only the booking owner or privileged roles can cancel
-    const booking = await service.findById(c.req.param('id'))
-    if (!booking) return fail(c, 'Booking not found', 404)
-    if (booking.renterId !== user.id && !PRIVILEGED_ROLES.has(user.role)) {
-      return fail(c, 'Forbidden', 403)
-    }
-
-    const result = await service.cancel(c.req.param('id'))
+    const result = await service.cancel(c.req.param('id'), user)
     if (!result.ok) {
       return fail(c, result.error, result.status)
     }

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,9 +1,6 @@
-import {
-  createThreadSchema,
-  markReadSchema,
-  sendMessageSchema,
-} from '@kuruma/shared/validators/message'
+import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
+import { getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
@@ -14,12 +11,11 @@ export function createMessageRoutes(
   const app = new Hono()
 
   app.get('/threads', async (c) => {
-    const userId = c.req.query('userId')
-    if (!userId) {
-      return fail(c, 'userId query parameter is required', 400)
-    }
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
 
-    const threads = await threadRepo.findAll(userId)
+    // Actor derivation: always use JWT sub, ignore query.userId
+    const threads = await threadRepo.findAll(user.id)
     return ok(c, threads)
   })
 
@@ -43,24 +39,29 @@ export function createMessageRoutes(
   })
 
   app.post('/threads/:id/messages', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
     const parsed = await parseBody(c, sendMessageSchema)
     if (!parsed.ok) return parsed.response
 
-    const message = await messageRepo.create(thread.id, parsed.data.senderId, parsed.data.content)
+    // Actor derivation: use JWT sub as senderId, ignore body.senderId
+    const message = await messageRepo.create(thread.id, user.id, parsed.data.content)
     return ok(c, message, 201)
   })
 
   app.post('/threads/:id/read', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
     if (!thread) return fail(c, 'Thread not found', 404)
 
-    const parsed = await parseBody(c, markReadSchema)
-    if (!parsed.ok) return parsed.response
-
-    await threadRepo.markAsRead(thread.id, parsed.data.userId)
+    // Actor derivation: use JWT sub, ignore body.userId
+    await threadRepo.markAsRead(thread.id, user.id)
     return ok(c, null)
   })
 

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,6 +1,6 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { getUser } from '../middleware/auth'
+import { PRIVILEGED_ROLES, getUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
@@ -20,8 +20,15 @@ export function createMessageRoutes(
   })
 
   app.get('/threads/:id', async (c) => {
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+
     const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) {
+    if (!thread) return fail(c, 'Thread not found', 404)
+
+    // Non-participants cannot view thread (return 404 to avoid leaking existence)
+    const isParticipant = thread.participants.some((p) => p.userId === user.id)
+    if (!isParticipant && !PRIVILEGED_ROLES.has(user.role)) {
       return fail(c, 'Thread not found', 404)
     }
     return ok(c, thread)

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -4,6 +4,7 @@ import {
   updateVehicleStatusSchema,
 } from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
+import { STAFF_ROLES, getUser } from '../middleware/auth'
 import type { Vehicle, VehicleRepository } from '../repositories/types'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
@@ -25,6 +26,9 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.post('/vehicles', async (c) => {
+    const user = getUser(c)
+    if (!user || !STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const parsed = await parseBody(c, createVehicleSchema)
     if (!parsed.ok) return parsed.response
 
@@ -48,6 +52,9 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.patch('/vehicles/:id', async (c) => {
+    const user = getUser(c)
+    if (!user || !STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)
@@ -74,6 +81,9 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.patch('/vehicles/:id/status', async (c) => {
+    const user = getUser(c)
+    if (!user || !STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)
@@ -87,6 +97,9 @@ export function createVehicleRoutes(repo: VehicleRepository): Hono {
   })
 
   vehicles.delete('/vehicles/:id', async (c) => {
+    const user = getUser(c)
+    if (!user || !STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const existing = await repo.findById(c.req.param('id'))
     if (!existing) {
       return fail(c, 'Vehicle not found', 404)

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -2,6 +2,8 @@ import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
+import { PRIVILEGED_ROLES } from '../middleware/auth'
+import type { AuthUser } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { BookingFilters, BookingRepository, VehicleRepository } from '../repositories/types'
 import type { Booking } from '../stores'
@@ -39,7 +41,7 @@ export type CancelResult =
       booking: Booking
       cancellation: ReturnType<typeof calculateCancellationFee>
     }
-  | { ok: false; status: 404 | 409; error: string }
+  | { ok: false; status: 403 | 404 | 409; error: string }
 
 export class BookingService {
   constructor(
@@ -218,10 +220,15 @@ export class BookingService {
     return { ok: true, booking: updated }
   }
 
-  async cancel(bookingId: string): Promise<CancelResult> {
+  async cancel(bookingId: string, actor?: AuthUser): Promise<CancelResult> {
     const booking = await this.bookingRepo.findById(bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
+    }
+
+    // Ownership check: only the booking owner or privileged roles can cancel
+    if (actor && booking.renterId !== actor.id && !PRIVILEGED_ROLES.has(actor.role)) {
+      return { ok: false, status: 403, error: 'Forbidden' }
     }
 
     if (booking.status !== 'CONFIRMED') {

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1,11 +1,13 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { requireAuth } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import { createBookingRoutes } from '../../src/routes/bookings'
 import { BookingService } from '../../src/services/booking'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 let app: Hono
 let vehicleRepo: InMemoryVehicleRepository
@@ -19,6 +21,11 @@ const V2 = '00000000-0000-4000-8000-000000000002'
 const USER1 = '00000000-0000-4000-8000-0000000000a1'
 const USER2 = '00000000-0000-4000-8000-0000000000a2'
 
+/** Default auth: ADMIN role with USER1 as sub — matches validBookingInput's expected renterId */
+async function adminHeaders(sub = USER1) {
+  return authHeaders({ sub, role: 'ADMIN' })
+}
+
 function validBookingInput() {
   return {
     vehicleId: V1,
@@ -29,26 +36,30 @@ function validBookingInput() {
   }
 }
 
-async function createBooking(input = validBookingInput()) {
+async function createBooking(input = validBookingInput(), sub = USER1) {
+  const headers = await adminHeaders(sub)
   return app.request('/bookings', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(input),
   })
 }
 
 describe('Booking Routes', () => {
   beforeEach(() => {
+    setupAuthEnv()
     vehicleRepo = new InMemoryVehicleRepository()
     const repo = new InMemoryBookingRepository()
     const service = new BookingService(repo, vehicleRepo)
     app = new Hono()
+    app.use('*', requireAuth())
     app.route('/', createBookingRoutes(service))
   })
 
   describe('GET /bookings', () => {
     it('returns empty list initially', async () => {
-      const res = await app.request('/bookings')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings', { headers })
 
       expect(res.status).toBe(200)
 
@@ -63,7 +74,8 @@ describe('Booking Routes', () => {
         vehicleId: V2,
       })
 
-      const res = await app.request('/bookings')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -73,7 +85,8 @@ describe('Booking Routes', () => {
     it('filters by status', async () => {
       await createBooking()
 
-      const res = await app.request('/bookings?status=CONFIRMED')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?status=CONFIRMED', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -84,7 +97,8 @@ describe('Booking Routes', () => {
     it('filters by status returning empty when no match', async () => {
       await createBooking()
 
-      const res = await app.request('/bookings?status=ACTIVE')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?status=ACTIVE', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -98,7 +112,8 @@ describe('Booking Routes', () => {
         vehicleId: V2,
       })
 
-      const res = await app.request(`/bookings?vehicleId=${V1}`)
+      const headers = await adminHeaders()
+      const res = await app.request(`/bookings?vehicleId=${V1}`, { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -108,13 +123,17 @@ describe('Booking Routes', () => {
 
     it('filters by renterId', async () => {
       await createBooking()
-      await createBooking({
-        ...validBookingInput(),
-        renterId: USER2,
-        vehicleId: V2,
-      })
+      await createBooking(
+        {
+          ...validBookingInput(),
+          renterId: USER2,
+          vehicleId: V2,
+        },
+        USER2,
+      )
 
-      const res = await app.request(`/bookings?renterId=${USER1}`)
+      const headers = await adminHeaders()
+      const res = await app.request(`/bookings?renterId=${USER1}`, { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -125,7 +144,8 @@ describe('Booking Routes', () => {
     it('filters by renterId returning empty when no match', async () => {
       await createBooking()
 
-      const res = await app.request('/bookings?renterId=nonexistent')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?renterId=nonexistent', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -139,8 +159,10 @@ describe('Booking Routes', () => {
       // Query range that overlaps (hour 30 to hour 60)
       const from = futureDate(30)
       const to = futureDate(60)
+      const headers = await adminHeaders()
       const res = await app.request(
         `/bookings?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+        { headers },
       )
       const body = await res.json()
 
@@ -155,8 +177,10 @@ describe('Booking Routes', () => {
       // Query range that does NOT overlap (hour 72 to hour 96)
       const from = futureDate(72)
       const to = futureDate(96)
+      const headers = await adminHeaders()
       const res = await app.request(
         `/bookings?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+        { headers },
       )
       const body = await res.json()
 
@@ -165,6 +189,8 @@ describe('Booking Routes', () => {
     })
 
     it('combines date range with status filter', async () => {
+      const headers = await adminHeaders()
+
       // Create two bookings in the same range
       await createBooking()
       await createBooking({
@@ -173,15 +199,19 @@ describe('Booking Routes', () => {
       })
 
       // Cancel one
-      const listRes = await app.request('/bookings')
+      const listRes = await app.request('/bookings', { headers })
       const allBookings = await listRes.json()
-      await app.request(`/bookings/${allBookings.data[0].id}/cancel`, { method: 'POST' })
+      await app.request(`/bookings/${allBookings.data[0].id}/cancel`, {
+        method: 'POST',
+        headers,
+      })
 
       // Query overlapping range with status=CONFIRMED
       const from = futureDate(20)
       const to = futureDate(50)
       const res = await app.request(
         `/bookings?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&status=CONFIRMED`,
+        { headers },
       )
       const body = await res.json()
 
@@ -191,7 +221,10 @@ describe('Booking Routes', () => {
     })
 
     it('returns 400 when from is provided without to', async () => {
-      const res = await app.request(`/bookings?from=${encodeURIComponent(futureDate(1))}`)
+      const headers = await adminHeaders()
+      const res = await app.request(`/bookings?from=${encodeURIComponent(futureDate(1))}`, {
+        headers,
+      })
       const body = await res.json()
 
       expect(res.status).toBe(400)
@@ -200,7 +233,8 @@ describe('Booking Routes', () => {
     })
 
     it('returns 400 for invalid date strings', async () => {
-      const res = await app.request('/bookings?from=not-a-date&to=also-bad')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?from=not-a-date&to=also-bad', { headers })
       const body = await res.json()
 
       expect(res.status).toBe(400)
@@ -209,10 +243,12 @@ describe('Booking Routes', () => {
     })
 
     it('returns 400 when to is before from', async () => {
+      const headers = await adminHeaders()
       const from = futureDate(48)
       const to = futureDate(24)
       const res = await app.request(
         `/bookings?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+        { headers },
       )
       const body = await res.json()
 
@@ -250,7 +286,8 @@ describe('Booking Routes', () => {
         vehicleId,
       })
 
-      const res = await app.request('/bookings?expand=vehicle')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?expand=vehicle', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -263,7 +300,8 @@ describe('Booking Routes', () => {
     it('returns bookings without vehicle data when expand is not set', async () => {
       await createBooking()
 
-      const res = await app.request('/bookings')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -274,11 +312,12 @@ describe('Booking Routes', () => {
 
   describe('GET /bookings — cursor pagination', () => {
     async function createNBookings(n: number) {
+      const headers = await adminHeaders()
       const ids: string[] = []
       for (let i = 0; i < n; i++) {
         const res = await app.request('/bookings', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...headers },
           body: JSON.stringify({
             vehicleId: `00000000-0000-4000-8000-00000000${String(i).padStart(4, '0')}`,
             renterId: USER1,
@@ -296,7 +335,8 @@ describe('Booking Routes', () => {
     it('returns at most limit items and a nextCursor when more exist', async () => {
       await createNBookings(5)
 
-      const res = await app.request('/bookings?limit=2')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?limit=2', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -308,7 +348,8 @@ describe('Booking Routes', () => {
     it('returns nextCursor null when no more results', async () => {
       await createNBookings(2)
 
-      const res = await app.request('/bookings?limit=10')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?limit=10', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -319,20 +360,22 @@ describe('Booking Routes', () => {
     it('pages through all results using nextCursor', async () => {
       await createNBookings(5)
 
+      const headers = await adminHeaders()
+
       // Page 1
-      const res1 = await app.request('/bookings?limit=2')
+      const res1 = await app.request('/bookings?limit=2', { headers })
       const body1 = await res1.json()
       expect(body1.data).toHaveLength(2)
       expect(body1.nextCursor).toBeDefined()
 
       // Page 2
-      const res2 = await app.request(`/bookings?limit=2&cursor=${body1.nextCursor}`)
+      const res2 = await app.request(`/bookings?limit=2&cursor=${body1.nextCursor}`, { headers })
       const body2 = await res2.json()
       expect(body2.data).toHaveLength(2)
       expect(body2.nextCursor).toBeDefined()
 
       // Page 3 (last item)
-      const res3 = await app.request(`/bookings?limit=2&cursor=${body2.nextCursor}`)
+      const res3 = await app.request(`/bookings?limit=2&cursor=${body2.nextCursor}`, { headers })
       const body3 = await res3.json()
       expect(body3.data).toHaveLength(1)
       expect(body3.nextCursor).toBeNull()
@@ -347,14 +390,15 @@ describe('Booking Routes', () => {
     })
 
     it('combines pagination with status filter', async () => {
+      const headers = await adminHeaders()
       await createNBookings(3)
       // Cancel the first one
-      const allRes = await app.request('/bookings')
+      const allRes = await app.request('/bookings', { headers })
       const allBody = await allRes.json()
       const firstId = allBody.data[0].id
-      await app.request(`/bookings/${firstId}/cancel`, { method: 'POST' })
+      await app.request(`/bookings/${firstId}/cancel`, { method: 'POST', headers })
 
-      const res = await app.request('/bookings?status=CONFIRMED&limit=10')
+      const res = await app.request('/bookings?status=CONFIRMED&limit=10', { headers })
       const body = await res.json()
 
       expect(body.data).toHaveLength(2)
@@ -363,7 +407,8 @@ describe('Booking Routes', () => {
     })
 
     it('defaults to 20 items when no limit specified', async () => {
-      const res = await app.request('/bookings')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings', { headers })
       const body = await res.json()
 
       // Existing behavior: returns all (empty here), with nextCursor null
@@ -371,12 +416,14 @@ describe('Booking Routes', () => {
     })
 
     it('rejects limit > 100', async () => {
-      const res = await app.request('/bookings?limit=200')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?limit=200', { headers })
       expect(res.status).toBe(400)
     })
 
     it('rejects limit < 1', async () => {
-      const res = await app.request('/bookings?limit=0')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings?limit=0', { headers })
       expect(res.status).toBe(400)
     })
   })
@@ -402,9 +449,10 @@ describe('Booking Routes', () => {
     })
 
     it('rejects invalid input with missing vehicleId and returns 400', async () => {
+      const headers = await adminHeaders()
       const res = await app.request('/bookings', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({
           renterId: USER1,
           startAt: futureDate(24),
@@ -435,9 +483,10 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'BANANA' }),
       })
 
@@ -488,7 +537,8 @@ describe('Booking Routes', () => {
       const first = await createBooking()
       const created = await first.json()
 
-      await app.request(`/bookings/${created.data.id}/cancel`, { method: 'POST' })
+      const headers = await adminHeaders()
+      await app.request(`/bookings/${created.data.id}/cancel`, { method: 'POST', headers })
 
       const res = await createBooking()
       expect(res.status).toBe(201)
@@ -703,9 +753,10 @@ describe('Booking Routes', () => {
           hourlyRateJpy: null,
         })
 
+        const headers = await adminHeaders()
         const res = await app.request('/bookings', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...headers },
           body: JSON.stringify({
             vehicleId,
             renterId: USER1,
@@ -746,7 +797,8 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
-      const res = await app.request(`/bookings/${created.data.id}`)
+      const headers = await adminHeaders()
+      const res = await app.request(`/bookings/${created.data.id}`, { headers })
 
       expect(res.status).toBe(200)
 
@@ -757,7 +809,8 @@ describe('Booking Routes', () => {
     })
 
     it('returns 404 for nonexistent booking', async () => {
-      const res = await app.request('/bookings/nonexistent-id')
+      const headers = await adminHeaders()
+      const res = await app.request('/bookings/nonexistent-id', { headers })
 
       expect(res.status).toBe(404)
 
@@ -772,9 +825,10 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'ACTIVE' }),
       })
 
@@ -790,9 +844,10 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'COMPLETED' }),
       })
 
@@ -807,15 +862,18 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
+
       // First cancel the booking
       await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       // Then try to transition from CANCELLED
       const res = await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'ACTIVE' }),
       })
 
@@ -827,9 +885,10 @@ describe('Booking Routes', () => {
     })
 
     it('returns 404 for nonexistent booking', async () => {
+      const headers = await adminHeaders()
       const res = await app.request('/bookings/nonexistent-id/status', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'ACTIVE' }),
       })
 
@@ -846,8 +905,10 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(200)
@@ -862,20 +923,23 @@ describe('Booking Routes', () => {
       const createRes = await createBooking()
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
+
       // Transition to ACTIVE then COMPLETED
       await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'ACTIVE' }),
       })
       await app.request(`/bookings/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status: 'COMPLETED' }),
       })
 
       const res = await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(409)
@@ -886,8 +950,10 @@ describe('Booking Routes', () => {
     })
 
     it('returns 404 for nonexistent booking', async () => {
+      const headers = await adminHeaders()
       const res = await app.request('/bookings/nonexistent-id/cancel', {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(404)
@@ -930,8 +996,10 @@ describe('Booking Routes', () => {
       })
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(200)
@@ -954,8 +1022,10 @@ describe('Booking Routes', () => {
       })
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(200)
@@ -975,8 +1045,10 @@ describe('Booking Routes', () => {
       })
       const created = await createRes.json()
 
+      const headers = await adminHeaders()
       const res = await app.request(`/bookings/${created.data.id}/cancel`, {
         method: 'POST',
+        headers,
       })
 
       expect(res.status).toBe(200)

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -1,10 +1,12 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { requireAuth } from '../../src/middleware/auth'
 import {
   InMemoryMessageRepository,
   InMemoryThreadRepository,
 } from '../../src/repositories/in-memory'
 import { createMessageRoutes } from '../../src/routes/messages'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 const U1 = '00000000-0000-4000-8000-0000000000a1'
 const U2 = '00000000-0000-4000-8000-0000000000a2'
@@ -16,15 +18,18 @@ let messageRepo: InMemoryMessageRepository
 
 describe('Message Routes', () => {
   beforeEach(() => {
+    setupAuthEnv()
     threadRepo = new InMemoryThreadRepository()
     messageRepo = new InMemoryMessageRepository(threadRepo)
     app = new Hono()
+    app.use('*', requireAuth())
     app.route('/', createMessageRoutes(threadRepo, messageRepo))
   })
 
   describe('GET /threads', () => {
     it('returns empty list when no threads exist for user', async () => {
-      const res = await app.request(`/threads?userId=${U1}`)
+      const headers = await authHeaders({ sub: U1 })
+      const res = await app.request('/threads', { headers })
 
       expect(res.status).toBe(200)
 
@@ -33,14 +38,15 @@ describe('Message Routes', () => {
     })
 
     it('returns created thread with participant info', async () => {
+      const u1Headers = await authHeaders({ sub: U1 })
       // Create a thread with two participants
       await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
-      const res = await app.request(`/threads?userId=${U1}`)
+      const res = await app.request('/threads', { headers: u1Headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -54,34 +60,38 @@ describe('Message Routes', () => {
     })
 
     it('filters by userId and only shows threads user participates in', async () => {
+      const u1Headers = await authHeaders({ sub: U1 })
+      const u2Headers = await authHeaders({ sub: U2 })
+      const u3Headers = await authHeaders({ sub: U3 })
+
       // Thread between user1 and user2
       await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
 
       // Thread between user2 and user3 (user1 is NOT a participant)
       await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u2Headers },
         body: JSON.stringify({ participantIds: [U2, U3] }),
       })
 
       // user1 should only see 1 thread
-      const res1 = await app.request(`/threads?userId=${U1}`)
+      const res1 = await app.request('/threads', { headers: u1Headers })
       const body1 = await res1.json()
       expect(body1.success).toBe(true)
       expect(body1.data).toHaveLength(1)
 
       // user2 should see both threads
-      const res2 = await app.request(`/threads?userId=${U2}`)
+      const res2 = await app.request('/threads', { headers: u2Headers })
       const body2 = await res2.json()
       expect(body2.success).toBe(true)
       expect(body2.data).toHaveLength(2)
 
       // user3 should see only 1 thread
-      const res3 = await app.request(`/threads?userId=${U3}`)
+      const res3 = await app.request('/threads', { headers: u3Headers })
       const body3 = await res3.json()
       expect(body3.success).toBe(true)
       expect(body3.data).toHaveLength(1)
@@ -90,9 +100,10 @@ describe('Message Routes', () => {
 
   describe('POST /threads', () => {
     it('creates a thread with participants', async () => {
+      const headers = await authHeaders({ sub: U1 })
       const res = await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({
           participantIds: [U1, U2],
         }),
@@ -111,10 +122,11 @@ describe('Message Routes', () => {
 
   describe('POST /threads/:id/messages', () => {
     it('sends a message to a thread', async () => {
+      const u1Headers = await authHeaders({ sub: U1 })
       // Create thread first
       const createRes = await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
@@ -122,7 +134,7 @@ describe('Message Routes', () => {
 
       const res = await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
 
@@ -140,10 +152,12 @@ describe('Message Routes', () => {
 
   describe('GET /threads/:id', () => {
     it('returns thread with messages', async () => {
+      const u1Headers = await authHeaders({ sub: U1 })
+      const u2Headers = await authHeaders({ sub: U2 })
       // Create thread
       const createRes = await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
@@ -152,16 +166,16 @@ describe('Message Routes', () => {
       // Send two messages
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u2Headers },
         body: JSON.stringify({ content: 'Hi there!', senderId: U2 }),
       })
 
-      const res = await app.request(`/threads/${threadId}`)
+      const res = await app.request(`/threads/${threadId}`, { headers: u1Headers })
 
       expect(res.status).toBe(200)
 
@@ -177,7 +191,8 @@ describe('Message Routes', () => {
     })
 
     it('returns 404 for nonexistent thread', async () => {
-      const res = await app.request('/threads/nonexistent-id')
+      const headers = await authHeaders({ sub: U1 })
+      const res = await app.request('/threads/nonexistent-id', { headers })
 
       expect(res.status).toBe(404)
 
@@ -189,10 +204,13 @@ describe('Message Routes', () => {
 
   describe('POST /threads/:id/read', () => {
     it('resets unread count for user after messages are sent', async () => {
+      const u1Headers = await authHeaders({ sub: U1 })
+      const u2Headers = await authHeaders({ sub: U2 })
+
       // Create thread
       const createRes = await app.request('/threads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
       const created = await createRes.json()
@@ -201,28 +219,28 @@ describe('Message Routes', () => {
       // user1 sends two messages (user2 gets unread incremented)
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ content: 'Hello!', senderId: U1 }),
       })
       await app.request(`/threads/${threadId}/messages`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...u1Headers },
         body: JSON.stringify({ content: 'Are you there?', senderId: U1 }),
       })
 
       // Verify user2 has unread messages via thread list
-      const beforeRes = await app.request(`/threads?userId=${U2}`)
+      const beforeRes = await app.request('/threads', { headers: u2Headers })
       const beforeBody = await beforeRes.json()
       const user2Participant = beforeBody.data[0].participants.find(
         (p: { userId: string }) => p.userId === U2,
       )
       expect(user2Participant.unreadCount).toBe(2)
 
-      // user2 marks as read
+      // user2 marks as read (JWT sub = U2, no body.userId needed)
       const readRes = await app.request(`/threads/${threadId}/read`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: U2 }),
+        headers: { 'Content-Type': 'application/json', ...u2Headers },
+        body: JSON.stringify({}),
       })
 
       expect(readRes.status).toBe(200)
@@ -230,7 +248,7 @@ describe('Message Routes', () => {
       expect(readBody.success).toBe(true)
 
       // Verify unread count is now 0
-      const afterRes = await app.request(`/threads?userId=${U2}`)
+      const afterRes = await app.request('/threads', { headers: u2Headers })
       const afterBody = await afterRes.json()
       const user2After = afterBody.data[0].participants.find(
         (p: { userId: string }) => p.userId === U2,

--- a/packages/api/tests/routes/rate-limit.test.ts
+++ b/packages/api/tests/routes/rate-limit.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+beforeAll(() => {
+  setupAuthEnv()
+})
 
 describe('rate limiting wiring', () => {
   it('app starts without rate limit binding (local dev)', async () => {
@@ -10,8 +15,9 @@ describe('rate limiting wiring', () => {
 
   it('all endpoints respond when no rate limit binding is present', async () => {
     const app = createApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
 
-    const vehicles = await app.request('/vehicles')
+    const vehicles = await app.request('/vehicles', { headers })
     expect(vehicles.status).toBe(200)
 
     const health = await app.request('/health')

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
 import {
   InMemoryAvailabilityRepository,
@@ -6,6 +6,11 @@ import {
   InMemoryStatsRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+beforeAll(() => {
+  setupAuthEnv()
+})
 
 function createTestApp() {
   const vehicleRepo = new InMemoryVehicleRepository()
@@ -56,10 +61,11 @@ const BOOKING_FIELDS = [
 describe('API responses contain only expected fields', () => {
   it('GET /vehicles returns vehicles with exact field set', async () => {
     const app = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
 
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -69,7 +75,7 @@ describe('API responses contain only expected fields', () => {
       }),
     })
 
-    const res = await app.request('/vehicles')
+    const res = await app.request('/vehicles', { headers })
     const body = await res.json()
     const vehicle = body.data[0]
 
@@ -82,10 +88,11 @@ describe('API responses contain only expected fields', () => {
 
   it('GET /vehicles/:id returns vehicle with exact field set', async () => {
     const app = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
 
     const createRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -96,7 +103,7 @@ describe('API responses contain only expected fields', () => {
     })
     const created = await createRes.json()
 
-    const res = await app.request(`/vehicles/${created.data.id}`)
+    const res = await app.request(`/vehicles/${created.data.id}`, { headers })
     const body = await res.json()
 
     for (const field of VEHICLE_FIELDS) {
@@ -107,11 +114,12 @@ describe('API responses contain only expected fields', () => {
 
   it('GET /bookings returns bookings with exact field set', async () => {
     const app = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
 
     // Create a vehicle first
     const vRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Test Car',
         description: 'Test',
@@ -124,7 +132,7 @@ describe('API responses contain only expected fields', () => {
 
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         renterId: 'user-1',
         vehicleId: vehicle.data.id,
@@ -134,7 +142,7 @@ describe('API responses contain only expected fields', () => {
       }),
     })
 
-    const res = await app.request('/bookings')
+    const res = await app.request('/bookings', { headers })
     const body = await res.json()
     const booking = body.data[0]
 

--- a/packages/api/tests/routes/stats.test.ts
+++ b/packages/api/tests/routes/stats.test.ts
@@ -6,6 +6,7 @@ import {
   InMemoryStatsRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 const TEST_API_KEY = 'test-stats-key'
 
@@ -28,13 +29,15 @@ function createTestApp() {
 }
 
 beforeAll(() => {
+  setupAuthEnv()
   process.env.STATS_API_KEY = TEST_API_KEY
 })
 
 describe('GET /stats', () => {
   it('returns 401 without API key', async () => {
     const { app } = createTestApp()
-    const res = await app.request('/stats')
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
+    const res = await app.request('/stats', { headers })
 
     expect(res.status).toBe(401)
     const body = await res.json()
@@ -43,8 +46,9 @@ describe('GET /stats', () => {
 
   it('returns 401 with wrong API key', async () => {
     const { app } = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
     const res = await app.request('/stats', {
-      headers: { 'X-API-Key': 'wrong-key' },
+      headers: { ...headers, 'X-API-Key': 'wrong-key' },
     })
 
     expect(res.status).toBe(401)
@@ -52,8 +56,9 @@ describe('GET /stats', () => {
 
   it('returns 200 with all zeros for empty stores', async () => {
     const { app } = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
     const res = await app.request('/stats', {
-      headers: { 'X-API-Key': TEST_API_KEY },
+      headers: { ...headers, 'X-API-Key': TEST_API_KEY },
     })
 
     expect(res.status).toBe(200)
@@ -72,11 +77,12 @@ describe('GET /stats', () => {
 
   it('returns correct counts after creating vehicles and bookings', async () => {
     const { app } = createTestApp()
+    const headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
 
     // Create 3 vehicles (2 AVAILABLE, 1 will be soft-deleted)
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Toyota Prius',
         description: 'Hybrid',
@@ -88,7 +94,7 @@ describe('GET /stats', () => {
     })
     await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Honda Fit',
         description: 'Compact',
@@ -100,7 +106,7 @@ describe('GET /stats', () => {
     })
     const maintenanceRes = await app.request('/vehicles', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         name: 'Suzuki Swift',
         description: 'Under repair',
@@ -113,10 +119,11 @@ describe('GET /stats', () => {
     const maintenanceBody = await maintenanceRes.json()
     await app.request(`/vehicles/${maintenanceBody.data.id}`, {
       method: 'DELETE',
+      headers,
     })
 
     // Create 2 bookings
-    const vehiclesRes = await app.request('/vehicles')
+    const vehiclesRes = await app.request('/vehicles', { headers })
     const vehiclesBody = await vehiclesRes.json()
     const availableVehicle = vehiclesBody.data.find(
       (v: { status: string }) => v.status === 'AVAILABLE',
@@ -124,7 +131,7 @@ describe('GET /stats', () => {
 
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         renterId: 'user-1',
         vehicleId: availableVehicle.id,
@@ -135,7 +142,7 @@ describe('GET /stats', () => {
     })
     await app.request('/bookings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         renterId: 'user-2',
         vehicleId: availableVehicle.id,
@@ -146,7 +153,7 @@ describe('GET /stats', () => {
     })
 
     const res = await app.request('/stats', {
-      headers: { 'X-API-Key': TEST_API_KEY },
+      headers: { ...headers, 'X-API-Key': TEST_API_KEY },
     })
     expect(res.status).toBe(200)
 

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { requireAuth } from '../../src/middleware/auth'
 import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
 import { createVehicleRoutes } from '../../src/routes/vehicles'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
 let app: Hono
+let headers: Record<string, string>
 
 function validVehicleInput() {
   return {
@@ -20,21 +23,24 @@ function validVehicleInput() {
 async function createVehicle(input = validVehicleInput()) {
   return app.request('/vehicles', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(input),
   })
 }
 
 describe('Vehicle CRUD Routes', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    setupAuthEnv()
+    headers = await authHeaders({ sub: 'test-user', role: 'ADMIN' })
     const repo = new InMemoryVehicleRepository()
     app = new Hono()
+    app.use('*', requireAuth())
     app.route('/', createVehicleRoutes(repo))
   })
 
   describe('GET /vehicles', () => {
     it('returns empty list initially', async () => {
-      const res = await app.request('/vehicles')
+      const res = await app.request('/vehicles', { headers })
 
       expect(res.status).toBe(200)
 
@@ -49,7 +55,7 @@ describe('Vehicle CRUD Routes', () => {
         name: 'Honda Civic',
       })
 
-      const res = await app.request('/vehicles')
+      const res = await app.request('/vehicles', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -66,9 +72,9 @@ describe('Vehicle CRUD Routes', () => {
       })
       const created = await createRes.json()
 
-      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
+      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE', headers })
 
-      const res = await app.request('/vehicles')
+      const res = await app.request('/vehicles', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -79,9 +85,9 @@ describe('Vehicle CRUD Routes', () => {
     it('returns RETIRED vehicles when filtered by status=RETIRED', async () => {
       const createRes = await createVehicle()
       const created = await createRes.json()
-      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
+      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE', headers })
 
-      const res = await app.request('/vehicles?status=RETIRED')
+      const res = await app.request('/vehicles?status=RETIRED', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -97,9 +103,9 @@ describe('Vehicle CRUD Routes', () => {
       })
       const created = await createRes.json()
 
-      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
+      await app.request(`/vehicles/${created.data.id}`, { method: 'DELETE', headers })
 
-      const res = await app.request('/vehicles?status=RETIRED')
+      const res = await app.request('/vehicles?status=RETIRED', { headers })
       const body = await res.json()
 
       expect(body.success).toBe(true)
@@ -137,7 +143,7 @@ describe('Vehicle CRUD Routes', () => {
     it('rejects invalid input with missing name and returns 400', async () => {
       const res = await app.request('/vehicles', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({
           seats: 5,
           transmission: 'AUTO',
@@ -171,7 +177,7 @@ describe('Vehicle CRUD Routes', () => {
     it('rejects invalid transmission value', async () => {
       const res = await app.request('/vehicles', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({
           ...validVehicleInput(),
           transmission: 'CVT',
@@ -190,7 +196,7 @@ describe('Vehicle CRUD Routes', () => {
       const createRes = await createVehicle()
       const created = await createRes.json()
 
-      const res = await app.request(`/vehicles/${created.data.id}`)
+      const res = await app.request(`/vehicles/${created.data.id}`, { headers })
 
       expect(res.status).toBe(200)
 
@@ -201,7 +207,7 @@ describe('Vehicle CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent vehicle', async () => {
-      const res = await app.request('/vehicles/nonexistent-id')
+      const res = await app.request('/vehicles/nonexistent-id', { headers })
 
       expect(res.status).toBe(404)
 
@@ -218,7 +224,7 @@ describe('Vehicle CRUD Routes', () => {
 
       const res = await app.request(`/vehicles/${created.data.id}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ name: 'Updated Name', seats: 7 }),
       })
 
@@ -235,7 +241,7 @@ describe('Vehicle CRUD Routes', () => {
     it('returns 404 for nonexistent vehicle', async () => {
       const res = await app.request('/vehicles/nonexistent-id', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ name: 'Updated' }),
       })
 
@@ -255,7 +261,7 @@ describe('Vehicle CRUD Routes', () => {
 
       const res = await app.request(`/vehicles/${created.data.id}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({
           photos: ['https://example.com/new1.jpg', 'https://example.com/new2.jpg'],
         }),
@@ -276,7 +282,7 @@ describe('Vehicle CRUD Routes', () => {
 
       const res = await app.request(`/vehicles/${created.data.id}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ seats: -5 }),
       })
 
@@ -291,7 +297,7 @@ describe('Vehicle CRUD Routes', () => {
     async function patchStatus(id: string, status: string) {
       return app.request(`/vehicles/${id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({ status }),
       })
     }
@@ -373,7 +379,7 @@ describe('Vehicle CRUD Routes', () => {
 
       const res = await app.request(`/vehicles/${created.data.id}/status`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...headers },
         body: JSON.stringify({}),
       })
 
@@ -392,7 +398,7 @@ describe('Vehicle CRUD Routes', () => {
 
       await patchStatus(created.data.id, 'MAINTENANCE')
 
-      const getRes = await app.request(`/vehicles/${created.data.id}`)
+      const getRes = await app.request(`/vehicles/${created.data.id}`, { headers })
       const getBody = await getRes.json()
       expect(getBody.data.name).toBe('Keep Me')
       expect(getBody.data.dailyRateJpy).toBe(12345)
@@ -407,6 +413,7 @@ describe('Vehicle CRUD Routes', () => {
 
       const res = await app.request(`/vehicles/${created.data.id}`, {
         method: 'DELETE',
+        headers,
       })
 
       expect(res.status).toBe(200)
@@ -416,7 +423,7 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data.status).toBe('RETIRED')
 
       // Verify via GET that the vehicle is now RETIRED
-      const getRes = await app.request(`/vehicles/${created.data.id}`)
+      const getRes = await app.request(`/vehicles/${created.data.id}`, { headers })
       const getBody = await getRes.json()
       expect(getBody.data.status).toBe('RETIRED')
     })
@@ -424,6 +431,7 @@ describe('Vehicle CRUD Routes', () => {
     it('returns 404 for nonexistent vehicle', async () => {
       const res = await app.request('/vehicles/nonexistent-id', {
         method: 'DELETE',
+        headers,
       })
 
       expect(res.status).toBe(404)

--- a/packages/shared/src/validators/message.ts
+++ b/packages/shared/src/validators/message.ts
@@ -8,12 +8,14 @@ export const createThreadSchema = z.object({
 })
 
 export const sendMessageSchema = z.object({
-  senderId: z.string().uuid('senderId must be a valid UUID'),
+  // senderId is derived from JWT in the route; kept optional for backward compat
+  senderId: z.string().uuid('senderId must be a valid UUID').optional(),
   content: z.string().trim().min(1, 'Message cannot be empty').max(5000),
 })
 
+// userId is derived from JWT in the route; schema kept for body structure validation
 export const markReadSchema = z.object({
-  userId: z.string().uuid('userId must be a valid UUID'),
+  userId: z.string().uuid('userId must be a valid UUID').optional(),
 })
 
 export type CreateThreadInput = z.infer<typeof createThreadSchema>

--- a/packages/shared/tests/validators/message.test.ts
+++ b/packages/shared/tests/validators/message.test.ts
@@ -67,9 +67,9 @@ describe('sendMessageSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects missing senderId', () => {
+  it('accepts missing senderId (derived from JWT in routes)', () => {
     const result = sendMessageSchema.safeParse({ content: 'Hello!' })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
   })
 
   it('rejects empty string content', () => {
@@ -120,8 +120,8 @@ describe('markReadSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects missing userId', () => {
+  it('accepts missing userId (derived from JWT in routes)', () => {
     const result = markReadSchema.safeParse({})
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Mount `requireAuth()` globally after `/health` — all routes now require JWT or API key
- Actor derivation: `POST /bookings` uses JWT `sub` as `renterId`, ignoring body
- Actor derivation: message routes use JWT `sub` for senderId/userId
- Ownership checks: cancel requires booking owner or STAFF+; GET /bookings/:id scoped to owner
- Role gates: vehicle mutations (POST/PATCH/DELETE) require STAFF/ADMIN
- Role gate: `PATCH /bookings/:id/status` requires STAFF+
- Participant check: `GET /threads/:id` returns 404 for non-participants
- TOCTOU fix: cancel ownership check moved into BookingService (single read)

## What changed per area
- `packages/api/src/index.ts` — mount middleware
- `packages/api/src/middleware/auth.ts` — remove dead export, move VALID_ROLES to module scope
- `packages/api/src/routes/bookings.ts` — actor derivation, ownership, role gates
- `packages/api/src/routes/vehicles.ts` — STAFF/ADMIN role gates
- `packages/api/src/routes/messages.ts` — actor derivation, participant check
- `packages/api/src/services/booking.ts` — cancel accepts actor for ownership check
- `packages/shared/src/validators/message.ts` — senderId/userId optional (JWT-derived)
- All route test files updated with auth headers

## Test plan
- [x] 172 API tests pass (18 files)
- [x] 128 shared tests pass
- [x] 216 web tests pass
- [x] Biome lint clean
- [x] TypeScript strict mode clean (api + web)
- [x] Import boundary check clean
- [ ] Smoke test: `curl` unauthenticated POST /bookings returns 401
- [ ] Smoke test: RENTER cannot POST /vehicles (403)

Closes #76