### PR TITLE
fix(api): extract resolveVehicle, harden trigger, fix CHECK operator

### DIFF
--- a/drizzle/0015_effective-end-trigger.sql
+++ b/drizzle/0015_effective-end-trigger.sql
@@ -4,12 +4,18 @@
 
 -- 1. Trigger function: compute effectiveEndAt from vehicle's bufferMinutes
 CREATE OR REPLACE FUNCTION compute_effective_end_at() RETURNS trigger AS $$
+DECLARE
+  _buffer int;
 BEGIN
-  NEW."effectiveEndAt" := NEW."endAt" + (
-    SELECT COALESCE("bufferMinutes", 60) * interval '1 minute'
+  SELECT "bufferMinutes" INTO _buffer
     FROM vehicles
-    WHERE id = NEW."vehicleId"
-  );
+    WHERE id = NEW."vehicleId";
+
+  IF _buffer IS NULL THEN
+    RAISE EXCEPTION 'Vehicle % not found or has NULL bufferMinutes', NEW."vehicleId";
+  END IF;
+
+  NEW."effectiveEndAt" := NEW."endAt" + _buffer * interval '1 minute';
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -19,6 +25,6 @@ CREATE TRIGGER bookings_set_effective_end_at
   BEFORE INSERT OR UPDATE OF "endAt", "vehicleId" ON bookings
   FOR EACH ROW EXECUTE FUNCTION compute_effective_end_at();
 
--- 3. CHECK: effectiveEndAt must always be after endAt
+-- 3. CHECK: effectiveEndAt must be at or after endAt (>= allows zero-buffer vehicles)
 ALTER TABLE bookings ADD CONSTRAINT effective_end_at_after_end_at
-  CHECK ("effectiveEndAt" > "endAt");
+  CHECK ("effectiveEndAt" >= "endAt");

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -101,52 +101,11 @@ export class BookingService {
     // Issue #65: rental rules + Issue #74: server-side pricing.
     // Both depend on the vehicle lookup. totalPrice is never accepted
     // from the client — always computed server-side.
-    let totalPrice: number | null = null
-    let bufferMinutes = DEFAULT_BUFFER_MINUTES
-    if (this.vehicleRepo) {
-      const vehicle = await this.vehicleRepo.findById(input.vehicleId)
-      if (vehicle) {
-        bufferMinutes = vehicle.bufferMinutes
-        const check = checkRentalRules(
-          {
-            minRentalHours: vehicle.minRentalHours,
-            maxRentalHours: vehicle.maxRentalHours,
-            advanceBookingHours: vehicle.advanceBookingHours,
-          },
-          input.startAt,
-          input.endAt,
-          now,
-        )
-        if (!check.ok) {
-          return {
-            ok: false,
-            status: 400,
-            error: 'Booking violates a rental rule on this vehicle',
-            code: check.code,
-            details: { required: check.required, actual: check.actual },
-          }
-        }
+    const vehicleLookup = await this.resolveVehicle(input, now)
+    if (vehicleLookup && !vehicleLookup.ok) return vehicleLookup
 
-        const pricing = calculateBookingPrice(
-          { dailyRateJpy: vehicle.dailyRateJpy, hourlyRateJpy: vehicle.hourlyRateJpy },
-          input.startAt,
-          input.endAt,
-        )
-        if (!pricing.ok) {
-          return {
-            ok: false,
-            status: 400,
-            error:
-              pricing.code === 'NO_RATES_SET'
-                ? 'Vehicle has no daily or hourly rate configured'
-                : 'Invalid booking duration',
-            code: pricing.code,
-          }
-        }
-        totalPrice = pricing.totalPriceJpy
-      }
-    }
-
+    const bufferMinutes = vehicleLookup?.bufferMinutes ?? DEFAULT_BUFFER_MINUTES
+    const totalPrice = vehicleLookup?.totalPrice ?? null
     const effectiveEndAt = new Date(input.endAt.getTime() + bufferMinutes * MS_PER_MINUTE)
 
     try {
@@ -249,5 +208,57 @@ export class BookingService {
       }
     }
     return { ok: true, booking: updated, cancellation }
+  }
+
+  private async resolveVehicle(
+    input: CreateBookingInput,
+    now: Date,
+  ): Promise<
+    | (CreateBookingResult & { ok: false })
+    | { ok: true; bufferMinutes: number; totalPrice: number }
+    | null
+  > {
+    if (!this.vehicleRepo) return null
+    const vehicle = await this.vehicleRepo.findById(input.vehicleId)
+    if (!vehicle) return null
+
+    const check = checkRentalRules(
+      {
+        minRentalHours: vehicle.minRentalHours,
+        maxRentalHours: vehicle.maxRentalHours,
+        advanceBookingHours: vehicle.advanceBookingHours,
+      },
+      input.startAt,
+      input.endAt,
+      now,
+    )
+    if (!check.ok) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Booking violates a rental rule on this vehicle',
+        code: check.code,
+        details: { required: check.required, actual: check.actual },
+      }
+    }
+
+    const pricing = calculateBookingPrice(
+      { dailyRateJpy: vehicle.dailyRateJpy, hourlyRateJpy: vehicle.hourlyRateJpy },
+      input.startAt,
+      input.endAt,
+    )
+    if (!pricing.ok) {
+      return {
+        ok: false,
+        status: 400,
+        error:
+          pricing.code === 'NO_RATES_SET'
+            ? 'Vehicle has no daily or hourly rate configured'
+            : 'Invalid booking duration',
+        code: pricing.code,
+      }
+    }
+
+    return { ok: true, bufferMinutes: vehicle.bufferMinutes, totalPrice: pricing.totalPriceJpy }
   }
 }


### PR DESCRIPTION
## Summary
Code review follow-up to PR #194 (#31):
- **Extract `resolveVehicle`** — eliminates mutable `let` for `bufferMinutes` and `totalPrice`; returns immutable discriminated union
- **Harden trigger** — raises exception if vehicle is missing instead of silently falling back to 60min default via COALESCE
- **CHECK `>=` not `>`** — allows zero-buffer vehicles in future without migration

## Test plan
- [x] All 53 booking route tests pass
- [x] tsc --noEmit clean (all packages)
- [x] Biome lint clean

Follow-up to #194 (Closes #31)