### PR TITLE
fix(db): restore 0023 journal monotonicity + detect future drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,11 @@ bun run db:verify   # must show 3 green checks
 
 **`bun run db:verify`** checks: schema-snapshot sync, journal-disk sync, journal-DB sync. CI enforces via `db-drift` job. Run before any commit touching `schema.ts` or `drizzle/`.
 
+**Gotcha — drizzle-kit migrate silently skips out-of-order timestamps (2026-04-17 incident).** Cherry-picking or rebasing a migration can leave its `when` field in `drizzle/meta/_journal.json` older than the preceding migration. `drizzle-kit migrate` treats migrations whose `when` is older than the last-applied as already-applied and skips them — while still printing "migrations applied successfully". The resulting column drift crashed the booking API (`column "phone" does not exist`) and blocked production Deploy for ~15 min. Mitigations:
+- **Never trust the `migrate` success line alone** — `db:verify` (journal-count vs applied-count) is the real signal. CI already fails on this via the `db-drift` job.
+- **If you rebase/cherry-pick a migration, bump its `when` in `_journal.json` to `max(previous_when) + 1`** before committing, or regenerate it. Don't merge until `db:verify` passes locally against a DB in the same state as prod.
+- **Recovery:** apply the skipped SQL manually (`ALTER TABLE … IF NOT EXISTS`), then insert a matching row into `drizzle.__drizzle_migrations` with the file's SHA256 hash and a post-predecessor timestamp.
+
 ---
 
 # Architecture Rules (Feature Modules)

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -166,7 +166,7 @@
     {
       "idx": 23,
       "version": "7",
-      "when": 1776384834572,
+      "when": 1776582822760,
       "tag": "0023_add_phone_to_users",
       "breakpoints": true
     }

--- a/scripts/db-verify.ts
+++ b/scripts/db-verify.ts
@@ -34,7 +34,7 @@ function listSnapshotFiles(): Set<string> {
   return new Set(readdirSync(META_DIR).filter((f) => /^\d{4}_snapshot\.json$/.test(f)))
 }
 
-type JournalEntry = { idx: number; tag: string }
+type JournalEntry = { idx: number; tag: string; when: number }
 type Journal = { entries: JournalEntry[] }
 
 let failures = 0
@@ -124,7 +124,44 @@ if (!existsSync(JOURNAL_PATH)) {
   }
 }
 
-// ---- Check 3: journal ↔ DB (only if DATABASE_URL set) ----
+// ---- Check 3: journal `when` monotonicity ----
+//
+// drizzle-kit migrate skips any entry whose `when` is older than the last-applied
+// migration's `when`, while still printing "migrations applied successfully". A
+// rebased or cherry-picked migration can inherit an earlier timestamp and be
+// silently skipped, causing schema drift at runtime. See CLAUDE.md gotcha
+// (2026-04-17 incident).
+if (existsSync(JOURNAL_PATH)) {
+  const journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf8')) as Journal
+  const outOfOrder: string[] = []
+  for (let i = 1; i < journal.entries.length; i++) {
+    const prev = journal.entries[i - 1]
+    const curr = journal.entries[i]
+    if (!prev || !curr) continue
+    if (curr.when <= prev.when) {
+      outOfOrder.push(
+        `${curr.tag} (when=${curr.when}) is not greater than ${prev.tag} (when=${prev.when})`,
+      )
+    }
+  }
+  if (outOfOrder.length > 0) {
+    fail(
+      'journal `when` monotonicity',
+      `Out-of-order timestamps will be silently skipped by drizzle-kit migrate.
+Bump each offending entry's \`when\` in drizzle/meta/_journal.json to
+max(previous.when) + 1, then re-run \`bun run db:migrate\`.
+
+${outOfOrder.join('\n')}`,
+    )
+  } else {
+    pass('journal `when` monotonicity', `${journal.entries.length} entries strictly increasing`)
+  }
+}
+
+// ---- Check 4: journal ↔ DB (only if DATABASE_URL set) ----
+//
+// CLAUDE.md gotcha: "migrations applied successfully" is not a reliable signal.
+// The authoritative check is applied-count vs journal-count.
 if (!process.env.DATABASE_URL) {
   console.log('• journal ↔ DB sync — skipped (no DATABASE_URL)')
 } else {


### PR DESCRIPTION
## Summary
- Bump `0023_add_phone_to_users` `when` to `max(previous) + 1` so drizzle-kit migrate applies it on fresh DBs (CI + new environments). Prior `when` was ~3.3 hours earlier than 0022, triggering drizzle's silent-skip behaviour.
- Add `db:verify` Check 3 — journal `when` monotonicity. Catches the bug class at commit time instead of at prod crash time.
- Document the 2026-04-17 incident in `CLAUDE.md` (under the drizzle migrations section).

## Root cause
drizzle-kit compares each journal entry's `when` field to the last-applied migration's `when`. Entries with an earlier timestamp are treated as "already applied" and skipped, even when their hash is absent from `__drizzle_migrations`. The `when` fell out of order after a rebase/cherry-pick of 0023 onto a main that had since merged later migrations (0020–0022).

## Impact
- Before: booking API returned `column "phone" does not exist`; PR #322 db-drift job failing with the same symptom on a fresh DB.
- After: fresh-DB `db:migrate` applies 0023. Prod (already at the right schema via manual recovery) is untouched — drizzle's hash guard still recognises 0023 as applied.

## Test plan
- [x] Drop + recreate `kuruma_test` locally
- [x] `bun run db:migrate` applies all 24 migrations
- [x] `bun run db:verify` — 4/4 checks pass
- [x] `\d users` confirms `phone` column exists
- [x] `bun run --filter @kuruma/api test:integration` — 74/74 pass
- [ ] CI on this PR is green
- [ ] After merge: rebase #322 and bump 0024's `when` (same root cause, different migration)