### PR TITLE
refactor(api): accept optional now param for testable date logic

### DIFF
--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -88,7 +88,7 @@ export class BookingService {
     return this.bookingRepo.findById(id)
   }
 
-  async create(input: CreateBookingInput): Promise<CreateBookingResult> {
+  async create(input: CreateBookingInput, now: Date = new Date()): Promise<CreateBookingResult> {
     // Idempotency: if a key was provided, check for an existing booking first.
     if (input.idempotencyKey) {
       const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
@@ -114,7 +114,7 @@ export class BookingService {
           },
           input.startAt,
           input.endAt,
-          new Date(),
+          now,
         )
         if (!check.ok) {
           return {
@@ -217,7 +217,7 @@ export class BookingService {
     return { ok: true, booking: updated }
   }
 
-  async cancel(bookingId: string): Promise<CancelResult> {
+  async cancel(bookingId: string, now: Date = new Date()): Promise<CancelResult> {
     const booking = await this.bookingRepo.findById(bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
@@ -231,7 +231,6 @@ export class BookingService {
       }
     }
 
-    const now = new Date()
     const cancellation = calculateCancellationFee(booking.startAt, now, booking.totalPrice ?? 0)
 
     const updated = await this.bookingRepo.cancel(booking.id, {


### PR DESCRIPTION
## Summary

- Cancellation fee calculation and booking service accept an optional `now` parameter
- Defaults to `new Date()` in production, injectable in tests
- Eliminates need for fake timers in date-dependent tests

Closes #147

## Test plan

- [x] All existing tests pass without modification
- [x] New tests use explicit `now` instead of `vi.setSystemTime`