### PR TITLE
feat(web): booking detail stub page + dialog link

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -139,7 +139,13 @@
           "month": "Month"
         },
         "noEventsInRange": "No bookings in this range",
-        "showMore": "+{count} more"
+        "showMore": "+{count} more",
+        "viewFullDetails": "View full details"
+      },
+      "detail": {
+        "stubTitle": "Booking detail",
+        "stubBody": "Full booking detail page coming soon — id: {id}",
+        "backToCalendar": "Back to calendar"
       }
     },
     "vehicles": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -139,7 +139,13 @@
           "month": "月"
         },
         "noEventsInRange": "この期間に予約はありません",
-        "showMore": "+{count}件"
+        "showMore": "+{count}件",
+        "viewFullDetails": "詳細を表示"
+      },
+      "detail": {
+        "stubTitle": "予約詳細",
+        "stubBody": "予約詳細ページは近日公開予定です — ID: {id}",
+        "backToCalendar": "カレンダーに戻る"
       }
     },
     "vehicles": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -139,7 +139,13 @@
           "month": "月"
         },
         "noEventsInRange": "该时段暂无预订",
-        "showMore": "+{count}条"
+        "showMore": "+{count}条",
+        "viewFullDetails": "查看详情"
+      },
+      "detail": {
+        "stubTitle": "预订详情",
+        "stubBody": "预订详情页即将推出 — ID：{id}",
+        "backToCalendar": "返回日历"
       }
     },
     "vehicles": {

--- a/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/BookingDetailStub.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/BookingDetailStub.tsx
@@ -12,7 +12,10 @@ export function BookingDetailStub({ id }: BookingDetailStubProps) {
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
       <h1 className="text-2xl font-semibold tracking-tight">{t('stubTitle')}</h1>
       <p className="text-sm text-muted-foreground">{t('stubBody', { id })}</p>
-      <Link href="/manage/bookings" className="inline-block text-sm text-primary hover:underline">
+      <Link
+        href="/manage/bookings"
+        className="inline-block text-sm text-primary hover:underline focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+      >
         {t('backToCalendar')}
       </Link>
     </div>

--- a/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/BookingDetailStub.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/BookingDetailStub.tsx
@@ -1,0 +1,20 @@
+import { Link } from '@/i18n/routing'
+import { useTranslations } from 'next-intl'
+
+interface BookingDetailStubProps {
+  readonly id: string
+}
+
+export function BookingDetailStub({ id }: BookingDetailStubProps) {
+  const t = useTranslations('business.bookings.detail')
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">{t('stubTitle')}</h1>
+      <p className="text-sm text-muted-foreground">{t('stubBody', { id })}</p>
+      <Link href="/manage/bookings" className="inline-block text-sm text-primary hover:underline">
+        {t('backToCalendar')}
+      </Link>
+    </div>
+  )
+}

--- a/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/page.tsx
+++ b/packages/web/src/app/[locale]/(business)/manage/bookings/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { BookingDetailStub } from './BookingDetailStub'
+
+interface BookingDetailPageProps {
+  params: Promise<{ id: string; locale: string }>
+}
+
+export default async function ManageBookingDetailPage({ params }: BookingDetailPageProps) {
+  const { id } = await params
+  return <BookingDetailStub id={id} />
+}

--- a/packages/web/src/components/calendar/BookingDetailDialog.tsx
+++ b/packages/web/src/components/calendar/BookingDetailDialog.tsx
@@ -157,7 +157,7 @@ export function BookingDetailDialog({
         {booking && (
           <Link
             href={`/manage/bookings/${booking.id}`}
-            className="text-sm text-primary hover:underline self-start"
+            className="text-sm text-primary hover:underline focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded self-start"
             onClick={onClose}
           >
             {t('viewFullDetails')}

--- a/packages/web/src/components/calendar/BookingDetailDialog.tsx
+++ b/packages/web/src/components/calendar/BookingDetailDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Link } from '@/i18n/routing'
 import type { CalendarBooking } from '@/lib/calendar'
 import { formatJpy } from '@/lib/format'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
@@ -152,6 +153,16 @@ export function BookingDetailDialog({
         )}
 
         {error && <p className="text-sm text-destructive px-1">{error}</p>}
+
+        {booking && (
+          <Link
+            href={`/manage/bookings/${booking.id}`}
+            className="text-sm text-primary hover:underline self-start"
+            onClick={onClose}
+          >
+            {t('viewFullDetails')}
+          </Link>
+        )}
 
         <DialogFooter>
           {booking?.status === 'CONFIRMED' && !showCancelConfirm && (

--- a/packages/web/tests/components/calendar/BookingDetailDialog-view-full-link.test.tsx
+++ b/packages/web/tests/components/calendar/BookingDetailDialog-view-full-link.test.tsx
@@ -1,0 +1,84 @@
+import { BookingDetailDialog } from '@/components/calendar/BookingDetailDialog'
+import type { CalendarBooking } from '@/lib/calendar'
+import { cleanup, render, screen } from '@testing-library/react'
+import type React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({
+    href,
+    children,
+    onClick,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    onClick?: () => void
+    className?: string
+  }) => (
+    <a href={href} onClick={onClick} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const m: Record<string, string> = {
+      bookingDetails: 'Booking Details',
+      status: 'Status',
+      start: 'Start',
+      end: 'End',
+      source: 'Source',
+      notes: 'Notes',
+      close: 'Close',
+      email: 'Email',
+      language: 'Language',
+      totalPrice: 'Total price',
+      startTrip: 'Start trip',
+      cancelBooking: 'Cancel booking',
+      viewFullDetails: 'View full details',
+      back: 'Back',
+    }
+    return m[key] ?? key
+  },
+}))
+
+vi.mock('@/components/calendar/calendar-actions', () => ({
+  updateBookingStatus: vi.fn(),
+  cancelBooking: vi.fn(),
+}))
+
+const booking: CalendarBooking = {
+  id: 'bk_abc123',
+  renterId: 'u1',
+  vehicleId: 'v1',
+  startAt: new Date('2026-05-01T10:00:00Z').toISOString(),
+  endAt: new Date('2026-05-02T10:00:00Z').toISOString(),
+  effectiveEndAt: new Date('2026-05-02T11:00:00Z').toISOString(),
+  status: 'CONFIRMED',
+  source: 'DIRECT',
+  renterName: 'Alice',
+  renterEmail: 'alice@example.com',
+  renterLanguage: null,
+  totalPrice: 10000,
+  notes: null,
+}
+
+afterEach(() => cleanup())
+
+describe('BookingDetailDialog — View full details link', () => {
+  it('renders a link to /manage/bookings/:id pointing at the booking', () => {
+    render(<BookingDetailDialog booking={booking} onClose={() => {}} />)
+    const link = screen.getByRole('link', { name: /view full details/i })
+    expect(link).toHaveAttribute('href', '/manage/bookings/bk_abc123')
+  })
+
+  it('calls onClose when the link is clicked', () => {
+    const onClose = vi.fn()
+    render(<BookingDetailDialog booking={booking} onClose={onClose} />)
+    const link = screen.getByRole('link', { name: /view full details/i })
+    link.click()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/web/tests/components/calendar/BookingDetailStub.test.tsx
+++ b/packages/web/tests/components/calendar/BookingDetailStub.test.tsx
@@ -23,7 +23,7 @@ vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, values?: Record<string, string>) => {
     const m: Record<string, string> = {
       stubTitle: 'Booking detail',
-      stubBody: `Booking detail page coming soon — id: ${values?.id ?? ''}`,
+      stubBody: `Full booking detail page coming soon — id: ${values?.id ?? ''}`,
       backToCalendar: 'Back to calendar',
     }
     return m[key] ?? key

--- a/packages/web/tests/components/calendar/BookingDetailStub.test.tsx
+++ b/packages/web/tests/components/calendar/BookingDetailStub.test.tsx
@@ -1,0 +1,51 @@
+import { BookingDetailStub } from '@/app/[locale]/(business)/manage/bookings/[id]/BookingDetailStub'
+import { cleanup, render, screen } from '@testing-library/react'
+import type React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string>) => {
+    const m: Record<string, string> = {
+      stubTitle: 'Booking detail',
+      stubBody: `Booking detail page coming soon — id: ${values?.id ?? ''}`,
+      backToCalendar: 'Back to calendar',
+    }
+    return m[key] ?? key
+  },
+}))
+
+afterEach(() => cleanup())
+
+describe('BookingDetailStub', () => {
+  it('renders the booking id from props in the body', () => {
+    render(<BookingDetailStub id="bk_xyz789" />)
+    expect(screen.getByText(/bk_xyz789/)).toBeInTheDocument()
+  })
+
+  it('renders a back link pointing to /manage/bookings', () => {
+    render(<BookingDetailStub id="anything" />)
+    const link = screen.getByRole('link', { name: /back to calendar/i })
+    expect(link).toHaveAttribute('href', '/manage/bookings')
+  })
+
+  it('renders the stub title as a heading', () => {
+    render(<BookingDetailStub id="x" />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/booking detail/i)
+  })
+})


### PR DESCRIPTION
## Summary
Final slice (5/5) of the react-big-calendar migration. Adds a minimal placeholder at `/manage/bookings/[id]` and a "View full details" link inside `BookingDetailDialog`.

Out of scope: real detail page with data/timeline/messaging — separate future slice.

## Changes
- `app/[locale]/(business)/manage/bookings/[id]/page.tsx` — async RSC, awaits `params.id`
- `BookingDetailStub.tsx` — pure component with heading, id body, back link
- `BookingDetailDialog.tsx` — inline Link below error slot, closes dialog on click
- i18n: `detail.stubTitle|stubBody|backToCalendar`, `calendar.viewFullDetails` in en/ja/zh

## Test plan
- [x] 3 stub page tests (id render, back href, heading)
- [x] 2 dialog link tests (href, onClose triggered)
- [x] 287 web tests passing (+5)
- [x] tsc/biome clean

Closes #58