### PR TITLE
ci(deploy): stop re-asserting secrets every deploy; add rotation workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,21 +48,30 @@ jobs:
           bun run db:migrate
           bun run db:verify
 
-      # 2. Set API Worker secrets (idempotent — wrangler secret put is a
-      # full replace, so running every deploy keeps the Worker in sync
-      # with whatever is in GitHub Secrets).
-      # IMPORTANT: AUTH_SECRET must match between API and Web workers.
-      # If you add a shared secret, add it to BOTH worker sections.
-      - name: Set API Worker secrets
-        working-directory: packages/api
-        run: |
-          echo "${{ secrets.PROD_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
-          echo "${{ secrets.AUTH_SECRET }}" | npx wrangler secret put AUTH_SECRET
-
-      # 3. Deploy API Worker. First-time run creates the Worker.
+      # 2. Deploy API Worker. First-time run creates the Worker.
+      # Secrets are NOT re-asserted on every deploy: wrangler 4's gradual
+      # deployments refuse `secret put` when there's an un-promoted pending
+      # version (cloudflare/workers-sdk#6763), and the old re-assert-every-
+      # deploy pattern accumulated those pending versions until deploys
+      # locked up. Rotate secrets via rotate-secrets.yml (workflow_dispatch);
+      # the presence check in step 3 fails the deploy loudly if one is gone.
       - name: Deploy API Worker
         working-directory: packages/api
         run: npx wrangler deploy
+
+      # 3. Verify required secrets exist on the API Worker. Read-only drift
+      # detector — catches "secret got deleted or never rotated" but NOT
+      # value mismatches (CF never returns secret values). Source-of-truth
+      # is GitHub Secrets, enforced by rotate-secrets.yml.
+      - name: Verify API Worker secrets present
+        working-directory: packages/api
+        run: |
+          secrets_json=$(npx wrangler secret list)
+          for key in DATABASE_URL AUTH_SECRET; do
+            echo "$secrets_json" | jq -e --arg k "$key" 'any(.[]; .name == $k)' > /dev/null \
+              || { echo "::error::Missing required secret on API Worker: $key (rotate via rotate-secrets.yml)"; exit 1; }
+          done
+          echo "API Worker secrets present"
 
       # 4. Smoke test the API before we point web traffic at it.
       # /health must return 200 and /bookings must not 500 (catches
@@ -77,16 +86,7 @@ jobs:
           curl -fsS --retry 10 --retry-delay 3 --retry-all-errors "$API_WORKER_URL/health"
           echo "API smoke test passed"
 
-      # 5. Set Web Worker secrets (same idempotent pattern).
-      - name: Set Web Worker secrets
-        working-directory: packages/web
-        run: |
-          echo "${{ secrets.PROD_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
-          echo "${{ secrets.AUTH_SECRET }}" | npx wrangler secret put AUTH_SECRET
-          echo "${{ secrets.AUTH_GOOGLE_ID }}" | npx wrangler secret put AUTH_GOOGLE_ID
-          echo "${{ secrets.AUTH_GOOGLE_SECRET }}" | npx wrangler secret put AUTH_GOOGLE_SECRET
-
-      # 6. Build web. NEXT_PUBLIC_API_URL must be set at build time --
+      # 5. Build web. NEXT_PUBLIC_API_URL must be set at build time --
       # Next.js bakes NEXT_PUBLIC_* into the JS bundle, it is NOT
       # resolved at runtime. This is why the current production is
       # broken: web was built without this set and fell back to
@@ -113,7 +113,19 @@ jobs:
         working-directory: packages/web
         run: npx wrangler deploy
 
-      # 7. Smoke test the web landing page (public, no auth required).
+      # 7. Verify required secrets exist on the Web Worker. Same read-only
+      # drift detector as the API step — see that step's comment for why.
+      - name: Verify Web Worker secrets present
+        working-directory: packages/web
+        run: |
+          secrets_json=$(npx wrangler secret list)
+          for key in DATABASE_URL AUTH_SECRET AUTH_GOOGLE_ID AUTH_GOOGLE_SECRET; do
+            echo "$secrets_json" | jq -e --arg k "$key" 'any(.[]; .name == $k)' > /dev/null \
+              || { echo "::error::Missing required secret on Web Worker: $key (rotate via rotate-secrets.yml)"; exit 1; }
+          done
+          echo "Web Worker secrets present"
+
+      # 8. Smoke test the web landing page (public, no auth required).
       # Same retry rationale as the API smoke test.
       - name: Smoke test Web
         run: |

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -1,0 +1,82 @@
+name: Rotate Worker Secrets
+
+# Manually-triggered only. Re-asserts every production secret from
+# GitHub Secrets onto both Workers, then does a fresh code deploy to
+# promote the new secret values.
+#
+# Why this exists: the old deploy.yml used to re-assert secrets on
+# every deploy to keep GitHub Secrets as the single source of truth
+# (fix for the April 12 AUTH_SECRET drift incident). That pattern
+# became incompatible with wrangler 4's gradual deployments, which
+# refuse `wrangler secret put` when an un-promoted pending version
+# exists (cloudflare/workers-sdk#6763). Removing the per-deploy
+# re-assertion unblocked deploys; this workflow preserves the
+# "GitHub Secrets = source of truth" story on a separate cadence.
+#
+# When to run:
+#   - After changing a secret value in GitHub repo settings.
+#   - If `Verify Worker secrets present` fails in a deploy.
+#   - If you suspect secret drift between API and Web Workers
+#     (AUTH_SECRET and DATABASE_URL MUST match across both).
+#   - As a scheduled hygiene task (not automated here — run on demand).
+#
+# Pre-req: state must be clean (no pending un-promoted Worker version).
+# A successful `deploy.yml` run leaves state clean; if this workflow
+# errors on `wrangler secret put`, run deploy.yml first to flush.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      # Each `wrangler secret put` uploads a new pending Worker version
+      # containing the updated secret. The following `wrangler deploy`
+      # then uploads a fresh code version and promotes it, which clears
+      # the pending state and makes the new secrets active.
+      # IMPORTANT: AUTH_SECRET and DATABASE_URL must match between API
+      # and Web workers. If you add a shared secret, add it to BOTH.
+      - name: Rotate API Worker secrets
+        working-directory: packages/api
+        run: |
+          echo "${{ secrets.PROD_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
+          echo "${{ secrets.AUTH_SECRET }}" | npx wrangler secret put AUTH_SECRET
+          npx wrangler deploy
+
+      # Web Worker needs a build before deploy. Build config MUST match
+      # deploy.yml's "Build Web Worker" step — see that step's comment
+      # for why NEXT_PUBLIC_API_URL is a literal and not an env ref.
+      - name: Build Web Worker
+        working-directory: packages/web
+        env:
+          NEXT_PUBLIC_API_URL: https://kuruma-api.kanata-studio-dev.workers.dev
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+        run: |
+          bun run build
+          bun run build:worker
+
+      - name: Rotate Web Worker secrets
+        working-directory: packages/web
+        run: |
+          echo "${{ secrets.PROD_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
+          echo "${{ secrets.AUTH_SECRET }}" | npx wrangler secret put AUTH_SECRET
+          echo "${{ secrets.AUTH_GOOGLE_ID }}" | npx wrangler secret put AUTH_GOOGLE_ID
+          echo "${{ secrets.AUTH_GOOGLE_SECRET }}" | npx wrangler secret put AUTH_GOOGLE_SECRET
+          npx wrangler deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Critical rules:
 3. **`open-next.config.ts` must exist** or the CLI hangs.
 4. **`typescript.ignoreBuildErrors: true`** in `next.config.ts` (tsc runs locally/CI, not during `next build`).
 5. Secrets set via `npx wrangler secret put` — CF dashboard wipes them on redeploy.
-6. **Shared secrets (AUTH_SECRET) must be set on BOTH workers.** `deploy.yml` is the single source of truth — never set secrets manually via `wrangler secret put` in production. If they drift, JWT verification fails silently ("Unauthorized").
+6. **Shared secrets (AUTH_SECRET, DATABASE_URL) must match between API and Web workers.** GitHub Secrets is the source of truth. `deploy.yml` no longer re-asserts secrets every deploy — wrangler 4's gradual deployments refuse `secret put` when a pending version exists (cloudflare/workers-sdk#6763) and the old pattern locked up deploys. Instead: `deploy.yml` runs a read-only `wrangler secret list` presence check; `rotate-secrets.yml` (workflow_dispatch) re-asserts values. Rotate after changing a GitHub Secret, whenever the presence check fails, or if "Unauthorized" starts appearing silently.
 
 ## i18n (next-intl v4)
 


### PR DESCRIPTION
## Summary

- **deploy.yml**: Remove per-deploy `wrangler secret put` steps. They were accumulating un-promoted pending Worker versions under wrangler 4's gradual deployments (cloudflare/workers-sdk#6763), which is what's been locking up recent deploys with the "latest version not yet deployed" error.
- **deploy.yml**: Add a read-only `wrangler secret list` presence check after each Worker deploy — missing secrets now fail the pipeline loudly instead of silently shipping.
- **rotate-secrets.yml** (new, `workflow_dispatch`-only): Dedicated workflow that re-asserts every production secret from GitHub Secrets onto both Workers and triggers a fresh deploy. This preserves the "GitHub Secrets = source of truth" story from the April 12 AUTH_SECRET drift fix, but on a separate, explicit cadence.
- **CLAUDE.md**: Update the Cloudflare-deployment gotcha to describe the new split.

## Why this split

The April 12 fix (re-assert secrets every deploy) was correct for wrangler 3, where `secret put` just overwrote the live value on the Worker. Wrangler 4 changed the semantics — each `secret put` now creates a new Worker version that must be deployed to promote. Re-asserting on every deploy meant every failed or unrelated-error deploy left behind a pending version; eventually the next `secret put` refused to run at all.

Root cause is the conflation of two concerns on one workflow: **config provisioning** (rare, explicit) and **code deploy** (frequent, clean). Separating them makes each workflow single-purpose and wrangler-4-safe.

## Known gap

The presence check catches missing/deleted secrets but NOT value mismatches between API and Web Workers — CF never returns secret values. Value-drift protection now lives in `rotate-secrets.yml`; run it after changing a GitHub Secret or whenever silent auth failures appear.

## Test plan

- [ ] Merge, then watch the next auto-triggered Deploy run succeed without the secret-put steps (it should clear any lingering pending version on promote).
- [ ] If the presence check flags a missing secret in prod, dispatch `rotate-secrets.yml` and re-run deploy.
- [ ] Manually dispatch `rotate-secrets.yml` once to confirm it promotes new values to both Workers end-to-end.
- [ ] Confirm `/health` on API and `/en` on Web still return 200 after the first post-merge deploy.