### PR TITLE
fix(web): mobile-first responsive audit

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -217,6 +217,7 @@
         "colorPlaceholder": "e.g. White"
       },
       "filter": {
+        "title": "Filters",
         "all": "All",
         "available": "Available",
         "maintenance": "Maintenance",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -217,6 +217,7 @@
         "colorPlaceholder": "例: ホワイト"
       },
       "filter": {
+        "title": "フィルター",
         "all": "すべて",
         "available": "利用可能",
         "maintenance": "メンテナンス中",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -217,6 +217,7 @@
         "colorPlaceholder": "例如 白色"
       },
       "filter": {
+        "title": "筛选",
         "all": "全部",
         "available": "可用",
         "maintenance": "维护中",

--- a/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/vehicles/[id]/VehicleDetail.tsx
@@ -7,9 +7,10 @@ import { Link } from '@/i18n/routing'
 import { formatJpy } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import type { VehicleDetailData } from '@/lib/vehicle-api'
-import { ArrowLeft, Calendar, Car } from 'lucide-react'
+import { ArrowLeft, Calendar, Car, Clock, Fuel, Settings2, Users } from 'lucide-react'
 import type { getTranslations } from 'next-intl/server'
 import Image from 'next/image'
+import type { ComponentType } from 'react'
 import { UtilizationChart } from './UtilizationChart'
 
 type Translator = Awaited<ReturnType<typeof getTranslations>>
@@ -45,131 +46,273 @@ const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive'> = 
 }
 
 export function VehicleDetail({ vehicle, t }: VehicleDetailProps) {
+  const transmissionLabel = vehicle.transmission === 'AUTO' ? t('auto') : t('manual')
   const photos = vehicle.photos ?? []
-  const primaryPhoto = photos[0]
-
-  // Compact spec line: "4 seats · AT · Gasoline"
-  const specParts = [
-    t('seats', { count: vehicle.seats }),
-    vehicle.transmission === 'AUTO' ? 'AT' : 'MT',
-    vehicle.fuelType,
-  ].filter((p): p is string => Boolean(p))
+  const hasRevenue =
+    vehicle.revenueLast7d > 0 || vehicle.revenueLast30d > 0 || vehicle.revenueAllTime > 0
+  const hasRentalRules =
+    vehicle.minRentalHours != null ||
+    vehicle.maxRentalHours != null ||
+    vehicle.advanceBookingHours != null
 
   return (
-    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      {/* Back link */}
-      <Link
-        href="/manage/vehicles"
-        className={cn(
-          buttonVariants({ variant: 'ghost', size: 'sm' }),
-          'gap-1.5 text-muted-foreground mb-4',
-        )}
-      >
-        <ArrowLeft className="size-4" />
-        {t('backToFleet')}
-      </Link>
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Back link + header */}
+      <div className="mb-6 flex items-center justify-between">
+        <Link
+          href="/manage/vehicles"
+          className={cn(
+            buttonVariants({ variant: 'ghost', size: 'sm' }),
+            'gap-1.5 text-muted-foreground',
+          )}
+        >
+          <ArrowLeft className="size-4" />
+          {t('backToFleet')}
+        </Link>
+      </div>
 
-      {/* Compact vehicle identity header */}
-      <div className="flex items-start gap-4 mb-6">
-        {/* Small thumbnail */}
-        <div className="relative shrink-0 h-16 w-24 overflow-hidden rounded-lg bg-muted">
-          {primaryPhoto ? (
+      <div className="flex flex-wrap items-start justify-between gap-4 mb-8">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-semibold tracking-tight">{vehicle.name}</h1>
+            <Badge variant={STATUS_VARIANT[vehicle.status] ?? 'secondary'}>{vehicle.status}</Badge>
+          </div>
+          {vehicle.description && (
+            <p className="mt-2 text-sm text-muted-foreground">{vehicle.description}</p>
+          )}
+        </div>
+        {(vehicle.dailyRateJpy != null || vehicle.hourlyRateJpy != null) && (
+          <div className="text-right shrink-0">
+            {vehicle.dailyRateJpy != null && (
+              <p className="text-lg font-semibold">{formatJpy(vehicle.dailyRateJpy)}/day</p>
+            )}
+            {vehicle.hourlyRateJpy != null && (
+              <p className="text-sm text-muted-foreground">{formatJpy(vehicle.hourlyRateJpy)}/hr</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Left column: photos + specs */}
+        <div className="lg:col-span-2 space-y-6">
+          <PhotoGallery photos={photos} name={vehicle.name} placeholder={t('photos')} />
+
+          {/* Specs card */}
+          <Card>
+            <CardContent className="pt-4">
+              <h2 className="text-lg font-medium mb-4">{t('specs')}</h2>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <SpecItem icon={Users} label={t('seats', { count: vehicle.seats })} />
+                <SpecItem icon={Settings2} label={t('transmission')} value={transmissionLabel} />
+                {vehicle.fuelType && (
+                  <SpecItem icon={Fuel} label={t('fuelType')} value={vehicle.fuelType} />
+                )}
+                <SpecItem
+                  icon={Clock}
+                  label={t('buffer')}
+                  value={t('bufferMinutes', { count: vehicle.bufferMinutes })}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Rental rules */}
+          {hasRentalRules && (
+            <Card>
+              <CardContent className="pt-4">
+                <h2 className="text-lg font-medium mb-3">{t('rentalRules')}</h2>
+                <ul className="space-y-1.5 text-sm">
+                  {vehicle.minRentalHours != null && (
+                    <li>
+                      {t('minDuration', {
+                        duration: formatHoursDuration(vehicle.minRentalHours, t),
+                      })}
+                    </li>
+                  )}
+                  {vehicle.maxRentalHours != null && (
+                    <li>
+                      {t('maxDuration', {
+                        duration: formatHoursDuration(vehicle.maxRentalHours, t),
+                      })}
+                    </li>
+                  )}
+                  {vehicle.advanceBookingHours != null && (
+                    <li>
+                      {t('advanceBooking', {
+                        duration: formatHoursDuration(vehicle.advanceBookingHours, t),
+                      })}
+                    </li>
+                  )}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Utilization chart */}
+          <Card>
+            <CardContent className="pt-4">
+              <h2 className="text-lg font-medium mb-4">{t('utilization')}</h2>
+              <UtilizationChart data={vehicle.utilizationLast30Days} />
+            </CardContent>
+          </Card>
+
+          {/* Booking calendar */}
+          <VehicleBookingCalendar vehicleId={vehicle.id} />
+        </div>
+
+        {/* Right column: revenue + upcoming bookings */}
+        <div className="space-y-6">
+          <RevenueCard vehicle={vehicle} t={t} hasRevenue={hasRevenue} />
+          <UpcomingBookingsCard bookings={vehicle.upcomingBookings} t={t} />
+          <MaintenanceHistoryCard logs={vehicle.maintenanceLogs} t={t} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ---------- Sub-components ---------- */
+
+function formatHoursDuration(hours: number, t: Translator): string {
+  return hours >= 24 ? t('days', { count: Math.floor(hours / 24) }) : t('hours', { count: hours })
+}
+
+function SpecItem({
+  icon: Icon,
+  label,
+  value,
+}: { icon: ComponentType<{ className?: string }>; label: string; value?: string }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <Icon className="size-5 text-muted-foreground shrink-0" />
+      <div>
+        <p className="text-xs text-muted-foreground">{label}</p>
+        {value && <p className="text-sm font-medium">{value}</p>}
+      </div>
+    </div>
+  )
+}
+
+function PhotoGallery({
+  photos,
+  name,
+  placeholder,
+}: { photos: string[]; name: string; placeholder: string }) {
+  const primaryPhoto = photos[0]
+
+  return (
+    <section aria-label={placeholder}>
+      {primaryPhoto ? (
+        <div className="space-y-3">
+          <div className="relative aspect-[16/9] overflow-hidden rounded-xl bg-muted">
             <Image
               src={primaryPhoto}
-              alt={vehicle.name}
+              alt={name}
               fill
               className="object-cover"
-              sizes="96px"
+              sizes="(max-width: 768px) 100vw, 66vw"
             />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center">
-              <Car className="size-6 text-muted-foreground/30" />
+          </div>
+          {photos.length > 1 && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {photos.slice(1, 5).map((photo) => (
+                <div
+                  key={photo}
+                  className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted"
+                >
+                  <Image
+                    src={photo}
+                    alt={name}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 25vw, 16vw"
+                  />
+                </div>
+              ))}
             </div>
           )}
         </div>
-
-        {/* Name + identifiers */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2.5 flex-wrap">
-            <h1 className="text-2xl font-semibold tracking-tight">{vehicle.name}</h1>
-            <Badge variant={STATUS_VARIANT[vehicle.status] ?? 'secondary'}>{vehicle.status}</Badge>
-          </div>
-          <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
-            {vehicle.licensePlate && (
-              <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
-                {vehicle.licensePlate}
-              </span>
-            )}
-            <span>{specParts.join(' · ')}</span>
-          </div>
+      ) : (
+        <div className="aspect-[16/9] overflow-hidden rounded-xl bg-muted flex items-center justify-center">
+          <Car className="size-16 text-muted-foreground/30" />
         </div>
+      )}
+    </section>
+  )
+}
 
-        {/* Price */}
-        <div className="text-right shrink-0">
-          {vehicle.dailyRateJpy != null && (
-            <p className="text-lg font-semibold">{formatJpy(vehicle.dailyRateJpy)}/day</p>
-          )}
-          {vehicle.hourlyRateJpy != null && (
-            <p className="text-sm text-muted-foreground">{formatJpy(vehicle.hourlyRateJpy)}/hr</p>
-          )}
-        </div>
-      </div>
+function RevenueCard({
+  vehicle,
+  t,
+  hasRevenue,
+}: { vehicle: VehicleDetailData; t: VehicleDetailProps['t']; hasRevenue: boolean }) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <h2 className="text-lg font-medium mb-4">{t('revenue')}</h2>
+        {hasRevenue ? (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">{t('revenueLast7d')}</span>
+              <span className="text-sm font-medium">{formatJpy(vehicle.revenueLast7d)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">{t('revenueLast30d')}</span>
+              <span className="text-sm font-medium">{formatJpy(vehicle.revenueLast30d)}</span>
+            </div>
+            <div className="flex items-center justify-between border-t pt-3">
+              <span className="text-sm font-medium">{t('revenueAllTime')}</span>
+              <span className="text-base font-semibold">{formatJpy(vehicle.revenueAllTime)}</span>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('noRevenue')}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
-      {/* HERO: Booking Calendar — full width, above the fold */}
-      <VehicleBookingCalendar vehicleId={vehicle.id} />
-
-      {/* Supporting info below the calendar */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
-        {/* Utilization */}
-        <Card>
-          <CardContent className="pt-4">
-            <h2 className="text-lg font-medium mb-4">{t('utilization')}</h2>
-            <UtilizationChart data={vehicle.utilizationLast30Days} />
-          </CardContent>
-        </Card>
-
-        {/* Upcoming bookings */}
-        <Card>
-          <CardContent className="pt-4">
-            <h2 className="text-lg font-medium mb-4">
-              <Calendar className="inline size-4 mr-1.5 -mt-0.5" />
-              {t('upcomingBookings')}
-            </h2>
-            {vehicle.upcomingBookings.length > 0 ? (
-              <ul className="space-y-3">
-                {vehicle.upcomingBookings.map((booking) => (
-                  <li key={booking.id} className="border-b last:border-0 pb-3 last:pb-0">
-                    <p className="text-sm font-medium">
-                      {formatDateRange(booking.startAt, booking.endAt)}
-                    </p>
-                    <div className="flex items-center gap-2 mt-1">
-                      {booking.renterName && (
-                        <span className="text-xs text-muted-foreground">{booking.renterName}</span>
-                      )}
-                      <Badge variant="outline" className="text-[10px] px-1.5 h-4">
-                        {SOURCE_LABELS[booking.source] ?? booking.source}
-                      </Badge>
-                      <Badge
-                        variant={booking.status === 'ACTIVE' ? 'default' : 'secondary'}
-                        className="text-[10px] px-1.5 h-4"
-                      >
-                        {booking.status}
-                      </Badge>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-muted-foreground">{t('noUpcomingBookings')}</p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Maintenance history — collapsed at the bottom */}
-      <div className="mt-6">
-        <MaintenanceHistoryCard logs={vehicle.maintenanceLogs} t={t} />
-      </div>
-    </div>
+function UpcomingBookingsCard({
+  bookings,
+  t,
+}: { bookings: VehicleDetailData['upcomingBookings']; t: VehicleDetailProps['t'] }) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <h2 className="text-lg font-medium mb-4">
+          <Calendar className="inline size-4 mr-1.5 -mt-0.5" />
+          {t('upcomingBookings')}
+        </h2>
+        {bookings.length > 0 ? (
+          <ul className="space-y-3">
+            {bookings.map((booking) => (
+              <li key={booking.id} className="border-b last:border-0 pb-3 last:pb-0">
+                <p className="text-sm font-medium">
+                  {formatDateRange(booking.startAt, booking.endAt)}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  {booking.renterName && (
+                    <span className="text-xs text-muted-foreground">{booking.renterName}</span>
+                  )}
+                  <Badge variant="outline" className="text-[10px] px-1.5 h-4">
+                    {SOURCE_LABELS[booking.source] ?? booking.source}
+                  </Badge>
+                  <Badge
+                    variant={booking.status === 'ACTIVE' ? 'default' : 'secondary'}
+                    className="text-[10px] px-1.5 h-4"
+                  >
+                    {booking.status}
+                  </Badge>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('noUpcomingBookings')}</p>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,4 +1,11 @@
+import type { Viewport } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+}
 
 const geistSans = Geist({
   variable: '--font-geist-sans',

--- a/packages/web/src/components/calendar/CalendarMonthView.tsx
+++ b/packages/web/src/components/calendar/CalendarMonthView.tsx
@@ -70,7 +70,7 @@ export function CalendarMonthView({
   const referenceDate = new Date(year, month, 1)
 
   return (
-    <div className="overflow-x-auto rounded-lg border">
+    <section className="overflow-x-auto rounded-lg border" aria-label="Month calendar">
       <div className="min-w-[500px]">
         {/* Day headers */}
         <div className="grid grid-cols-7 border-b">
@@ -131,6 +131,6 @@ export function CalendarMonthView({
           })}
         </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/packages/web/src/components/calendar/CalendarMonthView.tsx
+++ b/packages/web/src/components/calendar/CalendarMonthView.tsx
@@ -70,61 +70,66 @@ export function CalendarMonthView({
   const referenceDate = new Date(year, month, 1)
 
   return (
-    <div className="rounded-lg border">
-      {/* Day headers */}
-      <div className="grid grid-cols-7 border-b">
-        {DAY_HEADERS.map((day) => (
-          <div key={day} className="p-2 text-center text-xs font-medium text-muted-foreground">
-            {day}
-          </div>
-        ))}
-      </div>
-
-      {/* Day cells */}
-      <div className="grid grid-cols-7">
-        {/* Leading blank cells (static count per month, never reorder) */}
-        {Array.from({ length: leadingBlanks }, (_, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: blank spacer cells have no stable ID
-          <div key={`blank-${i}`} className="min-h-[80px] border-b border-r p-1.5 opacity-40" />
-        ))}
-
-        {/* Actual days */}
-        {days.map((day) => {
-          const key = format(day, 'yyyy-MM-dd')
-          const dayBookings = bookingsByDate.get(key) ?? []
-          const overflowCount = dayBookings.length - MAX_VISIBLE_CHIPS
-          const inMonth = isSameMonth(day, referenceDate)
-
-          return (
-            <div
-              key={key}
-              className={cn(
-                'min-h-[80px] border-b border-r p-1.5',
-                !inMonth && 'opacity-40',
-                isToday(day) && 'bg-primary/10',
-              )}
-            >
-              <div className={cn('mb-1 text-xs', isToday(day) && 'font-semibold text-primary')}>
-                {format(day, 'd')}
-              </div>
-              <div className="flex flex-col gap-0.5">
-                {dayBookings.slice(0, MAX_VISIBLE_CHIPS).map((booking) => (
-                  <BookingBlock
-                    key={booking.id}
-                    booking={booking}
-                    variant="chip"
-                    onClick={() => onBookingClick(booking)}
-                  />
-                ))}
-                {overflowCount > 0 && (
-                  <span className="text-[10px] text-muted-foreground pl-1.5">
-                    +{overflowCount} more
-                  </span>
-                )}
-              </div>
+    <div className="overflow-x-auto rounded-lg border">
+      <div className="min-w-[500px]">
+        {/* Day headers */}
+        <div className="grid grid-cols-7 border-b">
+          {DAY_HEADERS.map((day) => (
+            <div key={day} className="p-2 text-center text-xs font-medium text-muted-foreground">
+              {day}
             </div>
-          )
-        })}
+          ))}
+        </div>
+
+        {/* Day cells */}
+        <div className="grid grid-cols-7">
+          {/* Leading blank cells (static count per month, never reorder) */}
+          {Array.from({ length: leadingBlanks }, (_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: blank spacer cells have no stable ID
+              key={`blank-${i}`}
+              className="min-h-[60px] sm:min-h-[80px] border-b border-r p-1.5 opacity-40"
+            />
+          ))}
+
+          {/* Actual days */}
+          {days.map((day) => {
+            const key = format(day, 'yyyy-MM-dd')
+            const dayBookings = bookingsByDate.get(key) ?? []
+            const overflowCount = dayBookings.length - MAX_VISIBLE_CHIPS
+            const inMonth = isSameMonth(day, referenceDate)
+
+            return (
+              <div
+                key={key}
+                className={cn(
+                  'min-h-[60px] sm:min-h-[80px] border-b border-r p-1.5',
+                  !inMonth && 'opacity-40',
+                  isToday(day) && 'bg-primary/10',
+                )}
+              >
+                <div className={cn('mb-1 text-xs', isToday(day) && 'font-semibold text-primary')}>
+                  {format(day, 'd')}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  {dayBookings.slice(0, MAX_VISIBLE_CHIPS).map((booking) => (
+                    <BookingBlock
+                      key={booking.id}
+                      booking={booking}
+                      variant="chip"
+                      onClick={() => onBookingClick(booking)}
+                    />
+                  ))}
+                  {overflowCount > 0 && (
+                    <span className="text-[10px] text-muted-foreground pl-1.5">
+                      +{overflowCount} more
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/packages/web/src/components/calendar/CalendarNavigation.tsx
+++ b/packages/web/src/components/calendar/CalendarNavigation.tsx
@@ -39,7 +39,7 @@ export function CalendarNavigation({
   }
 
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <div className="flex items-center gap-1">
         <Button variant="outline" size="icon" onClick={handlePrev} aria-label="Previous">
           <ChevronLeft className="size-4" />
@@ -52,7 +52,9 @@ export function CalendarNavigation({
         </Button>
       </div>
 
-      <span className="text-sm font-medium">{formatLabel(currentDate, viewMode)}</span>
+      <span className="order-last w-full text-center text-sm font-medium sm:order-none sm:w-auto">
+        {formatLabel(currentDate, viewMode)}
+      </span>
 
       <div className="flex items-center gap-1">
         <Button

--- a/packages/web/src/components/calendar/CalendarWeekView.tsx
+++ b/packages/web/src/components/calendar/CalendarWeekView.tsx
@@ -70,77 +70,79 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
   const nowTop = (nowMinutes / 60) * PIXELS_PER_HOUR
 
   return (
-    <div className="rounded-lg border">
-      {/* Day header */}
-      <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
-        <div className="p-2" />
-        {days.map((day) => (
-          <div
-            key={day.toISOString()}
-            className={cn(
-              'p-2 text-center text-xs font-medium border-l',
-              isToday(day) && 'bg-primary/10',
-            )}
-          >
-            <div className="text-muted-foreground">{format(day, 'EEE')}</div>
-            <div className={cn('text-sm', isToday(day) && 'text-primary font-semibold')}>
-              {format(day, 'd')}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      <div className="overflow-y-auto max-h-[600px]">
-        <div className="grid grid-cols-[60px_repeat(7,1fr)]" style={{ height: totalHeight }}>
-          {/* Hour labels */}
-          <div className="relative">
-            {HOUR_SLOTS.map((hour, idx) => (
-              <div
-                key={hour}
-                className="absolute right-2 text-[10px] text-muted-foreground -translate-y-1/2"
-                style={{ top: idx * PIXELS_PER_HOUR }}
-              >
-                {hour}
+    <div className="overflow-x-auto rounded-lg border">
+      <div className="min-w-[700px]">
+        {/* Day header */}
+        <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
+          <div className="p-2" />
+          {days.map((day) => (
+            <div
+              key={day.toISOString()}
+              className={cn(
+                'p-2 text-center text-xs font-medium border-l',
+                isToday(day) && 'bg-primary/10',
+              )}
+            >
+              <div className="text-muted-foreground">{format(day, 'EEE')}</div>
+              <div className={cn('text-sm', isToday(day) && 'text-primary font-semibold')}>
+                {format(day, 'd')}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
+        </div>
 
-          {/* Day columns */}
-          {days.map((day, dayIdx) => (
-            <div key={day.toISOString()} className="relative border-l">
-              {/* Hour grid lines */}
-              {HOUR_SLOTS.map((hour, hourIdx) => (
+        <div className="overflow-y-auto max-h-[600px]">
+          <div className="grid grid-cols-[60px_repeat(7,1fr)]" style={{ height: totalHeight }}>
+            {/* Hour labels */}
+            <div className="relative">
+              {HOUR_SLOTS.map((hour, idx) => (
                 <div
                   key={hour}
-                  className="absolute inset-x-0 border-t border-border/50"
-                  style={{ top: hourIdx * PIXELS_PER_HOUR }}
-                />
-              ))}
-
-              {/* Now line */}
-              {isCurrentWeek && isToday(day) && (
-                <div
-                  className="absolute inset-x-0 z-10 border-t-2 border-destructive"
-                  style={{ top: nowTop }}
-                />
-              )}
-
-              {/* Booking blocks */}
-              {bookingsByDay.get(dayIdx)?.map(({ booking, top, height }) => (
-                <div
-                  key={`${booking.id}-${dayIdx}`}
-                  className="absolute inset-x-0 px-0.5"
-                  style={{ top, height }}
+                  className="absolute right-2 text-[10px] text-muted-foreground -translate-y-1/2"
+                  style={{ top: idx * PIXELS_PER_HOUR }}
                 >
-                  <BookingBlock
-                    booking={booking}
-                    variant="bar"
-                    onClick={() => onBookingClick(booking)}
-                  />
+                  {hour}
                 </div>
               ))}
             </div>
-          ))}
+
+            {/* Day columns */}
+            {days.map((day, dayIdx) => (
+              <div key={day.toISOString()} className="relative border-l">
+                {/* Hour grid lines */}
+                {HOUR_SLOTS.map((hour, hourIdx) => (
+                  <div
+                    key={hour}
+                    className="absolute inset-x-0 border-t border-border/50"
+                    style={{ top: hourIdx * PIXELS_PER_HOUR }}
+                  />
+                ))}
+
+                {/* Now line */}
+                {isCurrentWeek && isToday(day) && (
+                  <div
+                    className="absolute inset-x-0 z-10 border-t-2 border-destructive"
+                    style={{ top: nowTop }}
+                  />
+                )}
+
+                {/* Booking blocks */}
+                {bookingsByDay.get(dayIdx)?.map(({ booking, top, height }) => (
+                  <div
+                    key={`${booking.id}-${dayIdx}`}
+                    className="absolute inset-x-0 px-0.5"
+                    style={{ top, height }}
+                  >
+                    <BookingBlock
+                      booking={booking}
+                      variant="bar"
+                      onClick={() => onBookingClick(booking)}
+                    />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/calendar/CalendarWeekView.tsx
+++ b/packages/web/src/components/calendar/CalendarWeekView.tsx
@@ -70,7 +70,7 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
   const nowTop = (nowMinutes / 60) * PIXELS_PER_HOUR
 
   return (
-    <div className="overflow-x-auto rounded-lg border">
+    <section className="overflow-x-auto rounded-lg border" aria-label="Week calendar">
       <div className="min-w-[700px]">
         {/* Day header */}
         <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
@@ -145,6 +145,6 @@ export function CalendarWeekView({ bookings, weekStart, onBookingClick }: Calend
           </div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/packages/web/src/components/vehicles/BulkActionBar.tsx
+++ b/packages/web/src/components/vehicles/BulkActionBar.tsx
@@ -50,9 +50,9 @@ export function BulkActionBar({ selectedIds, onClearSelection }: BulkActionBarPr
   return (
     <>
       <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur-sm p-3">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
+        <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3">
           <span className="text-sm font-medium">{t('bulk.selectedCount', { count })}</span>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button variant="outline" size="sm" onClick={onClearSelection}>
               {t('bulk.deselectAll')}
             </Button>

--- a/packages/web/src/components/vehicles/FleetSummaryBar.tsx
+++ b/packages/web/src/components/vehicles/FleetSummaryBar.tsx
@@ -29,21 +29,21 @@ export function FleetSummaryBar({ overviews }: FleetSummaryBarProps) {
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg border bg-card px-4 py-3 text-sm">
       <span className="font-medium text-foreground">{t('fleet.summary.total', { n: total })}</span>
-      <span className="text-muted-foreground" aria-hidden>
+      <span className="hidden sm:inline text-muted-foreground" aria-hidden>
         ·
       </span>
       <span className="text-foreground">{t('fleet.summary.onRental', { n: onRental })}</span>
-      <span className="text-muted-foreground" aria-hidden>
+      <span className="hidden sm:inline text-muted-foreground" aria-hidden>
         ·
       </span>
       <span className="text-foreground">{t('fleet.summary.available', { n: available })}</span>
-      <span className="text-muted-foreground" aria-hidden>
+      <span className="hidden sm:inline text-muted-foreground" aria-hidden>
         ·
       </span>
       <span className="text-foreground">{t('fleet.summary.maintenance', { n: maintenance })}</span>
       {expiring > 0 && (
         <>
-          <span className="text-muted-foreground" aria-hidden>
+          <span className="hidden sm:inline text-muted-foreground" aria-hidden>
             ·
           </span>
           <span className="text-destructive">{t('fleet.summary.expiring', { n: expiring })}</span>

--- a/packages/web/src/components/vehicles/FleetViewToggle.tsx
+++ b/packages/web/src/components/vehicles/FleetViewToggle.tsx
@@ -47,7 +47,7 @@ export function FleetViewToggle({ value, onChange }: FleetViewToggleProps) {
   const t = useTranslations('business.vehicles')
 
   return (
-    <div className="inline-flex items-center gap-1 rounded-lg border bg-card p-1">
+    <div className="hidden md:inline-flex items-center gap-1 rounded-lg border bg-card p-1">
       <Button
         variant="ghost"
         size="sm"

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -216,6 +216,8 @@ export function VehicleList() {
           </div>
         )}
 
+        {/* Row view: desktop-only. On mobile, card grid below is the fallback.
+            Both lists mount when viewMode==='row' — acceptable for <=50 vehicles. */}
         {!isLoading && !isError && displayed.length > 0 && viewMode === 'row' && (
           <div className="hidden md:block space-y-2">
             {displayed.map((overview) => (

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AddVehicleDialog } from '@/components/vehicles/AddVehicleDialog'
 import { BulkActionBar } from '@/components/vehicles/BulkActionBar'
@@ -17,10 +18,11 @@ import {
   filterVehicles,
   sortVehicles,
 } from '@/lib/fleet-filters'
+import { cn } from '@/lib/utils'
 import { fetchFleetOverviewAction } from '@/lib/vehicle-actions'
 import type { VehicleData } from '@/lib/vehicle-api'
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, Car, Plus } from 'lucide-react'
+import { AlertCircle, Car, Plus, SlidersHorizontal } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useCallback, useMemo, useState } from 'react'
 
@@ -123,7 +125,7 @@ export function VehicleList() {
 
   return (
     <div className="flex flex-col lg:flex-row gap-6">
-      <aside className="lg:w-64 lg:sticky lg:top-20 lg:self-start shrink-0">
+      <aside className="hidden lg:block lg:w-64 lg:sticky lg:top-20 lg:self-start shrink-0">
         <FleetFilters
           filters={filters}
           sort={sort}
@@ -141,7 +143,37 @@ export function VehicleList() {
         {!isLoading && !isError && overviews && <FleetSummaryBar overviews={overviews} />}
 
         <div className="flex items-center justify-between gap-4">
-          <FleetViewToggle value={viewMode} onChange={setViewMode} />
+          <div className="flex items-center gap-2">
+            <Sheet>
+              <SheetTrigger
+                render={
+                  <Button variant="outline" size="sm" className="lg:hidden">
+                    <SlidersHorizontal className="size-4 mr-1.5" />
+                    {t('filter.title')}
+                  </Button>
+                }
+              />
+              <SheetContent side="left" className="w-72 overflow-y-auto">
+                <SheetHeader>
+                  <SheetTitle>{t('filter.title')}</SheetTitle>
+                </SheetHeader>
+                <div className="px-4 pb-4">
+                  <FleetFilters
+                    filters={filters}
+                    sort={sort}
+                    onFiltersChange={setFilters}
+                    onSortChange={setSort}
+                    seatsBounds={seatsBounds}
+                    availableMakes={availableMakes}
+                    availableModels={availableModels}
+                    availableYears={availableYears}
+                    availableColors={availableColors}
+                  />
+                </div>
+              </SheetContent>
+            </Sheet>
+            <FleetViewToggle value={viewMode} onChange={setViewMode} />
+          </div>
           <Button onClick={() => setShowAddDialog(true)}>
             <Plus className="size-4 mr-1.5" />
             {t('addVehicle')}
@@ -185,7 +217,7 @@ export function VehicleList() {
         )}
 
         {!isLoading && !isError && displayed.length > 0 && viewMode === 'row' && (
-          <div className="space-y-2">
+          <div className="hidden md:block space-y-2">
             {displayed.map((overview) => (
               <FleetVehicleRow
                 key={overview.id}
@@ -199,8 +231,13 @@ export function VehicleList() {
           </div>
         )}
 
-        {!isLoading && !isError && displayed.length > 0 && viewMode === 'grid' && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
+        {!isLoading && !isError && displayed.length > 0 && (
+          <div
+            className={cn(
+              'grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6',
+              viewMode === 'row' && 'md:hidden',
+            )}
+          >
             {displayed.map((overview) => (
               <FleetVehicleCard
                 key={overview.id}


### PR DESCRIPTION
Closes #245

## Summary

- Add viewport meta tag (`device-width`, `initialScale: 1`, `maximumScale: 5`)
- Fleet: force card view on mobile (hide row view + toggle below `md:`)
- Fleet: filter sidebar as Sheet slide-out on mobile (`lg:hidden` trigger)
- Calendar week/month: `overflow-x-auto` wrappers with min-width floors + semantic `<section>` elements
- Calendar nav: `flex-wrap` with date label on second row on mobile
- Summary bar: hide dot separators on mobile wrap
- Bulk action bar: `flex-wrap` buttons for narrow screens
- i18n: add `filter.title` key (en/ja/zh)

## Approach

CSS-only fixes using Tailwind breakpoints — no JS `useMediaQuery`. Matches existing codebase pattern where all responsive behavior uses Tailwind classes.

Fleet row view is hidden on mobile via `hidden md:block`; card grid always renders as fallback. Both lists mount when `viewMode === 'row'` — documented as acceptable for <=50 vehicles.

## Test plan

- [ ] 375px viewport (iPhone SE): card view only, no overflow, filter sheet opens from left
- [ ] Calendar views scroll horizontally on mobile
- [ ] Calendar navigation wraps cleanly (date label on second row)
- [ ] 768px+: row/grid toggle visible, sidebar shows, full calendar
- [ ] Existing tests pass (31/33 — 2 pre-existing failures on main)