### PR TITLE
test: scaffold Playwright E2E infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,46 @@ jobs:
         # vehicles, availability, messages, pricing). All integration
         # test files use postgres-js (TCP) via pg-test-client.ts.
         run: bun run --filter @kuruma/api test:integration
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+        env:
+          # Placeholder values — landing page has no API dependency today.
+          # Update when adding auth/booking flows.
+          AUTH_SECRET: ci-placeholder-secret-not-real
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ yarn-error.log*
 next-env.d.ts
 .claude/
 .next/
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ Enforced by `bun run --filter @kuruma/api lint:boundaries` (CI step).
 |------|---------|
 | Run all tests | `bun run test` |
 | Run one package's tests | `bun run --filter @kuruma/web test` |
+| Run E2E tests (Playwright) | `bun run test:e2e` |
+| Debug E2E in Playwright UI | `bun run test:e2e:ui` |
 | Dev server (web) | `bun run dev` |
 | Dev server (API) | `bun run dev:api` |
 | Lint | `bun run lint` |

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "kuruma-rental",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@playwright/test": "^1.59.1",
         "drizzle-kit": "^0.31.10",
         "husky": "^9.1.7",
         "knip": "^6.3.1",
@@ -613,6 +614,8 @@
     "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
@@ -1390,6 +1393,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "po-parser": ["po-parser@2.1.1", "", {}, "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
@@ -1743,6 +1750,8 @@
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Landing page', () => {
+  test('renders hero with marketing copy', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Explore Japan at your own pace' }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByText(
+        'Pick up a car in Osaka and drive anywhere. No approval wait, no hidden fees.',
+      ),
+    ).toBeVisible()
+  })
+
+  test('search widget is interactive', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('button', { name: 'Search' })).toBeVisible()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:api": "bun run --filter @kuruma/api dev",
     "build": "bun run --filter '*' build",
     "test": "bun run --filter '*' test",
+    "test:e2e": "bunx playwright test",
+    "test:e2e:ui": "bunx playwright test --ui",
     "lint": "bunx biome check . && bun run lint:size && bun run lint:modules",
     "lint:fix": "bunx biome check --write .",
     "lint:size": "bun run scripts/lint-file-size.ts",
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.59.1",
     "drizzle-kit": "^0.31.10",
     "husky": "^9.1.7",
     "knip": "^6.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 3001
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'bun run --filter @kuruma/web dev',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})


### PR DESCRIPTION
## Summary

Closes #294. Adds Playwright E2E as the missing third leg of the test pyramid — unit (76) and integration (7) were strong, E2E was at zero.

## Changes

- **Playwright config** (`playwright.config.ts`) — chromium-only, auto-starts web dev server on 3001, traces on retry, screenshots on failure
- **First spec** (`e2e/landing.spec.ts`) — 2 smoke tests: hero renders, search button visible. No API dependency — landing uses hardcoded sample data
- **Scripts** — `bun run test:e2e`, `bun run test:e2e:ui`
- **CI job** (`e2e` in `.github/workflows/ci.yml`) — caches Playwright browsers by `bun.lock` hash, uploads `playwright-report/` artifact on failure
- **.gitignore** — test-results, playwright-report, blob-report, playwright/.cache
- **AGENTS.md** — command table entries

## Verification

- [x] `bun run test:e2e` — 2 passed locally (6.2s)
- [x] `bun run lint` clean
- [x] `bun run --filter '*' typecheck` clean
- [x] CI `e2e` job is the golden-path verification

## Deferred to follow-up issues (per #294 Phase 2)

- OAuth sign-in (Google + Apple) — test-mode credentials
- Booking lifecycle + cancellation tiers (72h/48h/24h/same-day)
- Owner: manual booking, vehicle status toggle
- Multi-user double-booking hitting the Postgres exclusion constraint

## Test plan

- [x] Local run of `bun run test:e2e` passes
- [ ] CI `e2e` job passes
- [ ] HTML report uploaded on forced-failure (verify manually if needed)