### PR TITLE
fix(api): timeout + single retry on Google Translate fetch

### DIFF
--- a/packages/api/src/services/google-translation-provider.ts
+++ b/packages/api/src/services/google-translation-provider.ts
@@ -1,6 +1,8 @@
 import type { TranslationProvider } from './translation-provider'
 
 const ENDPOINT = 'https://translation.googleapis.com/language/translate/v2'
+const TIMEOUT_MS = 3000
+const MAX_ATTEMPTS = 2 // initial call + 1 retry
 
 interface GoogleResponse {
   data?: {
@@ -12,6 +14,10 @@ interface GoogleResponse {
 /**
  * Google Cloud Translation v2 REST client. REST over SDK so we run on
  * the Cloudflare Workers runtime without Node-only deps.
+ *
+ * Resilience: every request has a 3s timeout via AbortSignal, and transient
+ * failures (network error or 5xx) trigger a single retry. 4xx responses are
+ * returned immediately — they're caller errors, not transient upstream issues.
  */
 export class GoogleTranslationProvider implements TranslationProvider {
   constructor(
@@ -30,32 +36,61 @@ export class GoogleTranslationProvider implements TranslationProvider {
       format: 'text',
     })
     if (sourceLanguage) params.set('source', sourceLanguage)
+    const body = params.toString()
 
-    // API key in header, not body — prevents WAF/log middleware from
-    // capturing it in request-body traces.
-    const response = await this.fetchFn(ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'X-Goog-Api-Key': this.apiKey,
-      },
-      body: params.toString(),
-    })
+    let lastError: unknown
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const response = await this.fetchFn(ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-Goog-Api-Key': this.apiKey,
+          },
+          body,
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        })
 
-    const json = (await response.json()) as GoogleResponse
+        // 5xx is transient — retry. 4xx is the caller's problem — bail.
+        if (response.status >= 500 && attempt < MAX_ATTEMPTS) {
+          lastError = new Error(`Google Translate returned ${response.status}`)
+          continue
+        }
 
-    if (!response.ok || json.error) {
-      throw new Error(json.error?.message ?? `Google Translate returned ${response.status}`)
+        const json = (await response.json()) as GoogleResponse
+        if (!response.ok || json.error) {
+          throw new Error(json.error?.message ?? `Google Translate returned ${response.status}`)
+        }
+
+        const translation = json.data?.translations?.[0]
+        if (!translation) {
+          throw new Error('Google Translate returned no translation')
+        }
+
+        return {
+          translatedText: translation.translatedText,
+          detectedLanguage: translation.detectedSourceLanguage ?? sourceLanguage ?? targetLanguage,
+        }
+      } catch (err) {
+        // Network error (including AbortError from timeout) — retry once.
+        // Our own throws above (no-translation, 4xx) also land here, but we
+        // only retry when we have attempts left AND the error is transient.
+        const isTransient = isNetworkError(err)
+        if (isTransient && attempt < MAX_ATTEMPTS) {
+          lastError = err
+          continue
+        }
+        throw err
+      }
     }
 
-    const translation = json.data?.translations?.[0]
-    if (!translation) {
-      throw new Error('Google Translate returned no translation')
-    }
-
-    return {
-      translatedText: translation.translatedText,
-      detectedLanguage: translation.detectedSourceLanguage ?? sourceLanguage ?? targetLanguage,
-    }
+    throw lastError ?? new Error('Google Translate: exhausted retries')
   }
+}
+
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError) return true // fetch failed
+  if (err instanceof Error && err.name === 'AbortError') return true // timeout
+  if (err instanceof DOMException && err.name === 'TimeoutError') return true
+  return false
 }

--- a/packages/api/tests/services/google-translation-provider.test.ts
+++ b/packages/api/tests/services/google-translation-provider.test.ts
@@ -67,4 +67,54 @@ describe('GoogleTranslationProvider', () => {
     const result = await provider.translate('hi', null, 'en')
     expect(result.detectedLanguage).toBe('en')
   })
+
+  it('passes an AbortSignal to fetch so a hung upstream does not block forever', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ data: { translations: [{ translatedText: 'Hi' }] } }),
+    )
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    await provider.translate('hi', null, 'en')
+    const init = fetchFn.mock.calls[0]![1]!
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('retries once on 5xx and returns the translation from the retry', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: { message: 'upstream' } }, { status: 503 }))
+      .mockResolvedValueOnce(jsonResponse({ data: { translations: [{ translatedText: 'Hi' }] } }))
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    const result = await provider.translate('hi', null, 'en')
+    expect(result.translatedText).toBe('Hi')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries once on a network error and returns the translation from the retry', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(jsonResponse({ data: { translations: [{ translatedText: 'Hi' }] } }))
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    const result = await provider.translate('hi', null, 'en')
+    expect(result.translatedText).toBe('Hi')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT retry on 4xx — client errors are not transient', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ error: { message: 'API key invalid' } }, { status: 400 }),
+    )
+    const provider = new GoogleTranslationProvider('bad-key', fetchFn)
+    await expect(provider.translate('x', null, 'en')).rejects.toThrow('API key invalid')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('gives up after one retry — two 5xx in a row throws', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ error: { message: 'still down' } }, { status: 502 }),
+    )
+    const provider = new GoogleTranslationProvider('key', fetchFn)
+    await expect(provider.translate('x', null, 'en')).rejects.toThrow('still down')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
## Summary

Closes #331 — an unbounded upstream fetch was letting Google Translate set our latency SLO.

- Adds `AbortSignal.timeout(3000)` to the fetch call
- One retry on 5xx or network error (TypeError / AbortError / TimeoutError)
- 4xx returns immediately — caller errors aren't transient

No backoff delay — single retry keeps it simple and avoids chewing more CPU time on a degraded upstream.

## Learn: Unbounded Upstream Call
A fetch with no timeout lets the upstream set your latency SLO; third-party degradation propagates as 5xx on your service. **Heuristic:** every third-party fetch needs an explicit timeout and a retry ceiling.

## Test plan

- [x] 10 passing tests in `google-translation-provider.test.ts` (5 existing + 5 new)
- [x] Full API suite: 422/422 passing
- [x] `tsc --noEmit` clean
- [x] Biome clean