### PR TITLE
feat(marketplace): operator write-scope — OPERATOR_* fleet/class CRUD (#397)

### DIFF
--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -5,8 +5,8 @@ import {
 } from '@kuruma/shared/validators/vehicle-class'
 import { type Context, Hono } from 'hono'
 import {
+  FLEET_WRITE_ROLES,
   PUBLIC_CONTEXT,
-  STAFF_ROLES,
   requireAuth,
   requireUser,
   toCallerContext,
@@ -87,7 +87,7 @@ export function createVehicleClassRoutes(
       })
       .post('/vehicle-classes', async (c) => {
         const user = requireUser(c)
-        if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
         const parsed = await parseBody(c, createVehicleClassSchema)
         if (!parsed.ok) return parsed.response
@@ -116,7 +116,7 @@ export function createVehicleClassRoutes(
       })
       .patch('/vehicle-classes/:id', async (c) => {
         const user = requireUser(c)
-        if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
         const parsed = await parseBody(c, updateVehicleClassSchema)
         if (!parsed.ok) return parsed.response
@@ -131,7 +131,7 @@ export function createVehicleClassRoutes(
       })
       .delete('/vehicle-classes/:id', async (c) => {
         const user = requireUser(c)
-        if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
         const result = await service.archive(toCallerContext(user), c.req.param('id'))
         if (!result.ok) {

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -5,7 +5,7 @@ import {
   updateVehicleStatusWithReasonSchema,
 } from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
-import { STAFF_ROLES, requireUser, toCallerContext } from '../middleware/auth'
+import { FLEET_WRITE_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
@@ -38,7 +38,7 @@ export function createVehicleRoutes(
     })
     .post('/vehicles', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const parsed = await parseBody(c, createVehicleSchema)
@@ -82,7 +82,7 @@ export function createVehicleRoutes(
     })
     .patch('/vehicles/bulk-status', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const parsed = await parseBody(c, bulkUpdateVehicleStatusSchema)
@@ -106,7 +106,7 @@ export function createVehicleRoutes(
     })
     .patch('/vehicles/:id', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const existing = await repo.findById(ctx, c.req.param('id'))
@@ -172,7 +172,7 @@ export function createVehicleRoutes(
     })
     .patch('/vehicles/:id/status', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const parsed = await parseBody(c, updateVehicleStatusWithReasonSchema)
@@ -189,7 +189,7 @@ export function createVehicleRoutes(
     })
     .delete('/vehicles/:id', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const existing = await repo.findById(ctx, c.req.param('id'))

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -97,9 +97,10 @@ export class VehicleClassService {
     // Guard: cannot archive a class that still has live bookings via any of
     // its member vehicles. Owner must reassign/cancel those bookings first.
     // Client-side check in /manage/classes is racy — this is the server seal.
-    // Archive is a staff-only route; the route-level STAFF_ROLES gate
-    // already covers authz. Use SYSTEM_CONTEXT for this internal read so
-    // the service boundary stays auth-agnostic.
+    // The route-level FLEET_WRITE_ROLES gate (staff + tenant operators, #397)
+    // already covers authz, and the caller-scoped findById above bounds the
+    // operator to its own class. Use SYSTEM_CONTEXT for this internal members
+    // read so the service boundary stays auth-agnostic.
     const { data: members } = await this.vehicleRepo.findAll(SYSTEM_CONTEXT, {
       classId: id,
       includeRetired: true,

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -5,10 +5,15 @@ import { API_TOKEN_AUDIENCE, API_TOKEN_ISSUER, type UserRole } from '../../src/m
 export const TEST_AUTH_SECRET = 'test-auth-secret-at-least-32-chars-long'
 
 /** Middleware that sets a fake authenticated user for unit tests that
- *  mount route handlers directly (without the full createApp() + JWT flow). */
-export function testAuthMiddleware(id = 'test-user', role: UserRole = 'ADMIN'): MiddlewareHandler {
+ *  mount route handlers directly (without the full createApp() + JWT flow).
+ *  Pass `operatorId` to simulate a tenant-scoped OPERATOR_* caller. */
+export function testAuthMiddleware(
+  id = 'test-user',
+  role: UserRole = 'ADMIN',
+  operatorId?: string,
+): MiddlewareHandler {
   return async (c, next) => {
-    c.set('user', { id, role })
+    c.set('user', operatorId !== undefined ? { id, role, operatorId } : { id, role })
     return next()
   }
 }

--- a/packages/api/tests/integration/tenancy-isolation.test.ts
+++ b/packages/api/tests/integration/tenancy-isolation.test.ts
@@ -10,6 +10,7 @@ import {
   DrizzleVehicleClassRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
+import { VehicleClassService } from '../../src/services/vehicle-class'
 import type { Vehicle, VehicleClass } from '../../src/stores'
 import { DEFAULT_DAILY_RATE_JPY, db } from './setup'
 
@@ -397,5 +398,79 @@ describe('vehicle classId is sealed to the vehicle’s operator (composite FK)',
     const v = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(opAId, null))
     const updated = await vehicleRepo.update(SYSTEM_CONTEXT, v.id, { classId: classA.id })
     expect(updated?.classId).toBe(classA.id)
+  })
+})
+
+// #397 opens class writes to OPERATOR_* at the route. Class repo writes take no
+// ctx (no repo-layer guard), so the tenant seal for class update/archive lives
+// in VehicleClassService.{update,archive} via its caller-scoped findById. This
+// probes that seal against real Postgres: if an operator could mutate another
+// tenant's class, the service-layer boundary would be a real bypass and we'd
+// need a repo-layer guard. It must resolve to 404, leaving the row untouched.
+describe('cross-operator class WRITE denial (service seal, #397)', () => {
+  const classRepo = new DrizzleVehicleClassRepository(db)
+  const vehicleRepo = new DrizzleVehicleRepository(db)
+  const bookingRepo = new DrizzleBookingRepository(db)
+  const service = new VehicleClassService(classRepo, vehicleRepo, bookingRepo)
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `op_clsw_a_${uniq}`
+  const opBId = `op_clsw_b_${uniq}`
+  const createdClassIds: string[] = []
+  let classA: VehicleClass
+
+  const ctxFor = (operatorId: string): CallerContext => ({
+    userId: 'owner',
+    role: 'OPERATOR_OWNER',
+    operatorId,
+    bypassScope: false,
+  })
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opAId, slug: `clsw-a-${uniq}`, name: 'ClsW Operator A' },
+      { id: opBId, slug: `clsw-b-${uniq}`, name: 'ClsW Operator B' },
+    ])
+    classA = await classRepo.create({
+      operatorId: opAId,
+      name: 'ClsW Class A',
+      slug: `clsw-a-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+    createdClassIds.push(classA.id)
+  })
+
+  afterAll(async () => {
+    if (createdClassIds.length > 0) {
+      await db.delete(vehicleClasses).where(inArray(vehicleClasses.id, createdClassIds))
+    }
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+  })
+
+  it('operator B cannot update operator A class (404, row untouched)', async () => {
+    const res = await service.update(ctxFor(opBId), classA.id, { name: 'hijacked' })
+    expect(res).toMatchObject({ ok: false, status: 404, error: 'Vehicle class not found' })
+    expect(await classRepo.findById(SYSTEM_CONTEXT, classA.id)).toMatchObject({
+      name: 'ClsW Class A',
+    })
+  })
+
+  it('operator B cannot archive operator A class (404, still ACTIVE)', async () => {
+    const res = await service.archive(ctxFor(opBId), classA.id)
+    expect(res).toMatchObject({ ok: false, status: 404 })
+    expect(await classRepo.findById(SYSTEM_CONTEXT, classA.id)).toMatchObject({ status: 'ACTIVE' })
+  })
+
+  it('operator A can update its own class', async () => {
+    const res = await service.update(ctxFor(opAId), classA.id, { name: 'ClsW Class A v2' })
+    expect(res).toMatchObject({ ok: true, vehicleClass: { name: 'ClsW Class A v2' } })
   })
 })

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import { SYSTEM_CONTEXT, type UserRole } from '../../src/middleware/auth'
 import {
   InMemoryAvailabilityRepository,
   InMemoryBookingRepository,
@@ -413,6 +414,92 @@ describe('Vehicle Class CRUD Routes', () => {
       })
       expect(res.status).toBe(200)
       expect(res.headers.get('Cache-Control')).toBeNull()
+    })
+  })
+
+  // #397: operators must manage their OWN classes. Route gate widens from
+  // STAFF_ROLES to FLEET_WRITE_ROLES; tenant isolation stays enforced by the
+  // service's caller-scoped findById (other-tenant edits -> 404).
+  describe('Operator write-scope (#397)', () => {
+    const OP_A = 'operator-aaaaaaaa'
+    const OP_B = 'operator-bbbbbbbb'
+
+    function mountFor(repo: InMemoryVehicleClassRepository, role: UserRole, operatorId?: string) {
+      const vRepo = new InMemoryVehicleRepository()
+      const bRepo = new InMemoryBookingRepository()
+      const service = new VehicleClassService(repo, vRepo, bRepo)
+      const availabilityService = buildAvailabilityService(repo)
+      const a = new Hono()
+      setupGlobalHandlers(a)
+      a.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+      a.route('/', createVehicleClassRoutes(service, availabilityService))
+      return a
+    }
+
+    async function post(app: Hono, input = validInput()) {
+      return app.request('/vehicle-classes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+    }
+
+    it('lets an OPERATOR_OWNER create a class stamped with its own operatorId', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_OWNER', OP_A))
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.operatorId).toBe(OP_A)
+      expect(body.data.name).toBe('Compact')
+    })
+
+    it('lets an OPERATOR_STAFF create a class', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_STAFF', OP_A))
+
+      expect(res.status).toBe(201)
+      expect((await res.json()).data.operatorId).toBe(OP_A)
+    })
+
+    it('lets an OPERATOR_OWNER update its own class', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const ownerApp = mountFor(repo, 'OPERATOR_OWNER', OP_A)
+      const created = await (await post(ownerApp)).json()
+
+      const res = await ownerApp.request(`/vehicle-classes/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed by owner' }),
+      })
+
+      expect(res.status).toBe(200)
+      expect((await res.json()).data.name).toBe('Renamed by owner')
+    })
+
+    it("returns 404 when an OPERATOR_OWNER mutates another operator's class", async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const created = await (await post(mountFor(repo, 'OPERATOR_OWNER', OP_A))).json()
+      const intruder = mountFor(repo, 'OPERATOR_OWNER', OP_B)
+
+      const patch = await intruder.request(`/vehicle-classes/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Hijacked' }),
+      })
+      expect(patch.status).toBe(404)
+
+      const del = await intruder.request(`/vehicle-classes/${created.data.id}`, {
+        method: 'DELETE',
+      })
+      expect(del.status).toBe(404)
+    })
+
+    it('returns 403 (fail-closed) for an OPERATOR_OWNER missing its operatorId', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_OWNER'))
+
+      expect(res.status).toBe(403)
     })
   })
 })

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
-import { toCallerContext } from '../../src/middleware/auth'
+import { type UserRole, toCallerContext } from '../../src/middleware/auth'
 import {
   InMemoryMaintenanceLogRepository,
   InMemoryVehicleRepository,
@@ -695,6 +695,92 @@ describe('Vehicle CRUD Routes', () => {
       expect(res.status).toBe(403)
       const body = await res.json()
       expect(body).toEqual({ success: false, error: 'Forbidden' })
+    })
+  })
+
+  // #397: tenant-scoped operators must be able to manage their OWN fleet.
+  // The route gate was STAFF_ROLES (operators excluded -> 403 wall); it must
+  // widen to FLEET_WRITE_ROLES. Tenant isolation is still enforced downstream
+  // by the repo's operator predicate (other-tenant reads -> not found -> 404).
+  describe('Operator write-scope (#397)', () => {
+    const OP_A = 'operator-aaaaaaaa'
+    const OP_B = 'operator-bbbbbbbb'
+
+    function mountFor(repo: InMemoryVehicleRepository, role: UserRole, operatorId?: string) {
+      const maintenanceLogRepo = new InMemoryMaintenanceLogRepository()
+      const runInTransaction: RunInTransaction = async (fn) =>
+        fn({ vehicleRepo: repo, maintenanceLogRepo })
+      const maintenanceService = new MaintenanceService(repo, maintenanceLogRepo, runInTransaction)
+      const a = new Hono()
+      setupGlobalHandlers(a)
+      a.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+      a.route('/', createVehicleRoutes(repo, maintenanceService))
+      return a
+    }
+
+    async function post(app: Hono, input = validVehicleInput()) {
+      return app.request('/vehicles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+    }
+
+    it('lets an OPERATOR_OWNER create a vehicle stamped with its own operatorId', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_OWNER', OP_A))
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.data.operatorId).toBe(OP_A)
+      expect(body.data.name).toBe('Toyota Corolla')
+    })
+
+    it('lets an OPERATOR_STAFF create a vehicle', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_STAFF', OP_A))
+
+      expect(res.status).toBe(201)
+      expect((await res.json()).data.operatorId).toBe(OP_A)
+    })
+
+    it('lets an OPERATOR_OWNER update its own vehicle', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const ownerApp = mountFor(repo, 'OPERATOR_OWNER', OP_A)
+      const created = await (await post(ownerApp)).json()
+
+      const res = await ownerApp.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed by owner' }),
+      })
+
+      expect(res.status).toBe(200)
+      expect((await res.json()).data.name).toBe('Renamed by owner')
+    })
+
+    it("returns 404 when an OPERATOR_OWNER mutates another operator's vehicle", async () => {
+      const repo = new InMemoryVehicleRepository()
+      const created = await (await post(mountFor(repo, 'OPERATOR_OWNER', OP_A))).json()
+      const intruder = mountFor(repo, 'OPERATOR_OWNER', OP_B)
+
+      const patch = await intruder.request(`/vehicles/${created.data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Hijacked' }),
+      })
+      expect(patch.status).toBe(404)
+
+      const del = await intruder.request(`/vehicles/${created.data.id}`, { method: 'DELETE' })
+      expect(del.status).toBe(404)
+    })
+
+    it('returns 403 (fail-closed) for an OPERATOR_OWNER missing its operatorId', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await post(mountFor(repo, 'OPERATOR_OWNER'))
+
+      expect(res.status).toBe(403)
     })
   })
 })


### PR DESCRIPTION
Closes #397. Base: \`marketplace-pivot\`.

## Problem
\`OPERATOR_OWNER\` / \`OPERATOR_STAFF\` were **read-scoped** to their tenant but **write-locked**: every mutation route gated on \`STAFF_ROLES\` (\`{STAFF, ADMIN, PLATFORM_ADMIN}\`), which excludes operators. An operator could see its own fleet but got 403 trying to manage it — the wall blocking marketplace slices 2/3.

## What changed (the whole change)
Widen the route-level mutation gates from \`STAFF_ROLES\` to \`FLEET_WRITE_ROLES\` (= \`STAFF_ROLES ∪ OPERATOR_ROLES\`):
- \`routes/vehicles.ts\` — 5 writes (POST, bulk-status, PATCH, PATCH /:id/status, DELETE)
- \`routes/vehicle-classes.ts\` — 3 writes (POST, PATCH, DELETE)

No new tenant-isolation logic was needed — it already exists downstream (landed via #386 F2 / #399):
- **Vehicles:** the repo enforces tenancy — \`requireFleetWriteScope(ctx)\` + \`operatorReadScope(ctx)\` scope every write; cross-tenant mutation resolves to a no-op/404, and \`operatorId\` is immutable on update.
- **Classes:** the repo write methods take no \`ctx\`, so the tenant seal lives one layer up in \`VehicleClassService.{update,archive}\` via a caller-scoped \`findById(ctx,id)\` precheck (other-tenant → 404 before the unscoped \`repo.update\` runs).

\`testAuthMiddleware\` gains an optional \`operatorId\` for OPERATOR_* callers.

## Deliberately out of scope
- **#401** (new) — remove the \`resolveOperatorIdForWrite\` Best-Car-Rental fallback so platform/legacy admin writes can't be silently misattributed once operator #2 exists. Changes create contracts + web UI; must land before operator #2 *data*.
- **#400** — map PG 23503 → 422 in the vehicles route.
- A repo-layer guard on class writes was intentionally **not** added: the new real-PG integration test proves the service-layer seal is not bypassable. Adding one would be an interface change with no behavioral gain for this slice.

## Test plan
- [x] RED→GREEN per slice (route gate widening)
- [x] Route tests (in-memory): OPERATOR_OWNER/STAFF create stamps own \`operatorId\`; operator updates own; other-tenant mutate → 404; operator missing \`operatorId\` → 403 (fail-closed)
- [x] Real-PG integration: \`cross-operator class WRITE denial (service seal)\` — operator B → 404, row untouched; operator A edits its own
- [x] \`typecheck\` 0 · \`lint:boundaries\` OK · **553** unit tests pass · **110** integration tests pass · \`bun run lint\` exit 0
- [x] code-reviewer: APPROVE (no CRITICAL/HIGH/MEDIUM)

## Reviewer note
One **LOW** (cosmetic, pre-existing): an operator missing \`operatorId\` gets 403 on create vs 404 on update/delete. Both fail closed; same split exists on the vehicle side pre-#397. Not addressed here.