### PR TITLE
feat(api): public class catalog + availability-per-class endpoint

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -88,6 +88,7 @@ export function createApp(overrides?: {
   userRepo?: UserRepository
   photoUploadLimiter?: RateLimitBinding
   photoUploadUserLimiter?: RateLimitBinding
+  publicCatalogLimiter?: RateLimitBinding
 }) {
   let vehicleClassRepo: VehicleClassRepository
   let vehicleRepo: VehicleRepository
@@ -110,6 +111,9 @@ export function createApp(overrides?: {
     ((globalThis as Record<string, unknown>).PHOTO_UPLOAD_USER_LIMITER as
       | RateLimitBinding
       | undefined)
+  const publicCatalogLimiter =
+    overrides?.publicCatalogLimiter ??
+    ((globalThis as Record<string, unknown>).PUBLIC_CATALOG_LIMITER as RateLimitBinding | undefined)
 
   if (overrides) {
     ;({ vehicleRepo, bookingRepo, availabilityRepo } = overrides)
@@ -268,7 +272,7 @@ export function createApp(overrides?: {
     .route('/', health)
     .route('/', createFleetOverviewRoutes(fleetOverviewRepo))
     .route('/', createVehicleDetailRoutes(vehicleDetailRepo))
-    .route('/', createVehicleClassRoutes(vehicleClassService))
+    .route('/', createVehicleClassRoutes(vehicleClassService, publicCatalogLimiter))
     .route('/', createVehicleRoutes(vehicleRepo, maintenanceService))
     .route(
       '/',

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -243,9 +243,9 @@ export function createApp(overrides?: {
   }
 
   // Auth middleware on all protected paths.
-  // TODO(#247): vehicle-classes GETs should be public for renter catalog.
-  // Move public read routes before this block when building the catalog UI.
-  app.use('/vehicle-classes/*', requireAuth())
+  // Note: /vehicle-classes/* has per-route auth — GETs are public for the
+  // renter catalog; POST/PATCH/DELETE require STAFF via `requireAuth()` on
+  // each handler in `routes/vehicle-classes.ts` (see #309).
   app.use('/vehicles/*', requireAuth())
   app.use('/bookings/*', requireAuth())
   app.use('/availability/*', requireAuth())
@@ -253,7 +253,7 @@ export function createApp(overrides?: {
   app.use('/customers/*', requireAuth())
   app.use('/users/*', requireAuth())
 
-  const vehicleClassService = new VehicleClassService(vehicleClassRepo)
+  const vehicleClassService = new VehicleClassService(vehicleClassRepo, availabilityRepo)
   const bookingService = new BookingService(bookingRepo, vehicleRepo, userRepo)
   const customerService = new CustomerService(userRepo)
   const maintenanceService = new MaintenanceService(

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -66,6 +66,12 @@ export function requireUser(c: { get: (key: string) => unknown }): AuthUser {
 
 export function requireAuth(): MiddlewareHandler {
   return async (c: Context, next) => {
+    // Idempotent: if an earlier middleware already authenticated the caller,
+    // don't re-verify. This lets per-route requireAuth() compose with a
+    // globally-mounted requireAuth() (or a test auth shim) without
+    // double-verifying the token.
+    if (getUser(c)) return next()
+
     const authHeader = c.req.header('Authorization')
 
     if (authHeader?.startsWith('Bearer ')) {

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -67,9 +67,11 @@ export function requireUser(c: { get: (key: string) => unknown }): AuthUser {
 export function requireAuth(): MiddlewareHandler {
   return async (c: Context, next) => {
     // Idempotent: if an earlier middleware already authenticated the caller,
-    // don't re-verify. This lets per-route requireAuth() compose with a
-    // globally-mounted requireAuth() (or a test auth shim) without
-    // double-verifying the token.
+    // skip re-verification. Auth is a property of the request, not of the
+    // pipeline position — re-verifying a JWT we already verified is waste.
+    // This also lets tests set a user via testAuthMiddleware without the
+    // full JWT round-trip. Invariant: `c.get('user')` is only ever written
+    // by auth code paths (this file + test helpers), never from user input.
     if (getUser(c)) return next()
 
     const authHeader = c.req.header('Authorization')

--- a/packages/api/src/repositories/drizzle/availability.ts
+++ b/packages/api/src/repositories/drizzle/availability.ts
@@ -7,6 +7,31 @@ import { type Db, bookingColumns, toBooking, toVehicle, vehicleColumns } from '.
 export class DrizzleAvailabilityRepository implements AvailabilityRepository {
   constructor(private readonly db: Db) {}
 
+  async countClassAvailability(
+    classId: string,
+    from: Date,
+    to: Date,
+  ): Promise<{ total: number; available: number }> {
+    const fromIso = from.toISOString()
+    const toIso = to.toISOString()
+    const [row] = await this.db
+      .select({
+        total: sql<number>`count(*) filter (where ${vehicles.status} <> 'RETIRED')::int`,
+        available: sql<number>`count(*) filter (
+          where ${vehicles.status} = 'AVAILABLE'
+          AND NOT EXISTS (
+            SELECT 1 FROM bookings b
+            WHERE b."vehicleId" = ${vehicles.id}
+            AND b.status IN ('CONFIRMED', 'ACTIVE')
+            AND tstzrange(b."startAt", b."effectiveEndAt") && tstzrange(${fromIso}::timestamptz, ${toIso}::timestamptz)
+          )
+        )::int`,
+      })
+      .from(vehicles)
+      .where(eq(vehicles.classId, classId))
+    return { total: Number(row?.total ?? 0), available: Number(row?.available ?? 0) }
+  }
+
   async findAvailableVehicles(from: Date, to: Date): Promise<Vehicle[]> {
     const fromIso = from.toISOString()
     const toIso = to.toISOString()

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -9,6 +9,25 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
     private readonly bookingRepo: BookingRepository,
   ) {}
 
+  async countClassAvailability(
+    classId: string,
+    from: Date,
+    to: Date,
+  ): Promise<{ total: number; available: number }> {
+    const { data: all } = await this.vehicleRepo.findAll({ includeRetired: true })
+    const inClass = all.filter((v) => v.classId === classId && v.status !== 'RETIRED')
+    const total = inClass.length
+    if (total === 0) return { total: 0, available: 0 }
+
+    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
+    const available = inClass.filter((v) => {
+      if (v.status !== 'AVAILABLE') return false
+      const conflicts = getConflictingBookings(allBookings, v.id, v.bufferMinutes, from, to)
+      return conflicts.length === 0
+    }).length
+    return { total, available }
+  }
+
   async findAvailableVehicles(from: Date, to: Date): Promise<Vehicle[]> {
     const { data: vehicles } = await this.vehicleRepo.findAll({ status: 'AVAILABLE' })
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -142,6 +142,15 @@ export interface AvailabilityRepository {
       }
     | undefined
   >
+  /** Counts bookable vehicles for a class over a date range.
+   *  - `total`: non-retired vehicles tagged with this classId (the class pool)
+   *  - `available`: subset with no conflicting CONFIRMED/ACTIVE booking and
+   *    status = AVAILABLE (MAINTENANCE vehicles count toward total but not available) */
+  countClassAvailability(
+    classId: string,
+    from: Date,
+    to: Date,
+  ): Promise<{ total: number; available: number }>
 }
 
 // Enriched read for the owner-facing /manage/vehicles/[id] detail page.

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -3,9 +3,9 @@ import {
   updateVehicleClassSchema,
 } from '@kuruma/shared/validators/vehicle-class'
 import { Hono } from 'hono'
-import { STAFF_ROLES, requireUser } from '../middleware/auth'
+import { STAFF_ROLES, requireAuth, requireUser } from '../middleware/auth'
 import type { VehicleClassService } from '../services/vehicle-class'
-import { fail, ok, parseBody, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
 
 export function createVehicleClassRoutes(service: VehicleClassService) {
   return new Hono()
@@ -19,6 +19,18 @@ export function createVehicleClassRoutes(service: VehicleClassService) {
       )
       return ok(c, classes)
     })
+    .get('/vehicle-classes/by-slug/:slug/availability', async (c) => {
+      const range = parseDateRange(c, true)
+      if (!range.ok) return range.response
+      const result = await service.getAvailabilityBySlug(c.req.param('slug'), range.from, range.to)
+      if (!result.ok) return fail(c, result.error, result.status)
+      return ok(c, {
+        classId: result.vehicleClass.id,
+        slug: result.vehicleClass.slug,
+        total: result.counts.total,
+        available: result.counts.available,
+      })
+    })
     .get('/vehicle-classes/by-slug/:slug', async (c) => {
       const vc = await service.findBySlug(c.req.param('slug'))
       if (!vc) return fail(c, 'Vehicle class not found', 404)
@@ -29,7 +41,7 @@ export function createVehicleClassRoutes(service: VehicleClassService) {
       if (!vc) return fail(c, 'Vehicle class not found', 404)
       return ok(c, vc)
     })
-    .post('/vehicle-classes', async (c) => {
+    .post('/vehicle-classes', requireAuth(), async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
@@ -55,7 +67,7 @@ export function createVehicleClassRoutes(service: VehicleClassService) {
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, result.vehicleClass, 201)
     })
-    .patch('/vehicle-classes/:id', async (c) => {
+    .patch('/vehicle-classes/:id', requireAuth(), async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
@@ -69,7 +81,7 @@ export function createVehicleClassRoutes(service: VehicleClassService) {
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, result.vehicleClass)
     })
-    .delete('/vehicle-classes/:id', async (c) => {
+    .delete('/vehicle-classes/:id', requireAuth(), async (c) => {
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -1,14 +1,31 @@
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
 import {
   createVehicleClassSchema,
   updateVehicleClassSchema,
 } from '@kuruma/shared/validators/vehicle-class'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { STAFF_ROLES, requireAuth, requireUser } from '../middleware/auth'
 import type { VehicleClassService } from '../services/vehicle-class'
 import { fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
 
-export function createVehicleClassRoutes(service: VehicleClassService) {
-  return new Hono()
+export function createVehicleClassRoutes(
+  service: VehicleClassService,
+  publicCatalogLimiter?: RateLimitBinding,
+) {
+  const app = new Hono()
+
+  // Public catalog endpoints are unauthenticated so a stricter IP-based
+  // limit sits on top of the global limiter to blunt scraping and probes.
+  // If the binding is absent (local dev, test), the rate-limit middleware
+  // isn't attached — the global limiter in createApp() still covers DoS.
+  if (publicCatalogLimiter) {
+    const byIp = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
+    app.use('/vehicle-classes', rateLimit(publicCatalogLimiter, byIp))
+    app.use('/vehicle-classes/by-slug/*', rateLimit(publicCatalogLimiter, byIp))
+    app.use('/vehicle-classes/:id', rateLimit(publicCatalogLimiter, byIp))
+  }
+
+  return app
     .get('/vehicle-classes', async (c) => {
       const rawStatus = c.req.query('status')
       const status: 'ACTIVE' | 'ARCHIVED' | undefined =

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -14,15 +14,20 @@ export function createVehicleClassRoutes(
 ) {
   const app = new Hono()
 
-  // Public catalog endpoints are unauthenticated so a stricter IP-based
-  // limit sits on top of the global limiter to blunt scraping and probes.
-  // If the binding is absent (local dev, test), the rate-limit middleware
-  // isn't attached — the global limiter in createApp() still covers DoS.
+  // Public catalog GETs are unauthenticated so a stricter IP-based limit
+  // sits on top of the global limiter to blunt scraping and probes. Scoped
+  // to GET only so staff POST/PATCH/DELETE on /vehicle-classes/:id don't
+  // share the public bucket (different traffic shape, different tuning).
+  // If the binding is absent (local dev, test), the middleware isn't
+  // attached — the global limiter in createApp() still covers DoS.
   if (publicCatalogLimiter) {
     const byIp = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
-    app.use('/vehicle-classes', rateLimit(publicCatalogLimiter, byIp))
-    app.use('/vehicle-classes/by-slug/*', rateLimit(publicCatalogLimiter, byIp))
-    app.use('/vehicle-classes/:id', rateLimit(publicCatalogLimiter, byIp))
+    const limiter = rateLimit(publicCatalogLimiter, byIp)
+    const onlyGet = (mw: typeof limiter) => async (c: Context, next: () => Promise<void>) =>
+      c.req.method === 'GET' ? mw(c, next) : next()
+    app.use('/vehicle-classes', onlyGet(limiter))
+    app.use('/vehicle-classes/by-slug/*', onlyGet(limiter))
+    app.use('/vehicle-classes/:id', onlyGet(limiter))
   }
 
   return app

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -1,4 +1,8 @@
-import type { VehicleClassFilters, VehicleClassRepository } from '../repositories/types'
+import type {
+  AvailabilityRepository,
+  VehicleClassFilters,
+  VehicleClassRepository,
+} from '../repositories/types'
 import type { VehicleClass } from '../stores'
 
 export type CreateResult =
@@ -11,8 +15,28 @@ export type ArchiveResult =
   | { ok: true; vehicleClass: VehicleClass }
   | { ok: false; error: string; status: number }
 
+export type AvailabilityResult =
+  | { ok: true; vehicleClass: VehicleClass; counts: { total: number; available: number } }
+  | { ok: false; error: string; status: number }
+
 export class VehicleClassService {
-  constructor(private readonly repo: VehicleClassRepository) {}
+  constructor(
+    private readonly repo: VehicleClassRepository,
+    private readonly availabilityRepo?: AvailabilityRepository,
+  ) {}
+
+  async getAvailabilityBySlug(slug: string, from: Date, to: Date): Promise<AvailabilityResult> {
+    const vc = await this.repo.findBySlug(slug)
+    if (!vc) return { ok: false, error: 'Vehicle class not found', status: 404 }
+    if (vc.status === 'ARCHIVED') {
+      return { ok: false, error: 'Vehicle class not found', status: 404 }
+    }
+    if (!this.availabilityRepo) {
+      return { ok: false, error: 'Availability not configured', status: 500 }
+    }
+    const counts = await this.availabilityRepo.countClassAvailability(vc.id, from, to)
+    return { ok: true, vehicleClass: vc, counts }
+  }
 
   async findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]> {
     return this.repo.findAll(filters)

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -22,7 +22,7 @@ export type AvailabilityResult =
 export class VehicleClassService {
   constructor(
     private readonly repo: VehicleClassRepository,
-    private readonly availabilityRepo?: AvailabilityRepository,
+    private readonly availabilityRepo: AvailabilityRepository,
   ) {}
 
   async getAvailabilityBySlug(slug: string, from: Date, to: Date): Promise<AvailabilityResult> {
@@ -30,9 +30,6 @@ export class VehicleClassService {
     if (!vc) return { ok: false, error: 'Vehicle class not found', status: 404 }
     if (vc.status === 'ARCHIVED') {
       return { ok: false, error: 'Vehicle class not found', status: 404 }
-    }
-    if (!this.availabilityRepo) {
-      return { ok: false, error: 'Availability not configured', status: 500 }
     }
     const counts = await this.availabilityRepo.countClassAvailability(vc.id, from, to)
     return { ok: true, vehicleClass: vc, counts }

--- a/packages/api/tests/routes/vehicle-class-ratelimit.test.ts
+++ b/packages/api/tests/routes/vehicle-class-ratelimit.test.ts
@@ -1,0 +1,79 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+
+function createFakeLimiter(limit: number): RateLimitBinding {
+  const counts = new Map<string, number>()
+  return {
+    async limit({ key }) {
+      const next = (counts.get(key) ?? 0) + 1
+      counts.set(key, next)
+      return { success: next <= limit }
+    },
+  }
+}
+
+function buildApp(publicCatalogLimiter?: RateLimitBinding) {
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  return createApp({
+    vehicleRepo,
+    bookingRepo,
+    availabilityRepo,
+    publicCatalogLimiter,
+  })
+}
+
+describe('public catalog rate limiting', () => {
+  it('allows requests under the limit', async () => {
+    const app = buildApp(createFakeLimiter(3))
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request('/vehicle-classes', {
+        headers: { 'cf-connecting-ip': '1.2.3.4' },
+      })
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('returns 429 after exceeding the per-IP limit', async () => {
+    const app = buildApp(createFakeLimiter(2))
+    for (let i = 0; i < 2; i++) {
+      const res = await app.request('/vehicle-classes', {
+        headers: { 'cf-connecting-ip': '9.9.9.9' },
+      })
+      expect(res.status).toBe(200)
+    }
+    const res = await app.request('/vehicle-classes', {
+      headers: { 'cf-connecting-ip': '9.9.9.9' },
+    })
+    expect(res.status).toBe(429)
+  })
+
+  it('isolates buckets by IP', async () => {
+    const app = buildApp(createFakeLimiter(1))
+    const first = await app.request('/vehicle-classes', {
+      headers: { 'cf-connecting-ip': '1.1.1.1' },
+    })
+    expect(first.status).toBe(200)
+    const otherIp = await app.request('/vehicle-classes', {
+      headers: { 'cf-connecting-ip': '2.2.2.2' },
+    })
+    expect(otherIp.status).toBe(200)
+  })
+
+  it('does not rate-limit when binding is absent', async () => {
+    const app = buildApp()
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request('/vehicle-classes', {
+        headers: { 'cf-connecting-ip': '3.3.3.3' },
+      })
+      expect(res.status).toBe(200)
+    }
+  })
+})

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -33,13 +33,18 @@ async function createClass(input = validInput()) {
   })
 }
 
+function makeService(repo: InMemoryVehicleClassRepository) {
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  return new VehicleClassService(repo, new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo))
+}
+
 describe('Vehicle Class CRUD Routes', () => {
   beforeEach(() => {
     const repo = new InMemoryVehicleClassRepository()
-    const service = new VehicleClassService(repo)
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleClassRoutes(service))
+    app.route('/', createVehicleClassRoutes(makeService(repo)))
   })
 
   describe('GET /vehicle-classes', () => {
@@ -212,7 +217,7 @@ describe('Vehicle Class CRUD Routes', () => {
     it('RENTER can GET vehicle classes', async () => {
       const renterApp = new Hono()
       const repo = new InMemoryVehicleClassRepository()
-      const service = new VehicleClassService(repo)
+      const service = makeService(repo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
       renterApp.route('/', createVehicleClassRoutes(service))
       const res = await renterApp.request('/vehicle-classes')
@@ -222,7 +227,7 @@ describe('Vehicle Class CRUD Routes', () => {
     it('RENTER gets 403 on POST', async () => {
       const renterApp = new Hono()
       const repo = new InMemoryVehicleClassRepository()
-      const service = new VehicleClassService(repo)
+      const service = makeService(repo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
       renterApp.route('/', createVehicleClassRoutes(service))
       const res = await renterApp.request('/vehicle-classes', {
@@ -237,7 +242,7 @@ describe('Vehicle Class CRUD Routes', () => {
   describe('Public access (no auth)', () => {
     function publicApp() {
       const repo = new InMemoryVehicleClassRepository()
-      const service = new VehicleClassService(repo)
+      const service = makeService(repo)
       const a = new Hono()
       // Deliberately NO auth middleware — renter catalog must be crawlable.
       a.route('/', createVehicleClassRoutes(service))

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -1,6 +1,13 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { InMemoryVehicleClassRepository } from '../../src/repositories/in-memory'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleClassRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import type { Vehicle } from '../../src/repositories/types'
 import { createVehicleClassRoutes } from '../../src/routes/vehicle-classes'
 import { VehicleClassService } from '../../src/services/vehicle-class'
 import { testAuthMiddleware } from '../helpers/auth'
@@ -224,6 +231,259 @@ describe('Vehicle Class CRUD Routes', () => {
         body: JSON.stringify(validInput()),
       })
       expect(res.status).toBe(403)
+    })
+  })
+
+  describe('Public access (no auth)', () => {
+    function publicApp() {
+      const repo = new InMemoryVehicleClassRepository()
+      const service = new VehicleClassService(repo)
+      const a = new Hono()
+      // Deliberately NO auth middleware — renter catalog must be crawlable.
+      a.route('/', createVehicleClassRoutes(service))
+      return { app: a, service }
+    }
+
+    it('GET /vehicle-classes works unauthenticated', async () => {
+      const { app: a } = publicApp()
+      const res = await a.request('/vehicle-classes')
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data).toEqual([])
+    })
+
+    it('GET /vehicle-classes/by-slug/:slug works unauthenticated', async () => {
+      const { app: a, service } = publicApp()
+      await service.create({
+        name: 'Compact',
+        slug: 'compact',
+        description: null,
+        photos: [],
+        seats: 5,
+        luggageCapacity: 2,
+        transmission: 'AUTO',
+        fuelType: null,
+        dailyRateJpy: 5500,
+        hourlyRateJpy: null,
+        sortOrder: 0,
+        status: 'ACTIVE',
+      })
+      const res = await a.request('/vehicle-classes/by-slug/compact')
+      expect(res.status).toBe(200)
+      const { data } = await res.json()
+      expect(data.slug).toBe('compact')
+    })
+
+    it('POST returns 401 unauthenticated', async () => {
+      const { app: a } = publicApp()
+      const res = await a.request('/vehicle-classes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validInput()),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('PATCH returns 401 unauthenticated', async () => {
+      const { app: a } = publicApp()
+      const res = await a.request('/vehicle-classes/any-id', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'X' }),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('DELETE returns 401 unauthenticated', async () => {
+      const { app: a } = publicApp()
+      const res = await a.request('/vehicle-classes/any-id', { method: 'DELETE' })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('GET /vehicle-classes/by-slug/:slug/availability', () => {
+    let classRepo: InMemoryVehicleClassRepository
+    let vehicleRepo: InMemoryVehicleRepository
+    let bookingRepo: InMemoryBookingRepository
+    let avApp: Hono
+
+    async function makeVehicle(
+      classId: string,
+      overrides: Partial<Vehicle> = {},
+    ): Promise<Vehicle> {
+      return vehicleRepo.create({
+        classId,
+        name: 'Car',
+        description: null,
+        photos: [],
+        seats: 5,
+        transmission: 'AUTO',
+        fuelType: null,
+        licensePlate: null,
+        status: 'AVAILABLE',
+        bufferMinutes: 0,
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+        make: null,
+        model: null,
+        year: null,
+        color: null,
+        dailyRateJpy: 5000,
+        hourlyRateJpy: null,
+        shakenExpiryDate: null,
+        insuranceExpiryDate: null,
+        ...overrides,
+      })
+    }
+
+    beforeEach(async () => {
+      classRepo = new InMemoryVehicleClassRepository()
+      vehicleRepo = new InMemoryVehicleRepository()
+      bookingRepo = new InMemoryBookingRepository()
+      const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+      const service = new VehicleClassService(classRepo, availabilityRepo)
+      avApp = new Hono()
+      avApp.route('/', createVehicleClassRoutes(service))
+      await service.create({
+        name: 'Compact',
+        slug: 'compact',
+        description: null,
+        photos: [],
+        seats: 5,
+        luggageCapacity: 2,
+        transmission: 'AUTO',
+        fuelType: null,
+        dailyRateJpy: 5000,
+        hourlyRateJpy: null,
+        sortOrder: 0,
+        status: 'ACTIVE',
+      })
+    })
+
+    it('returns total=0, available=0 when no vehicles tagged to class', async () => {
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      expect(res.status).toBe(200)
+      const { data } = await res.json()
+      expect(data).toMatchObject({ slug: 'compact', total: 0, available: 0 })
+    })
+
+    it('returns available = total when vehicles are free', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      await makeVehicle(vc.id)
+      await makeVehicle(vc.id)
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 2, available: 2 })
+    })
+
+    it('subtracts vehicles with conflicting CONFIRMED bookings', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      const v1 = await makeVehicle(vc.id)
+      await makeVehicle(vc.id)
+      await bookingRepo.create(SYSTEM_CONTEXT, {
+        renterId: 'u1',
+        vehicleId: v1.id,
+        startAt: new Date('2026-06-01T12:00:00Z'),
+        endAt: new Date('2026-06-01T16:00:00Z'),
+        effectiveEndAt: new Date('2026-06-01T16:00:00Z'),
+        status: 'CONFIRMED',
+        source: 'DIRECT',
+        externalId: null,
+        notes: null,
+        totalPrice: null,
+        cancellationFee: null,
+        cancelledAt: null,
+        idempotencyKey: null,
+      })
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 2, available: 1 })
+    })
+
+    it('MAINTENANCE vehicles count in total but not in available', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      await makeVehicle(vc.id)
+      await makeVehicle(vc.id, { status: 'MAINTENANCE' })
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 2, available: 1 })
+    })
+
+    it('RETIRED vehicles are excluded from both counts', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      await makeVehicle(vc.id)
+      await makeVehicle(vc.id, { status: 'RETIRED' })
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 1, available: 1 })
+    })
+
+    it('ignores vehicles in other classes', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      await makeVehicle(vc.id)
+      await makeVehicle('some-other-class')
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 1, available: 1 })
+    })
+
+    it('CANCELLED bookings do not reduce availability', async () => {
+      const { data: vc } = await (await avApp.request('/vehicle-classes/by-slug/compact')).json()
+      const v1 = await makeVehicle(vc.id)
+      await bookingRepo.create(SYSTEM_CONTEXT, {
+        renterId: 'u1',
+        vehicleId: v1.id,
+        startAt: new Date('2026-06-01T12:00:00Z'),
+        endAt: new Date('2026-06-01T16:00:00Z'),
+        effectiveEndAt: new Date('2026-06-01T16:00:00Z'),
+        status: 'CANCELLED',
+        source: 'DIRECT',
+        externalId: null,
+        notes: null,
+        totalPrice: null,
+        cancellationFee: null,
+        cancelledAt: new Date(),
+        idempotencyKey: null,
+      })
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      const { data } = await res.json()
+      expect(data).toMatchObject({ total: 1, available: 1 })
+    })
+
+    it('returns 404 for unknown slug', async () => {
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/nonexistent/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 400 for missing date range', async () => {
+      const res = await avApp.request('/vehicle-classes/by-slug/compact/availability')
+      expect(res.status).toBe(400)
+    })
+
+    it('is accessible without auth (public endpoint)', async () => {
+      // No auth middleware mounted on avApp → unauthenticated request should succeed.
+      const res = await avApp.request(
+        '/vehicle-classes/by-slug/compact/availability?from=2026-06-01T10:00:00Z&to=2026-06-02T10:00:00Z',
+      )
+      expect(res.status).toBe(200)
     })
   })
 })

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -33,6 +33,14 @@ name = "PHOTO_UPLOAD_USER_LIMITER"
 namespace_id = "1003"
 simple = { limit = 50, period = 60 }
 
+# Public vehicle-class catalog (no auth, scrape-prone). 60 req/min/IP is
+# enough for renter browsing and blunts mass scraping/probing. Stacked on
+# top of RATE_LIMITER (100/60s) — callers hit whichever cap triggers first.
+[[ratelimits]]
+name = "PUBLIC_CATALOG_LIMITER"
+namespace_id = "1004"
+simple = { limit = 60, period = 60 }
+
 # R2 bucket for vehicle photo uploads. Create the bucket manually:
 #   npx wrangler r2 bucket create kuruma-vehicle-photos
 # Enable public access for dev:


### PR DESCRIPTION
## Summary
Closes #309.

- **Public GETs:** `/vehicle-classes`, `/vehicle-classes/by-slug/:slug`, `/vehicle-classes/:id` are now unauthenticated — renter catalog browsing has no login gate.
- **Per-route auth:** POST/PATCH/DELETE still require STAFF via `requireAuth()` attached per handler. Blanket `app.use('/vehicle-classes/*', requireAuth())` removed from `index.ts`.
- **New endpoint:** `GET /vehicle-classes/by-slug/:slug/availability?from=&to=` → `{ classId, slug, total, available }`. `total` = non-RETIRED vehicles in the class; `available` = AVAILABLE vehicles with no CONFIRMED/ACTIVE booking overlap (buffer-aware via `effectiveEndAt`).
- **Stacked rate limit:** `PUBLIC_CATALOG_LIMITER` binding (60/60s per IP) sits on top of the global `RATE_LIMITER`. Scoped to GET so staff writes don't share the public bucket. Graceful skip when the binding is absent.
- **`requireAuth()` idempotency:** no-ops if a user is already in context. Lets tests set a user without full JWT round-trip; auth is a property of the request, not pipeline position.

## Architecture
- `AvailabilityRepository` gains `countClassAvailability(classId, from, to)` — same overlap SQL as `findAvailableVehicles`, just aggregated and filtered by `classId`.
- `VehicleClassService` now takes `AvailabilityRepository` as a required collaborator (post-review: it was optional in the first cut; that hides broken wiring).
- Drizzle impl uses `count(*) filter (where ...)` with a correlated `NOT EXISTS` subquery for booking overlap — single round-trip.

## Test plan
- [x] 35 route tests (full public-access matrix, availability edge cases: no vehicles, MAINTENANCE, RETIRED, other-class, CANCELLED, 404, 400)
- [x] 4 rate-limit tests (happy path, 429, per-IP isolation, graceful skip without binding)
- [x] Full API suite: 400/400 passing
- [x] `tsc --noEmit` clean
- [x] `lint:boundaries` clean

## Follow-ups (separate issues)
- Index on `vehicles.classId` when fleet grows past ~500 (currently seq-scan is faster at 50 rows)
- Edge cache `Cache-Control: public, s-maxage=60` on public catalog GETs — eliminates 95%+ of origin hits at scale
- Consider public/admin sub-app split if vehicle-classes grows a 4th+ mutating verb