### PR TITLE
fix(api): push limit/offset into VehicleRepository query layer

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,7 +1,12 @@
 import { vehicles } from '@kuruma/shared/db/schema'
 import { type SQL, and, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
-import type { PaginatedResult, VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type {
+  PaginatedResult,
+  VehicleFilters,
+  VehicleRepository,
+  VehicleUpdateOptions,
+} from '../types'
 import { type Db, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
@@ -16,7 +21,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       conditions.push(ne(vehicles.status, 'RETIRED'))
     }
 
-    const where = conditions.length > 0 ? conditions[0]! : undefined
+    const where = conditions.length > 0 ? and(...conditions) : undefined
 
     const [countResult, rows] = await Promise.all([
       this.db.select({ value: count() }).from(vehicles).where(where),

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,25 +1,37 @@
 import { vehicles } from '@kuruma/shared/db/schema'
-import { and, eq, inArray, ne, sql } from 'drizzle-orm'
+import { type SQL, and, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
-import type { VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type { PaginatedResult, VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
 import { type Db, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
-    const query = this.db.select(vehicleColumns).from(vehicles)
+  async findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
+    const conditions: SQL[] = []
 
     if (filters?.status) {
-      const rows = await query.where(eq(vehicles.status, filters.status as Vehicle['status']))
-      return rows.map(toVehicle)
+      conditions.push(eq(vehicles.status, filters.status as Vehicle['status']))
+    } else if (!filters?.includeRetired) {
+      conditions.push(ne(vehicles.status, 'RETIRED'))
     }
 
-    const rows = filters?.includeRetired
-      ? await query
-      : await query.where(ne(vehicles.status, 'RETIRED'))
+    const where = conditions.length > 0 ? conditions[0]! : undefined
 
-    return rows.map(toVehicle)
+    const [countResult, rows] = await Promise.all([
+      this.db.select({ value: count() }).from(vehicles).where(where),
+      (() => {
+        let q = this.db.select(vehicleColumns).from(vehicles).where(where).$dynamic()
+        if (filters?.limit != null) q = q.limit(filters.limit)
+        if (filters?.offset != null) q = q.offset(filters.offset)
+        return q
+      })(),
+    ])
+
+    return {
+      data: rows.map(toVehicle),
+      total: countResult[0]?.value ?? 0,
+    }
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -10,7 +10,7 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
   ) {}
 
   async findAvailableVehicles(from: Date, to: Date): Promise<Vehicle[]> {
-    const vehicles = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
+    const { data: vehicles } = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return vehicles.filter((vehicle) => {

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -40,7 +40,7 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
     const now = new Date()
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
-    const vehicles = await this.vehicleRepo.findAll()
+    const { data: vehicles } = await this.vehicleRepo.findAll()
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return Promise.all(

--- a/packages/api/src/repositories/in-memory/stats.ts
+++ b/packages/api/src/repositories/in-memory/stats.ts
@@ -13,14 +13,14 @@ export class InMemoryStatsRepository implements StatsRepository {
   ) {}
 
   async getDashboardStats(): Promise<DashboardStats> {
-    const [vehicles, bookings] = await Promise.all([
+    const [vehicleResult, bookings] = await Promise.all([
       this.vehicleRepo.findAll({ status: 'AVAILABLE' }),
       this.bookingRepo.findAll(SYSTEM_CONTEXT),
     ])
 
     return {
       totalBookings: bookings.length,
-      activeVehicles: vehicles.length,
+      activeVehicles: vehicleResult.total,
       totalCustomers: 0, // No users table in InMemory
       unreadMessages: 0, // No messages table yet
     }

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -1,5 +1,10 @@
 import type { Vehicle } from '../../stores'
-import type { PaginatedResult, VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type {
+  PaginatedResult,
+  VehicleFilters,
+  VehicleRepository,
+  VehicleUpdateOptions,
+} from '../types'
 
 export class InMemoryVehicleRepository implements VehicleRepository {
   private readonly store: Map<string, Vehicle>

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -1,5 +1,5 @@
 import type { Vehicle } from '../../stores'
-import type { VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type { PaginatedResult, VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
 
 export class InMemoryVehicleRepository implements VehicleRepository {
   private readonly store: Map<string, Vehicle>
@@ -8,11 +8,21 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
+  async findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
     const all = [...this.store.values()]
-    if (filters?.status) return all.filter((v) => v.status === filters.status)
-    if (filters?.includeRetired) return all
-    return all.filter((v) => v.status !== 'RETIRED')
+    let filtered: Vehicle[]
+    if (filters?.status) {
+      filtered = all.filter((v) => v.status === filters.status)
+    } else if (filters?.includeRetired) {
+      filtered = all
+    } else {
+      filtered = all.filter((v) => v.status !== 'RETIRED')
+    }
+    const total = filtered.length
+    const offset = filters?.offset ?? 0
+    const limit = filters?.limit
+    const data = limit != null ? filtered.slice(offset, offset + limit) : filtered.slice(offset)
+    return { data, total }
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -30,6 +30,13 @@ import type {
 export interface VehicleFilters {
   status?: string
   includeRetired?: boolean
+  limit?: number
+  offset?: number
+}
+
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
 }
 
 export interface VehicleUpdateOptions {
@@ -37,7 +44,7 @@ export interface VehicleUpdateOptions {
 }
 
 export interface VehicleRepository {
-  findAll(filters?: VehicleFilters): Promise<Vehicle[]>
+  findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>>
   findById(id: string): Promise<Vehicle | undefined>
   findByIds(ids: string[]): Promise<Vehicle[]>
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -7,7 +7,7 @@ import {
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
-import type { Vehicle, VehicleRepository } from '../repositories/types'
+import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
@@ -30,9 +30,10 @@ export function createVehicleRoutes(
         return fail(c, 'offset must be a non-negative integer', 400)
       }
 
-      const all = status ? await repo.findAll({ status }) : await repo.findAll()
-      const page = all.slice(offset, offset + limit)
-      return ok(c, page, 200, { total: all.length, limit, offset })
+      const filters: VehicleFilters = { limit, offset }
+      if (status) filters.status = status
+      const { data, total } = await repo.findAll(filters)
+      return ok(c, data, 200, { total, limit, offset })
     })
     .get('/vehicles/:id', async (c) => {
       const vehicle = await repo.findById(c.req.param('id'))

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -30,8 +30,7 @@ export function createVehicleRoutes(
         return fail(c, 'offset must be a non-negative integer', 400)
       }
 
-      const filters: VehicleFilters = { limit, offset }
-      if (status) filters.status = status
+      const filters: VehicleFilters = { limit, offset, ...(status ? { status } : {}) }
       const { data, total } = await repo.findAll(filters)
       return ok(c, data, 200, { total, limit, offset })
     })

--- a/packages/api/tests/integration/vehicles-pricing.test.ts
+++ b/packages/api/tests/integration/vehicles-pricing.test.ts
@@ -214,7 +214,7 @@ describe('DrizzleVehicleRepository — pricing (#48)', () => {
       )
       createdVehicleIds.push(a.id, b.id)
 
-      const all = await repo.findAll()
+      const { data: all } = await repo.findAll()
       const aRow = all.find((v) => v.id === a.id)!
       const bRow = all.find((v) => v.id === b.id)!
 

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -123,13 +123,13 @@ describe('DrizzleVehicleRepository', () => {
     createdIds.push(maintenance.id)
 
     // findAll without filter should include both
-    const all = await repo.findAll()
+    const { data: all } = await repo.findAll()
     const allIds = all.map((v) => v.id)
     expect(allIds).toContain(available.id)
     expect(allIds).toContain(maintenance.id)
 
     // findAll with status filter should only include matching
-    const filtered = await repo.findAll({ status: 'MAINTENANCE' })
+    const { data: filtered } = await repo.findAll({ status: 'MAINTENANCE' })
     const filteredIds = filtered.map((v) => v.id)
     expect(filteredIds).toContain(maintenance.id)
     expect(filteredIds).not.toContain(available.id)

--- a/packages/api/tests/repositories/vehicle.test.ts
+++ b/packages/api/tests/repositories/vehicle.test.ts
@@ -24,6 +24,53 @@ function vehicleInput(overrides?: Partial<Vehicle>) {
   }
 }
 
+describe('VehicleRepository.findAll pagination', () => {
+  let repo: InMemoryVehicleRepository
+
+  beforeEach(async () => {
+    repo = new InMemoryVehicleRepository()
+    await repo.create(vehicleInput({ name: 'Car A' }))
+    await repo.create(vehicleInput({ name: 'Car B' }))
+    await repo.create(vehicleInput({ name: 'Car C' }))
+  })
+
+  it('returns paginated data with total count', async () => {
+    const result = await repo.findAll({ limit: 2, offset: 0 })
+
+    expect(result.data).toHaveLength(2)
+    expect(result.total).toBe(3)
+    expect(result.data[0]!.name).toBe('Car A')
+    expect(result.data[1]!.name).toBe('Car B')
+  })
+
+  it('returns correct page with offset', async () => {
+    const result = await repo.findAll({ limit: 2, offset: 2 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]!.name).toBe('Car C')
+    expect(result.total).toBe(3)
+  })
+
+  it('returns all items when no limit/offset given', async () => {
+    const result = await repo.findAll()
+
+    expect(result.data).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('applies status filter before pagination', async () => {
+    // Retire Car B
+    const all = await repo.findAll()
+    await repo.softDelete(all.data[1]!.id)
+
+    const result = await repo.findAll({ status: 'RETIRED', limit: 10, offset: 0 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]!.name).toBe('Car B')
+    expect(result.total).toBe(1)
+  })
+})
+
 describe('VehicleRepository.findByIds', () => {
   let repo: InMemoryVehicleRepository
 

--- a/packages/api/tests/repositories/vehicle.test.ts
+++ b/packages/api/tests/repositories/vehicle.test.ts
@@ -69,6 +69,13 @@ describe('VehicleRepository.findAll pagination', () => {
     expect(result.data[0]!.name).toBe('Car B')
     expect(result.total).toBe(1)
   })
+
+  it('returns empty data when offset exceeds total', async () => {
+    const result = await repo.findAll({ limit: 10, offset: 100 })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.total).toBe(3)
+  })
 })
 
 describe('VehicleRepository.findByIds', () => {

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -303,7 +303,7 @@ describe('Booking Routes', () => {
         insuranceExpiryDate: null,
       })
 
-      const allVehicles = await vehicleRepo.findAll()
+      const { data: allVehicles } = await vehicleRepo.findAll()
       const vehicleId = allVehicles[0]!.id
 
       await createBooking({

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -99,6 +99,35 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data[0].status).toBe('RETIRED')
     })
 
+    it('paginates with limit and offset', async () => {
+      await createVehicle({ ...validVehicleInput(), name: 'Car A' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car B' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car C' })
+
+      const res = await app.request('/vehicles?limit=2&offset=0')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(2)
+      expect(body.total).toBe(3)
+      expect(body.limit).toBe(2)
+      expect(body.offset).toBe(0)
+    })
+
+    it('returns second page with offset', async () => {
+      await createVehicle({ ...validVehicleInput(), name: 'Car A' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car B' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car C' })
+
+      const res = await app.request('/vehicles?limit=2&offset=2')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].name).toBe('Car C')
+      expect(body.total).toBe(3)
+    })
+
     it('filters by explicit status query param', async () => {
       await createVehicle()
       const createRes = await createVehicle({


### PR DESCRIPTION
## Summary
- Adds `limit`/`offset` to `VehicleFilters` and changes `findAll` return type to `{ data, total }` so pagination happens at the DB level instead of fetching all rows and slicing in JS
- Updates Drizzle impl with parallel `COUNT` + `SELECT...LIMIT...OFFSET` queries
- Updates InMemory impl with `slice()` after filtering
- Fixes all callers (availability, fleet-overview, stats repos + tests) to destructure `.data`

Closes #255

## Test plan
- [x] Repo-level tests: pagination with limit/offset, offset beyond total, status filter + pagination
- [x] Route-level tests: `GET /vehicles?limit=2&offset=0` and `?limit=2&offset=2`
- [x] All 265 tests pass (rebased onto latest main)
- [x] tsc --noEmit clean
- [x] Biome lint clean
- [x] Pre-commit hooks pass (file size, module boundaries)

Note: `rls-context.test.ts` integration failures in CI are pre-existing from the CallerContext work on another branch — not introduced by this PR.