### PR TITLE
feat(api): 3rd-party booking endpoint for Trip.com (Phase 3a)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -57,6 +57,7 @@ import { createFleetOverviewRoutes } from './routes/fleet-overview'
 import health from './routes/health'
 import { createMaintenanceLogRoutes } from './routes/maintenance-logs'
 import { createMessageRoutes } from './routes/messages'
+import { createPartnerBookingRoutes } from './routes/partner-bookings'
 import { createStatsRoutes } from './routes/stats'
 import { createTranslateRoutes } from './routes/translate'
 import { createUserRoutes } from './routes/users'
@@ -69,6 +70,7 @@ import { CustomerService } from './services/customer'
 import { GoogleTranslationProvider } from './services/google-translation-provider'
 import { MaintenanceService } from './services/maintenance'
 import { MessageTranslationService } from './services/message-translation'
+import { PartnerBookingService } from './services/partner-booking'
 import type { TranslationProvider } from './services/translation-provider'
 import { VehicleClassService } from './services/vehicle-class'
 import { VehiclePhotoService } from './services/vehicle-photo'
@@ -280,6 +282,7 @@ export function createApp(overrides?: {
     )
     .route('/', createMaintenanceLogRoutes(maintenanceService))
     .route('/', createBookingRoutes(bookingService))
+    .route('/', createPartnerBookingRoutes(new PartnerBookingService(bookingService, userRepo)))
     .route('/', createAvailabilityRoutes(availabilityRepo))
     .route('/', createStatsRoutes(statsRepo))
     .route('/', createMessageRoutes(threadRepo, messageRepo))

--- a/packages/api/src/routes/partner-bookings.ts
+++ b/packages/api/src/routes/partner-bookings.ts
@@ -1,0 +1,47 @@
+import { createPartnerBookingSchema } from '@kuruma/shared/validators/partner-booking'
+import { Hono } from 'hono'
+import { requireUser, toCallerContext } from '../middleware/auth'
+import type { PartnerBookingService } from '../services/partner-booking'
+import { fail, ok, parseBody } from './helpers'
+
+/**
+ * 3rd-party booking API (Phase 3a). Used by OTA partners like Trip.com.
+ * Requires an X-API-Key header (verified by `requireAuth` middleware).
+ * Callers arrive with role=PARTNER; the service forces source to one
+ * of the allowed partner enums and auto-upserts the renter by email.
+ */
+export function createPartnerBookingRoutes(service: PartnerBookingService) {
+  return new Hono().post('/external/bookings', async (c) => {
+    const user = requireUser(c)
+    if (user.role !== 'PARTNER') {
+      return fail(c, 'Forbidden: partner API key required', 403)
+    }
+
+    const ctx = toCallerContext(user)
+    const parsed = await parseBody(c, createPartnerBookingSchema)
+    if (!parsed.ok) return parsed.response
+
+    const result = await service.create(ctx, {
+      vehicleId: parsed.data.vehicleId,
+      renterEmail: parsed.data.renterEmail,
+      renterName: parsed.data.renterName,
+      renterPhone: parsed.data.renterPhone ?? null,
+      renterLanguage: parsed.data.renterLanguage,
+      startAt: new Date(parsed.data.startAt),
+      endAt: new Date(parsed.data.endAt),
+      source: parsed.data.source,
+      externalId: parsed.data.externalId,
+      notes: parsed.data.notes ?? null,
+      idempotencyKey: parsed.data.idempotencyKey ?? null,
+    })
+
+    if (!result.ok) {
+      return fail(c, result.error, result.status, {
+        ...(result.code ? { code: result.code } : {}),
+        ...(result.details ? { details: result.details } : {}),
+      })
+    }
+
+    return ok(c, result.booking, result.status ?? 201)
+  })
+}

--- a/packages/api/src/services/partner-booking.ts
+++ b/packages/api/src/services/partner-booking.ts
@@ -1,0 +1,53 @@
+import type { CallerContext } from '../middleware/auth'
+import type { UserRepository } from '../repositories/types'
+import type { Booking } from '../stores'
+import type { BookingService, CreateBookingResult } from './booking'
+
+export interface PartnerBookingInput {
+  vehicleId: string
+  renterEmail: string
+  renterName: string
+  renterPhone: string | null
+  renterLanguage: string
+  startAt: Date
+  endAt: Date
+  source: Booking['source']
+  externalId: string
+  notes: string | null
+  idempotencyKey?: string | null
+}
+
+/**
+ * Composes user-upsert + booking-create for partner-originated bookings
+ * (Trip.com and similar). The partner provides renter contact info; we
+ * resolve or create the renter row and delegate to BookingService.
+ *
+ * Exists as a separate service so the booking orchestration stays
+ * ignorant of user upsert semantics.
+ */
+export class PartnerBookingService {
+  constructor(
+    private readonly bookingService: BookingService,
+    private readonly userRepo: UserRepository,
+  ) {}
+
+  async create(ctx: CallerContext, input: PartnerBookingInput): Promise<CreateBookingResult> {
+    const renter = await this.userRepo.quickCreate({
+      name: input.renterName,
+      email: input.renterEmail,
+      phone: input.renterPhone,
+      language: input.renterLanguage,
+    })
+
+    return this.bookingService.create(ctx, {
+      vehicleId: input.vehicleId,
+      renterId: renter.id,
+      startAt: input.startAt,
+      endAt: input.endAt,
+      source: input.source,
+      externalId: input.externalId,
+      notes: input.notes,
+      idempotencyKey: input.idempotencyKey ?? null,
+    })
+  }
+}

--- a/packages/api/tests/routes/partner-bookings.test.ts
+++ b/packages/api/tests/routes/partner-bookings.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  InMemoryBookingRepository,
+  InMemoryUserRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { createPartnerBookingRoutes } from '../../src/routes/partner-bookings'
+import { BookingService } from '../../src/services/booking'
+import { PartnerBookingService } from '../../src/services/partner-booking'
+import { testAuthMiddleware } from '../helpers/auth'
+
+let vehicleRepo: InMemoryVehicleRepository
+let userRepo: InMemoryUserRepository
+let vehicleId: string
+
+function appAs(role: 'PARTNER' | 'RENTER' | 'STAFF' = 'PARTNER') {
+  const a = new Hono()
+  const bookingService = new BookingService(new InMemoryBookingRepository(), vehicleRepo, userRepo)
+  const service = new PartnerBookingService(bookingService, userRepo)
+  a.use('*', testAuthMiddleware('partner:api-key', role))
+  a.route('/', createPartnerBookingRoutes(service))
+  return a
+}
+
+beforeEach(async () => {
+  vehicleRepo = new InMemoryVehicleRepository()
+  userRepo = new InMemoryUserRepository()
+  const v = await vehicleRepo.create({
+    name: 'Test Car',
+    description: 'Test',
+    photos: [],
+    seats: 4,
+    transmission: 'AUTO' as const,
+    fuelType: 'GASOLINE',
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 0,
+    minRentalHours: 1,
+    maxRentalHours: 168,
+    advanceBookingHours: 0,
+    dailyRateJpy: 5000,
+    hourlyRateJpy: 1000,
+  })
+  vehicleId = v.id
+})
+
+const body = (overrides?: Record<string, unknown>) => ({
+  vehicleId,
+  renterEmail: 'tourist@example.com',
+  renterName: 'Tourist Alice',
+  renterLanguage: 'en',
+  startAt: '2026-05-01T10:00:00Z',
+  endAt: '2026-05-02T10:00:00Z',
+  externalId: 'TRIP-001',
+  ...overrides,
+})
+
+describe('POST /external/bookings', () => {
+  it('creates a booking with source TRIP_COM for PARTNER role', async () => {
+    const res = await appAs('PARTNER').request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body()),
+    })
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json.success).toBe(true)
+    expect(json.data.source).toBe('TRIP_COM')
+    expect(json.data.externalId).toBe('TRIP-001')
+  })
+
+  it('rejects RENTER with 403 (API-key-only endpoint)', async () => {
+    const res = await appAs('RENTER').request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body()),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects STAFF with 403 too', async () => {
+    const res = await appAs('STAFF').request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body()),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 on missing required field', async () => {
+    const res = await appAs('PARTNER').request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vehicleId, renterName: 'x' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 409 when the vehicle is already booked in the time range', async () => {
+    const app = appAs('PARTNER')
+    const first = await app.request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body({ externalId: 'TRIP-A' })),
+    })
+    expect(first.status).toBe(201)
+
+    const second = await app.request('/external/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body({ externalId: 'TRIP-B', renterEmail: 'b@e.com', renterName: 'B' })),
+    })
+    expect(second.status).toBe(409)
+  })
+})

--- a/packages/api/tests/services/partner-booking.test.ts
+++ b/packages/api/tests/services/partner-booking.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  InMemoryBookingRepository,
+  InMemoryUserRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { BookingService } from '../../src/services/booking'
+import { PartnerBookingService } from '../../src/services/partner-booking'
+import type { Vehicle } from '../../src/stores'
+
+const PARTNER = { userId: 'partner:api-key', role: 'PARTNER' as const }
+
+function vehicleInput(overrides?: Partial<Vehicle>) {
+  return {
+    name: 'Partner Car',
+    description: 'A vehicle',
+    photos: [] as string[],
+    seats: 4,
+    transmission: 'AUTO' as const,
+    fuelType: 'GASOLINE',
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 60,
+    minRentalHours: 1,
+    maxRentalHours: 168,
+    advanceBookingHours: 0,
+    dailyRateJpy: 5000,
+    hourlyRateJpy: 1000,
+    ...overrides,
+  }
+}
+
+let vehicleRepo: InMemoryVehicleRepository
+let bookingRepo: InMemoryBookingRepository
+let userRepo: InMemoryUserRepository
+let bookingService: BookingService
+let service: PartnerBookingService
+let vehicleId: string
+
+beforeEach(async () => {
+  vehicleRepo = new InMemoryVehicleRepository()
+  bookingRepo = new InMemoryBookingRepository()
+  userRepo = new InMemoryUserRepository()
+
+  bookingService = new BookingService(bookingRepo, vehicleRepo, userRepo)
+  service = new PartnerBookingService(bookingService, userRepo)
+
+  const v = await vehicleRepo.create(vehicleInput())
+  vehicleId = v.id
+})
+
+describe('PartnerBookingService.create', () => {
+  const baseInput = {
+    vehicleId: '',
+    renterEmail: 'tourist@example.com',
+    renterName: 'Tourist Alice',
+    renterPhone: null,
+    renterLanguage: 'en',
+    startAt: new Date('2026-05-01T10:00:00Z'),
+    endAt: new Date('2026-05-02T10:00:00Z'),
+    source: 'TRIP_COM' as const,
+    externalId: 'TRIP-ABC-123',
+    notes: null,
+  }
+
+  it('creates a booking with source TRIP_COM, externalId, and upserted renter', async () => {
+    const result = await service.create(PARTNER, { ...baseInput, vehicleId })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.source).toBe('TRIP_COM')
+    expect(result.booking.externalId).toBe('TRIP-ABC-123')
+
+    const renter = await userRepo.findByEmail('tourist@example.com')
+    expect(renter?.name).toBe('Tourist Alice')
+    expect(result.booking.renterId).toBe(renter?.id)
+  })
+
+  it('reuses an existing renter when the email already exists', async () => {
+    const existing = await userRepo.quickCreate({
+      name: 'Existing',
+      email: 'tourist@example.com',
+      phone: null,
+      language: 'en',
+    })
+
+    const result = await service.create(PARTNER, { ...baseInput, vehicleId })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.renterId).toBe(existing.id)
+  })
+
+  it('rejects when the vehicle is already booked (exclusion constraint path)', async () => {
+    const first = await service.create(PARTNER, {
+      ...baseInput,
+      vehicleId,
+      externalId: 'TRIP-1',
+    })
+    expect(first.ok).toBe(true)
+
+    const second = await service.create(PARTNER, {
+      ...baseInput,
+      vehicleId,
+      renterEmail: 'other@example.com',
+      renterName: 'Other',
+      externalId: 'TRIP-2',
+    })
+    expect(second.ok).toBe(false)
+    if (second.ok) return
+    expect(second.status).toBe(409)
+  })
+
+  it('deduplicates via idempotencyKey across retries', async () => {
+    const key = '00000000-0000-4000-8000-000000000001'
+    const first = await service.create(PARTNER, {
+      ...baseInput,
+      vehicleId,
+      externalId: 'TRIP-DUP',
+      idempotencyKey: key,
+    })
+    const second = await service.create(PARTNER, {
+      ...baseInput,
+      vehicleId,
+      externalId: 'TRIP-DUP',
+      idempotencyKey: key,
+    })
+
+    expect(first.ok && second.ok).toBe(true)
+    if (!first.ok || !second.ok) return
+    expect(second.booking.id).toBe(first.booking.id)
+    expect(second.status).toBe(200)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,8 @@
     "./validators/vehicle": "./src/validators/vehicle.ts",
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",
     "./validators/customer": "./src/validators/customer.ts",
-    "./validators/translation": "./src/validators/translation.ts"
+    "./validators/translation": "./src/validators/translation.ts",
+    "./validators/partner-booking": "./src/validators/partner-booking.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/shared/src/validators/partner-booking.ts
+++ b/packages/shared/src/validators/partner-booking.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+// Partner-originated bookings: Trip.com now, other OTAs later.
+const PARTNER_SOURCES = ['TRIP_COM'] as const
+
+export const createPartnerBookingSchema = z
+  .object({
+    vehicleId: z.string().uuid('vehicleId must be a UUID'),
+    renterEmail: z.string().email(),
+    renterName: z.string().min(1).max(200),
+    renterPhone: z.string().max(40).nullable().optional(),
+    renterLanguage: z.enum(['en', 'ja', 'zh']).default('en'),
+    startAt: z.string().datetime(),
+    endAt: z.string().datetime(),
+    source: z.enum(PARTNER_SOURCES).default('TRIP_COM'),
+    externalId: z.string().min(1).max(100),
+    notes: z.string().max(2000).nullable().optional(),
+    idempotencyKey: z.string().uuid().optional(),
+  })
+  .refine((d) => new Date(d.endAt) > new Date(d.startAt), {
+    message: 'endAt must be after startAt',
+    path: ['endAt'],
+  })
+
+export type CreatePartnerBookingInput = z.infer<typeof createPartnerBookingSchema>


### PR DESCRIPTION
## Summary
Phase 3a of #13 — OTA partners (Trip.com first) can create bookings via `POST /external/bookings`. Uses existing PARTNER-role API-key auth and the exclusion constraint already on `bookings` — prevents double-booking across platforms.

## Architecture
- `PartnerBookingService` composes `UserRepository.quickCreate` (email-keyed upsert) + `BookingService.create` with `source` forced to `TRIP_COM`
- `createPartnerBookingRoutes` is thin parse-and-dispatch, PARTNER-gated (403 for RENTER/STAFF/ADMIN)
- New Zod validator: UUID vehicleId, email, ISO datetime, required `externalId`, optional `idempotencyKey`

## What's NOT in this PR
- Webhook/callback for booking status changes — deferred to a follow-up issue (out of Phase 3a minimum)

## Test plan
- [x] 4 service tests (happy path, email reuse, exclusion 409, idempotency replay)
- [x] 5 route tests (PARTNER 201, RENTER/STAFF 403, 400 on bad body, 409 on overlap)
- [x] Full API suite passes

Closes #13