### PR TITLE
security(api): drop `as never` cast in privileged-role authz branch

### DIFF
--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
 import { PRIVILEGED_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { ThreadRepository, UserRepository } from '../repositories/types'
 import { fail, ok } from './helpers'
@@ -15,10 +16,10 @@ const idsSchema = z.array(z.string().uuid()).max(MAX_IDS)
  * user table 50 ids at a time.
  */
 async function allowedUserIds(
-  ctx: { userId: string; role: string },
+  ctx: CallerContext,
   threadRepo: ThreadRepository,
 ): Promise<Set<string> | 'all'> {
-  if (PRIVILEGED_ROLES.has(ctx.role as never)) return 'all'
+  if (PRIVILEGED_ROLES.has(ctx.role)) return 'all'
   const threads = await threadRepo.findAll({ userId: ctx.userId, role: 'RENTER' })
   const allowed = new Set<string>([ctx.userId])
   for (const thread of threads) {


### PR DESCRIPTION
Closes #332.

## Summary

\`routes/users.ts:21\` had:

\`\`\`ts
PRIVILEGED_ROLES.has(ctx.role as never)
\`\`\`

because the local \`ctx\` param was typed as \`{ role: string }\`. The cast was needed to satisfy \`ReadonlySet<UserRole>.has\` — but it silenced the type system on a security-critical branch.

Fix: narrow \`ctx\` to \`CallerContext\` (which already carries \`role: UserRole\`). No cast needed; the privileged-role check is now type-checked natively.

Also audited: only other \`as never\` / \`as unknown\` in \`packages/api/src\` is a drizzle-tx cast in \`transaction.ts\`, unrelated to authz.

## Learn: \`as never\` escape hatch in authz

A type assertion inside an authz branch silences the check the type system was running. After the surrounding code is refactored (e.g., a new role added), the cast still compiles but the privilege check may no longer be exhaustive — compile-time safety becomes a runtime coin-flip. **Heuristic:** \`as never\`/\`as unknown\` inside an authz branch is a smell; fix the surrounding types instead.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] API suite: 451/451 passing (user routes: 8/8)
- [x] Biome clean