### PR TITLE
test(e2e): renter public browse flow with mock API

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,7 +39,10 @@
       ".wrangler",
       "drizzle",
       "bun.lock",
-      "next-env.d.ts"
+      "next-env.d.ts",
+      "test-results",
+      "playwright-report",
+      "blob-report"
     ]
   }
 }

--- a/e2e/browse.spec.ts
+++ b/e2e/browse.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+
+const TEST_VEHICLE_NAME = 'E2E Test Honda N-BOX'
+const TEST_VEHICLE_ID = 'e2e-test-vehicle-1'
+
+test.describe('Renter public browse flow', () => {
+  test('vehicles list renders mocked fleet', async ({ page }) => {
+    await page.goto('/en/vehicles')
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Browse vehicles' })).toBeVisible()
+    await expect(page.getByText(TEST_VEHICLE_NAME)).toBeVisible()
+  })
+
+  test('clicking a vehicle card navigates to detail page', async ({ page }) => {
+    await page.goto('/en/vehicles')
+
+    await page
+      .getByRole('link', { name: new RegExp(TEST_VEHICLE_NAME) })
+      .first()
+      .click()
+
+    await expect(page).toHaveURL(new RegExp(`/vehicles/${TEST_VEHICLE_ID}$`))
+    await expect(page.getByRole('heading', { level: 1, name: TEST_VEHICLE_NAME })).toBeVisible()
+  })
+
+  test('detail page surfaces the book CTA', async ({ page }) => {
+    await page.goto(`/en/vehicles/${TEST_VEHICLE_ID}`)
+
+    await expect(page.getByRole('link', { name: 'Book this car' })).toBeVisible()
+  })
+})

--- a/e2e/browse.spec.ts
+++ b/e2e/browse.spec.ts
@@ -4,11 +4,16 @@ const TEST_VEHICLE_NAME = 'E2E Test Honda N-BOX'
 const TEST_VEHICLE_ID = 'e2e-test-vehicle-1'
 
 test.describe('Renter public browse flow', () => {
-  test('vehicles list renders mocked fleet', async ({ page }) => {
+  test('vehicles list renders mocked fleet with correct card link', async ({ page }) => {
     await page.goto('/en/vehicles')
 
     await expect(page.getByRole('heading', { level: 1, name: 'Browse vehicles' })).toBeVisible()
-    await expect(page.getByText(TEST_VEHICLE_NAME)).toBeVisible()
+
+    // Card link — only the correct render path produces a link whose href
+    // matches the detail route for this specific vehicle ID.
+    const cards = page.getByRole('link', { name: new RegExp(TEST_VEHICLE_NAME) })
+    await expect(cards).toHaveCount(1)
+    await expect(cards.first()).toHaveAttribute('href', new RegExp(`/vehicles/${TEST_VEHICLE_ID}$`))
   })
 
   test('clicking a vehicle card navigates to detail page', async ({ page }) => {
@@ -23,9 +28,17 @@ test.describe('Renter public browse flow', () => {
     await expect(page.getByRole('heading', { level: 1, name: TEST_VEHICLE_NAME })).toBeVisible()
   })
 
-  test('detail page surfaces the book CTA', async ({ page }) => {
+  test('detail page surfaces the book CTA with correct href', async ({ page }) => {
     await page.goto(`/en/vehicles/${TEST_VEHICLE_ID}`)
 
-    await expect(page.getByRole('link', { name: 'Book this car' })).toBeVisible()
+    // CTA must route to the booking flow for THIS vehicle — a naive
+    // toBeVisible() would pass even if the link pointed to the wrong ID
+    // or to a dead route.
+    const cta = page.getByRole('link', { name: 'Book this car' })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute(
+      'href',
+      new RegExp(`/bookings/new\\?vehicleId=${TEST_VEHICLE_ID}$`),
+    )
   })
 })

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -3,6 +3,9 @@
 // decoupled from Postgres + wrangler dev; real-DB coverage lives in the
 // integration suite.
 
+const MOCK_PORT = Number(process.env.MOCK_API_PORT ?? 8787)
+const FROZEN_TIMESTAMP = '2026-01-01T00:00:00.000Z'
+
 const TEST_VEHICLE = {
   id: 'e2e-test-vehicle-1',
   classId: null,
@@ -26,24 +29,31 @@ const TEST_VEHICLE = {
   hourlyRateJpy: null,
   shakenExpiryDate: null,
   insuranceExpiryDate: null,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
+  createdAt: FROZEN_TIMESTAMP,
+  updatedAt: FROZEN_TIMESTAMP,
 }
 
 const ok = (data: unknown) => Response.json({ success: true, data })
+const fail = (error: string, status: number) => Response.json({ success: false, error }, { status })
 
 Bun.serve({
-  port: 8787,
+  port: MOCK_PORT,
   fetch(req) {
     const url = new URL(req.url)
 
     if (url.pathname === '/vehicles') return ok([TEST_VEHICLE])
-    if (url.pathname === '/availability') return ok([TEST_VEHICLE])
+
+    // Mirror real contract: /availability requires from + to date range.
+    // See packages/api/src/routes/availability.ts — parseDateRange(c, true).
+    if (url.pathname === '/availability') {
+      const from = url.searchParams.get('from')
+      const to = url.searchParams.get('to')
+      if (!from || !to) return fail('from and to query parameters required', 400)
+      return ok([TEST_VEHICLE])
+    }
+
     if (url.pathname === `/vehicles/${TEST_VEHICLE.id}`) return ok(TEST_VEHICLE)
 
-    return Response.json({ success: false, error: 'Not found' }, { status: 404 })
+    return fail('Not found', 404)
   },
 })
-
-// biome-ignore lint/suspicious/noConsole: mock server startup log
-console.log('mock API listening on :8787')

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -1,0 +1,49 @@
+// Minimal mock API for Playwright E2E. Returns fixture data for the vehicle
+// endpoints that the renter public browse flow hits server-side. Keeps E2E
+// decoupled from Postgres + wrangler dev; real-DB coverage lives in the
+// integration suite.
+
+const TEST_VEHICLE = {
+  id: 'e2e-test-vehicle-1',
+  classId: null,
+  name: 'E2E Test Honda N-BOX',
+  description: 'Compact kei car used by the Playwright browse-flow spec.',
+  photos: ['https://images.unsplash.com/photo-1734857039653-c1b0a4b3422a?w=600&q=80'],
+  seats: 4,
+  transmission: 'AUTO',
+  fuelType: 'Petrol',
+  licensePlate: null,
+  status: 'AVAILABLE',
+  bufferMinutes: 60,
+  minRentalHours: null,
+  maxRentalHours: null,
+  advanceBookingHours: null,
+  make: 'Honda',
+  model: 'N-BOX',
+  year: 2024,
+  color: 'White',
+  dailyRateJpy: 5000,
+  hourlyRateJpy: null,
+  shakenExpiryDate: null,
+  insuranceExpiryDate: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const ok = (data: unknown) => Response.json({ success: true, data })
+
+Bun.serve({
+  port: 8787,
+  fetch(req) {
+    const url = new URL(req.url)
+
+    if (url.pathname === '/vehicles') return ok([TEST_VEHICLE])
+    if (url.pathname === '/availability') return ok([TEST_VEHICLE])
+    if (url.pathname === `/vehicles/${TEST_VEHICLE.id}`) return ok(TEST_VEHICLE)
+
+    return Response.json({ success: false, error: 'Not found' }, { status: 404 })
+  },
+})
+
+// biome-ignore lint/suspicious/noConsole: mock server startup log
+console.log('mock API listening on :8787')

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from '@playwright/test'
 
 const PORT = 3001
 const BASE_URL = `http://localhost:${PORT}`
+const MOCK_API_PORT = 8787
+const MOCK_API_URL = `http://localhost:${MOCK_API_PORT}`
 
 export default defineConfig({
   testDir: './e2e',
@@ -27,9 +29,10 @@ export default defineConfig({
   webServer: [
     {
       command: 'bun run e2e/mock-api.ts',
-      url: 'http://localhost:8787/vehicles',
+      url: `${MOCK_API_URL}/vehicles`,
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
+      env: { MOCK_API_PORT: String(MOCK_API_PORT) },
     },
     {
       command: 'bun run --filter @kuruma/web dev',
@@ -42,7 +45,7 @@ export default defineConfig({
         // and will crash on empty values even if the DB is never queried.
         AUTH_SECRET: 'e2e-placeholder-secret-not-real',
         DATABASE_URL: 'postgresql://e2e:e2e@localhost:5432/e2e?connect_timeout=1',
-        NEXT_PUBLIC_API_URL: 'http://localhost:8787',
+        NEXT_PUBLIC_API_URL: MOCK_API_URL,
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,10 +24,26 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    command: 'bun run --filter @kuruma/web dev',
-    url: BASE_URL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: [
+    {
+      command: 'bun run e2e/mock-api.ts',
+      url: 'http://localhost:8787/vehicles',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: 'bun run --filter @kuruma/web dev',
+      url: BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        // Valid-format placeholders — the E2E spec routes hit the mock API,
+        // not the real DB. Middleware's auth() import chain touches neon()
+        // and will crash on empty values even if the DB is never queried.
+        AUTH_SECRET: 'e2e-placeholder-secret-not-real',
+        DATABASE_URL: 'postgresql://e2e:e2e@localhost:5432/e2e?connect_timeout=1',
+        NEXT_PUBLIC_API_URL: 'http://localhost:8787',
+      },
+    },
+  ],
 })


### PR DESCRIPTION
## Summary

Closes #315. Extends the Phase 1 Playwright scaffold (#294) to cover the renter public journey — vehicles list → detail page → book CTA. Three tests in \`e2e/browse.spec.ts\`.

Decoupled from Postgres + wrangler dev via a Bun-based mock API on 8787 returning fixture JSON for the 3 SSR endpoints.

## Review fixes (in-session code-reviewer pass)

- **Mock drift**: \`/availability\` now rejects missing \`from\`/\`to\` (mirrors \`parseDateRange(c, true)\` in the real route)
- **Mutation-resistant assertions**: list card link points to \`/vehicles/:id\`, detail book CTA points to \`/bookings/new?vehicleId=:id\`, exactly-1 card count. No more bare \`.toBeVisible()\` checks.
- **Deterministic fixtures**: frozen \`FROZEN_TIMESTAMP\` replaces \`new Date()\`
- **Port consolidation**: single \`MOCK_API_PORT\` const, no more hardcoded 8787 in 3 places
- **Biome ignores Playwright output dirs**

## Verification

- [x] \`bun run test:e2e\` — 5/5 pass locally (landing + browse)
- [x] \`bun run lint\` clean (pre-existing ManualBookingDialog size warning is out of scope)
- [x] \`bun run --filter '*' typecheck\` clean
- [ ] CI \`e2e\` job passes

## Out of scope (future issues)

- OAuth sign-in E2E — needs test-mode credentials
- Booking lifecycle + cancellation tier fees E2E — needs real-DB track
- Owner flows + double-booking exclusion-constraint E2E — needs real-DB track

## Notes

The DB placeholder env vars in \`playwright.config.ts\` are required because the web middleware's auth() import chain touches \`neon()\` and crashes on empty strings even when the real DB is never queried. Not a leak — obvious placeholders.