### PR TITLE
chore(web): lint locale parity across messages/*.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check FK indexes
         run: bun run lint:fk-indexes
 
+      - name: Check i18n locale parity
+        run: bun run lint:i18n-parity
+
       - name: Check unused deps and exports
         run: bun run lint:deps
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:size": "bun run scripts/lint-file-size.ts",
     "lint:modules": "bun run scripts/lint-module-boundaries.ts",
     "lint:fk-indexes": "bun run scripts/lint-fk-indexes.ts",
+    "lint:i18n-parity": "bun run scripts/lint-i18n-parity.ts",
     "lint:deps": "bun node_modules/.bin/knip",
     "format": "bunx biome format --write .",
     "db:generate": "drizzle-kit generate",

--- a/scripts/lint-i18n-parity.test.ts
+++ b/scripts/lint-i18n-parity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+import { flattenKeys, reportParity } from './lint-i18n-parity'
+
+describe('flattenKeys', () => {
+  test('flattens nested objects with dot-joined paths', () => {
+    const keys = flattenKeys({ a: { b: { c: 'x' } }, d: 'y' })
+    expect([...keys].sort()).toEqual(['a.b.c', 'd'])
+  })
+
+  test('treats arrays and primitives as leaf values', () => {
+    const keys = flattenKeys({ list: ['a', 'b'], n: 1, b: true, nil: null })
+    expect([...keys].sort()).toEqual(['b', 'list', 'n', 'nil'])
+  })
+
+  test('returns empty set for an empty object', () => {
+    expect([...flattenKeys({})]).toEqual([])
+  })
+})
+
+describe('reportParity', () => {
+  test('empty missingByLocale when every locale has the same keys', () => {
+    const r = reportParity({
+      en: new Set(['a', 'b']),
+      ja: new Set(['a', 'b']),
+    })
+    expect(r.keyCount).toBe(2)
+    expect(r.missingByLocale).toEqual({})
+  })
+
+  test('reports each locale missing keys present in another', () => {
+    const r = reportParity({
+      en: new Set(['a', 'b', 'c']),
+      ja: new Set(['a', 'b']),
+      zh: new Set(['a']),
+    })
+    expect(r.keyCount).toBe(3)
+    expect(r.missingByLocale).toEqual({
+      ja: ['c'],
+      zh: ['b', 'c'],
+    })
+  })
+
+  test('locales are reported in sorted order for deterministic output', () => {
+    const r = reportParity({
+      zh: new Set(['a']),
+      en: new Set(['a']),
+      ja: new Set(['a']),
+    })
+    expect(r.locales).toEqual(['en', 'ja', 'zh'])
+  })
+})

--- a/scripts/lint-i18n-parity.ts
+++ b/scripts/lint-i18n-parity.ts
@@ -1,0 +1,88 @@
+/**
+ * Enforce: every configured locale's `messages/<locale>.json` declares the same
+ * set of translation keys. Missing keys render a `MISSING_MESSAGE` error at
+ * runtime in next-intl, breaking pages for renters on that locale.
+ *
+ * Most drift is introduced by merge conflict resolution — the CLAUDE.md gotcha
+ * (i18n section) calls this out explicitly. This lint kills the class at
+ * commit time.
+ *
+ * It does NOT check translation *quality* (whether a JA value was actually
+ * translated vs copied from EN). That's #364's manual-audit half. Here we
+ * just prove parity — the machine-checkable part.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, join } from 'node:path'
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue }
+
+export function flattenKeys(obj: JsonValue, prefix = ''): Set<string> {
+  const out = new Set<string>()
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    if (prefix) out.add(prefix)
+    return out
+  }
+  for (const [k, v] of Object.entries(obj)) {
+    const full = prefix ? `${prefix}.${k}` : k
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      for (const nested of flattenKeys(v, full)) out.add(nested)
+    } else {
+      out.add(full)
+    }
+  }
+  return out
+}
+
+export interface ParityReport {
+  locales: string[]
+  keyCount: number
+  missingByLocale: Record<string, string[]>
+}
+
+export function reportParity(locales: Record<string, Set<string>>): ParityReport {
+  const names = Object.keys(locales).sort()
+  const union = new Set<string>()
+  for (const s of Object.values(locales)) for (const k of s) union.add(k)
+  const missingByLocale: Record<string, string[]> = {}
+  for (const name of names) {
+    const missing: string[] = []
+    for (const k of union) if (!locales[name]!.has(k)) missing.push(k)
+    if (missing.length > 0) missingByLocale[name] = missing.sort()
+  }
+  return { locales: names, keyCount: union.size, missingByLocale }
+}
+
+export function loadLocales(messagesDir: string): Record<string, Set<string>> {
+  const files = readdirSync(messagesDir).filter((f) => f.endsWith('.json'))
+  const out: Record<string, Set<string>> = {}
+  for (const f of files) {
+    const locale = basename(f, '.json')
+    const content = JSON.parse(readFileSync(join(messagesDir, f), 'utf8')) as JsonValue
+    out[locale] = flattenKeys(content)
+  }
+  return out
+}
+
+function main() {
+  const dir = new URL('../packages/web/messages', import.meta.url).pathname
+  const locales = loadLocales(dir)
+  const report = reportParity(locales)
+  const missingCount = Object.values(report.missingByLocale).reduce((a, b) => a + b.length, 0)
+  if (missingCount > 0) {
+    console.error(
+      `[lint-i18n-parity] key drift across ${report.locales.length} locales (${report.keyCount} total keys):`,
+    )
+    for (const [locale, missing] of Object.entries(report.missingByLocale)) {
+      console.error(`\n  ${locale}.json missing ${missing.length} key(s):`)
+      for (const k of missing) console.error(`    - ${k}`)
+    }
+    console.error('\nAdd the missing keys to the offending locale files.')
+    process.exit(1)
+  }
+  console.log(
+    `[lint-i18n-parity] all ${report.locales.length} locales have the same ${report.keyCount} keys`,
+  )
+}
+
+if (import.meta.main) main()


### PR DESCRIPTION
Partial close of #364 — the machine-checkable half.

## Why

CLAUDE.md's i18n gotcha: *\"verify all i18n keys exist after merges; conflict resolution silently drops keys.\"* The failure mode is a \`MISSING_MESSAGE\` runtime error visible only to users on the affected locale — invisible in the author's native-language testing, invisible in unit tests (components mock \`t()\`).

## What

\`scripts/lint-i18n-parity.ts\` reads every \`packages/web/messages/*.json\`, flattens the key tree with dotted paths, and fails if the key sets diverge. Wired into the \`test-and-build\` CI job.

Currently clean: all 3 locales (en/ja/zh) share **501 keys**.

## Learn: Locale parity as an invariant

Three locales with the same key set is a tree invariant that drift silently violates. **Heuristic:** any data shape that must match across N files should have a CI lint asserting parity — humans can't be trusted to notice a missing leaf in a 635-line JSON after a merge.

## Scope NOT covered here

- **Hardcoded strings in TSX** — needs AST walk of JSX text nodes; worth a separate issue
- **Values identical to EN** (possible untranslated-but-present keys) — noisy for branded/numeric strings, needs a smart \"is this actually untranslated?\" heuristic
- **ZH + KO scope decision** — policy, not code
- **The full manual renter-funnel walk** requested in #364 — stays on the issue

## Test plan

- [x] 6 unit tests cover flatten + report (nested/arrays/empty/sorted output/drift)
- [x] Regression-tested: temporarily drop a leaf key from zh.json → lint fails with correct dotted path
- [x] \`bun run lint:i18n-parity\` green on current main
- [x] Biome clean