### PR TITLE
refactor(web): manual-booking cleanup — typed client, split dialog, debounce, error logs

### DIFF
--- a/packages/web/src/components/calendar/BookingSlotPicker.tsx
+++ b/packages/web/src/components/calendar/BookingSlotPicker.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import { useTranslations } from 'next-intl'
+
+export interface BookingSlotPickerValue {
+  vehicleId: string
+  startAt: string
+  endAt: string
+  notes: string
+}
+
+export const INITIAL_BOOKING_SLOT_PICKER_VALUE: BookingSlotPickerValue = {
+  vehicleId: '',
+  startAt: '',
+  endAt: '',
+  notes: '',
+}
+
+interface BookingSlotPickerProps {
+  readonly value: BookingSlotPickerValue
+  readonly onChange: (next: BookingSlotPickerValue) => void
+  readonly vehicles: readonly FleetVehicleOverviewData[]
+  // Rendered below the date inputs when the selected vehicle is unavailable
+  // for the chosen window. Parent owns the check (it's time-sensitive).
+  readonly availabilityError: string | null
+}
+
+export function BookingSlotPicker({
+  value,
+  onChange,
+  vehicles,
+  availabilityError,
+}: BookingSlotPickerProps) {
+  const t = useTranslations('business.bookings.manualBooking')
+  const availableVehicles = vehicles.filter((v) => v.status === 'AVAILABLE')
+
+  const patch = (p: Partial<BookingSlotPickerValue>) => onChange({ ...value, ...p })
+
+  return (
+    <fieldset className="grid gap-3">
+      <legend className="text-sm font-medium mb-1">{t('bookingDetails')}</legend>
+
+      <div>
+        <Label htmlFor="mb-vehicle">{t('vehicle')}</Label>
+        <select
+          id="mb-vehicle"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          value={value.vehicleId}
+          onChange={(e) => patch({ vehicleId: e.target.value })}
+        >
+          <option value="">{t('selectVehicle')}</option>
+          {availableVehicles.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.name} {v.licensePlate ? `(${v.licensePlate})` : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label htmlFor="mb-start">{t('startAt')}</Label>
+          <Input
+            id="mb-start"
+            type="datetime-local"
+            value={value.startAt}
+            onChange={(e) => patch({ startAt: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="mb-end">{t('endAt')}</Label>
+          <Input
+            id="mb-end"
+            type="datetime-local"
+            value={value.endAt}
+            onChange={(e) => patch({ endAt: e.target.value })}
+          />
+        </div>
+      </div>
+
+      {availabilityError && <p className="text-sm text-destructive">{availabilityError}</p>}
+
+      <div>
+        <Label htmlFor="mb-notes">{t('notes')}</Label>
+        <Textarea
+          id="mb-notes"
+          value={value.notes}
+          onChange={(e) => patch({ notes: e.target.value })}
+          placeholder={t('notesPlaceholder')}
+          rows={2}
+        />
+      </div>
+    </fieldset>
+  )
+}

--- a/packages/web/src/components/calendar/CustomerPicker.tsx
+++ b/packages/web/src/components/calendar/CustomerPicker.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useTranslations } from 'next-intl'
+
+export interface CustomerResult {
+  id: string
+  name: string | null
+  email: string | null
+  phone: string | null
+  language: string
+}
+
+export interface CustomerPickerValue {
+  mode: 'search' | 'create'
+  searchQuery: string
+  selectedCustomer: CustomerResult | null
+  newDraft: {
+    name: string
+    email: string
+    phone: string
+    language: string
+  }
+}
+
+export const INITIAL_CUSTOMER_PICKER_VALUE: CustomerPickerValue = {
+  mode: 'search',
+  searchQuery: '',
+  selectedCustomer: null,
+  newDraft: { name: '', email: '', phone: '', language: 'en' },
+}
+
+interface CustomerPickerProps {
+  readonly value: CustomerPickerValue
+  readonly onChange: (next: CustomerPickerValue) => void
+  // Parent owns the debounced search so side-effect timing is orchestrated
+  // in one place (ManualBookingDialog). This component is presentation-only.
+  readonly onSearchQueryChange: (query: string) => void
+  readonly searchResults: readonly CustomerResult[]
+  readonly isSearching: boolean
+}
+
+export function CustomerPicker({
+  value,
+  onChange,
+  onSearchQueryChange,
+  searchResults,
+  isSearching,
+}: CustomerPickerProps) {
+  const t = useTranslations('business.bookings.manualBooking')
+
+  const setMode = (mode: 'search' | 'create') => onChange({ ...value, mode })
+
+  const pickExisting = (customer: CustomerResult) =>
+    onChange({ ...value, selectedCustomer: customer })
+
+  const clearExisting = () => onChange({ ...value, selectedCustomer: null, searchQuery: '' })
+
+  const setDraft = (patch: Partial<CustomerPickerValue['newDraft']>) =>
+    onChange({ ...value, newDraft: { ...value.newDraft, ...patch } })
+
+  return (
+    <fieldset className="grid gap-3">
+      <legend className="text-sm font-medium mb-1">{t('customer')}</legend>
+
+      <div className="flex gap-2">
+        <Button
+          variant={value.mode === 'search' ? 'default' : 'outline'}
+          size="sm"
+          type="button"
+          onClick={() => setMode('search')}
+        >
+          {t('searchExisting')}
+        </Button>
+        <Button
+          variant={value.mode === 'create' ? 'default' : 'outline'}
+          size="sm"
+          type="button"
+          onClick={() => setMode('create')}
+        >
+          {t('createNew')}
+        </Button>
+      </div>
+
+      {value.mode === 'search' && (
+        <div className="grid gap-2">
+          <Input
+            placeholder={t('searchPlaceholder')}
+            value={value.searchQuery}
+            onChange={(e) => onSearchQueryChange(e.target.value)}
+          />
+          {isSearching && <p className="text-xs text-muted-foreground">{t('searching')}</p>}
+          {searchResults.length > 0 && !value.selectedCustomer && (
+            <ul className="border rounded-md max-h-32 overflow-y-auto">
+              {searchResults.map((c) => (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    className="w-full text-left px-3 py-2 hover:bg-accent text-sm"
+                    onClick={() => pickExisting(c)}
+                  >
+                    <span className="font-medium">{c.name ?? c.email ?? c.phone}</span>
+                    {c.name && (
+                      <span className="text-muted-foreground ml-2">{c.email ?? c.phone}</span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {value.selectedCustomer && (
+            <div className="flex items-center justify-between bg-accent/50 rounded-md px-3 py-2 text-sm">
+              <span>
+                {value.selectedCustomer.name ??
+                  value.selectedCustomer.email ??
+                  value.selectedCustomer.phone}
+                {value.selectedCustomer.name && (
+                  <span className="text-muted-foreground ml-2">
+                    {value.selectedCustomer.email ?? value.selectedCustomer.phone}
+                  </span>
+                )}
+              </span>
+              <Button variant="ghost" size="xs" onClick={clearExisting}>
+                {t('change')}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {value.mode === 'create' && (
+        <div className="grid gap-2">
+          <div>
+            <Label htmlFor="mb-name">{t('name')}</Label>
+            <Input
+              id="mb-name"
+              value={value.newDraft.name}
+              onChange={(e) => setDraft({ name: e.target.value })}
+              placeholder={t('namePlaceholder')}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label htmlFor="mb-email">{t('email')}</Label>
+              <Input
+                id="mb-email"
+                type="email"
+                value={value.newDraft.email}
+                onChange={(e) => setDraft({ email: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="mb-phone">{t('phone')}</Label>
+              <Input
+                id="mb-phone"
+                type="tel"
+                value={value.newDraft.phone}
+                onChange={(e) => setDraft({ phone: e.target.value })}
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="mb-lang">{t('language')}</Label>
+            <select
+              id="mb-lang"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={value.newDraft.language}
+              onChange={(e) => setDraft({ language: e.target.value })}
+            >
+              <option value="en">English</option>
+              <option value="ja">Japanese</option>
+              <option value="zh">Chinese</option>
+            </select>
+          </div>
+        </div>
+      )}
+    </fieldset>
+  )
+}

--- a/packages/web/src/components/calendar/ManualBookingDialog.tsx
+++ b/packages/web/src/components/calendar/ManualBookingDialog.tsx
@@ -9,13 +9,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-// Native <select> used for vehicle/language pickers — simpler than base-ui Select for this use case
-import { Textarea } from '@/components/ui/textarea'
 import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
 import { useTranslations } from 'next-intl'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  BookingSlotPicker,
+  type BookingSlotPickerValue,
+  INITIAL_BOOKING_SLOT_PICKER_VALUE,
+} from './BookingSlotPicker'
+import {
+  CustomerPicker,
+  type CustomerPickerValue,
+  type CustomerResult,
+  INITIAL_CUSTOMER_PICKER_VALUE,
+} from './CustomerPicker'
 import {
   checkAvailability,
   createManualBooking,
@@ -32,12 +39,41 @@ interface ManualBookingDialogProps {
   readonly defaultStartAt?: string | undefined
 }
 
-interface CustomerResult {
-  id: string
-  name: string | null
-  email: string | null
-  phone: string | null
-  language: string
+const SEARCH_DEBOUNCE_MS = 300
+const AVAILABILITY_DEBOUNCE_MS = 400
+
+// Resolve either an existing selected customer or a just-created one to a
+// renterId. Separated from React handlers so the submit flow stays flat —
+// validate, resolve, POST, done.
+async function resolveRenterId(
+  customer: CustomerPickerValue,
+  labels: {
+    selectCustomer: string
+    nameRequired: string
+    contactRequired: string
+  },
+): Promise<{ ok: true; renterId: string } | { ok: false; error: string }> {
+  if (customer.mode === 'search') {
+    if (!customer.selectedCustomer) return { ok: false, error: labels.selectCustomer }
+    return { ok: true, renterId: customer.selectedCustomer.id }
+  }
+
+  const draft = customer.newDraft
+  if (!draft.name.trim()) return { ok: false, error: labels.nameRequired }
+  if (!draft.email.trim() && !draft.phone.trim()) {
+    return { ok: false, error: labels.contactRequired }
+  }
+
+  const input: { name: string; email?: string; phone?: string; language?: string } = {
+    name: draft.name.trim(),
+    language: draft.language,
+  }
+  if (draft.email.trim()) input.email = draft.email.trim()
+  if (draft.phone.trim()) input.phone = draft.phone.trim()
+
+  const result = await quickCreateCustomer(input)
+  if (!result.success) return { ok: false, error: result.error }
+  return { ok: true, renterId: result.data.id }
 }
 
 export function ManualBookingDialog({
@@ -50,146 +86,107 @@ export function ManualBookingDialog({
 }: ManualBookingDialogProps) {
   const t = useTranslations('business.bookings.manualBooking')
 
-  // Customer state
-  const [customerMode, setCustomerMode] = useState<'search' | 'create'>('search')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [searchResults, setSearchResults] = useState<CustomerResult[]>([])
-  const [selectedCustomer, setSelectedCustomer] = useState<CustomerResult | null>(null)
+  const [customer, setCustomer] = useState<CustomerPickerValue>(INITIAL_CUSTOMER_PICKER_VALUE)
+  const [slot, setSlot] = useState<BookingSlotPickerValue>(INITIAL_BOOKING_SLOT_PICKER_VALUE)
+
+  const [searchResults, setSearchResults] = useState<readonly CustomerResult[]>([])
   const [isSearching, setIsSearching] = useState(false)
-  const [newName, setNewName] = useState('')
-  const [newEmail, setNewEmail] = useState('')
-  const [newPhone, setNewPhone] = useState('')
-  const [newLanguage, setNewLanguage] = useState('en')
-
-  // Booking state
-  const [vehicleId, setVehicleId] = useState(defaultVehicleId ?? '')
-  const [startAt, setStartAt] = useState(defaultStartAt ?? '')
-  const [endAt, setEndAt] = useState('')
-  const [notes, setNotes] = useState('')
-
-  // UI state
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [availabilityError, setAvailabilityError] = useState<string | null>(null)
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Tracks the most recent search request. Responses with an older seq are
-  // discarded so a slower earlier-fired request can't clobber a later one.
-  const searchSeqRef = useRef(0)
 
-  // Clear any pending timeout on unmount so late-resolving fetches don't
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const availabilityTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Sequence tokens: responses from a stale request are ignored. Prevents a
+  // slow early fetch from clobbering a newer query after the user keeps typing.
+  const searchSeqRef = useRef(0)
+  const availabilitySeqRef = useRef(0)
+
+  // Cancel any outstanding timers on unmount so late resolutions don't
   // setState on a torn-down component.
   useEffect(() => {
     return () => {
       if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current)
+      if (availabilityTimeoutRef.current) clearTimeout(availabilityTimeoutRef.current)
       searchSeqRef.current += 1
+      availabilitySeqRef.current += 1
     }
   }, [])
 
-  // Reset on open/close
+  // Reset on open so stale state from a prior session doesn't leak in.
   useEffect(() => {
-    if (open) {
-      setCustomerMode('search')
-      setSearchQuery('')
-      setSearchResults([])
-      setSelectedCustomer(null)
-      setNewName('')
-      setNewEmail('')
-      setNewPhone('')
-      setNewLanguage('en')
-      setVehicleId(defaultVehicleId ?? '')
-      setStartAt(defaultStartAt ?? '')
-      setEndAt('')
-      setNotes('')
-      setError(null)
-      setAvailabilityError(null)
-    }
+    if (!open) return
+    setCustomer(INITIAL_CUSTOMER_PICKER_VALUE)
+    setSlot({
+      ...INITIAL_BOOKING_SLOT_PICKER_VALUE,
+      vehicleId: defaultVehicleId ?? '',
+      startAt: defaultStartAt ?? '',
+    })
+    setSearchResults([])
+    setError(null)
+    setAvailabilityError(null)
   }, [open, defaultVehicleId, defaultStartAt])
 
-  // Debounced customer search with sequence-based response ordering.
-  const handleSearchChange = useCallback((value: string) => {
-    setSearchQuery(value)
-    setSelectedCustomer(null)
+  const handleSearchQueryChange = useCallback((query: string) => {
+    // Clear the selected customer mid-typing — the user is looking for someone else.
+    setCustomer((c) => ({ ...c, searchQuery: query, selectedCustomer: null }))
+
     if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current)
-    if (value.length < 2) {
+    if (query.length < 2) {
       setSearchResults([])
       return
     }
+
     searchTimeoutRef.current = setTimeout(async () => {
       const seq = ++searchSeqRef.current
       setIsSearching(true)
-      const result = await searchCustomers(value)
-      // Drop responses from superseded requests (stale query) or unmount.
+      const result = await searchCustomers(query)
       if (seq !== searchSeqRef.current) return
       if (result.success) setSearchResults(result.data)
       setIsSearching(false)
-    }, 300)
+    }, SEARCH_DEBOUNCE_MS)
   }, [])
 
-  // Availability check when vehicle + dates change
+  // Debounced availability check. Fires whenever vehicle + both dates are set;
+  // drops stale responses via the sequence token. Empty/invalid states clear
+  // the warning immediately (no waiting for a debounced success).
   useEffect(() => {
+    const { vehicleId, startAt, endAt } = slot
     if (!vehicleId || !startAt || !endAt) {
       setAvailabilityError(null)
       return
     }
-    let cancelled = false
-    const check = async () => {
+
+    if (availabilityTimeoutRef.current) clearTimeout(availabilityTimeoutRef.current)
+    availabilityTimeoutRef.current = setTimeout(async () => {
+      const seq = ++availabilitySeqRef.current
       const result = await checkAvailability(vehicleId, startAt, endAt)
-      if (cancelled) return
+      if (seq !== availabilitySeqRef.current) return
       if (result.success && !result.data.available) {
         setAvailabilityError(t('vehicleUnavailable'))
       } else {
         setAvailabilityError(null)
       }
-    }
-    check()
-    return () => {
-      cancelled = true
-    }
-  }, [vehicleId, startAt, endAt, t])
+    }, AVAILABILITY_DEBOUNCE_MS)
+  }, [slot, t])
 
   async function handleSubmit() {
     setError(null)
     setIsSubmitting(true)
 
     try {
-      let renterId: string
-
-      if (customerMode === 'search') {
-        if (!selectedCustomer) {
-          setError(t('selectCustomer'))
-          setIsSubmitting(false)
-          return
-        }
-        renterId = selectedCustomer.id
-      } else {
-        if (!newName.trim()) {
-          setError(t('nameRequired'))
-          setIsSubmitting(false)
-          return
-        }
-        if (!newEmail.trim() && !newPhone.trim()) {
-          setError(t('contactRequired'))
-          setIsSubmitting(false)
-          return
-        }
-        const customerInput: { name: string; email?: string; phone?: string; language?: string } = {
-          name: newName.trim(),
-          language: newLanguage,
-        }
-        if (newEmail.trim()) customerInput.email = newEmail.trim()
-        if (newPhone.trim()) customerInput.phone = newPhone.trim()
-        const createResult = await quickCreateCustomer(customerInput)
-        if (!createResult.success) {
-          setError(createResult.error)
-          setIsSubmitting(false)
-          return
-        }
-        renterId = createResult.data.id
+      const resolved = await resolveRenterId(customer, {
+        selectCustomer: t('selectCustomer'),
+        nameRequired: t('nameRequired'),
+        contactRequired: t('contactRequired'),
+      })
+      if (!resolved.ok) {
+        setError(resolved.error)
+        return
       }
 
-      if (!vehicleId || !startAt || !endAt) {
+      if (!slot.vehicleId || !slot.startAt || !slot.endAt) {
         setError(t('fillAllFields'))
-        setIsSubmitting(false)
         return
       }
 
@@ -200,30 +197,28 @@ export function ManualBookingDialog({
         endAt: string
         notes?: string
       } = {
-        vehicleId,
-        renterId,
-        startAt: new Date(startAt).toISOString(),
-        endAt: new Date(endAt).toISOString(),
+        vehicleId: slot.vehicleId,
+        renterId: resolved.renterId,
+        startAt: new Date(slot.startAt).toISOString(),
+        endAt: new Date(slot.endAt).toISOString(),
       }
-      if (notes.trim()) bookingInput.notes = notes.trim()
-      const result = await createManualBooking(bookingInput)
+      if (slot.notes.trim()) bookingInput.notes = slot.notes.trim()
 
+      const result = await createManualBooking(bookingInput)
       if (!result.success) {
         setError(result.error)
-        setIsSubmitting(false)
         return
       }
 
       onBookingCreated()
       onClose()
-    } catch {
+    } catch (err) {
+      console.error(err)
       setError(t('unexpectedError'))
     } finally {
       setIsSubmitting(false)
     }
   }
-
-  const availableVehicles = vehicles.filter((v) => v.status === 'AVAILABLE')
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -234,186 +229,19 @@ export function ManualBookingDialog({
         </DialogHeader>
 
         <div className="grid gap-4">
-          {/* Customer Section */}
-          <fieldset className="grid gap-3">
-            <legend className="text-sm font-medium mb-1">{t('customer')}</legend>
-
-            <div className="flex gap-2">
-              <Button
-                variant={customerMode === 'search' ? 'default' : 'outline'}
-                size="sm"
-                type="button"
-                onClick={() => setCustomerMode('search')}
-              >
-                {t('searchExisting')}
-              </Button>
-              <Button
-                variant={customerMode === 'create' ? 'default' : 'outline'}
-                size="sm"
-                type="button"
-                onClick={() => setCustomerMode('create')}
-              >
-                {t('createNew')}
-              </Button>
-            </div>
-
-            {customerMode === 'search' && (
-              <div className="grid gap-2">
-                <Input
-                  placeholder={t('searchPlaceholder')}
-                  value={searchQuery}
-                  onChange={(e) => handleSearchChange(e.target.value)}
-                />
-                {isSearching && <p className="text-xs text-muted-foreground">{t('searching')}</p>}
-                {searchResults.length > 0 && !selectedCustomer && (
-                  <ul className="border rounded-md max-h-32 overflow-y-auto">
-                    {searchResults.map((c) => (
-                      <li key={c.id}>
-                        <button
-                          type="button"
-                          className="w-full text-left px-3 py-2 hover:bg-accent text-sm"
-                          onClick={() => {
-                            setSelectedCustomer(c)
-                            setSearchResults([])
-                          }}
-                        >
-                          <span className="font-medium">{c.name ?? c.email ?? c.phone}</span>
-                          {c.name && (
-                            <span className="text-muted-foreground ml-2">{c.email ?? c.phone}</span>
-                          )}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-                {selectedCustomer && (
-                  <div className="flex items-center justify-between bg-accent/50 rounded-md px-3 py-2 text-sm">
-                    <span>
-                      {selectedCustomer.name ?? selectedCustomer.email ?? selectedCustomer.phone}
-                      {selectedCustomer.name && (
-                        <span className="text-muted-foreground ml-2">
-                          {selectedCustomer.email ?? selectedCustomer.phone}
-                        </span>
-                      )}
-                    </span>
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      onClick={() => {
-                        setSelectedCustomer(null)
-                        setSearchQuery('')
-                      }}
-                    >
-                      {t('change')}
-                    </Button>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {customerMode === 'create' && (
-              <div className="grid gap-2">
-                <div>
-                  <Label htmlFor="mb-name">{t('name')}</Label>
-                  <Input
-                    id="mb-name"
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    placeholder={t('namePlaceholder')}
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-2">
-                  <div>
-                    <Label htmlFor="mb-email">{t('email')}</Label>
-                    <Input
-                      id="mb-email"
-                      type="email"
-                      value={newEmail}
-                      onChange={(e) => setNewEmail(e.target.value)}
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="mb-phone">{t('phone')}</Label>
-                    <Input
-                      id="mb-phone"
-                      type="tel"
-                      value={newPhone}
-                      onChange={(e) => setNewPhone(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div>
-                  <Label htmlFor="mb-lang">{t('language')}</Label>
-                  <select
-                    id="mb-lang"
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    value={newLanguage}
-                    onChange={(e) => setNewLanguage(e.target.value)}
-                  >
-                    <option value="en">English</option>
-                    <option value="ja">Japanese</option>
-                    <option value="zh">Chinese</option>
-                  </select>
-                </div>
-              </div>
-            )}
-          </fieldset>
-
-          {/* Booking Section */}
-          <fieldset className="grid gap-3">
-            <legend className="text-sm font-medium mb-1">{t('bookingDetails')}</legend>
-
-            <div>
-              <Label htmlFor="mb-vehicle">{t('vehicle')}</Label>
-              <select
-                id="mb-vehicle"
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                value={vehicleId}
-                onChange={(e) => setVehicleId(e.target.value)}
-              >
-                <option value="">{t('selectVehicle')}</option>
-                {availableVehicles.map((v) => (
-                  <option key={v.id} value={v.id}>
-                    {v.name} {v.licensePlate ? `(${v.licensePlate})` : ''}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <Label htmlFor="mb-start">{t('startAt')}</Label>
-                <Input
-                  id="mb-start"
-                  type="datetime-local"
-                  value={startAt}
-                  onChange={(e) => setStartAt(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label htmlFor="mb-end">{t('endAt')}</Label>
-                <Input
-                  id="mb-end"
-                  type="datetime-local"
-                  value={endAt}
-                  onChange={(e) => setEndAt(e.target.value)}
-                />
-              </div>
-            </div>
-
-            {availabilityError && <p className="text-sm text-destructive">{availabilityError}</p>}
-
-            <div>
-              <Label htmlFor="mb-notes">{t('notes')}</Label>
-              <Textarea
-                id="mb-notes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                placeholder={t('notesPlaceholder')}
-                rows={2}
-              />
-            </div>
-          </fieldset>
+          <CustomerPicker
+            value={customer}
+            onChange={setCustomer}
+            onSearchQueryChange={handleSearchQueryChange}
+            searchResults={searchResults}
+            isSearching={isSearching}
+          />
+          <BookingSlotPicker
+            value={slot}
+            onChange={setSlot}
+            vehicles={vehicles}
+            availabilityError={availabilityError}
+          />
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}

--- a/packages/web/src/components/calendar/manual-booking-actions.ts
+++ b/packages/web/src/components/calendar/manual-booking-actions.ts
@@ -14,6 +14,14 @@ interface CustomerData {
   language: string
 }
 
+// Generic caught-error handler. Logs for Cloudflare Worker traces (so
+// real failures aren't silently mapped to "Network error") then returns
+// the user-facing message. Caller decides the string.
+function handleCaught(err: unknown, fallback: string): { success: false; error: string } {
+  console.error(err)
+  return { success: false, error: fallback }
+}
+
 export async function searchCustomers(query: string): Promise<ActionResult<CustomerData[]>> {
   const token = await getApiToken()
   if (!token) return { success: false, error: 'Authentication required' }
@@ -24,8 +32,8 @@ export async function searchCustomers(query: string): Promise<ActionResult<Custo
     const body = (await res.json()) as ApiResponse<CustomerData[]>
     if (!body.success) return { success: false, error: body.error ?? 'Search failed' }
     return { success: true, data: body.data }
-  } catch {
-    return { success: false, error: 'Network error' }
+  } catch (err) {
+    return handleCaught(err, 'Network error')
   }
 }
 
@@ -40,20 +48,12 @@ export async function quickCreateCustomer(input: {
 
   try {
     const client = createApiClient(token)
-    const url = client.customers['quick-create'].$url()
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(input),
-    })
+    const res = await client.customers['quick-create'].$post({ json: input })
     const body = (await res.json()) as ApiResponse<CustomerData>
     if (!body.success) return { success: false, error: body.error ?? 'Create failed' }
     return { success: true, data: body.data }
-  } catch {
-    return { success: false, error: 'Network error' }
+  } catch (err) {
+    return handleCaught(err, 'Network error')
   }
 }
 
@@ -83,11 +83,14 @@ export async function createManualBooking(input: {
     const body = (await res.json()) as ApiResponse<{ id: string }>
     if (!body.success) return { success: false, error: body.error ?? 'Booking failed' }
     return { success: true, data: body.data }
-  } catch {
-    return { success: false, error: 'Network error' }
+  } catch (err) {
+    return handleCaught(err, 'Network error')
   }
 }
 
+// Availability stays on raw fetch because the API route reads `from`/`to`
+// via c.req.query() directly (no zValidator), so the typed Hono client
+// doesn't carry them. URL construction is still type-safe via $url().
 export async function checkAvailability(
   vehicleId: string,
   from: string,
@@ -107,7 +110,7 @@ export async function checkAvailability(
     const body = (await res.json()) as ApiResponse<{ available: boolean }>
     if (!body.success) return { success: false, error: body.error ?? 'Check failed' }
     return { success: true, data: body.data }
-  } catch {
-    return { success: false, error: 'Network error' }
+  } catch (err) {
+    return handleCaught(err, 'Network error')
   }
 }


### PR DESCRIPTION
## Summary

Follow-ups from the PR #283 code review. Three concerns, one PR.

### 1. Typed Hono client for \`quickCreateCustomer\`
Was dropping to raw \`fetch\` with hand-written headers/stringify. Now uses \`client.customers['quick-create'].\$post({ json })\`.

\`checkAvailability\` stays on raw fetch because the availability route reads \`from\`/\`to\` via \`c.req.query()\` directly (no \`zValidator\`), so the typed client doesn't carry them. URL construction is still type-safe via \`\$url()\`. Adding \`zValidator\` to all routes is a bigger refactor, tabled.

### 2. \`console.error\` in caught branches
Previously every server-action catch mapped anything to \`"Network error"\` — JSON parse failures, timeouts, auth errors all indistinguishable in Cloudflare Worker logs. Now every caught error is logged before the user-facing message is returned.

### 3. Split the 432-line ManualBookingDialog
One component was owning customer state + quick-create draft + vehicle selection + datetime + debounce plumbing + availability polling + submit orchestration. Split by responsibility:

- \`CustomerPicker\` (182 lines) — presentation-only, mode toggle + search UI + existing selection + new-draft inputs. Controlled via \`value\`/\`onChange\`.
- \`BookingSlotPicker\` (99 lines) — presentation-only, vehicle select + datetime + notes + availability warning.
- \`ManualBookingDialog\` (260 lines) — owns state for both, orchestrates debounced \`searchCustomers\` + \`checkAvailability\`, resolves renterId via extracted \`resolveRenterId\` helper, submits.

### 4. Debounce the availability check
Previously fired on every datetime keystroke. Now 400ms debounced, stale responses dropped via sequence token, unmount clears the timer.

## Test plan
- [x] 381 API tests pass (unchanged — API untouched)
- [x] Web typecheck clean
- [x] Biome clean
- [ ] Manual: open /manage/bookings → "New Booking", verify customer search + create, verify availability warning debounces, submit flow end-to-end