### PR TITLE
fix(api): replace bare as-cast with isAuthUser type guard

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -22,6 +22,17 @@ function isValidRole(value: string): value is UserRole {
   return ALL_ROLES.has(value)
 }
 
+function isAuthUser(v: unknown): v is AuthUser {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'id' in v &&
+    typeof (v as AuthUser).id === 'string' &&
+    'role' in v &&
+    isValidRole((v as AuthUser).role)
+  )
+}
+
 /** Roles that can manage bookings across all users */
 export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN', 'PARTNER'])
 
@@ -29,7 +40,8 @@ export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'
 export const STAFF_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN'])
 
 export function getUser(c: { get: (key: string) => unknown }): AuthUser | undefined {
-  return c.get('user') as AuthUser | undefined
+  const raw = c.get('user')
+  return isAuthUser(raw) ? raw : undefined
 }
 
 export function requireUser(c: { get: (key: string) => unknown }): AuthUser | null {
@@ -74,7 +86,7 @@ async function verifyJwt(token: string): Promise<AuthUser | null> {
     const id = payload.sub
     if (!id) return null
 
-    const rawRole = payload.role as string | undefined
+    const rawRole = typeof payload.role === 'string' ? payload.role : undefined
     const role: UserRole = rawRole && isValidRole(rawRole) ? rawRole : 'RENTER'
     return { id, role }
   } catch {
@@ -90,5 +102,5 @@ function verifyApiKey(key: string): AuthUser | null {
   const b = Buffer.from(expected)
   if (a.length !== b.length || !timingSafeEqual(a, b)) return null
 
-  return { id: 'partner:api-key', role: 'PARTNER' as const }
+  return { id: 'partner:api-key', role: 'PARTNER' }
 }


### PR DESCRIPTION
## Summary

- Add `isAuthUser()` runtime type guard for `getUser()`
- Replace `payload.role as string` with `typeof` check in `verifyJwt()`
- Remove redundant `as const` on PARTNER literal

Single file change: `packages/api/src/middleware/auth.ts`

Refs #76