### PR TITLE
refactor(web): migrate raw fetch calls to typed Hono client

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -138,9 +138,6 @@ export function createApp(overrides?: {
     )
   }
 
-  // Public routes (no auth required)
-  app.route('/', health)
-
   // Auth middleware on all protected paths
   app.use('/vehicles/*', requireAuth())
   app.use('/bookings/*', requireAuth())
@@ -149,15 +146,17 @@ export function createApp(overrides?: {
 
   const bookingService = new BookingService(bookingRepo, vehicleRepo)
 
-  app.route('/', createFleetOverviewRoutes(fleetOverviewRepo))
-  app.route('/', createVehicleDetailRoutes(vehicleDetailRepo))
-  app.route('/', createVehicleRoutes(vehicleRepo))
-  app.route('/', createBookingRoutes(bookingService))
-  app.route('/', createAvailabilityRoutes(availabilityRepo))
-  app.route('/', createStatsRoutes(statsRepo))
-  app.route('/', createMessageRoutes(threadRepo, messageRepo))
-
+  // Chain .route() calls so TypeScript infers the full route type tree.
+  // hc<AppType> needs this to produce typed client methods.
   return app
+    .route('/', health)
+    .route('/', createFleetOverviewRoutes(fleetOverviewRepo))
+    .route('/', createVehicleDetailRoutes(vehicleDetailRepo))
+    .route('/', createVehicleRoutes(vehicleRepo))
+    .route('/', createBookingRoutes(bookingService))
+    .route('/', createAvailabilityRoutes(availabilityRepo))
+    .route('/', createStatsRoutes(statsRepo))
+    .route('/', createMessageRoutes(threadRepo, messageRepo))
 }
 
 const DEV_WEB_ORIGINS = ['http://localhost:3001', 'http://127.0.0.1:3001']

--- a/packages/api/src/routes/availability.ts
+++ b/packages/api/src/routes/availability.ts
@@ -2,37 +2,33 @@ import { Hono } from 'hono'
 import type { AvailabilityRepository } from '../repositories/types'
 import { fail, ok, parseDateRange } from './helpers'
 
-export function createAvailabilityRoutes(repo: AvailabilityRepository): Hono {
-  const availability = new Hono()
+export function createAvailabilityRoutes(repo: AvailabilityRepository) {
+  return new Hono()
+    .get('/availability', async (c) => {
+      const range = parseDateRange(c, true)
+      if (!range.ok) return range.response
 
-  availability.get('/availability', async (c) => {
-    const range = parseDateRange(c, true)
-    if (!range.ok) return range.response
-
-    const available = await repo.findAvailableVehicles(range.from, range.to)
-    return ok(c, available)
-  })
-
-  availability.get('/availability/:vehicleId', async (c) => {
-    const vehicleId = c.req.param('vehicleId')
-    const range = parseDateRange(c, true)
-    if (!range.ok) return range.response
-
-    const result = await repo.checkVehicleAvailability(vehicleId, range.from, range.to)
-    if (!result) {
-      return fail(c, 'Vehicle not found', 404)
-    }
-
-    if (result.available) {
-      return ok(c, { available: true, vehicle: result.vehicle })
-    }
-
-    return ok(c, {
-      available: false,
-      vehicle: result.vehicle,
-      conflicts: result.conflicts,
+      const available = await repo.findAvailableVehicles(range.from, range.to)
+      return ok(c, available)
     })
-  })
+    .get('/availability/:vehicleId', async (c) => {
+      const vehicleId = c.req.param('vehicleId')
+      const range = parseDateRange(c, true)
+      if (!range.ok) return range.response
 
-  return availability
+      const result = await repo.checkVehicleAvailability(vehicleId, range.from, range.to)
+      if (!result) {
+        return fail(c, 'Vehicle not found', 404)
+      }
+
+      if (result.available) {
+        return ok(c, { available: true, vehicle: result.vehicle })
+      }
+
+      return ok(c, {
+        available: false,
+        vehicle: result.vehicle,
+        conflicts: result.conflicts,
+      })
+    })
 }

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -5,147 +5,140 @@ import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
 import { fail, ok, parseDateRange } from './helpers'
 
-export function createBookingRoutes(service: BookingService): Hono {
-  const bookings = new Hono()
+export function createBookingRoutes(service: BookingService) {
+  return new Hono()
+    .get('/bookings', async (c) => {
+      const user = requireUser(c)
 
-  bookings.get('/bookings', async (c) => {
-    const user = requireUser(c)
+      const statusFilter = c.req.query('status')
+      const vehicleIdFilter = c.req.query('vehicleId')
+      const renterIdFilter = c.req.query('renterId')
+      const expand = c.req.query('expand')
+      const limitParam = c.req.query('limit')
+      const cursor = c.req.query('cursor')
 
-    const statusFilter = c.req.query('status')
-    const vehicleIdFilter = c.req.query('vehicleId')
-    const renterIdFilter = c.req.query('renterId')
-    const expand = c.req.query('expand')
-    const limitParam = c.req.query('limit')
-    const cursor = c.req.query('cursor')
+      const dateRange = parseDateRange(c, false)
+      if (!dateRange.ok) return dateRange.response
 
-    const dateRange = parseDateRange(c, false)
-    if (!dateRange.ok) return dateRange.response
+      // Validate limit: 1-100, default 20
+      const limit = limitParam ? Number.parseInt(limitParam, 10) : 20
+      if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+        return fail(c, 'limit must be between 1 and 100', 400)
+      }
 
-    // Validate limit: 1–100, default 20
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : 20
-    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
-      return fail(c, 'limit must be between 1 and 100', 400)
-    }
+      const filters: BookingFilters = { limit }
+      if (cursor) filters.cursor = cursor
+      if (statusFilter) filters.status = statusFilter
+      if (vehicleIdFilter) filters.vehicleId = vehicleIdFilter
+      if (renterIdFilter) filters.renterId = renterIdFilter
+      if (dateRange.from && dateRange.to) {
+        filters.from = dateRange.from
+        filters.to = dateRange.to
+      }
 
-    const filters: BookingFilters = { limit }
-    if (cursor) filters.cursor = cursor
-    if (statusFilter) filters.status = statusFilter
-    if (vehicleIdFilter) filters.vehicleId = vehicleIdFilter
-    if (renterIdFilter) filters.renterId = renterIdFilter
-    if (dateRange.from && dateRange.to) {
-      filters.from = dateRange.from
-      filters.to = dateRange.to
-    }
+      // Ownership: non-privileged users can only see their own bookings
+      if (!PRIVILEGED_ROLES.has(user.role)) {
+        filters.renterId = user.id
+      }
 
-    // Ownership: non-privileged users can only see their own bookings
-    if (!PRIVILEGED_ROLES.has(user.role)) {
-      filters.renterId = user.id
-    }
+      if (expand === 'vehicle') {
+        const result = await service.findAllWithVehiclesPaginated(filters)
+        return ok(c, result.data, 200, { nextCursor: result.nextCursor })
+      }
 
-    if (expand === 'vehicle') {
-      const result = await service.findAllWithVehiclesPaginated(filters)
+      const result = await service.findAllPaginated(filters)
       return ok(c, result.data, 200, { nextCursor: result.nextCursor })
-    }
-
-    const result = await service.findAllPaginated(filters)
-    return ok(c, result.data, 200, { nextCursor: result.nextCursor })
-  })
-
-  bookings.get('/bookings/:id', async (c) => {
-    const user = requireUser(c)
-
-    const booking = await service.findById(c.req.param('id'))
-    if (!booking) {
-      return fail(c, 'Booking not found', 404)
-    }
-
-    // Ownership: non-privileged users can only view their own bookings (404 to avoid info leak)
-    if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
-      return fail(c, 'Booking not found', 404)
-    }
-
-    return ok(c, booking)
-  })
-
-  bookings.post('/bookings', async (c) => {
-    const user = requireUser(c)
-
-    const body = await c.req.json()
-    const result = createBookingSchema.safeParse(body)
-
-    if (!result.success) {
-      return fail(c, result.error.flatten().fieldErrors, 400)
-    }
-
-    // Actor derivation: renterId comes from JWT, never from body
-    const createResult = await service.create({
-      vehicleId: result.data.vehicleId,
-      renterId: user.id,
-      startAt: new Date(result.data.startAt),
-      endAt: new Date(result.data.endAt),
-      source: result.data.source,
-      externalId: result.data.externalId ?? null,
-      notes: result.data.notes ?? null,
-      idempotencyKey: result.data.idempotencyKey ?? null,
     })
+    .get('/bookings/:id', async (c) => {
+      const user = requireUser(c)
 
-    if (!createResult.ok) {
-      return fail(c, createResult.error, createResult.status, {
-        ...(createResult.code ? { code: createResult.code } : {}),
-        ...(createResult.details ? { details: createResult.details } : {}),
+      const booking = await service.findById(c.req.param('id'))
+      if (!booking) {
+        return fail(c, 'Booking not found', 404)
+      }
+
+      // Ownership: non-privileged users can only view their own bookings (404 to avoid info leak)
+      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
+        return fail(c, 'Booking not found', 404)
+      }
+
+      return ok(c, booking)
+    })
+    .post('/bookings', async (c) => {
+      const user = requireUser(c)
+
+      const body = await c.req.json()
+      const result = createBookingSchema.safeParse(body)
+
+      if (!result.success) {
+        return fail(c, result.error.flatten().fieldErrors, 400)
+      }
+
+      // Actor derivation: renterId comes from JWT, never from body
+      const createResult = await service.create({
+        vehicleId: result.data.vehicleId,
+        renterId: user.id,
+        startAt: new Date(result.data.startAt),
+        endAt: new Date(result.data.endAt),
+        source: result.data.source,
+        externalId: result.data.externalId ?? null,
+        notes: result.data.notes ?? null,
+        idempotencyKey: result.data.idempotencyKey ?? null,
       })
-    }
 
-    return ok(c, createResult.booking, createResult.status ?? 201)
-  })
+      if (!createResult.ok) {
+        return fail(c, createResult.error, createResult.status, {
+          ...(createResult.code ? { code: createResult.code } : {}),
+          ...(createResult.details ? { details: createResult.details } : {}),
+        })
+      }
 
-  bookings.patch('/bookings/:id/status', async (c) => {
-    const user = requireUser(c)
+      return ok(c, createResult.booking, createResult.status ?? 201)
+    })
+    .patch('/bookings/:id/status', async (c) => {
+      const user = requireUser(c)
 
-    const booking = await service.findById(c.req.param('id'))
-    if (!booking) {
-      return fail(c, 'Booking not found', 404)
-    }
+      const booking = await service.findById(c.req.param('id'))
+      if (!booking) {
+        return fail(c, 'Booking not found', 404)
+      }
 
-    // Ownership: allow privileged roles or the booking owner (404 to avoid info leak)
-    if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
-      return fail(c, 'Booking not found', 404)
-    }
+      // Ownership: allow privileged roles or the booking owner (404 to avoid info leak)
+      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
+        return fail(c, 'Booking not found', 404)
+      }
 
-    const body = await c.req.json()
-    const parsed = updateBookingStatusSchema.safeParse(body)
-    if (!parsed.success) {
-      return fail(c, parsed.error.flatten().fieldErrors, 400)
-    }
+      const body = await c.req.json()
+      const parsed = updateBookingStatusSchema.safeParse(body)
+      if (!parsed.success) {
+        return fail(c, parsed.error.flatten().fieldErrors, 400)
+      }
 
-    const result = await service.updateStatus(c.req.param('id'), parsed.data.status)
-    if (!result.ok) {
-      return fail(c, result.error, result.status)
-    }
+      const result = await service.updateStatus(c.req.param('id'), parsed.data.status)
+      if (!result.ok) {
+        return fail(c, result.error, result.status)
+      }
 
-    return ok(c, result.booking)
-  })
+      return ok(c, result.booking)
+    })
+    .post('/bookings/:id/cancel', async (c) => {
+      const user = requireUser(c)
 
-  bookings.post('/bookings/:id/cancel', async (c) => {
-    const user = requireUser(c)
+      const booking = await service.findById(c.req.param('id'))
+      if (!booking) {
+        return fail(c, 'Booking not found', 404)
+      }
 
-    const booking = await service.findById(c.req.param('id'))
-    if (!booking) {
-      return fail(c, 'Booking not found', 404)
-    }
+      // Ownership: non-privileged users can only cancel their own bookings (404 to avoid info leak)
+      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
+        return fail(c, 'Booking not found', 404)
+      }
 
-    // Ownership: non-privileged users can only cancel their own bookings (404 to avoid info leak)
-    if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
-      return fail(c, 'Booking not found', 404)
-    }
+      const result = await service.cancel(c.req.param('id'))
+      if (!result.ok) {
+        return fail(c, result.error, result.status)
+      }
 
-    const result = await service.cancel(c.req.param('id'))
-    if (!result.ok) {
-      return fail(c, result.error, result.status)
-    }
-
-    return ok(c, result.booking, 200, { cancellation: result.cancellation })
-  })
-
-  return bookings
+      return ok(c, result.booking, 200, { cancellation: result.cancellation })
+    })
 }

--- a/packages/api/src/routes/fleet-overview.ts
+++ b/packages/api/src/routes/fleet-overview.ts
@@ -3,16 +3,12 @@ import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { FleetOverviewRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
 
-export function createFleetOverviewRoutes(repo: FleetOverviewRepository): Hono {
-  const routes = new Hono()
-
-  routes.get('/vehicles/fleet-overview', async (c) => {
+export function createFleetOverviewRoutes(repo: FleetOverviewRepository) {
+  return new Hono().get('/vehicles/fleet-overview', async (c) => {
     const user = requireUser(c)
     if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
     const data = await repo.findFleetOverview()
     return ok(c, data)
   })
-
-  return routes
 }

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -1,9 +1,5 @@
 import { Hono } from 'hono'
 
-const health = new Hono()
-
-health.get('/health', (c) => {
+export default new Hono().get('/health', (c) => {
   return c.json({ status: 'ok' })
 })
-
-export default health

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -4,12 +4,7 @@ import { PRIVILEGED_ROLES, STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
-export function createMessageRoutes(
-  threadRepo: ThreadRepository,
-  messageRepo: MessageRepository,
-): Hono {
-  const app = new Hono()
-
+export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: MessageRepository) {
   function isParticipant(
     thread: { participants: Array<{ userId: string }> },
     userId: string,
@@ -17,86 +12,81 @@ export function createMessageRoutes(
     return thread.participants.some((p) => p.userId === userId)
   }
 
-  app.get('/threads', async (c) => {
-    const user = requireUser(c)
+  return new Hono()
+    .get('/threads', async (c) => {
+      const user = requireUser(c)
 
-    const limitParam = c.req.query('limit')
-    const offsetParam = c.req.query('offset')
+      const limitParam = c.req.query('limit')
+      const offsetParam = c.req.query('offset')
 
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : 25
-    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
-      return fail(c, 'limit must be between 1 and 100', 400)
-    }
-    const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
-    if (Number.isNaN(offset) || offset < 0) {
-      return fail(c, 'offset must be a non-negative integer', 400)
-    }
+      const limit = limitParam ? Number.parseInt(limitParam, 10) : 25
+      if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+        return fail(c, 'limit must be between 1 and 100', 400)
+      }
+      const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
+      if (Number.isNaN(offset) || offset < 0) {
+        return fail(c, 'offset must be a non-negative integer', 400)
+      }
 
-    const all = await threadRepo.findAll(user.id)
-    const page = all.slice(offset, offset + limit)
-    return ok(c, page, 200, { total: all.length, limit, offset })
-  })
+      const all = await threadRepo.findAll(user.id)
+      const page = all.slice(offset, offset + limit)
+      return ok(c, page, 200, { total: all.length, limit, offset })
+    })
+    .get('/threads/:id', async (c) => {
+      const user = requireUser(c)
 
-  app.get('/threads/:id', async (c) => {
-    const user = requireUser(c)
+      const thread = await threadRepo.findById(c.req.param('id'))
+      if (!thread) return fail(c, 'Thread not found', 404)
 
-    const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) return fail(c, 'Thread not found', 404)
+      if (!isParticipant(thread, user.id) && !STAFF_ROLES.has(user.role)) {
+        return fail(c, 'Thread not found', 404)
+      }
 
-    if (!isParticipant(thread, user.id) && !STAFF_ROLES.has(user.role)) {
-      return fail(c, 'Thread not found', 404)
-    }
+      return ok(c, thread)
+    })
+    .post('/threads', async (c) => {
+      const user = requireUser(c)
 
-    return ok(c, thread)
-  })
+      const parsed = await parseBody(c, createThreadSchema)
+      if (!parsed.ok) return parsed.response
 
-  app.post('/threads', async (c) => {
-    const user = requireUser(c)
+      if (!PRIVILEGED_ROLES.has(user.role) && !parsed.data.participantIds.includes(user.id)) {
+        return fail(c, 'Caller must be a participant', 400)
+      }
 
-    const parsed = await parseBody(c, createThreadSchema)
-    if (!parsed.ok) return parsed.response
+      const thread = await threadRepo.create(
+        parsed.data.bookingId ?? null,
+        parsed.data.participantIds,
+      )
+      return ok(c, thread, 201)
+    })
+    .post('/threads/:id/messages', async (c) => {
+      const user = requireUser(c)
 
-    if (!PRIVILEGED_ROLES.has(user.role) && !parsed.data.participantIds.includes(user.id)) {
-      return fail(c, 'Caller must be a participant', 400)
-    }
+      const thread = await threadRepo.findById(c.req.param('id'))
+      if (!thread) return fail(c, 'Thread not found', 404)
 
-    const thread = await threadRepo.create(
-      parsed.data.bookingId ?? null,
-      parsed.data.participantIds,
-    )
-    return ok(c, thread, 201)
-  })
+      if (!isParticipant(thread, user.id)) {
+        return fail(c, 'Thread not found', 404)
+      }
 
-  app.post('/threads/:id/messages', async (c) => {
-    const user = requireUser(c)
+      const parsed = await parseBody(c, sendMessageSchema)
+      if (!parsed.ok) return parsed.response
 
-    const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) return fail(c, 'Thread not found', 404)
+      const message = await messageRepo.create(thread.id, user.id, parsed.data.content)
+      return ok(c, message, 201)
+    })
+    .post('/threads/:id/read', async (c) => {
+      const user = requireUser(c)
 
-    if (!isParticipant(thread, user.id)) {
-      return fail(c, 'Thread not found', 404)
-    }
+      const thread = await threadRepo.findById(c.req.param('id'))
+      if (!thread) return fail(c, 'Thread not found', 404)
 
-    const parsed = await parseBody(c, sendMessageSchema)
-    if (!parsed.ok) return parsed.response
+      if (!isParticipant(thread, user.id)) {
+        return fail(c, 'Thread not found', 404)
+      }
 
-    const message = await messageRepo.create(thread.id, user.id, parsed.data.content)
-    return ok(c, message, 201)
-  })
-
-  app.post('/threads/:id/read', async (c) => {
-    const user = requireUser(c)
-
-    const thread = await threadRepo.findById(c.req.param('id'))
-    if (!thread) return fail(c, 'Thread not found', 404)
-
-    if (!isParticipant(thread, user.id)) {
-      return fail(c, 'Thread not found', 404)
-    }
-
-    await threadRepo.markAsRead(thread.id, user.id)
-    return ok(c, null)
-  })
-
-  return app
+      await threadRepo.markAsRead(thread.id, user.id)
+      return ok(c, null)
+    })
 }

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -11,9 +11,7 @@ function safeKeyCompare(a: string, b: string): boolean {
 }
 
 export function createStatsRoutes(statsRepo: StatsRepository) {
-  const app = new Hono()
-
-  app.get('/stats', async (c) => {
+  return new Hono().get('/stats', async (c) => {
     const apiKey = c.req.header('X-API-Key')
     const expectedKey = process.env.STATS_API_KEY
 
@@ -24,6 +22,4 @@ export function createStatsRoutes(statsRepo: StatsRepository) {
     const data = await statsRepo.getDashboardStats()
     return ok(c, data)
   })
-
-  return app
 }

--- a/packages/api/src/routes/vehicle-detail.ts
+++ b/packages/api/src/routes/vehicle-detail.ts
@@ -2,16 +2,12 @@ import { Hono } from 'hono'
 import type { VehicleDetailRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
 
-export function createVehicleDetailRoutes(repo: VehicleDetailRepository): Hono {
-  const routes = new Hono()
-
-  routes.get('/vehicles/:id/detail', async (c) => {
+export function createVehicleDetailRoutes(repo: VehicleDetailRepository) {
+  return new Hono().get('/vehicles/:id/detail', async (c) => {
     const detail = await repo.findVehicleDetail(c.req.param('id'))
     if (!detail) {
       return fail(c, 'Vehicle not found', 404)
     }
     return ok(c, detail)
   })
-
-  return routes
 }

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -8,138 +8,130 @@ import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { Vehicle, VehicleRepository } from '../repositories/types'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
-export function createVehicleRoutes(repo: VehicleRepository): Hono {
-  const vehicles = new Hono()
+export function createVehicleRoutes(repo: VehicleRepository) {
+  return new Hono()
+    .get('/vehicles', async (c) => {
+      const status = c.req.query('status')
+      const limitParam = c.req.query('limit')
+      const offsetParam = c.req.query('offset')
 
-  vehicles.get('/vehicles', async (c) => {
-    const status = c.req.query('status')
-    const limitParam = c.req.query('limit')
-    const offsetParam = c.req.query('offset')
+      const limit = limitParam ? Number.parseInt(limitParam, 10) : 50
+      if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+        return fail(c, 'limit must be between 1 and 100', 400)
+      }
+      const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
+      if (Number.isNaN(offset) || offset < 0) {
+        return fail(c, 'offset must be a non-negative integer', 400)
+      }
 
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : 50
-    if (Number.isNaN(limit) || limit < 1 || limit > 100) {
-      return fail(c, 'limit must be between 1 and 100', 400)
-    }
-    const offset = offsetParam ? Number.parseInt(offsetParam, 10) : 0
-    if (Number.isNaN(offset) || offset < 0) {
-      return fail(c, 'offset must be a non-negative integer', 400)
-    }
-
-    const all = status ? await repo.findAll({ status }) : await repo.findAll()
-    const page = all.slice(offset, offset + limit)
-    return ok(c, page, 200, { total: all.length, limit, offset })
-  })
-
-  vehicles.get('/vehicles/:id', async (c) => {
-    const vehicle = await repo.findById(c.req.param('id'))
-    if (!vehicle) {
-      return fail(c, 'Vehicle not found', 404)
-    }
-    return ok(c, vehicle)
-  })
-
-  vehicles.post('/vehicles', async (c) => {
-    const user = requireUser(c)
-    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
-
-    const parsed = await parseBody(c, createVehicleSchema)
-    if (!parsed.ok) return parsed.response
-
-    const vehicle = await repo.create({
-      name: parsed.data.name,
-      description: parsed.data.description ?? null,
-      photos: parsed.data.photos,
-      seats: parsed.data.seats,
-      transmission: parsed.data.transmission,
-      fuelType: parsed.data.fuelType ?? null,
-      status: 'AVAILABLE',
-      bufferMinutes: parsed.data.bufferMinutes,
-      minRentalHours: parsed.data.minRentalHours ?? null,
-      maxRentalHours: parsed.data.maxRentalHours ?? null,
-      advanceBookingHours: parsed.data.advanceBookingHours ?? null,
-      dailyRateJpy: parsed.data.dailyRateJpy ?? null,
-      hourlyRateJpy: parsed.data.hourlyRateJpy ?? null,
+      const all = status ? await repo.findAll({ status }) : await repo.findAll()
+      const page = all.slice(offset, offset + limit)
+      return ok(c, page, 200, { total: all.length, limit, offset })
     })
+    .get('/vehicles/:id', async (c) => {
+      const vehicle = await repo.findById(c.req.param('id'))
+      if (!vehicle) {
+        return fail(c, 'Vehicle not found', 404)
+      }
+      return ok(c, vehicle)
+    })
+    .post('/vehicles', async (c) => {
+      const user = requireUser(c)
+      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    return ok(c, vehicle, 201)
-  })
+      const parsed = await parseBody(c, createVehicleSchema)
+      if (!parsed.ok) return parsed.response
 
-  vehicles.patch('/vehicles/:id', async (c) => {
-    const user = requireUser(c)
-    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const vehicle = await repo.create({
+        name: parsed.data.name,
+        description: parsed.data.description ?? null,
+        photos: parsed.data.photos,
+        seats: parsed.data.seats,
+        transmission: parsed.data.transmission,
+        fuelType: parsed.data.fuelType ?? null,
+        status: 'AVAILABLE',
+        bufferMinutes: parsed.data.bufferMinutes,
+        minRentalHours: parsed.data.minRentalHours ?? null,
+        maxRentalHours: parsed.data.maxRentalHours ?? null,
+        advanceBookingHours: parsed.data.advanceBookingHours ?? null,
+        dailyRateJpy: parsed.data.dailyRateJpy ?? null,
+        hourlyRateJpy: parsed.data.hourlyRateJpy ?? null,
+      })
 
-    const existing = await repo.findById(c.req.param('id'))
-    if (!existing) {
-      return fail(c, 'Vehicle not found', 404)
-    }
+      return ok(c, vehicle, 201)
+    })
+    .patch('/vehicles/:id', async (c) => {
+      const user = requireUser(c)
+      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    const parsed = await parseBody(c, updateVehicleSchema)
-    if (!parsed.ok) return parsed.response
+      const existing = await repo.findById(c.req.param('id'))
+      if (!existing) {
+        return fail(c, 'Vehicle not found', 404)
+      }
 
-    // Merge patch with existing: use patch value if key was sent (even null),
-    // otherwise keep existing. `??` would swallow explicit nulls.
-    const d = parsed.data
-    const merge = <T>(key: string, fallback: T): T =>
-      key in d ? ((d as Record<string, unknown>)[key] as T) : fallback
+      const parsed = await parseBody(c, updateVehicleSchema)
+      if (!parsed.ok) return parsed.response
 
-    const changes = {
-      ...d,
-      description: merge('description', existing.description),
-      fuelType: merge('fuelType', existing.fuelType),
-      minRentalHours: merge('minRentalHours', existing.minRentalHours),
-      maxRentalHours: merge('maxRentalHours', existing.maxRentalHours),
-      advanceBookingHours: merge('advanceBookingHours', existing.advanceBookingHours),
-      dailyRateJpy: merge('dailyRateJpy', existing.dailyRateJpy),
-      hourlyRateJpy: merge('hourlyRateJpy', existing.hourlyRateJpy),
-    }
+      // Merge patch with existing: use patch value if key was sent (even null),
+      // otherwise keep existing. `??` would swallow explicit nulls.
+      const d = parsed.data
+      const merge = <T>(key: string, fallback: T): T =>
+        key in d ? ((d as Record<string, unknown>)[key] as T) : fallback
 
-    if (changes.dailyRateJpy == null && changes.hourlyRateJpy == null) {
-      return fail(c, 'At least one rate (daily or hourly) is required', 400)
-    }
+      const changes = {
+        ...d,
+        description: merge('description', existing.description),
+        fuelType: merge('fuelType', existing.fuelType),
+        minRentalHours: merge('minRentalHours', existing.minRentalHours),
+        maxRentalHours: merge('maxRentalHours', existing.maxRentalHours),
+        advanceBookingHours: merge('advanceBookingHours', existing.advanceBookingHours),
+        dailyRateJpy: merge('dailyRateJpy', existing.dailyRateJpy),
+        hourlyRateJpy: merge('hourlyRateJpy', existing.hourlyRateJpy),
+      }
 
-    const mergedMin = changes.minRentalHours
-    const mergedMax = changes.maxRentalHours
-    if (mergedMin != null && mergedMax != null && mergedMin > mergedMax) {
-      return fail(
-        c,
-        { maxRentalHours: ['Maximum rental hours must be greater than or equal to minimum'] },
-        400,
-      )
-    }
+      if (changes.dailyRateJpy == null && changes.hourlyRateJpy == null) {
+        return fail(c, 'At least one rate (daily or hourly) is required', 400)
+      }
 
-    const updated = await repo.update(existing.id, stripUndefined(changes) as Partial<Vehicle>)
+      const mergedMin = changes.minRentalHours
+      const mergedMax = changes.maxRentalHours
+      if (mergedMin != null && mergedMax != null && mergedMin > mergedMax) {
+        return fail(
+          c,
+          { maxRentalHours: ['Maximum rental hours must be greater than or equal to minimum'] },
+          400,
+        )
+      }
 
-    return ok(c, updated)
-  })
+      const updated = await repo.update(existing.id, stripUndefined(changes) as Partial<Vehicle>)
 
-  vehicles.patch('/vehicles/:id/status', async (c) => {
-    const user = requireUser(c)
-    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      return ok(c, updated)
+    })
+    .patch('/vehicles/:id/status', async (c) => {
+      const user = requireUser(c)
+      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    const existing = await repo.findById(c.req.param('id'))
-    if (!existing) {
-      return fail(c, 'Vehicle not found', 404)
-    }
+      const existing = await repo.findById(c.req.param('id'))
+      if (!existing) {
+        return fail(c, 'Vehicle not found', 404)
+      }
 
-    const parsed = await parseBody(c, updateVehicleStatusSchema)
-    if (!parsed.ok) return parsed.response
+      const parsed = await parseBody(c, updateVehicleStatusSchema)
+      if (!parsed.ok) return parsed.response
 
-    const updated = await repo.update(existing.id, { status: parsed.data.status })
-    return ok(c, updated)
-  })
+      const updated = await repo.update(existing.id, { status: parsed.data.status })
+      return ok(c, updated)
+    })
+    .delete('/vehicles/:id', async (c) => {
+      const user = requireUser(c)
+      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-  vehicles.delete('/vehicles/:id', async (c) => {
-    const user = requireUser(c)
-    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const existing = await repo.findById(c.req.param('id'))
+      if (!existing) {
+        return fail(c, 'Vehicle not found', 404)
+      }
 
-    const existing = await repo.findById(c.req.param('id'))
-    if (!existing) {
-      return fail(c, 'Vehicle not found', 404)
-    }
-
-    const retired = await repo.softDelete(existing.id)
-    return ok(c, retired)
-  })
-
-  return vehicles
+      const retired = await repo.softDelete(existing.id)
+      return ok(c, retired)
+    })
 }

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -5,7 +5,7 @@ type AppType = ReturnType<typeof createApp>
 
 const DEFAULT_API_URL = 'http://localhost:8787'
 
-export function getApiBaseUrl(): string {
+function getApiBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL ?? DEFAULT_API_URL
   return url.replace(/\/$/, '')
 }

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -10,8 +10,9 @@ function getApiBaseUrl(): string {
   return url.replace(/\/$/, '')
 }
 
+// Response body types require `as ApiResponse<T>` casts because the API's
+// ok()/fail() helpers return plain Response, not Hono's TypedResponse.
+// Full end-to-end inference requires removing `: Response` from those helpers.
 export function createApiClient() {
   return hc<AppType>(getApiBaseUrl())
 }
-
-export type ApiClient = ReturnType<typeof createApiClient>

--- a/packages/web/src/lib/bookings.ts
+++ b/packages/web/src/lib/bookings.ts
@@ -30,11 +30,12 @@ export async function checkAvailability(
   endAt: Date,
 ): Promise<boolean> {
   const client = createApiClient()
-  // query params read manually by parseDateRange() -- not in Hono's type sig
-  const res = await client.availability[':vehicleId'].$get({
-    param: { vehicleId },
-    query: { from: startAt.toISOString(), to: endAt.toISOString() },
-  } as { param: { vehicleId: string } })
+  // Query params read manually by parseDateRange() — not in Hono's type sig,
+  // so we use $url() for typed path construction + fetch for query params.
+  const url = client.availability[':vehicleId'].$url({ param: { vehicleId } })
+  url.searchParams.set('from', startAt.toISOString())
+  url.searchParams.set('to', endAt.toISOString())
+  const res = await fetch(url)
   const json = (await res.json()) as ApiResponse<{ available: boolean }>
 
   if (!json.success) return false

--- a/packages/web/src/lib/bookings.ts
+++ b/packages/web/src/lib/bookings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { auth } from '@/auth'
-import { getApiBaseUrl } from '@/lib/api-client'
+import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
 interface CreateBookingInput {
@@ -29,13 +29,13 @@ export async function checkAvailability(
   startAt: Date,
   endAt: Date,
 ): Promise<boolean> {
-  const base = getApiBaseUrl()
-  const from = encodeURIComponent(startAt.toISOString())
-  const to = encodeURIComponent(endAt.toISOString())
-  const res = await fetch(
-    `${base}/availability/${encodeURIComponent(vehicleId)}?from=${from}&to=${to}`,
-  )
-  const json: ApiResponse<{ available: boolean }> = await res.json()
+  const client = createApiClient()
+  // query params read manually by parseDateRange() -- not in Hono's type sig
+  const res = await client.availability[':vehicleId'].$get({
+    param: { vehicleId },
+    query: { from: startAt.toISOString(), to: endAt.toISOString() },
+  } as { param: { vehicleId: string } })
+  const json = (await res.json()) as ApiResponse<{ available: boolean }>
 
   if (!json.success) return false
 
@@ -68,12 +68,10 @@ export async function createBooking(input: CreateBookingInput): Promise<CreateBo
   // round-trip adds latency and creates a race window where two users both
   // pass the check but only one succeeds at insert time. Handle the 409
   // (constraint violation) with a user-friendly message instead.
-  const base = getApiBaseUrl()
+  const client = createApiClient()
   const idempotencyKey = crypto.randomUUID()
-  const res = await fetch(`${base}/bookings`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  const res = await client.bookings.$post({
+    json: {
       vehicleId: input.vehicleId,
       renterId: session.user.id,
       startAt: input.startAt,
@@ -81,16 +79,16 @@ export async function createBooking(input: CreateBookingInput): Promise<CreateBo
       source: 'DIRECT',
       idempotencyKey,
       ...(input.notes ? { notes: input.notes } : {}),
-    }),
+    },
   })
 
-  const json: {
+  const json = (await res.json()) as {
     success: boolean
     data?: { id: string }
     error?: string
     code?: string
     details?: { required?: number; actual?: number }
-  } = await res.json()
+  }
 
   if (json.success && json.data) {
     return { success: true, bookingId: json.data.id }
@@ -149,9 +147,11 @@ interface BookingWithVehicleResponse {
 }
 
 export async function getBookingsByRenterId(userId: string): Promise<BookingWithVehicle[]> {
-  const base = getApiBaseUrl()
-  const res = await fetch(`${base}/bookings?renterId=${encodeURIComponent(userId)}&expand=vehicle`)
-  const json: ApiResponse<BookingWithVehicleResponse[]> = await res.json()
+  const client = createApiClient()
+  const res = await client.bookings.$get({
+    query: { renterId: userId, expand: 'vehicle' },
+  })
+  const json = (await res.json()) as ApiResponse<BookingWithVehicleResponse[]>
 
   if (!json.success) return []
 
@@ -183,9 +183,9 @@ interface Booking {
 }
 
 export async function getBookingById(id: string): Promise<Booking | null> {
-  const base = getApiBaseUrl()
-  const res = await fetch(`${base}/bookings/${encodeURIComponent(id)}`)
-  const json: ApiResponse<Booking> = await res.json()
+  const client = createApiClient()
+  const res = await client.bookings[':id'].$get({ param: { id } })
+  const json = (await res.json()) as ApiResponse<Booking>
 
   if (!json.success) return null
 

--- a/packages/web/src/lib/calendar.ts
+++ b/packages/web/src/lib/calendar.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from '@/lib/api-client'
+import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
 export interface CalendarBooking {
@@ -14,15 +14,14 @@ export interface CalendarBooking {
 }
 
 export async function fetchCalendarBookings(from: string, to: string): Promise<CalendarBooking[]> {
-  const base = getApiBaseUrl()
-  const params = new URLSearchParams({ from, to })
-  const res = await fetch(`${base}/bookings?${params.toString()}`)
+  const client = createApiClient()
+  const res = await client.bookings.$get({ query: { from, to } })
 
   if (!res.ok) {
     throw new Error(`Failed to fetch bookings: HTTP ${res.status}`)
   }
 
-  const body: ApiResponse<CalendarBooking[]> = await res.json()
+  const body = (await res.json()) as ApiResponse<CalendarBooking[]>
   if (!body.success) {
     throw new Error(body.error ?? 'Invalid bookings response')
   }

--- a/packages/web/src/lib/dashboard-stats.ts
+++ b/packages/web/src/lib/dashboard-stats.ts
@@ -1,18 +1,17 @@
 import type { DashboardStats } from '@kuruma/shared/types/stats'
-import { getApiBaseUrl } from './api-client'
+import { createApiClient } from './api-client'
 
 export type { DashboardStats } from '@kuruma/shared/types/stats'
 
 export async function fetchDashboardStats(): Promise<DashboardStats | null> {
   try {
-    const res = await fetch(`${getApiBaseUrl()}/stats`, {
-      headers: {
-        'X-API-Key': process.env.STATS_API_KEY ?? '',
-      },
+    const client = createApiClient()
+    const res = await client.stats.$get(undefined, {
+      headers: { 'X-API-Key': process.env.STATS_API_KEY ?? '' },
     })
     if (!res.ok) return null
 
-    const body = await res.json()
+    const body = (await res.json()) as { success: boolean; data?: DashboardStats }
     if (!body?.success || !body?.data) return null
 
     const { totalBookings, activeVehicles, totalCustomers, unreadMessages } = body.data

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from '@/lib/api-client'
+import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 import type { CreateVehicleInput, VehicleStatus } from '@kuruma/shared/validators/vehicle'
 
@@ -38,12 +38,11 @@ export interface FleetVehicleOverviewData extends VehicleData {
   nextBooking: FleetBookingSummaryData | null
 }
 
-async function apiRequest<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init)
-  const body: ApiResponse<T> = await res.json().catch(() => ({
+async function unwrap<T>(res: Response): Promise<T> {
+  const body = (await res.json().catch(() => ({
     success: false as const,
     error: 'Unknown error',
-  }))
+  }))) as ApiResponse<T>
 
   if (!body.success) {
     throw new Error(body.error ?? `HTTP ${res.status}`)
@@ -53,15 +52,16 @@ async function apiRequest<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 export async function fetchVehicles(status?: string): Promise<VehicleData[]> {
-  const base = getApiBaseUrl()
-  const params = status ? `?status=${status}` : ''
-  return apiRequest<VehicleData[]>(`${base}/vehicles${params}`)
+  const client = createApiClient()
+  const res = await client.vehicles.$get(status ? { query: { status } } : (undefined as never))
+  return unwrap<VehicleData[]>(res)
 }
 
 export async function fetchVehicleById(id: string): Promise<VehicleData | null> {
-  const base = getApiBaseUrl()
+  const client = createApiClient()
   try {
-    return await apiRequest<VehicleData>(`${base}/vehicles/${id}`)
+    const res = await client.vehicles[':id'].$get({ param: { id } })
+    return await unwrap<VehicleData>(res)
   } catch (e) {
     if (e instanceof Error && e.message === 'Vehicle not found') return null
     throw e
@@ -69,41 +69,43 @@ export async function fetchVehicleById(id: string): Promise<VehicleData | null> 
 }
 
 export async function createVehicle(data: CreateVehicleInput): Promise<VehicleData> {
-  const base = getApiBaseUrl()
-  return apiRequest<VehicleData>(`${base}/vehicles`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  })
+  const client = createApiClient()
+  const res = await client.vehicles.$post({ json: data })
+  return unwrap<VehicleData>(res)
 }
 
 export async function updateVehicle(
   id: string,
   data: Partial<CreateVehicleInput>,
 ): Promise<VehicleData> {
-  const base = getApiBaseUrl()
-  return apiRequest<VehicleData>(`${base}/vehicles/${id}`, {
+  const client = createApiClient()
+  const url = client.vehicles[':id'].$url({ param: { id } })
+  const res = await fetch(url, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
+  return unwrap<VehicleData>(res)
 }
 
 // Issue #51: one-shot status mutation for the fleet list inline toggle.
 // Kept separate from updateVehicle() so callers don't accidentally ship a
 // partial vehicle payload when they only mean to flip a status.
 export async function updateVehicleStatus(id: string, status: VehicleStatus): Promise<VehicleData> {
-  const base = getApiBaseUrl()
-  return apiRequest<VehicleData>(`${base}/vehicles/${id}/status`, {
+  const client = createApiClient()
+  const url = client.vehicles[':id'].status.$url({ param: { id } })
+  const res = await fetch(url, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status }),
   })
+  return unwrap<VehicleData>(res)
 }
 
 export async function retireVehicle(id: string): Promise<VehicleData> {
-  const base = getApiBaseUrl()
-  return apiRequest<VehicleData>(`${base}/vehicles/${id}`, { method: 'DELETE' })
+  const client = createApiClient()
+  const res = await client.vehicles[':id'].$delete({ param: { id } })
+  return unwrap<VehicleData>(res)
 }
 
 // Issue #53: enriched detail for /manage/vehicles/[id]. Dates are ISO
@@ -131,9 +133,10 @@ export interface VehicleDetailData extends VehicleData {
 }
 
 export async function fetchVehicleDetail(id: string): Promise<VehicleDetailData | null> {
-  const base = getApiBaseUrl()
+  const client = createApiClient()
   try {
-    return await apiRequest<VehicleDetailData>(`${base}/vehicles/${id}/detail`)
+    const res = await client.vehicles[':id'].detail.$get({ param: { id } })
+    return await unwrap<VehicleDetailData>(res)
   } catch (e) {
     if (e instanceof Error && e.message === 'Vehicle not found') return null
     throw e
@@ -141,6 +144,7 @@ export async function fetchVehicleDetail(id: string): Promise<VehicleDetailData 
 }
 
 export async function fetchFleetOverview(): Promise<FleetVehicleOverviewData[]> {
-  const base = getApiBaseUrl()
-  return apiRequest<FleetVehicleOverviewData[]>(`${base}/vehicles/fleet-overview`)
+  const client = createApiClient()
+  const res = await client.vehicles['fleet-overview'].$get()
+  return unwrap<FleetVehicleOverviewData[]>(res)
 }

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -41,7 +41,7 @@ export interface FleetVehicleOverviewData extends VehicleData {
 async function unwrap<T>(res: Response): Promise<T> {
   const body = (await res.json().catch(() => ({
     success: false as const,
-    error: 'Unknown error',
+    error: `Non-JSON response (HTTP ${res.status})`,
   }))) as ApiResponse<T>
 
   if (!body.success) {
@@ -53,7 +53,9 @@ async function unwrap<T>(res: Response): Promise<T> {
 
 export async function fetchVehicles(status?: string): Promise<VehicleData[]> {
   const client = createApiClient()
-  const res = await client.vehicles.$get(status ? { query: { status } } : (undefined as never))
+  const res = status
+    ? await client.vehicles.$get({ query: { status } })
+    : await client.vehicles.$get()
   return unwrap<VehicleData[]>(res)
 }
 

--- a/packages/web/src/lib/vehicles.ts
+++ b/packages/web/src/lib/vehicles.ts
@@ -1,7 +1,7 @@
 import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
-export interface Vehicle {
+interface Vehicle {
   id: string
   name: string
   description: string | null

--- a/packages/web/src/lib/vehicles.ts
+++ b/packages/web/src/lib/vehicles.ts
@@ -1,7 +1,7 @@
-import { getApiBaseUrl } from '@/lib/api-client'
+import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
-interface Vehicle {
+export interface Vehicle {
   id: string
   name: string
   description: string | null
@@ -19,15 +19,14 @@ interface Vehicle {
 }
 
 export async function getAvailableVehicles(from?: string, to?: string): Promise<Vehicle[]> {
-  const base = getApiBaseUrl()
+  const client = createApiClient()
 
-  const url =
+  const res =
     from && to
-      ? `${base}/availability?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
-      : `${base}/vehicles?status=AVAILABLE`
+      ? await client.availability.$get({ query: { from, to } })
+      : await client.vehicles.$get({ query: { status: 'AVAILABLE' } })
 
-  const res = await fetch(url)
-  const json: ApiResponse<Vehicle[]> = await res.json()
+  const json = (await res.json()) as ApiResponse<Vehicle[]>
 
   if (!json.success) return []
 
@@ -35,9 +34,9 @@ export async function getAvailableVehicles(from?: string, to?: string): Promise<
 }
 
 export async function getVehicleById(id: string): Promise<Vehicle | null> {
-  const base = getApiBaseUrl()
-  const res = await fetch(`${base}/vehicles/${encodeURIComponent(id)}`)
-  const json: ApiResponse<Vehicle> = await res.json()
+  const client = createApiClient()
+  const res = await client.vehicles[':id'].$get({ param: { id } })
+  const json = (await res.json()) as ApiResponse<Vehicle>
 
   if (!json.success) return null
 

--- a/packages/web/tests/lib/api-client.test.ts
+++ b/packages/web/tests/lib/api-client.test.ts
@@ -1,7 +1,8 @@
-import { getApiBaseUrl } from '@/lib/api-client'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
-describe('getApiBaseUrl', () => {
+import { createApiClient } from '@/lib/api-client'
+
+describe('createApiClient', () => {
   let originalUrl: string | undefined
 
   beforeEach(() => {
@@ -16,18 +17,27 @@ describe('getApiBaseUrl', () => {
     }
   })
 
-  test('returns NEXT_PUBLIC_API_URL when set', () => {
+  test('returns an hc client targeting NEXT_PUBLIC_API_URL when set', () => {
     process.env.NEXT_PUBLIC_API_URL = 'https://api.kuruma.example.com'
-    expect(getApiBaseUrl()).toBe('https://api.kuruma.example.com')
+    const client = createApiClient()
+    // hc client exposes $url() on route segments — verify the base URL is correct
+    const url = client.vehicles.$url()
+    expect(url.origin).toBe('https://api.kuruma.example.com')
   })
 
-  test('returns localhost fallback when env var is not set', () => {
+  test('returns an hc client targeting localhost fallback when env var is not set', () => {
     Reflect.deleteProperty(process.env, 'NEXT_PUBLIC_API_URL')
-    expect(getApiBaseUrl()).toBe('http://localhost:8787')
+    const client = createApiClient()
+    const url = client.vehicles.$url()
+    expect(url.origin).toBe('http://localhost:8787')
   })
 
   test('strips trailing slash from URL', () => {
     process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com/'
-    expect(getApiBaseUrl()).toBe('https://api.example.com')
+    const client = createApiClient()
+    const url = client.vehicles.$url()
+    expect(url.origin).toBe('https://api.example.com')
+    // Ensure no double-slash in path
+    expect(url.pathname).toBe('/vehicles')
   })
 })

--- a/packages/web/tests/lib/dashboard-stats.test.ts
+++ b/packages/web/tests/lib/dashboard-stats.test.ts
@@ -25,12 +25,11 @@ describe('fetchDashboardStats', () => {
 
     await fetchDashboardStats()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: { 'X-API-Key': 'test-key' },
-      }),
-    )
+    const calledUrl = mockFetch.mock.calls[0]?.[0]?.toString() ?? ''
+    expect(calledUrl).toContain('/stats')
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('X-API-Key')).toBe('test-key')
   })
 
   test('returns parsed stats on success', async () => {

--- a/packages/web/tests/lib/vehicles.test.ts
+++ b/packages/web/tests/lib/vehicles.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/api-client', () => ({
-  getApiBaseUrl: () => 'http://localhost:8787',
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc('http://localhost:8787')
+  },
 }))
 
 import { getAvailableVehicles, getVehicleById } from '@/lib/vehicles'

--- a/packages/web/tests/modules/bookings/actions.test.ts
+++ b/packages/web/tests/modules/bookings/actions.test.ts
@@ -7,7 +7,10 @@ vi.mock('@/auth', () => ({
 }))
 
 vi.mock('@/lib/api-client', () => ({
-  getApiBaseUrl: () => 'http://localhost:8787',
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc('http://localhost:8787')
+  },
 }))
 
 import { createBooking } from '@/lib/bookings'

--- a/packages/web/tests/modules/bookings/bookings-lib.test.ts
+++ b/packages/web/tests/modules/bookings/bookings-lib.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/api-client', () => ({
-  getApiBaseUrl: () => 'http://localhost:8787',
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc('http://localhost:8787')
+  },
 }))
 
 vi.mock('@/auth', () => ({

--- a/packages/web/tests/modules/bookings/getBookingsByRenterId.test.ts
+++ b/packages/web/tests/modules/bookings/getBookingsByRenterId.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/api-client', () => ({
-  getApiBaseUrl: () => 'http://localhost:8787',
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc('http://localhost:8787')
+  },
 }))
 
 vi.mock('@/auth', () => ({

--- a/packages/web/tests/modules/vehicles/vehicle-api.test.ts
+++ b/packages/web/tests/modules/vehicles/vehicle-api.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const API_BASE = 'http://localhost:8787'
 
-// Mock getApiBaseUrl before importing the module under test
+// Mock createApiClient before importing the module under test
 vi.mock('@/lib/api-client', () => ({
-  getApiBaseUrl: () => API_BASE,
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc('http://localhost:8787')
+  },
 }))
 
 const mockVehicle = {
@@ -41,7 +44,8 @@ describe('vehicle-api', () => {
       const { fetchVehicles } = await import('@/lib/vehicle-api')
       const result = await fetchVehicles()
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles`, undefined)
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles`)
       expect(result).toEqual([mockVehicle])
     })
 
@@ -56,7 +60,8 @@ describe('vehicle-api', () => {
       const { fetchVehicles } = await import('@/lib/vehicle-api')
       await fetchVehicles('RETIRED')
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles?status=RETIRED`, undefined)
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles?status=RETIRED`)
     })
 
     it('throws on API error response', async () => {
@@ -84,7 +89,8 @@ describe('vehicle-api', () => {
       const { fetchVehicleById } = await import('@/lib/vehicle-api')
       const result = await fetchVehicleById('v1')
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles/v1`, undefined)
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles/v1`)
       expect(result).toEqual(mockVehicle)
     })
 
@@ -121,11 +127,11 @@ describe('vehicle-api', () => {
       const { createVehicle } = await import('@/lib/vehicle-api')
       const result = await createVehicle(input)
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
-      })
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles`)
+      const init = spy.mock.calls[0]?.[1] as RequestInit
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(init.body as string)).toEqual(input)
       expect(result.name).toBe('Honda Fit')
     })
   })
@@ -143,11 +149,11 @@ describe('vehicle-api', () => {
       const { updateVehicle } = await import('@/lib/vehicle-api')
       const result = await updateVehicle('v1', updates)
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles/v1`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updates),
-      })
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles/v1`)
+      const init = spy.mock.calls[0]?.[1] as RequestInit
+      expect(init.method).toBe('PATCH')
+      expect(JSON.parse(init.body as string)).toEqual(updates)
       expect(result.name).toBe('Updated Corolla')
     })
   })
@@ -166,11 +172,11 @@ describe('vehicle-api', () => {
       const { updateVehicleStatus } = await import('@/lib/vehicle-api')
       const result = await updateVehicleStatus('v1', 'MAINTENANCE')
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles/v1/status`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'MAINTENANCE' }),
-      })
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles/v1/status`)
+      const init = spy.mock.calls[0]?.[1] as RequestInit
+      expect(init.method).toBe('PATCH')
+      expect(JSON.parse(init.body as string)).toEqual({ status: 'MAINTENANCE' })
       expect(result.status).toBe('MAINTENANCE')
     })
 
@@ -202,7 +208,10 @@ describe('vehicle-api', () => {
       const { retireVehicle } = await import('@/lib/vehicle-api')
       const result = await retireVehicle('v1')
 
-      expect(spy).toHaveBeenCalledWith(`${API_BASE}/vehicles/v1`, { method: 'DELETE' })
+      const calledUrl = spy.mock.calls[0]?.[0]?.toString() ?? ''
+      expect(calledUrl).toBe(`${API_BASE}/vehicles/v1`)
+      const init = spy.mock.calls[0]?.[1] as RequestInit
+      expect(init.method).toBe('DELETE')
       expect(result.status).toBe('RETIRED')
     })
   })


### PR DESCRIPTION
## Summary

- Refactored API route factories in `packages/api` to chain with `.route()` for proper `hc<AppType>` type inference
- Migrated all raw `fetch()` calls in `packages/web` to use typed Hono RPC client (`hc`)
- Removed `getApiBaseUrl()` in favor of `createApiClient()` which returns a typed client
- Updated all web tests to mock the new client pattern

## Test plan

- [x] 216 web tests pass
- [x] All packages typecheck
- [ ] CI passes

Closes #180