### PR TITLE
security(api): stack rate limits on photo upload/delete

### DIFF
--- a/packages/api/src/error-handlers.ts
+++ b/packages/api/src/error-handlers.ts
@@ -1,7 +1,15 @@
 import type { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 
 export function setupGlobalHandlers(app: Hono): void {
   app.onError((err, c) => {
+    // Defer only when the HTTPException carries an explicit safe response
+    // (e.g. rate-limit middleware does `new HTTPException(429, { res })`).
+    // A bare `new HTTPException(500, { message })` still falls through to the
+    // sanitized branch so internal error messages never leak.
+    if (err instanceof HTTPException && err.res) {
+      return err.getResponse()
+    }
     console.error(
       JSON.stringify({
         level: 'error',

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -79,6 +79,8 @@ export function createApp(overrides?: {
   maintenanceLogRepo?: MaintenanceLogRepository
   photoStorage?: PhotoStorage
   userRepo?: UserRepository
+  photoUploadLimiter?: RateLimitBinding
+  photoUploadUserLimiter?: RateLimitBinding
 }) {
   let vehicleClassRepo: VehicleClassRepository
   let vehicleRepo: VehicleRepository
@@ -93,6 +95,14 @@ export function createApp(overrides?: {
   let maintenanceLogRepo: MaintenanceLogRepository
   let photoStorage: PhotoStorage
   let runInTransaction: RunInTransaction
+  const photoUploadLimiter =
+    overrides?.photoUploadLimiter ??
+    ((globalThis as Record<string, unknown>).PHOTO_UPLOAD_LIMITER as RateLimitBinding | undefined)
+  const photoUploadUserLimiter =
+    overrides?.photoUploadUserLimiter ??
+    ((globalThis as Record<string, unknown>).PHOTO_UPLOAD_USER_LIMITER as
+      | RateLimitBinding
+      | undefined)
 
   if (overrides) {
     ;({ vehicleRepo, bookingRepo, availabilityRepo } = overrides)
@@ -229,7 +239,15 @@ export function createApp(overrides?: {
     .route('/', createVehicleDetailRoutes(vehicleDetailRepo))
     .route('/', createVehicleClassRoutes(vehicleClassService))
     .route('/', createVehicleRoutes(vehicleRepo, maintenanceService))
-    .route('/', createVehiclePhotoRoutes(vehicleRepo, photoStorage))
+    .route(
+      '/',
+      createVehiclePhotoRoutes(
+        vehicleRepo,
+        photoStorage,
+        photoUploadLimiter,
+        photoUploadUserLimiter,
+      ),
+    )
     .route('/', createMaintenanceLogRoutes(maintenanceService))
     .route('/', createBookingRoutes(bookingService))
     .route('/', createAvailabilityRoutes(availabilityRepo))

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,4 +1,5 @@
-import { Hono } from 'hono'
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
+import { type Context, Hono } from 'hono'
 import { detectImageType } from '../lib/image-signature'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { PhotoStorage, VehicleRepository } from '../repositories/types'
@@ -22,8 +23,27 @@ async function validateFile(file: File): Promise<{ ok: ValidatedFile } | { err: 
   return { ok: { file, bytes } }
 }
 
-export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: PhotoStorage) {
-  return new Hono()
+export function createVehiclePhotoRoutes(
+  repo: VehicleRepository,
+  storage: PhotoStorage,
+  photoUploadLimiter?: RateLimitBinding,
+  photoUploadUserLimiter?: RateLimitBinding,
+) {
+  const app = new Hono()
+
+  // Stack two limits. Per-user caps aggregate volume so rotating vehicle IDs
+  // can't burst around the per-(user,vehicle) bucket. Runs first so requests
+  // from a flooding account short-circuit before hitting the narrower limit.
+  const vehicleKey = (c: Context) => `${requireUser(c).id}:${c.req.param('id')}`
+  const userKey = (c: Context) => requireUser(c).id
+  if (photoUploadUserLimiter) {
+    app.use('/vehicles/:id/photos', rateLimit(photoUploadUserLimiter, userKey))
+  }
+  if (photoUploadLimiter) {
+    app.use('/vehicles/:id/photos', rateLimit(photoUploadLimiter, vehicleKey))
+  }
+
+  return app
     .post('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)

--- a/packages/api/tests/routes/vehicle-photo-ratelimit.test.ts
+++ b/packages/api/tests/routes/vehicle-photo-ratelimit.test.ts
@@ -1,0 +1,204 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { InMemoryPhotoStorage } from '../../src/repositories/in-memory/photo-storage'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+const JPEG_HEADER = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]
+
+function vehicleInput(overrides?: { photos?: string[] }) {
+  return {
+    name: 'Test Car',
+    description: 'A test vehicle',
+    photos: [] as string[],
+    seats: 4,
+    transmission: 'AUTO' as const,
+    fuelType: 'GASOLINE',
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 60,
+    minRentalHours: 1,
+    maxRentalHours: 168,
+    advanceBookingHours: 24,
+    dailyRateJpy: 5000,
+    hourlyRateJpy: 1000,
+    ...overrides,
+  }
+}
+
+function jpegForm(): FormData {
+  const buf = new Uint8Array(1024)
+  buf.set(JPEG_HEADER, 0)
+  const file = new File([buf.buffer], 'car.jpg', { type: 'image/jpeg' })
+  const form = new FormData()
+  form.append('file', file)
+  return form
+}
+
+function createFakeLimiter(limit: number): RateLimitBinding {
+  const counts = new Map<string, number>()
+  return {
+    async limit({ key }) {
+      const next = (counts.get(key) ?? 0) + 1
+      counts.set(key, next)
+      return { success: next <= limit }
+    },
+  }
+}
+
+function createTestApp(opts?: {
+  photoUploadLimiter?: RateLimitBinding
+  photoUploadUserLimiter?: RateLimitBinding
+}) {
+  setupAuthEnv()
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  const photoStorage = new InMemoryPhotoStorage()
+
+  return {
+    app: createApp({
+      vehicleRepo,
+      bookingRepo,
+      availabilityRepo,
+      photoStorage,
+      photoUploadLimiter: opts?.photoUploadLimiter,
+      photoUploadUserLimiter: opts?.photoUploadUserLimiter,
+    }),
+    vehicleRepo,
+  }
+}
+
+describe('photo upload rate limiting', () => {
+  it('returns 429 after exceeding the per-(user, vehicle) limit', async () => {
+    const ctx = createTestApp({ photoUploadLimiter: createFakeLimiter(2) })
+    const vehicle = await ctx.vehicleRepo.create(vehicleInput())
+    const headers = await authHeaders()
+
+    const first = await ctx.app.request(`/vehicles/${vehicle.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+    const second = await ctx.app.request(`/vehicles/${vehicle.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+    const third = await ctx.app.request(`/vehicles/${vehicle.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+    expect(third.status).toBe(429)
+  })
+
+  it('keeps separate buckets per (user, vehicle) pair', async () => {
+    const ctx = createTestApp({ photoUploadLimiter: createFakeLimiter(1) })
+    const v1 = await ctx.vehicleRepo.create(vehicleInput())
+    const v2 = await ctx.vehicleRepo.create(vehicleInput())
+    const headersUserA = await authHeaders({ sub: 'user-a', role: 'ADMIN' })
+    const headersUserB = await authHeaders({ sub: 'user-b', role: 'ADMIN' })
+
+    const userAv1 = await ctx.app.request(`/vehicles/${v1.id}/photos`, {
+      method: 'POST',
+      headers: headersUserA,
+      body: jpegForm(),
+    })
+    const userAv1Again = await ctx.app.request(`/vehicles/${v1.id}/photos`, {
+      method: 'POST',
+      headers: headersUserA,
+      body: jpegForm(),
+    })
+    const userAv2 = await ctx.app.request(`/vehicles/${v2.id}/photos`, {
+      method: 'POST',
+      headers: headersUserA,
+      body: jpegForm(),
+    })
+    const userBv1 = await ctx.app.request(`/vehicles/${v1.id}/photos`, {
+      method: 'POST',
+      headers: headersUserB,
+      body: jpegForm(),
+    })
+
+    expect(userAv1.status).toBe(201)
+    expect(userAv1Again.status).toBe(429)
+    expect(userAv2.status).toBe(201)
+    expect(userBv1.status).toBe(201)
+  })
+
+  it('bypasses rate limiting when no binding is injected (local dev)', async () => {
+    const ctx = createTestApp()
+    const vehicle = await ctx.vehicleRepo.create(vehicleInput())
+    const headers = await authHeaders()
+
+    for (let i = 0; i < 5; i++) {
+      const res = await ctx.app.request(`/vehicles/${vehicle.id}/photos`, {
+        method: 'POST',
+        headers,
+        body: jpegForm(),
+      })
+      expect(res.status).toBe(201)
+    }
+  })
+
+  it('also rate-limits DELETE requests (URL-query shape)', async () => {
+    const ctx = createTestApp({ photoUploadLimiter: createFakeLimiter(1) })
+    const vehicle = await ctx.vehicleRepo.create(
+      vehicleInput({ photos: ['https://test/a.jpg', 'https://test/b.jpg'] }),
+    )
+    const headers = await authHeaders()
+
+    const first = await ctx.app.request(
+      `/vehicles/${vehicle.id}/photos?url=${encodeURIComponent('https://test/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
+    const second = await ctx.app.request(
+      `/vehicles/${vehicle.id}/photos?url=${encodeURIComponent('https://test/b.jpg')}`,
+      { method: 'DELETE', headers },
+    )
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(429)
+  })
+
+  it('per-user limit caps aggregate uploads across many vehicles', async () => {
+    // Without this, a single staff token could rotate vehicle IDs to get
+    // fresh per-(user,vehicle) buckets and burst ~500MB/min of R2 writes.
+    const ctx = createTestApp({
+      photoUploadLimiter: createFakeLimiter(100),
+      photoUploadUserLimiter: createFakeLimiter(2),
+    })
+    const v1 = await ctx.vehicleRepo.create(vehicleInput())
+    const v2 = await ctx.vehicleRepo.create(vehicleInput())
+    const v3 = await ctx.vehicleRepo.create(vehicleInput())
+    const headers = await authHeaders()
+
+    const a = await ctx.app.request(`/vehicles/${v1.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+    const b = await ctx.app.request(`/vehicles/${v2.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+    const c = await ctx.app.request(`/vehicles/${v3.id}/photos`, {
+      method: 'POST',
+      headers,
+      body: jpegForm(),
+    })
+
+    expect(a.status).toBe(201)
+    expect(b.status).toBe(201)
+    expect(c.status).toBe(429)
+  })
+})

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -16,6 +16,23 @@ name = "RATE_LIMITER"
 namespace_id = "1001"
 simple = { limit = 100, period = 60 }
 
+# Stricter rate limit for photo upload/delete, keyed per (userId, vehicleId).
+# 5MB upload × global 100/60s per IP = 500MB/min R2 writes otherwise.
+# 10/60s per user+vehicle caps realistic owner behavior (uploading ~10 photos
+# for one vehicle) while blocking burst abuse.
+[[ratelimits]]
+name = "PHOTO_UPLOAD_LIMITER"
+namespace_id = "1002"
+simple = { limit = 10, period = 60 }
+
+# Per-user aggregate cap across all vehicles. Stops keyspace-rotation bypass
+# where a compromised staff token iterates vehicle IDs for fresh per-vehicle
+# buckets (10/min × 50 vehicles = 500 uploads/min otherwise).
+[[ratelimits]]
+name = "PHOTO_UPLOAD_USER_LIMITER"
+namespace_id = "1003"
+simple = { limit = 50, period = 60 }
+
 # R2 bucket for vehicle photo uploads. Create the bucket manually:
 #   npx wrangler r2 bucket create kuruma-vehicle-photos
 # Enable public access for dev:


### PR DESCRIPTION
## Summary
- Adds `PHOTO_UPLOAD_LIMITER` (10/60s, keyed `userId:vehicleId`) and `PHOTO_UPLOAD_USER_LIMITER` (50/60s, keyed `userId`) CF rate-limit bindings, applied to `POST` and `DELETE /vehicles/:id/photos`.
- Stacked so the per-user limit short-circuits before the per-vehicle bucket, closing the keyspace-rotation bypass (10/min × 50 vehicles would otherwise be 500 uploads/min).
- Fixes a latent bug in `setupGlobalHandlers`: `HTTPException` was being flattened to a generic 500, swallowing the 429 from rate-limit middleware. Now defers to `err.getResponse()` only when `err.res` is set, so `new HTTPException(500, { message: 'db foo' })` still falls through to the sanitized branch.

## Threat model
| Attack | Before | After |
|---|---|---|
| IP rotation | 500MB/min per IP | Still capped per (user, vehicle) |
| Vehicle ID rotation (one user) | 500MB/min | 50/min aggregate |
| Cold start / missing binding | n/a | Middleware bypasses (matches existing `RATE_LIMITER` pattern) |

## Rollout
Deploy wrangler config (new `[[ratelimits]]` bindings for namespaces 1002/1003) before or alongside this code. If the namespace is missing at runtime, CF rate-limit bindings fail closed — first requests would 500 until provisioned.

## Test plan
- [x] 5 new rate-limit tests (per-(user,vehicle) cap, per-(user,vehicle) isolation, no-binding bypass, DELETE limited, per-user aggregate cap via vehicle rotation)
- [x] 335/335 API tests pass
- [x] tsc clean, biome + lint:size + lint:modules clean

Closes #287