### PR TITLE
feat(marketplace): operator-scope VehicleClassRepository + composite FK seal (#395)

### DIFF
--- a/drizzle/0027_class_operator_fk.sql
+++ b/drizzle/0027_class_operator_fk.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "vehicles" DROP CONSTRAINT "vehicles_classId_vehicle_classes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "vehicle_classes" ADD CONSTRAINT "vehicle_classes_operatorId_id_unique" UNIQUE("operatorId","id");--> statement-breakpoint
+ALTER TABLE "vehicles" ADD CONSTRAINT "vehicles_operatorId_classId_fk" FOREIGN KEY ("operatorId","classId") REFERENCES "public"."vehicle_classes"("operatorId","id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1280 @@
+{
+  "id": "a75fb9f8-32fb-401f-ab97-a13ea2bd2629",
+  "prevId": "4f983e9b-48a0-4240-9041-34bdab9e441b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_classId_vehicle_classes_id_fk": {
+          "name": "bookings_classId_vehicle_classes_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "classId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_vehicleId_vehicles_id_fk": {
+          "name": "bookings_vehicleId_vehicles_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_pricing_at_least_one": {
+          "name": "vehicle_classes_pricing_at_least_one",
+          "value": "\"vehicle_classes\".\"dailyRateJpy\" IS NOT NULL OR \"vehicle_classes\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicle_classes_daily_rate_non_negative": {
+          "name": "vehicle_classes_daily_rate_non_negative",
+          "value": "\"vehicle_classes\".\"dailyRateJpy\" IS NULL OR \"vehicle_classes\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicle_classes_hourly_rate_non_negative": {
+          "name": "vehicle_classes_hourly_rate_non_negative",
+          "value": "\"vehicle_classes\".\"hourlyRateJpy\" IS NULL OR \"vehicle_classes\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "bufferMinutes": {
+          "name": "bufferMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1780029855505,
       "tag": "0026_slice1_tenancy",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1780370856695,
+      "tag": "0027_class_operator_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -109,6 +109,18 @@ export const SYSTEM_CONTEXT: CallerContext = {
 } as const
 
 /**
+ * Context for anonymous, public catalog reads (renter storefront). Renters
+ * browse the cross-operator marketplace, so this resolves to an `all` operator
+ * scope (operatorReadScope) — NOT a privilege bypass. Use it on unauthenticated
+ * routes so scoped repos still receive a caller context (#395).
+ */
+export const PUBLIC_CONTEXT: CallerContext = {
+  userId: 'public',
+  role: 'RENTER',
+  bypassScope: false,
+} as const
+
+/**
  * DEPRECATED — legacy global-bypass roles. Treated as temporary platform-admin
  * equivalents during the marketplace transition (proposal §6.2). Do NOT add new
  * users to these roles, and OPERATOR_OWNER / OPERATOR_STAFF must NEVER inherit

--- a/packages/api/src/repositories/drizzle/vehicle-class.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-class.ts
@@ -1,46 +1,57 @@
 import { vehicleClasses } from '@kuruma/shared/db/schema'
-import { asc, eq, ne, sql } from 'drizzle-orm'
+import { type SQL, and, asc, eq, ne, sql } from 'drizzle-orm'
+import type { CallerContext } from '../../middleware/auth'
 import type { VehicleClass } from '../../stores'
+import { operatorReadScope } from '../../tenancy'
 import type { VehicleClassFilters, VehicleClassRepository } from '../types'
 import { type Db, toVehicleClass, vehicleClassColumns } from './shared'
 
 export class DrizzleVehicleClassRepository implements VehicleClassRepository {
   constructor(private readonly db: Db) {}
 
-  async findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]> {
-    const query = this.db
-      .select(vehicleClassColumns)
-      .from(vehicleClasses)
-      .orderBy(asc(vehicleClasses.sortOrder))
-
-    if (filters?.status) {
-      const rows = await query.where(
-        eq(vehicleClasses.status, filters.status),
-      )
-      return rows.map(toVehicleClass)
+  async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
+    const scope = operatorReadScope(ctx)
+    const conditions: SQL[] = []
+    if (scope.kind === 'operator') {
+      conditions.push(eq(vehicleClasses.operatorId, scope.operatorId))
+    } else if (scope.kind === 'none') {
+      conditions.push(sql`false`)
     }
 
-    const rows = filters?.includeArchived
-      ? await query
-      : await query.where(ne(vehicleClasses.status, 'ARCHIVED'))
+    if (filters?.status) {
+      conditions.push(eq(vehicleClasses.status, filters.status))
+    } else if (!filters?.includeArchived) {
+      conditions.push(ne(vehicleClasses.status, 'ARCHIVED'))
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+    const rows = await this.db
+      .select(vehicleClassColumns)
+      .from(vehicleClasses)
+      .where(where)
+      .orderBy(asc(vehicleClasses.sortOrder))
 
     return rows.map(toVehicleClass)
   }
 
-  async findById(id: string): Promise<VehicleClass | undefined> {
-    const [row] = await this.db
-      .select(vehicleClassColumns)
-      .from(vehicleClasses)
-      .where(eq(vehicleClasses.id, id))
+  async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return undefined
+    const conditions: SQL[] = [eq(vehicleClasses.id, id)]
+    if (scope.kind === 'operator') conditions.push(eq(vehicleClasses.operatorId, scope.operatorId))
+
+    const [row] = await this.db.select(vehicleClassColumns).from(vehicleClasses).where(and(...conditions))
 
     return row ? toVehicleClass(row) : undefined
   }
 
-  async findBySlug(slug: string): Promise<VehicleClass | undefined> {
-    const [row] = await this.db
-      .select(vehicleClassColumns)
-      .from(vehicleClasses)
-      .where(eq(vehicleClasses.slug, slug))
+  async findBySlug(ctx: CallerContext, slug: string): Promise<VehicleClass | undefined> {
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return undefined
+    const conditions: SQL[] = [eq(vehicleClasses.slug, slug)]
+    if (scope.kind === 'operator') conditions.push(eq(vehicleClasses.operatorId, scope.operatorId))
+
+    const [row] = await this.db.select(vehicleClassColumns).from(vehicleClasses).where(and(...conditions))
 
     return row ? toVehicleClass(row) : undefined
   }

--- a/packages/api/src/repositories/in-memory/vehicle-class.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-class.ts
@@ -1,4 +1,6 @@
+import type { CallerContext } from '../../middleware/auth'
 import type { VehicleClass } from '../../stores'
+import { operatorReadScope } from '../../tenancy'
 import type { VehicleClassFilters, VehicleClassRepository } from '../types'
 
 export class InMemoryVehicleClassRepository implements VehicleClassRepository {
@@ -8,19 +10,33 @@ export class InMemoryVehicleClassRepository implements VehicleClassRepository {
     this.store = store ?? new Map()
   }
 
-  async findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]> {
-    const all = [...this.store.values()]
+  async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return []
+    const all = [...this.store.values()].filter((vc) =>
+      scope.kind === 'operator' ? vc.operatorId === scope.operatorId : true,
+    )
     if (filters?.status) return all.filter((vc) => vc.status === filters.status)
     if (filters?.includeArchived) return all
     return all.filter((vc) => vc.status !== 'ARCHIVED')
   }
 
-  async findById(id: string): Promise<VehicleClass | undefined> {
-    return this.store.get(id)
+  async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return undefined
+    const vc = this.store.get(id)
+    if (!vc) return undefined
+    if (scope.kind === 'operator' && vc.operatorId !== scope.operatorId) return undefined
+    return vc
   }
 
-  async findBySlug(slug: string): Promise<VehicleClass | undefined> {
-    return [...this.store.values()].find((vc) => vc.slug === slug)
+  async findBySlug(ctx: CallerContext, slug: string): Promise<VehicleClass | undefined> {
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return undefined
+    const vc = [...this.store.values()].find((v) => v.slug === slug)
+    if (!vc) return undefined
+    if (scope.kind === 'operator' && vc.operatorId !== scope.operatorId) return undefined
+    return vc
   }
 
   async create(data: Omit<VehicleClass, 'id' | 'createdAt' | 'updatedAt'>): Promise<VehicleClass> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -296,9 +296,9 @@ export interface VehicleClassFilters {
 }
 
 export interface VehicleClassRepository {
-  findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]>
-  findById(id: string): Promise<VehicleClass | undefined>
-  findBySlug(slug: string): Promise<VehicleClass | undefined>
+  findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]>
+  findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined>
+  findBySlug(ctx: CallerContext, slug: string): Promise<VehicleClass | undefined>
   create(data: Omit<VehicleClass, 'id' | 'createdAt' | 'updatedAt'>): Promise<VehicleClass>
   update(id: string, data: Partial<VehicleClass>): Promise<VehicleClass | undefined>
   archive(id: string): Promise<VehicleClass | undefined>

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -4,7 +4,13 @@ import {
   updateVehicleClassSchema,
 } from '@kuruma/shared/validators/vehicle-class'
 import { type Context, Hono } from 'hono'
-import { STAFF_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import {
+  PUBLIC_CONTEXT,
+  STAFF_ROLES,
+  requireAuth,
+  requireUser,
+  toCallerContext,
+} from '../middleware/auth'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import { resolveOperatorIdForWrite } from '../tenancy'
@@ -33,13 +39,12 @@ export function createVehicleClassRoutes(
   return (
     app
       .get('/vehicle-classes', async (c) => {
-        const rawStatus = c.req.query('status')
-        const status: 'ACTIVE' | 'ARCHIVED' | undefined =
-          rawStatus === 'ACTIVE' || rawStatus === 'ARCHIVED' ? rawStatus : undefined
-        const includeArchived = c.req.query('includeArchived') === 'true'
-        const classes = await service.findAll(
-          status ? { status } : includeArchived ? { includeArchived } : undefined,
-        )
+        // Public catalog: anonymous callers see the cross-operator marketplace
+        // (PUBLIC_CONTEXT -> 'all' scope) but only ACTIVE classes. status /
+        // includeArchived params are ignored here — archived inventory is never
+        // publicly listable (#395). Admin-scoped archived views go through the
+        // protected endpoints.
+        const classes = await service.findAll(PUBLIC_CONTEXT)
         // Catalog changes minutes-to-hours, not per-request. 60s at the edge
         // cuts origin traffic ~95% while keeping propagation fast enough that
         // owner edits (rate change, name fix) are visible within a minute.
@@ -47,7 +52,7 @@ export function createVehicleClassRoutes(
         return ok(c, classes)
       })
       .get('/vehicle-classes/by-slug/:slug', async (c) => {
-        const vc = await service.findBySlug(c.req.param('slug'))
+        const vc = await service.findBySlug(PUBLIC_CONTEXT, c.req.param('slug'))
         if (!vc) return fail(c, 'Vehicle class not found', 404)
         cachePublic(c, 60)
         return ok(c, vc)
@@ -57,6 +62,7 @@ export function createVehicleClassRoutes(
         if (!range.ok) return range.response
 
         const result = await availabilityService.getAvailabilityForClass(
+          PUBLIC_CONTEXT,
           c.req.param('slug'),
           range.from,
           range.to,
@@ -72,7 +78,10 @@ export function createVehicleClassRoutes(
       // --- Protected routes (auth required) ---
       .use('/vehicle-classes/*', requireAuth())
       .get('/vehicle-classes/:id', async (c) => {
-        const vc = await service.findById(c.req.param('id'))
+        // Operator-scoped: an OPERATOR_* caller can only read its own class;
+        // bypass roles (STAFF/ADMIN/PLATFORM_ADMIN) read across operators (#395).
+        const ctx = toCallerContext(requireUser(c))
+        const vc = await service.findById(ctx, c.req.param('id'))
         if (!vc) return fail(c, 'Vehicle class not found', 404)
         return ok(c, vc)
       })
@@ -84,7 +93,7 @@ export function createVehicleClassRoutes(
         if (!parsed.ok) return parsed.response
 
         const d = parsed.data
-        const result = await service.create({
+        const result = await service.create(toCallerContext(user), {
           // Transitional: legacy STAFF/ADMIN writes attach to the default
           // operator until operator-portal write flows land (#386).
           operatorId: resolveOperatorIdForWrite(toCallerContext(user)),
@@ -113,6 +122,7 @@ export function createVehicleClassRoutes(
         if (!parsed.ok) return parsed.response
 
         const result = await service.update(
+          toCallerContext(user),
           c.req.param('id'),
           stripUndefined(parsed.data) as Partial<import('../stores').VehicleClass>,
         )
@@ -123,7 +133,7 @@ export function createVehicleClassRoutes(
         const user = requireUser(c)
         if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-        const result = await service.archive(c.req.param('id'))
+        const result = await service.archive(toCallerContext(user), c.req.param('id'))
         if (!result.ok) {
           const extras: Record<string, unknown> = {}
           if (result.code) extras.code = result.code

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -2,7 +2,7 @@ import { type BookingStatus, VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
-import type { CallerContext } from '../middleware/auth'
+import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
   BookingFilters,
@@ -418,7 +418,10 @@ export class BookingService {
     if (!this.vehicleClassRepo) {
       throw new Error('BookingService missing vehicleClassRepo; check DI wiring')
     }
-    return (await this.vehicleClassRepo.findById(id)) ?? null
+    // Marketplace-wide lookup: a booking's class is resolved regardless of
+    // operator (the caller may be a renter/partner). SYSTEM_CONTEXT = 'all'
+    // scope; this is an internal pricing read, not per-tenant exposure (#395).
+    return (await this.vehicleClassRepo.findById(SYSTEM_CONTEXT, id)) ?? null
   }
 
   private async lookupVehicle(ctx: CallerContext, id: string): Promise<Vehicle | null> {

--- a/packages/api/src/services/vehicle-class-availability.ts
+++ b/packages/api/src/services/vehicle-class-availability.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_CONTEXT } from '../middleware/auth'
+import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import type {
   AvailabilityRepository,
   VehicleClassRepository,
@@ -33,11 +33,12 @@ export class VehicleClassAvailabilityService {
   ) {}
 
   async getAvailabilityForClass(
+    ctx: CallerContext,
     slug: string,
     from: Date,
     to: Date,
   ): Promise<ClassAvailabilityResult> {
-    const vc = await this.classRepo.findBySlug(slug)
+    const vc = await this.classRepo.findBySlug(ctx, slug)
     if (!vc) return { ok: false, error: 'Vehicle class not found', status: 404 }
 
     // Only AVAILABLE vehicles count toward the class total. MAINTENANCE and

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_CONTEXT } from '../middleware/auth'
+import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import type {
   BookingRepository,
   VehicleClassFilters,
@@ -30,20 +30,25 @@ export class VehicleClassService {
     private readonly bookingRepo: BookingRepository,
   ) {}
 
-  async findAll(filters?: VehicleClassFilters): Promise<VehicleClass[]> {
-    return this.repo.findAll(filters)
+  async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
+    return this.repo.findAll(ctx, filters)
   }
 
-  async findById(id: string): Promise<VehicleClass | undefined> {
-    return this.repo.findById(id)
+  async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {
+    return this.repo.findById(ctx, id)
   }
 
-  async findBySlug(slug: string): Promise<VehicleClass | undefined> {
-    return this.repo.findBySlug(slug)
+  async findBySlug(ctx: CallerContext, slug: string): Promise<VehicleClass | undefined> {
+    return this.repo.findBySlug(ctx, slug)
   }
 
-  async create(data: Omit<VehicleClass, 'id' | 'createdAt' | 'updatedAt'>): Promise<CreateResult> {
-    const existing = await this.repo.findBySlug(data.slug)
+  async create(
+    ctx: CallerContext,
+    data: Omit<VehicleClass, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<CreateResult> {
+    // Slug uniqueness is global (DB unique constraint), so the collision check
+    // must see across operators — scope it to SYSTEM, not the caller (#395).
+    const existing = await this.repo.findBySlug(SYSTEM_CONTEXT, data.slug)
     if (existing) {
       return { ok: false, error: 'Slug already in use', status: 409 }
     }
@@ -51,14 +56,15 @@ export class VehicleClassService {
     return { ok: true, vehicleClass }
   }
 
-  async update(id: string, data: Partial<VehicleClass>): Promise<UpdateResult> {
-    const existing = await this.repo.findById(id)
+  async update(ctx: CallerContext, id: string, data: Partial<VehicleClass>): Promise<UpdateResult> {
+    // Existence is caller-scoped: an operator may only edit its own class.
+    const existing = await this.repo.findById(ctx, id)
     if (!existing) {
       return { ok: false, error: 'Vehicle class not found', status: 404 }
     }
 
     if (data.slug !== undefined && data.slug !== existing.slug) {
-      const slugOwner = await this.repo.findBySlug(data.slug)
+      const slugOwner = await this.repo.findBySlug(SYSTEM_CONTEXT, data.slug)
       if (slugOwner && slugOwner.id !== id) {
         return { ok: false, error: 'Slug already in use', status: 409 }
       }
@@ -82,8 +88,8 @@ export class VehicleClassService {
     return { ok: true, vehicleClass: updated }
   }
 
-  async archive(id: string): Promise<ArchiveResult> {
-    const existing = await this.repo.findById(id)
+  async archive(ctx: CallerContext, id: string): Promise<ArchiveResult> {
+    const existing = await this.repo.findById(ctx, id)
     if (!existing) {
       return { ok: false, error: 'Vehicle class not found', status: 404 }
     }

--- a/packages/api/tests/integration/tenancy-isolation.test.ts
+++ b/packages/api/tests/integration/tenancy-isolation.test.ts
@@ -1,14 +1,16 @@
-import { operators, vehicles } from '@kuruma/shared/db/schema'
+import { operators, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type CallerContext, ForbiddenError, SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import { pgErrorCode } from '../../src/pg-errors'
 import {
   DrizzleBookingRepository,
   DrizzleMessageRepository,
   DrizzleThreadRepository,
+  DrizzleVehicleClassRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
-import type { Vehicle } from '../../src/stores'
+import type { Vehicle, VehicleClass } from '../../src/stores'
 import { DEFAULT_DAILY_RATE_JPY, db } from './setup'
 
 // An OPERATOR_* caller scoped to one tenant must never observe another
@@ -197,5 +199,203 @@ describe('cross-operator vehicle isolation', () => {
   it('an operator can update its own tenant vehicle', async () => {
     const updated = await vehicleRepo.update(ctxFor(opAId), vehicleA.id, { name: 'Iso Car A v2' })
     expect(updated).toMatchObject({ id: vehicleA.id, name: 'Iso Car A v2' })
+  })
+})
+
+// Vehicle-class reads are operator-scoped (#395): an OPERATOR_* caller only
+// sees its own tenant's classes; a tenant-less operator fails closed; admins
+// (SYSTEM_CONTEXT) read across operators. Exercised against real Postgres.
+describe('cross-operator class isolation', () => {
+  const classRepo = new DrizzleVehicleClassRepository(db)
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `op_cls_a_${uniq}`
+  const opBId = `op_cls_b_${uniq}`
+  const createdClassIds: string[] = []
+  let classA: VehicleClass
+  let classB: VehicleClass
+
+  const ctxFor = (operatorId: string): CallerContext => ({
+    userId: 'owner',
+    role: 'OPERATOR_OWNER',
+    operatorId,
+    bypassScope: false,
+  })
+
+  const seedClass = (operatorId: string, suffix: string): Promise<VehicleClass> =>
+    classRepo.create({
+      operatorId,
+      name: `Iso Class ${suffix}`,
+      slug: `iso-class-${suffix}-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opAId, slug: `cls-a-${uniq}`, name: 'Class Operator A' },
+      { id: opBId, slug: `cls-b-${uniq}`, name: 'Class Operator B' },
+    ])
+    classA = await seedClass(opAId, 'a')
+    classB = await seedClass(opBId, 'b')
+    createdClassIds.push(classA.id, classB.id)
+  })
+
+  afterAll(async () => {
+    if (createdClassIds.length > 0) {
+      await db.delete(vehicleClasses).where(inArray(vehicleClasses.id, createdClassIds))
+    }
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+  })
+
+  it('findAll returns only the scoped tenant classes', async () => {
+    const ids = (await classRepo.findAll(ctxFor(opAId))).map((c) => c.id)
+    expect(ids).toContain(classA.id)
+    expect(ids).not.toContain(classB.id)
+  })
+
+  it('findById cannot reach another tenant class', async () => {
+    const ctxA = ctxFor(opAId)
+    expect(await classRepo.findById(ctxA, classA.id)).toMatchObject({ id: classA.id })
+    expect(await classRepo.findById(ctxA, classB.id)).toBeUndefined()
+  })
+
+  it('findBySlug cannot reach another tenant class', async () => {
+    const ctxA = ctxFor(opAId)
+    expect(await classRepo.findBySlug(ctxA, classA.slug)).toMatchObject({ id: classA.id })
+    expect(await classRepo.findBySlug(ctxA, classB.slug)).toBeUndefined()
+  })
+
+  it('an OPERATOR_* caller with no tenant claim sees nothing (fail-closed)', async () => {
+    const noTenant: CallerContext = { userId: 'x', role: 'OPERATOR_OWNER', bypassScope: false }
+    expect(await classRepo.findAll(noTenant)).toHaveLength(0)
+    expect(await classRepo.findById(noTenant, classA.id)).toBeUndefined()
+    expect(await classRepo.findBySlug(noTenant, classA.slug)).toBeUndefined()
+  })
+
+  it('SYSTEM_CONTEXT reads classes across operators', async () => {
+    const ids = (await classRepo.findAll(SYSTEM_CONTEXT)).map((c) => c.id)
+    expect(ids).toContain(classA.id)
+    expect(ids).toContain(classB.id)
+  })
+})
+
+// Composite FK seal (#395 Phase 2): a vehicle's classId must belong to the
+// vehicle's own operator. Enforced at the DB by FK vehicles(operatorId,classId)
+// -> vehicle_classes(operatorId,id). A NULL classId stays allowed (MATCH SIMPLE),
+// so an unassigned vehicle is fine. Covers create AND update (reassign on edit).
+describe('vehicle classId is sealed to the vehicle’s operator (composite FK)', () => {
+  const vehicleRepo = new DrizzleVehicleRepository(db)
+  const classRepo = new DrizzleVehicleClassRepository(db)
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `op_fk_a_${uniq}`
+  const opBId = `op_fk_b_${uniq}`
+  let classA: VehicleClass
+  let classB: VehicleClass
+
+  const makeClass = (operatorId: string, suffix: string): Promise<VehicleClass> =>
+    classRepo.create({
+      operatorId,
+      name: `FK Class ${suffix}`,
+      slug: `fk-class-${suffix}-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+
+  const vehicleInput = (operatorId: string, classId: string | null) => ({
+    operatorId,
+    classId,
+    name: 'FK Vehicle',
+    description: null,
+    photos: [] as string[],
+    seats: 5,
+    transmission: 'AUTO' as const,
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+  })
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opAId, slug: `fk-a-${uniq}`, name: 'FK Operator A' },
+      { id: opBId, slug: `fk-b-${uniq}`, name: 'FK Operator B' },
+    ])
+    classA = await makeClass(opAId, 'a')
+    classB = await makeClass(opBId, 'b')
+  })
+
+  // Delete by operatorId so any vehicle created by a still-failing assertion
+  // (cross-tenant rows that wrongly succeed before the FK lands) is also removed.
+  afterAll(async () => {
+    await db.delete(vehicles).where(inArray(vehicles.operatorId, [opAId, opBId]))
+    await db.delete(vehicleClasses).where(inArray(vehicleClasses.operatorId, [opAId, opBId]))
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+  })
+
+  // Anchor to the PG foreign_key_violation code so the test cannot pass on an
+  // unrelated error (e.g. a future NOT NULL column) while the cross-tenant seal
+  // silently breaks. drizzle's err.message is just the failed SQL; the real PG
+  // code lives at err.cause.code — pgErrorCode() reads both paths.
+  const PG_FK_VIOLATION = '23503'
+  const violationCode = (p: Promise<unknown>): Promise<string | null> =>
+    p.then(
+      () => null,
+      (err) => pgErrorCode(err),
+    )
+
+  it('create rejects a class owned by another operator', async () => {
+    expect(
+      await violationCode(vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, classB.id))),
+    ).toBe(PG_FK_VIOLATION)
+  })
+
+  it('create accepts the operator’s own class', async () => {
+    const v = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, classA.id))
+    expect(v.classId).toBe(classA.id)
+  })
+
+  it('create accepts a null class (unassigned vehicle)', async () => {
+    const v = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, null))
+    expect(v.classId).toBeNull()
+  })
+
+  it('update rejects reassigning to another operator’s class', async () => {
+    const v = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, null))
+    expect(
+      await violationCode(vehicleRepo.update(SYSTEM_CONTEXT, v.id, { classId: classB.id })),
+    ).toBe(PG_FK_VIOLATION)
+  })
+
+  it('update accepts reassigning to the operator’s own class', async () => {
+    const v = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, null))
+    const updated = await vehicleRepo.update(SYSTEM_CONTEXT, v.id, { classId: classA.id })
+    expect(updated?.classId).toBe(classA.id)
   })
 })

--- a/packages/api/tests/repositories/vehicle-class.test.ts
+++ b/packages/api/tests/repositories/vehicle-class.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import { type CallerContext, PUBLIC_CONTEXT, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryVehicleClassRepository } from '../../src/repositories/in-memory'
 import type { VehicleClass } from '../../src/stores'
 
 function vehicleClassInput(overrides?: Partial<VehicleClass>) {
   return {
+    operatorId: 'op_test',
     name: 'Economy',
     slug: 'economy',
     description: 'Compact and fuel-efficient',
@@ -29,7 +31,7 @@ describe('InMemoryVehicleClassRepository', () => {
 
   describe('findAll', () => {
     it('returns empty array when no classes exist', async () => {
-      const result = await repo.findAll()
+      const result = await repo.findAll(SYSTEM_CONTEXT)
       expect(result).toEqual([])
     })
 
@@ -37,7 +39,7 @@ describe('InMemoryVehicleClassRepository', () => {
       await repo.create(vehicleClassInput({ name: 'Active', status: 'ACTIVE' }))
       await repo.create(vehicleClassInput({ name: 'Gone', slug: 'gone', status: 'ARCHIVED' }))
 
-      const result = await repo.findAll()
+      const result = await repo.findAll(SYSTEM_CONTEXT)
 
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Active')
@@ -47,7 +49,7 @@ describe('InMemoryVehicleClassRepository', () => {
       await repo.create(vehicleClassInput({ name: 'Active', status: 'ACTIVE' }))
       await repo.create(vehicleClassInput({ name: 'Gone', slug: 'gone', status: 'ARCHIVED' }))
 
-      const result = await repo.findAll({ includeArchived: true })
+      const result = await repo.findAll(SYSTEM_CONTEXT, { includeArchived: true })
 
       expect(result).toHaveLength(2)
     })
@@ -56,7 +58,7 @@ describe('InMemoryVehicleClassRepository', () => {
       await repo.create(vehicleClassInput({ name: 'Active', status: 'ACTIVE' }))
       await repo.create(vehicleClassInput({ name: 'Gone', slug: 'gone', status: 'ARCHIVED' }))
 
-      const result = await repo.findAll({ status: 'ARCHIVED' })
+      const result = await repo.findAll(SYSTEM_CONTEXT, { status: 'ARCHIVED' })
 
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Gone')
@@ -81,7 +83,7 @@ describe('InMemoryVehicleClassRepository', () => {
     it('returns the class when found', async () => {
       const created = await repo.create(vehicleClassInput())
 
-      const found = await repo.findById(created.id)
+      const found = await repo.findById(SYSTEM_CONTEXT, created.id)
 
       expect(found).toBeDefined()
       expect(found!.id).toBe(created.id)
@@ -89,7 +91,7 @@ describe('InMemoryVehicleClassRepository', () => {
     })
 
     it('returns undefined when not found', async () => {
-      const found = await repo.findById('nonexistent')
+      const found = await repo.findById(SYSTEM_CONTEXT, 'nonexistent')
       expect(found).toBeUndefined()
     })
   })
@@ -98,7 +100,7 @@ describe('InMemoryVehicleClassRepository', () => {
     it('returns the class when found', async () => {
       const created = await repo.create(vehicleClassInput({ slug: 'premium-suv' }))
 
-      const found = await repo.findBySlug('premium-suv')
+      const found = await repo.findBySlug(SYSTEM_CONTEXT, 'premium-suv')
 
       expect(found).toBeDefined()
       expect(found!.id).toBe(created.id)
@@ -106,7 +108,7 @@ describe('InMemoryVehicleClassRepository', () => {
     })
 
     it('returns undefined when not found', async () => {
-      const found = await repo.findBySlug('nonexistent')
+      const found = await repo.findBySlug(SYSTEM_CONTEXT, 'nonexistent')
       expect(found).toBeUndefined()
     })
   })
@@ -153,5 +155,69 @@ describe('InMemoryVehicleClassRepository', () => {
       const result = await repo.archive('nonexistent')
       expect(result).toBeUndefined()
     })
+  })
+})
+
+// Reads are operator-scoped (#395): an OPERATOR_* caller only sees its own
+// tenant's classes; admins (SYSTEM_CONTEXT) and the anonymous renter catalog
+// (PUBLIC_CONTEXT) see across operators; a tenant-less operator fails closed.
+// Mirrors the cross-operator vehicle isolation in tenancy-guards.test.ts.
+// Reads only: the class-operator write seal is a DB composite FK with no
+// in-memory equivalent, so it is exercised solely in the Drizzle integration
+// block ("...sealed to the vehicle's operator") in tenancy-isolation.test.ts.
+describe('InMemoryVehicleClassRepository operator-scopes reads', () => {
+  const opA = 'op_a'
+  const opB = 'op_b'
+
+  const ctxFor = (operatorId: string): CallerContext => ({
+    userId: 'owner',
+    role: 'OPERATOR_OWNER',
+    operatorId,
+    bypassScope: false,
+  })
+
+  const seed = async () => {
+    const repo = new InMemoryVehicleClassRepository()
+    const a = await repo.create(vehicleClassInput({ operatorId: opA, name: 'A', slug: 'a-class' }))
+    const b = await repo.create(vehicleClassInput({ operatorId: opB, name: 'B', slug: 'b-class' }))
+    return { repo, a, b }
+  }
+
+  it('findAll returns only the scoped tenant classes', async () => {
+    const { repo, a } = await seed()
+    const result = await repo.findAll(ctxFor(opA))
+    expect(result.map((vc) => vc.id)).toEqual([a.id])
+    expect(result.every((vc) => vc.operatorId === opA)).toBe(true)
+  })
+
+  it('findById cannot reach another tenant class', async () => {
+    const { repo, a, b } = await seed()
+    expect(await repo.findById(ctxFor(opA), a.id)).toMatchObject({ id: a.id })
+    expect(await repo.findById(ctxFor(opA), b.id)).toBeUndefined()
+  })
+
+  it('findBySlug cannot reach another tenant class', async () => {
+    const { repo } = await seed()
+    expect(await repo.findBySlug(ctxFor(opA), 'a-class')).toMatchObject({ slug: 'a-class' })
+    expect(await repo.findBySlug(ctxFor(opA), 'b-class')).toBeUndefined()
+  })
+
+  it('a tenant-less operator sees nothing (fail-closed)', async () => {
+    const { repo, a } = await seed()
+    const noTenant: CallerContext = { userId: 'x', role: 'OPERATOR_OWNER', bypassScope: false }
+    expect(await repo.findAll(noTenant)).toEqual([])
+    expect(await repo.findById(noTenant, a.id)).toBeUndefined()
+    expect(await repo.findBySlug(noTenant, 'a-class')).toBeUndefined()
+  })
+
+  it('the anonymous renter catalog sees every operator’s classes', async () => {
+    const { repo, a, b } = await seed()
+    const ids = (await repo.findAll(PUBLIC_CONTEXT)).map((vc) => vc.id).sort()
+    expect(ids).toEqual([a.id, b.id].sort())
+  })
+
+  it('an admin (SYSTEM_CONTEXT) sees every operator’s classes', async () => {
+    const { repo } = await seed()
+    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(2)
   })
 })

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm'
 import {
   check,
   date,
+  foreignKey,
   index,
   integer,
   pgEnum,
@@ -142,6 +143,10 @@ export const vehicleClasses = pgTable(
       sql`${table.hourlyRateJpy} IS NULL OR ${table.hourlyRateJpy} >= 0`,
     ),
     index('idx_vehicle_classes_operatorId').on(table.operatorId),
+    // Composite-FK target (#395 Phase 2): lets vehicles reference a class by
+    // (operatorId, id) so a vehicle can only point at a class in its own tenant.
+    // id is already unique (PK); this names the (operatorId, id) key for the FK.
+    unique('vehicle_classes_operatorId_id_unique').on(table.operatorId, table.id),
   ],
 )
 
@@ -155,7 +160,10 @@ export const vehicles = pgTable(
     operatorId: text('operatorId')
       .notNull()
       .references(() => operators.id),
-    classId: text('classId').references(() => vehicleClasses.id),
+    // FK is composite (operatorId, classId) -> vehicle_classes(operatorId, id),
+    // declared in the table extras below — NOT a single-column reference. This
+    // seals a vehicle's class to its own operator at the DB (#395 Phase 2).
+    classId: text('classId'),
     name: text('name').notNull(),
     description: text('description'),
     photos: text('photos').array().notNull().default([]),
@@ -204,6 +212,14 @@ export const vehicles = pgTable(
     // Every FK column needs its own index — pg doesn't auto-create one.
     index('idx_vehicles_classId').on(table.classId),
     index('idx_vehicles_operatorId').on(table.operatorId),
+    // A vehicle's class must belong to the vehicle's own operator (#395 Phase 2).
+    // classId is nullable + MATCH SIMPLE, so an unassigned vehicle (classId NULL)
+    // is unconstrained; when set, (operatorId, classId) must match a class row.
+    foreignKey({
+      columns: [table.operatorId, table.classId],
+      foreignColumns: [vehicleClasses.operatorId, vehicleClasses.id],
+      name: 'vehicles_operatorId_classId_fk',
+    }),
   ],
 )
 


### PR DESCRIPTION
Closes #395. Follow-up to #386 tenancy foundation. Base: `marketplace-pivot`.

## Summary
Makes `VehicleClassRepository` operator-aware so a tenant (OPERATOR_*) only sees its own classes, while admins and the anonymous renter catalog still read across the marketplace. Then seals class assignment to a vehicle's own operator at the DB level.

- **Phase 1 (reads):** `findAll/findById/findBySlug` take `CallerContext`; operator predicate via `operatorReadScope` (fail-closed on `none`). Slug-uniqueness checks use `SYSTEM_CONTEXT` (slug is globally unique); existence checks on update/archive use the caller's ctx. Public catalog GET uses `PUBLIC_CONTEXT` + forced ACTIVE-only. _(Source landed in 197f39a; this PR completes its tests.)_
- **Phase 2 (write seal):** composite FK `vehicles(operatorId, classId) -> vehicle_classes(operatorId, id)` + `UNIQUE(operatorId, id)` on `vehicle_classes`. A vehicle can only point at a class in its **own** tenant. `classId` is nullable + MATCH SIMPLE, so an unassigned vehicle (NULL classId) stays allowed; once set, `operatorId` is NOT NULL so the FK is fully enforced.

## ⚠️ Gate (carry forward)
Do **NOT** onboard operator #2 by any path until this lands. One operator exists today, so the class-scope leaks these changes fix are real-but-unexploitable. Sequence: **#395 -> #397**. (memory `project_operator-2-gate`)

## Changes
- `packages/shared/src/db/schema.ts` — UNIQUE(operatorId,id) on `vehicle_classes`; composite FK on `vehicles`.
- `drizzle/0027_class_operator_fk.sql` — generated; statements **reordered** so the UNIQUE constraint is created before the FK that references it (drizzle emitted them in FK-first order, which fails on apply).
- `packages/api/tests/repositories/vehicle-class.test.ts` — thread ctx through reads; in-memory cross-operator read isolation.
- `packages/api/tests/integration/tenancy-isolation.test.ts` — Drizzle cross-operator class isolation + composite-FK seal (create + update + null-allowed + FK-code-anchored rejection).

## Test plan
- [x] Unit: shared 181, api 543, web 381 — all pass
- [x] Integration (real PG): 106 pass; FK rejections anchored to PG `23503` via `pgErrorCode`
- [x] `db:verify` — 4 green (schema↔snapshot, journal↔disk, when-monotonicity, journal↔DB)
- [x] tsc x3 = 0, biome clean, import boundaries OK, fk-indexes all 15 indexed
- [x] code-reviewer pass (APPROVE; MEDIUM unanchored-assertion + LOW comment addressed)

## Follow-ups
- Map PG `23503` -> 422 in the vehicles route (helper `pgErrorCode` exists). Deferred: route tests use in-memory repos, which cannot exercise the DB-only FK — needs a Drizzle-backed route test to cover cleanly.
- Pre-existing, unrelated: `tests/integration/vehicle-detail.test.ts` "utilization" test fails on a date-window boundary (fails identically on clean `marketplace-pivot`). Not touched here.