### PR TITLE
test(web): harden hc client mocks

### DIFF
--- a/packages/web/tests/lib/dashboard-stats.test.ts
+++ b/packages/web/tests/lib/dashboard-stats.test.ts
@@ -1,5 +1,13 @@
-import { fetchDashboardStats } from '@/lib/dashboard-stats'
-import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const API_BASE = 'http://localhost:8787'
+
+vi.mock('@/lib/api-client', () => ({
+  createApiClient: () => {
+    const { hc } = require('hono/client')
+    return hc(API_BASE)
+  },
+}))
 
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
@@ -8,45 +16,49 @@ beforeAll(() => {
   process.env.STATS_API_KEY = 'test-key'
 })
 
+beforeEach(() => {
+  vi.resetModules()
+})
+
 afterEach(() => {
   mockFetch.mockReset()
 })
 
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 describe('fetchDashboardStats', () => {
   test('sends X-API-Key header', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          success: true,
-          data: { totalBookings: 0, activeVehicles: 0, totalCustomers: 0, unreadMessages: 0 },
-        }),
-    })
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: { totalBookings: 0, activeVehicles: 0, totalCustomers: 0, unreadMessages: 0 },
+      }),
+    )
 
+    const { fetchDashboardStats } = await import('@/lib/dashboard-stats')
     await fetchDashboardStats()
 
     const calledUrl = mockFetch.mock.calls[0]?.[0]?.toString() ?? ''
-    expect(calledUrl).toContain('/stats')
+    expect(calledUrl).toBe(`${API_BASE}/stats`)
     const init = mockFetch.mock.calls[0]?.[1] as RequestInit
     const headers = new Headers(init.headers)
     expect(headers.get('X-API-Key')).toBe('test-key')
   })
 
   test('returns parsed stats on success', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          success: true,
-          data: {
-            totalBookings: 10,
-            activeVehicles: 5,
-            totalCustomers: 20,
-            unreadMessages: 3,
-          },
-        }),
-    })
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: { totalBookings: 10, activeVehicles: 5, totalCustomers: 20, unreadMessages: 3 },
+      }),
+    )
 
+    const { fetchDashboardStats } = await import('@/lib/dashboard-stats')
     const result = await fetchDashboardStats()
 
     expect(result).toEqual({
@@ -58,11 +70,9 @@ describe('fetchDashboardStats', () => {
   })
 
   test('returns null when API returns non-ok response', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-    })
+    mockFetch.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }))
 
+    const { fetchDashboardStats } = await import('@/lib/dashboard-stats')
     const result = await fetchDashboardStats()
     expect(result).toBeNull()
   })
@@ -70,16 +80,15 @@ describe('fetchDashboardStats', () => {
   test('returns null when fetch throws (API unreachable)', async () => {
     mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
+    const { fetchDashboardStats } = await import('@/lib/dashboard-stats')
     const result = await fetchDashboardStats()
     expect(result).toBeNull()
   })
 
   test('returns null when response shape is unexpected', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ unexpected: true }),
-    })
+    mockFetch.mockResolvedValueOnce(jsonResponse({ unexpected: true }))
 
+    const { fetchDashboardStats } = await import('@/lib/dashboard-stats')
     const result = await fetchDashboardStats()
     expect(result).toBeNull()
   })

--- a/packages/web/tests/lib/vehicles.test.ts
+++ b/packages/web/tests/lib/vehicles.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const API_BASE = 'http://localhost:8787'
+
 vi.mock('@/lib/api-client', () => ({
   createApiClient: () => {
     const { hc } = require('hono/client')
@@ -49,8 +51,7 @@ describe('getAvailableVehicles', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1)
     const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0]?.toString() ?? ''
-    expect(calledUrl).toContain('/vehicles')
-    expect(calledUrl).not.toContain('/availability')
+    expect(calledUrl).toBe(`${API_BASE}/vehicles?status=AVAILABLE`)
     expect(result).toHaveLength(2)
     expect(result[0]?.name).toBe('Toyota Corolla')
   })
@@ -64,9 +65,7 @@ describe('getAvailableVehicles', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1)
     const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0]?.toString() ?? ''
-    expect(calledUrl).toContain('/availability')
-    expect(calledUrl).toContain('from=2026-04-10')
-    expect(calledUrl).toContain('to=2026-04-12')
+    expect(calledUrl).toBe(`${API_BASE}/availability?from=2026-04-10&to=2026-04-12`)
     expect(result).toHaveLength(1)
     expect(result[0]?.name).toBe('Toyota Corolla')
   })
@@ -108,7 +107,7 @@ describe('getVehicleById', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1)
     const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0]?.toString() ?? ''
-    expect(calledUrl).toContain('/vehicles/vehicle-001')
+    expect(calledUrl).toBe(`${API_BASE}/vehicles/vehicle-001`)
     expect(result).not.toBeNull()
     expect(result?.id).toBe('vehicle-001')
     expect(result?.name).toBe('Toyota Corolla')

--- a/packages/web/tests/modules/vehicles/vehicle-api.test.ts
+++ b/packages/web/tests/modules/vehicles/vehicle-api.test.ts
@@ -30,6 +30,7 @@ const mockVehicle = {
 describe('vehicle-api', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.resetModules()
   })
 
   describe('fetchVehicles', () => {


### PR DESCRIPTION
## Summary

- Add `vi.resetModules()` to `vehicle-api.test.ts` so dynamic imports get fresh modules
- Add `vi.mock('@/lib/api-client')` to `dashboard-stats.test.ts` for consistency with all other test files
- Upgrade `toContain` to `toBe` for URL assertions in `vehicles.test.ts` and `dashboard-stats.test.ts` (mutation resistance)
- Use real `Response` objects in `dashboard-stats.test.ts` instead of plain mocks

Follow-up to #216 — addresses code review findings on the test mocks.

## Test plan

- [x] 216 web tests pass
- [x] Pre-commit hooks pass (lint, typecheck)

Generated with [Claude Code](https://claude.com/claude-code)