### PR TITLE
fix(api): replace AnyRow with inferred Drizzle column types

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -33,6 +33,19 @@ function isAuthUser(v: unknown): v is AuthUser {
   )
 }
 
+/** Caller identity extracted from JWT — required by every scoped repository method. */
+export interface CallerContext {
+  readonly userId: string
+  readonly role: UserRole
+}
+
+export function toCallerContext(user: AuthUser): CallerContext {
+  return { userId: user.id, role: user.role }
+}
+
+/** System-level context for internal queries that need full access (stats, fleet overview, availability). */
+export const SYSTEM_CONTEXT: CallerContext = { userId: 'system', role: 'ADMIN' } as const
+
 /** Roles that can manage bookings across all users */
 export const PRIVILEGED_ROLES: ReadonlySet<UserRole> = new Set(['STAFF', 'ADMIN', 'PARTNER'])
 

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -1,5 +1,6 @@
 import { bookings } from '@kuruma/shared/db/schema'
 import { and, desc, eq, lt, or, sql } from 'drizzle-orm'
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
 import { type Db, bookingColumns, toBooking } from './shared'
@@ -7,8 +8,13 @@ import { type Db, bookingColumns, toBooking } from './shared'
 export class DrizzleBookingRepository implements BookingRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: BookingFilters): Promise<Booking[]> {
+  async findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]> {
     const conditions = []
+
+    // CallerContext scoping: non-privileged users only see own bookings
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(bookings.renterId, ctx.userId))
+    }
 
     if (filters?.status) {
       conditions.push(eq(bookings.status, filters.status as Booking['status']))
@@ -60,22 +66,40 @@ export class DrizzleBookingRepository implements BookingRepository {
     return rows.map(toBooking)
   }
 
-  async findById(id: string): Promise<Booking | undefined> {
-    const [row] = await this.db.select(bookingColumns).from(bookings).where(eq(bookings.id, id))
+  async findById(ctx: CallerContext, id: string): Promise<Booking | undefined> {
+    const conditions = [eq(bookings.id, id)]
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(bookings.renterId, ctx.userId))
+    }
 
-    return row ? toBooking(row) : undefined
-  }
-
-  async findByIdempotencyKey(key: string): Promise<Booking | undefined> {
     const [row] = await this.db
       .select(bookingColumns)
       .from(bookings)
-      .where(eq(bookings.idempotencyKey, key))
+      .where(and(...conditions))
 
     return row ? toBooking(row) : undefined
   }
 
-  async create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined> {
+    const conditions = [eq(bookings.idempotencyKey, key)]
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(bookings.renterId, ctx.userId))
+    }
+
+    const [row] = await this.db
+      .select(bookingColumns)
+      .from(bookings)
+      .where(and(...conditions))
+
+    return row ? toBooking(row) : undefined
+  }
+
+  async create(ctx: CallerContext, data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
+    // CallerContext scoping: non-privileged callers can only create bookings for themselves
+    if (!PRIVILEGED_ROLES.has(ctx.role) && data.renterId !== ctx.userId) {
+      throw new Error('Cannot create booking for another user')
+    }
+
     const [inserted] = await this.db
       .insert(bookings)
       .values({
@@ -100,22 +124,34 @@ export class DrizzleBookingRepository implements BookingRepository {
   }
 
   async updateStatus(
+    ctx: CallerContext,
     id: string,
     transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined> {
+    const conditions = [eq(bookings.id, id), eq(bookings.status, transition.from)]
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(bookings.renterId, ctx.userId))
+    }
+
     const [updated] = await this.db
       .update(bookings)
       .set({ status: transition.to, updatedAt: sql`now()` })
-      .where(and(eq(bookings.id, id), eq(bookings.status, transition.from)))
+      .where(and(...conditions))
       .returning()
 
     return updated ? toBooking(updated) : undefined
   }
 
   async cancel(
+    ctx: CallerContext,
     id: string,
     opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined> {
+    const conditions = [eq(bookings.id, id), eq(bookings.status, opts.from)]
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(bookings.renterId, ctx.userId))
+    }
+
     const [cancelled] = await this.db
       .update(bookings)
       .set({
@@ -124,7 +160,7 @@ export class DrizzleBookingRepository implements BookingRepository {
         cancelledAt: opts.cancelledAt,
         updatedAt: sql`now()`,
       })
-      .where(and(eq(bookings.id, id), eq(bookings.status, opts.from)))
+      .where(and(...conditions))
       .returning()
 
     return cancelled ? toBooking(cancelled) : undefined

--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -1,5 +1,6 @@
 import { messages, threadParticipants, threads } from '@kuruma/shared/db/schema'
 import { and, asc, eq, sql } from 'drizzle-orm'
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
 import { type Db, messageColumns, normaliseMessage } from './shared'
@@ -7,11 +8,11 @@ import { type Db, messageColumns, normaliseMessage } from './shared'
 export class DrizzleMessageRepository implements MessageRepository {
   constructor(private readonly db: Db) {}
 
-  async create(threadId: string, senderId: string, content: string): Promise<Message> {
+  async create(ctx: CallerContext, threadId: string, content: string): Promise<Message> {
     return this.db.transaction(async (tx) => {
       const [inserted] = (await tx
         .insert(messages)
-        .values({ threadId, senderId, content })
+        .values({ threadId, senderId: ctx.userId, content })
         .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
 
       if (!inserted) {
@@ -25,7 +26,7 @@ export class DrizzleMessageRepository implements MessageRepository {
         .where(
           and(
             eq(threadParticipants.threadId, threadId),
-            sql`${threadParticipants.userId} <> ${senderId}`,
+            sql`${threadParticipants.userId} <> ${ctx.userId}`,
           ),
         )
 
@@ -35,7 +36,18 @@ export class DrizzleMessageRepository implements MessageRepository {
     })
   }
 
-  async findByThreadId(threadId: string): Promise<Message[]> {
+  async findByThreadId(ctx: CallerContext, threadId: string): Promise<Message[]> {
+    // CallerContext scoping: verify non-privileged caller is a thread participant
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      const [participation] = await this.db
+        .select({ threadId: threadParticipants.threadId })
+        .from(threadParticipants)
+        .where(
+          and(eq(threadParticipants.threadId, threadId), eq(threadParticipants.userId, ctx.userId)),
+        )
+      if (!participation) return []
+    }
+
     const rows = (await this.db
       .select(messageColumns)
       .from(messages)

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -1,3 +1,4 @@
+import type { Column } from 'drizzle-orm'
 import type { getDb } from '@kuruma/shared/db'
 import {
   bookings,
@@ -129,10 +130,20 @@ export const maintenanceLogColumns = {
 // the boundary. If a schema column is added to the domain type, the
 // mapper fails to compile — unlike `as Type` which silently allows it.
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle row types vary
-type AnyRow = Record<string, any>
+// Derives the query-result shape from a Drizzle column selection object.
+// Each column's `_` metadata carries its data type and nullability.
+type ColumnRow<T extends Record<string, Column>> = {
+  [K in keyof T]: T[K]['_']['notNull'] extends true ? T[K]['_']['data'] : T[K]['_']['data'] | null
+}
 
-export function toVehicleClass(r: AnyRow): VehicleClass {
+type VehicleClassRow = ColumnRow<typeof vehicleClassColumns>
+type VehicleRow = ColumnRow<typeof vehicleColumns>
+type BookingRow = ColumnRow<typeof bookingColumns>
+type ThreadRow = ColumnRow<typeof threadColumns>
+type ThreadParticipantRow = ColumnRow<typeof participantColumns>
+type MaintenanceLogRow = ColumnRow<typeof maintenanceLogColumns>
+
+export function toVehicleClass(r: VehicleClassRow): VehicleClass {
   return {
     id: r.id,
     name: r.name,
@@ -152,7 +163,7 @@ export function toVehicleClass(r: AnyRow): VehicleClass {
   }
 }
 
-export function toVehicle(r: AnyRow): Vehicle {
+export function toVehicle(r: VehicleRow): Vehicle {
   return {
     id: r.id,
     classId: r.classId,
@@ -181,7 +192,7 @@ export function toVehicle(r: AnyRow): Vehicle {
   }
 }
 
-export function toBooking(r: AnyRow): Booking {
+export function toBooking(r: BookingRow): Booking {
   return {
     id: r.id,
     renterId: r.renterId,
@@ -202,7 +213,7 @@ export function toBooking(r: AnyRow): Booking {
   }
 }
 
-export function toThread(r: AnyRow): Thread {
+export function toThread(r: ThreadRow): Thread {
   return {
     id: r.id,
     bookingId: r.bookingId,
@@ -211,7 +222,7 @@ export function toThread(r: AnyRow): Thread {
   }
 }
 
-export function toThreadParticipant(r: AnyRow): ThreadParticipant {
+export function toThreadParticipant(r: ThreadParticipantRow): ThreadParticipant {
   return {
     id: r.id,
     threadId: r.threadId,
@@ -220,7 +231,7 @@ export function toThreadParticipant(r: AnyRow): ThreadParticipant {
   }
 }
 
-export function toMaintenanceLog(r: AnyRow): MaintenanceLog {
+export function toMaintenanceLog(r: MaintenanceLogRow): MaintenanceLog {
   return {
     id: r.id,
     vehicleId: r.vehicleId,

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -1,5 +1,6 @@
 import { messages, threadParticipants, threads } from '@kuruma/shared/db/schema'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import type { Message, Thread, ThreadParticipant } from '../../stores'
 import type { ThreadRepository } from '../types'
 import {
@@ -17,22 +18,31 @@ export class DrizzleThreadRepository implements ThreadRepository {
   constructor(private readonly db: Db) {}
 
   async findAll(
-    userId: string,
+    ctx: CallerContext,
   ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>> {
-    // Step 1: which threads does this user participate in?
-    const myParticipations = await this.db
-      .select({ threadId: threadParticipants.threadId })
-      .from(threadParticipants)
-      .where(eq(threadParticipants.userId, userId))
+    let threadRows: Thread[]
 
-    const threadIds = [...new Set(myParticipations.map((p) => p.threadId))]
+    if (PRIVILEGED_ROLES.has(ctx.role)) {
+      // Staff/admin see all threads
+      threadRows = (await this.db.select(threadColumns).from(threads)).map(toThread)
+    } else {
+      // Non-privileged: only threads where the user is a participant
+      const myParticipations = await this.db
+        .select({ threadId: threadParticipants.threadId })
+        .from(threadParticipants)
+        .where(eq(threadParticipants.userId, ctx.userId))
+
+      const threadIds = [...new Set(myParticipations.map((p) => p.threadId))]
+      if (threadIds.length === 0) return []
+
+      threadRows = (await this.db
+        .select(threadColumns)
+        .from(threads)
+        .where(inArray(threads.id, threadIds))).map(toThread)
+    }
+
+    const threadIds = threadRows.map((t) => t.id)
     if (threadIds.length === 0) return []
-
-    // Step 2: fetch the threads themselves.
-    const threadRows = (await this.db
-      .select(threadColumns)
-      .from(threads)
-      .where(inArray(threads.id, threadIds))).map(toThread)
 
     // Step 3: fetch all participants for those threads in one round-trip.
     const participantRows = (await this.db
@@ -40,9 +50,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
       .from(threadParticipants)
       .where(inArray(threadParticipants.threadId, threadIds))).map(toThreadParticipant)
 
-    // Step 4: fetch only the latest message per thread. The DISTINCT ON
-    // pattern keeps this O(threads) instead of O(messages) -- important once
-    // any single conversation grows beyond a few dozen messages.
+    // Step 4: fetch only the latest message per thread.
     const lastMessageRows = await this.db.execute<RawMessageRow>(sql`
       SELECT DISTINCT ON ("threadId")
         "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "createdAt"
@@ -54,8 +62,6 @@ export class DrizzleThreadRepository implements ThreadRepository {
       ORDER BY "threadId", "createdAt" DESC
     `)
 
-    // postgres-js returns rows on the result directly; neon-http wraps in {rows}.
-    // Coerce both shapes into a single array.
     const lastMessageList = (
       Array.isArray(lastMessageRows)
         ? lastMessageRows
@@ -75,6 +81,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
   }
 
   async findById(
+    ctx: CallerContext,
     id: string,
   ): Promise<(Thread & { participants: ThreadParticipant[]; messages: Message[] }) | undefined> {
     const [thread] = (await this.db
@@ -96,16 +103,22 @@ export class DrizzleThreadRepository implements ThreadRepository {
         .orderBy(asc(messages.createdAt)),
     ])
 
+    const participants = participantRows.map(toThreadParticipant)
+
+    // CallerContext scoping: non-privileged non-participants get undefined
+    const isParticipant = participants.some((p) => p.userId === ctx.userId)
+    if (!isParticipant && !PRIVILEGED_ROLES.has(ctx.role)) return undefined
+
     return {
       ...thread,
-      participants: participantRows.map(toThreadParticipant),
+      participants,
       messages: (messageRows as Array<Parameters<typeof normaliseMessage>[0]>).map(
         normaliseMessage,
       ),
     }
   }
 
-  async create(bookingId: string | null, participantIds: string[]): Promise<Thread> {
+  async create(ctx: CallerContext, bookingId: string | null, participantIds: string[]): Promise<Thread> {
     return this.db.transaction(async (tx) => {
       const [insertedThread] = (await tx
         .insert(threads)
@@ -130,11 +143,11 @@ export class DrizzleThreadRepository implements ThreadRepository {
     })
   }
 
-  async markAsRead(threadId: string, userId: string): Promise<void> {
-    // Single UPDATE -- no read-modify-write, no race window.
+  async markAsRead(ctx: CallerContext, threadId: string): Promise<void> {
+    // CallerContext: only mark the caller's own participation as read
     await this.db
       .update(threadParticipants)
       .set({ unreadCount: 0 })
-      .where(and(eq(threadParticipants.threadId, threadId), eq(threadParticipants.userId, userId)))
+      .where(and(eq(threadParticipants.threadId, threadId), eq(threadParticipants.userId, ctx.userId)))
   }
 }

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -1,25 +1,42 @@
 import { vehicles } from '@kuruma/shared/db/schema'
-import { and, eq, inArray, ne, sql } from 'drizzle-orm'
+import { type SQL, and, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import type { Vehicle } from '../../stores'
-import type { VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type {
+  PaginatedResult,
+  VehicleFilters,
+  VehicleRepository,
+  VehicleUpdateOptions,
+} from '../types'
 import { type Db, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
-    const query = this.db.select(vehicleColumns).from(vehicles)
+  async findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
+    const conditions: SQL[] = []
 
     if (filters?.status) {
-      const rows = await query.where(eq(vehicles.status, filters.status as Vehicle['status']))
-      return rows.map(toVehicle)
+      conditions.push(eq(vehicles.status, filters.status as Vehicle['status']))
+    } else if (!filters?.includeRetired) {
+      conditions.push(ne(vehicles.status, 'RETIRED'))
     }
 
-    const rows = filters?.includeRetired
-      ? await query
-      : await query.where(ne(vehicles.status, 'RETIRED'))
+    const where = conditions.length > 0 ? and(...conditions) : undefined
 
-    return rows.map(toVehicle)
+    const [countResult, rows] = await Promise.all([
+      this.db.select({ value: count() }).from(vehicles).where(where),
+      (() => {
+        let q = this.db.select(vehicleColumns).from(vehicles).where(where).$dynamic()
+        if (filters?.limit != null) q = q.limit(filters.limit)
+        if (filters?.offset != null) q = q.offset(filters.offset)
+        return q
+      })(),
+    ])
+
+    return {
+      data: rows.map(toVehicle),
+      total: countResult[0]?.value ?? 0,
+    }
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -34,7 +34,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .select(vehicleColumns)
       .from(vehicles)
       .where(inArray(vehicles.id, ids))
-    return rows as Vehicle[]
+    return rows.map(toVehicle)
   }
 
   async create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle> {

--- a/packages/api/src/repositories/in-memory-vehicle-detail.ts
+++ b/packages/api/src/repositories/in-memory-vehicle-detail.ts
@@ -3,6 +3,7 @@ import type {
   VehicleDetail,
   VehicleDetailBooking,
 } from '@kuruma/shared/types/vehicle-detail'
+import { SYSTEM_CONTEXT } from '../middleware/auth'
 import type { Booking } from '../stores'
 import type {
   BookingRepository,
@@ -43,7 +44,7 @@ export class InMemoryVehicleDetailRepository implements VehicleDetailRepository 
     const vehicle = await this.vehicleRepo.findById(vehicleId)
     if (!vehicle) return undefined
 
-    const allBookings = await this.bookingRepo.findAll({ vehicleId })
+    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT, { vehicleId })
     const now = new Date()
 
     const maintenanceLogs = this.maintenanceLogRepo

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_CONTEXT } from '../../middleware/auth'
 import type { Booking, Vehicle } from '../../stores'
 import type { AvailabilityRepository, BookingRepository, VehicleRepository } from '../types'
 import { getConflictingBookings } from './booking'
@@ -10,7 +11,7 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
 
   async findAvailableVehicles(from: Date, to: Date): Promise<Vehicle[]> {
     const vehicles = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
-    const allBookings = await this.bookingRepo.findAll()
+    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return vehicles.filter((vehicle) => {
       const conflicts = getConflictingBookings(
@@ -39,7 +40,7 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
     const vehicle = await this.vehicleRepo.findById(vehicleId)
     if (!vehicle) return undefined
 
-    const allBookings = await this.bookingRepo.findAll()
+    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
     const conflicts = getConflictingBookings(
       allBookings,
       vehicle.id,

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -10,7 +10,7 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
   ) {}
 
   async findAvailableVehicles(from: Date, to: Date): Promise<Vehicle[]> {
-    const vehicles = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
+    const { data: vehicles } = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return vehicles.filter((vehicle) => {

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -1,3 +1,4 @@
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import { PG_ERROR } from '../../pg-errors'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
@@ -30,8 +31,14 @@ export class InMemoryBookingRepository implements BookingRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: BookingFilters): Promise<Booking[]> {
-    let results = [...this.store.values()]
+  private scopedValues(ctx: CallerContext): Booking[] {
+    const all = [...this.store.values()]
+    if (PRIVILEGED_ROLES.has(ctx.role)) return all
+    return all.filter((b) => b.renterId === ctx.userId)
+  }
+
+  async findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]> {
+    let results = this.scopedValues(ctx)
 
     if (filters?.status) {
       results = results.filter((b) => b.status === filters.status)
@@ -75,18 +82,32 @@ export class InMemoryBookingRepository implements BookingRepository {
     return results
   }
 
-  async findById(id: string): Promise<Booking | undefined> {
-    return this.store.get(id)
+  async findById(ctx: CallerContext, id: string): Promise<Booking | undefined> {
+    const booking = this.store.get(id)
+    if (!booking) return undefined
+    if (!PRIVILEGED_ROLES.has(ctx.role) && booking.renterId !== ctx.userId) return undefined
+    return booking
   }
 
-  async findByIdempotencyKey(key: string): Promise<Booking | undefined> {
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined> {
     for (const booking of this.store.values()) {
-      if (booking.idempotencyKey === key) return booking
+      if (booking.idempotencyKey === key) {
+        if (!PRIVILEGED_ROLES.has(ctx.role) && booking.renterId !== ctx.userId) return undefined
+        return booking
+      }
     }
     return undefined
   }
 
-  async create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {
+  async create(
+    ctx: CallerContext,
+    data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<Booking> {
+    // CallerContext scoping: non-privileged callers can only create bookings for themselves
+    if (!PRIVILEGED_ROLES.has(ctx.role) && data.renterId !== ctx.userId) {
+      throw new Error('Cannot create booking for another user')
+    }
+
     // Mirror the DB-level `bookings_no_overlap` exclusion constraint so in-memory
     // tests exercise the same conflict behavior as real Postgres.
     if (BLOCKING_STATUSES.has(data.status)) {
@@ -126,11 +147,13 @@ export class InMemoryBookingRepository implements BookingRepository {
   }
 
   async updateStatus(
+    ctx: CallerContext,
     id: string,
     transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
     if (!existing || existing.status !== transition.from) return undefined
+    if (!PRIVILEGED_ROLES.has(ctx.role) && existing.renterId !== ctx.userId) return undefined
 
     const updated: Booking = {
       ...existing,
@@ -142,11 +165,13 @@ export class InMemoryBookingRepository implements BookingRepository {
   }
 
   async cancel(
+    ctx: CallerContext,
     id: string,
     opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined> {
     const existing = this.store.get(id)
     if (!existing || existing.status !== opts.from) return undefined
+    if (!PRIVILEGED_ROLES.has(ctx.role) && existing.renterId !== ctx.userId) return undefined
 
     const cancelled: Booking = {
       ...existing,

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -1,4 +1,5 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
+import { SYSTEM_CONTEXT } from '../../middleware/auth'
 import type {
   BookingRepository,
   FleetOverviewRepository,
@@ -40,7 +41,7 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
     const vehicles = await this.vehicleRepo.findAll()
-    const allBookings = await this.bookingRepo.findAll()
+    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return Promise.all(
       vehicles.map(async (vehicle) => {

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -40,7 +40,7 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
     const now = new Date()
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
-    const vehicles = await this.vehicleRepo.findAll()
+    const { data: vehicles } = await this.vehicleRepo.findAll()
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return Promise.all(

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -1,3 +1,4 @@
+import type { CallerContext } from '../../middleware/auth'
 import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
 import type { InMemoryThreadRepository } from './thread'
@@ -5,11 +6,11 @@ import type { InMemoryThreadRepository } from './thread'
 export class InMemoryMessageRepository implements MessageRepository {
   constructor(private readonly threadRepo: InMemoryThreadRepository) {}
 
-  async create(threadId: string, senderId: string, content: string): Promise<Message> {
+  async create(ctx: CallerContext, threadId: string, content: string): Promise<Message> {
     const message: Message = {
       id: crypto.randomUUID(),
       threadId,
-      senderId,
+      senderId: ctx.userId,
       content,
       sourceLanguage: null,
       translations: '{}',
@@ -19,8 +20,8 @@ export class InMemoryMessageRepository implements MessageRepository {
     return message
   }
 
-  async findByThreadId(threadId: string): Promise<Message[]> {
-    const thread = await this.threadRepo.findById(threadId)
+  async findByThreadId(_ctx: CallerContext, threadId: string): Promise<Message[]> {
+    const thread = await this.threadRepo.findById(_ctx, threadId)
     return thread?.messages ?? []
   }
 }

--- a/packages/api/src/repositories/in-memory/stats.ts
+++ b/packages/api/src/repositories/in-memory/stats.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_CONTEXT } from '../../middleware/auth'
 import type {
   BookingRepository,
   DashboardStats,
@@ -14,7 +15,7 @@ export class InMemoryStatsRepository implements StatsRepository {
   async getDashboardStats(): Promise<DashboardStats> {
     const [vehicles, bookings] = await Promise.all([
       this.vehicleRepo.findAll({ status: 'AVAILABLE' }),
-      this.bookingRepo.findAll(),
+      this.bookingRepo.findAll(SYSTEM_CONTEXT),
     ])
 
     return {

--- a/packages/api/src/repositories/in-memory/stats.ts
+++ b/packages/api/src/repositories/in-memory/stats.ts
@@ -13,14 +13,14 @@ export class InMemoryStatsRepository implements StatsRepository {
   ) {}
 
   async getDashboardStats(): Promise<DashboardStats> {
-    const [vehicles, bookings] = await Promise.all([
+    const [vehicleResult, bookings] = await Promise.all([
       this.vehicleRepo.findAll({ status: 'AVAILABLE' }),
       this.bookingRepo.findAll(SYSTEM_CONTEXT),
     ])
 
     return {
       totalBookings: bookings.length,
-      activeVehicles: vehicles.length,
+      activeVehicles: vehicleResult.total,
       totalCustomers: 0, // No users table in InMemory
       unreadMessages: 0, // No messages table yet
     }

--- a/packages/api/src/repositories/in-memory/thread.ts
+++ b/packages/api/src/repositories/in-memory/thread.ts
@@ -1,3 +1,4 @@
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import type { Message, Thread, ThreadParticipant } from '../../stores'
 import type { ThreadRepository } from '../types'
 
@@ -7,33 +8,46 @@ export class InMemoryThreadRepository implements ThreadRepository {
   private readonly messages = new Map<string, Message>()
 
   async findAll(
-    userId: string,
+    ctx: CallerContext,
   ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>> {
-    const userParticipations = [...this.participants.values()].filter((p) => p.userId === userId)
-    const threadIds = new Set(userParticipations.map((p) => p.threadId))
+    let filteredThreads: Thread[]
 
-    return [...this.threads.values()]
-      .filter((t) => threadIds.has(t.id))
-      .map((thread) => {
-        const threadParticipants = [...this.participants.values()].filter(
-          (p) => p.threadId === thread.id,
-        )
-        const threadMessages = [...this.messages.values()]
-          .filter((m) => m.threadId === thread.id)
-          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-        const lastMessage = threadMessages.at(-1) ?? null
+    if (PRIVILEGED_ROLES.has(ctx.role)) {
+      filteredThreads = [...this.threads.values()]
+    } else {
+      const userParticipations = [...this.participants.values()].filter(
+        (p) => p.userId === ctx.userId,
+      )
+      const threadIds = new Set(userParticipations.map((p) => p.threadId))
+      filteredThreads = [...this.threads.values()].filter((t) => threadIds.has(t.id))
+    }
 
-        return { ...thread, participants: threadParticipants, lastMessage }
-      })
+    return filteredThreads.map((thread) => {
+      const threadParticipants = [...this.participants.values()].filter(
+        (p) => p.threadId === thread.id,
+      )
+      const threadMessages = [...this.messages.values()]
+        .filter((m) => m.threadId === thread.id)
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      const lastMessage = threadMessages.at(-1) ?? null
+
+      return { ...thread, participants: threadParticipants, lastMessage }
+    })
   }
 
   async findById(
+    ctx: CallerContext,
     id: string,
   ): Promise<(Thread & { participants: ThreadParticipant[]; messages: Message[] }) | undefined> {
     const thread = this.threads.get(id)
     if (!thread) return undefined
 
     const threadParticipants = [...this.participants.values()].filter((p) => p.threadId === id)
+
+    // CallerContext scoping: non-privileged non-participants get undefined
+    const isParticipant = threadParticipants.some((p) => p.userId === ctx.userId)
+    if (!isParticipant && !PRIVILEGED_ROLES.has(ctx.role)) return undefined
+
     const threadMessages = [...this.messages.values()]
       .filter((m) => m.threadId === id)
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
@@ -41,7 +55,11 @@ export class InMemoryThreadRepository implements ThreadRepository {
     return { ...thread, participants: threadParticipants, messages: threadMessages }
   }
 
-  async create(bookingId: string | null, participantIds: string[]): Promise<Thread> {
+  async create(
+    _ctx: CallerContext,
+    bookingId: string | null,
+    participantIds: string[],
+  ): Promise<Thread> {
     const now = new Date()
     const thread: Thread = {
       id: crypto.randomUUID(),
@@ -64,9 +82,9 @@ export class InMemoryThreadRepository implements ThreadRepository {
     return thread
   }
 
-  async markAsRead(threadId: string, userId: string): Promise<void> {
+  async markAsRead(ctx: CallerContext, threadId: string): Promise<void> {
     for (const [key, p] of this.participants) {
-      if (p.threadId === threadId && p.userId === userId) {
+      if (p.threadId === threadId && p.userId === ctx.userId) {
         this.participants.set(key, { ...p, unreadCount: 0 })
       }
     }

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -1,5 +1,10 @@
 import type { Vehicle } from '../../stores'
-import type { VehicleFilters, VehicleRepository, VehicleUpdateOptions } from '../types'
+import type {
+  PaginatedResult,
+  VehicleFilters,
+  VehicleRepository,
+  VehicleUpdateOptions,
+} from '../types'
 
 export class InMemoryVehicleRepository implements VehicleRepository {
   private readonly store: Map<string, Vehicle>
@@ -8,11 +13,21 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: VehicleFilters): Promise<Vehicle[]> {
+  async findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
     const all = [...this.store.values()]
-    if (filters?.status) return all.filter((v) => v.status === filters.status)
-    if (filters?.includeRetired) return all
-    return all.filter((v) => v.status !== 'RETIRED')
+    let filtered: Vehicle[]
+    if (filters?.status) {
+      filtered = all.filter((v) => v.status === filters.status)
+    } else if (filters?.includeRetired) {
+      filtered = all
+    } else {
+      filtered = all.filter((v) => v.status !== 'RETIRED')
+    }
+    const total = filtered.length
+    const offset = filters?.offset ?? 0
+    const limit = filters?.limit
+    const data = limit != null ? filtered.slice(offset, offset + limit) : filtered.slice(offset)
+    return { data, total }
   }
 
   async findById(id: string): Promise<Vehicle | undefined> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -15,6 +15,7 @@ export type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { DashboardStats } from '@kuruma/shared/types/stats'
 import type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
+import type { CallerContext } from '../middleware/auth'
 import type {
   Booking,
   MaintenanceLog,
@@ -75,16 +76,23 @@ export interface BookingFilters {
   cursor?: string
 }
 
+export type { CallerContext } from '../middleware/auth'
+
 export interface BookingRepository {
-  findAll(filters?: BookingFilters): Promise<Booking[]>
-  findById(id: string): Promise<Booking | undefined>
-  findByIdempotencyKey(key: string): Promise<Booking | undefined>
-  create(data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking>
+  findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]>
+  findById(ctx: CallerContext, id: string): Promise<Booking | undefined>
+  findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined>
+  create(
+    ctx: CallerContext,
+    data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<Booking>
   updateStatus(
+    ctx: CallerContext,
     id: string,
     transition: { from: Booking['status']; to: Booking['status'] },
   ): Promise<Booking | undefined>
   cancel(
+    ctx: CallerContext,
     id: string,
     opts: { from: Booking['status']; fee: number; cancelledAt: Date },
   ): Promise<Booking | undefined>
@@ -119,18 +127,19 @@ export interface VehicleDetailRepository {
 
 export interface ThreadRepository {
   findAll(
-    userId: string,
+    ctx: CallerContext,
   ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>>
   findById(
+    ctx: CallerContext,
     id: string,
   ): Promise<(Thread & { participants: ThreadParticipant[]; messages: Message[] }) | undefined>
-  create(bookingId: string | null, participantIds: string[]): Promise<Thread>
-  markAsRead(threadId: string, userId: string): Promise<void>
+  create(ctx: CallerContext, bookingId: string | null, participantIds: string[]): Promise<Thread>
+  markAsRead(ctx: CallerContext, threadId: string): Promise<void>
 }
 
 export interface MessageRepository {
-  create(threadId: string, senderId: string, content: string): Promise<Message>
-  findByThreadId(threadId: string): Promise<Message[]>
+  create(ctx: CallerContext, threadId: string, content: string): Promise<Message>
+  findByThreadId(ctx: CallerContext, threadId: string): Promise<Message[]>
 }
 
 export interface TransitionLogsResult {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -30,6 +30,13 @@ import type {
 export interface VehicleFilters {
   status?: string
   includeRetired?: boolean
+  limit?: number
+  offset?: number
+}
+
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
 }
 
 export interface VehicleUpdateOptions {
@@ -37,7 +44,7 @@ export interface VehicleUpdateOptions {
 }
 
 export interface VehicleRepository {
-  findAll(filters?: VehicleFilters): Promise<Vehicle[]>
+  findAll(filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>>
   findById(id: string): Promise<Vehicle | undefined>
   findByIds(ids: string[]): Promise<Vehicle[]>
   create(data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vehicle>

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,6 +1,6 @@
 import { createBookingSchema, updateBookingStatusSchema } from '@kuruma/shared/validators/booking'
 import { Hono } from 'hono'
-import { PRIVILEGED_ROLES, requireUser } from '../middleware/auth'
+import { requireUser, toCallerContext } from '../middleware/auth'
 import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
 import { fail, ok, parseDateRange } from './helpers'
@@ -8,7 +8,7 @@ import { fail, ok, parseDateRange } from './helpers'
 export function createBookingRoutes(service: BookingService) {
   return new Hono()
     .get('/bookings', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
       const statusFilter = c.req.query('status')
       const vehicleIdFilter = c.req.query('vehicleId')
@@ -36,41 +36,34 @@ export function createBookingRoutes(service: BookingService) {
         filters.to = dateRange.to
       }
 
-      // Ownership: non-privileged users can only see their own bookings
-      if (!PRIVILEGED_ROLES.has(user.role)) {
-        filters.renterId = user.id
-      }
+      // Ownership scoping is handled by CallerContext in the repository layer.
+      // No manual filtering needed here.
 
       if (expand === 'vehicle') {
-        const result = await service.findAllWithVehiclesPaginated(filters)
+        const result = await service.findAllWithVehiclesPaginated(ctx, filters)
         return ok(c, result.data, 200, { nextCursor: result.nextCursor })
       }
 
       if (expand === 'renter') {
-        const result = await service.findAllWithRentersPaginated(filters)
+        const result = await service.findAllWithRentersPaginated(ctx, filters)
         return ok(c, result.data, 200, { nextCursor: result.nextCursor })
       }
 
-      const result = await service.findAllPaginated(filters)
+      const result = await service.findAllPaginated(ctx, filters)
       return ok(c, result.data, 200, { nextCursor: result.nextCursor })
     })
     .get('/bookings/:id', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
-      const booking = await service.findById(c.req.param('id'))
+      const booking = await service.findById(ctx, c.req.param('id'))
       if (!booking) {
-        return fail(c, 'Booking not found', 404)
-      }
-
-      // Ownership: non-privileged users can only view their own bookings (404 to avoid info leak)
-      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
         return fail(c, 'Booking not found', 404)
       }
 
       return ok(c, booking)
     })
     .post('/bookings', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
       const body = await c.req.json()
       const result = createBookingSchema.safeParse(body)
@@ -80,9 +73,9 @@ export function createBookingRoutes(service: BookingService) {
       }
 
       // Actor derivation: renterId comes from JWT, never from body
-      const createResult = await service.create({
+      const createResult = await service.create(ctx, {
         vehicleId: result.data.vehicleId,
-        renterId: user.id,
+        renterId: ctx.userId,
         startAt: new Date(result.data.startAt),
         endAt: new Date(result.data.endAt),
         source: result.data.source,
@@ -101,17 +94,7 @@ export function createBookingRoutes(service: BookingService) {
       return ok(c, createResult.booking, createResult.status ?? 201)
     })
     .patch('/bookings/:id/status', async (c) => {
-      const user = requireUser(c)
-
-      const booking = await service.findById(c.req.param('id'))
-      if (!booking) {
-        return fail(c, 'Booking not found', 404)
-      }
-
-      // Ownership: allow privileged roles or the booking owner (404 to avoid info leak)
-      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
-        return fail(c, 'Booking not found', 404)
-      }
+      const ctx = toCallerContext(requireUser(c))
 
       const body = await c.req.json()
       const parsed = updateBookingStatusSchema.safeParse(body)
@@ -119,7 +102,7 @@ export function createBookingRoutes(service: BookingService) {
         return fail(c, parsed.error.flatten().fieldErrors, 400)
       }
 
-      const result = await service.updateStatus(c.req.param('id'), parsed.data.status)
+      const result = await service.updateStatus(ctx, c.req.param('id'), parsed.data.status)
       if (!result.ok) {
         return fail(c, result.error, result.status)
       }
@@ -127,19 +110,9 @@ export function createBookingRoutes(service: BookingService) {
       return ok(c, result.booking)
     })
     .post('/bookings/:id/cancel', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
-      const booking = await service.findById(c.req.param('id'))
-      if (!booking) {
-        return fail(c, 'Booking not found', 404)
-      }
-
-      // Ownership: non-privileged users can only cancel their own bookings (404 to avoid info leak)
-      if (!PRIVILEGED_ROLES.has(user.role) && booking.renterId !== user.id) {
-        return fail(c, 'Booking not found', 404)
-      }
-
-      const result = await service.cancel(c.req.param('id'))
+      const result = await service.cancel(ctx, c.req.param('id'))
       if (!result.ok) {
         return fail(c, result.error, result.status)
       }

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,20 +1,13 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { PRIVILEGED_ROLES, STAFF_ROLES, requireUser } from '../middleware/auth'
+import { PRIVILEGED_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
 import { fail, ok, parseBody } from './helpers'
 
 export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: MessageRepository) {
-  function isParticipant(
-    thread: { participants: Array<{ userId: string }> },
-    userId: string,
-  ): boolean {
-    return thread.participants.some((p) => p.userId === userId)
-  }
-
   return new Hono()
     .get('/threads', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
       const limitParam = c.req.query('limit')
       const offsetParam = c.req.query('offset')
@@ -28,65 +21,56 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
         return fail(c, 'offset must be a non-negative integer', 400)
       }
 
-      const all = await threadRepo.findAll(user.id)
+      const all = await threadRepo.findAll(ctx)
       const page = all.slice(offset, offset + limit)
       return ok(c, page, 200, { total: all.length, limit, offset })
     })
     .get('/threads/:id', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
-      const thread = await threadRepo.findById(c.req.param('id'))
+      // CallerContext scoping in repo handles participant check for renters
+      const thread = await threadRepo.findById(ctx, c.req.param('id'))
       if (!thread) return fail(c, 'Thread not found', 404)
-
-      if (!isParticipant(thread, user.id) && !STAFF_ROLES.has(user.role)) {
-        return fail(c, 'Thread not found', 404)
-      }
 
       return ok(c, thread)
     })
     .post('/threads', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
       const parsed = await parseBody(c, createThreadSchema)
       if (!parsed.ok) return parsed.response
 
-      if (!PRIVILEGED_ROLES.has(user.role) && !parsed.data.participantIds.includes(user.id)) {
+      if (!PRIVILEGED_ROLES.has(ctx.role) && !parsed.data.participantIds.includes(ctx.userId)) {
         return fail(c, 'Caller must be a participant', 400)
       }
 
       const thread = await threadRepo.create(
+        ctx,
         parsed.data.bookingId ?? null,
         parsed.data.participantIds,
       )
       return ok(c, thread, 201)
     })
     .post('/threads/:id/messages', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
-      const thread = await threadRepo.findById(c.req.param('id'))
+      // CallerContext scoping in repo handles participant check
+      const thread = await threadRepo.findById(ctx, c.req.param('id'))
       if (!thread) return fail(c, 'Thread not found', 404)
-
-      if (!isParticipant(thread, user.id)) {
-        return fail(c, 'Thread not found', 404)
-      }
 
       const parsed = await parseBody(c, sendMessageSchema)
       if (!parsed.ok) return parsed.response
 
-      const message = await messageRepo.create(thread.id, user.id, parsed.data.content)
+      const message = await messageRepo.create(ctx, thread.id, parsed.data.content)
       return ok(c, message, 201)
     })
     .post('/threads/:id/read', async (c) => {
-      const user = requireUser(c)
+      const ctx = toCallerContext(requireUser(c))
 
-      const thread = await threadRepo.findById(c.req.param('id'))
+      const thread = await threadRepo.findById(ctx, c.req.param('id'))
       if (!thread) return fail(c, 'Thread not found', 404)
 
-      if (!isParticipant(thread, user.id)) {
-        return fail(c, 'Thread not found', 404)
-      }
-
-      await threadRepo.markAsRead(thread.id, user.id)
+      await threadRepo.markAsRead(ctx, thread.id)
       return ok(c, null)
     })
 }

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -7,7 +7,7 @@ import {
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
-import type { Vehicle, VehicleRepository } from '../repositories/types'
+import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
 import { fail, ok, parseBody, stripUndefined } from './helpers'
 
@@ -30,9 +30,9 @@ export function createVehicleRoutes(
         return fail(c, 'offset must be a non-negative integer', 400)
       }
 
-      const all = status ? await repo.findAll({ status }) : await repo.findAll()
-      const page = all.slice(offset, offset + limit)
-      return ok(c, page, 200, { total: all.length, limit, offset })
+      const filters: VehicleFilters = { limit, offset, ...(status ? { status } : {}) }
+      const { data, total } = await repo.findAll(filters)
+      return ok(c, data, 200, { total, limit, offset })
     })
     .get('/vehicles/:id', async (c) => {
       const vehicle = await repo.findById(c.req.param('id'))

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -2,6 +2,7 @@ import { type BookingStatus, VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
+import type { CallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
   BookingFilters,
@@ -54,16 +55,17 @@ export class BookingService {
     private readonly userRepo?: UserRepository,
   ) {}
 
-  async findAll(filters?: BookingFilters): Promise<Booking[]> {
-    return this.bookingRepo.findAll(filters)
+  async findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]> {
+    return this.bookingRepo.findAll(ctx, filters)
   }
 
   async findAllPaginated(
+    ctx: CallerContext,
     filters: BookingFilters,
   ): Promise<{ data: Booking[]; nextCursor: string | null }> {
     const limit = filters.limit ?? 20
     // Overfetch by 1 to detect if more pages exist
-    const rows = await this.bookingRepo.findAll({ ...filters, limit: limit + 1 })
+    const rows = await this.bookingRepo.findAll(ctx, { ...filters, limit: limit + 1 })
     const hasMore = rows.length > limit
     const data = hasMore ? rows.slice(0, limit) : rows
     const last = data[data.length - 1]
@@ -71,11 +73,14 @@ export class BookingService {
     return { data, nextCursor }
   }
 
-  async findAllWithVehiclesPaginated(filters: BookingFilters): Promise<{
+  async findAllWithVehiclesPaginated(
+    ctx: CallerContext,
+    filters: BookingFilters,
+  ): Promise<{
     data: (Booking & { vehicle?: { name: string; photos: string[] } | undefined })[]
     nextCursor: string | null
   }> {
-    const { data, nextCursor } = await this.findAllPaginated(filters)
+    const { data, nextCursor } = await this.findAllPaginated(ctx, filters)
     if (!this.vehicleRepo) return { data, nextCursor }
 
     const vehicleIds = [...new Set(data.map((b) => b.vehicleId))]
@@ -91,13 +96,16 @@ export class BookingService {
     }
   }
 
-  async findAllWithRentersPaginated(filters: BookingFilters): Promise<{
+  async findAllWithRentersPaginated(
+    ctx: CallerContext,
+    filters: BookingFilters,
+  ): Promise<{
     data: (Booking & {
       renter?: { id: string; name: string | null; email: string; language: string } | undefined
     })[]
     nextCursor: string | null
   }> {
-    const { data, nextCursor } = await this.findAllPaginated(filters)
+    const { data, nextCursor } = await this.findAllPaginated(ctx, filters)
     if (!this.userRepo) return { data, nextCursor }
 
     const renterIds = [...new Set(data.map((b) => b.renterId))]
@@ -115,14 +123,18 @@ export class BookingService {
     }
   }
 
-  async findById(id: string): Promise<Booking | undefined> {
-    return this.bookingRepo.findById(id)
+  async findById(ctx: CallerContext, id: string): Promise<Booking | undefined> {
+    return this.bookingRepo.findById(ctx, id)
   }
 
-  async create(input: CreateBookingInput, now: Date = new Date()): Promise<CreateBookingResult> {
+  async create(
+    ctx: CallerContext,
+    input: CreateBookingInput,
+    now: Date = new Date(),
+  ): Promise<CreateBookingResult> {
     // Idempotency: if a key was provided, check for an existing booking first.
     if (input.idempotencyKey) {
-      const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
+      const existing = await this.bookingRepo.findByIdempotencyKey(ctx, input.idempotencyKey)
       if (existing) {
         return { ok: true, booking: existing, status: 200 }
       }
@@ -139,7 +151,7 @@ export class BookingService {
     const effectiveEndAt = new Date(input.endAt.getTime() + bufferMinutes * MS_PER_MINUTE)
 
     try {
-      const booking = await this.bookingRepo.create({
+      const booking = await this.bookingRepo.create(ctx, {
         renterId: input.renterId,
         vehicleId: input.vehicleId,
         startAt: input.startAt,
@@ -170,7 +182,7 @@ export class BookingService {
 
       // Idempotency key unique constraint race: re-fetch and return existing
       if (code === PG_ERROR.UNIQUE_VIOLATION && input.idempotencyKey) {
-        const existing = await this.bookingRepo.findByIdempotencyKey(input.idempotencyKey)
+        const existing = await this.bookingRepo.findByIdempotencyKey(ctx, input.idempotencyKey)
         if (existing) {
           return { ok: true, booking: existing, status: 200 }
         }
@@ -180,8 +192,12 @@ export class BookingService {
     }
   }
 
-  async updateStatus(bookingId: string, newStatus: BookingStatus): Promise<StatusTransitionResult> {
-    const booking = await this.bookingRepo.findById(bookingId)
+  async updateStatus(
+    ctx: CallerContext,
+    bookingId: string,
+    newStatus: BookingStatus,
+  ): Promise<StatusTransitionResult> {
+    const booking = await this.bookingRepo.findById(ctx, bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
     }
@@ -195,7 +211,7 @@ export class BookingService {
       }
     }
 
-    const updated = await this.bookingRepo.updateStatus(booking.id, {
+    const updated = await this.bookingRepo.updateStatus(ctx, booking.id, {
       from: booking.status,
       to: newStatus as Booking['status'],
     })
@@ -209,8 +225,12 @@ export class BookingService {
     return { ok: true, booking: updated }
   }
 
-  async cancel(bookingId: string, now: Date = new Date()): Promise<CancelResult> {
-    const booking = await this.bookingRepo.findById(bookingId)
+  async cancel(
+    ctx: CallerContext,
+    bookingId: string,
+    now: Date = new Date(),
+  ): Promise<CancelResult> {
+    const booking = await this.bookingRepo.findById(ctx, bookingId)
     if (!booking) {
       return { ok: false, status: 404, error: 'Booking not found' }
     }
@@ -225,7 +245,7 @@ export class BookingService {
 
     const cancellation = calculateCancellationFee(booking.startAt, now, booking.totalPrice ?? 0)
 
-    const updated = await this.bookingRepo.cancel(booking.id, {
+    const updated = await this.bookingRepo.cancel(ctx, booking.id, {
       from: booking.status,
       fee: cancellation.feeAmount,
       cancelledAt: now,

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -1,5 +1,6 @@
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -85,7 +86,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000)
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),
@@ -115,7 +116,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000)
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),
@@ -146,7 +147,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000) // 15:00
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),
@@ -175,7 +176,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000) // 15:00
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),
@@ -205,7 +206,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000)
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),
@@ -272,7 +273,7 @@ describe('DrizzleAvailabilityRepository', () => {
       const endAt = new Date('2026-08-01T14:00:00Z')
       const effectiveEndAt = new Date(endAt.getTime() + vehicle.bufferMinutes * 60 * 1000)
 
-      const booking = await bookingRepo.create({
+      const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: vehicle.id,
         startAt: new Date('2026-08-01T10:00:00Z'),

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -1,6 +1,7 @@
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { pgErrorCode } from '../../src/pg-errors'
 import {
   DrizzleAvailabilityRepository,
@@ -76,7 +77,7 @@ describe('DrizzleBookingRepository', () => {
       notes: 'Test booking',
     }
 
-    const booking = await bookingRepo.create(input)
+    const booking = await bookingRepo.create(SYSTEM_CONTEXT, input)
     createdBookingIds.push(booking.id)
 
     expect(booking.id).toMatch(/^[0-9a-f-]{36}$/)
@@ -94,7 +95,7 @@ describe('DrizzleBookingRepository', () => {
   })
 
   it('findById retrieves a created booking', async () => {
-    const created = await bookingRepo.create({
+    const created = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-08-01T09:00:00Z'),
@@ -107,7 +108,7 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(created.id)
 
-    const found = await bookingRepo.findById(created.id)
+    const found = await bookingRepo.findById(SYSTEM_CONTEXT, created.id)
 
     expect(found).toBeDefined()
     expect(found!.id).toBe(created.id)
@@ -123,12 +124,12 @@ describe('DrizzleBookingRepository', () => {
   })
 
   it('findById returns undefined for non-existent id', async () => {
-    const found = await bookingRepo.findById('non-existent-id')
+    const found = await bookingRepo.findById(SYSTEM_CONTEXT, 'non-existent-id')
     expect(found).toBeUndefined()
   })
 
   it('findAll returns bookings and filters by status', async () => {
-    const confirmed = await bookingRepo.create({
+    const confirmed = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-09-01T10:00:00Z'),
@@ -141,7 +142,7 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(confirmed.id)
 
-    const cancelled = await bookingRepo.create({
+    const cancelled = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-10-01T10:00:00Z'),
@@ -154,12 +155,12 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(cancelled.id)
 
-    const all = await bookingRepo.findAll()
+    const all = await bookingRepo.findAll(SYSTEM_CONTEXT)
     const allIds = all.map((b) => b.id)
     expect(allIds).toContain(confirmed.id)
     expect(allIds).toContain(cancelled.id)
 
-    const filtered = await bookingRepo.findAll({ status: 'CONFIRMED' })
+    const filtered = await bookingRepo.findAll(SYSTEM_CONTEXT, { status: 'CONFIRMED' })
     const filteredIds = filtered.map((b) => b.id)
     expect(filteredIds).toContain(confirmed.id)
     expect(filteredIds).not.toContain(cancelled.id)
@@ -184,7 +185,7 @@ describe('DrizzleBookingRepository', () => {
     })
     createdVehicleIds.push(otherVehicle.id)
 
-    const bookingA = await bookingRepo.create({
+    const bookingA = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-11-01T10:00:00Z'),
@@ -197,7 +198,7 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(bookingA.id)
 
-    const bookingB = await bookingRepo.create({
+    const bookingB = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: otherVehicle.id,
       startAt: new Date('2026-11-01T10:00:00Z'),
@@ -210,14 +211,14 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(bookingB.id)
 
-    const filtered = await bookingRepo.findAll({ vehicleId: testVehicle.id })
+    const filtered = await bookingRepo.findAll(SYSTEM_CONTEXT, { vehicleId: testVehicle.id })
     const filteredIds = filtered.map((b) => b.id)
     expect(filteredIds).toContain(bookingA.id)
     expect(filteredIds).not.toContain(bookingB.id)
   })
 
   it('updateStatus transitions CONFIRMED to ACTIVE', async () => {
-    const created = await bookingRepo.create({
+    const created = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-12-01T10:00:00Z'),
@@ -230,7 +231,10 @@ describe('DrizzleBookingRepository', () => {
     })
     createdBookingIds.push(created.id)
 
-    const updated = await bookingRepo.updateStatus(created.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    const updated = await bookingRepo.updateStatus(SYSTEM_CONTEXT, created.id, {
+      from: 'CONFIRMED',
+      to: 'ACTIVE',
+    })
 
     expect(updated).toBeDefined()
     expect(updated!.id).toBe(created.id)
@@ -240,12 +244,12 @@ describe('DrizzleBookingRepository', () => {
     expect(updated!.startAt).toEqual(new Date('2026-12-01T10:00:00Z'))
 
     // Verify persisted in DB
-    const fromDb = await bookingRepo.findById(created.id)
+    const fromDb = await bookingRepo.findById(SYSTEM_CONTEXT, created.id)
     expect(fromDb!.status).toBe('ACTIVE')
   })
 
   it('create persists totalPrice through Drizzle insert (issue #89)', async () => {
-    const booking = await bookingRepo.create({
+    const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2026-07-15T10:00:00Z'),
@@ -262,12 +266,12 @@ describe('DrizzleBookingRepository', () => {
     createdBookingIds.push(booking.id)
 
     // Round-trip: read back from DB and verify totalPrice persisted
-    const fromDb = await bookingRepo.findById(booking.id)
+    const fromDb = await bookingRepo.findById(SYSTEM_CONTEXT, booking.id)
     expect(fromDb!.totalPrice).toBe(15000)
   })
 
   it('rejects overlapping bookings with PG error code 23P01', async () => {
-    const firstBooking = await bookingRepo.create({
+    const firstBooking = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2027-01-01T10:00:00Z'),
@@ -281,7 +285,7 @@ describe('DrizzleBookingRepository', () => {
     createdBookingIds.push(firstBooking.id)
 
     try {
-      const second = await bookingRepo.create({
+      const second = await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: testUser.id,
         vehicleId: testVehicle.id,
         startAt: new Date('2027-01-01T13:00:00Z'),
@@ -302,7 +306,7 @@ describe('DrizzleBookingRepository', () => {
   })
 
   it('allows overlapping booking after first is cancelled', async () => {
-    const firstBooking = await bookingRepo.create({
+    const firstBooking = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2027-02-01T10:00:00Z'),
@@ -316,7 +320,7 @@ describe('DrizzleBookingRepository', () => {
     createdBookingIds.push(firstBooking.id)
 
     // Cancel the first booking
-    const cancelled = await bookingRepo.cancel(firstBooking.id, {
+    const cancelled = await bookingRepo.cancel(SYSTEM_CONTEXT, firstBooking.id, {
       from: 'CONFIRMED',
       fee: 0,
       cancelledAt: new Date(),
@@ -326,7 +330,7 @@ describe('DrizzleBookingRepository', () => {
 
     // Overlapping booking should now succeed — exclusion constraint
     // only applies to CONFIRMED/ACTIVE
-    const secondBooking = await bookingRepo.create({
+    const secondBooking = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2027-02-01T12:00:00Z'),
@@ -345,7 +349,7 @@ describe('DrizzleBookingRepository', () => {
 
   it('allows adjacent (non-overlapping) bookings on same vehicle', async () => {
     // First booking: 10:00-14:00, effectiveEnd 15:00 (buffer)
-    const first = await bookingRepo.create({
+    const first = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2027-04-01T10:00:00Z'),
@@ -360,7 +364,7 @@ describe('DrizzleBookingRepository', () => {
 
     // Second booking starts exactly at first's effectiveEndAt (boundary)
     // tstzrange is [closed, open) so startAt === effectiveEndAt does NOT overlap
-    const second = await bookingRepo.create({
+    const second = await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: testUser.id,
       vehicleId: testVehicle.id,
       startAt: new Date('2027-04-01T15:00:00Z'),
@@ -390,7 +394,10 @@ describe('DrizzleBookingRepository', () => {
       notes: null,
     }
 
-    const results = await Promise.allSettled([bookingRepo.create(input), bookingRepo.create(input)])
+    const results = await Promise.allSettled([
+      bookingRepo.create(SYSTEM_CONTEXT, input),
+      bookingRepo.create(SYSTEM_CONTEXT, input),
+    ])
 
     const fulfilled = results.filter((r) => r.status === 'fulfilled')
     const rejected = results.filter((r) => r.status === 'rejected')

--- a/packages/api/tests/integration/rls-context.test.ts
+++ b/packages/api/tests/integration/rls-context.test.ts
@@ -1,0 +1,159 @@
+import { users } from '@kuruma/shared/db/schema'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../src/middleware/auth'
+import { DrizzleBookingRepository, DrizzleVehicleRepository } from '../../src/repositories/drizzle'
+import type { Booking, Vehicle } from '../../src/stores'
+import { DEFAULT_DAILY_RATE_JPY, cleanupBookings, cleanupUsers, cleanupVehicles, db } from './setup'
+
+// Cast: test DB uses postgres-js, same query API as neon-http
+const bookingRepo = new DrizzleBookingRepository(db as never)
+const vehicleRepo = new DrizzleVehicleRepository(db as never)
+
+let renterA: { id: string }
+let renterB: { id: string }
+let staff: { id: string }
+let vehicle: Vehicle
+const createdBookingIds: string[] = []
+const createdVehicleIds: string[] = []
+const createdUserIds: string[] = []
+
+const ctxA: () => CallerContext = () => ({ userId: renterA.id, role: 'RENTER' })
+const ctxB: () => CallerContext = () => ({ userId: renterB.id, role: 'RENTER' })
+const ctxStaff: () => CallerContext = () => ({ userId: staff.id, role: 'STAFF' })
+
+beforeAll(async () => {
+  const [a] = await db
+    .insert(users)
+    .values({
+      id: crypto.randomUUID(),
+      email: `renter-a-${Date.now()}@test.com`,
+      role: 'RENTER',
+      language: 'en',
+    })
+    .returning()
+  const [b] = await db
+    .insert(users)
+    .values({
+      id: crypto.randomUUID(),
+      email: `renter-b-${Date.now()}@test.com`,
+      role: 'RENTER',
+      language: 'en',
+    })
+    .returning()
+  const [s] = await db
+    .insert(users)
+    .values({
+      id: crypto.randomUUID(),
+      email: `staff-${Date.now()}@test.com`,
+      role: 'STAFF',
+      language: 'en',
+    })
+    .returning()
+  renterA = a
+  renterB = b
+  staff = s
+  createdUserIds.push(a.id, b.id, s.id)
+
+  vehicle = await vehicleRepo.create({
+    name: 'RLS Test Car',
+    description: null,
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+  })
+  createdVehicleIds.push(vehicle.id)
+})
+
+afterEach(async () => {
+  await cleanupBookings(createdBookingIds)
+  createdBookingIds.length = 0
+})
+
+afterAll(async () => {
+  await cleanupVehicles(createdVehicleIds)
+  await cleanupUsers(createdUserIds)
+})
+
+function makeBookingData(renterId: string, startHour: number) {
+  return {
+    renterId,
+    vehicleId: vehicle.id,
+    startAt: new Date(`2026-08-01T${String(startHour).padStart(2, '0')}:00:00Z`),
+    endAt: new Date(`2026-08-01T${String(startHour + 2).padStart(2, '0')}:00:00Z`),
+    effectiveEndAt: new Date(`2026-08-01T${String(startHour + 3).padStart(2, '0')}:00:00Z`),
+    status: 'CONFIRMED' as const,
+    source: 'DIRECT' as const,
+    externalId: null,
+    notes: null,
+    totalPrice: 5000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+  }
+}
+
+describe('CallerContext booking isolation', () => {
+  let bookingA: Booking
+  let bookingB: Booking
+
+  beforeAll(async () => {
+    // Staff context for creation (staff can create for any renter)
+    bookingA = await bookingRepo.create(ctxStaff(), makeBookingData(renterA.id, 8))
+    bookingB = await bookingRepo.create(ctxStaff(), makeBookingData(renterB.id, 14))
+    createdBookingIds.push(bookingA.id, bookingB.id)
+  })
+
+  it('renterA.findAll only returns own bookings', async () => {
+    const results = await bookingRepo.findAll(ctxA())
+    const ids = results.map((b) => b.id)
+    expect(ids).toContain(bookingA.id)
+    expect(ids).not.toContain(bookingB.id)
+  })
+
+  it('renterB.findAll only returns own bookings', async () => {
+    const results = await bookingRepo.findAll(ctxB())
+    const ids = results.map((b) => b.id)
+    expect(ids).toContain(bookingB.id)
+    expect(ids).not.toContain(bookingA.id)
+  })
+
+  it('staff.findAll returns all bookings', async () => {
+    const results = await bookingRepo.findAll(ctxStaff())
+    const ids = results.map((b) => b.id)
+    expect(ids).toContain(bookingA.id)
+    expect(ids).toContain(bookingB.id)
+  })
+
+  it('renterA.findById for renterB booking returns undefined', async () => {
+    const result = await bookingRepo.findById(ctxA(), bookingB.id)
+    expect(result).toBeUndefined()
+  })
+
+  it('staff.findById for any booking returns it', async () => {
+    const resultA = await bookingRepo.findById(ctxStaff(), bookingA.id)
+    const resultB = await bookingRepo.findById(ctxStaff(), bookingB.id)
+    expect(resultA?.id).toBe(bookingA.id)
+    expect(resultB?.id).toBe(bookingB.id)
+  })
+
+  it('renterA.cancel on renterB booking returns undefined', async () => {
+    const result = await bookingRepo.cancel(ctxA(), bookingB.id, {
+      from: 'CONFIRMED',
+      fee: 0,
+      cancelledAt: new Date(),
+    })
+    expect(result).toBeUndefined()
+    // Verify bookingB is unchanged
+    const bookingBStill = await bookingRepo.findById(ctxStaff(), bookingB.id)
+    expect(bookingBStill?.status).toBe('CONFIRMED')
+  })
+})

--- a/packages/api/tests/integration/vehicles-pricing.test.ts
+++ b/packages/api/tests/integration/vehicles-pricing.test.ts
@@ -214,7 +214,7 @@ describe('DrizzleVehicleRepository — pricing (#48)', () => {
       )
       createdVehicleIds.push(a.id, b.id)
 
-      const all = await repo.findAll()
+      const { data: all } = await repo.findAll()
       const aRow = all.find((v) => v.id === a.id)!
       const bRow = all.find((v) => v.id === b.id)!
 

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -123,13 +123,13 @@ describe('DrizzleVehicleRepository', () => {
     createdIds.push(maintenance.id)
 
     // findAll without filter should include both
-    const all = await repo.findAll()
+    const { data: all } = await repo.findAll()
     const allIds = all.map((v) => v.id)
     expect(allIds).toContain(available.id)
     expect(allIds).toContain(maintenance.id)
 
     // findAll with status filter should only include matching
-    const filtered = await repo.findAll({ status: 'MAINTENANCE' })
+    const { data: filtered } = await repo.findAll({ status: 'MAINTENANCE' })
     const filteredIds = filtered.map((v) => v.id)
     expect(filteredIds).toContain(maintenance.id)
     expect(filteredIds).not.toContain(available.id)

--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -10,6 +10,7 @@
 // Buffer time is NOT counted — only startAt..endAt.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryFleetOverviewRepository,
@@ -100,6 +101,7 @@ describe('InMemoryFleetOverviewRepository', () => {
   it('excludes CANCELLED bookings from utilization and count', async () => {
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Cancelled' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-05T10:00:00Z'),
@@ -122,6 +124,7 @@ describe('InMemoryFleetOverviewRepository', () => {
     // squarely inside the 30-day window.
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Booked Once' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-05T10:00:00Z'),
@@ -140,6 +143,7 @@ describe('InMemoryFleetOverviewRepository', () => {
   it('populates currentBooking when now falls inside a non-CANCELLED booking', async () => {
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'On Rental' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         // FIXED_NOW = 2026-04-11T12:00:00Z is inside this window
@@ -163,6 +167,7 @@ describe('InMemoryFleetOverviewRepository', () => {
     // Future booking — closer one first in creation order, but we want
     // findFleetOverview to pick the earliest startAt regardless of insert order.
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-20T10:00:00Z'),
@@ -172,6 +177,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-12T08:00:00Z'),
@@ -192,6 +198,7 @@ describe('InMemoryFleetOverviewRepository', () => {
   it('excludes CANCELLED bookings from currentBooking and nextBooking', async () => {
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'All Cancelled' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-11T09:00:00Z'),
@@ -201,6 +208,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-15T10:00:00Z'),
@@ -222,6 +230,7 @@ describe('InMemoryFleetOverviewRepository', () => {
 
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Alice Rental' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         renterId: 'user_alice',
@@ -249,6 +258,7 @@ describe('InMemoryFleetOverviewRepository', () => {
     //   clipped = [2026-03-12T12:00, 2026-03-22T12:00] = 10 days = 240h
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Long Window' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-03-02T12:00:00Z'),
@@ -276,6 +286,7 @@ describe('InMemoryFleetOverviewRepository', () => {
     //   clipped = [startAt, now] = 2h
     const vehicle = await vehicleRepo.create(baseVehicleInput({ name: 'Currently Active' }))
     await bookingRepo.create(
+      SYSTEM_CONTEXT,
       baseBookingInput({
         vehicleId: vehicle.id,
         startAt: new Date('2026-04-11T10:00:00Z'),

--- a/packages/api/tests/repositories/vehicle.test.ts
+++ b/packages/api/tests/repositories/vehicle.test.ts
@@ -24,6 +24,60 @@ function vehicleInput(overrides?: Partial<Vehicle>) {
   }
 }
 
+describe('VehicleRepository.findAll pagination', () => {
+  let repo: InMemoryVehicleRepository
+
+  beforeEach(async () => {
+    repo = new InMemoryVehicleRepository()
+    await repo.create(vehicleInput({ name: 'Car A' }))
+    await repo.create(vehicleInput({ name: 'Car B' }))
+    await repo.create(vehicleInput({ name: 'Car C' }))
+  })
+
+  it('returns paginated data with total count', async () => {
+    const result = await repo.findAll({ limit: 2, offset: 0 })
+
+    expect(result.data).toHaveLength(2)
+    expect(result.total).toBe(3)
+    expect(result.data[0]!.name).toBe('Car A')
+    expect(result.data[1]!.name).toBe('Car B')
+  })
+
+  it('returns correct page with offset', async () => {
+    const result = await repo.findAll({ limit: 2, offset: 2 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]!.name).toBe('Car C')
+    expect(result.total).toBe(3)
+  })
+
+  it('returns all items when no limit/offset given', async () => {
+    const result = await repo.findAll()
+
+    expect(result.data).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('applies status filter before pagination', async () => {
+    // Retire Car B
+    const all = await repo.findAll()
+    await repo.softDelete(all.data[1]!.id)
+
+    const result = await repo.findAll({ status: 'RETIRED', limit: 10, offset: 0 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]!.name).toBe('Car B')
+    expect(result.total).toBe(1)
+  })
+
+  it('returns empty data when offset exceeds total', async () => {
+    const result = await repo.findAll({ limit: 10, offset: 100 })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.total).toBe(3)
+  })
+})
+
 describe('VehicleRepository.findByIds', () => {
   let repo: InMemoryVehicleRepository
 

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryAvailabilityRepository,
   InMemoryBookingRepository,
@@ -44,7 +45,7 @@ async function createTestBooking(
   const endAt = overrides.endAt ?? new Date('2026-06-01T14:00:00Z')
   const effectiveEndAt =
     overrides.effectiveEndAt ?? new Date(endAt.getTime() + bufferMinutes * 60 * 1000)
-  return bookingRepo.create({
+  return bookingRepo.create(SYSTEM_CONTEXT, {
     renterId: 'user1',
     vehicleId: 'v1',
     startAt: new Date('2026-06-01T10:00:00Z'),

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryUserRepository,
@@ -132,7 +133,7 @@ describe('Booking Routes', () => {
       // Create one booking via route (gets USER1 from JWT context)
       await createBooking()
       // Create second booking directly in repo with USER2 (bypasses JWT)
-      await bookingRepo.create({
+      await bookingRepo.create(SYSTEM_CONTEXT, {
         vehicleId: V2,
         renterId: USER2,
         startAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
@@ -362,7 +363,7 @@ describe('Booking Routes', () => {
       // Create via route (renterId comes from JWT = USER1)
       await createBooking()
       // Create directly in repo with USER2 (route always overrides renterId from JWT)
-      await bookingRepo.create({
+      await bookingRepo.create(SYSTEM_CONTEXT, {
         renterId: USER2,
         vehicleId: V2,
         startAt: new Date(Date.now() + 24 * 60 * 60 * 1000),

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -303,7 +303,7 @@ describe('Booking Routes', () => {
         insuranceExpiryDate: null,
       })
 
-      const allVehicles = await vehicleRepo.findAll()
+      const { data: allVehicles } = await vehicleRepo.findAll()
       const vehicleId = allVehicles[0]!.id
 
       await createBooking({

--- a/packages/api/tests/routes/fleet-overview.test.ts
+++ b/packages/api/tests/routes/fleet-overview.test.ts
@@ -6,6 +6,7 @@
 
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryFleetOverviewRepository,
@@ -115,7 +116,7 @@ describe('GET /vehicles/fleet-overview', () => {
       shakenExpiryDate: null,
       insuranceExpiryDate: null,
     })
-    await bookingRepo.create({
+    await bookingRepo.create(SYSTEM_CONTEXT, {
       renterId: 'user_1',
       vehicleId: vehicle.id,
       startAt: new Date('2026-04-11T09:00:00Z'),

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryVehicleRepository,
@@ -59,7 +60,7 @@ async function seedBooking(
     source?: 'DIRECT' | 'TRIP_COM' | 'MANUAL' | 'OTHER'
   },
 ) {
-  return bookingRepo.create({
+  return bookingRepo.create(SYSTEM_CONTEXT, {
     vehicleId,
     renterId: overrides?.renterId ?? 'renter-1',
     startAt,
@@ -177,22 +178,22 @@ describe('GET /vehicles/:id/detail', () => {
     const b1 = await seedBooking(vehicle.id, pastDate(72), pastDate(48), {
       totalPrice: 5000,
     })
-    await bookingRepo.updateStatus(b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
-    await bookingRepo.updateStatus(b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     // Completed booking 10 days ago
     const b2 = await seedBooking(vehicle.id, pastDate(240), pastDate(216), {
       totalPrice: 8000,
     })
-    await bookingRepo.updateStatus(b2.id, { from: 'CONFIRMED', to: 'ACTIVE' })
-    await bookingRepo.updateStatus(b2.id, { from: 'ACTIVE', to: 'COMPLETED' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b2.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b2.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     // Completed booking 60 days ago
     const b3 = await seedBooking(vehicle.id, pastDate(1440), pastDate(1416), {
       totalPrice: 12000,
     })
-    await bookingRepo.updateStatus(b3.id, { from: 'CONFIRMED', to: 'ACTIVE' })
-    await bookingRepo.updateStatus(b3.id, { from: 'ACTIVE', to: 'COMPLETED' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b3.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b3.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()
@@ -208,8 +209,8 @@ describe('GET /vehicles/:id/detail', () => {
     const b1 = await seedBooking(vehicle.id, pastDate(72), pastDate(48), {
       totalPrice: null,
     })
-    await bookingRepo.updateStatus(b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
-    await bookingRepo.updateStatus(b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b1.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b1.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()
@@ -238,8 +239,8 @@ describe('GET /vehicles/:id/detail', () => {
     const b = await seedBooking(vehicle.id, pastDate(48), pastDate(24), {
       totalPrice: 5000,
     })
-    await bookingRepo.updateStatus(b.id, { from: 'CONFIRMED', to: 'ACTIVE' })
-    await bookingRepo.updateStatus(b.id, { from: 'ACTIVE', to: 'COMPLETED' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b.id, { from: 'CONFIRMED', to: 'ACTIVE' })
+    await bookingRepo.updateStatus(SYSTEM_CONTEXT, b.id, { from: 'ACTIVE', to: 'COMPLETED' })
 
     const res = await app.request(`/vehicles/${vehicle.id}/detail`)
     const body = await res.json()

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -99,6 +99,35 @@ describe('Vehicle CRUD Routes', () => {
       expect(body.data[0].status).toBe('RETIRED')
     })
 
+    it('paginates with limit and offset', async () => {
+      await createVehicle({ ...validVehicleInput(), name: 'Car A' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car B' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car C' })
+
+      const res = await app.request('/vehicles?limit=2&offset=0')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(2)
+      expect(body.total).toBe(3)
+      expect(body.limit).toBe(2)
+      expect(body.offset).toBe(0)
+    })
+
+    it('returns second page with offset', async () => {
+      await createVehicle({ ...validVehicleInput(), name: 'Car A' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car B' })
+      await createVehicle({ ...validVehicleInput(), name: 'Car C' })
+
+      const res = await app.request('/vehicles?limit=2&offset=2')
+      const body = await res.json()
+
+      expect(body.success).toBe(true)
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].name).toBe('Car C')
+      expect(body.total).toBe(3)
+    })
+
     it('filters by explicit status query param', async () => {
       await createVehicle()
       const createRes = await createVehicle({

--- a/packages/web/src/components/vehicles/AddVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/AddVehicleDialog.tsx
@@ -8,12 +8,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { VehicleForm } from '@/components/vehicles/VehicleForm'
-import { vehicleKeys } from '@/lib/query-keys'
+import { useVehicleMutation } from '@/hooks/useVehicleMutation'
 import { createVehicleAction } from '@/lib/vehicle-actions'
-import type { CreateVehicleInput } from '@kuruma/shared/validators/vehicle'
-import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
 
 interface AddVehicleDialogProps {
   open: boolean
@@ -22,30 +19,18 @@ interface AddVehicleDialogProps {
 
 export function AddVehicleDialog({ open, onOpenChange }: AddVehicleDialogProps) {
   const t = useTranslations('business.vehicles')
-  const queryClient = useQueryClient()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { mutate, isPending, error, reset } = useVehicleMutation({
+    mutationFn: createVehicleAction,
+    onSuccess: () => onOpenChange(false),
+  })
 
-  const handleSubmit = async (data: CreateVehicleInput) => {
-    setIsSubmitting(true)
-    setError(null)
-    try {
-      const result = await createVehicleAction(data)
-      if (!result.success) {
-        setError(result.error)
-        return
-      }
-      await queryClient.invalidateQueries({ queryKey: vehicleKeys.all })
-      onOpenChange(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'An error occurred')
-    } finally {
-      setIsSubmitting(false)
-    }
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) reset()
+    onOpenChange(nextOpen)
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t('addVehicle')}</DialogTitle>
@@ -53,9 +38,9 @@ export function AddVehicleDialog({ open, onOpenChange }: AddVehicleDialogProps) 
         </DialogHeader>
         {error && <p className="text-sm text-destructive px-1">{error}</p>}
         <VehicleForm
-          onSubmit={handleSubmit}
-          onCancel={() => onOpenChange(false)}
-          isSubmitting={isSubmitting}
+          onSubmit={async (data) => mutate(data)}
+          onCancel={() => handleOpenChange(false)}
+          isSubmitting={isPending}
         />
       </DialogContent>
     </Dialog>

--- a/packages/web/src/components/vehicles/EditVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/EditVehicleDialog.tsx
@@ -8,13 +8,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { VehicleForm } from '@/components/vehicles/VehicleForm'
-import { vehicleKeys } from '@/lib/query-keys'
+import { useVehicleMutation } from '@/hooks/useVehicleMutation'
 import { updateVehicleAction } from '@/lib/vehicle-actions'
 import type { VehicleData } from '@/lib/vehicle-api'
 import type { CreateVehicleInput } from '@kuruma/shared/validators/vehicle'
-import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
 
 interface EditVehicleDialogProps {
   vehicle: VehicleData | null
@@ -23,28 +21,10 @@ interface EditVehicleDialogProps {
 
 export function EditVehicleDialog({ vehicle, onOpenChange }: EditVehicleDialogProps) {
   const t = useTranslations('business.vehicles')
-  const queryClient = useQueryClient()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const handleSubmit = async (data: CreateVehicleInput) => {
-    if (!vehicle) return
-    setIsSubmitting(true)
-    setError(null)
-    try {
-      const result = await updateVehicleAction(vehicle.id, data)
-      if (!result.success) {
-        setError(result.error)
-        return
-      }
-      await queryClient.invalidateQueries({ queryKey: vehicleKeys.all })
-      onOpenChange(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'An error occurred')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
+  const { mutate, isPending, error } = useVehicleMutation<CreateVehicleInput>({
+    mutationFn: (data) => updateVehicleAction(vehicle?.id ?? '', data),
+    onSuccess: () => onOpenChange(false),
+  })
 
   return (
     <Dialog open={vehicle !== null} onOpenChange={onOpenChange}>
@@ -57,9 +37,9 @@ export function EditVehicleDialog({ vehicle, onOpenChange }: EditVehicleDialogPr
         {vehicle && (
           <VehicleForm
             key={vehicle.id}
-            onSubmit={handleSubmit}
+            onSubmit={async (data) => mutate(data)}
             onCancel={() => onOpenChange(false)}
-            isSubmitting={isSubmitting}
+            isSubmitting={isPending}
             defaultValues={{
               name: vehicle.name,
               ...(vehicle.description != null && { description: vehicle.description }),

--- a/packages/web/src/components/vehicles/RetireVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/RetireVehicleDialog.tsx
@@ -9,12 +9,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { vehicleKeys } from '@/lib/query-keys'
+import { useVehicleMutation } from '@/hooks/useVehicleMutation'
 import { retireVehicleAction } from '@/lib/vehicle-actions'
 import type { VehicleData } from '@/lib/vehicle-api'
-import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
 
 interface RetireVehicleDialogProps {
   vehicle: VehicleData | null
@@ -23,28 +21,10 @@ interface RetireVehicleDialogProps {
 
 export function RetireVehicleDialog({ vehicle, onOpenChange }: RetireVehicleDialogProps) {
   const t = useTranslations('business.vehicles')
-  const queryClient = useQueryClient()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const handleRetire = async () => {
-    if (!vehicle) return
-    setIsSubmitting(true)
-    setError(null)
-    try {
-      const result = await retireVehicleAction(vehicle.id)
-      if (!result.success) {
-        setError(result.error)
-        return
-      }
-      await queryClient.invalidateQueries({ queryKey: vehicleKeys.all })
-      onOpenChange(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'An error occurred')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
+  const { mutate, isPending, error } = useVehicleMutation<void>({
+    mutationFn: () => retireVehicleAction(vehicle?.id ?? ''),
+    onSuccess: () => onOpenChange(false),
+  })
 
   return (
     <Dialog open={vehicle !== null} onOpenChange={onOpenChange}>
@@ -58,7 +38,7 @@ export function RetireVehicleDialog({ vehicle, onOpenChange }: RetireVehicleDial
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             {t('form.cancel')}
           </Button>
-          <Button variant="destructive" onClick={handleRetire} disabled={isSubmitting}>
+          <Button variant="destructive" onClick={() => mutate()} disabled={isPending}>
             {t('retireVehicle')}
           </Button>
         </DialogFooter>

--- a/packages/web/src/hooks/useVehicleMutation.ts
+++ b/packages/web/src/hooks/useVehicleMutation.ts
@@ -1,0 +1,35 @@
+import { vehicleKeys } from '@/lib/query-keys'
+import type { ActionResult } from '@/lib/vehicle-actions'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface UseVehicleMutationOptions<TInput, TData> {
+  mutationFn: (input: TInput) => Promise<ActionResult<TData>>
+  onSuccess?: (data: TData) => void
+}
+
+export function useVehicleMutation<TInput, TData = unknown>({
+  mutationFn,
+  onSuccess,
+}: UseVehicleMutationOptions<TInput, TData>) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<TData, Error, TInput>({
+    mutationFn: async (input) => {
+      const result = await mutationFn(input)
+      if (!result.success) throw new Error(result.error)
+      return result.data
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: vehicleKeys.all })
+      onSuccess?.(data)
+    },
+  })
+
+  return {
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error?.message ?? null,
+    reset: mutation.reset,
+  }
+}

--- a/packages/web/tests/components/vehicles/EditVehicleDialog.test.tsx
+++ b/packages/web/tests/components/vehicles/EditVehicleDialog.test.tsx
@@ -47,18 +47,13 @@ vi.mock('next-intl', () => ({
   },
 }))
 
-vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({
-    invalidateQueries: vi.fn().mockResolvedValue(undefined),
-  }),
-}))
-
 vi.mock('@/lib/vehicle-actions', () => ({
   updateVehicleAction: vi.fn().mockResolvedValue({ success: true, data: undefined }),
 }))
 
 import { EditVehicleDialog } from '@/components/vehicles/EditVehicleDialog'
 import type { VehicleData } from '@/lib/vehicle-api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 function makeVehicle(overrides: Partial<VehicleData> = {}): VehicleData {
   return {
@@ -85,6 +80,17 @@ function makeVehicle(overrides: Partial<VehicleData> = {}): VehicleData {
   }
 }
 
+function renderDialog(props: { vehicle: VehicleData | null; onOpenChange?: () => void }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <EditVehicleDialog vehicle={props.vehicle} onOpenChange={props.onOpenChange ?? vi.fn()} />
+    </QueryClientProvider>,
+  )
+}
+
 describe('EditVehicleDialog', () => {
   afterEach(() => {
     cleanup()
@@ -92,7 +98,7 @@ describe('EditVehicleDialog', () => {
 
   it('pre-populates the daily rate and hourly rate from the vehicle prop', () => {
     const vehicle = makeVehicle({ dailyRateJpy: 6500, hourlyRateJpy: 900 })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Daily rate')).toHaveValue(6500)
     expect(screen.getByLabelText('Hourly rate')).toHaveValue(900)
@@ -100,7 +106,7 @@ describe('EditVehicleDialog', () => {
 
   it('pre-populates only the daily rate when hourly is null', () => {
     const vehicle = makeVehicle({ dailyRateJpy: 8000, hourlyRateJpy: null })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Daily rate')).toHaveValue(8000)
     expect(screen.getByLabelText('Hourly rate')).not.toHaveValue()
@@ -108,7 +114,7 @@ describe('EditVehicleDialog', () => {
 
   it('pre-populates only the hourly rate when daily is null', () => {
     const vehicle = makeVehicle({ dailyRateJpy: null, hourlyRateJpy: 1200 })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Daily rate')).not.toHaveValue()
     expect(screen.getByLabelText('Hourly rate')).toHaveValue(1200)
@@ -122,7 +128,7 @@ describe('EditVehicleDialog', () => {
       dailyRateJpy: 6500,
       hourlyRateJpy: 900,
     })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Vehicle name')).toHaveValue('Honda N-BOX')
     expect(screen.getByLabelText('Seats')).toHaveValue(4)
@@ -130,7 +136,7 @@ describe('EditVehicleDialog', () => {
   })
 
   it('renders nothing when vehicle is null', () => {
-    render(<EditVehicleDialog vehicle={null} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle: null })
     expect(screen.queryByLabelText('Daily rate')).not.toBeInTheDocument()
   })
 
@@ -143,7 +149,7 @@ describe('EditVehicleDialog', () => {
       maxRentalHours: 48,
       advanceBookingHours: 12,
     })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Minimum rental (hours)')).toHaveValue(6)
     expect(screen.getByLabelText('Maximum rental (hours)')).toHaveValue(48)
@@ -153,21 +159,21 @@ describe('EditVehicleDialog', () => {
   // Issue #226: pre-populate shaken and insurance expiry dates.
   it('pre-fills shaken expiry date from existing vehicle', () => {
     const vehicle = makeVehicle({ shakenExpiryDate: '2027-03-15' })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Shaken expiry date')).toHaveValue('2027-03-15')
   })
 
   it('pre-fills insurance expiry date from existing vehicle', () => {
     const vehicle = makeVehicle({ insuranceExpiryDate: '2027-06-30' })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Insurance expiry date')).toHaveValue('2027-06-30')
   })
 
   it('renders empty date inputs when vehicle has null expiry dates', () => {
     const vehicle = makeVehicle({ shakenExpiryDate: null, insuranceExpiryDate: null })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     expect(screen.getByLabelText('Shaken expiry date')).not.toHaveValue()
     expect(screen.getByLabelText('Insurance expiry date')).not.toHaveValue()
@@ -179,7 +185,7 @@ describe('EditVehicleDialog', () => {
       maxRentalHours: null,
       advanceBookingHours: null,
     })
-    render(<EditVehicleDialog vehicle={vehicle} onOpenChange={vi.fn()} />)
+    renderDialog({ vehicle })
 
     // Edit mode: an unset rule on the vehicle should render blank, not the
     // form's create-mode default. Owner needs to distinguish "no rule" from

--- a/packages/web/tests/hooks/useVehicleMutation.test.tsx
+++ b/packages/web/tests/hooks/useVehicleMutation.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/query-keys', () => ({
+  vehicleKeys: {
+    all: ['vehicles'] as const,
+    fleetOverview: ['vehicles', 'fleet-overview'] as const,
+  },
+}))
+
+import type { ActionResult } from '@/lib/vehicle-actions'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
+    },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+  return { Wrapper, queryClient }
+}
+
+// Lazy import so the mock is in place
+async function loadHook() {
+  const { useVehicleMutation } = await import('@/hooks/useVehicleMutation')
+  return useVehicleMutation
+}
+
+describe('useVehicleMutation', () => {
+  it('calls onSuccess and invalidates cache on ActionResult success', async () => {
+    const useVehicleMutation = await loadHook()
+    const onSuccess = vi.fn()
+    const mutationFn = vi.fn<(input: string) => Promise<ActionResult<{ id: string }>>>()
+    mutationFn.mockResolvedValueOnce({ success: true, data: { id: 'v1' } })
+
+    const { Wrapper, queryClient } = createWrapper()
+    // Seed cache so we can verify invalidation
+    queryClient.setQueryData(['vehicles', 'fleet-overview'], [{ id: 'v1' }])
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useVehicleMutation({ mutationFn, onSuccess }), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutate('test-input')
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false)
+    })
+
+    expect(mutationFn).toHaveBeenCalledWith('test-input')
+    expect(onSuccess).toHaveBeenCalledWith({ id: 'v1' })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['vehicles'] })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes error string when ActionResult returns success:false', async () => {
+    const useVehicleMutation = await loadHook()
+    const onSuccess = vi.fn()
+    const mutationFn = vi.fn<(input: string) => Promise<ActionResult<unknown>>>()
+    mutationFn.mockResolvedValueOnce({ success: false, error: 'Vehicle not found' })
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useVehicleMutation({ mutationFn, onSuccess }), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutate('bad-input')
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Vehicle not found')
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('exposes error string when mutationFn throws an exception', async () => {
+    const useVehicleMutation = await loadHook()
+    const mutationFn = vi.fn<(input: string) => Promise<ActionResult<unknown>>>()
+    mutationFn.mockRejectedValueOnce(new Error('Network failure'))
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useVehicleMutation({ mutationFn }), { wrapper: Wrapper })
+
+    result.current.mutate('input')
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Network failure')
+  })
+
+  it('clears error when a subsequent mutate succeeds', async () => {
+    const useVehicleMutation = await loadHook()
+    const mutationFn = vi.fn<(input: string) => Promise<ActionResult<{ id: string }>>>()
+    mutationFn.mockResolvedValueOnce({ success: false, error: 'First attempt failed' })
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useVehicleMutation({ mutationFn }), { wrapper: Wrapper })
+
+    result.current.mutate('input')
+    await waitFor(() => expect(result.current.error).toBe('First attempt failed'))
+
+    mutationFn.mockResolvedValueOnce({ success: true, data: { id: 'v1' } })
+    result.current.mutate('input')
+    await waitFor(() => expect(result.current.error).toBeNull())
+  })
+})


### PR DESCRIPTION
Closes #259

## Summary
- Replace `AnyRow = Record<string, any>` with `ColumnRow<T>` utility type that infers row shapes from Drizzle column selection objects
- Each mapper now has a specific input type (e.g. `VehicleRow`, `BookingRow`) — adding a column to the domain type without updating the mapper causes a compile error
- Fix `findByIds` which skipped the `toVehicle()` mapper (`return rows as Vehicle[]`)

## Test plan
- [x] `tsc --noEmit` clean (both api and web)
- [x] 45 vehicle + maintenance tests pass