### PR TITLE
fix(db): restore journal when monotonicity for 0023 + 0024 + add guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,11 @@ bun run db:verify   # must show 3 green checks
 
 **`bun run db:verify`** checks: schema-snapshot sync, journal-disk sync, journal-DB sync. CI enforces via `db-drift` job. Run before any commit touching `schema.ts` or `drizzle/`.
 
+**Gotcha — drizzle-kit migrate silently skips out-of-order timestamps (2026-04-17 incident).** Cherry-picking or rebasing a migration can leave its `when` field in `drizzle/meta/_journal.json` older than the preceding migration. `drizzle-kit migrate` treats migrations whose `when` is older than the last-applied as already-applied and skips them — while still printing "migrations applied successfully". The resulting column drift crashed the booking API (`column "phone" does not exist`) and blocked production Deploy for ~15 min. Mitigations:
+- **Never trust the `migrate` success line alone** — `db:verify` (journal-count vs applied-count) is the real signal. CI already fails on this via the `db-drift` job.
+- **If you rebase/cherry-pick a migration, bump its `when` in `_journal.json` to `max(previous_when) + 1`** before committing, or regenerate it. Don't merge until `db:verify` passes locally against a DB in the same state as prod.
+- **Recovery:** apply the skipped SQL manually (`ALTER TABLE … IF NOT EXISTS`), then insert a matching row into `drizzle.__drizzle_migrations` with the file's SHA256 hash and a post-predecessor timestamp.
+
 ---
 
 # Architecture Rules (Feature Modules)

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -166,7 +166,7 @@
     {
       "idx": 23,
       "version": "7",
-      "when": 1776384834572,
+      "when": 1776582822760,
       "tag": "0023_add_phone_to_users",
       "breakpoints": true
     },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -173,7 +173,7 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1776463363231,
+      "when": 1776582822761,
       "tag": "0024_booking_class_fk",
       "breakpoints": true
     }

--- a/scripts/db-verify.ts
+++ b/scripts/db-verify.ts
@@ -34,7 +34,7 @@ function listSnapshotFiles(): Set<string> {
   return new Set(readdirSync(META_DIR).filter((f) => /^\d{4}_snapshot\.json$/.test(f)))
 }
 
-type JournalEntry = { idx: number; tag: string }
+type JournalEntry = { idx: number; tag: string; when: number }
 type Journal = { entries: JournalEntry[] }
 
 let failures = 0
@@ -124,7 +124,44 @@ if (!existsSync(JOURNAL_PATH)) {
   }
 }
 
-// ---- Check 3: journal ↔ DB (only if DATABASE_URL set) ----
+// ---- Check 3: journal `when` monotonicity ----
+//
+// drizzle-kit migrate skips any entry whose `when` is older than the last-applied
+// migration's `when`, while still printing "migrations applied successfully". A
+// rebased or cherry-picked migration can inherit an earlier timestamp and be
+// silently skipped, causing schema drift at runtime. See CLAUDE.md gotcha
+// (2026-04-17 incident).
+if (existsSync(JOURNAL_PATH)) {
+  const journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf8')) as Journal
+  const outOfOrder: string[] = []
+  for (let i = 1; i < journal.entries.length; i++) {
+    const prev = journal.entries[i - 1]
+    const curr = journal.entries[i]
+    if (!prev || !curr) continue
+    if (curr.when <= prev.when) {
+      outOfOrder.push(
+        `${curr.tag} (when=${curr.when}) is not greater than ${prev.tag} (when=${prev.when})`,
+      )
+    }
+  }
+  if (outOfOrder.length > 0) {
+    fail(
+      'journal `when` monotonicity',
+      `Out-of-order timestamps will be silently skipped by drizzle-kit migrate.
+Bump each offending entry's \`when\` in drizzle/meta/_journal.json to
+max(previous.when) + 1, then re-run \`bun run db:migrate\`.
+
+${outOfOrder.join('\n')}`,
+    )
+  } else {
+    pass('journal `when` monotonicity', `${journal.entries.length} entries strictly increasing`)
+  }
+}
+
+// ---- Check 4: journal ↔ DB (only if DATABASE_URL set) ----
+//
+// CLAUDE.md gotcha: "migrations applied successfully" is not a reliable signal.
+// The authoritative check is applied-count vs journal-count.
 if (!process.env.DATABASE_URL) {
   console.log('• journal ↔ DB sync — skipped (no DATABASE_URL)')
 } else {


### PR DESCRIPTION
Replaces #341 (could not rebase that branch without a force push, which violates the repo's standing rule).

## Summary
- Bump `0023_add_phone_to_users` `when` from `1776384834572` → `1776582822760` (max(prev) + 1).
- Bump `0024_booking_class_fk` `when` from `1776463363231` → `1776582822761` (max(prev) + 1). Merged via #322 with the same out-of-order bug.
- Add `db:verify` Check 3 — journal `when` monotonicity. Fails loudly on any rebased/cherry-picked migration that inherits an earlier timestamp, closing the bug class at commit time.
- Document the 2026-04-17 incident + recovery playbook in `CLAUDE.md`.

## Root cause
drizzle-kit migrate compares each journal entry's `when` to the last-applied migration's `when`. Entries with an earlier timestamp are treated as "already applied" and skipped — even when their hash is absent from `__drizzle_migrations`. 0023 and 0024 both inherited earlier timestamps after rebases and were silently skipped on fresh DBs (CI and the 2026-04-17 prod incident).

## Impact
- Before: `column "phone" does not exist` on fresh DB → integration tests fail on `db-drift` CI job.
- After: fresh-DB `db:migrate` applies all 25 migrations in order. Prod (already at the right schema via manual recovery) is untouched — drizzle's hash guard still recognises 0023/0024 as applied.

## Test plan
- [x] Fresh `kuruma_test` DB → `bun run db:migrate` applies 25 migrations
- [x] `bun run db:verify` — 4/4 checks pass (incl. new monotonicity check)
- [x] `\d users` confirms `phone` column exists
- [x] `bun run --filter @kuruma/api test:integration` — 74/74 pass
- [ ] CI green on this PR