### PR TITLE
docs: add messaging, vehicle-class, and ops plans

### DIFF
--- a/docs/2026-04-12-prototype-debt-cleanup.md
+++ b/docs/2026-04-12-prototype-debt-cleanup.md
@@ -1,0 +1,55 @@
+# Prototype Debt Cleanup (2026-04-12)
+
+> **Warning:** AI-assisted rapid prototyping produces working features fast — but accumulates structural debt that compounds silently. This document records what went wrong, why, and what 76 commits in a single day had to fix. Read this before the next prototyping sprint.
+
+## What was wrong
+
+The codebase was a prototype that shipped. Fast iteration with AI agents produced working features but accumulated structural debt in five areas:
+
+### 1. No architecture boundaries
+
+Routes had DB queries inline, business logic mixed with HTTP handling. A "controller" might validate input, query Postgres, compute prices, and format the response all in one function.
+
+### 2. Type safety was theatrical
+
+20+ `as Vehicle` / `as Booking` casts scattered across repositories. If a field was added to the domain type, the cast silently allowed missing fields. `any` leaked through validators. `exactOptionalPropertyTypes` was off.
+
+### 3. Security was ad-hoc
+
+No JWT auth middleware (routes trusted session blindly), no ownership checks (any user could read any booking), timing-vulnerable API key comparison, stack traces leaked in errors, CORS wide open, no rate limiting.
+
+### 4. Data integrity gaps
+
+No optimistic locking (concurrent status updates could corrupt), no idempotency keys (double-submit = double booking), N+1 queries, unbounded list endpoints, missing FK indexes.
+
+### 5. Dead code and duplication
+
+4 separate `ApiResponse` type definitions, orphaned fetcher files, unused deps, a debug endpoint with no auth.
+
+## Why it was like that
+
+AI-assisted rapid prototyping. Each feature was built as a vertical spike to prove the concept, not to last. The priority was "does it work" not "is it safe/maintainable." Multiple parallel agent sessions compounded the duplication — each session generated its own local copy of shared types rather than reusing what existed.
+
+## What changed
+
+| Theme | Key PRs | Effect |
+|-------|---------|--------|
+| **MVC + DI** | #99, #122, #83 | Routes -> Services -> Repositories. Single composition root. Boundary linter enforced in CI. |
+| **Type safety** | #81, #93, #96, #164 | `exactOptionalPropertyTypes` on, 20 casts replaced with mapper functions, canonical `ApiResponse<T>` discriminated union, validators tightened to `z.enum`/`z.uuid` |
+| **Security** | #198, #165, #181, #128, #132 | JWT auth middleware on all routes, ownership checks, algorithm pinning, timing-safe comparisons, rate limiting, global error handler, CORS gated by `NODE_ENV` |
+| **Data integrity** | #126, #127, #201, #161, #170 | Optimistic locking, idempotency keys, DB trigger for `effectiveEndAt`, unique constraints, transactions on thread ops |
+| **Performance** | #120, #172, #156, #191, #176 | 8 FK indexes + status index, N+1 fix via batch lookup, `next/image`, JWT role caching |
+| **Cleanup** | #92, #70, #77, #208, #207 | Deduplicated types, removed dead code/deps/pages, trimmed CLAUDE.md by 70% |
+
+## What it's like now
+
+A layered API with enforced boundaries (lint + CI), type-safe mappers instead of casts, auth middleware on every route, and data integrity at the DB level. Still a small app, but the foundation won't fight you when features land on top of it.
+
+## Lessons for next time
+
+1. **Turn on strict TypeScript from day one.** Retrofitting `exactOptionalPropertyTypes` across 30+ files is painful. Starting strict costs nothing.
+2. **Add auth middleware before the second route.** Bolting auth onto 15 existing routes means 15 places to miss an ownership check.
+3. **One canonical type, one location.** If two agents need `ApiResponse`, put it in `shared/` before the first feature lands. Deduplicating 4 copies later is pure waste.
+4. **Casts are lies.** `as Vehicle` compiles today and breaks silently tomorrow. Mapper functions fail at compile time when the shape changes.
+5. **DB constraints over application checks.** Unique constraints, exclusion constraints, and triggers catch bugs that application code misses under concurrency.
+6. **Prototype sprints need a cleanup budget.** Plan for a hardening pass after every spike phase — or the debt compounds until a 76-commit day is the only way out.

--- a/docs/cloudflare-account-migration.md
+++ b/docs/cloudflare-account-migration.md
@@ -1,0 +1,68 @@
+# Cloudflare Account Migration
+
+Transfer Workers from personal CF account to freelance CF account.
+
+## Prerequisites
+
+- Freelance Gmail address
+- Access to GitHub repo secrets (Settings > Secrets and variables > Actions)
+- Current `AUTH_SECRET` value (stored in GitHub Secrets)
+
+## Steps
+
+### 1. Create new Cloudflare account
+
+- Sign up at https://dash.cloudflare.com/sign-up with freelance Gmail
+- Choose the Free plan (Workers free tier covers our usage)
+
+### 2. Generate API token on new account
+
+- Go to: My Profile > API Tokens > Create Token
+- Use the "Edit Cloudflare Workers" template
+- Copy the token and the Account ID (visible on the Workers dashboard overview page)
+
+### 3. Update GitHub repo secrets
+
+Replace these two secrets in the repo (Settings > Secrets > Actions):
+
+| Secret | New value |
+|--------|-----------|
+| `CLOUDFLARE_API_TOKEN` | Token from step 2 |
+| `CLOUDFLARE_ACCOUNT_ID` | Account ID from step 2 |
+
+All other secrets (`AUTH_SECRET`, `PROD_DATABASE_URL`, `AUTH_GOOGLE_*`) stay the same — they're app secrets, not CF-specific.
+
+### 4. Deploy to new account
+
+```bash
+gh workflow run deploy.yml
+```
+
+This creates both workers (`kuruma-api`, `kuruma-rental`) on the new account and sets all secrets automatically.
+
+### 5. Verify
+
+- API health: `curl https://kuruma-api.<new-subdomain>.workers.dev/health`
+- Web: visit `https://kuruma-rental.<new-subdomain>.workers.dev/en`
+- Log in and check the fleet page loads
+
+### 6. Update worker URLs
+
+The new account will have a different `*.workers.dev` subdomain. Update:
+
+- `packages/api/wrangler.toml` — `WEB_ORIGIN` var (CORS)
+- `.github/workflows/deploy.yml` — `API_WORKER_URL` and `WEB_WORKER_URL` env vars
+- Redeploy after updating these
+
+### 7. Custom domain (optional)
+
+If you set up a custom domain later (e.g. `api.kuruma.com`):
+
+1. Add domain to new CF account
+2. Add Workers routes in CF dashboard
+3. Update `NEXT_PUBLIC_API_URL` build-time env in `deploy.yml`
+
+### 8. Clean up old account
+
+- Delete `kuruma-api` and `kuruma-rental` workers from personal CF dashboard
+- Revoke the old API token

--- a/docs/plans/2026-04-14-messaging-design.md
+++ b/docs/plans/2026-04-14-messaging-design.md
@@ -1,0 +1,158 @@
+# Messaging Feature — Design Document
+
+> Fills gaps in the existing schema/API design (`2026-04-07-schema-api-design.md`).
+> Schema, API routes, validators, and translation model are already spec'd there — this doc covers UX decisions, thread lifecycle, notifications, RLS, and UI structure.
+
+## Decisions
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Thread creation | Auto-create on booking confirmation | Thread ready before anyone messages; empty threads negligible at 40-50 vehicles |
+| Pre-booking inquiries | Not in MVP | FAQ page handles common questions; owner can't scale replies to every inquiry |
+| Cancelled booking threads | Locked (no new messages) | Conversation history preserved, compose input disabled |
+| Completed booking threads | Stay writable | Post-rental coordination (lost items, receipts) |
+| Message content | Text only, max 5000 chars | Coordination channel, not a chat app. Users exchange Line/WeChat for richer comms |
+| Photos/attachments | Not in MVP | Not needed for basic coordination |
+| Message deletion | Not supported | Legal protection; Japan not subject to GDPR |
+| Thread cleanup | Scheduled deletion every few months/year | Future maintenance job, not MVP |
+| Staff assignment | `DEFAULT_STAFF_ID` env var | Single owner operation, no round-robin needed |
+| Real-time delivery | Polling on page load / navigation | Not WebSocket — async message exchange, not live chat |
+| Rate limiting | 10 messages per minute per user | Service-layer check |
+
+---
+
+## Notification Strategy
+
+| Sender | Recipient | Notification |
+|--------|-----------|-------------|
+| Renter sends message | Owner (staff) | **No email.** Unread badge in app sidebar only. Owner is in the app daily. |
+| Owner sends message | Renter | **Email on first unread only.** If `renterUnreadCount === 0` before increment, send one email. No email if they already have unread messages. |
+
+Email contains: message preview (first 200 chars) + link to thread in app. No reply-by-email.
+
+**Provider:** Resend (edge-compatible, free tier sufficient). Requires one-time DNS verification (SPF + DKIM).
+
+---
+
+## Row-Level Security (Prerequisite)
+
+> This is a cross-cutting concern — not messaging-specific. Must be implemented as a foundational layer before messaging, and applied to all tenant-scoped tables (bookings, threads, messages).
+
+**Approach:** Postgres-level RLS via Drizzle + Neon. Strictly enforced at the DB layer so no application bug can leak data across renters.
+
+### Why Postgres RLS, not application-level scoping
+
+Application-level (`WHERE renterId = ?` in every repository method) relies on every query getting it right. One missed filter = data leak. Postgres RLS enforces at the DB engine level — even a buggy query returns zero unauthorized rows.
+
+### Tables requiring RLS policies
+
+| Table | Renter policy | Staff/Admin policy |
+|-------|--------------|-------------------|
+| `bookings` | `SELECT/UPDATE` where `renterId = auth.uid()` | Full access |
+| `threads` | `SELECT` where `renterId = auth.uid()` | Full access |
+| `messages` | `SELECT` where message belongs to a thread where `renterId = auth.uid()` | Full access |
+
+### Implementation sketch (Drizzle + Neon)
+
+```typescript
+import { crudPolicy, authUid } from 'drizzle-orm/neon'
+
+export const threads = pgTable('threads', {
+  // ... columns
+}, (t) => [
+  crudPolicy({
+    role: authenticatedRole,
+    read: authUid(t.renterId),
+    modify: false,  // renters cannot update/delete threads
+  }),
+])
+```
+
+Staff/admin role bypasses policies (needs to see all threads/bookings).
+
+**Requires:** Setting JWT claims (`SET LOCAL request.jwt.claims = ...`) on each DB connection. Neon supports this natively in transactions.
+
+### Implementation order
+
+RLS must land before messaging. Suggested:
+1. Define Postgres roles (`authenticated`, `staff`, `admin`) in schema
+2. Add RLS policies to `bookings` table first (existing, easy to test)
+3. Verify with integration tests (renter A cannot see renter B's bookings)
+4. Extend to `threads` and `messages` tables as part of messaging slices
+
+---
+
+## UI Structure
+
+### Renter Side
+
+**Entry points:**
+- Booking detail page: "Messages" tab/section (primary access)
+- Nav bar: "Messages" link with unread badge count
+
+**Pages:**
+- `/bookings/[id]/messages` — thread view embedded in booking detail
+- `/messages` — inbox list (all threads, sorted by last activity)
+- `/messages/[threadId]` — full thread view
+
+### Staff (Owner) Side
+
+**Entry points:**
+- Sidebar: "Messages" nav item with unread badge
+- Booking detail: "Message Renter" button opens thread
+
+**Pages:**
+- `/manage/messages` — inbox (all threads, shows renter name + vehicle + booking dates)
+- `/manage/messages/[threadId]` — thread view
+
+### Shared Components
+
+```
+MessageInbox        — list of threads with last message preview + unread dot
+MessageThread       — scrollable message list + compose input
+MessageBubble       — single message, sender-aligned left/right
+TranslateButton     — inline "Translate" toggle per message bubble
+ComposeInput        — text input + send button (disabled when thread locked)
+UnreadBadge         — count badge for nav items
+```
+
+### Empty / Edge States
+
+| State | Display |
+|-------|---------|
+| No threads | "No messages yet" |
+| Thread with no messages | "Start the conversation" prompt |
+| Cancelled booking thread | Messages visible, compose disabled: "This booking was cancelled" |
+| Translation loading | Skeleton text below bubble |
+| Translation error | "Translation unavailable" with retry |
+
+---
+
+## Translation
+
+**Provider interface (in API composition root):**
+
+```typescript
+interface TranslationProvider {
+  translate(text: string, from: string, to: string): Promise<string>
+}
+```
+
+MVP concrete: `GoogleTranslationProvider`. Provider-agnostic — swap to DeepL, LibreTranslate, or OpenAI by changing one line in the composition root.
+
+**Flow:** User clicks "Translate" on a message bubble. API checks `translations` JSONB for cached result. Cache miss calls provider, stores result in JSONB. Subsequent requests served from cache.
+
+---
+
+## Implementation Slices
+
+| Slice | Scope | Depends on |
+|-------|-------|------------|
+| 0 | **RLS foundation** — Postgres roles, policies on bookings table, JWT claim wiring | Nothing |
+| 1 | Schema migration: threads + messages tables with RLS policies | Slice 0 |
+| 2 | API: auto-create thread on booking confirmation + send/list messages | Slice 1 |
+| 3 | API: unread counts (atomic increment on send, reset on read) + inbox list | Slice 2 |
+| 4 | Web: thread view + compose input on booking detail page | Slice 2 |
+| 5 | Web: inbox page with unread badges (both renter + staff sides) | Slice 3 |
+| 6 | Translation: provider interface + Google concrete + translate endpoint | Slice 2 |
+| 7 | Email notification to renter on first unread message (Resend) | Slice 2 |

--- a/docs/plans/2026-04-14-vehicle-class-abstraction.md
+++ b/docs/plans/2026-04-14-vehicle-class-abstraction.md
@@ -1,0 +1,159 @@
+# Vehicle Class Abstraction — Design Spec
+
+> **Goal:** Decouple the renter-facing catalog from the owner's physical fleet by introducing a Vehicle Class layer. Renters browse and book *classes* (e.g. "Compact — 5 seats"); the owner manages individual cars tagged to those classes. Inspired by NicoNico Rent-a-Car's catalog model.
+
+---
+
+## Problem
+
+Today, renters browse individual vehicles and book a specific car. This creates several issues:
+
+1. **Renter friction** — tourists don't care which exact Toyota Aqua they get; they care about size, seats, and luggage capacity.
+2. **Owner inflexibility** — if a booked car goes into maintenance, the booking is stuck. The owner can't swap in another car of the same type without cancelling/rebooking.
+3. **Catalog mismatch** — the owner wants a clean public page like NicoNico (browse by class), not a list of 40 individual cars.
+4. **3rd-party integration** — Trip.com and similar aggregators list by vehicle *category*, not by VIN.
+
+## Solution
+
+Introduce `vehicle_classes` as the renter-facing interface. Individual `vehicles` become the concrete implementations, tagged with a `classId`. Bookings are placed against a class; a specific vehicle is assigned later.
+
+```
+Renter → books a Class (interface)
+Owner  → assigns a Vehicle (implementation) before pickup
+```
+
+---
+
+## Schema Changes
+
+### New table: `vehicle_classes`
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| id | text | PK | UUIDv7 |
+| name | text | not null | e.g. "Compact", "SUV", "K-Car" |
+| slug | text | unique, not null | URL-friendly: "compact", "suv" |
+| description | text | | Renter-facing prose (i18n key or raw text TBD) |
+| photos | text[] | not null, default '{}' | Representative class photos (not a specific car) |
+| seats | integer | not null | Passenger capacity |
+| luggageCapacity | integer | not null | Number of standard suitcases |
+| transmission | transmission enum | not null | AUTO or MANUAL |
+| fuelType | text | | Petrol, Hybrid, EV, etc. |
+| dailyRateJpy | integer | | Whole JPY, class-level pricing |
+| hourlyRateJpy | integer | | Whole JPY |
+| sortOrder | integer | not null, default 0 | Display order on catalog page |
+| status | text | not null, default 'ACTIVE' | ACTIVE or ARCHIVED |
+| createdAt | timestamptz | not null, default now() | |
+| updatedAt | timestamptz | not null, default now() | |
+
+**CHECK:** at least one rate must be set (same pattern as current `vehicles` table).
+
+### Changes to `vehicles`
+
+| Change | Detail |
+|--------|--------|
+| Add `classId` | text, FK → vehicle_classes.id, **not null** |
+| Keep all existing columns | licensePlate, make, model, year, color, shaken, insurance, status, bufferMinutes, etc. |
+| Pricing columns become optional override | If null, inherit from class. If set, override class rate for this specific car. |
+| `seats`, `transmission` stay | Denormalized for fleet management; class values are the renter-facing source of truth. |
+
+The vehicle retains its own `name` (e.g. "Aqua 3-456") for owner identification. The renter never sees this.
+
+### Changes to `bookings`
+
+| Change | Detail |
+|--------|--------|
+| Add `classId` | text, FK → vehicle_classes.id, **not null** — what the renter chose |
+| `vehicleId` becomes nullable | null = class booked, car not yet assigned |
+| `totalPrice` computed from class rate | Unless vehicle has an override rate |
+
+**State flow:**
+```
+Renter books "Compact" for Apr 20-22
+  → booking created: classId=Compact, vehicleId=NULL, status=CONFIRMED
+
+Owner assigns Aqua (or system auto-assigns)
+  → booking updated: vehicleId=aqua-uuid
+
+Pickup day
+  → booking transitions: status=ACTIVE, specific car handed over
+```
+
+---
+
+## Availability Logic
+
+**Current:** "Is vehicle X free for these dates?"
+
+**New:** "How many vehicles in class Y are free for these dates?"
+
+```sql
+-- Count of vehicles in the class
+-- minus vehicles with overlapping non-CANCELLED bookings
+-- minus vehicles in MAINTENANCE or RETIRED status
+-- = available count for the class
+```
+
+A class is bookable if available count > 0. The renter never sees which specific cars are free.
+
+### Auto-assignment strategy
+
+When a booking is confirmed, the system can optionally auto-assign a vehicle:
+
+1. Query all AVAILABLE vehicles in the class
+2. Exclude vehicles with overlapping bookings (using existing exclusion constraint logic)
+3. Pick one (round-robin, least-recently-used, or random)
+4. Set `vehicleId` on the booking
+
+The owner can always manually reassign before pickup. Auto-assignment is a convenience, not a requirement for MVP.
+
+---
+
+## Migration Path
+
+This is **additive** — no destructive changes to existing data.
+
+### Phase 1: Schema
+1. Create `vehicle_classes` table
+2. Add `classId` column to `vehicles` (nullable initially for migration)
+3. Add `classId` column to `bookings` (nullable initially)
+4. Backfill: create classes from existing vehicle data, assign classIds
+5. Make `classId` not-null on both tables after backfill
+6. Make `bookings.vehicleId` nullable
+
+### Phase 2: API
+1. New CRUD routes for vehicle classes (`/api/vehicle-classes`)
+2. Update vehicle routes to include classId
+3. Update booking creation to accept classId instead of vehicleId
+4. Add availability endpoint per class
+5. Update fleet overview to group by class
+
+### Phase 3: Web (renter-facing)
+1. New catalog page: browse by vehicle class (like NicoNico)
+2. Booking flow: select class → pick dates → confirm
+3. Remove individual vehicle browsing for renters
+
+### Phase 4: Web (owner-facing)
+1. Vehicle class management UI (CRUD)
+2. Fleet view: group vehicles by class, show class-level stats
+3. Booking detail: vehicle assignment UI (dropdown of available cars in class)
+
+---
+
+## What Stays the Same
+
+- Owner's fleet management (individual cars, maintenance, status)
+- Booking lifecycle (CONFIRMED → ACTIVE → COMPLETED / CANCELLED)
+- Exclusion constraint for double-booking (still per-vehicle)
+- 3rd-party booking flow (now easier — they book by class, which is how aggregators work)
+- Auth, messaging, maintenance logs — untouched
+
+---
+
+## Open Questions
+
+1. **Pricing:** Class-level only, or per-vehicle overrides? (Proposed: class-level default, per-vehicle optional override)
+2. **i18n for class descriptions:** Use next-intl namespace keys, or store translated text in DB?
+3. **Auto-assignment timing:** At booking time, or deferred to owner? (Proposed: deferred for MVP, auto-assign as enhancement)
+4. **Existing bookings migration:** Backfill classId from vehicle's class, keep vehicleId as-is (already assigned)
+5. **Buffer minutes:** Class-level or vehicle-level? (Proposed: keep per-vehicle, as physical cars have different turnaround needs)


### PR DESCRIPTION
## Summary

- Lands design docs backing #300 (messaging backend) and #301 (vehicle class abstraction) so the issue links resolve.
- Also commits two untracked ops notes: prototype debt cleanup, Cloudflare account migration.

Docs-only, no code changes.

## Test plan

- [ ] Links in #300 and #301 resolve after merge.