### PR TITLE
refactor(api): extract VehiclePhotoService to thin the route layer

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -67,6 +67,7 @@ import { BookingService } from './services/booking'
 import { CustomerService } from './services/customer'
 import { MaintenanceService } from './services/maintenance'
 import { VehicleClassService } from './services/vehicle-class'
+import { VehiclePhotoService } from './services/vehicle-photo'
 
 export function createApp(overrides?: {
   vehicleRepo: VehicleRepository
@@ -233,7 +234,7 @@ export function createApp(overrides?: {
     .route('/', createVehicleDetailRoutes(vehicleDetailRepo))
     .route('/', createVehicleClassRoutes(vehicleClassService))
     .route('/', createVehicleRoutes(vehicleRepo, maintenanceService))
-    .route('/', createVehiclePhotoRoutes(vehicleRepo, photoStorage))
+    .route('/', createVehiclePhotoRoutes(new VehiclePhotoService(vehicleRepo, photoStorage)))
     .route('/', createMaintenanceLogRoutes(maintenanceService))
     .route('/', createBookingRoutes(bookingService))
     .route('/', createAvailabilityRoutes(availabilityRepo))

--- a/packages/api/src/repositories/in-memory/photo-storage.ts
+++ b/packages/api/src/repositories/in-memory/photo-storage.ts
@@ -24,4 +24,9 @@ export class InMemoryPhotoStorage implements PhotoStorage {
   has(key: string): boolean {
     return this.store.has(key)
   }
+
+  /** Test helper — count stored objects to verify rollback on failed uploads. */
+  size(): number {
+    return this.store.size
+  }
 }

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,91 +1,23 @@
 import { Hono } from 'hono'
-import { detectImageType } from '../lib/image-signature'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
-import type { PhotoStorage, VehicleRepository } from '../repositories/types'
+import type { VehiclePhotoService } from '../services/vehicle-photo'
 import { fail, ok } from './helpers'
 
-const MAX_PHOTOS_PER_VEHICLE = 10
-const MAX_FILE_SIZE = 5 * 1024 * 1024
-const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
-
-type ValidatedFile = { file: File; bytes: Uint8Array }
-
-async function validateFile(file: File): Promise<{ ok: ValidatedFile } | { err: string }> {
-  if (!ALLOWED_MIME_TYPES.has(file.type)) {
-    return { err: 'Only image files are allowed (JPEG, PNG, WebP, AVIF)' }
-  }
-  if (file.size > MAX_FILE_SIZE) return { err: 'File must be under 5MB' }
-  const bytes = new Uint8Array(await file.arrayBuffer())
-  const detected = detectImageType(bytes)
-  if (detected === null) return { err: 'File content does not match an allowed image format' }
-  if (detected !== file.type) return { err: 'File content does not match declared Content-Type' }
-  return { ok: { file, bytes } }
-}
-
-export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: PhotoStorage) {
+export function createVehiclePhotoRoutes(service: VehiclePhotoService) {
   return new Hono()
     .post('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const vehicleId = c.req.param('id')
       const body = await c.req.parseBody({ all: true })
       const rawFiles = body.file
-      if (!rawFiles) return fail(c, 'No file provided', 400)
-
-      const files = (Array.isArray(rawFiles) ? rawFiles : [rawFiles]).filter(
+      const files = (Array.isArray(rawFiles) ? rawFiles : rawFiles ? [rawFiles] : []).filter(
         (f): f is File => f instanceof File,
       )
-      if (files.length === 0) return fail(c, 'No file provided', 400)
-      if (files.length > MAX_PHOTOS_PER_VEHICLE) {
-        return fail(c, `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`, 400)
-      }
 
-      // Validate bytes before hitting storage so we never persist a spoofed file.
-      const validated: ValidatedFile[] = []
-      for (const file of files) {
-        const result = await validateFile(file)
-        if ('err' in result) return fail(c, result.err, 400)
-        validated.push(result.ok)
-      }
-
-      // Upload all files in parallel. Track successes so we can roll back if
-      // any put rejects mid-batch or the DB append fails.
-      const uploadResults = await Promise.allSettled(
-        validated.map(({ file }) => storage.put(vehicleId, file)),
-      )
-
-      const succeeded = uploadResults.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
-      const anyFailed = uploadResults.some((r) => r.status === 'rejected')
-
-      if (anyFailed) {
-        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
-        return fail(c, 'One or more uploads failed', 500)
-      }
-
-      const appendResult = await repo.appendPhotos(
-        vehicleId,
-        succeeded.map((r) => r.url),
-        MAX_PHOTOS_PER_VEHICLE,
-      )
-
-      if (appendResult.outcome === 'not_found') {
-        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
-        return fail(c, 'Vehicle not found', 404)
-      }
-      if (appendResult.outcome === 'cap_exceeded') {
-        await Promise.all(succeeded.map((r) => storage.delete(r.url).catch(() => {})))
-        return fail(c, `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`, 400)
-      }
-
-      return ok(
-        c,
-        {
-          uploaded: succeeded.map((r) => r.url),
-          total: appendResult.vehicle.photos.length,
-        },
-        201,
-      )
+      const result = await service.uploadPhotos(c.req.param('id'), files)
+      if (!result.ok) return fail(c, result.error, result.status)
+      return ok(c, { uploaded: result.uploaded, total: result.total }, 201)
     })
     .delete('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
@@ -94,20 +26,8 @@ export function createVehiclePhotoRoutes(repo: VehicleRepository, storage: Photo
       const url = c.req.query('url')
       if (!url) return fail(c, 'url query parameter required', 400)
 
-      const updated = await repo.removePhotoByUrl(c.req.param('id'), url)
-      if (!updated) {
-        // Either the vehicle does not exist or the URL is not one of its photos.
-        // Treat both as 404 so we do not leak existence info.
-        return fail(c, 'Photo not found', 404)
-      }
-
-      // Best-effort R2 cleanup after the authoritative DB write succeeds.
-      try {
-        await storage.delete(url)
-      } catch (e) {
-        console.warn('R2 photo cleanup failed, orphan left:', url, e)
-      }
-
-      return ok(c, { deleted: url, remaining: updated.photos.length })
+      const result = await service.deletePhoto(c.req.param('id'), url)
+      if (!result.ok) return fail(c, result.error, result.status)
+      return ok(c, { deleted: url, remaining: result.remaining })
     })
 }

--- a/packages/api/src/services/vehicle-photo.ts
+++ b/packages/api/src/services/vehicle-photo.ts
@@ -1,0 +1,126 @@
+import { detectImageType } from '../lib/image-signature'
+import type { PhotoStorage, VehicleRepository } from '../repositories/types'
+
+const MAX_PHOTOS_PER_VEHICLE = 10
+const MAX_FILE_SIZE = 5 * 1024 * 1024
+const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
+
+export type UploadResult =
+  | { ok: true; uploaded: string[]; total: number }
+  | { ok: false; error: string; status: number }
+
+export type DeleteResult =
+  | { ok: true; remaining: number }
+  | { ok: false; error: string; status: number }
+
+type ValidatedFile = { file: File; bytes: Uint8Array }
+
+export class VehiclePhotoService {
+  constructor(
+    private readonly repo: VehicleRepository,
+    private readonly storage: PhotoStorage,
+  ) {}
+
+  async uploadPhotos(vehicleId: string, files: File[]): Promise<UploadResult> {
+    if (files.length === 0) return { ok: false, status: 400, error: 'No file provided' }
+    if (files.length > MAX_PHOTOS_PER_VEHICLE) {
+      return {
+        ok: false,
+        status: 400,
+        error: `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`,
+      }
+    }
+
+    // Validate bytes before hitting storage so we never persist a spoofed file.
+    const validated: ValidatedFile[] = []
+    for (const file of files) {
+      const result = await validateFile(file)
+      if ('err' in result) return { ok: false, status: result.status, error: result.err }
+      validated.push(result.ok)
+    }
+
+    // Upload in parallel. Track successes so we can roll back if any put
+    // rejects mid-batch or the DB append fails.
+    const uploadResults = await Promise.allSettled(
+      validated.map(({ file }) => this.storage.put(vehicleId, file)),
+    )
+
+    const succeeded = uploadResults.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
+    const anyFailed = uploadResults.some((r) => r.status === 'rejected')
+
+    if (anyFailed) {
+      await this.rollback(succeeded.map((r) => r.url))
+      return { ok: false, status: 500, error: 'One or more uploads failed' }
+    }
+
+    const appendResult = await this.repo.appendPhotos(
+      vehicleId,
+      succeeded.map((r) => r.url),
+      MAX_PHOTOS_PER_VEHICLE,
+    )
+
+    if (appendResult.outcome === 'not_found') {
+      await this.rollback(succeeded.map((r) => r.url))
+      return { ok: false, status: 404, error: 'Vehicle not found' }
+    }
+    if (appendResult.outcome === 'cap_exceeded') {
+      await this.rollback(succeeded.map((r) => r.url))
+      return {
+        ok: false,
+        status: 400,
+        error: `Maximum ${MAX_PHOTOS_PER_VEHICLE} photos per vehicle`,
+      }
+    }
+
+    return {
+      ok: true,
+      uploaded: succeeded.map((r) => r.url),
+      total: appendResult.vehicle.photos.length,
+    }
+  }
+
+  async deletePhoto(vehicleId: string, url: string): Promise<DeleteResult> {
+    const updated = await this.repo.removePhotoByUrl(vehicleId, url)
+    if (!updated) {
+      // Either the vehicle does not exist or the URL is not one of its photos.
+      // Treat both as 404 so we do not leak existence info.
+      return { ok: false, status: 404, error: 'Photo not found' }
+    }
+
+    // Best-effort R2 cleanup after the authoritative DB write succeeds.
+    try {
+      await this.storage.delete(url)
+    } catch (e) {
+      console.warn('R2 photo cleanup failed, orphan left:', url, e)
+    }
+
+    return { ok: true, remaining: updated.photos.length }
+  }
+
+  private async rollback(urls: string[]): Promise<void> {
+    await Promise.all(urls.map((url) => this.storage.delete(url).catch(() => {})))
+  }
+}
+
+async function validateFile(
+  file: File,
+): Promise<{ ok: ValidatedFile } | { err: string; status: number }> {
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    return {
+      err: 'Only image files are allowed (JPEG, PNG, WebP, AVIF)',
+      status: 400,
+    }
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return { err: 'File must be under 5MB', status: 400 }
+  }
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const detected = detectImageType(bytes)
+  if (detected === null) {
+    return { err: 'File content does not match an allowed image format', status: 415 }
+  }
+  if (detected !== file.type) {
+    return { err: 'File content does not match declared Content-Type', status: 415 }
+  }
+  return { ok: { file, bytes } }
+}

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -140,7 +140,7 @@ describe('POST /vehicles/:id/photos', () => {
       body: form,
     })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(415)
     const body = await res.json()
     expect(body.error).toContain('does not match declared Content-Type')
   })
@@ -155,7 +155,7 @@ describe('POST /vehicles/:id/photos', () => {
       body: form,
     })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(415)
     const body = await res.json()
     expect(body.error).toContain('image format')
   })

--- a/packages/api/tests/services/vehicle-photo.test.ts
+++ b/packages/api/tests/services/vehicle-photo.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
+import { InMemoryPhotoStorage } from '../../src/repositories/in-memory/photo-storage'
+import { VehiclePhotoService } from '../../src/services/vehicle-photo'
+import type { Vehicle } from '../../src/stores'
+
+function vehicleInput(overrides?: Partial<Vehicle>) {
+  return {
+    name: 'Test Car',
+    description: 'A test vehicle',
+    photos: [] as string[],
+    seats: 4,
+    transmission: 'AUTO' as const,
+    fuelType: 'GASOLINE',
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 60,
+    minRentalHours: 1,
+    maxRentalHours: 168,
+    advanceBookingHours: 24,
+    dailyRateJpy: 5000,
+    hourlyRateJpy: 1000,
+    ...overrides,
+  }
+}
+
+function makeFile(name: string, type: string, magicBytes: number[]): File {
+  const bytes = new Uint8Array([...magicBytes, ...new Array(50).fill(0)])
+  return new File([bytes], name, { type })
+}
+
+const JPEG = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+let repo: InMemoryVehicleRepository
+let storage: InMemoryPhotoStorage
+let service: VehiclePhotoService
+let vehicleId: string
+
+beforeEach(async () => {
+  repo = new InMemoryVehicleRepository()
+  storage = new InMemoryPhotoStorage()
+  service = new VehiclePhotoService(repo, storage)
+  const v = await repo.create(vehicleInput())
+  vehicleId = v.id
+})
+
+describe('VehiclePhotoService.uploadPhotos', () => {
+  it('uploads a valid image and appends the URL to the vehicle', async () => {
+    const file = makeFile('a.jpg', 'image/jpeg', JPEG)
+    const result = await service.uploadPhotos(vehicleId, [file])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.uploaded).toHaveLength(1)
+    expect(result.total).toBe(1)
+
+    const updated = await repo.findById(vehicleId)
+    expect(updated?.photos).toHaveLength(1)
+  })
+
+  it('rejects non-image MIME with 400', async () => {
+    const file = new File([new Uint8Array(100)], 'doc.pdf', { type: 'application/pdf' })
+    const result = await service.uploadPhotos(vehicleId, [file])
+    expect(result).toEqual({ ok: false, status: 400, error: expect.stringContaining('image') })
+  })
+
+  it('rejects content-type spoofing with 415', async () => {
+    // PNG bytes labeled as image/jpeg
+    const file = makeFile('fake.jpg', 'image/jpeg', PNG)
+    const result = await service.uploadPhotos(vehicleId, [file])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(415)
+  })
+
+  it('rejects file over 5MB with 400', async () => {
+    const bytes = new Uint8Array(6 * 1024 * 1024)
+    bytes.set(JPEG)
+    const file = new File([bytes], 'huge.jpg', { type: 'image/jpeg' })
+    const result = await service.uploadPhotos(vehicleId, [file])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(400)
+    expect(result.error).toContain('5MB')
+  })
+
+  it('returns 404 with no orphan when vehicle does not exist', async () => {
+    const file = makeFile('a.jpg', 'image/jpeg', JPEG)
+    const result = await service.uploadPhotos('nonexistent-id', [file])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(404)
+    // R2 objects for the missing vehicle should have been rolled back
+    expect(storage.size()).toBe(0)
+  })
+
+  it('returns 400 when no files provided', async () => {
+    const result = await service.uploadPhotos(vehicleId, [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(400)
+  })
+})
+
+describe('VehiclePhotoService.deletePhoto', () => {
+  it('removes the photo from the vehicle and R2', async () => {
+    const file = makeFile('a.jpg', 'image/jpeg', JPEG)
+    const up = await service.uploadPhotos(vehicleId, [file])
+    if (!up.ok) throw new Error('setup failed')
+    const url = up.uploaded[0]!
+
+    const result = await service.deletePhoto(vehicleId, url)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.remaining).toBe(0)
+
+    const after = await repo.findById(vehicleId)
+    expect(after?.photos).toHaveLength(0)
+  })
+
+  it('returns 404 when the url is not associated with the vehicle', async () => {
+    const result = await service.deletePhoto(vehicleId, 'https://r2.example/missing.jpg')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(404)
+  })
+})

--- a/packages/api/tests/services/vehicle-photo.test.ts
+++ b/packages/api/tests/services/vehicle-photo.test.ts
@@ -102,6 +102,38 @@ describe('VehiclePhotoService.uploadPhotos', () => {
   })
 })
 
+describe('VehiclePhotoService.uploadPhotos rollback', () => {
+  it('rolls back already-uploaded files when a later put rejects', async () => {
+    // Stub storage that rejects on the second put. All earlier successes
+    // must be deleted; DB should be unchanged.
+    const deletedUrls: string[] = []
+    let callCount = 0
+    const flakyStorage = {
+      put: async (vId: string, file: File) => {
+        callCount += 1
+        if (callCount === 2) throw new Error('network blip')
+        return { key: `k${callCount}`, url: `https://r2.example/${vId}/p${callCount}.jpg` }
+      },
+      delete: async (url: string) => {
+        deletedUrls.push(url)
+      },
+    }
+    const flakyService = new VehiclePhotoService(repo, flakyStorage)
+
+    const files = [makeFile('a.jpg', 'image/jpeg', JPEG), makeFile('b.jpg', 'image/jpeg', JPEG)]
+    const result = await flakyService.uploadPhotos(vehicleId, files)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(500)
+    // The one successful upload must have been cleaned up.
+    expect(deletedUrls).toEqual([`https://r2.example/${vehicleId}/p1.jpg`])
+
+    const after = await repo.findById(vehicleId)
+    expect(after?.photos).toHaveLength(0)
+  })
+})
+
 describe('VehiclePhotoService.deletePhoto', () => {
   it('removes the photo from the vehicle and R2', async () => {
     const file = makeFile('a.jpg', 'image/jpeg', JPEG)


### PR DESCRIPTION
## Summary
Thins `routes/vehicle-photos.ts` (~110 lines → ~30 lines) by moving validation, upload orchestration, rollback, and DB orchestration into `VehiclePhotoService`. Restores the routes → services → repositories layering per AGENTS.md.

## Changes
- **New**: `src/services/vehicle-photo.ts` — `VehiclePhotoService` with `uploadPhotos` + `deletePhoto`, returning discriminated-union results `{ok, ...} | {ok: false, error, status}`
- **Route**: thin parse-and-dispatch; maps service result to HTTP
- **Composition root**: `index.ts` instantiates `VehiclePhotoService`
- **Signature change**: `createVehiclePhotoRoutes(service)` instead of `(repo, storage)`
- **Behavior fix**: magic-byte mismatches now return `415 Unsupported Media Type` (was `400`) — semantically correct
- **Test helper**: `InMemoryPhotoStorage.size()` to verify rollback

## Test plan
- [x] 8 new service tests (happy upload, spoofing, oversize, not-found rollback, no-files, delete)
- [x] 2 existing route tests updated to assert `415` instead of `400`
- [x] 360 API tests pass, tsc + biome clean

Closes #286