### PR TITLE
chore(api): server-side guard on DELETE /vehicle-classes against active bookings

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -264,7 +264,7 @@ export function createApp(overrides?: {
   app.use('/customers', requireAuth())
   app.use('/users/*', requireAuth())
 
-  const vehicleClassService = new VehicleClassService(vehicleClassRepo)
+  const vehicleClassService = new VehicleClassService(vehicleClassRepo, vehicleRepo, bookingRepo)
   const bookingService = new BookingService(bookingRepo, vehicleRepo, userRepo)
   const customerService = new CustomerService(customerRepo, userRepo)
   const maintenanceService = new MaintenanceService(

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -102,7 +102,7 @@ export class DrizzleBookingRepository implements BookingRepository {
       .where(
         and(
           inArray(bookings.vehicleId, vehicleIds),
-          sql`${bookings.status} IN ('CONFIRMED', 'ACTIVE')`,
+          inArray(bookings.status, ['CONFIRMED', 'ACTIVE'] as const),
         ),
       )
     return row?.value ?? 0

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -1,5 +1,5 @@
 import { bookings } from '@kuruma/shared/db/schema'
-import { and, desc, eq, lt, or, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, lt, or, sql } from 'drizzle-orm'
 import { type CallerContext, PRIVILEGED_ROLES } from '../../middleware/auth'
 import type { Booking } from '../../stores'
 import type { BookingFilters, BookingRepository } from '../types'
@@ -92,6 +92,20 @@ export class DrizzleBookingRepository implements BookingRepository {
       .where(and(...conditions))
 
     return row ? toBooking(row) : undefined
+  }
+
+  async countActiveForVehicles(vehicleIds: string[]): Promise<number> {
+    if (vehicleIds.length === 0) return 0
+    const [row] = await this.db
+      .select({ value: count() })
+      .from(bookings)
+      .where(
+        and(
+          inArray(bookings.vehicleId, vehicleIds),
+          sql`${bookings.status} IN ('CONFIRMED', 'ACTIVE')`,
+        ),
+      )
+    return row?.value ?? 0
   }
 
   async create(ctx: CallerContext, data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>): Promise<Booking> {

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -21,6 +21,10 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       conditions.push(ne(vehicles.status, 'RETIRED'))
     }
 
+    if (filters?.classId !== undefined) {
+      conditions.push(eq(vehicles.classId, filters.classId))
+    }
+
     const where = conditions.length > 0 ? and(...conditions) : undefined
 
     const [countResult, rows] = await Promise.all([

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -99,6 +99,16 @@ export class InMemoryBookingRepository implements BookingRepository {
     return undefined
   }
 
+  async countActiveForVehicles(vehicleIds: string[]): Promise<number> {
+    if (vehicleIds.length === 0) return 0
+    const ids = new Set(vehicleIds)
+    let count = 0
+    for (const booking of this.store.values()) {
+      if (ids.has(booking.vehicleId) && BLOCKING_STATUSES.has(booking.status)) count++
+    }
+    return count
+  }
+
   async create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -23,6 +23,9 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     } else {
       filtered = all.filter((v) => v.status !== 'RETIRED')
     }
+    if (filters?.classId !== undefined) {
+      filtered = filtered.filter((v) => v.classId === filters.classId)
+    }
     const total = filtered.length
     const offset = filters?.offset ?? 0
     const limit = filters?.limit

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -32,6 +32,7 @@ import type {
 export interface VehicleFilters {
   status?: string
   includeRetired?: boolean
+  classId?: string
   limit?: number
   offset?: number
 }
@@ -125,6 +126,10 @@ export interface BookingRepository {
   findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]>
   findById(ctx: CallerContext, id: string): Promise<Booking | undefined>
   findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined>
+  /** Counts bookings in BLOCKING_STATUSES (CONFIRMED, ACTIVE) for the given
+   *  vehicle set. Used to guard operations that assume no live bookings exist
+   *  for those vehicles — e.g. archiving a vehicle class. */
+  countActiveForVehicles(vehicleIds: string[]): Promise<number>
   create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -74,7 +74,14 @@ export function createVehicleClassRoutes(service: VehicleClassService) {
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const result = await service.archive(c.req.param('id'))
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) {
+        const extras: Record<string, unknown> = {}
+        if (result.code) extras.code = result.code
+        if (result.activeBookingsCount !== undefined) {
+          extras.activeBookingsCount = result.activeBookingsCount
+        }
+        return fail(c, result.error, result.status, extras)
+      }
       return ok(c, result.vehicleClass)
     })
 }

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -1,4 +1,9 @@
-import type { VehicleClassFilters, VehicleClassRepository } from '../repositories/types'
+import type {
+  BookingRepository,
+  VehicleClassFilters,
+  VehicleClassRepository,
+  VehicleRepository,
+} from '../repositories/types'
 import type { VehicleClass } from '../stores'
 
 export type CreateResult =
@@ -9,10 +14,20 @@ export type UpdateResult = CreateResult
 
 export type ArchiveResult =
   | { ok: true; vehicleClass: VehicleClass }
-  | { ok: false; error: string; status: number }
+  | {
+      ok: false
+      error: string
+      status: number
+      code?: 'CLASS_HAS_ACTIVE_BOOKINGS'
+      activeBookingsCount?: number
+    }
 
 export class VehicleClassService {
-  constructor(private readonly repo: VehicleClassRepository) {}
+  constructor(
+    private readonly repo: VehicleClassRepository,
+    private readonly vehicleRepo: VehicleRepository,
+    private readonly bookingRepo: BookingRepository,
+  ) {}
 
   async findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]> {
     return this.repo.findAll(filters)
@@ -71,6 +86,29 @@ export class VehicleClassService {
     if (!existing) {
       return { ok: false, error: 'Vehicle class not found', status: 404 }
     }
+
+    // Guard: cannot archive a class that still has live bookings via any of
+    // its member vehicles. Owner must reassign/cancel those bookings first.
+    // Client-side check in /manage/classes is racy — this is the server seal.
+    const { data: members } = await this.vehicleRepo.findAll({
+      classId: id,
+      includeRetired: true,
+    })
+    if (members.length > 0) {
+      const activeBookingsCount = await this.bookingRepo.countActiveForVehicles(
+        members.map((v) => v.id),
+      )
+      if (activeBookingsCount > 0) {
+        return {
+          ok: false,
+          error: 'Cannot archive a class with active bookings',
+          status: 409,
+          code: 'CLASS_HAS_ACTIVE_BOOKINGS',
+          activeBookingsCount,
+        }
+      }
+    }
+
     const archived = await this.repo.archive(id)
     if (!archived) {
       return { ok: false, error: 'Vehicle class not found', status: 404 }

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -1,11 +1,23 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { InMemoryVehicleClassRepository } from '../../src/repositories/in-memory'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  InMemoryBookingRepository,
+  InMemoryVehicleClassRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
 import { createVehicleClassRoutes } from '../../src/routes/vehicle-classes'
 import { VehicleClassService } from '../../src/services/vehicle-class'
 import { testAuthMiddleware } from '../helpers/auth'
 
 let app: Hono
+let classRepo: InMemoryVehicleClassRepository
+let vehicleRepo: InMemoryVehicleRepository
+let bookingRepo: InMemoryBookingRepository
+
+function makeService() {
+  return new VehicleClassService(classRepo, vehicleRepo, bookingRepo)
+}
 
 function validInput() {
   return {
@@ -28,11 +40,12 @@ async function createClass(input = validInput()) {
 
 describe('Vehicle Class CRUD Routes', () => {
   beforeEach(() => {
-    const repo = new InMemoryVehicleClassRepository()
-    const service = new VehicleClassService(repo)
+    classRepo = new InMemoryVehicleClassRepository()
+    vehicleRepo = new InMemoryVehicleRepository()
+    bookingRepo = new InMemoryBookingRepository()
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleClassRoutes(service))
+    app.route('/', createVehicleClassRoutes(makeService()))
   })
 
   describe('GET /vehicle-classes', () => {
@@ -186,13 +199,117 @@ describe('Vehicle Class CRUD Routes', () => {
   })
 
   describe('DELETE /vehicle-classes/:id', () => {
-    it('archives the class', async () => {
+    async function makeVehicle(classId: string) {
+      return vehicleRepo.create({
+        classId,
+        name: 'Test Car',
+        description: null,
+        photos: [],
+        seats: 5,
+        transmission: 'AUTO',
+        fuelType: null,
+        licensePlate: null,
+        status: 'AVAILABLE',
+        bufferMinutes: 0,
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+        make: null,
+        model: null,
+        year: null,
+        color: null,
+        dailyRateJpy: 5000,
+        hourlyRateJpy: null,
+        shakenExpiryDate: null,
+        insuranceExpiryDate: null,
+      })
+    }
+
+    async function makeBooking(
+      vehicleId: string,
+      status: 'CONFIRMED' | 'ACTIVE' | 'CANCELLED' | 'COMPLETED',
+    ) {
+      return bookingRepo.create(SYSTEM_CONTEXT, {
+        renterId: 'user-1',
+        vehicleId,
+        startAt: new Date('2026-06-01T10:00:00Z'),
+        endAt: new Date('2026-06-01T14:00:00Z'),
+        effectiveEndAt: new Date('2026-06-01T14:00:00Z'),
+        status,
+        source: 'DIRECT',
+        externalId: null,
+        notes: null,
+        totalPrice: null,
+        cancellationFee: null,
+        cancelledAt: status === 'CANCELLED' ? new Date() : null,
+        idempotencyKey: null,
+      })
+    }
+
+    it('archives the class when no vehicles or bookings exist', async () => {
       const createRes = await createClass()
       const { data: created } = await createRes.json()
       const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
       expect(res.status).toBe(200)
       const { data } = await res.json()
       expect(data.status).toBe('ARCHIVED')
+    })
+
+    it('archives the class when member vehicles have no active bookings', async () => {
+      const { data: created } = await (await createClass()).json()
+      await makeVehicle(created.id)
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(200)
+    })
+
+    it('returns 409 with CLASS_HAS_ACTIVE_BOOKINGS when a member has a CONFIRMED booking', async () => {
+      const { data: created } = await (await createClass()).json()
+      const v = await makeVehicle(created.id)
+      await makeBooking(v.id, 'CONFIRMED')
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.code).toBe('CLASS_HAS_ACTIVE_BOOKINGS')
+      expect(body.activeBookingsCount).toBe(1)
+    })
+
+    it('returns 409 when a member has an ACTIVE booking', async () => {
+      const { data: created } = await (await createClass()).json()
+      const v = await makeVehicle(created.id)
+      await makeBooking(v.id, 'ACTIVE')
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(409)
+    })
+
+    it('allows archive when bookings are CANCELLED or COMPLETED', async () => {
+      const { data: created } = await (await createClass()).json()
+      const v = await makeVehicle(created.id)
+      await makeBooking(v.id, 'CANCELLED')
+      await makeBooking(v.id, 'COMPLETED')
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(200)
+    })
+
+    it('counts bookings across multiple member vehicles', async () => {
+      const { data: created } = await (await createClass()).json()
+      const v1 = await makeVehicle(created.id)
+      const v2 = await makeVehicle(created.id)
+      await makeBooking(v1.id, 'CONFIRMED')
+      await makeBooking(v2.id, 'ACTIVE')
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.activeBookingsCount).toBe(2)
+    })
+
+    it('ignores active bookings on vehicles in a different class', async () => {
+      const { data: created } = await (await createClass()).json()
+      const other = await (await createClass({ ...validInput(), slug: 'suv', name: 'SUV' })).json()
+      const v = await makeVehicle(other.data.id)
+      await makeBooking(v.id, 'CONFIRMED')
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(200)
     })
 
     it('returns 404 for nonexistent', async () => {
@@ -204,8 +321,10 @@ describe('Vehicle Class CRUD Routes', () => {
   describe('Authorization', () => {
     it('RENTER can GET vehicle classes', async () => {
       const renterApp = new Hono()
-      const repo = new InMemoryVehicleClassRepository()
-      const service = new VehicleClassService(repo)
+      const localClassRepo = new InMemoryVehicleClassRepository()
+      const localVehicleRepo = new InMemoryVehicleRepository()
+      const localBookingRepo = new InMemoryBookingRepository()
+      const service = new VehicleClassService(localClassRepo, localVehicleRepo, localBookingRepo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
       renterApp.route('/', createVehicleClassRoutes(service))
       const res = await renterApp.request('/vehicle-classes')
@@ -214,8 +333,10 @@ describe('Vehicle Class CRUD Routes', () => {
 
     it('RENTER gets 403 on POST', async () => {
       const renterApp = new Hono()
-      const repo = new InMemoryVehicleClassRepository()
-      const service = new VehicleClassService(repo)
+      const localClassRepo = new InMemoryVehicleClassRepository()
+      const localVehicleRepo = new InMemoryVehicleRepository()
+      const localBookingRepo = new InMemoryBookingRepository()
+      const service = new VehicleClassService(localClassRepo, localVehicleRepo, localBookingRepo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
       renterApp.route('/', createVehicleClassRoutes(service))
       const res = await renterApp.request('/vehicle-classes', {

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -303,6 +303,20 @@ describe('Vehicle Class CRUD Routes', () => {
       expect(body.activeBookingsCount).toBe(2)
     })
 
+    it('blocks archive when a RETIRED member vehicle has an active booking', async () => {
+      // A retired car can still have a future CONFIRMED booking — the owner
+      // retired the vehicle but hasn't cancelled/reassigned the booking yet.
+      // Archiving the class before that is resolved would leave an orphan.
+      const { data: created } = await (await createClass()).json()
+      const v = await makeVehicle(created.id)
+      await makeBooking(v.id, 'CONFIRMED')
+      await vehicleRepo.softDelete(v.id)
+      const res = await app.request(`/vehicle-classes/${created.id}`, { method: 'DELETE' })
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.activeBookingsCount).toBe(1)
+    })
+
     it('ignores active bookings on vehicles in a different class', async () => {
       const { data: created } = await (await createClass()).json()
       const other = await (await createClass({ ...validInput(), slug: 'suv', name: 'SUV' })).json()


### PR DESCRIPTION
Closes #319.

## Summary
The `/manage/classes` UI guards archive with a client-side stats check, but a race between fetch and archive can slip through (stats go stale, user clicks delete, meanwhile a booking lands). This seals the check at the service layer.

## Change shape
- `VehicleFilters` gains `classId` (in-memory + drizzle impls).
- `BookingRepository.countActiveForVehicles(vehicleIds: string[]): Promise<number>` — new primitive counting bookings in `BLOCKING_STATUSES` (CONFIRMED, ACTIVE) for the given vehicle set. In-memory and drizzle impls.
- `VehicleClassService.archive`:
  1. Finds member vehicles for the class (`includeRetired: true` — a retired car with a live booking still blocks).
  2. Counts active bookings via `BookingRepository.countActiveForVehicles`.
  3. Returns `409 { code: 'CLASS_HAS_ACTIVE_BOOKINGS', activeBookingsCount }` if > 0.
- Route passes `code` + `activeBookingsCount` through via `fail()` extras.
- `VehicleClassService` now takes `VehicleRepository` + `BookingRepository` as **required** collaborators. Avoids the optional-that-500s anti-pattern (#309 review lesson).

## Test plan
- [x] 7 new DELETE tests: no vehicles, vehicles with no bookings, CONFIRMED blocks, ACTIVE blocks, CANCELLED/COMPLETED allow, multi-vehicle count, other-class isolation, 404
- [x] All 26 vehicle-class route tests pass
- [x] Full API suite: 400/400
- [x] Full web suite: 341/341
- [x] `tsc --noEmit` clean
- [x] `lint:boundaries` clean

## UI impact
Minimal. Existing `DeleteClassDialog` surfaces `mutation.error.message` — the 409 string "Cannot archive a class with active bookings" shows inline. The `code` + `activeBookingsCount` extras are on the wire for a future i18n'd message (e.g. "This class has 2 active bookings. Cancel or reassign first."); not consumed yet.