### PR TITLE
test(api): integration tests for POST /bookings overlap → 409

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,7 @@ jobs:
         run: bun run db:verify
 
       - name: Run repository integration tests against fresh Postgres
-        # Exercises the Drizzle repos that talk to real tables. Right now
-        # only the messaging repo tests run here (issue #28); the other
-        # integration test files under packages/api/tests/integration/ still
-        # go through the neon-http driver and can't connect to a local
-        # postgres — issue #29 tracks migrating them. As more repo tests
-        # land, expand the `test:integration` script to include them.
+        # Exercises all Drizzle repos against real tables (bookings,
+        # vehicles, availability, messages, pricing). All integration
+        # test files use postgres-js (TCP) via pg-test-client.ts.
         run: bun run --filter @kuruma/api test:integration

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts tests/integration/vehicles-pricing.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts tests/integration/vehicles-pricing.test.ts tests/integration/bookings.test.ts",
     "typecheck": "tsc --noEmit",
     "lint:boundaries": "bun run scripts/check-import-boundaries.ts"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "deploy": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/messages.test.ts tests/integration/vehicles-pricing.test.ts tests/integration/bookings.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
     "lint:boundaries": "bun run scripts/check-import-boundaries.ts"
   },

--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -7,11 +7,28 @@ export const PG_ERROR = {
   UNIQUE_VIOLATION: '23505',
 } as const
 
-/** Extract the Postgres error code from an unknown thrown value, or null. */
+/** Extract the Postgres error code from an unknown thrown value, or null.
+ *
+ * Drizzle + postgres-js wraps the raw PostgresError inside `err.cause`,
+ * so the PG error code lives at `err.cause.code`, not `err.code`.
+ * We check both paths so the same helper works with raw PG errors
+ * (in-memory repo) and wrapped drizzle errors (real DB). */
 export function pgErrorCode(err: unknown): string | null {
-  if (err && typeof err === 'object' && 'code' in err) {
-    const code = (err as { code: unknown }).code
+  const code = extractCode(err) ?? extractCode(getCause(err))
+  return code
+}
+
+function extractCode(val: unknown): string | null {
+  if (val && typeof val === 'object' && 'code' in val) {
+    const code = (val as { code: unknown }).code
     return typeof code === 'string' ? code : null
+  }
+  return null
+}
+
+function getCause(val: unknown): unknown {
+  if (val && typeof val === 'object' && 'cause' in val) {
+    return (val as { cause: unknown }).cause
   }
   return null
 }

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -6,7 +6,7 @@ import {
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
 import type { Vehicle } from '../../src/stores'
-import { cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
+import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
 const vehicleRepo = new DrizzleVehicleRepository(db)
 const bookingRepo = new DrizzleBookingRepository(db)
@@ -53,6 +53,7 @@ function createTestVehicle(
     minRentalHours: overrides.minRentalHours ?? null,
     maxRentalHours: overrides.maxRentalHours ?? null,
     advanceBookingHours: overrides.advanceBookingHours ?? null,
+    dailyRateJpy: overrides.dailyRateJpy ?? DEFAULT_DAILY_RATE_JPY,
   })
 }
 

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -1,11 +1,44 @@
-import { users } from '@kuruma/shared/db/schema'
+import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { DrizzleBookingRepository, DrizzleVehicleRepository } from '../../src/repositories/drizzle'
+import { createApp } from '../../src/index'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import type { Db } from '../../src/repositories/drizzle/shared'
 import type { Vehicle } from '../../src/stores'
-import { cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { testDb } from './pg-test-client'
+
+// Cast once: postgres-js and neon-http share the drizzle query API surface,
+// but the Drizzle repos are typed for neon-http. See pg-test-client.ts.
+const db = testDb as unknown as Db
 
 const bookingRepo = new DrizzleBookingRepository(db)
 const vehicleRepo = new DrizzleVehicleRepository(db)
+
+// --- Cleanup helpers (use testDb to avoid Neon HTTP driver) ---
+
+async function cleanupBookings(ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+  await testDb.delete(bookings).where(inArray(bookings.id, ids))
+}
+
+async function cleanupVehicles(vehicleIds: string[]): Promise<void> {
+  if (vehicleIds.length === 0) return
+  await testDb.delete(bookings).where(inArray(bookings.vehicleId, vehicleIds))
+  await testDb.delete(vehicles).where(inArray(vehicles.id, vehicleIds))
+}
+
+async function cleanupUsers(userIds: string[]): Promise<void> {
+  if (userIds.length === 0) return
+  await testDb.delete(bookings).where(inArray(bookings.renterId, userIds))
+  await testDb.delete(users).where(inArray(users.id, userIds))
+}
+
+// --- Test data ---
 
 let testUser: { id: string; email: string }
 let testVehicle: Vehicle
@@ -13,7 +46,7 @@ const createdBookingIds: string[] = []
 const createdVehicleIds: string[] = []
 
 beforeAll(async () => {
-  const [user] = await db
+  const [user] = await testDb
     .insert(users)
     .values({
       id: crypto.randomUUID(),
@@ -35,6 +68,8 @@ beforeAll(async () => {
     minRentalHours: null,
     maxRentalHours: null,
     advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
   })
   createdVehicleIds.push(testVehicle.id)
 })
@@ -164,6 +199,8 @@ describe('DrizzleBookingRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
     })
     createdVehicleIds.push(otherVehicle.id)
 
@@ -249,7 +286,7 @@ describe('DrizzleBookingRepository', () => {
     expect(fromDb!.totalPrice).toBe(15000)
   })
 
-  it('rejects overlapping bookings via exclusion constraint', async () => {
+  it('rejects overlapping bookings with PG error code 23P01', async () => {
     const firstBooking = await bookingRepo.create({
       renterId: testUser.id,
       vehicleId: testVehicle.id,
@@ -263,8 +300,8 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(firstBooking.id)
 
-    await expect(
-      bookingRepo.create({
+    try {
+      const second = await bookingRepo.create({
         renterId: testUser.id,
         vehicleId: testVehicle.id,
         startAt: new Date('2027-01-01T13:00:00Z'),
@@ -274,8 +311,59 @@ describe('DrizzleBookingRepository', () => {
         source: 'DIRECT',
         externalId: null,
         notes: null,
-      }),
-    ).rejects.toThrow()
+      })
+      // If we get here, the constraint didn't fire
+      createdBookingIds.push(second.id)
+      expect.unreachable('Expected exclusion constraint violation')
+    } catch (err) {
+      // postgres-js wraps the PG error in err.cause
+      expect(err).toHaveProperty('cause')
+      const cause = (err as { cause: { code: string } }).cause
+      expect(cause).toHaveProperty('code', '23P01')
+      expect(cause).toHaveProperty('constraint_name', 'bookings_no_overlap')
+    }
+  })
+
+  it('allows overlapping booking after first is cancelled', async () => {
+    const firstBooking = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-02-01T10:00:00Z'),
+      endAt: new Date('2027-02-01T14:00:00Z'),
+      effectiveEndAt: new Date('2027-02-01T15:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(firstBooking.id)
+
+    // Cancel the first booking
+    const cancelled = await bookingRepo.cancel(firstBooking.id, {
+      from: 'CONFIRMED',
+      fee: 0,
+      cancelledAt: new Date(),
+    })
+    expect(cancelled).toBeDefined()
+    expect(cancelled!.status).toBe('CANCELLED')
+
+    // Overlapping booking should now succeed — exclusion constraint
+    // only applies to CONFIRMED/ACTIVE
+    const secondBooking = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-02-01T12:00:00Z'),
+      endAt: new Date('2027-02-01T16:00:00Z'),
+      effectiveEndAt: new Date('2027-02-01T17:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(secondBooking.id)
+
+    expect(secondBooking.status).toBe('CONFIRMED')
+    expect(secondBooking.vehicleId).toBe(testVehicle.id)
   })
 
   it('concurrent overlapping bookings: exactly one succeeds', async () => {
@@ -302,5 +390,98 @@ describe('DrizzleBookingRepository', () => {
     // Clean up the one that succeeded
     const winner = (fulfilled[0] as PromiseFulfilledResult<{ id: string }>).value
     createdBookingIds.push(winner.id)
+  })
+})
+
+describe('POST /bookings overlap via HTTP (real Postgres)', () => {
+  const httpBookingIds: string[] = []
+  let httpUser: { id: string; email: string }
+  let httpVehicle: Vehicle
+  let app: ReturnType<typeof createApp>
+  let headers: Record<string, string>
+
+  beforeAll(async () => {
+    setupAuthEnv()
+
+    const [user] = await testDb
+      .insert(users)
+      .values({
+        id: crypto.randomUUID(),
+        email: `http-overlap-${Date.now()}@kuruma-test.com`,
+        role: 'RENTER',
+        language: 'en',
+      })
+      .returning()
+    httpUser = user
+
+    const httpVehicleRepo = new DrizzleVehicleRepository(db)
+    const httpBookingRepo = new DrizzleBookingRepository(db)
+    const httpAvailabilityRepo = new DrizzleAvailabilityRepository(db)
+
+    httpVehicle = await httpVehicleRepo.create({
+      name: 'HTTP Overlap Test Car',
+      description: null,
+      seats: 4,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    app = createApp({
+      vehicleRepo: httpVehicleRepo,
+      bookingRepo: httpBookingRepo,
+      availabilityRepo: httpAvailabilityRepo,
+    })
+    headers = await authHeaders({ sub: httpUser.id, role: 'RENTER' })
+  })
+
+  afterEach(async () => {
+    await cleanupBookings(httpBookingIds)
+    httpBookingIds.length = 0
+  })
+
+  afterAll(async () => {
+    if (httpVehicle) await cleanupVehicles([httpVehicle.id])
+    if (httpUser) await cleanupUsers([httpUser.id])
+  })
+
+  it('returns 409 when second booking overlaps an existing CONFIRMED booking', async () => {
+    const bookingBody = {
+      vehicleId: httpVehicle.id,
+      startAt: '2027-03-01T10:00:00Z',
+      endAt: '2027-03-01T14:00:00Z',
+      source: 'DIRECT',
+    }
+
+    const first = await app.request('/bookings', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(bookingBody),
+    })
+    expect(first.status).toBe(201)
+    const firstBody = await first.json()
+    httpBookingIds.push(firstBody.data.id)
+
+    // Second request with overlapping time range
+    const second = await app.request('/bookings', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...bookingBody,
+        startAt: '2027-03-01T13:00:00Z',
+        endAt: '2027-03-01T17:00:00Z',
+      }),
+    })
+
+    expect(second.status).toBe(409)
+    const secondBody = await second.json()
+    expect(secondBody.success).toBe(false)
+    expect(secondBody.error).toMatch(/already booked/i)
   })
 })

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -11,6 +11,9 @@ import type { Vehicle } from '../../src/stores'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
 import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
+const bookingRepo = new DrizzleBookingRepository(db)
+const vehicleRepo = new DrizzleVehicleRepository(db)
+
 // --- Test data ---
 
 let testUser: { id: string; email: string }

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -1,5 +1,4 @@
-import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
-import { inArray } from 'drizzle-orm'
+import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
 import { pgErrorCode } from '../../src/pg-errors'
@@ -8,36 +7,9 @@ import {
   DrizzleBookingRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
-import type { Db } from '../../src/repositories/drizzle/shared'
 import type { Vehicle } from '../../src/stores'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
-import { testDb } from './pg-test-client'
-
-// Cast once: postgres-js and neon-http share the drizzle query API surface,
-// but the Drizzle repos are typed for neon-http. See pg-test-client.ts.
-const db = testDb as unknown as Db
-
-const bookingRepo = new DrizzleBookingRepository(db)
-const vehicleRepo = new DrizzleVehicleRepository(db)
-
-// --- Cleanup helpers (use testDb to avoid Neon HTTP driver) ---
-
-async function cleanupBookings(ids: string[]): Promise<void> {
-  if (ids.length === 0) return
-  await testDb.delete(bookings).where(inArray(bookings.id, ids))
-}
-
-async function cleanupVehicles(vehicleIds: string[]): Promise<void> {
-  if (vehicleIds.length === 0) return
-  await testDb.delete(bookings).where(inArray(bookings.vehicleId, vehicleIds))
-  await testDb.delete(vehicles).where(inArray(vehicles.id, vehicleIds))
-}
-
-async function cleanupUsers(userIds: string[]): Promise<void> {
-  if (userIds.length === 0) return
-  await testDb.delete(bookings).where(inArray(bookings.renterId, userIds))
-  await testDb.delete(users).where(inArray(users.id, userIds))
-}
+import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
 // --- Test data ---
 
@@ -47,7 +19,7 @@ const createdBookingIds: string[] = []
 const createdVehicleIds: string[] = []
 
 beforeAll(async () => {
-  const [user] = await testDb
+  const [user] = await db
     .insert(users)
     .values({
       id: crypto.randomUUID(),
@@ -69,8 +41,7 @@ beforeAll(async () => {
     minRentalHours: null,
     maxRentalHours: null,
     advanceBookingHours: null,
-    dailyRateJpy: 8000,
-    hourlyRateJpy: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
   })
   createdVehicleIds.push(testVehicle.id)
 })
@@ -200,8 +171,7 @@ describe('DrizzleBookingRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
-      dailyRateJpy: 8000,
-      hourlyRateJpy: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdVehicleIds.push(otherVehicle.id)
 
@@ -435,7 +405,7 @@ describe('POST /bookings overlap via HTTP (real Postgres)', () => {
   beforeAll(async () => {
     setupAuthEnv()
 
-    const [user] = await testDb
+    const [user] = await db
       .insert(users)
       .values({
         id: crypto.randomUUID(),

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -2,6 +2,7 @@ import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
+import { pgErrorCode } from '../../src/pg-errors'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -316,11 +317,8 @@ describe('DrizzleBookingRepository', () => {
       createdBookingIds.push(second.id)
       expect.unreachable('Expected exclusion constraint violation')
     } catch (err) {
-      // postgres-js wraps the PG error in err.cause
-      expect(err).toHaveProperty('cause')
-      const cause = (err as { cause: { code: string } }).cause
-      expect(cause).toHaveProperty('code', '23P01')
-      expect(cause).toHaveProperty('constraint_name', 'bookings_no_overlap')
+      // Validate through the same abstraction the production code uses
+      expect(pgErrorCode(err)).toBe('23P01')
     }
   })
 
@@ -364,6 +362,40 @@ describe('DrizzleBookingRepository', () => {
 
     expect(secondBooking.status).toBe('CONFIRMED')
     expect(secondBooking.vehicleId).toBe(testVehicle.id)
+  })
+
+  it('allows adjacent (non-overlapping) bookings on same vehicle', async () => {
+    // First booking: 10:00-14:00, effectiveEnd 15:00 (buffer)
+    const first = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-04-01T10:00:00Z'),
+      endAt: new Date('2027-04-01T14:00:00Z'),
+      effectiveEndAt: new Date('2027-04-01T15:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(first.id)
+
+    // Second booking starts exactly at first's effectiveEndAt (boundary)
+    // tstzrange is [closed, open) so startAt === effectiveEndAt does NOT overlap
+    const second = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-04-01T15:00:00Z'),
+      endAt: new Date('2027-04-01T19:00:00Z'),
+      effectiveEndAt: new Date('2027-04-01T20:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(second.id)
+
+    expect(second.status).toBe('CONFIRMED')
+    expect(second.startAt).toEqual(new Date('2027-04-01T15:00:00Z'))
   })
 
   it('concurrent overlapping bookings: exactly one succeeds', async () => {

--- a/packages/api/tests/integration/setup.ts
+++ b/packages/api/tests/integration/setup.ts
@@ -1,10 +1,13 @@
-import { getDb } from '@kuruma/shared/db'
 import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
 import { eq } from 'drizzle-orm'
+import { testDb } from './pg-test-client'
 
-const db = getDb()
-
+// Re-export as `db` so existing test files keep their import unchanged.
+const db = testDb
 export { db }
+
+/** Satisfies the vehicles_pricing_at_least_one CHECK constraint. */
+export const DEFAULT_DAILY_RATE_JPY = 5000
 
 export async function cleanupVehicles(ids: string[]): Promise<void> {
   if (ids.length === 0) return

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { DrizzleVehicleRepository } from '../../src/repositories/drizzle'
-import { cleanupVehicles, db } from './setup'
+import { DEFAULT_DAILY_RATE_JPY, cleanupVehicles, db } from './setup'
 
 const repo = new DrizzleVehicleRepository(db)
 const createdIds: string[] = []
@@ -23,6 +23,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: 4,
       maxRentalHours: 72,
       advanceBookingHours: 24,
+      dailyRateJpy: 8000,
     }
 
     const vehicle = await repo.create(input)
@@ -39,6 +40,7 @@ describe('DrizzleVehicleRepository', () => {
     expect(vehicle.minRentalHours).toBe(4)
     expect(vehicle.maxRentalHours).toBe(72)
     expect(vehicle.advanceBookingHours).toBe(24)
+    expect(vehicle.dailyRateJpy).toBe(8000)
     expect(vehicle.createdAt).toBeInstanceOf(Date)
     expect(vehicle.updatedAt).toBeInstanceOf(Date)
   })
@@ -55,6 +57,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 
@@ -88,6 +91,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(available.id)
 
@@ -102,6 +106,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(maintenance.id)
 
@@ -130,6 +135,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 
@@ -170,6 +176,7 @@ describe('DrizzleVehicleRepository', () => {
       minRentalHours: null,
       maxRentalHours: null,
       advanceBookingHours: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
     })
     createdIds.push(created.id)
 

--- a/packages/api/tests/pg-errors.test.ts
+++ b/packages/api/tests/pg-errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { pgErrorCode } from '../src/pg-errors'
+
+describe('pgErrorCode', () => {
+  it('extracts code from a raw PG error (in-memory repo style)', () => {
+    const err = Object.assign(new Error('exclusion'), { code: '23P01' })
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('extracts code from drizzle-wrapped error (err.cause.code)', () => {
+    const cause = Object.assign(new Error('PG error'), { code: '23P01' })
+    const err = new Error('Failed query')
+    ;(err as unknown as { cause: Error }).cause = cause
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('prefers err.code over err.cause.code when both exist', () => {
+    const cause = Object.assign(new Error('inner'), { code: '23505' })
+    const err = Object.assign(new Error('outer'), { code: '23P01' })
+    ;(err as unknown as { cause: Error }).cause = cause
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('returns null for null input', () => {
+    expect(pgErrorCode(null)).toBeNull()
+  })
+
+  it('returns null for undefined input', () => {
+    expect(pgErrorCode(undefined)).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(pgErrorCode('string')).toBeNull()
+    expect(pgErrorCode(42)).toBeNull()
+  })
+
+  it('returns null when code is not a string', () => {
+    const err = Object.assign(new Error('bad'), { code: 123 })
+    expect(pgErrorCode(err)).toBeNull()
+  })
+
+  it('returns null when neither err.code nor err.cause.code exist', () => {
+    const err = new Error('plain error')
+    expect(pgErrorCode(err)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Add 3 integration tests proving the booking overlap exclusion constraint works end-to-end against real Postgres
- Fix `pgErrorCode()` to check `err.cause.code` (postgres-js wraps PG errors in `cause`)
- Add unit tests for `pgErrorCode` itself
- Add `bookings.test.ts` to the `test:integration` script
- Migrate bookings integration tests from Neon HTTP driver to postgres-js (`testDb`)

## Bug found

`pgErrorCode()` only checked `err.code`, but postgres-js puts the PG error code at `err.cause.code`. This meant the real DB path returned **500 instead of 409** on booking overlap. The in-memory tests passed because `InMemoryBookingRepo` throws with `code` directly on the error object — masking the driver mismatch.

## Tests added

| Test | What it proves |
|------|---------------|
| Overlap → `23P01` | Exclusion constraint fires, pgErrorCode extracts the code through `err.cause` |
| Cancel → rebooking succeeds | `WHERE status IN ('CONFIRMED','ACTIVE')` clause works (CANCELLED bookings don't block) |
| Adjacent bookings succeed | Boundary: `startAt === prior effectiveEndAt` is allowed (tstzrange `[closed, open)`) |
| HTTP POST → 409 | Full stack: service catches 23P01, returns 409 with correct error body |
| Concurrent overlap → exactly one wins | Race condition: two simultaneous inserts, one succeeds |
| pgErrorCode unit tests | 8 cases: raw code, wrapped cause, both, null, undefined, non-object, non-string code |

## Test plan

- [x] `bun run --filter @kuruma/api test` — 193 unit tests pass
- [x] `DATABASE_URL=... bun run --filter @kuruma/api test:integration` — 40 integration tests pass
- [x] Pre-commit hooks pass (biome, tsc, file-size, module-boundaries)

Closes #30