### PR TITLE
fix(api): use vehicle.bufferMinutes for effectiveEndAt + add DB trigger

### DIFF
--- a/drizzle/0015_effective-end-trigger.sql
+++ b/drizzle/0015_effective-end-trigger.sql
@@ -1,0 +1,24 @@
+-- Issue #31: enforce effectiveEndAt = endAt + vehicle.bufferMinutes
+-- Trigger computes the correct value on every insert/update.
+-- CHECK constraint is defense-in-depth (catches direct SQL manipulation).
+
+-- 1. Trigger function: compute effectiveEndAt from vehicle's bufferMinutes
+CREATE OR REPLACE FUNCTION compute_effective_end_at() RETURNS trigger AS $$
+BEGIN
+  NEW."effectiveEndAt" := NEW."endAt" + (
+    SELECT COALESCE("bufferMinutes", 60) * interval '1 minute'
+    FROM vehicles
+    WHERE id = NEW."vehicleId"
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. Fire on INSERT or UPDATE of endAt/vehicleId
+CREATE TRIGGER bookings_set_effective_end_at
+  BEFORE INSERT OR UPDATE OF "endAt", "vehicleId" ON bookings
+  FOR EACH ROW EXECUTE FUNCTION compute_effective_end_at();
+
+-- 3. CHECK: effectiveEndAt must always be after endAt
+ALTER TABLE bookings ADD CONSTRAINT effective_end_at_after_end_at
+  CHECK ("effectiveEndAt" > "endAt");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776017978486,
       "tag": "0014_add-bookings-status-index",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1776021003180,
+      "tag": "0015_effective-end-trigger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -6,7 +6,8 @@ import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { BookingFilters, BookingRepository, VehicleRepository } from '../repositories/types'
 import type { Booking } from '../stores'
 
-const DEFAULT_BUFFER_MS = 60 * 60 * 1000 // 60 minutes
+const DEFAULT_BUFFER_MINUTES = 60
+const MS_PER_MINUTE = 60 * 1000
 
 export interface CreateBookingInput {
   vehicleId: string
@@ -97,15 +98,15 @@ export class BookingService {
       }
     }
 
-    const effectiveEndAt = new Date(input.endAt.getTime() + DEFAULT_BUFFER_MS)
-
     // Issue #65: rental rules + Issue #74: server-side pricing.
     // Both depend on the vehicle lookup. totalPrice is never accepted
     // from the client — always computed server-side.
     let totalPrice: number | null = null
+    let bufferMinutes = DEFAULT_BUFFER_MINUTES
     if (this.vehicleRepo) {
       const vehicle = await this.vehicleRepo.findById(input.vehicleId)
       if (vehicle) {
+        bufferMinutes = vehicle.bufferMinutes
         const check = checkRentalRules(
           {
             minRentalHours: vehicle.minRentalHours,
@@ -145,6 +146,8 @@ export class BookingService {
         totalPrice = pricing.totalPriceJpy
       }
     }
+
+    const effectiveEndAt = new Date(input.endAt.getTime() + bufferMinutes * MS_PER_MINUTE)
 
     try {
       const booking = await this.bookingRepo.create({


### PR DESCRIPTION
## Summary
- **Bug fix:** `effectiveEndAt` was computed with a hardcoded 60min buffer, ignoring `vehicle.bufferMinutes` (some vehicles use 90min). Now reads the actual per-vehicle value.
- **DB trigger:** `BEFORE INSERT OR UPDATE` trigger computes `effectiveEndAt` from `endAt + vehicle.bufferMinutes` at the DB level — impossible to bypass from application code, admin tools, or future insert paths.
- **CHECK constraint:** `effectiveEndAt > endAt` as defense-in-depth — catches the case where the trigger is dropped or data is manipulated via direct SQL.

## What changed
- `packages/api/src/services/booking.ts` — read `vehicle.bufferMinutes` instead of hardcoded `DEFAULT_BUFFER_MS`
- `drizzle/0015_effective-end-trigger.sql` — custom migration (trigger + CHECK)

## Test plan
- [x] All 53 booking route tests pass
- [x] tsc --noEmit passes all packages
- [x] `db:verify` — schema/journal in sync
- [x] CI `db-drift` job will validate migration against real Postgres

Closes #31