### PR TITLE
refactor(shared): remove dead senderId/markReadSchema from message validators

### DIFF
--- a/packages/shared/src/validators/message.ts
+++ b/packages/shared/src/validators/message.ts
@@ -8,14 +8,8 @@ export const createThreadSchema = z.object({
 })
 
 export const sendMessageSchema = z.object({
-  senderId: z.string().uuid('senderId must be a valid UUID'),
   content: z.string().trim().min(1, 'Message cannot be empty').max(5000),
-})
-
-export const markReadSchema = z.object({
-  userId: z.string().uuid('userId must be a valid UUID'),
 })
 
 export type CreateThreadInput = z.infer<typeof createThreadSchema>
 export type SendMessageInput = z.infer<typeof sendMessageSchema>
-export type MarkReadInput = z.infer<typeof markReadSchema>

--- a/packages/shared/tests/validators/message.test.ts
+++ b/packages/shared/tests/validators/message.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createThreadSchema, markReadSchema, sendMessageSchema } from '../../src/validators/message'
+import { createThreadSchema, sendMessageSchema } from '../../src/validators/message'
 
 const UUID1 = '550e8400-e29b-41d4-a716-446655440001'
 const UUID2 = '550e8400-e29b-41d4-a716-446655440002'
@@ -51,49 +51,36 @@ describe('createThreadSchema', () => {
 })
 
 describe('sendMessageSchema', () => {
-  const valid = { senderId: UUID1, content: 'Hello!' }
-
-  it('accepts valid input', () => {
-    const result = sendMessageSchema.safeParse(valid)
+  it('accepts content-only (senderId derived from JWT)', () => {
+    const result = sendMessageSchema.safeParse({ content: 'Hello!' })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.senderId).toBe(UUID1)
       expect(result.data.content).toBe('Hello!')
     }
   })
 
-  it('rejects non-UUID senderId', () => {
-    const result = sendMessageSchema.safeParse({ senderId: 'user-1', content: 'Hello!' })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects missing senderId', () => {
-    const result = sendMessageSchema.safeParse({ content: 'Hello!' })
-    expect(result.success).toBe(false)
-  })
-
   it('rejects empty string content', () => {
-    const result = sendMessageSchema.safeParse({ ...valid, content: '' })
+    const result = sendMessageSchema.safeParse({ content: '' })
     expect(result.success).toBe(false)
   })
 
   it('rejects whitespace-only content', () => {
-    const result = sendMessageSchema.safeParse({ ...valid, content: '   ' })
+    const result = sendMessageSchema.safeParse({ content: '   ' })
     expect(result.success).toBe(false)
   })
 
   it('rejects content over 5000 characters', () => {
-    const result = sendMessageSchema.safeParse({ ...valid, content: 'a'.repeat(5001) })
+    const result = sendMessageSchema.safeParse({ content: 'a'.repeat(5001) })
     expect(result.success).toBe(false)
   })
 
   it('accepts content of exactly 5000 characters', () => {
-    const result = sendMessageSchema.safeParse({ ...valid, content: 'a'.repeat(5000) })
+    const result = sendMessageSchema.safeParse({ content: 'a'.repeat(5000) })
     expect(result.success).toBe(true)
   })
 
   it('trims whitespace from content', () => {
-    const result = sendMessageSchema.safeParse({ ...valid, content: '  Hello!  ' })
+    const result = sendMessageSchema.safeParse({ content: '  Hello!  ' })
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.content).toBe('Hello!')
@@ -101,27 +88,7 @@ describe('sendMessageSchema', () => {
   })
 
   it('rejects missing content', () => {
-    const result = sendMessageSchema.safeParse({ senderId: UUID1 })
-    expect(result.success).toBe(false)
-  })
-})
-
-describe('markReadSchema', () => {
-  it('accepts valid UUID userId', () => {
-    const result = markReadSchema.safeParse({ userId: UUID1 })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.userId).toBe(UUID1)
-    }
-  })
-
-  it('rejects non-UUID userId', () => {
-    const result = markReadSchema.safeParse({ userId: 'user-1' })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects missing userId', () => {
-    const result = markReadSchema.safeParse({})
+    const result = sendMessageSchema.safeParse({})
     expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Remove `senderId` from `sendMessageSchema` — routes derive it from JWT
- Remove `markReadSchema` entirely — route doesn't parse body for `/read`
- Remove `MarkReadInput` type export
- Update validator tests to match new contract

Net: -39 lines. Clients no longer need to send a field the server ignores.

## Test plan

- [x] 14 shared validator tests pass
- [x] 14 message route tests pass
- [x] TypeScript strict mode passes for api + web

Closes #203