### PR TITLE
refactor(api): use parseBody() helper in bookings + customers routes

### DIFF
--- a/packages/api/scripts/check-import-boundaries.ts
+++ b/packages/api/scripts/check-import-boundaries.ts
@@ -40,12 +40,26 @@ function checkFile(filePath: string): Violation[] {
   const isRoute = rel.startsWith('routes/')
   const isService = rel.startsWith('services/')
   const isCompositionRoot = rel === 'index.ts'
+  const isHelpers = rel === 'routes/helpers.ts'
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
     const trimmed = line.trim()
 
-    // Skip non-import lines
+    // Rule 4: Routes must parse request bodies via parseBody(c, schema) from
+    // helpers.ts, not via direct c.req.json() + ad-hoc safeParse. Keeps error-
+    // envelope shape consistent across the API. helpers.ts itself is the one
+    // legitimate caller of c.req.json().
+    if (isRoute && !isHelpers && /\bc\.req\.json\s*\(/.test(trimmed)) {
+      violations.push({
+        file: rel,
+        line: i + 1,
+        text: trimmed,
+        rule: 'Routes must use parseBody(c, schema) from helpers.ts instead of calling c.req.json() directly.',
+      })
+    }
+
+    // Skip non-import lines for the remaining rules
     if (!trimmed.startsWith('import ') && !trimmed.startsWith('import{')) continue
 
     // Rule 1: Routes must not import concrete repositories.

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
-import { fail, ok, parseDateRange, parseLimit } from './helpers'
+import { fail, ok, parseBody, parseDateRange, parseLimit } from './helpers'
 
 export function createBookingRoutes(service: BookingService) {
   return new Hono()
@@ -62,30 +62,26 @@ export function createBookingRoutes(service: BookingService) {
     .post('/bookings', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      const body = await c.req.json()
-      const result = createBookingSchema.safeParse(body)
-
-      if (!result.success) {
-        return fail(c, result.error.flatten().fieldErrors, 400)
-      }
+      const parsed = await parseBody(c, createBookingSchema)
+      if (!parsed.ok) return parsed.response
 
       // Staff/admin can create bookings on behalf of a customer (manual bookings).
       // Non-staff always book as themselves and source is forced to DIRECT
       // to prevent advance-booking-hours bypass via source=MANUAL.
       const isStaff = STAFF_ROLES.has(ctx.role)
-      const renterId = isStaff && result.data.renterId ? result.data.renterId : ctx.userId
-      const source = isStaff ? result.data.source : 'DIRECT'
+      const renterId = isStaff && parsed.data.renterId ? parsed.data.renterId : ctx.userId
+      const source = isStaff ? parsed.data.source : 'DIRECT'
 
       const createResult = await service.create(ctx, {
-        classId: result.data.classId,
-        vehicleId: result.data.vehicleId ?? null,
+        classId: parsed.data.classId,
+        vehicleId: parsed.data.vehicleId ?? null,
         renterId,
-        startAt: new Date(result.data.startAt),
-        endAt: new Date(result.data.endAt),
+        startAt: new Date(parsed.data.startAt),
+        endAt: new Date(parsed.data.endAt),
         source,
-        externalId: result.data.externalId ?? null,
-        notes: result.data.notes ?? null,
-        idempotencyKey: result.data.idempotencyKey ?? null,
+        externalId: parsed.data.externalId ?? null,
+        notes: parsed.data.notes ?? null,
+        idempotencyKey: parsed.data.idempotencyKey ?? null,
       })
 
       if (!createResult.ok) {
@@ -100,11 +96,8 @@ export function createBookingRoutes(service: BookingService) {
     .patch('/bookings/:id/status', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      const body = await c.req.json()
-      const parsed = updateBookingStatusSchema.safeParse(body)
-      if (!parsed.success) {
-        return fail(c, parsed.error.flatten().fieldErrors, 400)
-      }
+      const parsed = await parseBody(c, updateBookingStatusSchema)
+      if (!parsed.ok) return parsed.response
 
       const result = await service.updateStatus(ctx, c.req.param('id'), parsed.data.status)
       if (!result.ok) {

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -2,7 +2,7 @@ import { quickCreateCustomerSchema } from '@kuruma/shared/validators/customer'
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { CustomerService } from '../services/customer'
-import { fail, ok, parseLimit } from './helpers'
+import { fail, ok, parseBody, parseLimit } from './helpers'
 
 const ALLOWED_SORTS = new Set(['lastBookingAt', 'bookingCount', 'name'])
 
@@ -44,13 +44,10 @@ export function createCustomerRoutes(service: CustomerService) {
       return ok(c, customers)
     })
     .post('/customers/quick-create', async (c) => {
-      const body = await c.req.json()
-      const result = quickCreateCustomerSchema.safeParse(body)
-      if (!result.success) {
-        return fail(c, result.error.flatten().fieldErrors as Record<string, unknown>, 400)
-      }
+      const parsed = await parseBody(c, quickCreateCustomerSchema)
+      if (!parsed.ok) return parsed.response
 
-      const { user: customer, created } = await service.quickCreate(result.data)
+      const { user: customer, created } = await service.quickCreate(parsed.data)
       return ok(c, customer, created ? 201 : 200)
     })
     .get('/customers/:id', async (c) => {


### PR DESCRIPTION
Closes #333.

## Summary

- Swap the 2 ad-hoc \`c.req.json() + schema.safeParse()\` sites in \`routes/bookings.ts\` (POST /bookings, PATCH /bookings/:id/status) for the existing \`parseBody(c, schema)\` helper.
- Found and fixed the same pattern at \`routes/customers.ts:47\` (POST /customers/quick-create) — same intent, same drift risk.
- Add **Rule 4** to \`scripts/check-import-boundaries.ts\`: routes must not call \`c.req.json()\` directly. \`routes/helpers.ts\` itself is the one legitimate caller. CI's \`lint:boundaries\` step blocks new routes that copy the old pattern.

## Learn: Boundary Validation Drift

Two patterns for the same concern (input parsing) coexist in one module. New contributors copy whichever they see first; the error-envelope shape diverges silently; clients can't depend on a single contract. **Heuristic:** one validation helper per HTTP layer. A lint that grep-flags bypass is cheaper than a code review that catches it *sometimes*.

## Test plan

- [x] API suite: 446/446 passing (bookings: 63, customers: 26)
- [x] \`tsc --noEmit\` clean
- [x] \`lint:boundaries\` clean — and the new rule fires (tested by temporarily reverting customers.ts: caught it at line 47)
- [x] Biome clean