### PR TITLE
fix(fleet): harden photo upload — magic bytes + atomic array ops

### DIFF
--- a/packages/api/src/lib/image-signature.ts
+++ b/packages/api/src/lib/image-signature.ts
@@ -1,0 +1,51 @@
+// Magic-byte signatures for the image formats we accept. Trusting the
+// multipart Content-Type is not sufficient — an attacker can set any header
+// on arbitrary bytes. If R2 serves those bytes back with the declared
+// contentType (it does), the public bucket URL becomes a stored-XSS vector.
+
+export type DetectedImage = 'image/jpeg' | 'image/png' | 'image/webp' | 'image/avif'
+
+export function detectImageType(bytes: Uint8Array): DetectedImage | null {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg'
+  }
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return 'image/png'
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return 'image/webp'
+  }
+  // ISO base media: bytes 4..7 === 'ftyp', then a brand. AVIF brands:
+  // avif, avis, mif1 (heif-compat), heic, heix — we accept avif/avis only.
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(bytes[8]!, bytes[9]!, bytes[10]!, bytes[11]!)
+    if (brand === 'avif' || brand === 'avis') return 'image/avif'
+  }
+  return null
+}

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -120,4 +120,49 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .returning()
     return rows.map(toVehicle)
   }
+
+  async appendPhotos(
+    id: string,
+    urls: string[],
+    maxPhotos: number,
+  ): Promise<
+    { outcome: 'ok'; vehicle: Vehicle } | { outcome: 'cap_exceeded' } | { outcome: 'not_found' }
+  > {
+    // Single-statement conditional append: only succeed if the resulting
+    // cardinality stays within the cap. Concurrent callers serialize at
+    // the row level, so two racing uploads cannot both pass the guard.
+    // URLs are chained via array_append to keep them as bound parameters
+    // rather than interpolated literals.
+    let photosExpr: SQL = sql`${vehicles.photos}`
+    for (const url of urls) {
+      photosExpr = sql`array_append(${photosExpr}, ${url})`
+    }
+    const [updated] = await this.db
+      .update(vehicles)
+      .set({ photos: photosExpr, updatedAt: sql`now()` })
+      .where(
+        and(
+          eq(vehicles.id, id),
+          sql`cardinality(${vehicles.photos}) + ${urls.length} <= ${maxPhotos}`,
+        ),
+      )
+      .returning()
+
+    if (updated) return { outcome: 'ok', vehicle: toVehicle(updated) }
+    const existing = await this.findById(id)
+    return existing ? { outcome: 'cap_exceeded' } : { outcome: 'not_found' }
+  }
+
+  async removePhotoByUrl(id: string, url: string): Promise<Vehicle | undefined> {
+    // array_remove is atomic — no TOCTOU between read of photos and write.
+    const [updated] = await this.db
+      .update(vehicles)
+      .set({
+        photos: sql`array_remove(${vehicles.photos}, ${url})`,
+        updatedAt: sql`now()`,
+      })
+      .where(and(eq(vehicles.id, id), sql`${url} = ANY(${vehicles.photos})`))
+      .returning()
+    return updated ? toVehicle(updated) : undefined
+  }
 }

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -98,4 +98,36 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     }
     return updated
   }
+
+  async appendPhotos(
+    id: string,
+    urls: string[],
+    maxPhotos: number,
+  ): Promise<
+    { outcome: 'ok'; vehicle: Vehicle } | { outcome: 'cap_exceeded' } | { outcome: 'not_found' }
+  > {
+    const existing = this.store.get(id)
+    if (!existing) return { outcome: 'not_found' }
+    if (existing.photos.length + urls.length > maxPhotos) return { outcome: 'cap_exceeded' }
+    const updated: Vehicle = {
+      ...existing,
+      photos: [...existing.photos, ...urls],
+      updatedAt: new Date(),
+    }
+    this.store.set(updated.id, updated)
+    return { outcome: 'ok', vehicle: updated }
+  }
+
+  async removePhotoByUrl(id: string, url: string): Promise<Vehicle | undefined> {
+    const existing = this.store.get(id)
+    if (!existing) return undefined
+    if (!existing.photos.includes(url)) return undefined
+    const updated: Vehicle = {
+      ...existing,
+      photos: existing.photos.filter((u) => u !== url),
+      updatedAt: new Date(),
+    }
+    this.store.set(updated.id, updated)
+    return updated
+  }
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -55,6 +55,16 @@ export interface VehicleRepository {
   ): Promise<Vehicle | undefined>
   softDelete(id: string): Promise<Vehicle | undefined>
   bulkUpdateStatus(ids: string[], status: 'AVAILABLE' | 'MAINTENANCE'): Promise<Vehicle[]>
+  // Atomic photo-array ops. Single SQL statements so concurrent callers
+  // cannot race a read-modify-write on the photos array.
+  appendPhotos(
+    id: string,
+    urls: string[],
+    maxPhotos: number,
+  ): Promise<
+    { outcome: 'ok'; vehicle: Vehicle } | { outcome: 'cap_exceeded' } | { outcome: 'not_found' }
+  >
+  removePhotoByUrl(id: string, url: string): Promise<Vehicle | undefined>
 }
 
 // Aggregated read for the owner-facing /manage/vehicles list. Enriches

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { detectImageType } from '../lib/image-signature'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { PhotoStorage, VehicleRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
@@ -7,14 +8,18 @@ const MAX_PHOTOS_PER_VEHICLE = 10
 const MAX_FILE_SIZE = 5 * 1024 * 1024
 const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
 
-function validateFile(file: File): string | null {
+type ValidatedFile = { file: File; bytes: Uint8Array }
+
+async function validateFile(file: File): Promise<{ ok: ValidatedFile } | { err: string }> {
   if (!ALLOWED_MIME_TYPES.has(file.type)) {
-    return 'Only image files are allowed (JPEG, PNG, WebP, AVIF)'
+    return { err: 'Only image files are allowed (JPEG, PNG, WebP, AVIF)' }
   }
-  if (file.size > MAX_FILE_SIZE) {
-    return 'File must be under 5MB'
-  }
-  return null
+  if (file.size > MAX_FILE_SIZE) return { err: 'File must be under 5MB' }
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const detected = detectImageType(bytes)
+  if (detected === null) return { err: 'File content does not match an allowed image format' }
+  if (detected !== file.type) return { err: 'File content does not match declared Content-Type' }
+  return { ok: { file, bytes } }
 }
 
 export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: PhotoStorage) {
@@ -23,9 +28,7 @@ export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: Photo
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const vehicle = await repo.findById(c.req.param('id'))
-      if (!vehicle) return fail(c, 'Vehicle not found', 404)
-
+      const vehicleId = c.req.param('id')
       const body = await c.req.parseBody({ all: true })
       const rawFiles = body.file
       if (!rawFiles) return fail(c, 'No file provided', 400)
@@ -34,55 +37,77 @@ export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: Photo
         (f): f is File => f instanceof File,
       )
       if (files.length === 0) return fail(c, 'No file provided', 400)
-
-      // TODO: race condition — concurrent uploads can exceed limit.
-      // Fix with DB-level constraint or SELECT FOR UPDATE when needed.
-      if (vehicle.photos.length + files.length > MAX_PHOTOS_PER_VEHICLE) {
+      if (files.length > MAX_PHOTOS_PER_VEHICLE) {
         return fail(c, `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`, 400)
       }
 
+      // Validate bytes before hitting storage so we never persist a spoofed file.
+      const validated: ValidatedFile[] = []
       for (const file of files) {
-        const error = validateFile(file)
-        if (error) return fail(c, error, 400)
+        const result = await validateFile(file)
+        if ('err' in result) return fail(c, result.err, 400)
+        validated.push(result.ok)
       }
 
-      const results = await Promise.all(files.map((f) => storage.put(vehicle.id, f)))
-      const uploaded = results.map((r) => r.url)
+      // Upload all files in parallel. Track successes so we can roll back if
+      // any put rejects mid-batch or the DB append fails.
+      const uploadResults = await Promise.allSettled(
+        validated.map(({ file }) => storage.put(vehicleId, file)),
+      )
 
-      try {
-        await repo.update(vehicle.id, { photos: [...vehicle.photos, ...uploaded] })
-      } catch (e) {
-        // Clean up uploaded files if DB update fails to avoid orphans
-        await Promise.all(results.map((r) => storage.delete(r.url).catch(() => {}))).catch(() => {})
-        throw e
+      const succeeded = uploadResults.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
+      const anyFailed = uploadResults.some((r) => r.status === 'rejected')
+
+      if (anyFailed) {
+        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
+        return fail(c, 'One or more uploads failed', 500)
       }
 
-      return ok(c, { uploaded, total: vehicle.photos.length + uploaded.length }, 201)
+      const appendResult = await repo.appendPhotos(
+        vehicleId,
+        succeeded.map((r) => r.url),
+        MAX_PHOTOS_PER_VEHICLE,
+      )
+
+      if (appendResult.outcome === 'not_found') {
+        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
+        return fail(c, 'Vehicle not found', 404)
+      }
+      if (appendResult.outcome === 'cap_exceeded') {
+        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
+        return fail(c, `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`, 400)
+      }
+
+      return ok(
+        c,
+        {
+          uploaded: succeeded.map((r) => r.url),
+          total: appendResult.vehicle.photos.length,
+        },
+        201,
+      )
     })
-    .delete('/vehicles/:id/photos/:photoIdx', async (c) => {
+    .delete('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const vehicle = await repo.findById(c.req.param('id'))
-      if (!vehicle) return fail(c, 'Vehicle not found', 404)
+      const url = c.req.query('url')
+      if (!url) return fail(c, 'url query parameter required', 400)
 
-      const idx = Number.parseInt(c.req.param('photoIdx'), 10)
-      if (Number.isNaN(idx) || idx < 0 || idx >= vehicle.photos.length) {
-        return fail(c, 'Photo index out of range', 400)
+      const updated = await repo.removePhotoByUrl(c.req.param('id'), url)
+      if (!updated) {
+        // Either the vehicle does not exist or the URL is not one of its photos.
+        // Treat both as 404 so we do not leak existence info.
+        return fail(c, 'Photo not found', 404)
       }
 
-      const deletedUrl = vehicle.photos[idx]!
-      const photos = vehicle.photos.filter((_, i) => i !== idx)
-
-      await repo.update(vehicle.id, { photos })
-
-      // Best-effort R2 cleanup after DB update succeeds.
+      // Best-effort R2 cleanup after the authoritative DB write succeeds.
       try {
-        await storage.delete(deletedUrl)
+        await storage.delete(url)
       } catch (e) {
-        console.warn('R2 photo cleanup failed, orphan left:', deletedUrl, e)
+        console.warn('R2 photo cleanup failed, orphan left:', url, e)
       }
 
-      return ok(c, { deleted: deletedUrl, remaining: photos.length })
+      return ok(c, { deleted: url, remaining: updated.photos.length })
     })
 }

--- a/packages/api/tests/lib/image-signature.test.ts
+++ b/packages/api/tests/lib/image-signature.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { detectImageType } from '../../src/lib/image-signature'
+
+const JPEG_SOI = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
+const PNG_HEADER = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+const WEBP_HEADER = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+])
+const AVIF_HEADER = new Uint8Array([
+  0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66, 0x00, 0x00,
+])
+
+describe('detectImageType', () => {
+  it('returns image/jpeg for JPEG magic bytes', () => {
+    expect(detectImageType(JPEG_SOI)).toBe('image/jpeg')
+  })
+
+  it('returns image/png for PNG magic bytes', () => {
+    expect(detectImageType(PNG_HEADER)).toBe('image/png')
+  })
+
+  it('returns image/webp for RIFF...WEBP', () => {
+    expect(detectImageType(WEBP_HEADER)).toBe('image/webp')
+  })
+
+  it('returns image/avif for ftypavif', () => {
+    expect(detectImageType(AVIF_HEADER)).toBe('image/avif')
+  })
+
+  it('returns null for SVG content (XSS vector)', () => {
+    const svg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg">')
+    expect(detectImageType(svg)).toBeNull()
+  })
+
+  it('returns null for HTML content spoofing as JPEG', () => {
+    const html = new TextEncoder().encode('<!DOCTYPE html><script>alert(1)</script>')
+    expect(detectImageType(html)).toBeNull()
+  })
+
+  it('returns null for all-zeroes (what the test fixtures currently use)', () => {
+    expect(detectImageType(new Uint8Array(32))).toBeNull()
+  })
+
+  it('returns null for too-short buffers', () => {
+    expect(detectImageType(new Uint8Array([0xff, 0xd8]))).toBeNull()
+  })
+
+  it('rejects heic/heix ftyp brands (not in allowlist)', () => {
+    const heic = new Uint8Array([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
+    ])
+    expect(detectImageType(heic)).toBeNull()
+  })
+})

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -9,6 +9,9 @@ import { InMemoryPhotoStorage } from '../../src/repositories/in-memory/photo-sto
 import type { Vehicle } from '../../src/stores'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
+const JPEG_HEADER = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]
+const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]
+
 function vehicleInput(overrides?: Partial<Vehicle>) {
   return {
     name: 'Test Car',
@@ -28,9 +31,19 @@ function vehicleInput(overrides?: Partial<Vehicle>) {
   }
 }
 
-function makeFormData(name: string, type: string, sizeBytes: number): FormData {
-  const buffer = new ArrayBuffer(sizeBytes)
-  const file = new File([buffer], name, { type })
+function imageBuffer(header: number[], totalSize: number): ArrayBuffer {
+  const buf = new Uint8Array(totalSize)
+  buf.set(header, 0)
+  return buf.buffer
+}
+
+function makeFormData(
+  name: string,
+  type: string,
+  sizeBytes: number,
+  header: number[] = JPEG_HEADER,
+): FormData {
+  const file = new File([imageBuffer(header, sizeBytes)], name, { type })
   const form = new FormData()
   form.append('file', file)
   return form
@@ -117,6 +130,36 @@ describe('POST /vehicles/:id/photos', () => {
     expect(res.status).toBe(400)
   })
 
+  it('rejects PNG bytes declared as image/jpeg (content-type spoofing)', async () => {
+    const headers = await authHeaders()
+    const form = makeFormData('spoof.jpg', 'image/jpeg', 1024, PNG_HEADER)
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('does not match declared Content-Type')
+  })
+
+  it('rejects non-image bytes declared as image/jpeg (magic-byte check)', async () => {
+    const headers = await authHeaders()
+    const form = makeFormData('fake.jpg', 'image/jpeg', 1024, [0x3c, 0x21, 0x44, 0x4f])
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('image format')
+  })
+
   it('rejects file larger than 5MB with 400', async () => {
     const headers = await authHeaders()
     const form = makeFormData('huge.jpg', 'image/jpeg', 6 * 1024 * 1024)
@@ -190,8 +233,35 @@ describe('POST /vehicles/:id/photos', () => {
   })
 })
 
+describe('concurrent upload race on photo cap', () => {
+  it('serializes appends so cap cannot be exceeded', async () => {
+    const ctx = createTestApp()
+    const photos = Array.from({ length: 9 }, (_, i) => `https://example.com/photo${i}.jpg`)
+    const v = await ctx.vehicleRepo.create(vehicleInput({ photos }))
+    const headers = await authHeaders()
+
+    // Three concurrent single-photo uploads against a vehicle with 9 existing.
+    // Exactly one should succeed, two should 400.
+    const responses = await Promise.all(
+      [0, 1, 2].map(() =>
+        ctx.app.request(`/vehicles/${v.id}/photos`, {
+          method: 'POST',
+          headers,
+          body: makeFormData('extra.jpg', 'image/jpeg', 1024),
+        }),
+      ),
+    )
+
+    const statuses = responses.map((r) => r.status).sort()
+    expect(statuses).toEqual([201, 400, 400])
+
+    const updated = await ctx.vehicleRepo.findById(v.id)
+    expect(updated?.photos).toHaveLength(10)
+  })
+})
+
 describe('upload → delete round-trip', () => {
-  it('upload then delete by index removes file from storage', async () => {
+  it('upload then delete by URL removes file from storage', async () => {
     const ctx = createTestApp()
     const vehicle = await ctx.vehicleRepo.create(vehicleInput())
     const headers = await authHeaders()
@@ -203,11 +273,12 @@ describe('upload → delete round-trip', () => {
       body: form,
     })
     expect(uploadRes.status).toBe(201)
+    const uploaded: string = (await uploadRes.json()).data.uploaded[0]
 
-    const deleteRes = await ctx.app.request(`/vehicles/${vehicle.id}/photos/0`, {
-      method: 'DELETE',
-      headers,
-    })
+    const deleteRes = await ctx.app.request(
+      `/vehicles/${vehicle.id}/photos?url=${encodeURIComponent(uploaded)}`,
+      { method: 'DELETE', headers },
+    )
     expect(deleteRes.status).toBe(200)
 
     const updated = await ctx.vehicleRepo.findById(vehicle.id)
@@ -215,7 +286,7 @@ describe('upload → delete round-trip', () => {
   })
 })
 
-describe('DELETE /vehicles/:id/photos/:photoIdx', () => {
+describe('DELETE /vehicles/:id/photos?url=', () => {
   let app: ReturnType<typeof createTestApp>['app']
   let vehicleRepo: InMemoryVehicleRepository
   let vehicleId: string
@@ -230,13 +301,13 @@ describe('DELETE /vehicles/:id/photos/:photoIdx', () => {
     vehicleId = v.id
   })
 
-  it('deletes a photo by index', async () => {
+  it('deletes a photo by URL', async () => {
     const headers = await authHeaders()
 
-    const res = await app.request(`/vehicles/${vehicleId}/photos/0`, {
-      method: 'DELETE',
-      headers,
-    })
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
 
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -248,10 +319,10 @@ describe('DELETE /vehicles/:id/photos/:photoIdx', () => {
     expect(updated?.photos).toEqual(['https://test.com/b.jpg'])
   })
 
-  it('returns 400 for out-of-range index', async () => {
+  it('returns 400 when url query is missing', async () => {
     const headers = await authHeaders()
 
-    const res = await app.request(`/vehicles/${vehicleId}/photos/5`, {
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
       method: 'DELETE',
       headers,
     })
@@ -259,24 +330,24 @@ describe('DELETE /vehicles/:id/photos/:photoIdx', () => {
     expect(res.status).toBe(400)
   })
 
-  it('returns 400 for non-numeric index', async () => {
+  it('returns 404 for URL not in vehicle.photos', async () => {
     const headers = await authHeaders()
 
-    const res = await app.request(`/vehicles/${vehicleId}/photos/abc`, {
-      method: 'DELETE',
-      headers,
-    })
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/other.jpg')}`,
+      { method: 'DELETE', headers },
+    )
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(404)
   })
 
   it('returns 404 for nonexistent vehicle', async () => {
     const headers = await authHeaders()
 
-    const res = await app.request('/vehicles/nonexistent/photos/0', {
-      method: 'DELETE',
-      headers,
-    })
+    const res = await app.request(
+      `/vehicles/nonexistent/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
 
     expect(res.status).toBe(404)
   })
@@ -284,10 +355,10 @@ describe('DELETE /vehicles/:id/photos/:photoIdx', () => {
   it('returns 403 for RENTER role', async () => {
     const headers = await authHeaders({ sub: 'renter-1', role: 'RENTER' })
 
-    const res = await app.request(`/vehicles/${vehicleId}/photos/0`, {
-      method: 'DELETE',
-      headers,
-    })
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
 
     expect(res.status).toBe(403)
   })

--- a/packages/web/src/components/vehicles/PhotoUpload.tsx
+++ b/packages/web/src/components/vehicles/PhotoUpload.tsx
@@ -22,7 +22,7 @@ export function PhotoUpload({ vehicleId, initialPhotos }: PhotoUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [photos, setPhotos] = useState(initialPhotos)
   const [uploading, setUploading] = useState(false)
-  const [deleting, setDeleting] = useState<number | null>(null)
+  const [deletingUrl, setDeletingUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [dragOver, setDragOver] = useState(false)
 
@@ -46,13 +46,10 @@ export function PhotoUpload({ vehicleId, initialPhotos }: PhotoUploadProps) {
         return
       }
 
-      setPhotos((prev) => {
-        if (prev.length + imageFiles.length > MAX_PHOTOS) {
-          setError(t('photoLimit', { max: MAX_PHOTOS }))
-          return prev
-        }
-        return prev
-      })
+      if (photos.length + imageFiles.length > MAX_PHOTOS) {
+        setError(t('photoLimit', { max: MAX_PHOTOS }))
+        return
+      }
 
       setUploading(true)
       const formData = new FormData()
@@ -71,23 +68,23 @@ export function PhotoUpload({ vehicleId, initialPhotos }: PhotoUploadProps) {
       setPhotos((prev) => [...prev, ...result.data.uploaded])
       invalidate()
     },
-    [vehicleId, t, invalidate],
+    [vehicleId, t, invalidate, photos.length],
   )
 
   const handleDelete = useCallback(
-    async (idx: number) => {
+    async (url: string) => {
       setError(null)
-      setDeleting(idx)
+      setDeletingUrl(url)
 
-      const result = await deleteVehiclePhotoAction(vehicleId, idx)
-      setDeleting(null)
+      const result = await deleteVehiclePhotoAction(vehicleId, url)
+      setDeletingUrl(null)
 
       if (!result.success) {
         setError(result.error)
         return
       }
 
-      setPhotos((prev) => prev.filter((_, i) => i !== idx))
+      setPhotos((prev) => prev.filter((u) => u !== url))
       invalidate()
     },
     [vehicleId, invalidate],
@@ -131,12 +128,12 @@ export function PhotoUpload({ vehicleId, initialPhotos }: PhotoUploadProps) {
               />
               <button
                 type="button"
-                onClick={() => handleDelete(idx)}
-                disabled={deleting === idx}
+                onClick={() => handleDelete(url)}
+                disabled={deletingUrl === url}
                 className="absolute top-1 right-1 bg-black/60 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50"
                 aria-label={t('deletePhoto')}
               >
-                {deleting === idx ? '...' : '\u00d7'}
+                {deletingUrl === url ? '...' : '\u00d7'}
               </button>
             </div>
           ))}

--- a/packages/web/src/lib/vehicle-actions.ts
+++ b/packages/web/src/lib/vehicle-actions.ts
@@ -75,7 +75,7 @@ export async function uploadVehiclePhotosAction(
 
 export async function deleteVehiclePhotoAction(
   vehicleId: string,
-  photoIdx: number,
+  photoUrl: string,
 ): Promise<ActionResult<PhotoDeleteResult>> {
-  return withAuth((token) => deleteVehiclePhoto(vehicleId, photoIdx, token))
+  return withAuth((token) => deleteVehiclePhoto(vehicleId, photoUrl, token))
 }

--- a/packages/web/src/lib/vehicle-api.ts
+++ b/packages/web/src/lib/vehicle-api.ts
@@ -221,11 +221,11 @@ export async function uploadVehiclePhotos(
 
 export async function deleteVehiclePhoto(
   vehicleId: string,
-  photoIdx: number,
+  photoUrl: string,
   token?: string,
 ): Promise<PhotoDeleteResult> {
   const client = createApiClient()
-  const url = `${client.vehicles[':id'].$url({ param: { id: vehicleId } }).toString()}/photos/${photoIdx}`
+  const url = `${client.vehicles[':id'].$url({ param: { id: vehicleId } }).toString()}/photos?url=${encodeURIComponent(photoUrl)}`
   const headers: Record<string, string> = {}
   if (token) {
     headers.Authorization = `Bearer ${token}`


### PR DESCRIPTION
## Summary

Addresses the CRITICAL and two HIGH findings from the #244 post-merge review, tracked in #285.

- **Content-type spoofing (CRITICAL → stored XSS)** — Added \`src/lib/image-signature.ts\` which sniffs JPEG/PNG/WebP/AVIF magic bytes. Every upload must have bytes that match the declared Content-Type; mismatch or unknown format → 400.
- **TOCTOU on photo cap + array write (HIGH → silent photo loss)** — Pushed the append into \`VehicleRepository.appendPhotos\` as an atomic op. Drizzle uses chained \`array_append\` with a \`cardinality() <= max\` guard in the WHERE clause. InMemory mirrors the atomicity semantics.
- **Index-based delete race (HIGH → array corruption)** — Changed \`DELETE /vehicles/:id/photos/:photoIdx\` to \`DELETE /vehicles/:id/photos?url=<encoded>\`. Backed by \`VehicleRepository.removePhotoByUrl\` which uses Postgres \`array_remove\` (atomic). Frontend + server action + api client updated.

Plus:
- Multi-file upload now uses \`Promise.allSettled\` + rollback so partial failures don't leave orphans in R2.
- CQS violation in \`PhotoUpload.tsx\` fixed — the photo-cap check was inside a \`setPhotos\` updater that also called \`setError\`. Moved guard out of the updater.

## Test plan

- [x] 9 new unit tests for \`detectImageType\`
- [x] 17 route tests including content-type spoofing + 3-way concurrent race
- [x] 322 API tests, 282 web tests pass
- [x] tsc clean, biome + boundary lints clean
- [ ] Manual: upload a real JPEG/PNG, delete it

## Not in this PR

- Service layer extraction → #286
- Rate limiting → #287

Closes #285