### PR TITLE
fix(db): monotonic journal `when` + db:verify guard against silent-skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,13 @@ bun run db:verify   # must show 3 green checks
 
 **Hand-written migrations:** use `bun run db:generate --custom --name <name>`, never drop raw `.sql` into `drizzle/`.
 
-**`bun run db:verify`** checks: schema-snapshot sync, journal-disk sync, journal-DB sync. CI enforces via `db-drift` job. Run before any commit touching `schema.ts` or `drizzle/`.
+**`bun run db:verify`** checks: schema-snapshot sync, monotonic journal `when`, journal-disk sync, journal-DB sync. CI enforces via `db-drift` job. Run before any commit touching `schema.ts` or `drizzle/`.
+
+**Gotcha — drizzle-kit migrate silently skips out-of-order timestamps (2026-04-17 incident).** Cherry-picking or rebasing a migration can leave its `when` field in `drizzle/meta/_journal.json` older than the preceding migration. `drizzle-kit migrate` treats migrations whose `when` is older than the last-applied as already-applied and skips them — while still printing "migrations applied successfully". The resulting column drift crashed the booking API (`column "phone" does not exist`) and blocked production Deploy for ~15 min.
+- **`db:verify` now enforces strictly monotonic `when` at commit time** — this is the primary guard. Do not remove the check.
+- **If you rebase/cherry-pick a migration**, bump its `when` in `_journal.json` to `max(previous_when) + 1` before committing; `db:verify` will tell you if you forgot.
+- **Do not trust `drizzle-kit migrate`'s success line alone** — it prints "migrations applied successfully" even when it skipped an entry. The `journal ↔ DB sync` check (count vs count) is what actually catches a skip post-deploy.
+- **Recovery if a skip reaches prod:** apply the skipped SQL manually (`ALTER TABLE … IF NOT EXISTS` form), then insert a matching row into `drizzle.__drizzle_migrations` with the file's SHA256 hash and a `created_at` strictly greater than its predecessor.
 
 ---
 

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -166,14 +166,14 @@
     {
       "idx": 23,
       "version": "7",
-      "when": 1776384834572,
+      "when": 1776582822760,
       "tag": "0023_add_phone_to_users",
       "breakpoints": true
     },
     {
       "idx": 24,
       "version": "7",
-      "when": 1776463363231,
+      "when": 1776582822761,
       "tag": "0024_booking_class_fk",
       "breakpoints": true
     }

--- a/scripts/db-verify.ts
+++ b/scripts/db-verify.ts
@@ -7,14 +7,17 @@
  * This script runs three checks; any failure exits non-zero and blocks CI / commits.
  *
  * Checks:
- *  1. Schema ↔ snapshot sync (drizzle-kit check) — editing schema.ts without
- *     running db:generate is detected here. No DB connection required.
- *  2. Journal ↔ disk sync — every `_journal.json` entry must map to an on-disk
- *     `.sql` file and vice versa. No DB connection required.
- *  3. Journal ↔ DB sync — the number of applied migrations in
- *     `drizzle.__drizzle_migrations` must equal the number of journal entries.
- *     Only runs when DATABASE_URL is set (skipped cleanly otherwise so the other
- *     two checks still gate local commits).
+ *  1.   Schema ↔ snapshot sync (drizzle-kit check) — editing schema.ts without
+ *       running db:generate is detected here. No DB connection required.
+ *  1.5. Journal `when` strictly monotonic — guards against drizzle-orm's
+ *       silent-skip behavior when a cherry-picked/rebased migration has an
+ *       older `when` than its predecessor. See the CLAUDE.md gotcha.
+ *  2.   Journal ↔ disk sync — every `_journal.json` entry must map to an
+ *       on-disk `.sql` file and vice versa. No DB connection required.
+ *  3.   Journal ↔ DB sync — the number of applied migrations in
+ *       `drizzle.__drizzle_migrations` must equal the number of journal
+ *       entries. Only runs when DATABASE_URL is set (skipped cleanly
+ *       otherwise so the other checks still gate local commits).
  */
 
 import { execSync } from 'node:child_process'
@@ -34,7 +37,7 @@ function listSnapshotFiles(): Set<string> {
   return new Set(readdirSync(META_DIR).filter((f) => /^\d{4}_snapshot\.json$/.test(f)))
 }
 
-type JournalEntry = { idx: number; tag: string }
+type JournalEntry = { idx: number; tag: string; when: number }
 type Journal = { entries: JournalEntry[] }
 
 let failures = 0
@@ -90,6 +93,40 @@ drizzle-kit would have created: ${newFiles.join(', ')}
   const stdout = (err as { stdout?: Buffer }).stdout?.toString() ?? ''
   const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? ''
   fail('drizzle-kit generate failed', `${stdout}\n${stderr}`.trim())
+}
+
+// ---- Check 1.5: journal `when` strictly monotonic ----
+//
+// `drizzle-orm`'s pg migrator applies a migration iff
+//   lastDbMigration.created_at < migration.folderMillis
+// where `folderMillis` is `entry.when` from _journal.json. If a cherry-picked
+// or rebased migration has an older `when` than its predecessor, migrate
+// SILENTLY skips it on incremental prod deploys — fresh CI misses it because
+// lastDbMigration is null there and everything applies. See issue #[TBD].
+// Enforce strictly monotonic `when` at commit time.
+if (existsSync(JOURNAL_PATH)) {
+  const journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf8')) as Journal
+  const violations: string[] = []
+  for (let i = 1; i < journal.entries.length; i++) {
+    const prev = journal.entries[i - 1]!
+    const cur = journal.entries[i]!
+    if (cur.when <= prev.when) {
+      violations.push(`  ${cur.tag} (when=${cur.when}) <= ${prev.tag} (when=${prev.when})`)
+    }
+  }
+  if (violations.length > 0) {
+    fail(
+      'journal `when` strictly monotonic',
+      `drizzle-orm migrate skips any entry whose \`when\` is <= the latest applied \`created_at\`.
+${violations.join('\n')}
+
+Fix: bump the offending entries' \`when\` in drizzle/meta/_journal.json so each is
+strictly greater than its predecessor. \`when\` is only an ordering signal; bumping
+does not affect already-applied rows in \`drizzle.__drizzle_migrations\`.`,
+    )
+  } else {
+    pass('journal `when` strictly monotonic', `${journal.entries.length} entries`)
+  }
 }
 
 // ---- Check 2: journal ↔ disk ----


### PR DESCRIPTION
## Why

`drizzle-orm`'s pg migrator applies a migration iff `lastDbMigration.created_at < entry.when`. Cherry-picking migrations left 0023 and 0024 with `when` values **older than** 0022's, so incremental prod deploys silently skipped them. Fresh CI missed it because `lastDbMigration` is null on a clean DB and everything applies. That's the 2026-04-17 `column "phone" does not exist` 15-min outage.

## What

- **Bump 0023 / 0024 `when`** to `max(predecessor) + 1` so the next incremental deploy applies them (or, if they were recovered manually, correctly skips them — the delta is minimal enough that any recovery timestamp ≥ these values still satisfies drizzle's skip condition).
- **Add check 1.5 to `db:verify`**: every entry's `when` must be strictly greater than the previous. Fails CI via the `db-drift` job if violated. Kills the entire class of cherry-pick-breaks-prod bugs at commit time.
- **Update the CLAUDE.md gotcha** to say the monotonic check is now the primary guard.

## Learn: Silent Ordering Bug in Migration Journal
`drizzle-orm` compares `when` (journal) to `created_at` (DB) as the "apply-me" condition; an out-of-order `when` is indistinguishable from "already applied" from a fresh CI's perspective. **Heuristic:** any ordering-sensitive metadata that's hand-authored in a monorepo (migration `when`, schema version numbers) needs a pre-commit invariant check — rebase/cherry-pick will violate it otherwise.

## Test plan

- [x] `bun run db:verify` green locally
- [x] Regression test: temporarily revert 0023's `when` → check fires with the right message (see commit body)
- [ ] CI db-drift runs `db:migrate` against fresh postgres + `db:verify`
- [ ] Confirm prod DB state before deploy (see runbook)

## Out of scope / follow-ups

- **drizzle-kit generate exits 0 despite snapshot-chain collision** (0021 and 0022 share an `id`). Separate issue.
- **FK index enforcement lint** (#330) — deferred.
- **Root cause — index-only migrations without `.index()` in schema.ts** — meta issue, needs repo-wide fix.