### PR TITLE
test(api): integration tests for POST /bookings overlap 409

### DIFF
--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -7,11 +7,28 @@ export const PG_ERROR = {
   UNIQUE_VIOLATION: '23505',
 } as const
 
-/** Extract the Postgres error code from an unknown thrown value, or null. */
+/** Extract the Postgres error code from an unknown thrown value, or null.
+ *
+ * Drizzle + postgres-js wraps the raw PostgresError inside `err.cause`,
+ * so the PG error code lives at `err.cause.code`, not `err.code`.
+ * We check both paths so the same helper works with raw PG errors
+ * (in-memory repo) and wrapped drizzle errors (real DB). */
 export function pgErrorCode(err: unknown): string | null {
-  if (err && typeof err === 'object' && 'code' in err) {
-    const code = (err as { code: unknown }).code
+  const code = extractCode(err) ?? extractCode(getCause(err))
+  return code
+}
+
+function extractCode(val: unknown): string | null {
+  if (val && typeof val === 'object' && 'code' in val) {
+    const code = (val as { code: unknown }).code
     return typeof code === 'string' ? code : null
+  }
+  return null
+}
+
+function getCause(val: unknown): unknown {
+  if (val && typeof val === 'object' && 'cause' in val) {
+    return (val as { cause: unknown }).cause
   }
   return null
 }

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -1,11 +1,20 @@
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { DrizzleBookingRepository, DrizzleVehicleRepository } from '../../src/repositories/drizzle'
+import { createApp } from '../../src/index'
+import { pgErrorCode } from '../../src/pg-errors'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
 import type { Vehicle } from '../../src/stores'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
 import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
 
 const bookingRepo = new DrizzleBookingRepository(db)
 const vehicleRepo = new DrizzleVehicleRepository(db)
+
+// --- Test data ---
 
 let testUser: { id: string; email: string }
 let testVehicle: Vehicle
@@ -251,7 +260,7 @@ describe('DrizzleBookingRepository', () => {
     expect(fromDb!.totalPrice).toBe(15000)
   })
 
-  it('rejects overlapping bookings via exclusion constraint', async () => {
+  it('rejects overlapping bookings with PG error code 23P01', async () => {
     const firstBooking = await bookingRepo.create({
       renterId: testUser.id,
       vehicleId: testVehicle.id,
@@ -265,8 +274,8 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(firstBooking.id)
 
-    await expect(
-      bookingRepo.create({
+    try {
+      const second = await bookingRepo.create({
         renterId: testUser.id,
         vehicleId: testVehicle.id,
         startAt: new Date('2027-01-01T13:00:00Z'),
@@ -276,8 +285,90 @@ describe('DrizzleBookingRepository', () => {
         source: 'DIRECT',
         externalId: null,
         notes: null,
-      }),
-    ).rejects.toThrow()
+      })
+      // If we get here, the constraint didn't fire
+      createdBookingIds.push(second.id)
+      expect.unreachable('Expected exclusion constraint violation')
+    } catch (err) {
+      // Validate through the same abstraction the production code uses
+      expect(pgErrorCode(err)).toBe('23P01')
+    }
+  })
+
+  it('allows overlapping booking after first is cancelled', async () => {
+    const firstBooking = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-02-01T10:00:00Z'),
+      endAt: new Date('2027-02-01T14:00:00Z'),
+      effectiveEndAt: new Date('2027-02-01T15:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(firstBooking.id)
+
+    // Cancel the first booking
+    const cancelled = await bookingRepo.cancel(firstBooking.id, {
+      from: 'CONFIRMED',
+      fee: 0,
+      cancelledAt: new Date(),
+    })
+    expect(cancelled).toBeDefined()
+    expect(cancelled!.status).toBe('CANCELLED')
+
+    // Overlapping booking should now succeed — exclusion constraint
+    // only applies to CONFIRMED/ACTIVE
+    const secondBooking = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-02-01T12:00:00Z'),
+      endAt: new Date('2027-02-01T16:00:00Z'),
+      effectiveEndAt: new Date('2027-02-01T17:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(secondBooking.id)
+
+    expect(secondBooking.status).toBe('CONFIRMED')
+    expect(secondBooking.vehicleId).toBe(testVehicle.id)
+  })
+
+  it('allows adjacent (non-overlapping) bookings on same vehicle', async () => {
+    // First booking: 10:00-14:00, effectiveEnd 15:00 (buffer)
+    const first = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-04-01T10:00:00Z'),
+      endAt: new Date('2027-04-01T14:00:00Z'),
+      effectiveEndAt: new Date('2027-04-01T15:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(first.id)
+
+    // Second booking starts exactly at first's effectiveEndAt (boundary)
+    // tstzrange is [closed, open) so startAt === effectiveEndAt does NOT overlap
+    const second = await bookingRepo.create({
+      renterId: testUser.id,
+      vehicleId: testVehicle.id,
+      startAt: new Date('2027-04-01T15:00:00Z'),
+      endAt: new Date('2027-04-01T19:00:00Z'),
+      effectiveEndAt: new Date('2027-04-01T20:00:00Z'),
+      status: 'CONFIRMED',
+      source: 'DIRECT',
+      externalId: null,
+      notes: null,
+    })
+    createdBookingIds.push(second.id)
+
+    expect(second.status).toBe('CONFIRMED')
+    expect(second.startAt).toEqual(new Date('2027-04-01T15:00:00Z'))
   })
 
   it('concurrent overlapping bookings: exactly one succeeds', async () => {
@@ -304,5 +395,98 @@ describe('DrizzleBookingRepository', () => {
     // Clean up the one that succeeded
     const winner = (fulfilled[0] as PromiseFulfilledResult<{ id: string }>).value
     createdBookingIds.push(winner.id)
+  })
+})
+
+describe('POST /bookings overlap via HTTP (real Postgres)', () => {
+  const httpBookingIds: string[] = []
+  let httpUser: { id: string; email: string }
+  let httpVehicle: Vehicle
+  let app: ReturnType<typeof createApp>
+  let headers: Record<string, string>
+
+  beforeAll(async () => {
+    setupAuthEnv()
+
+    const [user] = await db
+      .insert(users)
+      .values({
+        id: crypto.randomUUID(),
+        email: `http-overlap-${Date.now()}@kuruma-test.com`,
+        role: 'RENTER',
+        language: 'en',
+      })
+      .returning()
+    httpUser = user
+
+    const httpVehicleRepo = new DrizzleVehicleRepository(db)
+    const httpBookingRepo = new DrizzleBookingRepository(db)
+    const httpAvailabilityRepo = new DrizzleAvailabilityRepository(db)
+
+    httpVehicle = await httpVehicleRepo.create({
+      name: 'HTTP Overlap Test Car',
+      description: null,
+      seats: 4,
+      transmission: 'AUTO',
+      fuelType: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+    })
+
+    app = createApp({
+      vehicleRepo: httpVehicleRepo,
+      bookingRepo: httpBookingRepo,
+      availabilityRepo: httpAvailabilityRepo,
+    })
+    headers = await authHeaders({ sub: httpUser.id, role: 'RENTER' })
+  })
+
+  afterEach(async () => {
+    await cleanupBookings(httpBookingIds)
+    httpBookingIds.length = 0
+  })
+
+  afterAll(async () => {
+    if (httpVehicle) await cleanupVehicles([httpVehicle.id])
+    if (httpUser) await cleanupUsers([httpUser.id])
+  })
+
+  it('returns 409 when second booking overlaps an existing CONFIRMED booking', async () => {
+    const bookingBody = {
+      vehicleId: httpVehicle.id,
+      startAt: '2027-03-01T10:00:00Z',
+      endAt: '2027-03-01T14:00:00Z',
+      source: 'DIRECT',
+    }
+
+    const first = await app.request('/bookings', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(bookingBody),
+    })
+    expect(first.status).toBe(201)
+    const firstBody = await first.json()
+    httpBookingIds.push(firstBody.data.id)
+
+    // Second request with overlapping time range
+    const second = await app.request('/bookings', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...bookingBody,
+        startAt: '2027-03-01T13:00:00Z',
+        endAt: '2027-03-01T17:00:00Z',
+      }),
+    })
+
+    expect(second.status).toBe(409)
+    const secondBody = await second.json()
+    expect(secondBody.success).toBe(false)
+    expect(secondBody.error).toMatch(/already booked/i)
   })
 })

--- a/packages/api/tests/pg-errors.test.ts
+++ b/packages/api/tests/pg-errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { pgErrorCode } from '../src/pg-errors'
+
+describe('pgErrorCode', () => {
+  it('extracts code from a raw PG error (in-memory repo style)', () => {
+    const err = Object.assign(new Error('exclusion'), { code: '23P01' })
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('extracts code from drizzle-wrapped error (err.cause.code)', () => {
+    const cause = Object.assign(new Error('PG error'), { code: '23P01' })
+    const err = new Error('Failed query')
+    ;(err as unknown as { cause: Error }).cause = cause
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('prefers err.code over err.cause.code when both exist', () => {
+    const cause = Object.assign(new Error('inner'), { code: '23505' })
+    const err = Object.assign(new Error('outer'), { code: '23P01' })
+    ;(err as unknown as { cause: Error }).cause = cause
+    expect(pgErrorCode(err)).toBe('23P01')
+  })
+
+  it('returns null for null input', () => {
+    expect(pgErrorCode(null)).toBeNull()
+  })
+
+  it('returns null for undefined input', () => {
+    expect(pgErrorCode(undefined)).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(pgErrorCode('string')).toBeNull()
+    expect(pgErrorCode(42)).toBeNull()
+  })
+
+  it('returns null when code is not a string', () => {
+    const err = Object.assign(new Error('bad'), { code: 123 })
+    expect(pgErrorCode(err)).toBeNull()
+  })
+
+  it('returns null when neither err.code nor err.cause.code exist', () => {
+    const err = new Error('plain error')
+    expect(pgErrorCode(err)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `pgErrorCode()` utility to extract PG error codes from postgres-js errors
- Tests the exclusion constraint at repo layer (direct DB) and HTTP layer (POST /bookings → 409)
- Covers: overlap rejection with error code 23P01, cancel-then-rebook, adjacent boundary (tstzrange `[)` semantics), concurrent race condition

## Test plan

- [x] 58 integration tests pass against local Postgres
- [x] Typecheck passes
- [x] Pre-commit hooks pass
- [ ] CI `db-drift` job passes

Closes #30