### PR TITLE
security(api): block content-type spoofing in vehicle photo upload

### DIFF
--- a/packages/api/src/lib/magic-bytes.ts
+++ b/packages/api/src/lib/magic-bytes.ts
@@ -1,0 +1,46 @@
+export type ImageType = 'jpeg' | 'png' | 'webp' | 'avif'
+
+/**
+ * Sniff the image type from the first bytes of a file. Returns null if the
+ * bytes don't match any allowed image format. Used to block content-type
+ * spoofing — a client-declared `image/jpeg` header does not guarantee JPEG
+ * bytes, so we must verify at the byte level before storing on R2.
+ */
+export function detectImageType(bytes: Uint8Array): ImageType | null {
+  if (isJpeg(bytes)) return 'jpeg'
+  if (isPng(bytes)) return 'png'
+  if (isWebp(bytes)) return 'webp'
+  if (isAvif(bytes)) return 'avif'
+  return null
+}
+
+function isJpeg(b: Uint8Array): boolean {
+  return b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff
+}
+
+function isPng(b: Uint8Array): boolean {
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  if (b.length < sig.length) return false
+  for (let i = 0; i < sig.length; i++) {
+    if (b[i] !== sig[i]) return false
+  }
+  return true
+}
+
+function isWebp(b: Uint8Array): boolean {
+  // RIFF....WEBP — "RIFF" at 0-3, "WEBP" at 8-11
+  if (b.length < 12) return false
+  const riff = b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46
+  const webp = b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  return riff && webp
+}
+
+function isAvif(b: Uint8Array): boolean {
+  // ISO-BMFF: 4-byte box size, "ftyp" at 4-7, brand at 8-11
+  if (b.length < 12) return false
+  const ftyp = b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70
+  if (!ftyp) return false
+  // brand: "avif" or "avis"
+  const brandIsAvi = b[8] === 0x61 && b[9] === 0x76 && b[10] === 0x69
+  return brandIsAvi && (b[11] === 0x66 || b[11] === 0x73)
+}

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { type ImageType, detectImageType } from '../lib/magic-bytes'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { PhotoStorage, VehicleRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
@@ -7,12 +8,34 @@ const MAX_PHOTOS_PER_VEHICLE = 10
 const MAX_FILE_SIZE = 5 * 1024 * 1024
 const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
 
+// Enough bytes to sniff every supported format (AVIF needs 12).
+const SNIFF_BYTES = 16
+
+const MIME_TO_TYPE: Record<string, ImageType> = {
+  'image/jpeg': 'jpeg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/avif': 'avif',
+}
+
 function validateFile(file: File): string | null {
   if (!ALLOWED_MIME_TYPES.has(file.type)) {
     return 'Only image files are allowed (JPEG, PNG, WebP, AVIF)'
   }
   if (file.size > MAX_FILE_SIZE) {
     return 'File must be under 5MB'
+  }
+  return null
+}
+
+/** Verify the declared MIME matches the sniffed magic bytes. Blocks
+ *  content-type spoofing — a stored XSS vector if we trust `file.type`. */
+async function verifyMagicBytes(file: File): Promise<string | null> {
+  const head = new Uint8Array(await file.slice(0, SNIFF_BYTES).arrayBuffer())
+  const detected = detectImageType(head)
+  if (!detected) return 'File content does not match any supported image format'
+  if (MIME_TO_TYPE[file.type] !== detected) {
+    return 'File content does not match declared content type'
   }
   return null
 }
@@ -44,6 +67,11 @@ export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: Photo
       for (const file of files) {
         const error = validateFile(file)
         if (error) return fail(c, error, 400)
+      }
+
+      for (const file of files) {
+        const error = await verifyMagicBytes(file)
+        if (error) return fail(c, error, 415)
       }
 
       const results = await Promise.all(files.map((f) => storage.put(vehicle.id, f)))

--- a/packages/api/tests/lib/magic-bytes.test.ts
+++ b/packages/api/tests/lib/magic-bytes.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { detectImageType } from '../../src/lib/magic-bytes'
+
+function bytesOf(...hex: string[]): Uint8Array {
+  return new Uint8Array(hex.map((h) => Number.parseInt(h, 16)))
+}
+
+describe('detectImageType', () => {
+  it('detects JPEG from FF D8 FF magic', () => {
+    expect(detectImageType(bytesOf('FF', 'D8', 'FF', 'E0', '00', '10'))).toBe('jpeg')
+  })
+
+  it('detects PNG from 89 50 4E 47 0D 0A 1A 0A magic', () => {
+    expect(detectImageType(bytesOf('89', '50', '4E', '47', '0D', '0A', '1A', '0A'))).toBe('png')
+  })
+
+  it('detects WebP from RIFF....WEBP magic', () => {
+    // "RIFF" + 4-byte size + "WEBP"
+    const bytes = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ])
+    expect(detectImageType(bytes)).toBe('webp')
+  })
+
+  it('detects AVIF from ftypavif brand', () => {
+    // 4-byte box size + "ftyp" + "avif"
+    const bytes = new Uint8Array([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
+    ])
+    expect(detectImageType(bytes)).toBe('avif')
+  })
+
+  it('detects AVIF from ftypavis brand', () => {
+    const bytes = new Uint8Array([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x73,
+    ])
+    expect(detectImageType(bytes)).toBe('avif')
+  })
+
+  it('returns null for HTML bytes', () => {
+    const bytes = new TextEncoder().encode('<html><script>alert(1)</script>')
+    expect(detectImageType(bytes)).toBeNull()
+  })
+
+  it('returns null for SVG bytes (not an image bitmap)', () => {
+    const bytes = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg">')
+    expect(detectImageType(bytes)).toBeNull()
+  })
+
+  it('returns null for empty buffer', () => {
+    expect(detectImageType(new Uint8Array([]))).toBeNull()
+  })
+
+  it('returns null for RIFF without WEBP marker', () => {
+    const bytes = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45,
+    ]) // RIFF....WAVE (audio)
+    expect(detectImageType(bytes)).toBeNull()
+  })
+
+  it('returns null for ftyp without avif/avis brand', () => {
+    const bytes = new Uint8Array([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32,
+    ]) // ftypmp42 (MP4 video)
+    expect(detectImageType(bytes)).toBeNull()
+  })
+
+  it('returns null for truncated JPEG (only FF D8)', () => {
+    expect(detectImageType(bytesOf('FF', 'D8'))).toBeNull()
+  })
+})

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -28,9 +28,27 @@ function vehicleInput(overrides?: Partial<Vehicle>) {
   }
 }
 
+/** Magic byte prefixes so the declared content-type matches the sniffed type. */
+const MAGIC: Record<string, number[]> = {
+  'image/jpeg': [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10],
+  'image/png': [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  'image/webp': [0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50],
+  'image/avif': [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66],
+}
+
 function makeFormData(name: string, type: string, sizeBytes: number): FormData {
-  const buffer = new ArrayBuffer(sizeBytes)
-  const file = new File([buffer], name, { type })
+  const prefix = MAGIC[type] ?? []
+  const bytes = new Uint8Array(sizeBytes)
+  bytes.set(prefix.slice(0, sizeBytes))
+  const file = new File([bytes], name, { type })
+  const form = new FormData()
+  form.append('file', file)
+  return form
+}
+
+/** Build FormData with explicit raw bytes — use to test spoofing scenarios. */
+function makeFormDataWithBytes(name: string, type: string, bytes: Uint8Array): FormData {
+  const file = new File([bytes], name, { type })
   const form = new FormData()
   form.append('file', file)
   return form
@@ -115,6 +133,52 @@ describe('POST /vehicles/:id/photos', () => {
     })
 
     expect(res.status).toBe(400)
+  })
+
+  it('rejects HTML bytes labeled image/jpeg (content-type spoofing) with 415', async () => {
+    const headers = await authHeaders()
+    const htmlBytes = new TextEncoder().encode('<html><script>alert(1)</script></html>')
+    const form = makeFormDataWithBytes('evil.jpg', 'image/jpeg', htmlBytes)
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(415)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toMatch(/content|format|image/i)
+  })
+
+  it('rejects PNG bytes labeled image/jpeg (type mismatch) with 415', async () => {
+    const headers = await authHeaders()
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
+    const form = makeFormDataWithBytes('fake.jpg', 'image/jpeg', pngBytes)
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(415)
+  })
+
+  it('accepts when declared content-type matches actual bytes', async () => {
+    const headers = await authHeaders()
+    // PNG bytes with matching image/png content-type
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
+    const form = makeFormDataWithBytes('real.png', 'image/png', pngBytes)
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(201)
   })
 
   it('rejects file larger than 5MB with 400', async () => {


### PR DESCRIPTION
## Summary
Fixes the CRITICAL item from #285 — stored XSS via content-type spoofing on photo upload.

Before: multipart `Content-Type: image/jpeg` was trusted; attacker could upload HTML labeled as a JPEG and R2 would serve it with that content-type, enabling stored XSS on origin.

After: sniff first 16 bytes, verify against magic byte signatures for JPEG/PNG/WebP/AVIF, reject with 415 when bytes don't match the declared MIME (or match nothing).

## Scope
- CRITICAL: content-type spoofing — **this PR**
- HIGH items (TOCTOU, partial-upload orphans, index-based delete race) are scoped for a separate PR

## Test plan
- [x] 11 unit tests on `detectImageType` (valid + spoofing + truncation cases)
- [x] 3 route-level tests: HTML-as-JPEG → 415, PNG-as-JPEG → 415, PNG-as-PNG → 201
- [x] 324 total tests passing
- [x] tsc clean, biome clean

Refs #285