### PR TITLE
feat(marketplace): drop BCR operator fallback — count-gated resolution + complete FK→422 (#401, #400)

### DIFF
--- a/packages/api/src/error-handlers.ts
+++ b/packages/api/src/error-handlers.ts
@@ -1,6 +1,6 @@
 import type { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import { ForbiddenError } from './middleware/auth'
+import { ForbiddenError, OperatorRequiredError } from './middleware/auth'
 
 export function setupGlobalHandlers(app: Hono): void {
   app.onError((err, c) => {
@@ -16,6 +16,11 @@ export function setupGlobalHandlers(app: Hono): void {
     // clients see a policy denial, not a server outage.
     if (err instanceof ForbiddenError) {
       return c.json({ success: false, error: 'Forbidden' }, 403)
+    }
+    // A non-operator write that named no target operator and could not be
+    // inferred (zero or 2+ operators). Well-formed but unprocessable (#401).
+    if (err instanceof OperatorRequiredError) {
+      return c.json({ success: false, error: err.message }, 422)
     }
     console.error(
       JSON.stringify({

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -84,6 +84,7 @@ import { VehicleClassService } from './services/vehicle-class'
 import { VehicleClassAvailabilityService } from './services/vehicle-class-availability'
 import { VehicleDetailService } from './services/vehicle-detail'
 import { VehiclePhotoService } from './services/vehicle-photo'
+import { type ResolveWriteOperatorId, resolveOperatorIdForWrite } from './tenancy'
 
 export function createApp(overrides?: {
   vehicleRepo: VehicleRepository
@@ -311,6 +312,10 @@ export function createApp(overrides?: {
   const fleetOverviewService = new FleetOverviewService(fleetOverviewRepo)
   const vehicleDetailService = new VehicleDetailService(vehicleDetailRepo)
   const operatorService = new OperatorService(operatorRepo)
+  // #401: bind the write-operator resolver to the concrete operator lookup, so
+  // the write routes resolve the target tenant without importing a repository.
+  const resolveWriteOperatorId: ResolveWriteOperatorId = (ctx, inputOperatorId) =>
+    resolveOperatorIdForWrite(ctx, inputOperatorId, operatorRepo)
 
   // Chain .route() calls so TypeScript infers the full route type tree.
   // hc<AppType> needs this to produce typed client methods.
@@ -323,10 +328,11 @@ export function createApp(overrides?: {
       createVehicleClassRoutes(
         vehicleClassService,
         vehicleClassAvailabilityService,
+        resolveWriteOperatorId,
         publicCatalogLimiter,
       ),
     )
-    .route('/', createVehicleRoutes(vehicleRepo, maintenanceService))
+    .route('/', createVehicleRoutes(vehicleRepo, maintenanceService, resolveWriteOperatorId))
     .route(
       '/',
       createVehiclePhotoRoutes(

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -167,6 +167,21 @@ export class ForbiddenError extends Error {
 }
 
 /**
+ * Thrown when a non-operator caller (PLATFORM_ADMIN / legacy STAFF / ADMIN) tries
+ * to create tenant-owned inventory without naming a target operator, and the
+ * target cannot be inferred (zero or 2+ operators exist). Replaces the old
+ * silent Best-Car-Rental default (#401) so a legacy admin write can no longer be
+ * misattributed once a second operator exists. Mapped to 422 by the global
+ * handler — the request is well-formed but missing a required `operatorId`.
+ */
+export class OperatorRequiredError extends Error {
+  readonly name = 'OperatorRequiredError'
+  constructor(message = 'operatorId is required') {
+    super(message)
+  }
+}
+
+/**
  * Repo-layer guard for fleet mutation methods. Admits STAFF roles and
  * tenant-scoped operators (`FLEET_WRITE_ROLES`); a tenant-scoped caller missing
  * its operatorId fails closed via `requireOperatorScope`. Defence in depth

--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -5,6 +5,7 @@
 export const PG_ERROR = {
   EXCLUSION_VIOLATION: '23P01',
   UNIQUE_VIOLATION: '23505',
+  FOREIGN_KEY_VIOLATION: '23503',
 } as const
 
 /** Extract the Postgres error code from an unknown thrown value, or null.

--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -8,6 +8,14 @@ export const PG_ERROR = {
   FOREIGN_KEY_VIOLATION: '23503',
 } as const
 
+/**
+ * Composite FK vehicles(operatorId, classId) -> vehicle_classes(operatorId, id),
+ * named explicitly in schema.ts. The vehicles table also carries a single
+ * operatorId -> operators FK, so a 23503 alone is ambiguous; match on this name
+ * to tell a bad classId apart from a bad operatorId (#400).
+ */
+export const VEHICLES_CLASS_FK = 'vehicles_operatorId_classId_fk'
+
 /** Extract the Postgres error code from an unknown thrown value, or null.
  *
  * Drizzle + postgres-js wraps the raw PostgresError inside `err.cause`,
@@ -17,6 +25,21 @@ export const PG_ERROR = {
 export function pgErrorCode(err: unknown): string | null {
   const code = extractCode(err) ?? extractCode(getCause(err))
   return code
+}
+
+/** Extract the violated constraint name from a thrown PG error, or null.
+ * Like the code, postgres-js exposes `constraint_name`; drizzle wraps the
+ * PostgresError under `err.cause`, so we check both paths. */
+export function pgConstraintName(err: unknown): string | null {
+  return extractConstraint(err) ?? extractConstraint(getCause(err))
+}
+
+function extractConstraint(val: unknown): string | null {
+  if (val && typeof val === 'object' && 'constraint_name' in val) {
+    const name = (val as { constraint_name: unknown }).constraint_name
+    return typeof name === 'string' ? name : null
+  }
+  return null
 }
 
 function extractCode(val: unknown): string | null {

--- a/packages/api/src/repositories/drizzle/operator.ts
+++ b/packages/api/src/repositories/drizzle/operator.ts
@@ -16,6 +16,13 @@ export class DrizzleOperatorRepository implements OperatorRepository {
     return row !== undefined
   }
 
+  async findSoleId(): Promise<string | null> {
+    // LIMIT 2 is enough to distinguish "exactly one" from "zero or many"
+    // without scanning the whole table.
+    const rows = await this.db.select({ id: operators.id }).from(operators).limit(2)
+    return rows.length === 1 ? (rows[0]?.id ?? null) : null
+  }
+
   async create(data: {
     name: string
     slug: string

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -2,7 +2,7 @@ import { vehicles } from '@kuruma/shared/db/schema'
 import { type SQL, and, count, eq, inArray, ne, sql } from 'drizzle-orm'
 import { type CallerContext, requireFleetWriteScope } from '../../middleware/auth'
 import type { Vehicle } from '../../stores'
-import { operatorReadScope, resolveOperatorIdForWrite } from '../../tenancy'
+import { operatorReadScope } from '../../tenancy'
 import type {
   PaginatedResult,
   VehicleFilters,
@@ -89,11 +89,11 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     const [inserted] = await this.db
       .insert(vehicles)
       .values({
-        // Transitional (#386): the route resolves operatorId, but direct-repo
-        // callers (seeds, internal jobs, tests) may omit it — fall back to the
-        // caller's tenant or the seeded Best Car Rental operator. Idempotent
-        // with the route's resolution. Drop once operators own their writes.
-        operatorId: resolveOperatorIdForWrite(ctx, data.operatorId),
+        // operatorId arrives already resolved by the route's write-operator
+        // resolver (#401); the repo trusts it. requireFleetWriteScope above is
+        // the repo-layer authz seal, and the composite FK seals cross-tenant
+        // classId at the DB (#395).
+        operatorId: data.operatorId,
         classId: data.classId,
         name: data.name,
         description: data.description,

--- a/packages/api/src/repositories/in-memory/operator.ts
+++ b/packages/api/src/repositories/in-memory/operator.ts
@@ -15,6 +15,12 @@ export class InMemoryOperatorRepository implements OperatorRepository {
     return false
   }
 
+  async findSoleId(): Promise<string | null> {
+    if (this.store.size !== 1) return null
+    const [id] = this.store.keys()
+    return id ?? null
+  }
+
   async create(data: {
     name: string
     slug: string

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -1,6 +1,6 @@
 import { type CallerContext, requireFleetWriteScope } from '../../middleware/auth'
 import type { Vehicle } from '../../stores'
-import { operatorReadScope, resolveOperatorIdForWrite } from '../../tenancy'
+import { operatorReadScope } from '../../tenancy'
 import type {
   PaginatedResult,
   VehicleFilters,
@@ -65,11 +65,11 @@ export class InMemoryVehicleRepository implements VehicleRepository {
   ): Promise<Vehicle> {
     requireFleetWriteScope(ctx)
     const now = new Date()
+    // operatorId arrives already resolved by the route's write-operator
+    // resolver (#401); the repo trusts it. requireFleetWriteScope above is the
+    // repo-layer authz seal.
     const vehicle: Vehicle = {
       ...data,
-      // Transitional (#386): mirror DrizzleVehicleRepository — resolve the
-      // tenant for direct-repo callers that omit operatorId.
-      operatorId: resolveOperatorIdForWrite(ctx, data.operatorId),
       id: crypto.randomUUID(),
       createdAt: now,
       updatedAt: now,

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -39,6 +39,13 @@ export interface OperatorRepository {
     preAuthHandoffUrl: string | null
   }): Promise<Operator>
   existsBySlug(slug: string): Promise<boolean>
+  /**
+   * Id of the only operator, or null when there is not exactly one (zero or
+   * 2+). The write-operator resolver uses it to infer the tenant for a
+   * non-operator create while a single operator exists, and to reject the
+   * ambiguous multi-operator case (#401). Structurally satisfies `OperatorLookup`.
+   */
+  findSoleId(): Promise<string | null>
 }
 
 export interface VehicleFilters {

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -13,12 +13,13 @@ import {
 } from '../middleware/auth'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
-import { resolveOperatorIdForWrite } from '../tenancy'
+import type { ResolveWriteOperatorId } from '../tenancy'
 import { cachePublic, fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
 
 export function createVehicleClassRoutes(
   service: VehicleClassService,
   availabilityService: VehicleClassAvailabilityService,
+  resolveWriteOperatorId: ResolveWriteOperatorId,
   publicCatalogLimiter?: RateLimitBinding,
 ) {
   const app = new Hono()
@@ -93,10 +94,12 @@ export function createVehicleClassRoutes(
         if (!parsed.ok) return parsed.response
 
         const d = parsed.data
-        const result = await service.create(toCallerContext(user), {
-          // Transitional: legacy STAFF/ADMIN writes attach to the default
-          // operator until operator-portal write flows land (#386).
-          operatorId: resolveOperatorIdForWrite(toCallerContext(user)),
+        const ctx = toCallerContext(user)
+        // Resolve the target tenant before the create; a missing/ambiguous
+        // operatorId (#401) throws to the global handler as 403/422.
+        const operatorId = await resolveWriteOperatorId(ctx, d.operatorId)
+        const result = await service.create(ctx, {
+          operatorId,
           name: d.name,
           slug: d.slug,
           description: d.description ?? null,

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -11,6 +11,7 @@ import {
   requireUser,
   toCallerContext,
 } from '../middleware/auth'
+import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
@@ -98,24 +99,34 @@ export function createVehicleClassRoutes(
         // Resolve the target tenant before the create; a missing/ambiguous
         // operatorId (#401) throws to the global handler as 403/422.
         const operatorId = await resolveWriteOperatorId(ctx, d.operatorId)
-        const result = await service.create(ctx, {
-          operatorId,
-          name: d.name,
-          slug: d.slug,
-          description: d.description ?? null,
-          photos: d.photos,
-          seats: d.seats,
-          luggageCapacity: d.luggageCapacity,
-          transmission: d.transmission,
-          fuelType: d.fuelType ?? null,
-          dailyRateJpy: d.dailyRateJpy ?? null,
-          hourlyRateJpy: d.hourlyRateJpy ?? null,
-          sortOrder: d.sortOrder,
-          status: 'ACTIVE',
-        })
+        try {
+          const result = await service.create(ctx, {
+            operatorId,
+            name: d.name,
+            slug: d.slug,
+            description: d.description ?? null,
+            photos: d.photos,
+            seats: d.seats,
+            luggageCapacity: d.luggageCapacity,
+            transmission: d.transmission,
+            fuelType: d.fuelType ?? null,
+            dailyRateJpy: d.dailyRateJpy ?? null,
+            hourlyRateJpy: d.hourlyRateJpy ?? null,
+            sortOrder: d.sortOrder,
+            status: 'ACTIVE',
+          })
 
-        if (!result.ok) return fail(c, result.error, result.status)
-        return ok(c, result.vehicleClass, 201)
+          if (!result.ok) return fail(c, result.error, result.status)
+          return ok(c, result.vehicleClass, 201)
+        } catch (err) {
+          // #400: vehicleClasses.operatorId -> operators is the only FK a create
+          // can violate. An unknown operatorId rejects at the DB (23503); surface
+          // it as 422, not a raw 500.
+          if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
+            return fail(c, 'Invalid operator', 422)
+          }
+          throw err
+        }
       })
       .patch('/vehicle-classes/:id', async (c) => {
         const user = requireUser(c)

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -9,12 +9,13 @@ import { FLEET_WRITE_ROLES, requireUser, toCallerContext } from '../middleware/a
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
-import { resolveOperatorIdForWrite } from '../tenancy'
+import type { ResolveWriteOperatorId } from '../tenancy'
 import { fail, ok, parseBody, parsePagination, stripUndefined } from './helpers'
 
 export function createVehicleRoutes(
   repo: VehicleRepository,
   maintenanceService: MaintenanceService,
+  resolveWriteOperatorId: ResolveWriteOperatorId,
 ) {
   return new Hono()
     .get('/vehicles', async (c) => {
@@ -44,11 +45,14 @@ export function createVehicleRoutes(
       const parsed = await parseBody(c, createVehicleSchema)
       if (!parsed.ok) return parsed.response
 
+      // Resolve the target tenant before the insert so a missing/ambiguous
+      // operatorId (#401) surfaces as 403/422 from the global handler rather
+      // than as a caught DB error below.
+      const operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
+
       try {
         const vehicle = await repo.create(ctx, {
-          // Transitional: legacy STAFF/ADMIN writes attach to the default
-          // operator until operator-portal write flows land (#386).
-          operatorId: resolveOperatorIdForWrite(ctx),
+          operatorId,
           classId: parsed.data.classId ?? null,
           name: parsed.data.name,
           description: parsed.data.description ?? null,
@@ -76,6 +80,11 @@ export function createVehicleRoutes(
       } catch (err) {
         if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION) {
           return fail(c, 'License plate already in use', 409)
+        }
+        // #400: the composite FK (operatorId,classId) -> vehicle_classes rejects
+        // an unknown or cross-tenant classId at the DB. Surface as 422, not 500.
+        if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
+          return fail(c, 'Invalid vehicle class', 422)
         }
         throw err
       }
@@ -166,6 +175,11 @@ export function createVehicleRoutes(
       } catch (err) {
         if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION) {
           return fail(c, 'License plate already in use', 409)
+        }
+        // #400: the composite FK (operatorId,classId) -> vehicle_classes rejects
+        // an unknown or cross-tenant classId at the DB. Surface as 422, not 500.
+        if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
+          return fail(c, 'Invalid vehicle class', 422)
         }
         throw err
       }

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -6,11 +6,19 @@ import {
 } from '@kuruma/shared/validators/vehicle'
 import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireUser, toCallerContext } from '../middleware/auth'
-import { PG_ERROR, pgErrorCode } from '../pg-errors'
+import { PG_ERROR, VEHICLES_CLASS_FK, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import { fail, ok, parseBody, parsePagination, stripUndefined } from './helpers'
+
+// #400: vehicles carries two FKs — the composite (operatorId, classId) ->
+// vehicle_classes (classId guard) and the single operatorId -> operators. Map
+// each 23503 to the cause that actually failed so a bad operatorId isn't
+// reported as "Invalid vehicle class".
+function fkViolationMessage(err: unknown): string {
+  return pgConstraintName(err) === VEHICLES_CLASS_FK ? 'Invalid vehicle class' : 'Invalid operator'
+}
 
 export function createVehicleRoutes(
   repo: VehicleRepository,
@@ -81,10 +89,11 @@ export function createVehicleRoutes(
         if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION) {
           return fail(c, 'License plate already in use', 409)
         }
-        // #400: the composite FK (operatorId,classId) -> vehicle_classes rejects
-        // an unknown or cross-tenant classId at the DB. Surface as 422, not 500.
+        // #400: a FK violation (unknown/cross-tenant classId, or unknown
+        // operatorId) is a client error, not a server fault — map to 422 with
+        // the cause that actually failed.
         if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
-          return fail(c, 'Invalid vehicle class', 422)
+          return fail(c, fkViolationMessage(err), 422)
         }
         throw err
       }
@@ -176,10 +185,11 @@ export function createVehicleRoutes(
         if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION) {
           return fail(c, 'License plate already in use', 409)
         }
-        // #400: the composite FK (operatorId,classId) -> vehicle_classes rejects
-        // an unknown or cross-tenant classId at the DB. Surface as 422, not 500.
+        // #400: a FK violation (unknown/cross-tenant classId, or unknown
+        // operatorId) is a client error, not a server fault — map to 422 with
+        // the cause that actually failed.
         if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
-          return fail(c, 'Invalid vehicle class', 422)
+          return fail(c, fkViolationMessage(err), 422)
         }
         throw err
       }

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -43,7 +43,10 @@ export class VehicleClassService {
   }
 
   async create(
-    ctx: CallerContext,
+    // Intentionally unscoped: create takes ctx for interface symmetry with the
+    // other methods, but slug uniqueness is global so it uses SYSTEM_CONTEXT
+    // below, not the caller. Underscore-prefixed to mark it deliberately unused.
+    _ctx: CallerContext,
     data: Omit<VehicleClass, 'id' | 'createdAt' | 'updatedAt'>,
   ): Promise<CreateResult> {
     // Slug uniqueness is global (DB unique constraint), so the collision check

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -1,5 +1,28 @@
-import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
-import { type CallerContext, ForbiddenError, isOperatorRole } from './middleware/auth'
+import {
+  type CallerContext,
+  ForbiddenError,
+  OperatorRequiredError,
+  isOperatorRole,
+} from './middleware/auth'
+
+/**
+ * Narrow read capability the write-operator resolver needs: the id of the only
+ * operator, or null when there is not exactly one (zero or 2+). Implemented by
+ * `OperatorRepository`; injected so the resolver stays a pure policy function.
+ */
+export interface OperatorLookup {
+  findSoleId(): Promise<string | null>
+}
+
+/**
+ * The write-operator resolver bound to a concrete `OperatorLookup` at the
+ * composition root and injected into the write routes — so a route can resolve
+ * the target tenant without importing a repository (layering boundary).
+ */
+export type ResolveWriteOperatorId = (
+  ctx: CallerContext,
+  inputOperatorId?: string,
+) => Promise<string>
 
 /**
  * How a scoped repository read should be filtered by operator:
@@ -24,20 +47,30 @@ export function operatorReadScope(ctx: CallerContext): OperatorReadScope {
 }
 
 /**
- * Resolve the operatorId to stamp on a write. TRANSITIONAL (slice 1, #386):
- * - OPERATOR_OWNER / OPERATOR_STAFF must write under their own tenant; missing
- *   operatorId fails closed. They cannot write on behalf of another operator,
- *   so an `inputOperatorId` is ignored for them.
- * - PLATFORM_ADMIN / legacy STAFF / ADMIN may pass an explicit operatorId, else
- *   fall back to the seeded Best Car Rental operator so the existing owner
- *   create-flow keeps working until operator-portal write paths land.
- *
- * Once admin create endpoints take an explicit operatorId, drop the fallback.
+ * Resolve the operatorId to stamp on a write (#401):
+ * - OPERATOR_OWNER / OPERATOR_STAFF write under their own tenant; missing
+ *   operatorId fails closed. They cannot write for another operator, so an
+ *   `inputOperatorId` is ignored.
+ * - PLATFORM_ADMIN / legacy STAFF / ADMIN must name the target operator — either
+ *   explicitly via `inputOperatorId`, or implicitly when exactly one operator
+ *   exists (single-tenant inference). Zero or 2+ operators with no explicit id
+ *   is ambiguous and rejected (`OperatorRequiredError` -> 422), so a legacy
+ *   admin write can never be silently misattributed once operator #2 exists.
+ *   Replaces the old hardcoded Best-Car-Rental fallback.
  */
-export function resolveOperatorIdForWrite(ctx: CallerContext, inputOperatorId?: string): string {
+export async function resolveOperatorIdForWrite(
+  ctx: CallerContext,
+  inputOperatorId: string | undefined,
+  operators: OperatorLookup,
+): Promise<string> {
   if (isOperatorRole(ctx.role)) {
     if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
     return ctx.operatorId
   }
-  return inputOperatorId ?? BEST_CAR_RENTAL_OPERATOR_ID
+  if (inputOperatorId) return inputOperatorId
+  const soleOperatorId = await operators.findSoleId()
+  if (soleOperatorId) return soleOperatorId
+  throw new OperatorRequiredError(
+    'operatorId is required: specify a target operator (zero or multiple operators exist)',
+  )
 }

--- a/packages/api/tests/helpers/operator.ts
+++ b/packages/api/tests/helpers/operator.ts
@@ -1,0 +1,39 @@
+import { InMemoryOperatorRepository } from '../../src/repositories/in-memory'
+import type { Operator } from '../../src/stores'
+import { type ResolveWriteOperatorId, resolveOperatorIdForWrite } from '../../src/tenancy'
+
+/** The seeded sole operator most route tests run against (single-operator MVP). */
+export const TEST_OPERATOR_ID = 'op_test'
+
+/**
+ * A write-operator resolver backed by a single in-memory operator, so a
+ * non-operator (STAFF/ADMIN) create infers that sole operator — mirroring the
+ * single-operator MVP. Operator-role callers resolve to their own
+ * `ctx.operatorId`. Pass `null` to model the ambiguous case (zero or 2+
+ * operators), where a non-operator create with no explicit operatorId is
+ * rejected with `OperatorRequiredError` -> 422 (#401).
+ */
+export function testResolveWriteOperatorId(
+  soleOperatorId: string | null = TEST_OPERATOR_ID,
+): ResolveWriteOperatorId {
+  return (ctx, input) =>
+    resolveOperatorIdForWrite(ctx, input, { findSoleId: async () => soleOperatorId })
+}
+
+/**
+ * An in-memory operator repo seeded with exactly one operator, for
+ * `createApp`-based tests whose non-operator creates rely on sole-operator
+ * inference (#401).
+ */
+export function seededOperatorRepo(id: string = TEST_OPERATOR_ID): InMemoryOperatorRepository {
+  const now = new Date()
+  const operator: Operator = {
+    id,
+    name: 'Test Operator',
+    slug: 'test-operator',
+    preAuthHandoffUrl: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+  return new InMemoryOperatorRepository(new Map([[id, operator]]))
+}

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -1,3 +1,4 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
@@ -59,6 +60,7 @@ function createTestVehicle(
   overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
 ): Promise<Vehicle> {
   return vehicleRepo.create(SYSTEM_CONTEXT, {
+    operatorId: overrides.operatorId ?? BEST_CAR_RENTAL_OPERATOR_ID,
     classId: overrides.classId ?? testClassId,
     name: overrides.name ?? 'Avail Test Car',
     description: overrides.description ?? null,

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -1,3 +1,4 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
@@ -50,6 +51,7 @@ beforeAll(async () => {
   createdClassIds.push(klass.id)
 
   testVehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
     classId: testClassId,
     name: 'Booking Test Car',
     description: null,
@@ -189,6 +191,7 @@ describe('DrizzleBookingRepository', () => {
 
   it('findAll filters by vehicleId', async () => {
     const otherVehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       classId: testClassId,
       name: 'Other Car',
       description: null,
@@ -471,6 +474,7 @@ describe('POST /bookings overlap via HTTP (real Postgres)', () => {
     const httpVehicleClassRepo = new DrizzleVehicleClassRepository(db)
 
     httpVehicle = await httpVehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       classId: testClassId,
       name: 'HTTP Overlap Test Car',
       description: null,

--- a/packages/api/tests/integration/global-setup.ts
+++ b/packages/api/tests/integration/global-setup.ts
@@ -7,10 +7,10 @@ import { operators } from '@kuruma/shared/db/schema'
 import { testDb } from './pg-test-client'
 
 // Slice 1 (#386) made vehicles.operatorId / vehicle_classes.operatorId NOT
-// NULL with an FK to operators. Every integration test that seeds a vehicle
-// or class needs the transitional Best Car Rental operator to exist, and repo
-// writes that omit operatorId fall back to it (resolveOperatorIdForWrite).
-// Seed it once per run; idempotent so reruns against a warm DB are safe.
+// NULL with an FK to operators. Every integration test that seeds a vehicle or
+// class needs the transitional Best Car Rental operator to exist and must pass
+// its operatorId explicitly — #401 removed the silent resolveOperatorIdForWrite
+// fall-back. Seed it once per run; idempotent so reruns against a warm DB are safe.
 export async function setup(): Promise<void> {
   await testDb
     .insert(operators)

--- a/packages/api/tests/integration/rls-context.test.ts
+++ b/packages/api/tests/integration/rls-context.test.ts
@@ -1,3 +1,4 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { users } from '@kuruma/shared/db/schema'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
@@ -69,6 +70,7 @@ beforeAll(async () => {
   createdClassIds.push(klass.id)
 
   vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
     classId: testClassId,
     name: 'RLS Test Car',
     description: null,

--- a/packages/api/tests/integration/vehicle-classes-route-fk.test.ts
+++ b/packages/api/tests/integration/vehicle-classes-route-fk.test.ts
@@ -1,0 +1,68 @@
+import { users, vehicleClasses } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { db } from './setup'
+
+// #400: vehicle_classes.operatorId is a NOT NULL FK to operators.id
+// (vehicle_classes_operatorId_operators_id_fk). A non-operator (STAFF) caller
+// that names a non-existent operator hits that FK at the DB with 23503. The
+// route must map it to 422 'Invalid operator' rather than letting a raw 500
+// page on-call. In-memory repos cannot exercise a DB-only FK, so this drives
+// the full HTTP app against real Postgres.
+describe('POST /vehicle-classes maps an unknown operatorId to 422 (#400)', () => {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const staffUserId = crypto.randomUUID()
+  const missingOperatorId = `op_missing_${uniq}`
+  const slug = `route-fk-class-${uniq}`
+  let app: ReturnType<typeof createApp>
+  let headers: Record<string, string>
+
+  beforeAll(async () => {
+    setupAuthEnv()
+    await db.insert(users).values({
+      id: staffUserId,
+      email: `vc-route-fk-${uniq}@kuruma-test.com`,
+      role: 'STAFF',
+      language: 'en',
+    })
+    app = createApp({
+      vehicleRepo: new DrizzleVehicleRepository(db),
+      bookingRepo: new DrizzleBookingRepository(db),
+      availabilityRepo: new DrizzleAvailabilityRepository(db),
+      vehicleClassRepo: new DrizzleVehicleClassRepository(db),
+    })
+    headers = await authHeaders({ sub: staffUserId, role: 'STAFF' })
+  })
+
+  afterAll(async () => {
+    // The create fails the FK so no class row is written; delete defensively.
+    await db.delete(vehicleClasses).where(eq(vehicleClasses.slug, slug))
+    await db.delete(users).where(eq(users.id, staffUserId))
+  })
+
+  it('returns 422 "Invalid operator" for a non-existent operatorId', async () => {
+    const res = await app.request('/vehicle-classes', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        operatorId: missingOperatorId,
+        name: 'Route FK Class',
+        slug,
+        seats: 5,
+        luggageCapacity: 2,
+        transmission: 'AUTO',
+        dailyRateJpy: 8000,
+      }),
+    })
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid operator')
+  })
+})

--- a/packages/api/tests/integration/vehicle-detail.test.ts
+++ b/packages/api/tests/integration/vehicle-detail.test.ts
@@ -1,3 +1,4 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { users } from '@kuruma/shared/db/schema'
 import { sql } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
@@ -72,6 +73,7 @@ afterAll(async () => {
 
 async function createVehicle(): Promise<Vehicle> {
   const v = await vehicleRepo.create(SYSTEM_CONTEXT, {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
     classId: testClassId,
     name: 'VD Test Car',
     description: null,

--- a/packages/api/tests/integration/vehicles-pricing.test.ts
+++ b/packages/api/tests/integration/vehicles-pricing.test.ts
@@ -11,6 +11,7 @@
 //   cd packages/api && DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test \
 //     bun run test:integration
 
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { afterEach, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { DrizzleVehicleRepository } from '../../src/repositories/drizzle'
@@ -69,6 +70,7 @@ function baseVehicle(
   overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
 ): Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'> {
   return {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
     name: 'Test Vehicle',
     description: null,
     photos: [],

--- a/packages/api/tests/integration/vehicles-route-fk.test.ts
+++ b/packages/api/tests/integration/vehicles-route-fk.test.ts
@@ -1,0 +1,116 @@
+import { operators, users, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import type { VehicleClass } from '../../src/stores'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { db } from './setup'
+
+// #400: the composite FK vehicles(operatorId,classId) -> vehicle_classes(operatorId,id)
+// (#395) rejects a cross-tenant classId at the DB with 23503. The vehicles route
+// must map that to 422 rather than surfacing a raw 500. In-memory repos cannot
+// exercise the DB-only FK, so this drives the full HTTP app against real Postgres.
+describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () => {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `op_route_a_${uniq}`
+  const opBId = `op_route_b_${uniq}`
+  const staffUserId = crypto.randomUUID()
+  let classA: VehicleClass
+  let classB: VehicleClass
+  let app: ReturnType<typeof createApp>
+  let headers: Record<string, string>
+
+  const makeClass = (operatorId: string, suffix: string): Promise<VehicleClass> =>
+    new DrizzleVehicleClassRepository(db).create({
+      operatorId,
+      name: `Route FK Class ${suffix}`,
+      slug: `route-fk-${suffix}-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+
+  // A non-operator (STAFF) caller names the target operator explicitly via the
+  // body, so resolution is unambiguous; the classId is what the DB FK rejects.
+  const vehicleBody = (operatorId: string, classId: string) => ({
+    operatorId,
+    classId,
+    name: 'Route FK Vehicle',
+    seats: 5,
+    transmission: 'AUTO' as const,
+    bufferMinutes: 60,
+    licensePlate: null,
+    dailyRateJpy: 8000,
+  })
+
+  beforeAll(async () => {
+    setupAuthEnv()
+    await db.insert(operators).values([
+      { id: opAId, slug: `route-a-${uniq}`, name: 'Route Operator A' },
+      { id: opBId, slug: `route-b-${uniq}`, name: 'Route Operator B' },
+    ])
+    classA = await makeClass(opAId, 'a')
+    classB = await makeClass(opBId, 'b')
+    await db.insert(users).values({
+      id: staffUserId,
+      email: `route-fk-${uniq}@kuruma-test.com`,
+      role: 'STAFF',
+      language: 'en',
+    })
+    app = createApp({
+      vehicleRepo: new DrizzleVehicleRepository(db),
+      bookingRepo: new DrizzleBookingRepository(db),
+      availabilityRepo: new DrizzleAvailabilityRepository(db),
+      vehicleClassRepo: new DrizzleVehicleClassRepository(db),
+    })
+    headers = await authHeaders({ sub: staffUserId, role: 'STAFF' })
+  })
+
+  afterAll(async () => {
+    await db.delete(vehicles).where(inArray(vehicles.operatorId, [opAId, opBId]))
+    await db.delete(vehicleClasses).where(inArray(vehicleClasses.operatorId, [opAId, opBId]))
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+    await db.delete(users).where(inArray(users.id, [staffUserId]))
+  })
+
+  const post = (body: unknown) =>
+    app.request('/vehicles', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+  it('POST returns 422 for a classId owned by another operator', async () => {
+    const res = await post(vehicleBody(opAId, classB.id))
+    expect(res.status).toBe(422)
+  })
+
+  it('POST returns 201 for the operator’s own class', async () => {
+    const res = await post(vehicleBody(opAId, classA.id))
+    expect(res.status).toBe(201)
+    expect((await res.json()).data.operatorId).toBe(opAId)
+  })
+
+  it('PATCH returns 422 when reassigning to another operator’s class', async () => {
+    const created = await (await post(vehicleBody(opAId, classA.id))).json()
+    const res = await app.request(`/vehicles/${created.data.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ classId: classB.id }),
+    })
+    expect(res.status).toBe(422)
+  })
+})

--- a/packages/api/tests/integration/vehicles-route-fk.test.ts
+++ b/packages/api/tests/integration/vehicles-route-fk.test.ts
@@ -113,4 +113,23 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
     })
     expect(res.status).toBe(422)
   })
+
+  // The single-column vehicles.operatorId -> operators FK is distinct from the
+  // composite classId FK. classId: null leaves the composite FK unconstrained
+  // (MATCH SIMPLE), so an unknown operatorId trips operators FK alone — and must
+  // report "Invalid operator", not the misleading "Invalid vehicle class".
+  it('POST returns 422 "Invalid operator" for a non-existent operatorId', async () => {
+    const res = await post({
+      operatorId: `op_missing_${uniq}`,
+      classId: null,
+      name: 'Route FK Vehicle',
+      seats: 5,
+      transmission: 'AUTO' as const,
+      bufferMinutes: 60,
+      licensePlate: null,
+      dailyRateJpy: 8000,
+    })
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid operator')
+  })
 })

--- a/packages/api/tests/integration/vehicles.test.ts
+++ b/packages/api/tests/integration/vehicles.test.ts
@@ -1,3 +1,4 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { afterEach, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { DrizzleVehicleRepository } from '../../src/repositories/drizzle'
@@ -14,6 +15,7 @@ afterEach(async () => {
 describe('DrizzleVehicleRepository', () => {
   it('create inserts and returns a vehicle with correct fields', async () => {
     const input = {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'Test Corolla',
       description: 'A test vehicle',
       seats: 5,
@@ -51,6 +53,7 @@ describe('DrizzleVehicleRepository', () => {
 
   it('findById retrieves a created vehicle', async () => {
     const created = await repo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'Findable Car',
       description: null,
       seats: 4,
@@ -88,6 +91,7 @@ describe('DrizzleVehicleRepository', () => {
 
   it('findAll returns all vehicles and filters by status', async () => {
     const available = await repo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'Available Car',
       description: null,
       seats: 5,
@@ -106,6 +110,7 @@ describe('DrizzleVehicleRepository', () => {
     createdIds.push(available.id)
 
     const maintenance = await repo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'Maintenance Car',
       description: null,
       seats: 4,
@@ -138,6 +143,7 @@ describe('DrizzleVehicleRepository', () => {
 
   it('update modifies specified fields and preserves others', async () => {
     const created = await repo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'Original Name',
       description: 'Original desc',
       seats: 5,
@@ -182,6 +188,7 @@ describe('DrizzleVehicleRepository', () => {
 
   it('softDelete sets status to RETIRED', async () => {
     const created = await repo.create(SYSTEM_CONTEXT, {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
       name: 'To Be Retired',
       description: null,
       seats: 4,

--- a/packages/api/tests/routes/actor-derivation.test.ts
+++ b/packages/api/tests/routes/actor-derivation.test.ts
@@ -8,6 +8,7 @@ import {
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { seededOperatorRepo } from '../helpers/operator'
 
 function futureDate(hoursFromNow: number): string {
   const d = new Date()
@@ -38,7 +39,13 @@ async function createTestApp() {
     status: 'ACTIVE',
   })
   return {
-    app: createApp({ vehicleRepo, bookingRepo, availabilityRepo, vehicleClassRepo }),
+    app: createApp({
+      vehicleRepo,
+      bookingRepo,
+      availabilityRepo,
+      vehicleClassRepo,
+      operatorRepo: seededOperatorRepo(),
+    }),
     vehicleRepo,
     classId: klass.id,
   }

--- a/packages/api/tests/routes/bulk-vehicle-status.test.ts
+++ b/packages/api/tests/routes/bulk-vehicle-status.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
 import { createVehicleRoutes } from '../../src/routes/vehicles'
 import { testAuthMiddleware } from '../helpers/auth'
+import { testResolveWriteOperatorId } from '../helpers/operator'
 
 let app: Hono
 let repo: InMemoryVehicleRepository
@@ -41,7 +42,8 @@ describe('PATCH /vehicles/bulk-status', () => {
     repo = new InMemoryVehicleRepository()
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleRoutes(repo))
+    // maintenanceService is unused by the bulk-status + create paths under test.
+    app.route('/', createVehicleRoutes(repo, undefined, testResolveWriteOperatorId()))
   })
 
   it('updates all vehicles to MAINTENANCE and returns them', async () => {
@@ -115,7 +117,7 @@ describe('PATCH /vehicles/bulk-status', () => {
   it('returns 403 when user is a RENTER', async () => {
     const renterApp = new Hono()
     renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
-    renterApp.route('/', createVehicleRoutes(repo))
+    renterApp.route('/', createVehicleRoutes(repo, undefined, testResolveWriteOperatorId()))
 
     const v1 = await createVehicle()
 

--- a/packages/api/tests/routes/maintenance-logs.test.ts
+++ b/packages/api/tests/routes/maintenance-logs.test.ts
@@ -8,6 +8,7 @@ import { createMaintenanceLogRoutes } from '../../src/routes/maintenance-logs'
 import { createVehicleRoutes } from '../../src/routes/vehicles'
 import { MaintenanceService } from '../../src/services/maintenance'
 import { testAuthMiddleware } from '../helpers/auth'
+import { testResolveWriteOperatorId } from '../helpers/operator'
 
 let app: Hono
 let maintenanceService: MaintenanceService
@@ -56,7 +57,10 @@ describe('Maintenance Logs', () => {
 
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleRoutes(vehicleRepo, maintenanceService))
+    app.route(
+      '/',
+      createVehicleRoutes(vehicleRepo, maintenanceService, testResolveWriteOperatorId()),
+    )
     app.route('/', createMaintenanceLogRoutes(maintenanceService))
   })
 

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -8,6 +8,7 @@ import {
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { seededOperatorRepo } from '../helpers/operator'
 
 async function createTestApp() {
   setupAuthEnv()
@@ -31,7 +32,14 @@ async function createTestApp() {
     status: 'ACTIVE',
   })
   return {
-    app: createApp({ vehicleRepo, bookingRepo, availabilityRepo, statsRepo, vehicleClassRepo }),
+    app: createApp({
+      vehicleRepo,
+      bookingRepo,
+      availabilityRepo,
+      statsRepo,
+      vehicleClassRepo,
+      operatorRepo: seededOperatorRepo(),
+    }),
     classId: klass.id,
   }
 }

--- a/packages/api/tests/routes/stats.test.ts
+++ b/packages/api/tests/routes/stats.test.ts
@@ -8,6 +8,7 @@ import {
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { seededOperatorRepo } from '../helpers/operator'
 
 const TEST_API_KEY = 'test-stats-key'
 
@@ -40,6 +41,7 @@ async function createTestApp() {
       availabilityRepo,
       statsRepo,
       vehicleClassRepo,
+      operatorRepo: seededOperatorRepo(),
     }),
     vehicleRepo,
     bookingRepo,

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -12,6 +12,7 @@ import { createVehicleClassRoutes } from '../../src/routes/vehicle-classes'
 import { VehicleClassService } from '../../src/services/vehicle-class'
 import { VehicleClassAvailabilityService } from '../../src/services/vehicle-class-availability'
 import { testAuthMiddleware } from '../helpers/auth'
+import { testResolveWriteOperatorId } from '../helpers/operator'
 
 function buildAvailabilityService(classRepo: InMemoryVehicleClassRepository) {
   const vehicleRepo = new InMemoryVehicleRepository()
@@ -56,7 +57,10 @@ describe('Vehicle Class CRUD Routes', () => {
     const availabilityService = buildAvailabilityService(classRepo)
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleClassRoutes(makeService(), availabilityService))
+    app.route(
+      '/',
+      createVehicleClassRoutes(makeService(), availabilityService, testResolveWriteOperatorId()),
+    )
   })
 
   describe('GET /vehicle-classes', () => {
@@ -352,7 +356,10 @@ describe('Vehicle Class CRUD Routes', () => {
       const service = new VehicleClassService(localClassRepo, localVehicleRepo, localBookingRepo)
       const availabilityService = buildAvailabilityService(localClassRepo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
-      renterApp.route('/', createVehicleClassRoutes(service, availabilityService))
+      renterApp.route(
+        '/',
+        createVehicleClassRoutes(service, availabilityService, testResolveWriteOperatorId()),
+      )
       const res = await renterApp.request('/vehicle-classes')
       expect(res.status).toBe(200)
     })
@@ -365,7 +372,10 @@ describe('Vehicle Class CRUD Routes', () => {
       const service = new VehicleClassService(localClassRepo, localVehicleRepo, localBookingRepo)
       const availabilityService = buildAvailabilityService(localClassRepo)
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
-      renterApp.route('/', createVehicleClassRoutes(service, availabilityService))
+      renterApp.route(
+        '/',
+        createVehicleClassRoutes(service, availabilityService, testResolveWriteOperatorId()),
+      )
       const res = await renterApp.request('/vehicle-classes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -432,7 +442,10 @@ describe('Vehicle Class CRUD Routes', () => {
       const a = new Hono()
       setupGlobalHandlers(a)
       a.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
-      a.route('/', createVehicleClassRoutes(service, availabilityService))
+      a.route(
+        '/',
+        createVehicleClassRoutes(service, availabilityService, testResolveWriteOperatorId()),
+      )
       return a
     }
 

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -10,6 +10,7 @@ import type { RunInTransaction } from '../../src/repositories/types'
 import { createVehicleRoutes } from '../../src/routes/vehicles'
 import { MaintenanceService } from '../../src/services/maintenance'
 import { testAuthMiddleware } from '../helpers/auth'
+import { testResolveWriteOperatorId } from '../helpers/operator'
 
 let app: Hono
 
@@ -43,7 +44,7 @@ describe('Vehicle CRUD Routes', () => {
     const maintenanceService = new MaintenanceService(repo, maintenanceLogRepo, runInTransaction)
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createVehicleRoutes(repo, maintenanceService))
+    app.route('/', createVehicleRoutes(repo, maintenanceService, testResolveWriteOperatorId()))
   })
 
   describe('GET /vehicles', () => {
@@ -706,7 +707,12 @@ describe('Vehicle CRUD Routes', () => {
     const OP_A = 'operator-aaaaaaaa'
     const OP_B = 'operator-bbbbbbbb'
 
-    function mountFor(repo: InMemoryVehicleRepository, role: UserRole, operatorId?: string) {
+    function mountFor(
+      repo: InMemoryVehicleRepository,
+      role: UserRole,
+      operatorId?: string,
+      resolve = testResolveWriteOperatorId(),
+    ) {
       const maintenanceLogRepo = new InMemoryMaintenanceLogRepository()
       const runInTransaction: RunInTransaction = async (fn) =>
         fn({ vehicleRepo: repo, maintenanceLogRepo })
@@ -714,7 +720,7 @@ describe('Vehicle CRUD Routes', () => {
       const a = new Hono()
       setupGlobalHandlers(a)
       a.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
-      a.route('/', createVehicleRoutes(repo, maintenanceService))
+      a.route('/', createVehicleRoutes(repo, maintenanceService, resolve))
       return a
     }
 
@@ -781,6 +787,59 @@ describe('Vehicle CRUD Routes', () => {
       const res = await post(mountFor(repo, 'OPERATOR_OWNER'))
 
       expect(res.status).toBe(403)
+    })
+  })
+
+  // #401: a non-operator caller (PLATFORM_ADMIN / legacy STAFF / ADMIN) must name
+  // the target operator — explicitly, or implicitly when exactly one operator
+  // exists. The old silent Best-Car-Rental default is gone.
+  describe('Non-operator write-operator resolution (#401)', () => {
+    const SOME_OPERATOR = 'op_explicit_target'
+
+    function mountStaff(repo: InMemoryVehicleRepository, resolve = testResolveWriteOperatorId()) {
+      const maintenanceLogRepo = new InMemoryMaintenanceLogRepository()
+      const runInTransaction: RunInTransaction = async (fn) =>
+        fn({ vehicleRepo: repo, maintenanceLogRepo })
+      const maintenanceService = new MaintenanceService(repo, maintenanceLogRepo, runInTransaction)
+      const a = new Hono()
+      setupGlobalHandlers(a)
+      a.use('*', testAuthMiddleware('staff-user', 'STAFF'))
+      a.route('/', createVehicleRoutes(repo, maintenanceService, resolve))
+      return a
+    }
+
+    function postVehicle(a: Hono, input: Record<string, unknown> = validVehicleInput()) {
+      return a.request('/vehicles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+    }
+
+    it('infers the sole operator for a legacy STAFF create when exactly one exists', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await postVehicle(mountStaff(repo, testResolveWriteOperatorId('op_only')))
+
+      expect(res.status).toBe(201)
+      expect((await res.json()).data.operatorId).toBe('op_only')
+    })
+
+    it('honours an explicit operatorId in the body even when inference is ambiguous', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await postVehicle(mountStaff(repo, testResolveWriteOperatorId(null)), {
+        ...validVehicleInput(),
+        operatorId: SOME_OPERATOR,
+      })
+
+      expect(res.status).toBe(201)
+      expect((await res.json()).data.operatorId).toBe(SOME_OPERATOR)
+    })
+
+    it('rejects with 422 when no operatorId is given and there is not exactly one operator', async () => {
+      const repo = new InMemoryVehicleRepository()
+      const res = await postVehicle(mountStaff(repo, testResolveWriteOperatorId(null)))
+
+      expect(res.status).toBe(422)
     })
   })
 })

--- a/packages/api/tests/tenancy.test.ts
+++ b/packages/api/tests/tenancy.test.ts
@@ -1,7 +1,17 @@
-import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { describe, expect, test } from 'vitest'
-import { type CallerContext, ForbiddenError } from '../src/middleware/auth'
-import { operatorReadScope, resolveOperatorIdForWrite } from '../src/tenancy'
+import { type CallerContext, ForbiddenError, OperatorRequiredError } from '../src/middleware/auth'
+import { type OperatorLookup, operatorReadScope, resolveOperatorIdForWrite } from '../src/tenancy'
+
+const lookupReturning = (soleId: string | null): OperatorLookup => ({
+  findSoleId: async () => soleId,
+})
+const lookupNeverCalled: OperatorLookup = {
+  findSoleId: async () => {
+    throw new Error(
+      'findSoleId must not be called for operator-scoped or explicit-operatorId writes',
+    )
+  },
+}
 
 const operatorCtx = (operatorId?: string): CallerContext =>
   operatorId !== undefined
@@ -32,24 +42,39 @@ describe('operatorReadScope', () => {
 })
 
 describe('resolveOperatorIdForWrite', () => {
-  test('operator role writes under its own ctx.operatorId', () => {
-    expect(resolveOperatorIdForWrite(operatorCtx('op_7'))).toBe('op_7')
+  test('operator role writes under its own ctx.operatorId', async () => {
+    await expect(
+      resolveOperatorIdForWrite(operatorCtx('op_7'), undefined, lookupNeverCalled),
+    ).resolves.toBe('op_7')
   })
 
-  test('operator role with no operatorId fails closed', () => {
-    expect(() => resolveOperatorIdForWrite(operatorCtx())).toThrow(ForbiddenError)
+  test('operator role with no operatorId fails closed', async () => {
+    await expect(
+      resolveOperatorIdForWrite(operatorCtx(), undefined, lookupNeverCalled),
+    ).rejects.toBeInstanceOf(ForbiddenError)
   })
 
-  test('operator role ignores an input operatorId (cannot write for another tenant)', () => {
-    expect(resolveOperatorIdForWrite(operatorCtx('op_7'), 'op_other')).toBe('op_7')
+  test('operator role ignores an input operatorId (cannot write for another tenant)', async () => {
+    await expect(
+      resolveOperatorIdForWrite(operatorCtx('op_7'), 'op_other', lookupNeverCalled),
+    ).resolves.toBe('op_7')
   })
 
-  test('legacy/admin falls back to seeded Best Car Rental operator', () => {
-    expect(resolveOperatorIdForWrite(legacyStaffCtx)).toBe(BEST_CAR_RENTAL_OPERATOR_ID)
-    expect(resolveOperatorIdForWrite(adminCtx)).toBe(BEST_CAR_RENTAL_OPERATOR_ID)
+  test('non-operator honours an explicit input operatorId without consulting the lookup', async () => {
+    await expect(
+      resolveOperatorIdForWrite(adminCtx, 'op_explicit', lookupNeverCalled),
+    ).resolves.toBe('op_explicit')
   })
 
-  test('legacy/admin honours an explicit input operatorId when given', () => {
-    expect(resolveOperatorIdForWrite(adminCtx, 'op_explicit')).toBe('op_explicit')
+  test('non-operator with no input infers the sole operator (no BCR hardcode)', async () => {
+    await expect(
+      resolveOperatorIdForWrite(legacyStaffCtx, undefined, lookupReturning('op_only')),
+    ).resolves.toBe('op_only')
+  })
+
+  test('non-operator with no input is rejected when zero or 2+ operators exist', async () => {
+    await expect(
+      resolveOperatorIdForWrite(adminCtx, undefined, lookupReturning(null)),
+    ).rejects.toBeInstanceOf(OperatorRequiredError)
   })
 })

--- a/packages/shared/src/validators/vehicle-class.ts
+++ b/packages/shared/src/validators/vehicle-class.ts
@@ -23,15 +23,24 @@ const vehicleClassObjectSchema = z.object({
   sortOrder: z.number().int().min(0).default(0),
 })
 
-export const createVehicleClassSchema = vehicleClassObjectSchema.superRefine((data, ctx) => {
-  if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['dailyRateJpy'],
-      message: 'At least one rate (daily or hourly) is required',
-    })
-  }
-})
+export const createVehicleClassSchema = vehicleClassObjectSchema
+  .extend({
+    // #401: a non-operator (platform/legacy admin) caller may name the target
+    // operator. OPERATOR_* callers' tenant comes from their token and this is
+    // ignored for them. Optional — omit when exactly one operator exists.
+    // `operators.id` is text (e.g. the seeded `op_best_car_rental`), not a UUID;
+    // existence is enforced by the DB FK (23503 -> 422), not here.
+    operatorId: z.string().min(1, 'Operator ID must not be empty').optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dailyRateJpy'],
+        message: 'At least one rate (daily or hourly) is required',
+      })
+    }
+  })
 
 export const updateVehicleClassSchema = vehicleClassObjectSchema
   .partial()

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -50,29 +50,38 @@ const vehicleObjectSchema = z.object({
   color: z.string().trim().nullish(),
 })
 
-export const createVehicleSchema = vehicleObjectSchema.superRefine((data, ctx) => {
-  if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['dailyRateJpy'],
-      message: 'At least one rate (daily or hourly) is required',
-    })
-  }
+export const createVehicleSchema = vehicleObjectSchema
+  .extend({
+    // #401: a non-operator (platform/legacy admin) caller may name the target
+    // operator. OPERATOR_* callers' tenant comes from their token and this is
+    // ignored for them. Optional — omit when exactly one operator exists.
+    // `operators.id` is text (e.g. the seeded `op_best_car_rental`), not a UUID;
+    // existence is enforced by the DB FK (23503 -> 422), not here.
+    operatorId: z.string().min(1, 'Operator ID must not be empty').optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.dailyRateJpy == null && data.hourlyRateJpy == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dailyRateJpy'],
+        message: 'At least one rate (daily or hourly) is required',
+      })
+    }
 
-  // Issue #50: if both rental bounds are set, min must be <= max. Otherwise
-  // the owner could create a vehicle nobody can book ("min 10h, max 5h").
-  // Enforced here rather than on the column so each field can still be
-  // optional independently.
-  const min = data.minRentalHours
-  const max = data.maxRentalHours
-  if (min != null && max != null && min > max) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['maxRentalHours'],
-      message: 'Maximum rental hours must be greater than or equal to minimum',
-    })
-  }
-})
+    // Issue #50: if both rental bounds are set, min must be <= max. Otherwise
+    // the owner could create a vehicle nobody can book ("min 10h, max 5h").
+    // Enforced here rather than on the column so each field can still be
+    // optional independently.
+    const min = data.minRentalHours
+    const max = data.maxRentalHours
+    if (min != null && max != null && min > max) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['maxRentalHours'],
+        message: 'Maximum rental hours must be greater than or equal to minimum',
+      })
+    }
+  })
 
 export const updateVehicleSchema = vehicleObjectSchema.partial().superRefine((data, ctx) => {
   // Only check when both rate keys are present in the patch — a patch with


### PR DESCRIPTION
## Summary

Removes the hardcoded **Best-Car-Rental** default operator in write paths and replaces it with **count-gated** operator resolution, so a non-operator write can never be silently misattributed once operator #2 exists. Also completes the #400 FK→422 mapping across both vehicle and vehicle-class writes.

## What shipped

**#401 — drop the fallback (`tenancy.ts`)**
`resolveOperatorIdForWrite` is now async + count-gated. A non-operator caller (`PLATFORM_ADMIN` / legacy `STAFF`/`ADMIN`) resolves the target operator by: explicit body `operatorId` → else the sole operator if exactly one exists → else **422** (`OperatorRequiredError`). `OPERATOR_*` callers are unchanged — locked to their own tenant, fail-closed. The hardcoded default is gone.
- `OperatorLookup` + `ResolveWriteOperatorId` (function injection); wired once in `index.ts`, injected into vehicle + class routes (routes never import a repo).
- `OperatorRepository.findSoleId()` on both impls. Vehicle repos no longer self-resolve — route resolves, repo trusts.
- Validators: optional `operatorId` as `z.string().min(1)` (text ids like `op_best_car_rental`, **not** uuid; DB FK is the existence guard).

**#400 — FK→422 mapping (now complete)**
- `POST/PATCH /vehicles`: a `23503` was mapped to a flat "Invalid vehicle class". vehicles carries **two** FKs (composite `operatorId,classId` + single `operatorId`); now branches on the constraint name so a bad operatorId reports "Invalid operator".
- `POST /vehicle-classes`: previously had **no** FK catch — an unknown `operatorId` returned a raw **500** (pages on-call). Now caught → **422 "Invalid operator"**.
- `pg-errors`: `pgConstraintName()` helper + `VEHICLES_CLASS_FK` constant.

## Review

code-reviewer + architect both returned **SHIP**, no CRITICAL/HIGH. Tenant isolation holds (OPERATOR_* can't write cross-tenant; PATCH can't re-tenant), DI boundaries intact, tests mutation-resistant. The convergent finding — incomplete/inconsistent FK→422 mapping — is fixed in this PR (commit `9cacfff`). The LOW TOCTOU on sole-operator inference is deferred to the operator-#2 gate.

## Test plan

- [x] `557` unit/route tests pass
- [x] `115` integration tests pass (was 113; +2 real-PG: unknown operatorId on each route)
- [x] api + web `tsc --noEmit` clean
- [x] import boundaries OK, biome clean (pre-commit enforces all)

## Follow-up

**#407** — `GET /operators` + web admin operator picker. **Hard gate before operator #2 onboarding**: the `/manage/{vehicles,classes}` forms carry no `operatorId` in the JWT and rely on sole-operator inference until the picker lands; the day a 2nd operator is seeded, admin creates 422 until #407 ships.

Closes #401
Closes #400