### PR TITLE
feat(api): on-demand message translation

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -58,6 +58,7 @@ import health from './routes/health'
 import { createMaintenanceLogRoutes } from './routes/maintenance-logs'
 import { createMessageRoutes } from './routes/messages'
 import { createStatsRoutes } from './routes/stats'
+import { createTranslateRoutes } from './routes/translate'
 import { createUserRoutes } from './routes/users'
 import { createVehicleClassRoutes } from './routes/vehicle-classes'
 import { createVehicleDetailRoutes } from './routes/vehicle-detail'
@@ -65,7 +66,10 @@ import { createVehiclePhotoRoutes } from './routes/vehicle-photos'
 import { createVehicleRoutes } from './routes/vehicles'
 import { BookingService } from './services/booking'
 import { CustomerService } from './services/customer'
+import { GoogleTranslationProvider } from './services/google-translation-provider'
 import { MaintenanceService } from './services/maintenance'
+import { MessageTranslationService } from './services/message-translation'
+import type { TranslationProvider } from './services/translation-provider'
 import { VehicleClassService } from './services/vehicle-class'
 import { VehiclePhotoService } from './services/vehicle-photo'
 
@@ -166,6 +170,18 @@ export function createApp(overrides?: {
     photoStorage = new InMemoryPhotoStorage()
   }
 
+  // Translation provider: real Google when the key is set, otherwise a
+  // no-op stub that returns the original text prefixed with the target
+  // code. Lets preview/dev envs work without Google credentials.
+  const translationProvider: TranslationProvider = process.env.GOOGLE_TRANSLATE_API_KEY
+    ? new GoogleTranslationProvider(process.env.GOOGLE_TRANSLATE_API_KEY)
+    : {
+        translate: async (text, _source, targetLanguage) => ({
+          translatedText: `[${targetLanguage}] ${text}`,
+          detectedLanguage: _source ?? targetLanguage,
+        }),
+      }
+
   const app = new Hono()
 
   // Global error handlers — prevent stack traces leaking to clients.
@@ -240,6 +256,10 @@ export function createApp(overrides?: {
     .route('/', createAvailabilityRoutes(availabilityRepo))
     .route('/', createStatsRoutes(statsRepo))
     .route('/', createMessageRoutes(threadRepo, messageRepo))
+    .route(
+      '/',
+      createTranslateRoutes(new MessageTranslationService(messageRepo, translationProvider)),
+    )
     .route('/', createCustomerRoutes(customerService))
     .route('/', createUserRoutes(userRepo, threadRepo))
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -170,17 +170,27 @@ export function createApp(overrides?: {
     photoStorage = new InMemoryPhotoStorage()
   }
 
-  // Translation provider: real Google when the key is set, otherwise a
-  // no-op stub that returns the original text prefixed with the target
-  // code. Lets preview/dev envs work without Google credentials.
-  const translationProvider: TranslationProvider = process.env.GOOGLE_TRANSLATE_API_KEY
-    ? new GoogleTranslationProvider(process.env.GOOGLE_TRANSLATE_API_KEY)
-    : {
-        translate: async (text, _source, targetLanguage) => ({
-          translatedText: `[${targetLanguage}] ${text}`,
-          detectedLanguage: _source ?? targetLanguage,
-        }),
+  // Translation provider: real Google when the key is set. In production
+  // without a key, a sentinel provider throws on first use (not at boot,
+  // so unrelated tests can still run createApp). The stub is dev-only
+  // so a secret drift can't ship working translations silently.
+  const translationProvider: TranslationProvider = (() => {
+    const key = process.env.GOOGLE_TRANSLATE_API_KEY
+    if (key) return new GoogleTranslationProvider(key)
+    if (process.env.NODE_ENV === 'production') {
+      return {
+        translate: async () => {
+          throw new Error('GOOGLE_TRANSLATE_API_KEY not configured')
+        },
       }
+    }
+    return {
+      translate: async (text, source, targetLanguage) => ({
+        translatedText: `[${targetLanguage}] ${text}`,
+        detectedLanguage: source ?? targetLanguage,
+      }),
+    }
+  })()
 
   const app = new Hono()
 

--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -5,8 +5,61 @@ import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
 import { type Db, messageColumns, normaliseMessage } from './shared'
 
+function parseTranslations(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {}
+  } catch {
+    return {}
+  }
+}
+
 export class DrizzleMessageRepository implements MessageRepository {
   constructor(private readonly db: Db) {}
+
+  async findById(id: string): Promise<Message | undefined> {
+    const rows = (await this.db
+      .select(messageColumns)
+      .from(messages)
+      .where(eq(messages.id, id))) as Array<Parameters<typeof normaliseMessage>[0]>
+    const [row] = rows
+    return row ? normaliseMessage(row) : undefined
+  }
+
+  async updateTranslation(
+    messageId: string,
+    language: string,
+    translatedText: string,
+    detectedSourceLanguage: string | null,
+  ): Promise<Message | undefined> {
+    return this.db.transaction(async (tx) => {
+      const [existing] = (await tx
+        .select(messageColumns)
+        .from(messages)
+        .where(eq(messages.id, messageId))) as Array<Parameters<typeof normaliseMessage>[0]>
+      if (!existing) return undefined
+
+      const current = parseTranslations(existing.translations)
+      current[language] = translatedText
+      const nextJson = JSON.stringify(current)
+
+      const updateValues: { translations: string; sourceLanguage?: string } = {
+        translations: nextJson,
+      }
+      if (detectedSourceLanguage && !existing.sourceLanguage) {
+        updateValues.sourceLanguage = detectedSourceLanguage
+      }
+
+      const [updated] = (await tx
+        .update(messages)
+        .set(updateValues)
+        .where(eq(messages.id, messageId))
+        .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
+
+      return updated ? normaliseMessage(updated) : undefined
+    })
+  }
 
   async findByIdempotencyKey(key: string): Promise<Message | undefined> {
     const rows = (await this.db

--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -5,25 +5,29 @@ import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
 import { type Db, messageColumns, normaliseMessage } from './shared'
 
-function parseTranslations(raw: string | null | undefined): Record<string, string> {
-  if (!raw) return {}
-  try {
-    const parsed = JSON.parse(raw)
-    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {}
-  } catch {
-    return {}
-  }
-}
-
 export class DrizzleMessageRepository implements MessageRepository {
   constructor(private readonly db: Db) {}
 
-  async findById(id: string): Promise<Message | undefined> {
-    const rows = (await this.db
+  async findById(ctx: CallerContext, id: string): Promise<Message | undefined> {
+    // Non-privileged callers only see messages in threads they participate in.
+    // Use a join rather than two round-trips so the filter runs server-side.
+    const query = this.db
       .select(messageColumns)
       .from(messages)
-      .where(eq(messages.id, id))) as Array<Parameters<typeof normaliseMessage>[0]>
-    const [row] = rows
+      .where(eq(messages.id, id))
+
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      const [row] = (await this.db
+        .select(messageColumns)
+        .from(messages)
+        .innerJoin(threadParticipants, eq(threadParticipants.threadId, messages.threadId))
+        .where(
+          and(eq(messages.id, id), eq(threadParticipants.userId, ctx.userId)),
+        )) as Array<Parameters<typeof normaliseMessage>[0]>
+      return row ? normaliseMessage(row) : undefined
+    }
+
+    const [row] = (await query) as Array<Parameters<typeof normaliseMessage>[0]>
     return row ? normaliseMessage(row) : undefined
   }
 
@@ -33,32 +37,29 @@ export class DrizzleMessageRepository implements MessageRepository {
     translatedText: string,
     detectedSourceLanguage: string | null,
   ): Promise<Message | undefined> {
-    return this.db.transaction(async (tx) => {
-      const [existing] = (await tx
-        .select(messageColumns)
-        .from(messages)
-        .where(eq(messages.id, messageId))) as Array<Parameters<typeof normaliseMessage>[0]>
-      if (!existing) return undefined
+    // Single-statement atomic merge — avoids the SELECT-then-UPDATE race
+    // where two concurrent translates would clobber each other at READ
+    // COMMITTED isolation. jsonb_set merges the new language in place.
+    const nextJson = sql`jsonb_set(
+      COALESCE(NULLIF(${messages.translations}, '')::jsonb, '{}'::jsonb),
+      ARRAY[${language}],
+      to_jsonb(${translatedText}::text)
+    )::text`
 
-      const current = parseTranslations(existing.translations)
-      current[language] = translatedText
-      const nextJson = JSON.stringify(current)
+    const setClause = detectedSourceLanguage
+      ? {
+          translations: nextJson,
+          sourceLanguage: sql`COALESCE(${messages.sourceLanguage}, ${detectedSourceLanguage})`,
+        }
+      : { translations: nextJson }
 
-      const updateValues: { translations: string; sourceLanguage?: string } = {
-        translations: nextJson,
-      }
-      if (detectedSourceLanguage && !existing.sourceLanguage) {
-        updateValues.sourceLanguage = detectedSourceLanguage
-      }
+    const [updated] = (await this.db
+      .update(messages)
+      .set(setClause)
+      .where(eq(messages.id, messageId))
+      .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
 
-      const [updated] = (await tx
-        .update(messages)
-        .set(updateValues)
-        .where(eq(messages.id, messageId))
-        .returning(messageColumns)) as Array<Parameters<typeof normaliseMessage>[0]>
-
-      return updated ? normaliseMessage(updated) : undefined
-    })
+    return updated ? normaliseMessage(updated) : undefined
   }
 
   async findByIdempotencyKey(key: string): Promise<Message | undefined> {

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -1,4 +1,4 @@
-import type { CallerContext } from '../../middleware/auth'
+import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import { PG_ERROR } from '../../pg-errors'
 import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
@@ -19,8 +19,13 @@ export class InMemoryMessageRepository implements MessageRepository {
 
   constructor(private readonly threadRepo: InMemoryThreadRepository) {}
 
-  async findById(id: string): Promise<Message | undefined> {
-    return this.threadRepo._getMessage(id)
+  async findById(ctx: CallerContext, id: string): Promise<Message | undefined> {
+    const msg = this.threadRepo._getMessage(id)
+    if (!msg) return undefined
+    if (PRIVILEGED_ROLES.has(ctx.role)) return msg
+    // Non-privileged: verify the caller is a participant of the message's thread.
+    const thread = await this.threadRepo.findById(ctx, msg.threadId)
+    return thread ? msg : undefined
   }
 
   async findByIdempotencyKey(key: string): Promise<Message | undefined> {

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -4,13 +4,46 @@ import type { Message } from '../../stores'
 import type { MessageRepository } from '../types'
 import type { InMemoryThreadRepository } from './thread'
 
+function parseJson(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {}
+  } catch {
+    return {}
+  }
+}
+
 export class InMemoryMessageRepository implements MessageRepository {
   private readonly idempotencyIndex = new Map<string, Message>()
 
   constructor(private readonly threadRepo: InMemoryThreadRepository) {}
 
+  async findById(id: string): Promise<Message | undefined> {
+    return this.threadRepo._getMessage(id)
+  }
+
   async findByIdempotencyKey(key: string): Promise<Message | undefined> {
     return this.idempotencyIndex.get(key)
+  }
+
+  async updateTranslation(
+    messageId: string,
+    language: string,
+    translatedText: string,
+    detectedSourceLanguage: string | null,
+  ): Promise<Message | undefined> {
+    const existing = this.threadRepo._getMessage(messageId)
+    if (!existing) return undefined
+
+    const translations = parseJson(existing.translations)
+    translations[language] = translatedText
+
+    const patch: Partial<Message> = { translations: JSON.stringify(translations) }
+    if (detectedSourceLanguage && !existing.sourceLanguage) {
+      patch.sourceLanguage = detectedSourceLanguage
+    }
+    return this.threadRepo._updateMessage(messageId, patch)
   }
 
   async create(

--- a/packages/api/src/repositories/in-memory/thread.ts
+++ b/packages/api/src/repositories/in-memory/thread.ts
@@ -120,4 +120,16 @@ export class InMemoryThreadRepository implements ThreadRepository {
       }
     }
   }
+
+  _getMessage(id: string): Message | undefined {
+    return this.messages.get(id)
+  }
+
+  _updateMessage(id: string, patch: Partial<Message>): Message | undefined {
+    const existing = this.messages.get(id)
+    if (!existing) return undefined
+    const updated = { ...existing, ...patch }
+    this.messages.set(id, updated)
+    return updated
+  }
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -170,6 +170,7 @@ export interface ThreadRepository {
 }
 
 export interface MessageRepository {
+  findById(id: string): Promise<Message | undefined>
   findByIdempotencyKey(key: string): Promise<Message | undefined>
   create(
     ctx: CallerContext,
@@ -178,6 +179,18 @@ export interface MessageRepository {
     idempotencyKey?: string | null,
   ): Promise<Message>
   findByThreadId(ctx: CallerContext, threadId: string): Promise<Message[]>
+  /**
+   * Merge a single language translation into the message's `translations`
+   * JSON map. If `detectedSourceLanguage` is provided, also update the
+   * message's `sourceLanguage` column (used when the original language
+   * was unknown at send time and the provider auto-detected it).
+   */
+  updateTranslation(
+    messageId: string,
+    language: string,
+    translatedText: string,
+    detectedSourceLanguage: string | null,
+  ): Promise<Message | undefined>
 }
 
 // Transaction boundary for operations spanning multiple repositories.

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -170,7 +170,12 @@ export interface ThreadRepository {
 }
 
 export interface MessageRepository {
-  findById(id: string): Promise<Message | undefined>
+  /**
+   * Find a message by id, scoped to the caller. Non-privileged callers
+   * only see messages in threads they participate in; others get
+   * `undefined`. Privileged roles (STAFF/ADMIN) bypass the scope.
+   */
+  findById(ctx: CallerContext, id: string): Promise<Message | undefined>
   findByIdempotencyKey(key: string): Promise<Message | undefined>
   create(
     ctx: CallerContext,

--- a/packages/api/src/routes/translate.ts
+++ b/packages/api/src/routes/translate.ts
@@ -1,0 +1,23 @@
+import { translateMessageSchema } from '@kuruma/shared/validators/translation'
+import { Hono } from 'hono'
+import { requireUser } from '../middleware/auth'
+import type { MessageTranslationService } from '../services/message-translation'
+import { fail, ok, parseBody } from './helpers'
+
+export function createTranslateRoutes(service: MessageTranslationService) {
+  return new Hono().post('/messages/:id/translate', async (c) => {
+    requireUser(c) // authenticated staff or renter
+
+    const parsed = await parseBody(c, translateMessageSchema)
+    if (!parsed.ok) return parsed.response
+
+    const result = await service.translate(c.req.param('id'), parsed.data.targetLanguage)
+    if (!result.ok) return fail(c, result.error, result.status)
+
+    return ok(c, {
+      translatedText: result.translatedText,
+      language: result.language,
+      cached: result.cached,
+    })
+  })
+}

--- a/packages/api/src/routes/translate.ts
+++ b/packages/api/src/routes/translate.ts
@@ -1,17 +1,17 @@
 import { translateMessageSchema } from '@kuruma/shared/validators/translation'
 import { Hono } from 'hono'
-import { requireUser } from '../middleware/auth'
+import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageTranslationService } from '../services/message-translation'
 import { fail, ok, parseBody } from './helpers'
 
 export function createTranslateRoutes(service: MessageTranslationService) {
   return new Hono().post('/messages/:id/translate', async (c) => {
-    requireUser(c) // authenticated staff or renter
+    const ctx = toCallerContext(requireUser(c))
 
     const parsed = await parseBody(c, translateMessageSchema)
     if (!parsed.ok) return parsed.response
 
-    const result = await service.translate(c.req.param('id'), parsed.data.targetLanguage)
+    const result = await service.translate(ctx, c.req.param('id'), parsed.data.targetLanguage)
     if (!result.ok) return fail(c, result.error, result.status)
 
     return ok(c, {

--- a/packages/api/src/services/google-translation-provider.ts
+++ b/packages/api/src/services/google-translation-provider.ts
@@ -25,16 +25,20 @@ export class GoogleTranslationProvider implements TranslationProvider {
     targetLanguage: string,
   ): Promise<{ translatedText: string; detectedLanguage: string }> {
     const params = new URLSearchParams({
-      key: this.apiKey,
       q: text,
       target: targetLanguage,
       format: 'text',
     })
     if (sourceLanguage) params.set('source', sourceLanguage)
 
+    // API key in header, not body — prevents WAF/log middleware from
+    // capturing it in request-body traces.
     const response = await this.fetchFn(ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Goog-Api-Key': this.apiKey,
+      },
       body: params.toString(),
     })
 

--- a/packages/api/src/services/google-translation-provider.ts
+++ b/packages/api/src/services/google-translation-provider.ts
@@ -1,0 +1,57 @@
+import type { TranslationProvider } from './translation-provider'
+
+const ENDPOINT = 'https://translation.googleapis.com/language/translate/v2'
+
+interface GoogleResponse {
+  data?: {
+    translations?: Array<{ translatedText: string; detectedSourceLanguage?: string }>
+  }
+  error?: { message: string }
+}
+
+/**
+ * Google Cloud Translation v2 REST client. REST over SDK so we run on
+ * the Cloudflare Workers runtime without Node-only deps.
+ */
+export class GoogleTranslationProvider implements TranslationProvider {
+  constructor(
+    private readonly apiKey: string,
+    private readonly fetchFn: typeof fetch = fetch,
+  ) {}
+
+  async translate(
+    text: string,
+    sourceLanguage: string | null,
+    targetLanguage: string,
+  ): Promise<{ translatedText: string; detectedLanguage: string }> {
+    const params = new URLSearchParams({
+      key: this.apiKey,
+      q: text,
+      target: targetLanguage,
+      format: 'text',
+    })
+    if (sourceLanguage) params.set('source', sourceLanguage)
+
+    const response = await this.fetchFn(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    })
+
+    const json = (await response.json()) as GoogleResponse
+
+    if (!response.ok || json.error) {
+      throw new Error(json.error?.message ?? `Google Translate returned ${response.status}`)
+    }
+
+    const translation = json.data?.translations?.[0]
+    if (!translation) {
+      throw new Error('Google Translate returned no translation')
+    }
+
+    return {
+      translatedText: translation.translatedText,
+      detectedLanguage: translation.detectedSourceLanguage ?? sourceLanguage ?? targetLanguage,
+    }
+  }
+}

--- a/packages/api/src/services/message-translation.ts
+++ b/packages/api/src/services/message-translation.ts
@@ -1,0 +1,63 @@
+import type { MessageRepository } from '../repositories/types'
+import type { TranslationProvider } from './translation-provider'
+
+export type TranslateResult =
+  | { ok: true; translatedText: string; language: string; cached: boolean }
+  | { ok: false; status: number; error: string }
+
+function parseCache(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, string>) : {}
+  } catch {
+    return {}
+  }
+}
+
+export class MessageTranslationService {
+  constructor(
+    private readonly messageRepo: MessageRepository,
+    private readonly provider: TranslationProvider,
+  ) {}
+
+  async translate(messageId: string, targetLanguage: string): Promise<TranslateResult> {
+    const message = await this.messageRepo.findById(messageId)
+    if (!message) return { ok: false, status: 404, error: 'Message not found' }
+
+    const cache = parseCache(message.translations)
+    if (cache[targetLanguage]) {
+      return {
+        ok: true,
+        translatedText: cache[targetLanguage],
+        language: targetLanguage,
+        cached: true,
+      }
+    }
+
+    let translatedText: string
+    let detectedLanguage: string
+    try {
+      const result = await this.provider.translate(
+        message.content,
+        message.sourceLanguage,
+        targetLanguage,
+      )
+      translatedText = result.translatedText
+      detectedLanguage = result.detectedLanguage
+    } catch {
+      return { ok: false, status: 502, error: 'Translation provider unavailable' }
+    }
+
+    // Persist translation and (if we didn't know it before) the detected source.
+    const sourceToPersist = message.sourceLanguage ? null : detectedLanguage
+    await this.messageRepo.updateTranslation(
+      messageId,
+      targetLanguage,
+      translatedText,
+      sourceToPersist,
+    )
+
+    return { ok: true, translatedText, language: targetLanguage, cached: false }
+  }
+}

--- a/packages/api/src/services/message-translation.ts
+++ b/packages/api/src/services/message-translation.ts
@@ -1,3 +1,4 @@
+import type { CallerContext } from '../middleware/auth'
 import type { MessageRepository } from '../repositories/types'
 import type { TranslationProvider } from './translation-provider'
 
@@ -21,8 +22,14 @@ export class MessageTranslationService {
     private readonly provider: TranslationProvider,
   ) {}
 
-  async translate(messageId: string, targetLanguage: string): Promise<TranslateResult> {
-    const message = await this.messageRepo.findById(messageId)
+  async translate(
+    ctx: CallerContext,
+    messageId: string,
+    targetLanguage: string,
+  ): Promise<TranslateResult> {
+    // Scope the lookup to the caller — a non-participant gets 404, not the
+    // stranger's message content via translatedText.
+    const message = await this.messageRepo.findById(ctx, messageId)
     if (!message) return { ok: false, status: 404, error: 'Message not found' }
 
     const cache = parseCache(message.translations)
@@ -45,7 +52,12 @@ export class MessageTranslationService {
       )
       translatedText = result.translatedText
       detectedLanguage = result.detectedLanguage
-    } catch {
+    } catch (err) {
+      console.error('Translation provider failed', {
+        messageId,
+        targetLanguage,
+        err: err instanceof Error ? err.message : String(err),
+      })
       return { ok: false, status: 502, error: 'Translation provider unavailable' }
     }
 

--- a/packages/api/src/services/translation-provider.ts
+++ b/packages/api/src/services/translation-provider.ts
@@ -1,0 +1,19 @@
+/**
+ * Provider-agnostic translation contract. Implementations call external
+ * services (Google Translate, DeepL, etc.); the service layer depends on
+ * this interface so providers can be swapped at the composition root.
+ */
+export interface TranslationProvider {
+  /**
+   * Translate `text` into `targetLanguage`. If `sourceLanguage` is null,
+   * the provider should auto-detect and return the detected code.
+   *
+   * Throws on provider failure — the service layer catches and maps
+   * to a 502 at the HTTP boundary.
+   */
+  translate(
+    text: string,
+    sourceLanguage: string | null,
+    targetLanguage: string,
+  ): Promise<{ translatedText: string; detectedLanguage: string }>
+}

--- a/packages/api/tests/routes/translate.test.ts
+++ b/packages/api/tests/routes/translate.test.ts
@@ -1,0 +1,84 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  InMemoryMessageRepository,
+  InMemoryThreadRepository,
+} from '../../src/repositories/in-memory'
+import { createTranslateRoutes } from '../../src/routes/translate'
+import { MessageTranslationService } from '../../src/services/message-translation'
+import { testAuthMiddleware } from '../helpers/auth'
+
+function appWith(messageRepo: InMemoryMessageRepository) {
+  const a = new Hono()
+  const service = new MessageTranslationService(messageRepo, {
+    translate: async (text, _src, target) => ({
+      translatedText: `[${target}] ${text}`,
+      detectedLanguage: 'ja',
+    }),
+  })
+  a.use('*', testAuthMiddleware('u1', 'RENTER'))
+  a.route('/', createTranslateRoutes(service))
+  return a
+}
+
+let threadRepo: InMemoryThreadRepository
+let messageRepo: InMemoryMessageRepository
+let messageId: string
+
+beforeEach(async () => {
+  threadRepo = new InMemoryThreadRepository()
+  messageRepo = new InMemoryMessageRepository(threadRepo)
+  const thread = await threadRepo.create({ userId: 'u1', role: 'RENTER' }, null, ['u1', 'u2'])
+  const msg = await messageRepo.create({ userId: 'u1', role: 'RENTER' }, thread.id, 'こんにちは')
+  messageId = msg.id
+})
+
+describe('POST /messages/:id/translate', () => {
+  it('returns the translation with cached=false on first call', async () => {
+    const res = await appWith(messageRepo).request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'en' }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      success: true,
+      data: { translatedText: '[en] こんにちは', language: 'en', cached: false },
+    })
+  })
+
+  it('returns cached=true on subsequent calls', async () => {
+    const app = appWith(messageRepo)
+    await app.request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'en' }),
+    })
+    const second = await app.request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'en' }),
+    })
+    const body = await second.json()
+    expect(body.data.cached).toBe(true)
+  })
+
+  it('returns 404 for an unknown message', async () => {
+    const res = await appWith(messageRepo).request('/messages/nonexistent/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'en' }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects an invalid targetLanguage with 400', async () => {
+    const res = await appWith(messageRepo).request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'xx' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/api/tests/services/google-translation-provider.test.ts
+++ b/packages/api/tests/services/google-translation-provider.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GoogleTranslationProvider } from '../../src/services/google-translation-provider'
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('GoogleTranslationProvider', () => {
+  it('posts the text + target to the Google endpoint and returns the translation', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          translations: [{ translatedText: 'Hello', detectedSourceLanguage: 'ja' }],
+        },
+      }),
+    )
+    const provider = new GoogleTranslationProvider('test-key', fetchFn)
+
+    const result = await provider.translate('こんにちは', null, 'en')
+    expect(result).toEqual({ translatedText: 'Hello', detectedLanguage: 'ja' })
+
+    const [url, init] = fetchFn.mock.calls[0]!
+    expect(url).toBe('https://translation.googleapis.com/language/translate/v2')
+    expect(init?.method).toBe('POST')
+    const body = init?.body as string
+    expect(body).toContain('key=test-key')
+    expect(body).toContain('target=en')
+    expect(body).toContain('q=')
+  })
+
+  it('passes source when provided', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        data: { translations: [{ translatedText: 'Hi' }] },
+      }),
+    )
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    await provider.translate('hi', 'ja', 'en')
+    expect(fetchFn.mock.calls[0]![1]!.body as string).toContain('source=ja')
+  })
+
+  it('throws with the Google error message on non-2xx', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ error: { message: 'API key invalid' } }, { status: 400 }),
+    )
+    const provider = new GoogleTranslationProvider('bad-key', fetchFn)
+    await expect(provider.translate('x', null, 'en')).rejects.toThrow('API key invalid')
+  })
+
+  it('throws if Google returns no translations', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ data: { translations: [] } }))
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    await expect(provider.translate('x', null, 'en')).rejects.toThrow(/no translation/i)
+  })
+
+  it('falls back to targetLanguage for detectedLanguage when Google omits it', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ data: { translations: [{ translatedText: 'Hi' }] } }),
+    )
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    const result = await provider.translate('hi', null, 'en')
+    expect(result.detectedLanguage).toBe('en')
+  })
+})

--- a/packages/api/tests/services/google-translation-provider.test.ts
+++ b/packages/api/tests/services/google-translation-provider.test.ts
@@ -26,8 +26,10 @@ describe('GoogleTranslationProvider', () => {
     const [url, init] = fetchFn.mock.calls[0]!
     expect(url).toBe('https://translation.googleapis.com/language/translate/v2')
     expect(init?.method).toBe('POST')
+    const headers = init?.headers as Record<string, string>
+    expect(headers['X-Goog-Api-Key']).toBe('test-key')
     const body = init?.body as string
-    expect(body).toContain('key=test-key')
+    expect(body).not.toContain('key=test-key')
     expect(body).toContain('target=en')
     expect(body).toContain('q=')
   })

--- a/packages/api/tests/services/message-translation.test.ts
+++ b/packages/api/tests/services/message-translation.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  InMemoryMessageRepository,
+  InMemoryThreadRepository,
+} from '../../src/repositories/in-memory'
+import { MessageTranslationService } from '../../src/services/message-translation'
+import type { TranslationProvider } from '../../src/services/translation-provider'
+
+const RENTER = { userId: 'u1', role: 'RENTER' as const }
+const U2 = 'u2'
+
+function stubProvider(map: Record<string, string>, detected?: string): TranslationProvider {
+  return {
+    translate: vi.fn(async (text: string, _source, target) => ({
+      translatedText: map[`${text}|${target}`] ?? `[${target}] ${text}`,
+      detectedLanguage: detected ?? 'ja',
+    })),
+  }
+}
+
+let threadRepo: InMemoryThreadRepository
+let messageRepo: InMemoryMessageRepository
+let threadId: string
+let messageId: string
+
+beforeEach(async () => {
+  threadRepo = new InMemoryThreadRepository()
+  messageRepo = new InMemoryMessageRepository(threadRepo)
+  const thread = await threadRepo.create(RENTER, null, [RENTER.userId, U2])
+  threadId = thread.id
+  const msg = await messageRepo.create(RENTER, threadId, 'こんにちは')
+  messageId = msg.id
+})
+
+describe('MessageTranslationService.translate', () => {
+  it('returns the cached translation without calling the provider on a cache hit', async () => {
+    const cached = await messageRepo.updateTranslation(messageId, 'en', 'Hello (cached)', null)
+    expect(cached).toBeDefined()
+
+    const provider = stubProvider({})
+    const service = new MessageTranslationService(messageRepo, provider)
+
+    const result = await service.translate(messageId, 'en')
+    expect(result).toEqual({
+      ok: true,
+      translatedText: 'Hello (cached)',
+      language: 'en',
+      cached: true,
+    })
+    expect(provider.translate).not.toHaveBeenCalled()
+  })
+
+  it('calls the provider on a cache miss, persists the translation', async () => {
+    const provider = stubProvider({ 'こんにちは|en': 'Hello' })
+    const service = new MessageTranslationService(messageRepo, provider)
+
+    const first = await service.translate(messageId, 'en')
+    expect(first).toEqual({
+      ok: true,
+      translatedText: 'Hello',
+      language: 'en',
+      cached: false,
+    })
+    expect(provider.translate).toHaveBeenCalledOnce()
+
+    // Second call hits the cache.
+    const second = await service.translate(messageId, 'en')
+    expect(second.ok && second.cached).toBe(true)
+    expect(provider.translate).toHaveBeenCalledOnce() // still 1
+  })
+
+  it('persists detectedLanguage back to the message on cache miss', async () => {
+    const provider = stubProvider({ 'こんにちは|en': 'Hello' }, 'ja')
+    const service = new MessageTranslationService(messageRepo, provider)
+
+    await service.translate(messageId, 'en')
+    const updated = await messageRepo.findById(messageId)
+    expect(updated?.sourceLanguage).toBe('ja')
+  })
+
+  it('returns 404 for an unknown message', async () => {
+    const service = new MessageTranslationService(messageRepo, stubProvider({}))
+    const result = await service.translate('missing-id', 'en')
+    expect(result).toEqual({ ok: false, status: 404, error: 'Message not found' })
+  })
+
+  it('returns 502 when the provider throws', async () => {
+    const provider: TranslationProvider = {
+      translate: vi.fn(async () => {
+        throw new Error('Google API down')
+      }),
+    }
+    const service = new MessageTranslationService(messageRepo, provider)
+    const result = await service.translate(messageId, 'en')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(502)
+    expect(result.error).toMatch(/translation|provider/i)
+  })
+})

--- a/packages/api/tests/services/message-translation.test.ts
+++ b/packages/api/tests/services/message-translation.test.ts
@@ -40,7 +40,7 @@ describe('MessageTranslationService.translate', () => {
     const provider = stubProvider({})
     const service = new MessageTranslationService(messageRepo, provider)
 
-    const result = await service.translate(messageId, 'en')
+    const result = await service.translate(RENTER, messageId, 'en')
     expect(result).toEqual({
       ok: true,
       translatedText: 'Hello (cached)',
@@ -54,7 +54,7 @@ describe('MessageTranslationService.translate', () => {
     const provider = stubProvider({ 'こんにちは|en': 'Hello' })
     const service = new MessageTranslationService(messageRepo, provider)
 
-    const first = await service.translate(messageId, 'en')
+    const first = await service.translate(RENTER, messageId, 'en')
     expect(first).toEqual({
       ok: true,
       translatedText: 'Hello',
@@ -64,7 +64,7 @@ describe('MessageTranslationService.translate', () => {
     expect(provider.translate).toHaveBeenCalledOnce()
 
     // Second call hits the cache.
-    const second = await service.translate(messageId, 'en')
+    const second = await service.translate(RENTER, messageId, 'en')
     expect(second.ok && second.cached).toBe(true)
     expect(provider.translate).toHaveBeenCalledOnce() // still 1
   })
@@ -73,14 +73,14 @@ describe('MessageTranslationService.translate', () => {
     const provider = stubProvider({ 'こんにちは|en': 'Hello' }, 'ja')
     const service = new MessageTranslationService(messageRepo, provider)
 
-    await service.translate(messageId, 'en')
-    const updated = await messageRepo.findById(messageId)
+    await service.translate(RENTER, messageId, 'en')
+    const updated = await messageRepo.findById(RENTER, messageId)
     expect(updated?.sourceLanguage).toBe('ja')
   })
 
   it('returns 404 for an unknown message', async () => {
     const service = new MessageTranslationService(messageRepo, stubProvider({}))
-    const result = await service.translate('missing-id', 'en')
+    const result = await service.translate(RENTER, 'missing-id', 'en')
     expect(result).toEqual({ ok: false, status: 404, error: 'Message not found' })
   })
 
@@ -91,10 +91,21 @@ describe('MessageTranslationService.translate', () => {
       }),
     }
     const service = new MessageTranslationService(messageRepo, provider)
-    const result = await service.translate(messageId, 'en')
+    const result = await service.translate(RENTER, messageId, 'en')
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.status).toBe(502)
     expect(result.error).toMatch(/translation|provider/i)
+  })
+
+  it('returns 404 when a non-participant tries to translate', async () => {
+    const outsider = { userId: 'stranger', role: 'RENTER' as const }
+    const provider = stubProvider({ 'こんにちは|en': 'Hello' })
+    const service = new MessageTranslationService(messageRepo, provider)
+
+    const result = await service.translate(outsider, messageId, 'en')
+    expect(result).toEqual({ ok: false, status: 404, error: 'Message not found' })
+    // Must not have leaked via the provider cache either
+    expect(provider.translate).not.toHaveBeenCalled()
   })
 })

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,8 @@
     "./validators/booking": "./src/validators/booking.ts",
     "./validators/vehicle": "./src/validators/vehicle.ts",
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",
-    "./validators/customer": "./src/validators/customer.ts"
+    "./validators/customer": "./src/validators/customer.ts",
+    "./validators/translation": "./src/validators/translation.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/shared/src/validators/translation.ts
+++ b/packages/shared/src/validators/translation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const SUPPORTED_TARGET_LANGUAGES = ['en', 'ja', 'zh'] as const
+export type TargetLanguage = (typeof SUPPORTED_TARGET_LANGUAGES)[number]
+
+export const translateMessageSchema = z.object({
+  targetLanguage: z.enum(SUPPORTED_TARGET_LANGUAGES),
+})
+
+export type TranslateMessageInput = z.infer<typeof translateMessageSchema>


### PR DESCRIPTION
## Summary
Adds `POST /messages/:id/translate`. Cache-first — reads `messages.translations` JSON, returns cached text on hit; calls provider on miss, persists, returns fresh. Auto-detects source language when absent.

## Architecture
- `TranslationProvider` interface — framework-agnostic contract (just `translate(text, src, target)`)
- `GoogleTranslationProvider` — REST to `/language/translate/v2` (Workers-compatible, no Node deps)
- `MessageTranslationService` — cache + provider + persist orchestration
- `MessageRepository` extended: `findById` + `updateTranslation` (atomic merge into JSON map)
- Route: thin parse-and-dispatch; maps service result to HTTP
- Composition: real Google when `GOOGLE_TRANSLATE_API_KEY` set, else a stub that prefixes `[en] ` — keeps preview/dev envs working without credentials

## Errors
- 400 bad body (Zod)
- 404 unknown message
- 502 provider down (caught, not swallowed)

## Test plan
- [x] 5 service tests (cache hit/miss, detected lang persisted, 404, provider error)
- [x] 4 route tests (happy + cached=true + 404 + 400)
- [x] 5 GoogleTranslationProvider tests (POST body shape, source, error, empty, fallback)
- [x] 375 API tests pass

Closes #37