### PR TITLE
security(api): scope idempotency key lookup to caller

### DIFF
--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -62,11 +62,19 @@ export class DrizzleMessageRepository implements MessageRepository {
     return updated ? normaliseMessage(updated) : undefined
   }
 
-  async findByIdempotencyKey(key: string): Promise<Message | undefined> {
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Message | undefined> {
+    // CallerContext scoping (issue #328): the key is sender-owned, so
+    // non-privileged callers only match messages they themselves sent.
+    // Privileged roles bypass the sender filter.
+    const conditions = [eq(messages.idempotencyKey, key)]
+    if (!PRIVILEGED_ROLES.has(ctx.role)) {
+      conditions.push(eq(messages.senderId, ctx.userId))
+    }
+
     const rows = (await this.db
       .select(messageColumns)
       .from(messages)
-      .where(eq(messages.idempotencyKey, key))) as Array<Parameters<typeof normaliseMessage>[0]>
+      .where(and(...conditions))) as Array<Parameters<typeof normaliseMessage>[0]>
     const [row] = rows
     return row ? normaliseMessage(row) : undefined
   }

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -118,12 +118,26 @@ export class DrizzleThreadRepository implements ThreadRepository {
     }
   }
 
-  async findByIdempotencyKey(key: string): Promise<Thread | undefined> {
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Thread | undefined> {
+    // CallerContext scoping (issue #328): non-privileged callers only match
+    // threads where they are a participant. Join the single thread row
+    // against thread_participants so filtering happens server-side.
+    if (PRIVILEGED_ROLES.has(ctx.role)) {
+      const [row] = (await this.db
+        .select(threadColumns)
+        .from(threads)
+        .where(eq(threads.idempotencyKey, key))).map(toThread)
+      return row
+    }
+
     const [row] = (await this.db
       .select(threadColumns)
       .from(threads)
-      .where(eq(threads.idempotencyKey, key))).map(toThread)
-    return row
+      .innerJoin(threadParticipants, eq(threadParticipants.threadId, threads.id))
+      .where(
+        and(eq(threads.idempotencyKey, key), eq(threadParticipants.userId, ctx.userId)),
+      )) as Array<Parameters<typeof toThread>[0]>
+    return row ? toThread(row) : undefined
   }
 
   async create(

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -28,8 +28,13 @@ export class InMemoryMessageRepository implements MessageRepository {
     return thread ? msg : undefined
   }
 
-  async findByIdempotencyKey(key: string): Promise<Message | undefined> {
-    return this.idempotencyIndex.get(key)
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Message | undefined> {
+    // CallerContext scoping (issue #328): the key is sender-owned, so
+    // non-privileged callers only match messages they themselves sent.
+    const msg = this.idempotencyIndex.get(key)
+    if (!msg) return undefined
+    if (PRIVILEGED_ROLES.has(ctx.role)) return msg
+    return msg.senderId === ctx.userId ? msg : undefined
   }
 
   async updateTranslation(

--- a/packages/api/src/repositories/in-memory/thread.ts
+++ b/packages/api/src/repositories/in-memory/thread.ts
@@ -56,9 +56,16 @@ export class InMemoryThreadRepository implements ThreadRepository {
     return { ...thread, participants: threadParticipants, messages: threadMessages }
   }
 
-  async findByIdempotencyKey(key: string): Promise<Thread | undefined> {
+  async findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Thread | undefined> {
+    // CallerContext scoping (issue #328): non-privileged callers only match
+    // threads they participate in. Privileged roles see all.
     for (const thread of this.threads.values()) {
-      if (thread.idempotencyKey === key) return thread
+      if (thread.idempotencyKey !== key) continue
+      if (PRIVILEGED_ROLES.has(ctx.role)) return thread
+      const isParticipant = [...this.participants.values()].some(
+        (p) => p.threadId === thread.id && p.userId === ctx.userId,
+      )
+      if (isParticipant) return thread
     }
     return undefined
   }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -184,7 +184,13 @@ export interface ThreadRepository {
     ctx: CallerContext,
     id: string,
   ): Promise<(Thread & { participants: ThreadParticipant[]; messages: Message[] }) | undefined>
-  findByIdempotencyKey(key: string): Promise<Thread | undefined>
+  /**
+   * Look up a thread by idempotency key scoped to the caller. Non-privileged
+   * callers only match threads where they are a participant. Prevents
+   * cross-tenant leakage when a client replays a key observed from another
+   * tenant (issue #328).
+   */
+  findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Thread | undefined>
   create(
     ctx: CallerContext,
     bookingId: string | null,
@@ -201,7 +207,13 @@ export interface MessageRepository {
    * `undefined`. Privileged roles (STAFF/ADMIN) bypass the scope.
    */
   findById(ctx: CallerContext, id: string): Promise<Message | undefined>
-  findByIdempotencyKey(key: string): Promise<Message | undefined>
+  /**
+   * Look up a message by idempotency key scoped to the caller. The key is
+   * sender-owned: the lookup matches only messages where `senderId = ctx.userId`
+   * for non-privileged callers. Prevents cross-tenant leakage when a client
+   * replays a key observed from another sender (issue #328).
+   */
+  findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Message | undefined>
   create(
     ctx: CallerContext,
     threadId: string,

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -66,7 +66,7 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
       const idempotencyKey = parsed.data.idempotencyKey ?? null
       const { record: thread, status } = await idempotentCreate(
         idempotencyKey,
-        (k) => threadRepo.findByIdempotencyKey(k),
+        (k) => threadRepo.findByIdempotencyKey(ctx, k),
         () =>
           threadRepo.create(
             ctx,
@@ -90,7 +90,7 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
       const msgIdempotencyKey = parsed.data.idempotencyKey ?? null
       const { record: message, status } = await idempotentCreate(
         msgIdempotencyKey,
-        (k) => messageRepo.findByIdempotencyKey(k),
+        (k) => messageRepo.findByIdempotencyKey(ctx, k),
         () => messageRepo.create(ctx, thread.id, parsed.data.content, msgIdempotencyKey),
       )
       return ok(c, message, status)

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -196,6 +196,59 @@ describe('Message Routes', () => {
         const b2 = await r2.json()
         expect(b1.data.id).toBe(b2.data.id)
       })
+
+      // Issue #328: without caller scope on findByIdempotencyKey, a renter
+      // who guessed or observed another tenant's key would receive the
+      // other tenant's thread on replay. Lookup must filter by participant.
+      it('cross-tenant: U3 replaying U1/U2 thread key gets a fresh thread, not theirs', async () => {
+        const sharedKey = '00000000-0000-4000-8000-aaaa0f0f0f01'
+
+        // U1 creates a thread with U2 using the key.
+        const first = await appAs(U1).request('/threads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: sharedKey }),
+        })
+        expect(first.status).toBe(201)
+        const firstThreadId = (await first.json()).data.id
+
+        // U3 attempts to replay the same key (between themselves and some other user).
+        // Must NOT return U1/U2's thread. Because uniqueness is global on the
+        // idempotency key column, U3's insert will collide; the correct fix
+        // scopes the *lookup* so the post-race re-fetch also returns nothing
+        // for U3. This leaves U3 with a 500 from the collision OR a clean
+        // scope miss — either way, U3 must not see U1/U2's thread id.
+        const second = await appAs(U3).request('/threads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantIds: [U3, U2], idempotencyKey: sharedKey }),
+        })
+        if (second.status === 200 || second.status === 201) {
+          const secondBody = await second.json()
+          expect(secondBody.data.id).not.toBe(firstThreadId)
+        }
+        // If status is 500, the collision was caught but not leaked — also acceptable.
+        expect([200, 201, 500]).toContain(second.status)
+      })
+
+      it('same caller replaying own key returns their existing thread', async () => {
+        const key = '00000000-0000-4000-8000-aaaa0f0f0f02'
+        const first = await appAs(U1).request('/threads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
+        })
+        expect(first.status).toBe(201)
+        const firstId = (await first.json()).data.id
+
+        const replay = await appAs(U1).request('/threads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
+        })
+        expect(replay.status).toBe(200)
+        expect((await replay.json()).data.id).toBe(firstId)
+      })
     })
   })
 
@@ -401,6 +454,62 @@ describe('Message Routes', () => {
         const b1 = await r1.json()
         const b2 = await r2.json()
         expect(b1.data.id).toBe(b2.data.id)
+      })
+
+      // Issue #328: findByIdempotencyKey must scope to sender. Two
+      // participants in the same thread replaying the same key must
+      // not see each other's messages.
+      it('cross-tenant: U2 replaying U1 message key does not leak U1 message', async () => {
+        // U1 creates thread and sends a message with idempotency key.
+        const createRes = await appAs(U1).request('/threads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantIds: [U1, U2] }),
+        })
+        const threadId = (await createRes.json()).data.id
+
+        const sharedKey = '00000000-0000-4000-8000-bbbb0f0f0f01'
+        const u1Msg = await appAs(U1).request(`/threads/${threadId}/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'From U1', idempotencyKey: sharedKey }),
+        })
+        expect(u1Msg.status).toBe(201)
+        const u1MsgId = (await u1Msg.json()).data.id
+
+        // U2 sends in the same thread with the same key. U2 must NOT get U1's message back.
+        const u2Msg = await appAs(U2).request(`/threads/${threadId}/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'From U2', idempotencyKey: sharedKey }),
+        })
+        if (u2Msg.status === 200 || u2Msg.status === 201) {
+          const body = await u2Msg.json()
+          expect(body.data.id).not.toBe(u1MsgId)
+          expect(body.data.senderId).toBe(U2)
+        }
+        expect([200, 201, 500]).toContain(u2Msg.status)
+      })
+
+      it('same sender replaying own key returns their existing message', async () => {
+        const threadId = await createThread()
+        const key = '00000000-0000-4000-8000-bbbb0f0f0f02'
+
+        const first = await appAs(U1).request(`/threads/${threadId}/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'Hi', idempotencyKey: key }),
+        })
+        expect(first.status).toBe(201)
+        const firstId = (await first.json()).data.id
+
+        const replay = await appAs(U1).request(`/threads/${threadId}/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'Hi', idempotencyKey: key }),
+        })
+        expect(replay.status).toBe(200)
+        expect((await replay.json()).data.id).toBe(firstId)
       })
     })
   })


### PR DESCRIPTION
Closes #328

## Summary
P0 security fix from architect audit: `findByIdempotencyKey` on `ThreadRepository` and `MessageRepository` took a client-supplied key with no scope check, so an authenticated renter who learned or brute-forced another tenant's key could replay the lookup and receive that tenant's thread or message.

- Thread + Message `findByIdempotencyKey` now require `CallerContext`.
- Non-privileged callers only match rows they own (threads: caller is a participant; messages: caller is the sender). Privileged roles (STAFF/ADMIN/PARTNER) bypass — matches the pattern `BookingRepository.findByIdempotencyKey` already uses.
- Route layer (`/threads` POST, `/threads/:id/messages` POST) threads `ctx` through the idempotent-create helper.
- Drizzle impl: server-side filter via `innerJoin threadParticipants` (threads) and `eq(messages.senderId, ctx.userId)` (messages).
- InMemory impl: filters on participants / senderId to mirror the Drizzle behaviour for unit tests.

No schema migration: the existing global unique indices on `threads.idempotencyKey` and `messages.idempotencyKey` still prevent collisions at the DB level. The lookup is the only surface that leaked; tightening uniqueness to `(sender, key)` would be a follow-up UX polish, not a security requirement.

## Test plan
- [x] New: U3 replaying U1/U2's thread idempotency key does not return U1/U2's thread id
- [x] New: U2 replaying U1's message idempotency key does not return U1's message
- [x] New: same caller/sender replaying their own key returns their existing record (idempotency still works)
- [x] Existing 22 message route tests still pass, including privileged-role bypass, concurrent-race, and per-user participant scoping
- [x] `bun run --filter @kuruma/api test` — 433 passed (was 429; +4 new scenarios)
- [x] `bunx tsc --noEmit`, `bun run lint`, `bun run --filter @kuruma/api lint:boundaries` — clean