### PR TITLE
fix(web): fleet list UX — badge colors, name truncation

### DIFF
--- a/packages/web/src/components/vehicles/FleetVehicleRow.tsx
+++ b/packages/web/src/components/vehicles/FleetVehicleRow.tsx
@@ -88,7 +88,6 @@ export function FleetVehicleRow({
     `${overview.seats}`,
     overview.transmission === 'AUTO' ? 'AT' : 'MT',
     overview.fuelType,
-    overview.licensePlate,
   ].filter((p): p is string => Boolean(p))
 
   return (
@@ -127,7 +126,7 @@ export function FleetVehicleRow({
       </div>
 
       {/* Name + subtitle */}
-      <div className="min-w-0 flex-1">
+      <div className="min-w-[10rem] flex-1">
         <div className="truncate font-medium text-foreground">{overview.name}</div>
         <div data-testid="fleet-row-subtitle" className="truncate text-sm text-muted-foreground">
           {subtitleParts.join(' · ')}
@@ -156,7 +155,7 @@ export function FleetVehicleRow({
       </div>
 
       {/* Booking indicator */}
-      <div className="flex-shrink-0 min-w-[12rem]">
+      <div className="flex-shrink-0 min-w-[10rem]">
         <BookingIndicator current={overview.currentBooking} next={overview.nextBooking} t={t} />
       </div>
 
@@ -168,7 +167,7 @@ export function FleetVehicleRow({
       {/* Utilization */}
       <div
         data-testid="fleet-row-utilization"
-        className="flex-shrink-0 min-w-[10rem] text-right text-sm text-muted-foreground"
+        className="flex-shrink-0 min-w-[8rem] text-right text-sm text-muted-foreground"
       >
         {t('fleet.utilizationLabel', {
           percent: Math.round(overview.utilization),

--- a/packages/web/src/components/vehicles/VehicleStatusBadge.tsx
+++ b/packages/web/src/components/vehicles/VehicleStatusBadge.tsx
@@ -1,16 +1,30 @@
 import { Badge } from '@/components/ui/badge'
 import { useTranslations } from 'next-intl'
 
-const variantMap = {
-  AVAILABLE: 'default',
-  MAINTENANCE: 'secondary',
-  RETIRED: 'destructive',
+const styleMap = {
+  AVAILABLE: {
+    variant: 'outline' as const,
+    className: 'border-emerald-500 text-emerald-700 bg-emerald-50',
+  },
+  MAINTENANCE: {
+    variant: 'outline' as const,
+    className: 'border-amber-500 text-amber-700 bg-amber-50',
+  },
+  RETIRED: {
+    variant: 'outline' as const,
+    className: 'border-muted-foreground/30 text-muted-foreground',
+  },
 } as const
 
-type VehicleStatus = keyof typeof variantMap
+type VehicleStatus = keyof typeof styleMap
 
 export function VehicleStatusBadge({ status }: { status: VehicleStatus }) {
   const t = useTranslations('business.vehicles.status')
+  const { variant, className } = styleMap[status]
 
-  return <Badge variant={variantMap[status]}>{t(status)}</Badge>
+  return (
+    <Badge variant={variant} className={className}>
+      {t(status)}
+    </Badge>
+  )
 }


### PR DESCRIPTION
## Summary
- Status badges: Available=green, Maintenance=amber, Retired=gray (was all black)
- Name column gets min-w-[10rem] to prevent "Honda N-B..." truncation
- Reduced booking/utilization column min-widths to free space for name
- Removed licensePlate from subtitle to prevent overflow

## Test plan
- [x] 290 web tests pass
- [x] tsc clean
- [ ] Visual check: badges show correct colors, names display fully

Closes #242