### PR TITLE
fix(db): repair drizzle-kit snapshot chain + guard db:verify against silent errors

### DIFF
--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1c559150-9101-42a7-89c7-a9a2da918740",
-  "prevId": "f166e36a-63c0-4fb2-bc10-cec95681f770",
+  "id": "41bba898-085e-4bbf-af70-e80d8640fcdf",
+  "prevId": "1c559150-9101-42a7-89c7-a9a2da918740",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "051d9009-5366-43cc-990c-f7642f94c385",
-  "prevId": "1c559150-9101-42a7-89c7-a9a2da918740",
+  "prevId": "41bba898-085e-4bbf-af70-e80d8640fcdf",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/scripts/db-verify.ts
+++ b/scripts/db-verify.ts
@@ -62,11 +62,20 @@ const snapshotFilesBefore = listSnapshotFiles()
 const journalBefore = readFileSync(JOURNAL_PATH, 'utf8')
 
 try {
-  execSync('bunx drizzle-kit generate', { cwd: REPO_ROOT, stdio: 'pipe' })
+  // Capture stdout. drizzle-kit exits 0 on some fatal conditions (snapshot
+  // collisions, malformed journal) and writes the error to stdout. Without
+  // checking the captured output, the success path below would run even when
+  // the internal state was broken — false positive. See issue #349.
+  const result = execSync('bunx drizzle-kit generate', {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
   const sqlFilesAfter = listMigrationFiles()
   const newFiles = [...sqlFilesAfter].filter((f) => !sqlFilesBefore.has(f))
 
-  if (newFiles.length === 0) {
+  if (/^\s*Error:/im.test(result)) {
+    fail('drizzle-kit generate produced an error', result.trim())
+  } else if (newFiles.length === 0) {
     pass('schema.ts ↔ snapshot in sync', 'no pending changes')
   } else {
     // Rollback the accidental generation: delete the new .sql + snapshot, restore journal.


### PR DESCRIPTION
Closes #349.

## The two bugs

**(1) Snapshot chain collision.** 0021 and 0022 had identical \`id\` AND \`prevId\`. 0022 was an index-only migration, and since the repo pattern doesn't declare indexes in \`schema.ts\`, drizzle-kit saw no diff and emitted an identical snapshot. Every \`drizzle-kit generate\` afterwards errored — which is why #322's migration 0024 had to be hand-authored (see its file comment).

**(2) db:verify false positive.** drizzle-kit exits 0 on the collision error (it writes \"Error: ...\" to stdout and bails via \`process.exit(0)\`). \`db:verify\` Check 1 used \`execSync\` with \`stdio: 'pipe'\` and only treated non-zero exit as failure. So every run reported \`✓ schema.ts ↔ snapshot in sync\` even with the generator completely broken.

## Fixes

**(1)** Give 0022 a fresh random UUID for \`id\` AND set its \`prevId\` to 0021's id (previously pointed at 0020). Cascade: 0023's \`prevId\` now points at the new 0022 id. Chain is now a proper linked list: 0020 → 0021 → 0022 → 0023 → 0024. **Snapshot *content* is unchanged** — index-only migrations produce identical snapshots by design; only the chain metadata differs.

**(2)** Capture drizzle-kit's stdout (\`encoding: 'utf8'\`) and fail \`db:verify\` if the output contains an \"Error:\" line, even on exit 0. Regression-tested locally by reverting 0022's metadata — the guard fires correctly.

## Verification

- \`bunx drizzle-kit generate\` → \"No schema changes, nothing to migrate\" (clean, previously errored)
- \`bun run db:verify\` → all checks pass
- API suite: 451/451
- No migration SQL changed, no schema changes, no \`__drizzle_migrations\` impact (the migrator stores SQL hashes, not snapshot ids)

## Learn: Upstream tool silent-error defense

Tools that exit 0 on fatal conditions break every \"did my check run\" assumption. **Heuristic:** when shelling out to a tool whose failure is load-bearing, grep stdout for error markers in addition to the exit code. Exit codes are a contract; stdout error strings are evidence.

## Follow-ups

- Unblocks #330 (add FK index + lint). Will open as follow-up.
- Root cause — index-only migrations without \`.index()\` in \`schema.ts\` — separate meta issue worth filing.