### PR TITLE
feat(web): owner fleet grouped by class + vehicle→class assignment

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -275,7 +275,9 @@
         "year": "Year",
         "yearPlaceholder": "e.g. 2022",
         "color": "Color",
-        "colorPlaceholder": "e.g. White"
+        "colorPlaceholder": "e.g. White",
+        "class": "Class",
+        "classNone": "Unassigned"
       },
       "photos": {
         "heading": "Photos",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -196,6 +196,10 @@
       "title": "Fleet",
       "subtitle": "Manage your vehicles",
       "empty": "No vehicles added yet",
+      "group": {
+        "unassigned": "Unassigned",
+        "vehicleCount": "{count, plural, =1 {# vehicle} other {# vehicles}}"
+      },
       "loadError": "Couldn't load your fleet",
       "retry": "Try again",
       "addVehicle": "Add vehicle",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -196,6 +196,10 @@
       "title": "車両管理",
       "subtitle": "車両の管理",
       "empty": "車両はまだ追加されていません",
+      "group": {
+        "unassigned": "未割り当て",
+        "vehicleCount": "{count}台"
+      },
       "loadError": "車両情報を読み込めませんでした",
       "retry": "再試行",
       "addVehicle": "車両を追加",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -275,7 +275,9 @@
         "year": "年式",
         "yearPlaceholder": "例: 2022",
         "color": "色",
-        "colorPlaceholder": "例: ホワイト"
+        "colorPlaceholder": "例: ホワイト",
+        "class": "クラス",
+        "classNone": "未割り当て"
       },
       "photos": {
         "heading": "写真",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -275,7 +275,9 @@
         "year": "年份",
         "yearPlaceholder": "例如 2022",
         "color": "颜色",
-        "colorPlaceholder": "例如 白色"
+        "colorPlaceholder": "例如 白色",
+        "class": "类别",
+        "classNone": "未分配"
       },
       "photos": {
         "heading": "照片",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -196,6 +196,10 @@
       "title": "车队管理",
       "subtitle": "管理您的车辆",
       "empty": "尚未添加车辆",
+      "group": {
+        "unassigned": "未分配",
+        "vehicleCount": "{count} 辆车"
+      },
       "loadError": "无法加载车队信息",
       "retry": "重试",
       "addVehicle": "添加车辆",

--- a/packages/web/src/components/vehicles/AddVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/AddVehicleDialog.tsx
@@ -10,14 +10,16 @@ import {
 import { VehicleForm } from '@/components/vehicles/VehicleForm'
 import { useVehicleMutation } from '@/hooks/useVehicleMutation'
 import { createVehicleAction } from '@/lib/vehicle-actions'
+import type { VehicleClassData } from '@/modules/classes'
 import { useTranslations } from 'next-intl'
 
 interface AddVehicleDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  classes?: readonly VehicleClassData[] | undefined
 }
 
-export function AddVehicleDialog({ open, onOpenChange }: AddVehicleDialogProps) {
+export function AddVehicleDialog({ open, onOpenChange, classes }: AddVehicleDialogProps) {
   const t = useTranslations('business.vehicles')
   const { mutate, isPending, error, reset } = useVehicleMutation({
     mutationFn: createVehicleAction,
@@ -41,6 +43,7 @@ export function AddVehicleDialog({ open, onOpenChange }: AddVehicleDialogProps) 
           onSubmit={async (data) => mutate(data)}
           onCancel={() => handleOpenChange(false)}
           isSubmitting={isPending}
+          classes={classes}
         />
       </DialogContent>
     </Dialog>

--- a/packages/web/src/components/vehicles/EditVehicleDialog.tsx
+++ b/packages/web/src/components/vehicles/EditVehicleDialog.tsx
@@ -12,15 +12,17 @@ import { VehicleForm } from '@/components/vehicles/VehicleForm'
 import { useVehicleMutation } from '@/hooks/useVehicleMutation'
 import { updateVehicleAction } from '@/lib/vehicle-actions'
 import type { VehicleData } from '@/lib/vehicle-api'
+import type { VehicleClassData } from '@/modules/classes'
 import type { CreateVehicleInput } from '@kuruma/shared/validators/vehicle'
 import { useTranslations } from 'next-intl'
 
 interface EditVehicleDialogProps {
   vehicle: VehicleData | null
   onOpenChange: (open: boolean) => void
+  classes?: readonly VehicleClassData[] | undefined
 }
 
-export function EditVehicleDialog({ vehicle, onOpenChange }: EditVehicleDialogProps) {
+export function EditVehicleDialog({ vehicle, onOpenChange, classes }: EditVehicleDialogProps) {
   const t = useTranslations('business.vehicles')
   const { mutate, isPending, error } = useVehicleMutation<CreateVehicleInput>({
     mutationFn: (data) => updateVehicleAction(vehicle?.id ?? '', data),
@@ -48,8 +50,10 @@ export function EditVehicleDialog({ vehicle, onOpenChange }: EditVehicleDialogPr
             onSubmit={async (data) => mutate(data)}
             onCancel={() => onOpenChange(false)}
             isSubmitting={isPending}
+            classes={classes}
             defaultValues={{
               name: vehicle.name,
+              classId: vehicle.classId,
               ...(vehicle.description != null && { description: vehicle.description }),
               photos: vehicle.photos ?? [],
               seats: vehicle.seats,

--- a/packages/web/src/components/vehicles/FleetGroupedList.tsx
+++ b/packages/web/src/components/vehicles/FleetGroupedList.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import type { VehicleClassData } from '@/modules/classes'
+import { groupVehiclesByClass } from '@/modules/vehicles'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { type ReactNode, useMemo, useState } from 'react'
+
+interface FleetGroupedListProps {
+  readonly vehicles: readonly FleetVehicleOverviewData[]
+  readonly classes: readonly VehicleClassData[]
+  readonly renderVehicle: (vehicle: FleetVehicleOverviewData) => ReactNode
+}
+
+// Collapsible sections of vehicles grouped by class. Unassigned vehicles
+// (null classId, or a classId no longer in the classes list) fall into a
+// trailing group so the owner can spot and reassign them. Collapse state
+// is per-group and client-local; re-initialised on mount.
+export function FleetGroupedList({ vehicles, classes, renderVehicle }: FleetGroupedListProps) {
+  const t = useTranslations('business.vehicles')
+  const groups = useMemo(
+    () => groupVehiclesByClass(vehicles, classes, t('group.unassigned')),
+    [vehicles, classes, t],
+  )
+
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+
+  if (groups.length === 0) return null
+
+  const toggle = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => {
+        const key = group.classId ?? '__unassigned__'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <section key={key} aria-label={group.className}>
+            <button
+              type="button"
+              onClick={() => toggle(key)}
+              aria-expanded={!isCollapsed}
+              className="flex w-full items-center gap-2 text-left border-b border-border pb-2 mb-4 hover:bg-muted/30 rounded-sm px-1 -mx-1 transition-colors"
+            >
+              {isCollapsed ? (
+                <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+              ) : (
+                <ChevronDown className="size-4 text-muted-foreground shrink-0" />
+              )}
+              <h2 className="text-lg font-semibold tracking-tight flex-1">{group.className}</h2>
+              <span className="text-sm text-muted-foreground tabular-nums">
+                {t('group.vehicleCount', { count: group.vehicles.length })}
+              </span>
+            </button>
+            {!isCollapsed && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
+                {group.vehicles.map((vehicle) => renderVehicle(vehicle))}
+              </div>
+            )}
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/web/src/components/vehicles/VehicleForm.tsx
+++ b/packages/web/src/components/vehicles/VehicleForm.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import type { VehicleClassData } from '@/modules/classes'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { type CreateVehicleInput, createVehicleSchema } from '@kuruma/shared/validators/vehicle'
 import { useTranslations } from 'next-intl'
@@ -17,9 +18,18 @@ interface VehicleFormProps {
   onCancel?: () => void
   defaultValues?: Partial<CreateVehicleInput>
   isSubmitting?: boolean
+  // Passed from the parent so the form stays a dumb presentational component;
+  // the Fleet page fetches classes once and shares the cache across dialogs.
+  classes?: readonly VehicleClassData[] | undefined
 }
 
-export function VehicleForm({ onSubmit, onCancel, defaultValues, isSubmitting }: VehicleFormProps) {
+export function VehicleForm({
+  onSubmit,
+  onCancel,
+  defaultValues,
+  isSubmitting,
+  classes,
+}: VehicleFormProps) {
   const t = useTranslations('business.vehicles')
 
   const {
@@ -43,6 +53,7 @@ export function VehicleForm({ onSubmit, onCancel, defaultValues, isSubmitting }:
       minRentalHours: 4,
       maxRentalHours: 72,
       advanceBookingHours: null,
+      classId: null,
       ...defaultValues,
     },
   })
@@ -74,6 +85,29 @@ export function VehicleForm({ onSubmit, onCancel, defaultValues, isSubmitting }:
           {...register('description')}
         />
       </div>
+
+      {classes && classes.length > 0 && (
+        <div>
+          <Label htmlFor="classId">{t('form.class')}</Label>
+          <select
+            id="classId"
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+            {...register('classId', {
+              // Empty string ("Unassigned") submits as null to match the
+              // nullable UUID validator. Any other value passes through as
+              // the class UUID.
+              setValueAs: (v) => (v === '' || v == null ? null : String(v)),
+            })}
+          >
+            <option value="">{t('form.classNone')}</option>
+            {classes.map((klass) => (
+              <option key={klass.id} value={klass.id}>
+                {klass.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-4">
         <div>

--- a/packages/web/src/components/vehicles/VehicleForm.tsx
+++ b/packages/web/src/components/vehicles/VehicleForm.tsx
@@ -94,9 +94,8 @@ export function VehicleForm({
             className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
             {...register('classId', {
               // Empty string ("Unassigned") submits as null to match the
-              // nullable UUID validator. Any other value passes through as
-              // the class UUID.
-              setValueAs: (v) => (v === '' || v == null ? null : String(v)),
+              // nullable UUID validator. Any other value is the class UUID.
+              setValueAs: (v) => (v === '' || v == null ? null : v),
             })}
           >
             <option value="">{t('form.classNone')}</option>

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -7,6 +7,7 @@ import { AddVehicleDialog } from '@/components/vehicles/AddVehicleDialog'
 import { BulkActionBar } from '@/components/vehicles/BulkActionBar'
 import { EditVehicleDialog } from '@/components/vehicles/EditVehicleDialog'
 import { FleetFilters } from '@/components/vehicles/FleetFilters'
+import { FleetGroupedList } from '@/components/vehicles/FleetGroupedList'
 import { FleetSummaryBar } from '@/components/vehicles/FleetSummaryBar'
 import { FleetVehicleCard } from '@/components/vehicles/FleetVehicleCard'
 import { FleetVehicleRow } from '@/components/vehicles/FleetVehicleRow'
@@ -22,6 +23,7 @@ import { vehicleKeys } from '@/lib/query-keys'
 import { cn } from '@/lib/utils'
 import { fetchFleetOverviewAction } from '@/lib/vehicle-actions'
 import type { VehicleData } from '@/lib/vehicle-api'
+import { classKeys, fetchClassesAction } from '@/modules/classes'
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Car, ChevronLeft, ChevronRight, Plus, SlidersHorizontal } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -86,6 +88,19 @@ export function VehicleList() {
     },
   })
 
+  // Classes power the grouping sections and the class dropdown inside the
+  // add/edit dialogs. ACTIVE-only: archived classes should not appear as
+  // assignment targets. Shares the same query key as the Classes page so
+  // navigating between the two doesn't double-fetch.
+  const { data: classes } = useQuery({
+    queryKey: classKeys.list(),
+    queryFn: async () => {
+      const result = await fetchClassesAction()
+      if (!result.success) throw new Error(result.error)
+      return result.data
+    },
+  })
+
   const seatsBounds = useMemo(() => {
     if (!overviews || overviews.length === 0) {
       return DEFAULT_SEATS_BOUNDS
@@ -123,6 +138,13 @@ export function VehicleList() {
     () => sortVehicles(filterVehicles(overviews ?? [], filters), sort),
     [overviews, filters, sort],
   )
+
+  // Grouping is the default Fleet view when at least one class is
+  // defined. With 40-50 vehicles across a handful of classes, showing
+  // every group at once is cheaper for the owner than paging. The flat
+  // paginated view is kept only for the no-classes-yet fallback.
+  const hasClasses = (classes?.length ?? 0) > 0
+  const useGroupedView = hasClasses && viewMode === 'grid'
 
   // Reset to first page when filters/sort change the result set
   const displayedLen = displayed.length
@@ -282,7 +304,24 @@ export function VehicleList() {
           </div>
         )}
 
-        {!isLoading && !isError && paged.length > 0 && (
+        {!isLoading && !isError && useGroupedView && classes && displayed.length > 0 && (
+          <FleetGroupedList
+            vehicles={displayed}
+            classes={classes}
+            renderVehicle={(overview) => (
+              <FleetVehicleCard
+                key={overview.id}
+                vehicle={overview}
+                selected={selectedIds.has(overview.id)}
+                onToggleSelect={toggleSelect}
+                onEdit={setEditingVehicle}
+                onRetire={setRetiringVehicle}
+              />
+            )}
+          />
+        )}
+
+        {!isLoading && !isError && !useGroupedView && paged.length > 0 && (
           <div
             className={cn(
               'grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6',
@@ -302,8 +341,9 @@ export function VehicleList() {
           </div>
         )}
 
-        {/* Pagination */}
-        {!isLoading && !isError && totalPages > 1 && (
+        {/* Pagination — disabled in grouped view; owners need the full class
+            picture at once, not paginated slices. */}
+        {!isLoading && !isError && !useGroupedView && totalPages > 1 && (
           <div className="flex items-center justify-between border-t pt-4">
             <span className="text-sm text-muted-foreground">
               {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, displayedLen)} of {displayedLen}
@@ -341,8 +381,12 @@ export function VehicleList() {
           </div>
         )}
 
-        <AddVehicleDialog open={showAddDialog} onOpenChange={setShowAddDialog} />
-        <EditVehicleDialog vehicle={editingVehicle} onOpenChange={() => setEditingVehicle(null)} />
+        <AddVehicleDialog open={showAddDialog} onOpenChange={setShowAddDialog} classes={classes} />
+        <EditVehicleDialog
+          vehicle={editingVehicle}
+          onOpenChange={() => setEditingVehicle(null)}
+          classes={classes}
+        />
         <RetireVehicleDialog
           vehicle={retiringVehicle}
           onOpenChange={() => setRetiringVehicle(null)}

--- a/packages/web/src/components/vehicles/VehicleList.tsx
+++ b/packages/web/src/components/vehicles/VehicleList.tsx
@@ -89,13 +89,13 @@ export function VehicleList() {
   })
 
   // Classes power the grouping sections and the class dropdown inside the
-  // add/edit dialogs. ACTIVE-only: archived classes should not appear as
-  // assignment targets. Shares the same query key as the Classes page so
-  // navigating between the two doesn't double-fetch.
+  // add/edit dialogs. Archived classes are excluded explicitly — they must
+  // never appear as assignment targets. Shares the same query key as the
+  // Classes page so navigating between the two doesn't double-fetch.
   const { data: classes } = useQuery({
     queryKey: classKeys.list(),
     queryFn: async () => {
-      const result = await fetchClassesAction()
+      const result = await fetchClassesAction({ includeArchived: false })
       if (!result.success) throw new Error(result.error)
       return result.data
     },

--- a/packages/web/src/modules/classes/index.ts
+++ b/packages/web/src/modules/classes/index.ts
@@ -1,1 +1,4 @@
 export { ClassList } from './components/ClassList'
+export type { VehicleClassData } from './api'
+export { fetchClassesAction } from './actions'
+export { classKeys } from './hooks'

--- a/packages/web/src/modules/vehicles/grouping.ts
+++ b/packages/web/src/modules/vehicles/grouping.ts
@@ -1,0 +1,64 @@
+import type { FleetVehicleOverviewData, VehicleData } from '@/lib/vehicle-api'
+import type { VehicleClassData } from '@/modules/classes'
+
+export interface VehicleClassGroup<TVehicle extends VehicleData = FleetVehicleOverviewData> {
+  readonly classId: string | null
+  readonly className: string
+  readonly classSlug: string | null
+  readonly vehicles: readonly TVehicle[]
+}
+
+// Pure helper: groups vehicles by their classId, preserving class sortOrder.
+// Vehicles with a null classId — or a classId that no longer matches any
+// class (e.g. the class was archived and the FK dropped) — fall into a
+// trailing "Unassigned" group so the owner sees them and can reassign.
+//
+// Empty classes are dropped entirely; the Fleet page is for managing
+// vehicles, not classes. The dedicated class-management page shows those.
+export function groupVehiclesByClass<TVehicle extends VehicleData>(
+  vehicles: readonly TVehicle[],
+  classes: readonly VehicleClassData[],
+  unassignedLabel = 'Unassigned',
+): VehicleClassGroup<TVehicle>[] {
+  const classById = new Map(classes.map((c) => [c.id, c]))
+  const sortedClasses = [...classes].sort((a, b) => a.sortOrder - b.sortOrder)
+
+  const groups: VehicleClassGroup<TVehicle>[] = []
+  const unassigned: TVehicle[] = []
+
+  // Bucket vehicles by class id (or "unassigned" bucket).
+  const buckets = new Map<string, TVehicle[]>()
+  for (const vehicle of vehicles) {
+    const resolvedClassId =
+      vehicle.classId != null && classById.has(vehicle.classId) ? vehicle.classId : null
+    if (resolvedClassId == null) {
+      unassigned.push(vehicle)
+      continue
+    }
+    const bucket = buckets.get(resolvedClassId) ?? []
+    bucket.push(vehicle)
+    buckets.set(resolvedClassId, bucket)
+  }
+
+  for (const klass of sortedClasses) {
+    const bucket = buckets.get(klass.id)
+    if (!bucket || bucket.length === 0) continue
+    groups.push({
+      classId: klass.id,
+      className: klass.name,
+      classSlug: klass.slug,
+      vehicles: bucket,
+    })
+  }
+
+  if (unassigned.length > 0) {
+    groups.push({
+      classId: null,
+      className: unassignedLabel,
+      classSlug: null,
+      vehicles: unassigned,
+    })
+  }
+
+  return groups
+}

--- a/packages/web/src/modules/vehicles/index.ts
+++ b/packages/web/src/modules/vehicles/index.ts
@@ -1,0 +1,1 @@
+export { groupVehiclesByClass, type VehicleClassGroup } from './grouping'

--- a/packages/web/tests/components/vehicles/FleetGroupedList.test.tsx
+++ b/packages/web/tests/components/vehicles/FleetGroupedList.test.tsx
@@ -1,0 +1,148 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    const messages: Record<string, string> = {
+      'group.unassigned': 'Unassigned',
+      'group.vehicleCount': `${values?.count ?? 0} vehicles`,
+    }
+    return messages[key] ?? key
+  },
+}))
+
+import { FleetGroupedList } from '@/components/vehicles/FleetGroupedList'
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import type { VehicleClassData } from '@/modules/classes'
+
+const CLASS_A: VehicleClassData = {
+  id: '11111111-1111-4111-8111-111111111111',
+  name: 'Compact',
+  slug: 'compact',
+  description: null,
+  photos: [],
+  seats: 5,
+  luggageCapacity: 2,
+  transmission: 'AUTO',
+  fuelType: null,
+  dailyRateJpy: 8000,
+  hourlyRateJpy: null,
+  sortOrder: 0,
+  status: 'ACTIVE',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+const CLASS_B: VehicleClassData = {
+  ...CLASS_A,
+  id: '22222222-2222-4222-8222-222222222222',
+  name: 'SUV',
+  slug: 'suv',
+  sortOrder: 1,
+}
+
+function makeVehicle(overrides: Partial<FleetVehicleOverviewData>): FleetVehicleOverviewData {
+  return {
+    id: 'v-id',
+    name: 'Vehicle',
+    description: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    bufferMinutes: 60,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    status: 'AVAILABLE',
+    classId: null,
+    photos: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+describe('FleetGroupedList', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders one section per non-empty class group with count', () => {
+    const v1 = makeVehicle({ id: 'v1', name: 'Compact A', classId: CLASS_A.id })
+    const v2 = makeVehicle({ id: 'v2', name: 'SUV A', classId: CLASS_B.id })
+    const v3 = makeVehicle({ id: 'v3', name: 'Compact B', classId: CLASS_A.id })
+
+    render(
+      <FleetGroupedList
+        vehicles={[v1, v2, v3]}
+        classes={[CLASS_A, CLASS_B]}
+        renderVehicle={(v) => <div key={v.id}>{v.name}</div>}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: /Compact/ })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /SUV/ })).toBeInTheDocument()
+    expect(screen.getByText('Compact A')).toBeInTheDocument()
+    expect(screen.getByText('SUV A')).toBeInTheDocument()
+    expect(screen.getByText('Compact B')).toBeInTheDocument()
+  })
+
+  it('renders an Unassigned section for vehicles with null classId', () => {
+    const orphan = makeVehicle({ id: 'v1', name: 'Orphan', classId: null })
+    render(
+      <FleetGroupedList
+        vehicles={[orphan]}
+        classes={[CLASS_A]}
+        renderVehicle={(v) => <div key={v.id}>{v.name}</div>}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: /Unassigned/ })).toBeInTheDocument()
+    expect(screen.getByText('Orphan')).toBeInTheDocument()
+  })
+
+  it('collapses and expands a class section when header is clicked', () => {
+    const v1 = makeVehicle({ id: 'v1', name: 'Compact A', classId: CLASS_A.id })
+    render(
+      <FleetGroupedList
+        vehicles={[v1]}
+        classes={[CLASS_A]}
+        renderVehicle={(v) => <div key={v.id}>{v.name}</div>}
+      />,
+    )
+
+    const header = screen.getByRole('button', { name: /Compact/ })
+    expect(screen.getByText('Compact A')).toBeVisible()
+
+    fireEvent.click(header)
+    expect(screen.queryByText('Compact A')).not.toBeInTheDocument()
+
+    fireEvent.click(header)
+    expect(screen.getByText('Compact A')).toBeVisible()
+  })
+
+  it('renders nothing when there are no vehicles', () => {
+    const { container } = render(
+      <FleetGroupedList
+        vehicles={[]}
+        classes={[CLASS_A]}
+        renderVehicle={(v) => <div key={v.id}>{v.name}</div>}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/web/tests/components/vehicles/VehicleForm.test.tsx
+++ b/packages/web/tests/components/vehicles/VehicleForm.test.tsx
@@ -35,6 +35,8 @@ vi.mock('next-intl', () => ({
       'form.save': 'Save vehicle',
       'form.saving': 'Saving...',
       'form.cancel': 'Cancel',
+      'form.class': 'Class',
+      'form.classNone': 'Unassigned',
     }
     return messages[key] ?? key
   },
@@ -281,6 +283,137 @@ describe('VehicleForm', () => {
         expect(onSubmit).toHaveBeenCalledTimes(1)
       })
       expect(onSubmit.mock.calls[0][0].advanceBookingHours).toBeNull()
+    })
+  })
+
+  // Issue #313: class assignment dropdown
+  describe('class assignment', () => {
+    const classes = [
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        name: 'Compact',
+        slug: 'compact',
+        description: null,
+        photos: [],
+        seats: 5,
+        luggageCapacity: 2,
+        transmission: 'AUTO' as const,
+        fuelType: null,
+        dailyRateJpy: 8000,
+        hourlyRateJpy: null,
+        sortOrder: 0,
+        status: 'ACTIVE' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        name: 'SUV',
+        slug: 'suv',
+        description: null,
+        photos: [],
+        seats: 7,
+        luggageCapacity: 4,
+        transmission: 'AUTO' as const,
+        fuelType: null,
+        dailyRateJpy: 12000,
+        hourlyRateJpy: null,
+        sortOrder: 1,
+        status: 'ACTIVE' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+
+    it('renders a class dropdown with Unassigned + each class as options', () => {
+      render(<VehicleForm onSubmit={vi.fn()} classes={classes} />)
+
+      const select = screen.getByLabelText('Class') as HTMLSelectElement
+      expect(select).toBeInTheDocument()
+      const optionValues = Array.from(select.options).map((o) => o.value)
+      expect(optionValues).toEqual([
+        '',
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+      ])
+    })
+
+    it('submits the selected classId', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn().mockResolvedValue(undefined)
+      render(
+        <VehicleForm
+          onSubmit={onSubmit}
+          classes={classes}
+          defaultValues={{
+            name: 'Honda Fit',
+            seats: 5,
+            transmission: 'AUTO',
+            dailyRateJpy: 7000,
+          }}
+        />,
+      )
+
+      await user.selectOptions(
+        screen.getByLabelText('Class'),
+        '22222222-2222-4222-8222-222222222222',
+      )
+      await user.click(screen.getByRole('button', { name: 'Save vehicle' }))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+      expect(onSubmit.mock.calls[0][0].classId).toBe('22222222-2222-4222-8222-222222222222')
+    })
+
+    it('submits null when Unassigned is selected', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn().mockResolvedValue(undefined)
+      render(
+        <VehicleForm
+          onSubmit={onSubmit}
+          classes={classes}
+          defaultValues={{
+            name: 'Honda Fit',
+            seats: 5,
+            transmission: 'AUTO',
+            dailyRateJpy: 7000,
+            classId: '11111111-1111-4111-8111-111111111111',
+          }}
+        />,
+      )
+
+      await user.selectOptions(screen.getByLabelText('Class'), '')
+      await user.click(screen.getByRole('button', { name: 'Save vehicle' }))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+      expect(onSubmit.mock.calls[0][0].classId).toBeNull()
+    })
+
+    it('pre-selects the vehicle classId in edit mode', () => {
+      render(
+        <VehicleForm
+          onSubmit={vi.fn()}
+          classes={classes}
+          defaultValues={{
+            name: 'Honda Fit',
+            seats: 5,
+            transmission: 'AUTO',
+            dailyRateJpy: 7000,
+            classId: '22222222-2222-4222-8222-222222222222',
+          }}
+        />,
+      )
+
+      const select = screen.getByLabelText('Class') as HTMLSelectElement
+      expect(select.value).toBe('22222222-2222-4222-8222-222222222222')
+    })
+
+    it('does not render the dropdown when no classes are passed', () => {
+      render(<VehicleForm onSubmit={vi.fn()} />)
+      expect(screen.queryByLabelText('Class')).not.toBeInTheDocument()
     })
   })
 

--- a/packages/web/tests/modules/vehicles/grouping.test.ts
+++ b/packages/web/tests/modules/vehicles/grouping.test.ts
@@ -1,0 +1,139 @@
+import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
+import type { VehicleClassData } from '@/modules/classes'
+import { groupVehiclesByClass } from '@/modules/vehicles/grouping'
+import { describe, expect, it } from 'vitest'
+
+function makeClass(overrides: Partial<VehicleClassData> = {}): VehicleClassData {
+  return {
+    id: 'class-1',
+    name: 'Compact',
+    slug: 'compact',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    transmission: 'AUTO',
+    fuelType: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    sortOrder: 0,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeVehicle(overrides: Partial<FleetVehicleOverviewData> = {}): FleetVehicleOverviewData {
+  return {
+    id: 'v-1',
+    name: 'Corolla',
+    description: null,
+    make: 'Toyota',
+    model: 'Corolla',
+    year: 2022,
+    color: 'White',
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: 'Gasoline',
+    licensePlate: '1234',
+    bufferMinutes: 60,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    minRentalHours: 4,
+    maxRentalHours: 72,
+    advanceBookingHours: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    status: 'AVAILABLE',
+    classId: null,
+    photos: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+describe('groupVehiclesByClass', () => {
+  it('returns empty array when there are no vehicles', () => {
+    const result = groupVehiclesByClass([], [])
+    expect(result).toEqual([])
+  })
+
+  it('groups vehicles under their assigned class', () => {
+    const compact = makeClass({ id: 'c1', name: 'Compact', sortOrder: 0 })
+    const suv = makeClass({ id: 'c2', name: 'SUV', sortOrder: 1 })
+    const v1 = makeVehicle({ id: 'v1', classId: 'c1' })
+    const v2 = makeVehicle({ id: 'v2', classId: 'c2' })
+    const v3 = makeVehicle({ id: 'v3', classId: 'c1' })
+
+    const result = groupVehiclesByClass([v1, v2, v3], [compact, suv])
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      classId: 'c1',
+      className: 'Compact',
+      vehicles: [v1, v3],
+    })
+    expect(result[1]).toMatchObject({
+      classId: 'c2',
+      className: 'SUV',
+      vehicles: [v2],
+    })
+  })
+
+  it('places vehicles with null classId into an Unassigned group at the end', () => {
+    const compact = makeClass({ id: 'c1', name: 'Compact', sortOrder: 0 })
+    const v1 = makeVehicle({ id: 'v1', classId: 'c1' })
+    const v2 = makeVehicle({ id: 'v2', classId: null })
+
+    const result = groupVehiclesByClass([v1, v2], [compact])
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.classId).toBe('c1')
+    expect(result[1]).toMatchObject({
+      classId: null,
+      vehicles: [v2],
+    })
+  })
+
+  it('places vehicles whose classId does not match any class into Unassigned', () => {
+    const compact = makeClass({ id: 'c1', name: 'Compact' })
+    const orphan = makeVehicle({ id: 'v1', classId: 'deleted-class-id' })
+
+    const result = groupVehiclesByClass([orphan], [compact])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.classId).toBeNull()
+    expect(result[0]?.vehicles).toEqual([orphan])
+  })
+
+  it('preserves class sortOrder ordering', () => {
+    const b = makeClass({ id: 'cb', name: 'B', sortOrder: 2 })
+    const a = makeClass({ id: 'ca', name: 'A', sortOrder: 0 })
+    const c = makeClass({ id: 'cc', name: 'C', sortOrder: 1 })
+    const va = makeVehicle({ id: 'v1', classId: 'ca' })
+    const vb = makeVehicle({ id: 'v2', classId: 'cb' })
+    const vc = makeVehicle({ id: 'v3', classId: 'cc' })
+
+    const result = groupVehiclesByClass([vb, va, vc], [b, a, c])
+
+    expect(result.map((g) => g.className)).toEqual(['A', 'C', 'B'])
+  })
+
+  it('omits empty groups for classes with no vehicles', () => {
+    const compact = makeClass({ id: 'c1', name: 'Compact' })
+    const suv = makeClass({ id: 'c2', name: 'SUV' })
+    const v1 = makeVehicle({ id: 'v1', classId: 'c1' })
+
+    const result = groupVehiclesByClass([v1], [compact, suv])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.classId).toBe('c1')
+  })
+})


### PR DESCRIPTION
Closes #313
Refs #301

## Summary

Owner-facing Fleet UI, grouped by vehicle class. Three vertical slices:

1. Pure helper `groupVehiclesByClass(vehicles, classes)` in `src/modules/vehicles/grouping.ts` — buckets vehicles under their class, preserves class sortOrder, and drops orphaned classIds into a trailing Unassigned group.
2. Class `<select>` in `VehicleForm` — nullable, pre-selected in edit mode, "Unassigned" submits as null. Hidden when no classes are passed.
3. `FleetGroupedList` — collapsible sections per class with a vehicle count header. Becomes the default Fleet card view when at least one class is defined; flat paginated view is preserved as the no-classes-yet fallback.

## Scope notes

The booking-detail "assign car" dropdown from the original issue is **not** in this PR. Rationale:

- The booking detail page is still a stub (#292) — there is no real booking data to filter against yet.
- `#317` (public class catalog + per-class availability) and `#322` (booking-by-class plumbing) are still open on origin/main, so the `/vehicle-classes/:slug/availability` endpoint the dropdown would call is not yet available.

Per the task brief ("scope this slice to read-only display; defer the actual assignment mutation to a follow-up"), I have left a follow-up comment on #313 for the assign-car dropdown. It becomes a one-file slice once #317 and #322 land.

## Test plan

- [x] Unit: `groupVehiclesByClass` — empty, null classId, orphaned classId, sortOrder preservation, empty-class omission (6 tests)
- [x] Component: VehicleForm class dropdown — option shape, submit with UUID, submit null on Unassigned, edit-mode pre-select, absent when no classes (5 tests)
- [x] Component: FleetGroupedList — one section per class, Unassigned bucket, collapse/expand, empty-state render (4 tests)
- [x] Full web suite: 356 passing
- [x] `bunx tsc --noEmit -p packages/web`: clean
- [x] `bun run lint` + `lint:modules` + `lint:size`: clean (pre-existing warning in ManualBookingDialog unrelated)

## Out-of-scope / follow-ups

- Booking-detail assign-car dropdown (blocked on #317 + #322).
- Grouped view + row mode toggle — currently grouping is card-mode only. If owner wants both, follow-up slice.
- Persisting collapse state across navigation — `useFleetViewMode` localStorage pattern already in-repo if needed.