### PR TITLE
fix(web): pin booking datetime-local inputs to JST

### DIFF
--- a/packages/web/src/app/[locale]/bookings/new/ClassBookingForm.tsx
+++ b/packages/web/src/app/[locale]/bookings/new/ClassBookingForm.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useRouter } from '@/i18n/routing'
 import { createClassBooking } from '@/lib/bookings'
+import { parseJstDateTimeLocal } from '@/lib/datetime'
 import { fetchClassAvailability } from '@/modules/classes'
 import { CheckCircle2, XCircle } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -40,7 +41,9 @@ export function ClassBookingForm({ vehicleClass }: ClassBookingFormProps) {
     error: null,
   })
 
-  const hasValidRange = startAt !== '' && endAt !== '' && new Date(endAt) > new Date(startAt)
+  // datetime-local wall clock is always JST — see parseJstDateTimeLocal.
+  const hasValidRange =
+    startAt !== '' && endAt !== '' && parseJstDateTimeLocal(endAt) > parseJstDateTimeLocal(startAt)
 
   // Debounced availability check: fire when the user has a valid pair of
   // dates. The endpoint is cheap and idempotent, so there's no need for
@@ -54,8 +57,8 @@ export function ClassBookingForm({ vehicleClass }: ClassBookingFormProps) {
     }
     let cancelled = false
     setAvailability({ status: 'checking' })
-    const from = new Date(startAt)
-    const to = new Date(endAt)
+    const from = parseJstDateTimeLocal(startAt)
+    const to = parseJstDateTimeLocal(endAt)
     const timer = setTimeout(async () => {
       const result = await fetchClassAvailability(vehicleClass.slug, from, to)
       if (cancelled) return
@@ -84,8 +87,8 @@ export function ClassBookingForm({ vehicleClass }: ClassBookingFormProps) {
     setSubmitState({ isPending: true, error: null })
     const result = await createClassBooking({
       classId: vehicleClass.id,
-      startAt: new Date(startAt).toISOString(),
-      endAt: new Date(endAt).toISOString(),
+      startAt: parseJstDateTimeLocal(startAt).toISOString(),
+      endAt: parseJstDateTimeLocal(endAt).toISOString(),
     })
     if (result.success) {
       router.push(`/bookings/confirmation?bookingId=${result.bookingId}`)

--- a/packages/web/src/components/calendar/ManualBookingDialog.tsx
+++ b/packages/web/src/components/calendar/ManualBookingDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { parseJstDateTimeLocal } from '@/lib/datetime'
 import type { FleetVehicleOverviewData } from '@/lib/vehicle-api'
 import { useTranslations } from 'next-intl'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -160,7 +161,14 @@ export function ManualBookingDialog({
     if (availabilityTimeoutRef.current) clearTimeout(availabilityTimeoutRef.current)
     availabilityTimeoutRef.current = setTimeout(async () => {
       const seq = ++availabilitySeqRef.current
-      const result = await checkAvailability(vehicleId, startAt, endAt)
+      // Pin the wall-clock strings to JST before crossing the network —
+      // see parseJstDateTimeLocal for why. The API parses the query params
+      // with native Date(), which would otherwise interpret them as UTC.
+      const result = await checkAvailability(
+        vehicleId,
+        parseJstDateTimeLocal(startAt).toISOString(),
+        parseJstDateTimeLocal(endAt).toISOString(),
+      )
       if (seq !== availabilitySeqRef.current) return
       if (result.success && !result.data.available) {
         setAvailabilityError(t('vehicleUnavailable'))
@@ -199,8 +207,8 @@ export function ManualBookingDialog({
       } = {
         vehicleId: slot.vehicleId,
         renterId: resolved.renterId,
-        startAt: new Date(slot.startAt).toISOString(),
-        endAt: new Date(slot.endAt).toISOString(),
+        startAt: parseJstDateTimeLocal(slot.startAt).toISOString(),
+        endAt: parseJstDateTimeLocal(slot.endAt).toISOString(),
       }
       if (slot.notes.trim()) bookingInput.notes = slot.notes.trim()
 

--- a/packages/web/src/lib/datetime.ts
+++ b/packages/web/src/lib/datetime.ts
@@ -1,0 +1,24 @@
+/**
+ * Parse a `<input type="datetime-local">` string as wall-clock JST.
+ *
+ * `<input type="datetime-local">` yields "YYYY-MM-DDTHH:mm" (or with seconds)
+ * with **no timezone** attached. The native `new Date(value)` then interprets
+ * that wall clock in the **browser's** timezone. That's wrong for Kuruma:
+ * the bookings UI always means "Tokyo wall clock" — the cars live in Osaka
+ * and the owner schedules in JST — while the primary users are inbound
+ * tourists booking from LA/HKG/SYD.
+ *
+ * This helper appends `+09:00` so the parser anchors to JST regardless of
+ * where the browser lives. Tokyo is UTC+9 year-round (no DST), so the fixed
+ * offset is correct.
+ */
+export function parseJstDateTimeLocal(value: string): Date {
+  if (!value) throw new Error(`parseJstDateTimeLocal: invalid value: ${JSON.stringify(value)}`)
+  // Append seconds if caller passed the minute-granularity form, then pin to JST.
+  const withSeconds = /T\d{2}:\d{2}$/.test(value) ? `${value}:00` : value
+  const d = new Date(`${withSeconds}+09:00`)
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`parseJstDateTimeLocal: invalid value: ${JSON.stringify(value)}`)
+  }
+  return d
+}

--- a/packages/web/tests/lib/datetime.test.ts
+++ b/packages/web/tests/lib/datetime.test.ts
@@ -1,0 +1,42 @@
+import { parseJstDateTimeLocal } from '@/lib/datetime'
+import { describe, expect, it } from 'vitest'
+
+describe('parseJstDateTimeLocal', () => {
+  it('interprets a datetime-local string as wall-clock JST, not browser TZ', () => {
+    // Input: "2026-05-01T10:00" means 10:00 Tokyo wall clock.
+    // Tokyo is UTC+9 year-round (no DST), so 10:00 JST = 01:00 UTC.
+    // The ISO output is TZ-independent — it's always the same regardless of
+    // where the browser lives.
+    const d = parseJstDateTimeLocal('2026-05-01T10:00')
+    expect(d.toISOString()).toBe('2026-05-01T01:00:00.000Z')
+  })
+
+  it('handles the with-seconds form from step=1 inputs', () => {
+    const d = parseJstDateTimeLocal('2026-05-01T10:30:45')
+    expect(d.toISOString()).toBe('2026-05-01T01:30:45.000Z')
+  })
+
+  it('rolls across the date boundary when the wall time is before 09:00 JST', () => {
+    // 08:00 JST on May 1 is 23:00 UTC on April 30 — different day.
+    const d = parseJstDateTimeLocal('2026-05-01T08:00')
+    expect(d.toISOString()).toBe('2026-04-30T23:00:00.000Z')
+  })
+
+  it('produces a Date whose getTime() is deterministic across browser TZs', () => {
+    // Two identical inputs should parse to the same millisecond value no
+    // matter where they're invoked — that's the whole point of pinning JST.
+    const a = parseJstDateTimeLocal('2026-05-01T10:00').getTime()
+    const b = parseJstDateTimeLocal('2026-05-01T10:00').getTime()
+    expect(a).toBe(b)
+    // And the underlying epoch should match the documented JST→UTC conversion.
+    expect(a).toBe(Date.UTC(2026, 4, 1, 1, 0, 0))
+  })
+
+  it('throws on a value the native Date parser rejects', () => {
+    expect(() => parseJstDateTimeLocal('not-a-date')).toThrow(/invalid/i)
+  })
+
+  it('throws on an empty string rather than silently producing epoch', () => {
+    expect(() => parseJstDateTimeLocal('')).toThrow(/invalid/i)
+  })
+})


### PR DESCRIPTION
Closes #346.

## Why

\`<input type=\"datetime-local\">\` yields a wall-clock string with no timezone. Native \`new Date(value)\` parses that in the **browser's** timezone. Kuruma's renters are inbound tourists booking from LA/HKG/SYD, so \"2026-05-01 10:00\" typed in LA was being recorded as 10:00 LA time (= 02:00 JST next day) while the confirmation page displayed in \`Asia/Tokyo\` — user confusion, possible missed pickup.

## What

- New \`packages/web/src/lib/datetime.ts\` with \`parseJstDateTimeLocal(value)\`. Appends \`+09:00\` so the wall clock anchors to JST regardless of browser locale. Tokyo is UTC+9 year-round (no DST), so a fixed offset is correct.
- \`ClassBookingForm\` (renter): replace \`new Date(startAt/endAt)\` in \`hasValidRange\`, the availability \`useEffect\`, and the booking-creation payload.
- \`ManualBookingDialog\` (owner): replace \`new Date(slot.startAt/endAt)\` in both the \`checkAvailability\` call and the booking-creation payload.

## Learn: Timezone at the ingress, not at the display

The fix lives at the *parse* point, not the *display* point. If the Date going into the API is wrong, every downstream surface shows something different (confirmation page, owner calendar, email). **Heuristic:** timezone handling belongs at the system boundary where the ambiguous string becomes an instant — after that, everything is UTC and displays format per-view.

## Test plan

- [x] 6 new TZ-independent tests for \`parseJstDateTimeLocal\` (date boundary, with-seconds form, empty-string throws, etc.)
- [x] Web suite: 379/379 passing
- [x] \`tsc --noEmit\` + biome clean
- [ ] Manual smoke: open \`/bookings/new?class=...\` with system TZ set to LA, type \"2026-05-01T10:00\", submit, confirm that the saved booking shows 2026-05-01 10:00 JST on the confirmation page