### PR TITLE
feat(web): vehicle booking calendar with week/month views

### DIFF
--- a/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
@@ -1,3 +1,4 @@
+import { VehicleBookingCalendar } from '@/components/calendar/VehicleBookingCalendar'
 import { Badge } from '@/components/ui/badge'
 import { buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -154,6 +155,9 @@ export function VehicleDetail({ vehicle, t }: VehicleDetailProps) {
               <UtilizationChart data={vehicle.utilizationLast30Days} />
             </CardContent>
           </Card>
+
+          {/* Booking calendar */}
+          <VehicleBookingCalendar vehicleId={vehicle.id} />
         </div>
 
         {/* Right column: revenue + upcoming bookings */}

--- a/packages/web/src/components/calendar/BookingBlock.tsx
+++ b/packages/web/src/components/calendar/BookingBlock.tsx
@@ -11,8 +11,13 @@ interface BookingBlockProps {
   readonly onClick: () => void
 }
 
+const FALLBACK_COLORS = {
+  bg: 'bg-gray-100 dark:bg-gray-900',
+  text: 'text-gray-800 dark:text-gray-200',
+} as const
+
 function getSourceColor(source: string): { bg: string; text: string } {
-  return SOURCE_COLORS[source] ?? SOURCE_COLORS.OTHER!
+  return SOURCE_COLORS[source] ?? FALLBACK_COLORS
 }
 
 export function BookingBlock({ booking, variant, onClick }: BookingBlockProps) {

--- a/packages/web/src/components/calendar/BookingBlock.tsx
+++ b/packages/web/src/components/calendar/BookingBlock.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import type { CalendarBooking } from '@/lib/calendar'
+import { cn } from '@/lib/utils'
+import { format } from 'date-fns'
+import { SOURCE_COLORS } from './calendar-utils'
+
+interface BookingBlockProps {
+  readonly booking: CalendarBooking
+  readonly variant: 'bar' | 'chip'
+  readonly onClick: () => void
+}
+
+function getSourceColor(source: string): { bg: string; text: string } {
+  return SOURCE_COLORS[source] ?? SOURCE_COLORS.OTHER!
+}
+
+export function BookingBlock({ booking, variant, onClick }: BookingBlockProps) {
+  const colors = getSourceColor(booking.source)
+
+  if (variant === 'chip') {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'flex w-full items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left text-[11px] leading-tight',
+          'cursor-pointer hover:brightness-110 transition-all',
+          colors.bg,
+          colors.text,
+        )}
+      >
+        <span
+          className={cn('size-1.5 shrink-0 rounded-full', colors.text)}
+          style={{ backgroundColor: 'currentColor' }}
+        />
+        <span className="truncate">
+          {format(new Date(booking.startAt), 'HH:mm')}
+          {booking.renterName ? ` ${booking.renterName}` : ''}
+        </span>
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'absolute inset-x-0.5 overflow-hidden rounded px-1.5 py-0.5 text-[11px] leading-tight',
+        'cursor-pointer hover:brightness-110 transition-all',
+        colors.bg,
+        colors.text,
+      )}
+    >
+      <span className="font-medium">
+        {format(new Date(booking.startAt), 'HH:mm')} - {format(new Date(booking.endAt), 'HH:mm')}
+      </span>
+      {booking.renterName && (
+        <span className="block truncate opacity-80">{booking.renterName}</span>
+      )}
+    </button>
+  )
+}

--- a/packages/web/src/components/calendar/CalendarMonthView.tsx
+++ b/packages/web/src/components/calendar/CalendarMonthView.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import type { CalendarBooking } from '@/lib/calendar'
+import { cn } from '@/lib/utils'
+import {
+  eachDayOfInterval,
+  endOfMonth,
+  format,
+  getDay,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+} from 'date-fns'
+import { useMemo } from 'react'
+import { BookingBlock } from './BookingBlock'
+
+interface CalendarMonthViewProps {
+  readonly bookings: readonly CalendarBooking[]
+  readonly month: number
+  readonly year: number
+  readonly onBookingClick: (booking: CalendarBooking) => void
+}
+
+const DAY_HEADERS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const
+const MAX_VISIBLE_CHIPS = 3
+
+function getMonthDays(year: number, month: number): Date[] {
+  const monthStart = startOfMonth(new Date(year, month))
+  const monthEnd = endOfMonth(monthStart)
+  return eachDayOfInterval({ start: monthStart, end: monthEnd })
+}
+
+function getLeadingBlanks(year: number, month: number): number {
+  const firstDay = getDay(startOfMonth(new Date(year, month)))
+  // Convert Sunday=0 to Monday-start: Mon=0, Tue=1, ... Sun=6
+  return firstDay === 0 ? 6 : firstDay - 1
+}
+
+function groupBookingsByDate(bookings: readonly CalendarBooking[]): Map<string, CalendarBooking[]> {
+  const map = new Map<string, CalendarBooking[]>()
+
+  for (const booking of bookings) {
+    const start = new Date(booking.startAt)
+    const end = new Date(booking.endAt)
+
+    // Add booking to every day it spans
+    let current = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+    const endDay = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+
+    while (current <= endDay) {
+      const key = format(current, 'yyyy-MM-dd')
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(booking)
+      } else {
+        map.set(key, [booking])
+      }
+      current = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 1)
+    }
+  }
+
+  return map
+}
+
+export function CalendarMonthView({
+  bookings,
+  month,
+  year,
+  onBookingClick,
+}: CalendarMonthViewProps) {
+  const days = useMemo(() => getMonthDays(year, month), [year, month])
+  const leadingBlanks = useMemo(() => getLeadingBlanks(year, month), [year, month])
+  const bookingsByDate = useMemo(() => groupBookingsByDate(bookings), [bookings])
+
+  const referenceDate = new Date(year, month, 1)
+
+  return (
+    <div className="rounded-lg border">
+      {/* Day headers */}
+      <div className="grid grid-cols-7 border-b">
+        {DAY_HEADERS.map((day) => (
+          <div key={day} className="p-2 text-center text-xs font-medium text-muted-foreground">
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7">
+        {/* Leading blank cells (static count per month, never reorder) */}
+        {Array.from({ length: leadingBlanks }, (_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: blank spacer cells have no stable ID
+          <div key={`blank-${i}`} className="min-h-[80px] border-b border-r p-1.5 opacity-40" />
+        ))}
+
+        {/* Actual days */}
+        {days.map((day) => {
+          const key = format(day, 'yyyy-MM-dd')
+          const dayBookings = bookingsByDate.get(key) ?? []
+          const overflowCount = dayBookings.length - MAX_VISIBLE_CHIPS
+          const inMonth = isSameMonth(day, referenceDate)
+
+          return (
+            <div
+              key={key}
+              className={cn(
+                'min-h-[80px] border-b border-r p-1.5',
+                !inMonth && 'opacity-40',
+                isToday(day) && 'bg-primary/10',
+              )}
+            >
+              <div className={cn('mb-1 text-xs', isToday(day) && 'font-semibold text-primary')}>
+                {format(day, 'd')}
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {dayBookings.slice(0, MAX_VISIBLE_CHIPS).map((booking) => (
+                  <BookingBlock
+                    key={booking.id}
+                    booking={booking}
+                    variant="chip"
+                    onClick={() => onBookingClick(booking)}
+                  />
+                ))}
+                {overflowCount > 0 && (
+                  <span className="text-[10px] text-muted-foreground pl-1.5">
+                    +{overflowCount} more
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/calendar/CalendarMonthView.tsx
+++ b/packages/web/src/components/calendar/CalendarMonthView.tsx
@@ -49,12 +49,7 @@ function groupBookingsByDate(bookings: readonly CalendarBooking[]): Map<string, 
 
     while (current <= endDay) {
       const key = format(current, 'yyyy-MM-dd')
-      const existing = map.get(key)
-      if (existing) {
-        existing.push(booking)
-      } else {
-        map.set(key, [booking])
-      }
+      map.set(key, [...(map.get(key) ?? []), booking])
       current = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 1)
     }
   }

--- a/packages/web/src/components/calendar/CalendarNavigation.tsx
+++ b/packages/web/src/components/calendar/CalendarNavigation.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { addMonths, addWeeks, endOfWeek, format, startOfWeek, subMonths, subWeeks } from 'date-fns'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface CalendarNavigationProps {
+  readonly currentDate: Date
+  readonly viewMode: 'week' | 'month'
+  readonly onDateChange: (date: Date) => void
+  readonly onViewModeChange: (mode: 'week' | 'month') => void
+}
+
+function formatLabel(date: Date, viewMode: 'week' | 'month'): string {
+  if (viewMode === 'month') {
+    return format(date, 'MMMM yyyy')
+  }
+  const weekStart = startOfWeek(date, { weekStartsOn: 1 })
+  const weekEnd = endOfWeek(date, { weekStartsOn: 1 })
+  return `${format(weekStart, 'MMM d')} - ${format(weekEnd, 'd, yyyy')}`
+}
+
+export function CalendarNavigation({
+  currentDate,
+  viewMode,
+  onDateChange,
+  onViewModeChange,
+}: CalendarNavigationProps) {
+  const handlePrev = () => {
+    onDateChange(viewMode === 'week' ? subWeeks(currentDate, 1) : subMonths(currentDate, 1))
+  }
+
+  const handleNext = () => {
+    onDateChange(viewMode === 'week' ? addWeeks(currentDate, 1) : addMonths(currentDate, 1))
+  }
+
+  const handleToday = () => {
+    onDateChange(new Date())
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-1">
+        <Button variant="outline" size="icon" onClick={handlePrev} aria-label="Previous">
+          <ChevronLeft className="size-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleToday}>
+          Today
+        </Button>
+        <Button variant="outline" size="icon" onClick={handleNext} aria-label="Next">
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      <span className="text-sm font-medium">{formatLabel(currentDate, viewMode)}</span>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant={viewMode === 'week' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => onViewModeChange('week')}
+        >
+          Week
+        </Button>
+        <Button
+          variant={viewMode === 'month' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => onViewModeChange('month')}
+        >
+          Month
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/calendar/CalendarWeekView.tsx
+++ b/packages/web/src/components/calendar/CalendarWeekView.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import type { CalendarBooking } from '@/lib/calendar'
+import { cn } from '@/lib/utils'
+import { addDays, format, isToday, startOfWeek } from 'date-fns'
+import { useMemo } from 'react'
+import { BookingBlock } from './BookingBlock'
+import {
+  PIXELS_PER_HOUR,
+  bookingToWeekPosition,
+  getHourSlots,
+  splitMultiDayBooking,
+} from './calendar-utils'
+
+interface CalendarWeekViewProps {
+  readonly bookings: readonly CalendarBooking[]
+  readonly weekStart: Date
+  readonly onBookingClick: (booking: CalendarBooking) => void
+}
+
+function getDayColumns(weekStart: Date): Date[] {
+  const monday = startOfWeek(weekStart, { weekStartsOn: 1 })
+  return Array.from({ length: 7 }, (_, i) => addDays(monday, i))
+}
+
+interface PositionedBooking {
+  booking: CalendarBooking
+  top: number
+  height: number
+}
+
+export function CalendarWeekView({ bookings, weekStart, onBookingClick }: CalendarWeekViewProps) {
+  const hours = getHourSlots()
+  const days = useMemo(() => getDayColumns(weekStart), [weekStart])
+
+  const rangeStart = days[0]!
+  const rangeEnd = addDays(days[6]!, 1)
+
+  const bookingsByDay = useMemo(() => {
+    const map = new Map<number, PositionedBooking[]>()
+
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
+      map.set(dayIdx, [])
+    }
+
+    for (const booking of bookings) {
+      const segments = splitMultiDayBooking(booking, rangeStart, rangeEnd)
+      for (const segment of segments) {
+        const dayIdx = days.findIndex((d) => d.toDateString() === segment.date.toDateString())
+        if (dayIdx < 0) continue
+
+        const day = days[dayIdx]!
+        const { top, height } = bookingToWeekPosition(booking.startAt, booking.endAt, day)
+        if (height <= 0) continue
+
+        map.get(dayIdx)!.push({ booking, top, height })
+      }
+    }
+
+    return map
+  }, [bookings, days, rangeStart, rangeEnd])
+
+  const totalHeight = 24 * PIXELS_PER_HOUR
+
+  // Current time indicator
+  const now = new Date()
+  const isCurrentWeek = days.some((d) => isToday(d))
+  const nowMinutes = now.getHours() * 60 + now.getMinutes()
+  const nowTop = (nowMinutes / 60) * PIXELS_PER_HOUR
+
+  return (
+    <div className="rounded-lg border">
+      {/* Day header */}
+      <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
+        <div className="p-2" />
+        {days.map((day) => (
+          <div
+            key={day.toISOString()}
+            className={cn(
+              'p-2 text-center text-xs font-medium border-l',
+              isToday(day) && 'bg-primary/10',
+            )}
+          >
+            <div className="text-muted-foreground">{format(day, 'EEE')}</div>
+            <div className={cn('text-sm', isToday(day) && 'text-primary font-semibold')}>
+              {format(day, 'd')}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="overflow-y-auto max-h-[600px]">
+        <div className="grid grid-cols-[60px_repeat(7,1fr)]" style={{ height: totalHeight }}>
+          {/* Hour labels */}
+          <div className="relative">
+            {hours.map((hour, idx) => (
+              <div
+                key={hour}
+                className="absolute right-2 text-[10px] text-muted-foreground -translate-y-1/2"
+                style={{ top: idx * PIXELS_PER_HOUR }}
+              >
+                {hour}
+              </div>
+            ))}
+          </div>
+
+          {/* Day columns */}
+          {days.map((day, dayIdx) => (
+            <div key={day.toISOString()} className="relative border-l">
+              {/* Hour grid lines */}
+              {hours.map((hour, hourIdx) => (
+                <div
+                  key={hour}
+                  className="absolute inset-x-0 border-t border-border/50"
+                  style={{ top: hourIdx * PIXELS_PER_HOUR }}
+                />
+              ))}
+
+              {/* Now line */}
+              {isCurrentWeek && isToday(day) && (
+                <div
+                  className="absolute inset-x-0 z-10 border-t-2 border-destructive"
+                  style={{ top: nowTop }}
+                />
+              )}
+
+              {/* Booking blocks */}
+              {bookingsByDay.get(dayIdx)?.map(({ booking, top, height }) => (
+                <div
+                  key={`${booking.id}-${dayIdx}`}
+                  className="absolute inset-x-0 px-0.5"
+                  style={{ top, height }}
+                >
+                  <BookingBlock
+                    booking={booking}
+                    variant="bar"
+                    onClick={() => onBookingClick(booking)}
+                  />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/calendar/CalendarWeekView.tsx
+++ b/packages/web/src/components/calendar/CalendarWeekView.tsx
@@ -23,6 +23,8 @@ function getDayColumns(weekStart: Date): Date[] {
   return Array.from({ length: 7 }, (_, i) => addDays(monday, i))
 }
 
+const HOUR_SLOTS = getHourSlots()
+
 interface PositionedBooking {
   booking: CalendarBooking
   top: number
@@ -30,7 +32,6 @@ interface PositionedBooking {
 }
 
 export function CalendarWeekView({ bookings, weekStart, onBookingClick }: CalendarWeekViewProps) {
-  const hours = getHourSlots()
   const days = useMemo(() => getDayColumns(weekStart), [weekStart])
 
   const rangeStart = days[0]!
@@ -53,7 +54,7 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
         const { top, height } = bookingToWeekPosition(booking.startAt, booking.endAt, day)
         if (height <= 0) continue
 
-        map.get(dayIdx)!.push({ booking, top, height })
+        map.set(dayIdx, [...(map.get(dayIdx) ?? []), { booking, top, height }])
       }
     }
 
@@ -93,7 +94,7 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
         <div className="grid grid-cols-[60px_repeat(7,1fr)]" style={{ height: totalHeight }}>
           {/* Hour labels */}
           <div className="relative">
-            {hours.map((hour, idx) => (
+            {HOUR_SLOTS.map((hour, idx) => (
               <div
                 key={hour}
                 className="absolute right-2 text-[10px] text-muted-foreground -translate-y-1/2"
@@ -108,7 +109,7 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
           {days.map((day, dayIdx) => (
             <div key={day.toISOString()} className="relative border-l">
               {/* Hour grid lines */}
-              {hours.map((hour, hourIdx) => (
+              {HOUR_SLOTS.map((hour, hourIdx) => (
                 <div
                   key={hour}
                   className="absolute inset-x-0 border-t border-border/50"

--- a/packages/web/src/components/calendar/VehicleBookingCalendar.tsx
+++ b/packages/web/src/components/calendar/VehicleBookingCalendar.tsx
@@ -2,7 +2,6 @@
 
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { fetchCalendarBookings } from '@/lib/calendar'
 import type { CalendarBooking } from '@/lib/calendar'
 import { useQuery } from '@tanstack/react-query'
 import { startOfWeek } from 'date-fns'
@@ -12,6 +11,7 @@ import { BookingDetailDialog } from './BookingDetailDialog'
 import { CalendarMonthView } from './CalendarMonthView'
 import { CalendarNavigation } from './CalendarNavigation'
 import { CalendarWeekView } from './CalendarWeekView'
+import { fetchVehicleCalendarBookings } from './calendar-actions'
 import { SOURCE_COLORS, SOURCE_LABELS, getMonthRange, getWeekRange } from './calendar-utils'
 
 interface VehicleBookingCalendarProps {
@@ -25,9 +25,13 @@ export function VehicleBookingCalendar({ vehicleId }: VehicleBookingCalendarProp
 
   const { from, to } = viewMode === 'week' ? getWeekRange(currentDate) : getMonthRange(currentDate)
 
-  const { data: bookings = [], isLoading } = useQuery({
+  const {
+    data: bookings = [],
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['bookings', 'calendar', vehicleId, from, to],
-    queryFn: () => fetchCalendarBookings(from, to, vehicleId),
+    queryFn: () => fetchVehicleCalendarBookings(vehicleId, from, to),
   })
 
   const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 })
@@ -53,6 +57,12 @@ export function VehicleBookingCalendar({ vehicleId }: VehicleBookingCalendarProp
               <Skeleton className="h-8 w-full" />
               <Skeleton className="h-[400px] w-full" />
             </div>
+          ) : error ? (
+            <Card>
+              <CardContent className="pt-4">
+                <p className="text-sm text-destructive">Failed to load bookings</p>
+              </CardContent>
+            </Card>
           ) : viewMode === 'week' ? (
             <CalendarWeekView
               bookings={bookings}

--- a/packages/web/src/components/calendar/VehicleBookingCalendar.tsx
+++ b/packages/web/src/components/calendar/VehicleBookingCalendar.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { fetchCalendarBookings } from '@/lib/calendar'
+import type { CalendarBooking } from '@/lib/calendar'
+import { useQuery } from '@tanstack/react-query'
+import { startOfWeek } from 'date-fns'
+import { Calendar } from 'lucide-react'
+import { useState } from 'react'
+import { BookingDetailDialog } from './BookingDetailDialog'
+import { CalendarMonthView } from './CalendarMonthView'
+import { CalendarNavigation } from './CalendarNavigation'
+import { CalendarWeekView } from './CalendarWeekView'
+import { SOURCE_COLORS, SOURCE_LABELS, getMonthRange, getWeekRange } from './calendar-utils'
+
+interface VehicleBookingCalendarProps {
+  readonly vehicleId: string
+}
+
+export function VehicleBookingCalendar({ vehicleId }: VehicleBookingCalendarProps) {
+  const [currentDate, setCurrentDate] = useState(() => new Date())
+  const [viewMode, setViewMode] = useState<'week' | 'month'>('week')
+  const [selectedBooking, setSelectedBooking] = useState<CalendarBooking | null>(null)
+
+  const { from, to } = viewMode === 'week' ? getWeekRange(currentDate) : getMonthRange(currentDate)
+
+  const { data: bookings = [], isLoading } = useQuery({
+    queryKey: ['bookings', 'calendar', vehicleId, from, to],
+    queryFn: () => fetchCalendarBookings(from, to, vehicleId),
+  })
+
+  const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 })
+
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <h2 className="text-lg font-medium mb-4 flex items-center gap-2">
+          <Calendar className="size-4" />
+          Booking Calendar
+        </h2>
+
+        <div className="space-y-4">
+          <CalendarNavigation
+            currentDate={currentDate}
+            viewMode={viewMode}
+            onDateChange={setCurrentDate}
+            onViewModeChange={setViewMode}
+          />
+
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-[400px] w-full" />
+            </div>
+          ) : viewMode === 'week' ? (
+            <CalendarWeekView
+              bookings={bookings}
+              weekStart={weekStart}
+              onBookingClick={setSelectedBooking}
+            />
+          ) : (
+            <CalendarMonthView
+              bookings={bookings}
+              month={currentDate.getMonth()}
+              year={currentDate.getFullYear()}
+              onBookingClick={setSelectedBooking}
+            />
+          )}
+
+          {/* Source legend */}
+          <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground pt-2">
+            {Object.entries(SOURCE_COLORS).map(([source, colors]) => (
+              <div key={source} className="flex items-center gap-1.5">
+                <span className={`inline-block size-3 rounded-sm ${colors.bg}`} />
+                <span>{SOURCE_LABELS[source] ?? source}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <BookingDetailDialog booking={selectedBooking} onClose={() => setSelectedBooking(null)} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/web/src/components/calendar/calendar-actions.ts
+++ b/packages/web/src/components/calendar/calendar-actions.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { auth } from '@/auth'
+import { signApiToken } from '@/lib/api-client'
+import { fetchCalendarBookings } from '@/lib/calendar'
+import type { CalendarBooking } from '@/lib/calendar'
+
+export async function fetchVehicleCalendarBookings(
+  vehicleId: string,
+  from: string,
+  to: string,
+): Promise<CalendarBooking[]> {
+  const session = await auth()
+  const user = session?.user as { id?: string; role?: string } | undefined
+  if (!user?.id) throw new Error('Not authenticated')
+
+  const token = await signApiToken({ id: user.id, role: user.role ?? 'RENTER' })
+  return fetchCalendarBookings(from, to, vehicleId, token)
+}

--- a/packages/web/src/components/calendar/calendar-utils.ts
+++ b/packages/web/src/components/calendar/calendar-utils.ts
@@ -1,0 +1,140 @@
+import {
+  addDays,
+  differenceInMinutes,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  getHours,
+  getMinutes,
+  isAfter,
+  isBefore,
+  isSameDay,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns'
+
+const PIXELS_PER_HOUR = 48
+
+export function getWeekRange(date: Date): { from: string; to: string } {
+  const from = startOfWeek(date, { weekStartsOn: 1 })
+  const to = endOfWeek(date, { weekStartsOn: 1 })
+  return { from: from.toISOString(), to: to.toISOString() }
+}
+
+export function getMonthRange(date: Date): { from: string; to: string } {
+  const from = startOfMonth(date)
+  const to = endOfMonth(date)
+  return { from: from.toISOString(), to: to.toISOString() }
+}
+
+export function getHourSlots(): string[] {
+  return Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}:00`)
+}
+
+export function bookingToWeekPosition(
+  startAt: string,
+  endAt: string,
+  dayStart: Date,
+): { top: number; height: number } {
+  const bookingStart = new Date(startAt)
+  const bookingEnd = new Date(endAt)
+  const dayEnd = endOfDay(dayStart)
+
+  // Clamp to day boundaries
+  const clampedStart = isBefore(bookingStart, dayStart) ? dayStart : bookingStart
+  const clampedEnd = isAfter(bookingEnd, dayEnd) ? dayEnd : bookingEnd
+
+  const startMinutes = differenceInMinutes(clampedStart, dayStart)
+  const durationMinutes = differenceInMinutes(clampedEnd, clampedStart)
+
+  const top = (startMinutes / 60) * PIXELS_PER_HOUR
+  const height = (durationMinutes / 60) * PIXELS_PER_HOUR
+
+  return { top, height }
+}
+
+export function splitMultiDayBooking(
+  booking: { startAt: string; endAt: string },
+  rangeStart: Date,
+  rangeEnd: Date,
+): Array<{
+  date: Date
+  startHour: number
+  endHour: number
+  isStart: boolean
+  isEnd: boolean
+}> {
+  const bookingStart = new Date(booking.startAt)
+  const bookingEnd = new Date(booking.endAt)
+
+  // Clamp to visible range
+  const effectiveStart = isBefore(bookingStart, rangeStart) ? rangeStart : bookingStart
+  const effectiveEnd = isAfter(bookingEnd, rangeEnd) ? rangeEnd : bookingEnd
+
+  const segments: Array<{
+    date: Date
+    startHour: number
+    endHour: number
+    isStart: boolean
+    isEnd: boolean
+  }> = []
+
+  let current = startOfDay(effectiveStart)
+
+  while (isBefore(current, effectiveEnd) || isSameDay(current, effectiveEnd)) {
+    const dayStartTime = startOfDay(current)
+    const dayEndTime = endOfDay(current)
+
+    const segStart = isBefore(effectiveStart, dayStartTime) ? dayStartTime : effectiveStart
+    const segEnd = isAfter(effectiveEnd, dayEndTime) ? dayEndTime : effectiveEnd
+
+    // Skip if segment end is before segment start (no overlap with this day)
+    if (!isBefore(segEnd, segStart)) {
+      const startHour = isSameDay(segStart, dayStartTime)
+        ? getHours(segStart) + getMinutes(segStart) / 60
+        : 0
+      // When effective end is at or past end of day (23:59:xx), treat as full day (24)
+      const segEndHours = getHours(segEnd)
+      const segEndMinutes = getMinutes(segEnd)
+      const isAtEndOfDay = segEndHours === 23 && segEndMinutes >= 59
+      const endHour =
+        isAfter(effectiveEnd, dayEndTime) || isAtEndOfDay ? 24 : segEndHours + segEndMinutes / 60
+
+      const isStart = isSameDay(effectiveStart, current) && isSameDay(bookingStart, effectiveStart)
+      const isEnd = isSameDay(effectiveEnd, current) && isSameDay(bookingEnd, effectiveEnd)
+
+      segments.push({
+        date: dayStartTime,
+        startHour,
+        endHour,
+        isStart,
+        isEnd,
+      })
+    }
+
+    current = addDays(current, 1)
+
+    // Safety: break if we've gone past the range
+    if (isAfter(current, addDays(rangeEnd, 1))) break
+  }
+
+  return segments
+}
+
+export const SOURCE_COLORS: Record<string, { bg: string; text: string }> = {
+  DIRECT: { bg: 'bg-blue-100 dark:bg-blue-900', text: 'text-blue-800 dark:text-blue-200' },
+  TRIP_COM: {
+    bg: 'bg-purple-100 dark:bg-purple-900',
+    text: 'text-purple-800 dark:text-purple-200',
+  },
+  MANUAL: { bg: 'bg-amber-100 dark:bg-amber-900', text: 'text-amber-800 dark:text-amber-200' },
+  OTHER: { bg: 'bg-gray-100 dark:bg-gray-900', text: 'text-gray-800 dark:text-gray-200' },
+}
+
+export const SOURCE_LABELS: Record<string, string> = {
+  DIRECT: 'Direct',
+  TRIP_COM: 'Trip.com',
+  MANUAL: 'Manual',
+  OTHER: 'Other',
+}

--- a/packages/web/src/components/calendar/calendar-utils.ts
+++ b/packages/web/src/components/calendar/calendar-utils.ts
@@ -14,7 +14,7 @@ import {
   startOfWeek,
 } from 'date-fns'
 
-const PIXELS_PER_HOUR = 48
+export const PIXELS_PER_HOUR = 48
 
 export function getWeekRange(date: Date): { from: string; to: string } {
   const from = startOfWeek(date, { weekStartsOn: 1 })

--- a/packages/web/src/lib/calendar.ts
+++ b/packages/web/src/lib/calendar.ts
@@ -11,15 +11,19 @@ export interface CalendarBooking {
   status: 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
   source: 'DIRECT' | 'TRIP_COM' | 'MANUAL' | 'OTHER'
   notes: string | null
+  renterName?: string | null
 }
 
 export async function fetchCalendarBookings(
   from: string,
   to: string,
+  vehicleId?: string,
   token?: string,
 ): Promise<CalendarBooking[]> {
   const client = createApiClient(token)
-  const res = await client.bookings.$get({ query: { from, to } })
+  const query: Record<string, string> = { from, to }
+  if (vehicleId) query.vehicleId = vehicleId
+  const res = await client.bookings.$get({ query })
 
   if (!res.ok) {
     throw new Error(`Failed to fetch bookings: HTTP ${res.status}`)

--- a/packages/web/tests/components/calendar/calendar-utils.test.ts
+++ b/packages/web/tests/components/calendar/calendar-utils.test.ts
@@ -1,0 +1,265 @@
+import {
+  SOURCE_COLORS,
+  SOURCE_LABELS,
+  bookingToWeekPosition,
+  getHourSlots,
+  getMonthRange,
+  getWeekRange,
+  splitMultiDayBooking,
+} from '@/components/calendar/calendar-utils'
+import { describe, expect, it } from 'vitest'
+
+/** Parse ISO string back to local Date and check date components. */
+function expectLocalDate(iso: string, year: number, month: number, day: number): void {
+  const d = new Date(iso)
+  expect(d.getFullYear()).toBe(year)
+  expect(d.getMonth() + 1).toBe(month) // getMonth is 0-indexed
+  expect(d.getDate()).toBe(day)
+}
+
+describe('getWeekRange', () => {
+  it('returns Monday-Sunday range for a Wednesday', () => {
+    // 2026-04-08 is a Wednesday
+    const date = new Date(2026, 3, 8) // April 8, 2026
+    const range = getWeekRange(date)
+
+    // Monday April 6
+    expectLocalDate(range.from, 2026, 4, 6)
+    // Sunday April 12
+    expectLocalDate(range.to, 2026, 4, 12)
+  })
+
+  it('returns same week when given a Monday', () => {
+    const monday = new Date(2026, 3, 6) // April 6, 2026 (Monday)
+    const range = getWeekRange(monday)
+
+    expectLocalDate(range.from, 2026, 4, 6)
+    expectLocalDate(range.to, 2026, 4, 12)
+  })
+
+  it('returns same week when given a Sunday', () => {
+    const sunday = new Date(2026, 3, 12) // April 12, 2026 (Sunday)
+    const range = getWeekRange(sunday)
+
+    expectLocalDate(range.from, 2026, 4, 6)
+    expectLocalDate(range.to, 2026, 4, 12)
+  })
+})
+
+describe('getMonthRange', () => {
+  it('returns correct range for a 31-day month (January)', () => {
+    const date = new Date(2026, 0, 15) // January 15
+    const range = getMonthRange(date)
+
+    expectLocalDate(range.from, 2026, 1, 1)
+    expectLocalDate(range.to, 2026, 1, 31)
+  })
+
+  it('returns correct range for a 30-day month (April)', () => {
+    const date = new Date(2026, 3, 10) // April 10
+    const range = getMonthRange(date)
+
+    expectLocalDate(range.from, 2026, 4, 1)
+    expectLocalDate(range.to, 2026, 4, 30)
+  })
+
+  it('returns correct range for February (28 days in 2026)', () => {
+    const date = new Date(2026, 1, 14) // February 14
+    const range = getMonthRange(date)
+
+    expectLocalDate(range.from, 2026, 2, 1)
+    expectLocalDate(range.to, 2026, 2, 28)
+  })
+
+  it('returns correct range for February in leap year (29 days in 2028)', () => {
+    const date = new Date(2028, 1, 14) // February 14, 2028
+    const range = getMonthRange(date)
+
+    expectLocalDate(range.from, 2028, 2, 1)
+    expectLocalDate(range.to, 2028, 2, 29)
+  })
+})
+
+describe('getHourSlots', () => {
+  it('returns exactly 24 items', () => {
+    const slots = getHourSlots()
+    expect(slots).toHaveLength(24)
+  })
+
+  it('starts with 00:00 and ends with 23:00', () => {
+    const slots = getHourSlots()
+    expect(slots[0]).toBe('00:00')
+    expect(slots[23]).toBe('23:00')
+  })
+
+  it('has correct format for all entries', () => {
+    const slots = getHourSlots()
+    for (const slot of slots) {
+      expect(slot).toMatch(/^\d{2}:00$/)
+    }
+  })
+
+  it('contains specific mid-day values', () => {
+    const slots = getHourSlots()
+    expect(slots[12]).toBe('12:00')
+    expect(slots[6]).toBe('06:00')
+    expect(slots[18]).toBe('18:00')
+  })
+})
+
+describe('bookingToWeekPosition', () => {
+  it('returns correct top and height for a 2-hour booking at 10:00', () => {
+    // dayStart = April 8, 2026 at midnight
+    const dayStart = new Date(2026, 3, 8, 0, 0, 0)
+    const startAt = new Date(2026, 3, 8, 10, 0, 0).toISOString()
+    const endAt = new Date(2026, 3, 8, 12, 0, 0).toISOString()
+
+    const pos = bookingToWeekPosition(startAt, endAt, dayStart)
+
+    // 10 hours * 48px = 480
+    expect(pos.top).toBe(480)
+    // 2 hours * 48px = 96
+    expect(pos.height).toBe(96)
+  })
+
+  it('returns correct position for a 30-minute booking', () => {
+    const dayStart = new Date(2026, 3, 8, 0, 0, 0)
+    const startAt = new Date(2026, 3, 8, 14, 0, 0).toISOString()
+    const endAt = new Date(2026, 3, 8, 14, 30, 0).toISOString()
+
+    const pos = bookingToWeekPosition(startAt, endAt, dayStart)
+
+    // 14 hours * 48px = 672
+    expect(pos.top).toBe(672)
+    // 30 min = 0.5 hours * 48px = 24
+    expect(pos.height).toBe(24)
+  })
+
+  it('clamps booking that starts before midnight to top=0', () => {
+    const dayStart = new Date(2026, 3, 8, 0, 0, 0)
+    // Booking starts previous day at 22:00
+    const startAt = new Date(2026, 3, 7, 22, 0, 0).toISOString()
+    const endAt = new Date(2026, 3, 8, 3, 0, 0).toISOString()
+
+    const pos = bookingToWeekPosition(startAt, endAt, dayStart)
+
+    expect(pos.top).toBe(0)
+    // 3 hours * 48px = 144
+    expect(pos.height).toBe(144)
+  })
+
+  it('clamps booking that ends after 23:59 to day boundary', () => {
+    const dayStart = new Date(2026, 3, 8, 0, 0, 0)
+    const startAt = new Date(2026, 3, 8, 22, 0, 0).toISOString()
+    // Booking ends next day at 3:00
+    const endAt = new Date(2026, 3, 9, 3, 0, 0).toISOString()
+
+    const pos = bookingToWeekPosition(startAt, endAt, dayStart)
+
+    // 22 hours * 48px = 1056
+    expect(pos.top).toBe(1056)
+    // Clamped to end of day: 24-22 = 2 hours * 48px = 96
+    // Actually 23:59:59.999 - 22:00 ~= 2 hours
+    expect(pos.height).toBeCloseTo(96, -1)
+  })
+})
+
+describe('splitMultiDayBooking', () => {
+  it('splits a 3-day booking into 3 segments', () => {
+    const booking = {
+      startAt: new Date(2026, 3, 8, 14, 0, 0).toISOString(), // Apr 8 14:00
+      endAt: new Date(2026, 3, 10, 10, 0, 0).toISOString(), // Apr 10 10:00
+    }
+    const rangeStart = new Date(2026, 3, 6) // Monday Apr 6
+    const rangeEnd = new Date(2026, 3, 12, 23, 59, 59) // Sunday Apr 12
+
+    const segments = splitMultiDayBooking(booking, rangeStart, rangeEnd)
+
+    expect(segments).toHaveLength(3)
+
+    // Day 1: Apr 8, 14:00 - 24:00, isStart=true, isEnd=false
+    expect(segments[0]!.startHour).toBe(14)
+    expect(segments[0]!.endHour).toBe(24)
+    expect(segments[0]!.isStart).toBe(true)
+    expect(segments[0]!.isEnd).toBe(false)
+
+    // Day 2: Apr 9, 0:00 - 24:00, isStart=false, isEnd=false
+    expect(segments[1]!.startHour).toBe(0)
+    expect(segments[1]!.endHour).toBe(24)
+    expect(segments[1]!.isStart).toBe(false)
+    expect(segments[1]!.isEnd).toBe(false)
+
+    // Day 3: Apr 10, 0:00 - 10:00, isStart=false, isEnd=true
+    expect(segments[2]!.startHour).toBe(0)
+    expect(segments[2]!.endHour).toBe(10)
+    expect(segments[2]!.isStart).toBe(false)
+    expect(segments[2]!.isEnd).toBe(true)
+  })
+
+  it('returns a single segment for a booking within one day', () => {
+    const booking = {
+      startAt: new Date(2026, 3, 8, 9, 0, 0).toISOString(), // Apr 8 09:00
+      endAt: new Date(2026, 3, 8, 17, 0, 0).toISOString(), // Apr 8 17:00
+    }
+    const rangeStart = new Date(2026, 3, 6)
+    const rangeEnd = new Date(2026, 3, 12, 23, 59, 59)
+
+    const segments = splitMultiDayBooking(booking, rangeStart, rangeEnd)
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0]!.startHour).toBe(9)
+    expect(segments[0]!.endHour).toBe(17)
+    expect(segments[0]!.isStart).toBe(true)
+    expect(segments[0]!.isEnd).toBe(true)
+  })
+
+  it('clips booking to visible range when booking extends beyond range', () => {
+    const booking = {
+      startAt: new Date(2026, 3, 5, 10, 0, 0).toISOString(), // Apr 5 (before range)
+      endAt: new Date(2026, 3, 14, 10, 0, 0).toISOString(), // Apr 14 (after range)
+    }
+    const rangeStart = new Date(2026, 3, 6)
+    const rangeEnd = new Date(2026, 3, 12, 23, 59, 59)
+
+    const segments = splitMultiDayBooking(booking, rangeStart, rangeEnd)
+
+    // Should have 7 segments (Apr 6-12)
+    expect(segments).toHaveLength(7)
+    // First segment starts at 0 (clipped from before range)
+    expect(segments[0]!.startHour).toBe(0)
+    expect(segments[0]!.isStart).toBe(false)
+    // Last segment ends at 24 (clipped from after range)
+    expect(segments[6]!.endHour).toBe(24)
+    expect(segments[6]!.isEnd).toBe(false)
+  })
+})
+
+describe('SOURCE_COLORS', () => {
+  it('has all 4 sources', () => {
+    expect(Object.keys(SOURCE_COLORS)).toHaveLength(4)
+    expect(SOURCE_COLORS).toHaveProperty('DIRECT')
+    expect(SOURCE_COLORS).toHaveProperty('TRIP_COM')
+    expect(SOURCE_COLORS).toHaveProperty('MANUAL')
+    expect(SOURCE_COLORS).toHaveProperty('OTHER')
+  })
+
+  it('each source has bg and text properties', () => {
+    for (const [, colors] of Object.entries(SOURCE_COLORS)) {
+      expect(colors).toHaveProperty('bg')
+      expect(colors).toHaveProperty('text')
+      expect(typeof colors.bg).toBe('string')
+      expect(typeof colors.text).toBe('string')
+    }
+  })
+})
+
+describe('SOURCE_LABELS', () => {
+  it('has all 4 sources with correct display labels', () => {
+    expect(SOURCE_LABELS).toEqual({
+      DIRECT: 'Direct',
+      TRIP_COM: 'Trip.com',
+      MANUAL: 'Manual',
+      OTHER: 'Other',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Custom calendar on vehicle detail page with week + month views
- Source color-coding: blue (Direct), purple (Trip.com), amber (Manual), gray (Other)
- Click booking blocks to open detail dialog
- Authenticated server action for data fetching via react-query

## Test plan
- [x] 261 web tests pass (21 new calendar-utils tests)
- [x] tsc + biome clean
- [x] Code review: auth, immutability, error state fixes applied

Closes #227