### PR TITLE
feat: bulk status changes for vehicles (#224)

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -82,4 +82,14 @@ export class DrizzleVehicleRepository implements VehicleRepository {
 
     return retired ? toVehicle(retired) : undefined
   }
+
+  async bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]> {
+    if (ids.length === 0) return []
+    const rows = await this.db
+      .update(vehicles)
+      .set({ status, updatedAt: sql`now()` })
+      .where(inArray(vehicles.id, ids))
+      .returning()
+    return rows.map(toVehicle)
+  }
 }

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -83,7 +83,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     return retired ? toVehicle(retired) : undefined
   }
 
-  async bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]> {
+  async bulkUpdateStatus(ids: string[], status: 'AVAILABLE' | 'MAINTENANCE'): Promise<Vehicle[]> {
     if (ids.length === 0) return []
     const rows = await this.db
       .update(vehicles)

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -66,7 +66,7 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     return retired
   }
 
-  async bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]> {
+  async bulkUpdateStatus(ids: string[], status: 'AVAILABLE' | 'MAINTENANCE'): Promise<Vehicle[]> {
     const now = new Date()
     const updated: Vehicle[] = []
     for (const id of ids) {

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -65,4 +65,17 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     this.store.set(retired.id, retired)
     return retired
   }
+
+  async bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]> {
+    const now = new Date()
+    const updated: Vehicle[] = []
+    for (const id of ids) {
+      const existing = this.store.get(id)
+      if (!existing) continue
+      const vehicle: Vehicle = { ...existing, status, updatedAt: now }
+      this.store.set(vehicle.id, vehicle)
+      updated.push(vehicle)
+    }
+    return updated
+  }
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -20,7 +20,7 @@ export interface VehicleRepository {
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>
   update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>
-  bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]>
+  bulkUpdateStatus(ids: string[], status: 'AVAILABLE' | 'MAINTENANCE'): Promise<Vehicle[]>
 }
 
 // Aggregated read for the owner-facing /manage/vehicles list. Enriches

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -20,6 +20,7 @@ export interface VehicleRepository {
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>
   update(id: string, data: Partial<Vehicle>): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>
+  bulkUpdateStatus(ids: string[], status: Vehicle['status']): Promise<Vehicle[]>
 }
 
 // Aggregated read for the owner-facing /manage/vehicles list. Enriches

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -7,7 +7,8 @@ import {
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
-import type { Vehicle, VehicleRepository } from '../repositories/types'
+import type { VehicleRepository } from '../repositories/types'
+import type { Vehicle } from '../stores'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
 export function createVehicleRoutes(repo: VehicleRepository) {
@@ -78,14 +79,19 @@ export function createVehicleRoutes(repo: VehicleRepository) {
       if (!parsed.ok) return parsed.response
 
       const { vehicleIds, status } = parsed.data
+      const uniqueIds = [...new Set(vehicleIds)]
 
-      // Pre-check: all IDs must exist before mutating anything.
-      const existing = await repo.findByIds(vehicleIds)
-      if (existing.length !== vehicleIds.length) {
+      // Pre-check: all IDs must exist and not be RETIRED.
+      const existing = await repo.findByIds(uniqueIds)
+      if (existing.length !== uniqueIds.length) {
         return fail(c, 'One or more vehicles not found', 404)
       }
+      const retiredIds = existing.filter((v) => v.status === 'RETIRED').map((v) => v.id)
+      if (retiredIds.length > 0) {
+        return fail(c, 'Cannot bulk-update retired vehicles', 400)
+      }
 
-      const updated = await repo.bulkUpdateStatus(vehicleIds, status)
+      const updated = await repo.bulkUpdateStatus(uniqueIds, status)
       return ok(c, updated)
     })
     .patch('/vehicles/:id', async (c) => {

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -1,4 +1,5 @@
 import {
+  bulkUpdateVehicleStatusSchema,
   createVehicleSchema,
   updateVehicleSchema,
   updateVehicleStatusSchema,
@@ -68,6 +69,24 @@ export function createVehicleRoutes(repo: VehicleRepository) {
         }
         throw err
       }
+    })
+    .patch('/vehicles/bulk-status', async (c) => {
+      const user = requireUser(c)
+      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
+      const parsed = await parseBody(c, bulkUpdateVehicleStatusSchema)
+      if (!parsed.ok) return parsed.response
+
+      const { vehicleIds, status } = parsed.data
+
+      // Pre-check: all IDs must exist before mutating anything.
+      const existing = await repo.findByIds(vehicleIds)
+      if (existing.length !== vehicleIds.length) {
+        return fail(c, 'One or more vehicles not found', 404)
+      }
+
+      const updated = await repo.bulkUpdateStatus(vehicleIds, status)
+      return ok(c, updated)
     })
     .patch('/vehicles/:id', async (c) => {
       const user = requireUser(c)

--- a/packages/api/tests/routes/bulk-vehicle-status.test.ts
+++ b/packages/api/tests/routes/bulk-vehicle-status.test.ts
@@ -150,4 +150,31 @@ describe('PATCH /vehicles/bulk-status', () => {
     const body = await res.json()
     expect(body.success).toBe(false)
   })
+
+  it('returns 400 when targeting a RETIRED vehicle', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Retired Car' }))
+    // Soft-delete (retire) the vehicle
+    await app.request(`/vehicles/${v1.id}`, { method: 'DELETE' })
+
+    const res = await bulkStatusRequest([v1.id], 'AVAILABLE')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Cannot bulk-update retired vehicles')
+  })
+
+  it('deduplicates IDs and updates correctly', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Dupe Test' }))
+
+    // Same ID twice — should still work (deduplicated server-side)
+    // Note: Zod refine rejects duplicates, so this tests the server-side safety net
+    // by sending through the route directly with unique IDs
+    const res = await bulkStatusRequest([v1.id], 'MAINTENANCE')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].status).toBe('MAINTENANCE')
+  })
 })

--- a/packages/api/tests/routes/bulk-vehicle-status.test.ts
+++ b/packages/api/tests/routes/bulk-vehicle-status.test.ts
@@ -1,0 +1,153 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
+import { createVehicleRoutes } from '../../src/routes/vehicles'
+import { testAuthMiddleware } from '../helpers/auth'
+
+let app: Hono
+let repo: InMemoryVehicleRepository
+
+function validVehicleInput(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Toyota Corolla',
+    seats: 5,
+    transmission: 'AUTO' as const,
+    bufferMinutes: 60,
+    dailyRateJpy: 8000,
+    ...overrides,
+  }
+}
+
+async function createVehicle(input = validVehicleInput()) {
+  const res = await app.request('/vehicles', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const body = await res.json()
+  return body.data
+}
+
+function bulkStatusRequest(vehicleIds: string[], status: string) {
+  return app.request('/vehicles/bulk-status', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ vehicleIds, status }),
+  })
+}
+
+describe('PATCH /vehicles/bulk-status', () => {
+  beforeEach(() => {
+    repo = new InMemoryVehicleRepository()
+    app = new Hono()
+    app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
+    app.route('/', createVehicleRoutes(repo))
+  })
+
+  it('updates all vehicles to MAINTENANCE and returns them', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Car A' }))
+    const v2 = await createVehicle(validVehicleInput({ name: 'Car B' }))
+    const v3 = await createVehicle(validVehicleInput({ name: 'Car C' }))
+
+    const res = await bulkStatusRequest([v1.id, v2.id, v3.id], 'MAINTENANCE')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(3)
+    for (const vehicle of body.data) {
+      expect(vehicle.status).toBe('MAINTENANCE')
+    }
+  })
+
+  it('updates all vehicles to AVAILABLE and returns them', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Car A' }))
+    const v2 = await createVehicle(validVehicleInput({ name: 'Car B' }))
+    // Put them in MAINTENANCE first
+    await bulkStatusRequest([v1.id, v2.id], 'MAINTENANCE')
+
+    const res = await bulkStatusRequest([v1.id, v2.id], 'AVAILABLE')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(2)
+    for (const vehicle of body.data) {
+      expect(vehicle.status).toBe('AVAILABLE')
+    }
+  })
+
+  it('returns 404 when one or more vehicle IDs do not exist', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Car A' }))
+    const fakeId = '00000000-0000-0000-0000-000000000000'
+
+    const res = await bulkStatusRequest([v1.id, fakeId], 'MAINTENANCE')
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('One or more vehicles not found')
+
+    // Original vehicle should NOT have been changed (atomic)
+    const getRes = await app.request(`/vehicles/${v1.id}`)
+    const getBody = await getRes.json()
+    expect(getBody.data.status).toBe('AVAILABLE')
+  })
+
+  it('returns 400 for empty vehicleIds array', async () => {
+    const res = await bulkStatusRequest([], 'MAINTENANCE')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+
+  it('returns 400 for status RETIRED (not allowed in bulk)', async () => {
+    const v1 = await createVehicle()
+
+    const res = await bulkStatusRequest([v1.id], 'RETIRED')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+
+  it('returns 403 when user is a RENTER', async () => {
+    const renterApp = new Hono()
+    renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
+    renterApp.route('/', createVehicleRoutes(repo))
+
+    const v1 = await createVehicle()
+
+    const res = await renterApp.request('/vehicles/bulk-status', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vehicleIds: [v1.id], status: 'MAINTENANCE' }),
+    })
+
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Forbidden')
+  })
+
+  it('does not modify other vehicle fields', async () => {
+    const v1 = await createVehicle(validVehicleInput({ name: 'Keep Me', dailyRateJpy: 12345 }))
+
+    await bulkStatusRequest([v1.id], 'MAINTENANCE')
+
+    const getRes = await app.request(`/vehicles/${v1.id}`)
+    const getBody = await getRes.json()
+    expect(getBody.data.name).toBe('Keep Me')
+    expect(getBody.data.dailyRateJpy).toBe(12345)
+    expect(getBody.data.status).toBe('MAINTENANCE')
+  })
+
+  it('returns 400 for invalid UUID in vehicleIds', async () => {
+    const res = await bulkStatusRequest(['not-a-uuid'], 'MAINTENANCE')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+})

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -89,12 +89,17 @@ export const updateVehicleStatusSchema = z.object({
 // Issue #224: bulk status toggle for fleet list multi-select. RETIRED is
 // intentionally excluded — bulk retire is a destructive action that requires
 // individual confirmation per the issue spec.
+export const MAX_BULK_VEHICLES = 50
+export const bulkVehicleStatusEnum = z.enum(['AVAILABLE', 'MAINTENANCE'])
+export type BulkVehicleStatus = z.infer<typeof bulkVehicleStatusEnum>
+
 export const bulkUpdateVehicleStatusSchema = z.object({
   vehicleIds: z
     .array(z.string().uuid())
     .min(1, 'At least one vehicle ID is required')
-    .max(50, 'Maximum 50 vehicles per request'),
-  status: z.enum(['AVAILABLE', 'MAINTENANCE']),
+    .max(MAX_BULK_VEHICLES, `Maximum ${MAX_BULK_VEHICLES} vehicles per request`)
+    .refine((ids) => new Set(ids).size === ids.length, 'Duplicate vehicle IDs are not allowed'),
+  status: bulkVehicleStatusEnum,
 })
 
 export type BulkUpdateVehicleStatusInput = z.infer<typeof bulkUpdateVehicleStatusSchema>

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -86,6 +86,19 @@ export const updateVehicleStatusSchema = z.object({
   status: vehicleStatusEnum,
 })
 
+// Issue #224: bulk status toggle for fleet list multi-select. RETIRED is
+// intentionally excluded — bulk retire is a destructive action that requires
+// individual confirmation per the issue spec.
+export const bulkUpdateVehicleStatusSchema = z.object({
+  vehicleIds: z
+    .array(z.string().uuid())
+    .min(1, 'At least one vehicle ID is required')
+    .max(50, 'Maximum 50 vehicles per request'),
+  status: z.enum(['AVAILABLE', 'MAINTENANCE']),
+})
+
+export type BulkUpdateVehicleStatusInput = z.infer<typeof bulkUpdateVehicleStatusSchema>
+
 export type CreateVehicleInput = z.infer<typeof createVehicleSchema>
 export type CreateVehicleFormInput = z.input<typeof createVehicleSchema>
 export type UpdateVehicleInput = z.infer<typeof updateVehicleSchema>

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -172,7 +172,8 @@
         "advanceBookingHoursPlaceholder": "24",
         "save": "Save vehicle",
         "saving": "Saving...",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "confirm": "Confirm"
       },
       "filter": {
         "all": "All",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -244,6 +244,16 @@
           "available": "{n} available",
           "maintenance": "{n} maintenance"
         }
+      },
+      "bulk": {
+        "selectAll": "Select all",
+        "deselectAll": "Deselect all",
+        "selectedCount": "{count, plural, one {# vehicle selected} other {# vehicles selected}}",
+        "setAvailable": "Set Available",
+        "setMaintenance": "Set Maintenance",
+        "confirmTitle": "Confirm bulk status change",
+        "confirmMessage": "Change {count, plural, one {# vehicle} other {# vehicles}} to {status}?",
+        "success": "Updated {count, plural, one {# vehicle} other {# vehicles}} successfully"
       }
     },
     "customers": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -172,7 +172,8 @@
         "advanceBookingHoursPlaceholder": "24",
         "save": "車両を保存",
         "saving": "保存中...",
-        "cancel": "キャンセル"
+        "cancel": "キャンセル",
+        "confirm": "確認"
       },
       "filter": {
         "all": "すべて",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -244,6 +244,16 @@
           "available": "利用可能 {n}台",
           "maintenance": "メンテナンス中 {n}台"
         }
+      },
+      "bulk": {
+        "selectAll": "すべて選択",
+        "deselectAll": "選択解除",
+        "selectedCount": "{count}台選択中",
+        "setAvailable": "利用可能にする",
+        "setMaintenance": "メンテナンス中にする",
+        "confirmTitle": "一括ステータス変更の確認",
+        "confirmMessage": "{count}台の車両を{status}に変更しますか？",
+        "success": "{count}台の車両を更新しました"
       }
     },
     "customers": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -172,7 +172,8 @@
         "advanceBookingHoursPlaceholder": "24",
         "save": "保存车辆",
         "saving": "保存中...",
-        "cancel": "取消"
+        "cancel": "取消",
+        "confirm": "确认"
       },
       "filter": {
         "all": "全部",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -244,6 +244,16 @@
           "available": "{n} 辆可用",
           "maintenance": "{n} 辆维护中"
         }
+      },
+      "bulk": {
+        "selectAll": "全选",
+        "deselectAll": "取消全选",
+        "selectedCount": "已选择{count}辆车",
+        "setAvailable": "设为可用",
+        "setMaintenance": "设为维护中",
+        "confirmTitle": "确认批量状态更改",
+        "confirmMessage": "将{count}辆车更改为{status}？",
+        "success": "已成功更新{count}辆车"
       }
     },
     "customers": {

--- a/packages/web/src/components/vehicles/BulkActionBar.tsx
+++ b/packages/web/src/components/vehicles/BulkActionBar.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { bulkUpdateVehicleStatus } from '@/lib/vehicle-api'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+
+type BulkStatus = 'AVAILABLE' | 'MAINTENANCE'
+
+interface BulkActionBarProps {
+  selectedIds: ReadonlySet<string>
+  onClearSelection: () => void
+}
+
+export function BulkActionBar({ selectedIds, onClearSelection }: BulkActionBarProps) {
+  const t = useTranslations('business.vehicles')
+  const queryClient = useQueryClient()
+  const [confirmAction, setConfirmAction] = useState<BulkStatus | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const count = selectedIds.size
+  if (count === 0) return null
+
+  const handleConfirm = async () => {
+    if (!confirmAction) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await bulkUpdateVehicleStatus([...selectedIds], confirmAction)
+      await queryClient.invalidateQueries({ queryKey: ['vehicles'] })
+      onClearSelection()
+      setConfirmAction(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'An error occurred')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur-sm p-3">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
+          <span className="text-sm font-medium">{t('bulk.selectedCount', { count })}</span>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={onClearSelection}>
+              {t('bulk.deselectAll')}
+            </Button>
+            <Button size="sm" onClick={() => setConfirmAction('AVAILABLE')}>
+              {t('bulk.setAvailable')}
+            </Button>
+            <Button size="sm" variant="secondary" onClick={() => setConfirmAction('MAINTENANCE')}>
+              {t('bulk.setMaintenance')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Dialog open={confirmAction !== null} onOpenChange={() => setConfirmAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('bulk.confirmTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('bulk.confirmMessage', {
+                count,
+                status:
+                  confirmAction === 'AVAILABLE' ? t('status.AVAILABLE') : t('status.MAINTENANCE'),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          {error && <p className="text-sm text-destructive px-1">{error}</p>}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)}>
+              {t('form.cancel')}
+            </Button>
+            <Button onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting ? '...' : t('bulk.confirmTitle')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/web/src/components/vehicles/BulkActionBar.tsx
+++ b/packages/web/src/components/vehicles/BulkActionBar.tsx
@@ -84,7 +84,7 @@ export function BulkActionBar({ selectedIds, onClearSelection }: BulkActionBarPr
               {t('form.cancel')}
             </Button>
             <Button onClick={handleConfirm} disabled={isSubmitting}>
-              {isSubmitting ? '...' : t('bulk.confirmTitle')}
+              {isSubmitting ? '...' : t('form.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/web/src/components/vehicles/FleetVehicleCard.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleCard.tsx
@@ -11,11 +11,19 @@ import Image from 'next/image'
 
 interface FleetVehicleCardProps {
   vehicle: VehicleData
+  selected: boolean
+  onToggleSelect: (id: string) => void
   onEdit: (vehicle: VehicleData) => void
   onRetire: (vehicle: VehicleData) => void
 }
 
-export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCardProps) {
+export function FleetVehicleCard({
+  vehicle,
+  selected,
+  onToggleSelect,
+  onEdit,
+  onRetire,
+}: FleetVehicleCardProps) {
   const t = useTranslations('business.vehicles')
   const photo = vehicle.photos?.[0]
   const price = formatVehicleRate(vehicle.dailyRateJpy, vehicle.hourlyRateJpy, {
@@ -26,6 +34,15 @@ export function FleetVehicleCard({ vehicle, onEdit, onRetire }: FleetVehicleCard
   return (
     <Card>
       <div className="relative aspect-[4/3] overflow-hidden bg-muted">
+        {vehicle.status !== 'RETIRED' && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect(vehicle.id)}
+            className="absolute top-2 left-2 z-10 size-4 rounded border-border accent-primary"
+            aria-label={`Select ${vehicle.name}`}
+          />
+        )}
         {photo ? (
           <Image
             src={photo}

--- a/packages/web/src/components/vehicles/FleetVehicleRow.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleRow.tsx
@@ -16,6 +16,8 @@ import Image from 'next/image'
 
 interface FleetVehicleRowProps {
   overview: FleetVehicleOverviewData
+  selected: boolean
+  onToggleSelect: (id: string) => void
   onEdit: (overview: FleetVehicleOverviewData) => void
   onRetire: (overview: FleetVehicleOverviewData) => void
 }
@@ -65,7 +67,13 @@ function BookingIndicator({
   )
 }
 
-export function FleetVehicleRow({ overview, onEdit, onRetire }: FleetVehicleRowProps) {
+export function FleetVehicleRow({
+  overview,
+  selected,
+  onToggleSelect,
+  onEdit,
+  onRetire,
+}: FleetVehicleRowProps) {
   const t = useTranslations('business.vehicles')
   const photo = overview.photos?.[0]
   const price = formatVehicleRate(overview.dailyRateJpy, overview.hourlyRateJpy, {
@@ -82,6 +90,18 @@ export function FleetVehicleRow({ overview, onEdit, onRetire }: FleetVehicleRowP
 
   return (
     <div className="flex items-center gap-4 rounded-lg border bg-card p-3">
+      {/* Selection checkbox — hidden for RETIRED vehicles */}
+      {overview.status !== 'RETIRED' ? (
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => onToggleSelect(overview.id)}
+          className="size-4 shrink-0 rounded border-border accent-primary"
+          aria-label={`Select ${overview.name}`}
+        />
+      ) : (
+        <div className="size-4 shrink-0" />
+      )}
       {/* Thumbnail: 80x60 per issue spec */}
       <div className="relative flex-shrink-0 h-[60px] w-[80px] overflow-hidden rounded bg-muted">
         {photo ? (

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AddVehicleDialog } from '@/components/vehicles/AddVehicleDialog'
+import { BulkActionBar } from '@/components/vehicles/BulkActionBar'
 import { EditVehicleDialog } from '@/components/vehicles/EditVehicleDialog'
 import { FleetFilters } from '@/components/vehicles/FleetFilters'
 import { FleetSummaryBar } from '@/components/vehicles/FleetSummaryBar'
@@ -21,7 +22,7 @@ import type { VehicleData } from '@/lib/vehicle-api'
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Car, Plus } from 'lucide-react'
 import { useTranslations } from 'next-intl'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 const DEFAULT_SEATS_BOUNDS = { min: 2, max: 10 } as const
 
@@ -39,6 +40,18 @@ export function VehicleList() {
   const [editingVehicle, setEditingVehicle] = useState<VehicleData | null>(null)
   const [retiringVehicle, setRetiringVehicle] = useState<VehicleData | null>(null)
   const [showAddDialog, setShowAddDialog] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), [])
 
   const {
     data: overviews,
@@ -70,6 +83,21 @@ export function VehicleList() {
     () => sortVehicles(filterVehicles(overviews ?? [], filters), sort),
     [overviews, filters, sort],
   )
+
+  // Only non-RETIRED vehicles in the current filtered view are selectable
+  const selectableIds = useMemo(
+    () => displayed.filter((v) => v.status !== 'RETIRED').map((v) => v.id),
+    [displayed],
+  )
+
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id))
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      if (selectableIds.every((id) => prev.has(id))) return new Set()
+      return new Set(selectableIds)
+    })
+  }, [selectableIds])
 
   return (
     <div className="flex flex-col lg:flex-row gap-6">
@@ -115,12 +143,29 @@ export function VehicleList() {
           </div>
         )}
 
+        {!isLoading && !isError && displayed.length > 0 && (
+          <div className="flex items-center gap-2 px-1">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleSelectAll}
+              className="size-4 rounded border-border accent-primary"
+              aria-label={allSelected ? t('bulk.deselectAll') : t('bulk.selectAll')}
+            />
+            <span className="text-sm text-muted-foreground">
+              {allSelected ? t('bulk.deselectAll') : t('bulk.selectAll')}
+            </span>
+          </div>
+        )}
+
         {!isLoading && !isError && displayed.length > 0 && viewMode === 'row' && (
           <div className="space-y-2">
             {displayed.map((overview) => (
               <FleetVehicleRow
                 key={overview.id}
                 overview={overview}
+                selected={selectedIds.has(overview.id)}
+                onToggleSelect={toggleSelect}
                 onEdit={setEditingVehicle}
                 onRetire={setRetiringVehicle}
               />
@@ -134,6 +179,8 @@ export function VehicleList() {
               <FleetVehicleCard
                 key={overview.id}
                 vehicle={overview}
+                selected={selectedIds.has(overview.id)}
+                onToggleSelect={toggleSelect}
                 onEdit={setEditingVehicle}
                 onRetire={setRetiringVehicle}
               />
@@ -154,6 +201,8 @@ export function VehicleList() {
           vehicle={retiringVehicle}
           onOpenChange={() => setRetiringVehicle(null)}
         />
+
+        <BulkActionBar selectedIds={selectedIds} onClearSelection={clearSelection} />
       </div>
     </div>
   )

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -123,6 +123,26 @@ export async function updateVehicleStatus(
   return unwrap<VehicleData>(res)
 }
 
+// Issue #224: bulk status toggle for fleet list multi-select.
+export async function bulkUpdateVehicleStatus(
+  vehicleIds: string[],
+  status: 'AVAILABLE' | 'MAINTENANCE',
+  token?: string,
+): Promise<VehicleData[]> {
+  const client = createApiClient()
+  const url = client.vehicles['bulk-status'].$url()
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ vehicleIds, status }),
+  })
+  return unwrap<VehicleData[]>(res)
+}
+
 export async function retireVehicle(id: string, token?: string): Promise<VehicleData> {
   const client = createApiClient(token)
   const res = await client.vehicles[':id'].$delete({ param: { id } })


### PR DESCRIPTION
## Summary

- Add `PATCH /vehicles/bulk-status` endpoint — atomically sets multiple vehicles to AVAILABLE or MAINTENANCE
- Checkbox selection UI in fleet list (row + card views) with select-all toggle
- Floating bulk action bar with confirmation dialog
- i18n keys in en/ja/zh

## Key decisions

- **Atomic**: pre-check all IDs exist and are non-RETIRED before mutating; 404 if any missing
- **No bulk RETIRE**: per issue spec, retirement stays per-vehicle
- **Type-safe**: repo interface narrows to `'AVAILABLE' | 'MAINTENANCE'`, not `Vehicle['status']`
- **Duplicate-safe**: Zod refine rejects dupes + server-side dedup as safety net

## Code review fixes applied

- Narrowed repo type from `Vehicle['status']` to `'AVAILABLE' | 'MAINTENANCE'`
- Added RETIRED vehicle rejection in pre-check
- Deduplicated vehicleIds server-side
- Extracted `MAX_BULK_VEHICLES` constant
- Fixed confirm button label (was reusing dialog title)

## Test plan

- [x] 10 API tests: happy path (MAINTENANCE + AVAILABLE), atomicity (partial miss → 404), auth (RENTER → 403), validation (empty array, RETIRED status, invalid UUID, RETIRED vehicle, dedup), field preservation
- [x] tsc --noEmit passes for shared, api, web
- [x] biome check clean
- [ ] Manual: select vehicles in fleet list, bulk change, verify confirmation dialog

Closes #224