### PR TITLE
chore(api): disable R2 vehicle photo binding to unblock prod deploy

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@ import { setupGlobalHandlers } from './error-handlers'
 import { requireAuth } from './middleware/auth'
 import { structuredLogger } from './middleware/logger'
 import { requestId } from './middleware/request-id'
+import { DisabledPhotoStorage } from './repositories/disabled-photo-storage'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
@@ -160,10 +161,13 @@ export function createApp(overrides?: {
       | R2BucketLike
       | undefined
     const photosPublicUrl = process.env.VEHICLE_PHOTOS_PUBLIC_URL ?? ''
+    // In the Drizzle branch (production) an InMemory fallback is dangerous —
+    // each CF Worker request gets a fresh instance, so uploads "succeed" but
+    // return URLs pointing at nothing. DisabledPhotoStorage throws loudly.
     photoStorage =
       vehiclePhotosBucket && photosPublicUrl
         ? new R2PhotoStorage(vehiclePhotosBucket, photosPublicUrl)
-        : new InMemoryPhotoStorage()
+        : new DisabledPhotoStorage()
   } else {
     vehicleClassRepo = new InMemoryVehicleClassRepository()
     vehicleRepo = new InMemoryVehicleRepository()

--- a/packages/api/src/repositories/disabled-photo-storage.ts
+++ b/packages/api/src/repositories/disabled-photo-storage.ts
@@ -1,0 +1,17 @@
+import type { PhotoStorage } from './types'
+
+/**
+ * Used in production when the R2 binding is absent (R2 not enabled on the
+ * CF account). Rejects on every write so the upload route returns a loud
+ * error instead of silently accepting into per-request InMemoryPhotoStorage —
+ * which would "succeed" but return URLs pointing at nothing.
+ */
+export class DisabledPhotoStorage implements PhotoStorage {
+  async put(): Promise<{ key: string; url: string }> {
+    throw new Error('Vehicle photo storage is disabled: R2 binding missing in this environment.')
+  }
+
+  async delete(): Promise<void> {
+    throw new Error('Vehicle photo storage is disabled: R2 binding missing in this environment.')
+  }
+}

--- a/packages/api/tests/repositories/disabled-photo-storage.test.ts
+++ b/packages/api/tests/repositories/disabled-photo-storage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { DisabledPhotoStorage } from '../../src/repositories/disabled-photo-storage'
+
+describe('DisabledPhotoStorage', () => {
+  it('put rejects with a clear message identifying R2 as unavailable', async () => {
+    const storage = new DisabledPhotoStorage()
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], 'a.jpg', { type: 'image/jpeg' })
+    await expect(storage.put('veh_1', file)).rejects.toThrow(/vehicle photo storage is disabled/i)
+  })
+
+  it('delete rejects with the same message', async () => {
+    const storage = new DisabledPhotoStorage()
+    await expect(storage.delete('some-key')).rejects.toThrow(/vehicle photo storage is disabled/i)
+  })
+})

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -43,13 +43,18 @@ name = "PUBLIC_CATALOG_LIMITER"
 namespace_id = "1004"
 simple = { limit = 30, period = 60 }
 
-# R2 bucket for vehicle photo uploads. Create the bucket manually:
+# R2 bucket for vehicle photo uploads — DISABLED.
+# R2 is not enabled on the current Cloudflare account (blocked on #304 account
+# migration). Re-enable by uncommenting once R2 is provisioned:
 #   npx wrangler r2 bucket create kuruma-vehicle-photos
-# Enable public access for dev:
 #   npx wrangler r2 bucket dev-url-enable kuruma-vehicle-photos
-[[r2_buckets]]
-binding = "VEHICLE_PHOTOS"
-bucket_name = "kuruma-vehicle-photos"
+# With the binding commented out, wrangler deploy no longer calls the R2 API
+# (which was returning 10042 "Please enable R2"). Runtime: the composition
+# root falls back to DisabledPhotoStorage, which returns a clear 500 on any
+# upload attempt instead of silently accepting into ephemeral per-request memory.
+# [[r2_buckets]]
+# binding = "VEHICLE_PHOTOS"
+# bucket_name = "kuruma-vehicle-photos"
 
 [vars]
 WEB_ORIGIN = "https://kuruma-rental.kanata-studio-dev.workers.dev"


### PR DESCRIPTION
## Why

Every Deploy workflow run since 22:09 UTC has failed at **Deploy API Worker** with:

```
ERROR: A request to the Cloudflare API (/accounts/***/r2/buckets/kuruma-vehicle-photos) failed.
Please enable R2 through the Cloudflare Dashboard. [code: 10042]
```

R2 isn't enabled on the target CF account — that's gated on the account migration work tracked in #304 (HITL). Production has been frozen behind this for multiple builds.

## What

1. **Comment out the `[[r2_buckets]]` binding in `packages/api/wrangler.toml`.** Stops wrangler from calling the R2 admin API at deploy time.
2. **Add `DisabledPhotoStorage`** that rejects `put`/`delete` with a clear error.
3. **Wire it into the Drizzle composition branch** in `packages/api/src/index.ts` as the fallback when `VEHICLE_PHOTOS` binding is absent.

The previous fallback was `InMemoryPhotoStorage`. On Cloudflare Workers each request instantiates the composition root fresh, so an InMemory fallback would make uploads "succeed" into memory that's gone at request end, handing out URLs that point at nothing. Loud failure is safer than silent data loss — tests + overrides path (which production never takes) still default to `InMemoryPhotoStorage` so nothing in the test suite changes.

## Re-enable later

Uncomment the three lines at the bottom of `packages/api/wrangler.toml` once R2 is provisioned on the freelance account. The runtime code already picks up the binding conditionally — no other code change needed.

## Test plan

- [x] `bun run --filter @kuruma/api test` — 426/426 passing (including 2 new `DisabledPhotoStorage` tests)
- [x] `bunx tsc --noEmit` on api + web — clean
- [x] `bun run lint` — clean
- [x] `bun run --filter @kuruma/api lint:boundaries` — OK
- [ ] Deploy workflow runs green after merge
- [ ] Owner photo-upload UI returns an error (not silent data loss) — manual check post-merge

Refs #304.