### PR TITLE
test(api): run all integration tests against real Postgres in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,7 @@ jobs:
         run: bun run db:verify
 
       - name: Run repository integration tests against fresh Postgres
-        # Exercises the Drizzle repos that talk to real tables. Right now
-        # only the messaging repo tests run here (issue #28); the other
-        # integration test files under packages/api/tests/integration/ still
-        # go through the neon-http driver and can't connect to a local
-        # postgres — issue #29 tracks migrating them. As more repo tests
-        # land, expand the `test:integration` script to include them.
+        # Exercises all Drizzle repos against real tables (bookings,
+        # vehicles, availability, messages, pricing). All integration
+        # test files use postgres-js (TCP) via pg-test-client.ts.
         run: bun run --filter @kuruma/api test:integration

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts tests/integration/vehicles-pricing.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
     "lint:boundaries": "bun run scripts/check-import-boundaries.ts"
   },

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -53,6 +53,7 @@ function createTestVehicle(
     minRentalHours: overrides.minRentalHours ?? null,
     maxRentalHours: overrides.maxRentalHours ?? null,
     advanceBookingHours: overrides.advanceBookingHours ?? null,
+    dailyRateJpy: overrides.dailyRateJpy ?? 5000,
   })
 }
 

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -6,7 +6,7 @@ import {
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
 import type { Vehicle } from '../../src/stores'
-import { cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
+import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
 const vehicleRepo = new DrizzleVehicleRepository(db)
 const bookingRepo = new DrizzleBookingRepository(db)
@@ -53,7 +53,7 @@ function createTestVehicle(
     minRentalHours: overrides.minRentalHours ?? null,
     maxRentalHours: overrides.maxRentalHours ?? null,
     advanceBookingHours: overrides.advanceBookingHours ?? null,
-    dailyRateJpy: overrides.dailyRateJpy ?? 5000,
+    dailyRateJpy: overrides.dailyRateJpy ?? DEFAULT_DAILY_RATE_JPY,
   })
 }
 

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
     minRentalHours: null,
     maxRentalHours: null,
     advanceBookingHours: null,
+    dailyRateJpy: 5000,
   })
   createdVehicleIds.push(testVehicle.id)
 })
@@ -164,6 +165,7 @@ describe('DrizzleBookingRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdVehicleIds.push(otherVehicle.id)
 

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -2,7 +2,7 @@ import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { DrizzleBookingRepository, DrizzleVehicleRepository } from '../../src/repositories/drizzle'
 import type { Vehicle } from '../../src/stores'
-import { cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
+import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
 const bookingRepo = new DrizzleBookingRepository(db)
 const vehicleRepo = new DrizzleVehicleRepository(db)
@@ -35,7 +35,7 @@ beforeAll(async () => {
     minRentalHours: null,
     maxRentalHours: null,
     advanceBookingHours: null,
-    dailyRateJpy: 5000,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
   })
   createdVehicleIds.push(testVehicle.id)
 })
@@ -165,7 +165,7 @@ describe('DrizzleBookingRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdVehicleIds.push(otherVehicle.id)
 

--- a/packages/api/tests/integration/setup.ts
+++ b/packages/api/tests/integration/setup.ts
@@ -1,9 +1,9 @@
-import { getDb } from '@kuruma/shared/db'
 import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
 import { eq } from 'drizzle-orm'
+import { testDb } from './pg-test-client'
 
-const db = getDb()
-
+// Re-export as `db` so existing test files keep their import unchanged.
+const db = testDb
 export { db }
 
 export async function cleanupVehicles(ids: string[]): Promise<void> {

--- a/packages/api/tests/integration/setup.ts
+++ b/packages/api/tests/integration/setup.ts
@@ -6,6 +6,9 @@ import { testDb } from './pg-test-client'
 const db = testDb
 export { db }
 
+/** Satisfies the vehicles_pricing_at_least_one CHECK constraint. */
+export const DEFAULT_DAILY_RATE_JPY = 5000
+
 export async function cleanupVehicles(ids: string[]): Promise<void> {
   if (ids.length === 0) return
 

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -23,6 +23,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: 4,
       maxRentalHours: 72,
       advanceBookingHours: 24,
+      dailyRateJpy: 8000,
     }
 
     const vehicle = await repo.create(input)
@@ -39,6 +40,7 @@ describe('DrizzleVehicleRepository', () => {
     expect(vehicle.minRentalHours).toBe(4)
     expect(vehicle.maxRentalHours).toBe(72)
     expect(vehicle.advanceBookingHours).toBe(24)
+    expect(vehicle.dailyRateJpy).toBe(8000)
     expect(vehicle.createdAt).toBeInstanceOf(Date)
     expect(vehicle.updatedAt).toBeInstanceOf(Date)
   })
@@ -55,6 +57,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdIds.push(created.id)
 
@@ -88,6 +91,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdIds.push(available.id)
 
@@ -102,6 +106,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdIds.push(maintenance.id)
 
@@ -130,6 +135,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdIds.push(created.id)
 
@@ -170,6 +176,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 5000,
     })
     createdIds.push(created.id)
 

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { DrizzleVehicleRepository } from '../../src/repositories/drizzle'
-import { cleanupVehicles, db } from './setup'
+import { DEFAULT_DAILY_RATE_JPY, cleanupVehicles, db } from './setup'
 
 const repo = new DrizzleVehicleRepository(db)
 const createdIds: string[] = []
@@ -57,7 +57,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 
@@ -91,7 +91,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(available.id)
 
@@ -106,7 +106,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(maintenance.id)
 
@@ -135,7 +135,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 
@@ -176,7 +176,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 5000,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 


### PR DESCRIPTION
## Summary

- Migrated `setup.ts` from Neon HTTP driver (`getDb`) to postgres-js TCP (`pg-test-client.ts`) so all 5 integration test files connect to the CI Postgres container
- Added `dailyRateJpy` to vehicle fixtures to satisfy the `vehicles_pricing_at_least_one` CHECK constraint (previously invisible because tests never hit a real DB)
- Expanded `test:integration` script to use config glob instead of explicit 2-file list
- Extracted `DEFAULT_DAILY_RATE_JPY` constant to eliminate magic number across 8 fixtures

## Test plan

- [x] All 55 integration tests pass against local docker Postgres
- [x] All 185 unit tests still pass
- [x] Typecheck passes
- [x] Pre-commit hooks (biome, tsc, lint) pass
- [ ] CI `db-drift` job runs all 5 integration test files (verify after push)

Closes #29