### PR TITLE
perf(db): index vehicles.classId + bookings.classId FKs; add lint guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check shared export drift
         run: bun run scripts/lint-export-drift.ts
 
+      - name: Check FK indexes
+        run: bun run lint:fk-indexes
+
       - name: Check unused deps and exports
         run: bun run lint:deps
         continue-on-error: true

--- a/drizzle/0025_add_class_fk_indexes.sql
+++ b/drizzle/0025_add_class_fk_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "idx_bookings_classId" ON "bookings" USING btree ("classId");--> statement-breakpoint
+CREATE INDEX "idx_vehicles_classId" ON "vehicles" USING btree ("classId");

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "7f832ec1-8438-437f-9930-006dbb6c0d03",
+  "prevId": "e8a4d07b-830a-4e27-97c3-31a4bc4edef1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_classId_vehicle_classes_id_fk": {
+          "name": "bookings_classId_vehicle_classes_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "classId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_vehicleId_vehicles_id_fk": {
+          "name": "bookings_vehicleId_vehicles_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_pricing_at_least_one": {
+          "name": "vehicle_classes_pricing_at_least_one",
+          "value": "\"vehicle_classes\".\"dailyRateJpy\" IS NOT NULL OR \"vehicle_classes\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicle_classes_daily_rate_non_negative": {
+          "name": "vehicle_classes_daily_rate_non_negative",
+          "value": "\"vehicle_classes\".\"dailyRateJpy\" IS NULL OR \"vehicle_classes\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicle_classes_hourly_rate_non_negative": {
+          "name": "vehicle_classes_hourly_rate_non_negative",
+          "value": "\"vehicle_classes\".\"hourlyRateJpy\" IS NULL OR \"vehicle_classes\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "bufferMinutes": {
+          "name": "bufferMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_classId_vehicle_classes_id_fk": {
+          "name": "vehicles_classId_vehicle_classes_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "classId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1776582822761,
       "tag": "0024_booking_class_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1776596311383,
+      "tag": "0025_add_class_fk_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "bunx biome check --write .",
     "lint:size": "bun run scripts/lint-file-size.ts",
     "lint:modules": "bun run scripts/lint-module-boundaries.ts",
+    "lint:fk-indexes": "bun run scripts/lint-fk-indexes.ts",
     "lint:deps": "bun node_modules/.bin/knip",
     "format": "bunx biome format --write .",
     "db:generate": "drizzle-kit generate",

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm'
 import {
   check,
   date,
+  index,
   integer,
   pgEnum,
   pgTable,
@@ -155,36 +156,47 @@ export const vehicles = pgTable(
       'vehicles_hourly_rate_non_negative',
       sql`${table.hourlyRateJpy} IS NULL OR ${table.hourlyRateJpy} >= 0`,
     ),
+    // Issue #330: renter catalog + booking-by-class filter on classId.
+    // Every FK column needs its own index — pg doesn't auto-create one.
+    index('idx_vehicles_classId').on(table.classId),
   ],
 )
 
-export const bookings = pgTable('bookings', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  renterId: text('renterId')
-    .notNull()
-    .references(() => users.id),
-  // Issue #308: classId is the renter's choice (always present).
-  // vehicleId is nullable — owner assigns a specific car later.
-  classId: text('classId')
-    .notNull()
-    .references(() => vehicleClasses.id),
-  vehicleId: text('vehicleId').references(() => vehicles.id),
-  startAt: timestamp('startAt', { withTimezone: true, mode: 'date' }).notNull(),
-  endAt: timestamp('endAt', { withTimezone: true, mode: 'date' }).notNull(),
-  effectiveEndAt: timestamp('effectiveEndAt', { withTimezone: true, mode: 'date' }).notNull(),
-  status: bookingStatusEnum('status').notNull().default('CONFIRMED'),
-  source: bookingSourceEnum('source').notNull().default('DIRECT'),
-  externalId: text('externalId'),
-  notes: text('notes'),
-  totalPrice: integer('totalPrice'), // whole JPY, nullable for legacy bookings
-  cancellationFee: integer('cancellationFee'), // whole JPY, set on cancellation
-  cancelledAt: timestamp('cancelledAt', { withTimezone: true, mode: 'date' }),
-  idempotencyKey: text('idempotencyKey'),
-  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
-})
+export const bookings = pgTable(
+  'bookings',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    renterId: text('renterId')
+      .notNull()
+      .references(() => users.id),
+    // Issue #308: classId is the renter's choice (always present).
+    // vehicleId is nullable — owner assigns a specific car later.
+    classId: text('classId')
+      .notNull()
+      .references(() => vehicleClasses.id),
+    vehicleId: text('vehicleId').references(() => vehicles.id),
+    startAt: timestamp('startAt', { withTimezone: true, mode: 'date' }).notNull(),
+    endAt: timestamp('endAt', { withTimezone: true, mode: 'date' }).notNull(),
+    effectiveEndAt: timestamp('effectiveEndAt', { withTimezone: true, mode: 'date' }).notNull(),
+    status: bookingStatusEnum('status').notNull().default('CONFIRMED'),
+    source: bookingSourceEnum('source').notNull().default('DIRECT'),
+    externalId: text('externalId'),
+    notes: text('notes'),
+    totalPrice: integer('totalPrice'), // whole JPY, nullable for legacy bookings
+    cancellationFee: integer('cancellationFee'), // whole JPY, set on cancellation
+    cancelledAt: timestamp('cancelledAt', { withTimezone: true, mode: 'date' }),
+    idempotencyKey: text('idempotencyKey'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // Issue #330: booking-by-class queries filter on classId every request.
+    // Paired with idx_vehicles_classId to avoid sequential scans at scale.
+    index('idx_bookings_classId').on(table.classId),
+  ],
+)
 
 // Issue #225: maintenance log and notes per vehicle. Tracks why a vehicle
 // entered MAINTENANCE, with optional cost tracking and resolution timestamp.

--- a/scripts/lint-fk-indexes.test.ts
+++ b/scripts/lint-fk-indexes.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { findUnindexedFks, parseMigrationIndexes } from './lint-fk-indexes'
+
+describe('parseMigrationIndexes', () => {
+  test('parses CREATE INDEX on a single column', () => {
+    const sql = 'CREATE INDEX IF NOT EXISTS "idx_bookings_renterId" ON "bookings" ("renterId");'
+    expect(parseMigrationIndexes(sql)).toEqual([{ table: 'bookings', columns: ['renterId'] }])
+  })
+
+  test('parses CREATE UNIQUE INDEX', () => {
+    const sql = 'CREATE UNIQUE INDEX "u_users_phone" ON "users" ("phone");'
+    expect(parseMigrationIndexes(sql)).toEqual([{ table: 'users', columns: ['phone'] }])
+  })
+
+  test('parses drizzle-kit output with USING btree', () => {
+    const sql = 'CREATE INDEX "idx_vehicles_classId" ON "vehicles" USING btree ("classId");'
+    expect(parseMigrationIndexes(sql)).toEqual([{ table: 'vehicles', columns: ['classId'] }])
+  })
+
+  test('parses composite indexes', () => {
+    const sql = 'CREATE INDEX "idx_tp_composite" ON "thread_participants" ("threadId", "userId");'
+    expect(parseMigrationIndexes(sql)).toEqual([
+      { table: 'thread_participants', columns: ['threadId', 'userId'] },
+    ])
+  })
+
+  test('ignores commented-out and non-index statements', () => {
+    const sql = `
+      CREATE TABLE "x" ("id" text PRIMARY KEY);
+      -- CREATE INDEX commented ON x (y);
+      ALTER TABLE "x" ADD COLUMN "y" text;
+    `
+    expect(parseMigrationIndexes(sql)).toEqual([])
+  })
+})
+
+describe('findUnindexedFks', () => {
+  test('empty when every FK has a matching leading-column index', () => {
+    const missing = findUnindexedFks(
+      [{ table: 'bookings', column: 'renterId' }],
+      [],
+      [{ table: 'bookings', columns: ['renterId'] }],
+    )
+    expect(missing).toEqual([])
+  })
+
+  test('primary-key columns are treated as already indexed', () => {
+    const missing = findUnindexedFks(
+      [{ table: 'accounts', column: 'providerAccountId' }],
+      [{ table: 'accounts', column: 'providerAccountId' }],
+      [],
+    )
+    expect(missing).toEqual([])
+  })
+
+  test('reports an FK that has no covering index', () => {
+    const missing = findUnindexedFks(
+      [{ table: 'vehicles', column: 'classId' }],
+      [{ table: 'vehicles', column: 'id' }],
+      [],
+    )
+    expect(missing).toEqual([{ table: 'vehicles', column: 'classId' }])
+  })
+
+  test('composite index covers the LEADING column only', () => {
+    const missing = findUnindexedFks(
+      [
+        { table: 't', column: 'a' },
+        { table: 't', column: 'b' },
+      ],
+      [],
+      [{ table: 't', columns: ['a', 'b'] }],
+    )
+    expect(missing).toEqual([{ table: 't', column: 'b' }])
+  })
+
+  test('honours explicit exemptions', () => {
+    const missing = findUnindexedFks([{ table: 'x', column: 'y' }], [], [], new Set(['x.y']))
+    expect(missing).toEqual([])
+  })
+})

--- a/scripts/lint-fk-indexes.ts
+++ b/scripts/lint-fk-indexes.ts
@@ -1,0 +1,149 @@
+/**
+ * Enforce: every FK column in the drizzle schema must have a covering index.
+ *
+ * Postgres does NOT auto-create indexes on FK columns. An unindexed FK turns
+ * every JOIN or WHERE-by-fk into a sequential scan. Invisible at 50 rows;
+ * outage-grade at 50k. Same pattern as issue #88 and #254.
+ *
+ * How we check:
+ *  - Introspect schema.ts at runtime via drizzle-orm's getTableConfig.
+ *    This gives authoritative FK columns per table.
+ *  - Parse every drizzle/*.sql migration for CREATE [UNIQUE] INDEX and
+ *    collect (table, leading-column) pairs. Indexes declared in schema.ts
+ *    via `.index()` are also caught because drizzle-kit emits them as
+ *    CREATE INDEX in the generated SQL.
+ *  - A FK is "indexed" if the column is a primary key OR the leading column
+ *    of any index. Trailing columns of a composite index don't count —
+ *    matches Postgres's actual query-planning behavior.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { getTableConfig } from 'drizzle-orm/pg-core'
+
+export interface ForeignKey {
+  table: string
+  column: string
+}
+
+export interface PrimaryKeyColumn {
+  table: string
+  column: string
+}
+
+export interface IndexedColumns {
+  table: string
+  columns: string[]
+}
+
+export function parseMigrationIndexes(sql: string): IndexedColumns[] {
+  // Strip line comments so "-- CREATE INDEX ..." doesn't count.
+  const cleaned = sql.replace(/--[^\n]*/g, '')
+  const re =
+    /create\s+(?:unique\s+)?index(?:\s+if\s+not\s+exists)?\s+(?:"[^"]+"|\w+)\s+on\s+(?:"([^"]+)"|(\w+))\s*(?:using\s+\w+\s*)?\(([^)]+)\)/gi
+  const out: IndexedColumns[] = []
+  for (const m of cleaned.matchAll(re)) {
+    const table = m[1] ?? m[2]
+    if (!table) continue
+    const columns = (m[3] ?? '')
+      .split(',')
+      .map((c) => c.trim().replace(/^"|"$/g, ''))
+      .filter((c) => c.length > 0)
+    if (columns.length > 0) out.push({ table, columns })
+  }
+  return out
+}
+
+export function findUnindexedFks(
+  fks: ForeignKey[],
+  pks: PrimaryKeyColumn[],
+  indexed: IndexedColumns[],
+  exemptions: ReadonlySet<string> = new Set(),
+): ForeignKey[] {
+  const pkSet = new Set(pks.map((p) => `${p.table}.${p.column}`))
+  const idxLeading = new Set(
+    indexed
+      .map((i) => (i.columns[0] ? `${i.table}.${i.columns[0]}` : null))
+      .filter((s): s is string => s !== null),
+  )
+  return fks.filter((fk) => {
+    const key = `${fk.table}.${fk.column}`
+    if (exemptions.has(key)) return false
+    if (pkSet.has(key)) return false
+    if (idxLeading.has(key)) return false
+    return true
+  })
+}
+
+export async function introspectSchemaFks(schemaPath: string): Promise<{
+  fks: ForeignKey[]
+  pks: PrimaryKeyColumn[]
+}> {
+  // biome-ignore lint/suspicious/noExplicitAny: dynamic import of drizzle schema
+  const mod: Record<string, any> = await import(schemaPath)
+  const fks: ForeignKey[] = []
+  const pks: PrimaryKeyColumn[] = []
+  for (const value of Object.values(mod)) {
+    if (!value || typeof value !== 'object' || !('getSQL' in value)) continue
+    // biome-ignore lint/suspicious/noExplicitAny: drizzle internals
+    const cfg = getTableConfig(value as any)
+    for (const fk of cfg.foreignKeys) {
+      // biome-ignore lint/suspicious/noExplicitAny: drizzle reference shape
+      const ref = (fk as any).reference() as { columns: { name: string }[] }
+      for (const col of ref.columns) fks.push({ table: cfg.name, column: col.name })
+    }
+    for (const col of Object.values(cfg.columns)) {
+      if ((col as { primary?: boolean }).primary) {
+        pks.push({ table: cfg.name, column: (col as { name: string }).name })
+      }
+    }
+    for (const pk of cfg.primaryKeys) {
+      for (const col of (pk as { columns: { name: string }[] }).columns) {
+        pks.push({ table: cfg.name, column: col.name })
+      }
+    }
+  }
+  return { fks, pks }
+}
+
+export function readMigrationIndexes(drizzleDir: string): IndexedColumns[] {
+  const entries = readdirSync(drizzleDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+  const all: IndexedColumns[] = []
+  for (const f of entries) {
+    all.push(...parseMigrationIndexes(readFileSync(join(drizzleDir, f), 'utf8')))
+  }
+  return all
+}
+
+export async function runLint(opts: {
+  schemaPath: string
+  drizzleDir: string
+  exemptions?: ReadonlySet<string>
+}): Promise<{ missing: ForeignKey[]; totalFks: number }> {
+  const { fks, pks } = await introspectSchemaFks(opts.schemaPath)
+  const indexed = readMigrationIndexes(opts.drizzleDir)
+  const missing = findUnindexedFks(fks, pks, indexed, opts.exemptions ?? new Set())
+  return { missing, totalFks: fks.length }
+}
+
+async function main() {
+  const schemaPath = new URL('../packages/shared/src/db/schema.ts', import.meta.url).pathname
+  const drizzleDir = new URL('../drizzle', import.meta.url).pathname
+  const { missing, totalFks } = await runLint({ schemaPath, drizzleDir })
+  if (missing.length > 0) {
+    console.error(`[lint-fk-indexes] ${missing.length} of ${totalFks} FKs lack an index:`)
+    for (const fk of missing) console.error(`  - ${fk.table}.${fk.column}`)
+    console.error(
+      '\nAdd `.index(...).on(table.col)` to schema.ts and run `bun run db:generate`,\n' +
+        'or CREATE INDEX in a custom migration. Primary-key columns are considered indexed.',
+    )
+    process.exit(1)
+  }
+  console.log(`[lint-fk-indexes] all ${totalFks} FKs are indexed`)
+}
+
+if (import.meta.main) {
+  void main()
+}


### PR DESCRIPTION
Closes #330. Unblocked by #349 (drizzle-kit snapshot repair).

## Why

Both \`classId\` FKs were added after migration 0010 (the one-time FK-index audit) so they missed that pass. Postgres doesn't auto-create indexes on FK columns, so every \`WHERE classId = ?\` or join-via-classId was doing a sequential scan. Invisible at 40-50 vehicles; painful at 2000+ users and a catalog that filters by class.

## What

**Schema + migration**
- \`.index('idx_vehicles_classId').on(classId)\` on \`vehicles\`
- \`.index('idx_bookings_classId').on(classId)\` on \`bookings\`
- drizzle-kit generated \`0025_add_class_fk_indexes.sql\` (now working again after #349 repaired the snapshot chain)

**Lint guard** — \`scripts/lint-fk-indexes.ts\` + test + \`lint:fk-indexes\` npm script + new CI step.
- Introspects \`schema.ts\` at runtime via \`getTableConfig\` for authoritative FK columns
- Parses every \`drizzle/*.sql\` for \`CREATE [UNIQUE] INDEX\` (including \`USING btree\` from drizzle-kit output)
- Treats primary keys and leading columns of composite indexes as covering; trailing columns of composite indexes don't count (matches pg planner behaviour)
- Fails CI with a list of offenders + fix instructions

## Learn: FK-Added-After-Index-Audit

Every new \`.references()\` is a future table scan unless paired with an index in the same migration. One-time audits don't cover future migrations. **Heuristic:** every \`.references(...)\` in schema.ts gets a matching \`.index(...)\` in the same commit — enforce in CI, not in retrospect.

## Verification

- \`bun run lint:fk-indexes\` → \"all 11 FKs are indexed\"
- \`bun run db:verify\` → all checks pass (including the monotonic-\`when\` and drizzle-kit-stderr guards)
- \`bun run test\`: all packages green (web 379, api 451, shared tests)
- 10 unit tests for the lint itself cover the main cases