### PR TITLE
refactor(shared): extract canonical VehicleBase type

### DIFF
--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -16,34 +16,7 @@ export interface VehicleClass {
   updatedAt: Date
 }
 
-export interface Vehicle {
-  id: string
-  classId: string | null
-  name: string
-  description: string | null
-  photos: string[]
-  seats: number
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  licensePlate: string | null
-  status: 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
-  bufferMinutes: number
-  minRentalHours: number | null
-  maxRentalHours: number | null
-  advanceBookingHours: number | null
-  make: string | null
-  model: string | null
-  year: number | null
-  color: string | null
-  // JPY rates. At least one is non-null (enforced by DB CHECK constraint
-  // `vehicles_pricing_at_least_one` and by createVehicleSchema). See #48.
-  dailyRateJpy: number | null
-  hourlyRateJpy: number | null
-  shakenExpiryDate: string | null
-  insuranceExpiryDate: string | null
-  createdAt: Date
-  updatedAt: Date
-}
+export type { VehicleBase as Vehicle } from '@kuruma/shared/types/vehicle'
 
 export interface Booking {
   id: string

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,7 @@
     "./types/stats": "./src/types/stats.ts",
     "./types/api-response": "./src/types/api-response.ts",
     "./types/fleet": "./src/types/fleet.ts",
+    "./types/vehicle": "./src/types/vehicle.ts",
     "./types/vehicle-detail": "./src/types/vehicle-detail.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/pricing": "./src/lib/pricing.ts",

--- a/packages/shared/src/types/fleet.ts
+++ b/packages/shared/src/types/fleet.ts
@@ -4,37 +4,15 @@
 // per-request by the repository; NOT denormalized into the vehicles
 // table. See issue #52.
 
+import type { VehicleBase } from './vehicle'
+
 export interface FleetBookingSummary {
   startAt: Date
   endAt: Date
   renterName: string | null
 }
 
-export interface FleetVehicleOverview {
-  // All columns from the underlying Vehicle row. Kept as a structural
-  // match rather than `extends Vehicle` so this file has zero runtime
-  // dependency on the api package.
-  id: string
-  classId: string | null
-  name: string
-  description: string | null
-  photos: string[]
-  seats: number
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  licensePlate: string | null
-  status: 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
-  bufferMinutes: number
-  minRentalHours: number | null
-  maxRentalHours: number | null
-  advanceBookingHours: number | null
-  dailyRateJpy: number | null
-  hourlyRateJpy: number | null
-  shakenExpiryDate: string | null
-  insuranceExpiryDate: string | null
-  createdAt: Date
-  updatedAt: Date
-
+export interface FleetVehicleOverview extends VehicleBase {
   // Utilization: fraction of hours booked in the last 30 days, expressed
   // as a percentage 0..100. CANCELLED bookings excluded. Buffer time is
   // NOT counted — only the renter-facing window (startAt..endAt).

--- a/packages/shared/src/types/vehicle-detail.ts
+++ b/packages/shared/src/types/vehicle-detail.ts
@@ -3,6 +3,7 @@
 // Computed per-request by the repository. See issue #53.
 
 import type { MaintenanceLogSummary } from './maintenance-log'
+import type { VehicleBase } from './vehicle'
 
 export interface VehicleDetailBooking {
   id: string
@@ -18,27 +19,7 @@ export interface DailyUtilization {
   bookedHours: number
 }
 
-export interface VehicleDetail {
-  id: string
-  name: string
-  description: string | null
-  photos: string[]
-  seats: number
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  licensePlate: string | null
-  status: 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
-  bufferMinutes: number
-  minRentalHours: number | null
-  maxRentalHours: number | null
-  advanceBookingHours: number | null
-  dailyRateJpy: number | null
-  hourlyRateJpy: number | null
-  shakenExpiryDate: string | null
-  insuranceExpiryDate: string | null
-  createdAt: Date
-  updatedAt: Date
-
+export interface VehicleDetail extends VehicleBase {
   // Issue #225: full maintenance history for the vehicle.
   maintenanceLogs: MaintenanceLogSummary[]
 

--- a/packages/shared/src/types/vehicle.ts
+++ b/packages/shared/src/types/vehicle.ts
@@ -1,0 +1,31 @@
+export type VehicleStatus = 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
+export type Transmission = 'AUTO' | 'MANUAL'
+
+export interface VehicleBase {
+  id: string
+  classId: string | null
+  name: string
+  description: string | null
+  photos: string[]
+  seats: number
+  transmission: Transmission
+  fuelType: string | null
+  licensePlate: string | null
+  status: VehicleStatus
+  bufferMinutes: number
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
+  make: string | null
+  model: string | null
+  year: number | null
+  color: string | null
+  // JPY rates. At least one is non-null (enforced by DB CHECK constraint
+  // `vehicles_pricing_at_least_one` and by createVehicleSchema). See #48.
+  dailyRateJpy: number | null
+  hourlyRateJpy: number | null
+  shakenExpiryDate: string | null
+  insuranceExpiryDate: string | null
+  createdAt: Date
+  updatedAt: Date
+}

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -1,30 +1,11 @@
 import { createApiClient } from '@/lib/api-client'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
+import type { VehicleBase } from '@kuruma/shared/types/vehicle'
 import type { CreateVehicleInput, VehicleStatus } from '@kuruma/shared/validators/vehicle'
 
-export interface VehicleData {
-  id: string
-  classId: string | null
-  name: string
-  description: string | null
+// JSON-serialized Vehicle — dates come as ISO strings from the API.
+export type VehicleData = Omit<VehicleBase, 'createdAt' | 'updatedAt'> & {
   photos?: string[]
-  seats: number
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  licensePlate: string | null
-  status: 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
-  bufferMinutes: number
-  minRentalHours: number | null
-  maxRentalHours: number | null
-  advanceBookingHours: number | null
-  make: string | null
-  model: string | null
-  year: number | null
-  color: string | null
-  dailyRateJpy: number | null
-  hourlyRateJpy: number | null
-  shakenExpiryDate: string | null
-  insuranceExpiryDate: string | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/web/src/lib/vehicles.ts
+++ b/packages/web/src/lib/vehicles.ts
@@ -1,22 +1,8 @@
 import { createApiClient } from '@/lib/api-client'
+import type { VehicleData } from '@/lib/vehicle-api'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 
-interface Vehicle {
-  id: string
-  name: string
-  description: string | null
-  photos?: string[]
-  seats: number
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  status: string
-  bufferMinutes: number
-  minRentalHours: number | null
-  maxRentalHours: number | null
-  advanceBookingHours: number | null
-  createdAt: string
-  updatedAt: string
-}
+type Vehicle = VehicleData
 
 export async function getAvailableVehicles(
   from?: string,


### PR DESCRIPTION
## Summary
- Creates `VehicleBase` in `@kuruma/shared/types/vehicle` with all 24 vehicle fields
- `FleetVehicleOverview` and `VehicleDetail` now `extends VehicleBase` instead of re-listing 20 fields each
- API `Vehicle` re-exports `VehicleBase` (zero field duplication)
- Web `VehicleData` derives from `VehicleBase` with `string` dates for JSON serialization
- Deletes stale local `Vehicle` type in `vehicles.ts` (was missing 10 fields)

Net: -112 lines added, +43 lines = **-69 lines** of duplicated type definitions

Closes #257

## Test plan
- [x] tsc --noEmit clean across all 3 packages (shared, api, web)
- [x] 266 API tests pass
- [x] 169 shared tests pass
- [x] Biome lint clean
- [x] Pre-commit hooks pass