### PR TITLE
fix(api): security — role check + data stripping on vehicle detail & availability

### DIFF
--- a/drizzle/0020_add-maintenance-logs-vehicle-index.sql
+++ b/drizzle/0020_add-maintenance-logs-vehicle-index.sql
@@ -1,0 +1,3 @@
+-- Issue #254: maintenance_logs.vehicleId FK was missing an index.
+-- Every findByVehicleId query was doing a sequential scan.
+CREATE INDEX IF NOT EXISTS "idx_maintenance_logs_vehicleId" ON "maintenance_logs" ("vehicleId");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776219790405,
       "tag": "0019_add-vehicle-classes",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1776566400000,
+      "tag": "0020_add-maintenance-logs-vehicle-index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/routes/availability.ts
+++ b/packages/api/src/routes/availability.ts
@@ -27,7 +27,7 @@ export function createAvailabilityRoutes(repo: AvailabilityRepository) {
       }
 
       const user = getUser(c)
-      const isStaff = user && STAFF_ROLES.has(user.role)
+      const isStaff = user != null && STAFF_ROLES.has(user.role)
 
       const conflicts = isStaff
         ? result.conflicts

--- a/packages/api/src/routes/availability.ts
+++ b/packages/api/src/routes/availability.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { STAFF_ROLES, getUser } from '../middleware/auth'
 import type { AvailabilityRepository } from '../repositories/types'
 import { fail, ok, parseDateRange } from './helpers'
 
@@ -25,10 +26,17 @@ export function createAvailabilityRoutes(repo: AvailabilityRepository) {
         return ok(c, { available: true, vehicle: result.vehicle })
       }
 
+      const user = getUser(c)
+      const isStaff = user && STAFF_ROLES.has(user.role)
+
+      const conflicts = isStaff
+        ? result.conflicts
+        : result.conflicts.map((b) => ({ startAt: b.startAt, effectiveEndAt: b.effectiveEndAt }))
+
       return ok(c, {
         available: false,
         vehicle: result.vehicle,
-        conflicts: result.conflicts,
+        conflicts,
       })
     })
 }

--- a/packages/api/src/routes/vehicle-detail.ts
+++ b/packages/api/src/routes/vehicle-detail.ts
@@ -1,9 +1,13 @@
 import { Hono } from 'hono'
+import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { VehicleDetailRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
 
 export function createVehicleDetailRoutes(repo: VehicleDetailRepository) {
   return new Hono().get('/vehicles/:id/detail', async (c) => {
+    const user = requireUser(c)
+    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
     const detail = await repo.findVehicleDetail(c.req.param('id'))
     if (!detail) {
       return fail(c, 'Vehicle not found', 404)

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -7,10 +7,12 @@ import {
 } from '../../src/repositories/in-memory'
 import type { Booking, Vehicle } from '../../src/repositories/types'
 import { createAvailabilityRoutes } from '../../src/routes/availability'
+import { testAuthMiddleware } from '../helpers/auth'
 
 let app: Hono
 let vehicleRepo: InMemoryVehicleRepository
 let bookingRepo: InMemoryBookingRepository
+let availabilityRepo: InMemoryAvailabilityRepository
 
 async function createTestVehicle(
   overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
@@ -60,8 +62,9 @@ describe('Availability Routes', () => {
   beforeEach(() => {
     vehicleRepo = new InMemoryVehicleRepository()
     bookingRepo = new InMemoryBookingRepository()
-    const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+    availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
     app = new Hono()
+    app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
     app.route('/', createAvailabilityRoutes(availabilityRepo))
   })
 
@@ -278,6 +281,42 @@ describe('Availability Routes', () => {
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBe('Vehicle not found')
+    })
+
+    it('strips conflict details for RENTER role', async () => {
+      const renterApp = new Hono()
+      renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
+      renterApp.route('/', createAvailabilityRoutes(availabilityRepo))
+
+      const vehicle = await createTestVehicle()
+      await createTestBooking({
+        vehicleId: vehicle.id,
+        renterId: 'other-renter',
+        notes: 'secret internal note',
+        startAt: new Date('2026-06-01T10:00:00Z'),
+        endAt: new Date('2026-06-01T14:00:00Z'),
+        status: 'CONFIRMED',
+      })
+
+      const res = await renterApp.request(
+        `/availability/${vehicle.id}?from=2026-06-01T12:00:00Z&to=2026-06-01T16:00:00Z`,
+      )
+
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data.available).toBe(false)
+      expect(body.data.conflicts).toHaveLength(1)
+
+      const conflict = body.data.conflicts[0]
+      // Should only have time window fields
+      expect(Object.keys(conflict)).toEqual(['startAt', 'effectiveEndAt'])
+      // Should NOT leak sensitive fields
+      expect(conflict).not.toHaveProperty('id')
+      expect(conflict).not.toHaveProperty('renterId')
+      expect(conflict).not.toHaveProperty('notes')
+      expect(conflict).not.toHaveProperty('status')
     })
   })
 })

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -274,4 +274,14 @@ describe('GET /vehicles/:id/detail', () => {
     const res = await renterApp.request(`/vehicles/${vehicle.id}/detail`)
     expect(res.status).toBe(403)
   })
+
+  it('fails closed when no auth middleware is present', async () => {
+    const vehicle = await seedVehicle()
+    const noAuthApp = new Hono()
+    const repo = new InMemoryVehicleDetailRepository(vehicleRepo, bookingRepo, renterNames)
+    noAuthApp.route('/', createVehicleDetailRoutes(repo))
+    const res = await noAuthApp.request(`/vehicles/${vehicle.id}/detail`)
+    // requireUser throws → 500 (fail-closed, not a silent pass-through)
+    expect(res.status).toBe(500)
+  })
 })

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -7,6 +7,7 @@ import {
 import { InMemoryVehicleDetailRepository } from '../../src/repositories/in-memory-vehicle-detail'
 import { createVehicleDetailRoutes } from '../../src/routes/vehicle-detail'
 import type { Vehicle } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
 
 let app: Hono
 let vehicleRepo: InMemoryVehicleRepository
@@ -83,6 +84,7 @@ describe('GET /vehicles/:id/detail', () => {
 
     const detailRepo = new InMemoryVehicleDetailRepository(vehicleRepo, bookingRepo, renterNames)
     app = new Hono()
+    app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
     app.route('/', createVehicleDetailRoutes(detailRepo))
   })
 
@@ -261,5 +263,15 @@ describe('GET /vehicles/:id/detail', () => {
     const body = await res.json()
 
     expect(body.data.upcomingBookings).toHaveLength(0)
+  })
+
+  it('returns 403 for RENTER role', async () => {
+    const vehicle = await seedVehicle()
+    const renterApp = new Hono()
+    renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
+    const repo = new InMemoryVehicleDetailRepository(vehicleRepo, bookingRepo, renterNames)
+    renterApp.route('/', createVehicleDetailRoutes(repo))
+    const res = await renterApp.request(`/vehicles/${vehicle.id}/detail`)
+    expect(res.status).toBe(403)
   })
 })


### PR DESCRIPTION
Closes #252, Closes #253, Closes #254

## Summary

- **#252**: Add `STAFF_ROLES` check to `GET /vehicles/:id/detail` — renters can no longer access revenue/utilization data
- **#253**: Strip availability conflicts to `{ startAt, effectiveEndAt }` for non-staff users — prevents PII leak (renterId, notes)
- **#254**: Add missing FK index on `maintenance_logs.vehicleId` — was doing sequential scans

## Test plan

- [ ] `GET /vehicles/:id/detail` returns 403 for RENTER role
- [ ] `GET /availability/:vehicleId` returns only `{ startAt, effectiveEndAt }` in conflicts for RENTER
- [ ] `GET /availability/:vehicleId` returns full conflict objects for STAFF
- [ ] All 256 API tests pass
- [ ] Run `db:migrate` to apply index migration