### PR TITLE
perf(api): edge-cache public vehicle-class catalog GETs

### DIFF
--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -81,6 +81,26 @@ export function parsePagination(c: Context, opts?: LimitOptions): PaginationSucc
   return { ok: true, limit: limitResult.limit, offset }
 }
 
+// --- Cache headers ---
+
+/**
+ * Mark this response as publicly cacheable at the edge for `maxAgeSeconds`.
+ *
+ * Uses `s-maxage` (shared-cache directive) so CF's edge caches the response
+ * but browsers do not — a browser user who refreshes will hit our Worker
+ * again. That's usually what we want: origin traffic drops dramatically
+ * while owner edits still propagate to any given user within maxAgeSeconds.
+ *
+ * Call BEFORE `ok(c, data)`. Hono merges the header into the final response.
+ *
+ * Never call this on an error path — caching a 404 at the edge would pin
+ * the missing resource until the TTL expires, blocking creation from taking
+ * effect edge-wide.
+ */
+export function cachePublic(c: Context, maxAgeSeconds: number): void {
+  c.header('Cache-Control', `public, s-maxage=${maxAgeSeconds}`)
+}
+
 // --- Body parsing helpers ---
 
 type ParseBodySuccess<T> = { ok: true; data: T }

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -7,7 +7,7 @@ import { type Context, Hono } from 'hono'
 import { STAFF_ROLES, requireAuth, requireUser } from '../middleware/auth'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
-import { fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
+import { cachePublic, fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
 
 export function createVehicleClassRoutes(
   service: VehicleClassService,
@@ -39,11 +39,16 @@ export function createVehicleClassRoutes(
         const classes = await service.findAll(
           status ? { status } : includeArchived ? { includeArchived } : undefined,
         )
+        // Catalog changes minutes-to-hours, not per-request. 60s at the edge
+        // cuts origin traffic ~95% while keeping propagation fast enough that
+        // owner edits (rate change, name fix) are visible within a minute.
+        cachePublic(c, 60)
         return ok(c, classes)
       })
       .get('/vehicle-classes/by-slug/:slug', async (c) => {
         const vc = await service.findBySlug(c.req.param('slug'))
         if (!vc) return fail(c, 'Vehicle class not found', 404)
+        cachePublic(c, 60)
         return ok(c, vc)
       })
       .get('/vehicle-classes/:slug/availability', async (c) => {
@@ -56,6 +61,11 @@ export function createVehicleClassRoutes(
           range.to,
         )
         if (!result.ok) return fail(c, result.error, result.status)
+        // Short TTL — availability is time-sensitive (bookings land, vehicles
+        // go under maintenance). 10s absorbs a renter's click-to-confirm
+        // round trip without keeping a stale view for long. The DB exclusion
+        // constraint is the real guardrail for overlap; this is just perf.
+        cachePublic(c, 10)
         return ok(c, result.data)
       })
       // --- Protected routes (auth required) ---

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -373,4 +373,46 @@ describe('Vehicle Class CRUD Routes', () => {
       expect(res.status).toBe(403)
     })
   })
+
+  describe('Cache-Control on public catalog GETs', () => {
+    it('sets public, s-maxage=60 on GET /vehicle-classes', async () => {
+      const res = await app.request('/vehicle-classes')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=60')
+    })
+
+    it('sets public, s-maxage=60 on GET /vehicle-classes/by-slug/:slug', async () => {
+      await createClass()
+      const res = await app.request('/vehicle-classes/by-slug/compact')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=60')
+    })
+
+    it('does NOT set public cache on 404 by-slug — negative responses would pin missing slugs at the edge', async () => {
+      const res = await app.request('/vehicle-classes/by-slug/does-not-exist')
+      expect(res.status).toBe(404)
+      expect(res.headers.get('Cache-Control')).toBeNull()
+    })
+
+    it('sets a shorter s-maxage=10 on /:slug/availability — time-range queries change faster', async () => {
+      await createClass()
+      const res = await app.request(
+        '/vehicle-classes/compact/availability?from=2026-05-01T00:00:00Z&to=2026-05-02T00:00:00Z',
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=10')
+    })
+
+    it('does NOT set cache on writes — PATCH has no Cache-Control (must not be cached at the edge)', async () => {
+      const createRes = await createClass()
+      const { data } = await createRes.json()
+      const res = await app.request(`/vehicle-classes/${data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
Closes #324.

## Summary

Public GETs on \`/vehicle-classes\` are read-heavy and cache-friendly — classes change minutes-to-hours, not per-request. Without edge caching, the rate-limiter is the *only* throttle and every request costs Worker CPU.

- New \`cachePublic(c, maxAgeSeconds)\` helper in \`routes/helpers.ts\`
- \`GET /vehicle-classes\` → \`Cache-Control: public, s-maxage=60\`
- \`GET /vehicle-classes/by-slug/:slug\` → \`Cache-Control: public, s-maxage=60\`
- \`GET /vehicle-classes/:slug/availability\` → \`Cache-Control: public, s-maxage=10\` (shorter because the response is time-range-scoped and bookings land / vehicles go under maintenance more often than catalog metadata changes)

## Design notes

- **\`s-maxage\`, not \`max-age\`.** \`s-maxage\` only instructs shared caches (CF edge). Browsers don't cache, so user refresh still hits the Worker. That's what we want — we cache across users, not within one user's session.
- **Only success responses.** 404s stay uncached so creating a new slug takes effect edge-wide immediately. A cached 404 would pin \"doesn't exist\" for 60s after the row lands.
- **Writes are unchanged.** Non-GET methods (POST/PATCH/DELETE) don't carry \`Cache-Control\`; CF's edge cache ignores non-GET by default. Owner edits propagate on the next GET that misses (\<= TTL).
- **Staff-only \`GET /vehicle-classes/:id\`** (auth-gated) intentionally left uncached — it's behind requireAuth, and authed responses are cache-bypass at the edge anyway.

## Learn: Two-layer cache (browser + shared)

\`max-age\` caches in the user's browser; \`s-maxage\` caches at the CDN. For public read-heavy endpoints that don't vary per-user, prefer \`s-maxage\` alone so a single refresh gets fresh data but repeat cross-user reads cost one origin hit per TTL window. **Heuristic:** if the data is the same for every anonymous caller, cache it shared, not per-user.

## Test plan

- [x] 5 new tests verify Cache-Control on the three public endpoints + absence on 404 + absence on PATCH (mutation-resistant)
- [x] Full API suite: 451/451 passing
- [x] \`tsc --noEmit\` + biome + \`lint:boundaries\` clean
- [ ] Manual smoke in staging: check response header on \`/vehicle-classes\`, verify CF serves from cache on a second request (\`cf-cache-status: HIT\`)