### PR TITLE
arch(api): lazy worker entry, separate from createApp (#327, #334)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -350,4 +350,9 @@ function resolveAllowedOrigins(envValue: string | undefined): string[] {
   return [...new Set([...devOrigins, ...fromEnv])]
 }
 
-export default createApp()
+/**
+ * Inferred type of the composed app; used by the web client for `hc<AppType>()`.
+ * Declared here so consumers can `import type { AppType } from '@kuruma/api'`
+ * without triggering any runtime side-effects.
+ */
+export type AppType = ReturnType<typeof createApp>

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -1,0 +1,27 @@
+/**
+ * CF Workers entry point. Split from index.ts so that importing `@kuruma/api`
+ * for types (e.g. `type AppType` in the web client) does NOT construct the
+ * full app and pay the Drizzle repo / service wiring cost (#334).
+ *
+ * The app is memoised per-isolate. Each CF Workers isolate cold-starts once
+ * then handles many requests; constructing lazily means the first request
+ * pays the init cost but we never run `createApp()` at module load, which
+ * is the rule CLAUDE.md calls out for CF Workers (#327).
+ */
+
+import { type AppType, createApp } from './index'
+
+let cachedApp: AppType | null = null
+
+function getApp(): AppType {
+  if (!cachedApp) {
+    cachedApp = createApp()
+  }
+  return cachedApp
+}
+
+export default {
+  fetch(request: Request, env?: unknown, ctx?: ExecutionContext): Response | Promise<Response> {
+    return getApp().fetch(request, env, ctx)
+  },
+}

--- a/packages/api/tests/routes/cors.test.ts
+++ b/packages/api/tests/routes/cors.test.ts
@@ -3,10 +3,15 @@
 // (http://localhost:8787) rejects, and the fleet page hangs on skeleton
 // loaders forever. See packages/api/src/index.ts for the middleware.
 
-import { describe, expect, it } from 'vitest'
-import app from '../../src/index'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { type AppType, createApp } from '../../src/index'
 
 describe('CORS middleware', () => {
+  let app: AppType
+  beforeAll(() => {
+    app = createApp()
+  })
+
   it('emits Access-Control-Allow-Origin for the web dev origin on a simple GET', async () => {
     const res = await app.request('/health', {
       headers: { Origin: 'http://localhost:3001' },

--- a/packages/api/tests/routes/health.test.ts
+++ b/packages/api/tests/routes/health.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import app from '../../src/index'
+import { createApp } from '../../src/index'
 
 describe('GET /health', () => {
   it('returns 200 with status ok', async () => {
+    const app = createApp()
     const res = await app.request('/health')
 
     expect(res.status).toBe(200)

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -1,5 +1,5 @@
 name = "kuruma-api"
-main = "src/index.ts"
+main = "src/worker.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
Closes #327 and #334 — both target the same \`export default createApp()\` at the bottom of \`index.ts\`.

## Problem

\`packages/api/src/index.ts:353\` had \`export default createApp()\`. At import time, every consumer:

- Called \`getDb()\` and constructed **13 Drizzle repos + 6 services** during module load
- Violated CLAUDE.md's own CF Workers rule (\`never call getDb() or NextAuth() at module scope\`) — any init-time throw crashes the isolate before it can respond to a request
- Dragged the runtime into type-only importers: the web package only needed \`type AppType\`, but got the runtime as a side effect

## Fix

1. \`packages/api/src/worker.ts\` (new) — CF Workers entry point. Memoises the app per-isolate, calls \`createApp()\` lazily on the first fetch.
2. \`packages/api/src/index.ts\` — drop the default export. Add \`export type AppType = ReturnType<typeof createApp>\` so consumers can \`import type { AppType } from '@kuruma/api'\`.
3. \`packages/api/wrangler.toml\` — \`main = \"src/worker.ts\"\`.
4. Two tests (\`cors.test.ts\`, \`health.test.ts\`) used \`import app from '../../src/index'\`; updated to \`createApp()\` explicitly.

## Learn: Eager Composition Root

A composition root that runs at module-import time fuses two concerns: \"what the app IS\" (declarative) and \"start the app\" (imperative). CF Workers wants a declarative module with a default-exported handler; any runtime work belongs inside that handler. **Heuristic:** declarations at module scope; work in exported functions. \`new X()\` in the top level of a module is a smell.

## Verification

- \`tsc --noEmit\` clean (api and web)
- 451/451 API tests pass
- \`wrangler deploy --dry-run\` succeeds with the new \`worker.ts\` entry (build output unchanged)
- Web \`hc<AppType>(...)\` continues to work — it was already importing the type, not the runtime
- \`lint:boundaries\` + biome clean

## Next cold-start path

\`worker.ts\` on import → constants initialized, no DB call. First request → \`getApp()\` runs \`createApp()\` → builds repos + services. Any throw surfaces as a 500 to that request instead of a silent-dead-isolate. Subsequent requests reuse the memoised app.