### PR TITLE
fix(web): replace double scrollbar with seat count badges

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -183,7 +183,6 @@
         "transmissionAuto": "Auto",
         "transmissionManual": "Manual",
         "capacityHeading": "Capacity",
-        "seatsLabel": "{min}-{max} seats",
         "sortHeading": "Sort by",
         "sortUtilizationDesc": "Utilization: most booked first",
         "sortNameAsc": "Name A-Z",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -183,6 +183,7 @@
         "transmissionAuto": "Auto",
         "transmissionManual": "Manual",
         "capacityHeading": "Capacity",
+        "seatsBadgeLabel": "{count} seats",
         "sortHeading": "Sort by",
         "sortUtilizationDesc": "Utilization: most booked first",
         "sortNameAsc": "Name A-Z",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -183,7 +183,6 @@
         "transmissionAuto": "オートマ",
         "transmissionManual": "マニュアル",
         "capacityHeading": "定員",
-        "seatsLabel": "{min}〜{max}人乗り",
         "sortHeading": "並び替え",
         "sortUtilizationDesc": "稼働率 (高い順)",
         "sortNameAsc": "名前 (A-Z)",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -183,6 +183,7 @@
         "transmissionAuto": "オートマ",
         "transmissionManual": "マニュアル",
         "capacityHeading": "定員",
+        "seatsBadgeLabel": "{count}人乗り",
         "sortHeading": "並び替え",
         "sortUtilizationDesc": "稼働率 (高い順)",
         "sortNameAsc": "名前 (A-Z)",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -183,6 +183,7 @@
         "transmissionAuto": "自动",
         "transmissionManual": "手动",
         "capacityHeading": "座位数",
+        "seatsBadgeLabel": "{count} 座",
         "sortHeading": "排序",
         "sortUtilizationDesc": "使用率由高到低",
         "sortNameAsc": "名称 A-Z",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -183,7 +183,6 @@
         "transmissionAuto": "自动",
         "transmissionManual": "手动",
         "capacityHeading": "座位数",
-        "seatsLabel": "{min}-{max} 座",
         "sortHeading": "排序",
         "sortUtilizationDesc": "使用率由高到低",
         "sortNameAsc": "名称 A-Z",

--- a/packages/web/src/components/vehicles/FleetFilters.tsx
+++ b/packages/web/src/components/vehicles/FleetFilters.tsx
@@ -12,6 +12,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import type { FleetFilterState, SortOrder, Transmission, VehicleStatus } from '@/lib/fleet-filters'
 import { useTranslations } from 'next-intl'
+import { useMemo } from 'react'
 
 interface FleetFiltersProps {
   readonly filters: FleetFilterState
@@ -70,9 +71,16 @@ export function FleetFilters({
 
   const hasCapacityRange = seatsBounds.min < seatsBounds.max
 
-  const seatOptions: number[] = hasCapacityRange
-    ? Array.from({ length: seatsBounds.max - seatsBounds.min + 1 }, (_, i) => seatsBounds.min + i)
-    : []
+  const seatOptions = useMemo(
+    () =>
+      hasCapacityRange
+        ? Array.from(
+            { length: seatsBounds.max - seatsBounds.min + 1 },
+            (_, i) => seatsBounds.min + i,
+          )
+        : [],
+    [hasCapacityRange, seatsBounds.min, seatsBounds.max],
+  )
 
   const statusLabel = (status: VehicleStatus): string => tStatus(STATUS_LABEL_KEYS[status])
 
@@ -182,7 +190,6 @@ export function FleetFilters({
             <div className="flex flex-wrap gap-1.5">
               {seatOptions.map((seats) => {
                 const isSelected = filters.seats?.includes(seats) ?? false
-                const label = String(seats)
                 return (
                   <Badge
                     key={seats}
@@ -191,12 +198,12 @@ export function FleetFilters({
                       <button
                         type="button"
                         aria-pressed={isSelected}
-                        aria-label={label}
+                        aria-label={t('seatsBadgeLabel', { count: seats })}
                         onClick={() => handleSeatsToggle(seats)}
                       />
                     }
                   >
-                    {label}
+                    {seats}
                   </Badge>
                 )
               })}

--- a/packages/web/src/components/vehicles/FleetFilters.tsx
+++ b/packages/web/src/components/vehicles/FleetFilters.tsx
@@ -203,7 +203,7 @@ export function FleetFilters({
                       />
                     }
                   >
-                    {seats}
+                    {t('seatsBadgeLabel', { count: seats })}
                   </Badge>
                 )
               })}

--- a/packages/web/src/components/vehicles/FleetFilters.tsx
+++ b/packages/web/src/components/vehicles/FleetFilters.tsx
@@ -68,9 +68,11 @@ export function FleetFilters({
   const t = useTranslations('business.vehicles.filter')
   const tStatus = useTranslations('business.vehicles')
 
-  const seatsMin = filters.seatsMin ?? seatsBounds.min
-  const seatsMax = filters.seatsMax ?? seatsBounds.max
   const hasCapacityRange = seatsBounds.min < seatsBounds.max
+
+  const seatOptions: number[] = hasCapacityRange
+    ? Array.from({ length: seatsBounds.max - seatsBounds.min + 1 }, (_, i) => seatsBounds.min + i)
+    : []
 
   const statusLabel = (status: VehicleStatus): string => tStatus(STATUS_LABEL_KEYS[status])
 
@@ -93,23 +95,10 @@ export function FleetFilters({
     })
   }
 
-  const handleSeatsMinChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const nextMin = Number(event.target.value)
-    const clampedMax = Math.max(nextMin, seatsMax)
+  const handleSeatsToggle = (seats: number) => {
     onFiltersChange({
       ...filters,
-      seatsMin: nextMin,
-      seatsMax: clampedMax,
-    })
-  }
-
-  const handleSeatsMaxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const nextMax = Number(event.target.value)
-    const clampedMin = Math.min(seatsMin, nextMax)
-    onFiltersChange({
-      ...filters,
-      seatsMin: clampedMin,
-      seatsMax: nextMax,
+      seats: toggleInArray(filters.seats, seats),
     })
   }
 
@@ -190,28 +179,27 @@ export function FleetFilters({
           <Separator />
           <div className="space-y-2">
             <SectionHeading>{t('capacityHeading')}</SectionHeading>
-            <p className="text-sm text-foreground">
-              {t('seatsLabel', { min: seatsMin, max: seatsMax })}
-            </p>
-            <div className="space-y-2">
-              <input
-                type="range"
-                aria-label={t('capacityHeading')}
-                min={seatsBounds.min}
-                max={seatsBounds.max}
-                value={seatsMin}
-                onChange={handleSeatsMinChange}
-                className="w-full accent-primary"
-              />
-              <input
-                type="range"
-                aria-label={t('capacityHeading')}
-                min={seatsBounds.min}
-                max={seatsBounds.max}
-                value={seatsMax}
-                onChange={handleSeatsMaxChange}
-                className="w-full accent-primary"
-              />
+            <div className="flex flex-wrap gap-1.5">
+              {seatOptions.map((seats) => {
+                const isSelected = filters.seats?.includes(seats) ?? false
+                const label = String(seats)
+                return (
+                  <Badge
+                    key={seats}
+                    variant={isSelected ? 'default' : 'outline'}
+                    render={
+                      <button
+                        type="button"
+                        aria-pressed={isSelected}
+                        aria-label={label}
+                        onClick={() => handleSeatsToggle(seats)}
+                      />
+                    }
+                  >
+                    {label}
+                  </Badge>
+                )
+              })}
             </div>
           </div>
         </>

--- a/packages/web/src/lib/fleet-filters.ts
+++ b/packages/web/src/lib/fleet-filters.ts
@@ -7,8 +7,7 @@ export interface FleetFilterState {
   search?: string | undefined
   statuses?: VehicleStatus[] | undefined
   transmissions?: Transmission[] | undefined
-  seatsMin?: number | undefined
-  seatsMax?: number | undefined
+  seats?: number[] | undefined
 }
 
 // Generic in T so the owner list (FleetVehicleOverviewData) and any
@@ -37,14 +36,9 @@ export function filterVehicles<T extends FilterableVehicle>(
     result = result.filter((v) => allowed.has(v.transmission))
   }
 
-  if (filters.seatsMin !== undefined) {
-    const min = filters.seatsMin
-    result = result.filter((v) => v.seats >= min)
-  }
-
-  if (filters.seatsMax !== undefined) {
-    const max = filters.seatsMax
-    result = result.filter((v) => v.seats <= max)
+  if (filters.seats && filters.seats.length > 0) {
+    const allowed = new Set(filters.seats)
+    result = result.filter((v) => allowed.has(v.seats))
   }
 
   return result

--- a/packages/web/src/lib/fleet-filters.ts
+++ b/packages/web/src/lib/fleet-filters.ts
@@ -27,18 +27,18 @@ export function filterVehicles<T extends FilterableVehicle>(
   }
 
   if (filters.statuses && filters.statuses.length > 0) {
-    const allowed = new Set(filters.statuses)
-    result = result.filter((v) => allowed.has(v.status))
+    const allowedStatuses = new Set(filters.statuses)
+    result = result.filter((v) => allowedStatuses.has(v.status))
   }
 
   if (filters.transmissions && filters.transmissions.length > 0) {
-    const allowed = new Set(filters.transmissions)
-    result = result.filter((v) => allowed.has(v.transmission))
+    const allowedTransmissions = new Set(filters.transmissions)
+    result = result.filter((v) => allowedTransmissions.has(v.transmission))
   }
 
   if (filters.seats && filters.seats.length > 0) {
-    const allowed = new Set(filters.seats)
-    result = result.filter((v) => allowed.has(v.seats))
+    const allowedSeats = new Set(filters.seats)
+    result = result.filter((v) => allowedSeats.has(v.seats))
   }
 
   return result

--- a/packages/web/tests/components/vehicles/FleetFilters.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetFilters.test.tsx
@@ -94,10 +94,45 @@ describe('FleetFilters', () => {
     expect(onSortChange).toHaveBeenCalledWith('seats-desc')
   })
 
-  it('hides the capacity slider section when all vehicles have the same seat count', () => {
+  it('hides the capacity section when all vehicles have the same seat count', () => {
     render(<FleetFilters {...defaultProps} seatsBounds={{ min: 5, max: 5 }} />)
 
-    // The seats section heading should not be rendered when there is no range to pick from
-    expect(screen.queryByRole('slider')).toBeNull()
+    expect(screen.queryByText('capacityHeading')).toBeNull()
+  })
+
+  it('toggles a seat count badge on when clicked', async () => {
+    const onFiltersChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FleetFilters
+        {...defaultProps}
+        filters={{}}
+        onFiltersChange={onFiltersChange}
+        seatsBounds={{ min: 2, max: 5 }}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: '4' }))
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ seats: [4] }))
+  })
+
+  it('toggles a seat count badge off when already selected', async () => {
+    const onFiltersChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FleetFilters
+        {...defaultProps}
+        filters={{ seats: [4, 5] }}
+        onFiltersChange={onFiltersChange}
+        seatsBounds={{ min: 2, max: 5 }}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: '4' }))
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ seats: [5] }))
   })
 })

--- a/packages/web/tests/components/vehicles/FleetFilters.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetFilters.test.tsx
@@ -3,9 +3,14 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Mock next-intl so tests don't depend on translation content.
-// t(key) returns the key verbatim, so queries use keys (not English strings).
+// t(key) returns the key verbatim; t(key, params) appends param values
+// so badges with different counts get distinguishable accessible names.
 vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations: () => (key: string, params?: Record<string, unknown>) => {
+    if (!params) return key
+    const suffix = Object.values(params).join(',')
+    return `${key}(${suffix})`
+  },
 }))
 
 import { FleetFilters } from '@/components/vehicles/FleetFilters'
@@ -113,7 +118,7 @@ describe('FleetFilters', () => {
       />,
     )
 
-    await user.click(screen.getByRole('button', { name: '4' }))
+    await user.click(screen.getByRole('button', { name: 'seatsBadgeLabel(4)' }))
 
     expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ seats: [4] }))
   })
@@ -131,7 +136,7 @@ describe('FleetFilters', () => {
       />,
     )
 
-    await user.click(screen.getByRole('button', { name: '4' }))
+    await user.click(screen.getByRole('button', { name: 'seatsBadgeLabel(4)' }))
 
     expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ seats: [5] }))
   })

--- a/packages/web/tests/lib/fleet-filters.test.ts
+++ b/packages/web/tests/lib/fleet-filters.test.ts
@@ -111,18 +111,26 @@ describe('filterVehicles', () => {
     })
   })
 
-  describe('seats range filter', () => {
-    it('returns only vehicles within the seats range (inclusive)', () => {
+  describe('seats filter', () => {
+    it('returns only vehicles whose seat count is in the selected set', () => {
       const vehicles = [
         makeVehicle({ name: 'Kei', seats: 4 }),
         makeVehicle({ name: 'Sedan', seats: 5 }),
         makeVehicle({ name: 'Van', seats: 8 }),
       ]
 
-      const result = filterVehicles(vehicles, { seatsMin: 5, seatsMax: 7 })
+      const result = filterVehicles(vehicles, { seats: [5, 8] })
 
-      expect(result).toHaveLength(1)
-      expect(result[0]?.name).toBe('Sedan')
+      expect(result).toHaveLength(2)
+      expect(result.map((v) => v.name).sort()).toEqual(['Sedan', 'Van'])
+    })
+
+    it('returns all vehicles when seats filter is empty', () => {
+      const vehicles = [makeVehicle({ seats: 4 }), makeVehicle({ seats: 5 })]
+
+      const result = filterVehicles(vehicles, { seats: [] })
+
+      expect(result).toHaveLength(2)
     })
   })
 
@@ -139,8 +147,7 @@ describe('filterVehicles', () => {
         search: 'toyota',
         statuses: ['AVAILABLE'],
         transmissions: ['AUTO'],
-        seatsMin: 4,
-        seatsMax: 6,
+        seats: [4, 5, 6],
       })
 
       expect(result).toHaveLength(1)


### PR DESCRIPTION
## Summary
- Replace two `<input type="range">` sliders (min/max seats) with toggleable Badge chips in fleet filters
- Simplify `FleetFilterState` from `seatsMin`/`seatsMax` range to `seats?: number[]` set-based filter
- Add proper a11y labels via i18n (`seatsBadgeLabel`) across en/zh/ja locales
- Memoize seat options array

Closes #219

## Test plan
- [x] Unit tests: `filterVehicles` with `seats: [5, 8]` and empty `seats: []`
- [x] Component tests: badge toggle on/off, hidden when single seat count
- [x] TypeScript: clean `tsc --noEmit`
- [x] Biome lint + format: all hooks pass
- [ ] Visual: verify badges render correctly on fleet management page