### PR TITLE
docs(plans): slice 3-8 implementation plans for marketplace MVP

### DIFF
--- a/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
+++ b/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
@@ -31,8 +31,8 @@ The demo target (proposal §6 row 3) is: *operator adds a Toyota Yaris in class 
 | Precondition | Why | Status 2026-06-02 |
 |---|---|---|
 | **#386 (slice 1 tenancy) merged to `marketplace-pivot`** | Slice 3 builds on `operators` table, `roleEnum` (`OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicleClasses.operatorId` + `vehicles.operatorId` (NOT NULL FKs), the `vehicle_classes_operatorId_id_unique` composite key (#395), and `CallerContext.operatorId`/`bypassScope`. | `origin/marketplace-pivot` contains the slice-1/operator-scope commits; the local `marketplace-pivot` branch is stale at `main`. Create worktrees from `origin/marketplace-pivot` or fast-forward the local tracking branch before kickoff. |
-| **#401 (drop operator fallback) merged** | The write contract this slice extends: `resolveOperatorIdForWrite(ctx, inputOperatorId, operators)` in `packages/api/src/tenancy.ts` with single-operator inference + `OperatorRequiredError` (→ 422), **no `BEST_CAR_RENTAL` hardcode**. Building on the pre-#401 synchronous resolver bakes in a contract being removed (`memory/project_operator-2-gate`). | On `feat/401-drop-operator-fallback`, not yet merged |
-| **#387 (locations) merged** — for the WEB layer only | Slice-3 web reuses #387's `[operatorSlug]` layout + slug-resolution + `BusinessSidebar` conditional-link pattern. Class/vehicle backend has no #387 dependency. | In progress (`feature/387-locations`) |
+| **#401 (drop operator fallback) merged** | The write contract this slice extends: `resolveOperatorIdForWrite(ctx, inputOperatorId, operators)` in `packages/api/src/tenancy.ts` with single-operator inference + `OperatorRequiredError` (→ 422), **no `BEST_CAR_RENTAL` hardcode**. | Merged to `origin/marketplace-pivot` via PR #408. The local `marketplace-pivot` branch may still be stale; branch from `origin/marketplace-pivot` or fast-forward local before kickoff. |
+| **#387 (locations) merged** — for the WEB layer only | Slice-3 web reuses #387's flat `/manage/*` business portal gate + `BusinessSidebar` link pattern. Routing is JWT-scoped (`/manage/classes`) with **no `[operatorSlug]` segment**. Class/vehicle backend has no #387 dependency. | In review (PR #414 → `marketplace-pivot`) |
 
 If contract names differ at kickoff, this PR adapts — never refactor a landed slice.
 
@@ -52,7 +52,7 @@ Two *different* established shapes coexist; pick the right one per entity (per A
 
 **Validators** (`packages/shared/src/validators/`): `create<X>Schema` / `update<X>Schema = base.partial()`, cross-field via `.superRefine()`. Platform-admin create variants add `operatorId` (the class validator already extends `operatorId` optional per #401).
 
-**Web**: `packages/web/src/modules/classes/*` (`ClassForm`, `ClassList`, `AddClassDialog`, etc.) + `manage/[operatorSlug]/classes/page.tsx` (post-#387 layout). i18n namespace `business.classes.*`; a new `acriss.*` namespace for the code→label dictionary.
+**Web**: `packages/web/src/modules/classes/*` (`ClassForm`, `ClassList`, `AddClassDialog`, etc.) + flat `app/[locale]/(business)/manage/classes/page.tsx` (JWT-scoped, no `[operatorSlug]`). i18n namespace `business.classes.*`; a new `acriss.*` namespace for the code→label dictionary.
 
 ---
 
@@ -221,7 +221,8 @@ All green before merge:
 ## 9. Execution order & worktrees
 
 ```bash
-git worktree add ../kuruma-acriss -b feature/388-acriss-vehicle-crud marketplace-pivot
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-acriss -b feature/388-acriss-vehicle-crud origin/marketplace-pivot
 cd ../kuruma-acriss && bun install && bunx tsc --noEmit   # fresh-worktree hygiene (CLAUDE.md)
 ```
 
@@ -249,7 +250,7 @@ Conventional commits, small + focused. Never force-push; always rebase (`memory/
 | **Insurance options / fee schedules** | **Slice 4a/4b** | proposal §6 row 4 |
 | **Renter storefront search / per-class availability summaries / "from ¥X"** | **Slice 5** (#391) | proposal §6 row 5, §10 item 21 |
 | **Booking with requested/assigned vehicle, fee snapshot, exclusion constraint** | **Slice 6** (#392) | proposal §6 row 6, §10 item 14 |
-| **Locations CRUD + `vehicles.pickupLocationId` operational attach** | **Slice 2** (#387) — already merged | proposal §6 row 2 (column exists; bookings attach in slice 6) |
+| **Locations CRUD + `vehicles.pickupLocationId` operational attach** | **Slice 2** (#387) — PR #414 in review | proposal §6 row 2 (column exists on the slice-2 branch; bookings attach in slice 6) |
 | **Structural/positional ACRISS validation, full ACRISS table (~hundreds of codes)** | Post-MVP refinement | §2 reversibility ("rename labels"); MVP needs only the seed subset |
 | **Sha-ken expiry reminder UX** | Post-MVP | proposal §9 item 8 ("data column required now; reminder UX is post-MVP" — column already exists) |
 
@@ -289,4 +290,4 @@ Conventional commits, small + focused. Never force-push; always rebase (`memory/
 
 ## 14. Review log
 
-**v1 (2026-06-02)** — initial draft. Grounded against merged `feat/401-drop-operator-fallback` + `feature/387-locations` code (tenancy.ts, vehicle/class repos, routes, validators, seed, ClassForm). Key finding surfaced: plate/shaken/vehicle-operator-scoping already merged; net-new = `acrissCode` on `vehicle_classes` + taxonomy seed + i18n. Awaiting reviewer green light.
+**v1 (2026-06-02)** — initial draft. Grounded against `origin/marketplace-pivot` + PR #414 slice-2 code (tenancy.ts, vehicle/class repos, routes, validators, seed, ClassForm). Key finding surfaced: plate/shaken/vehicle-operator-scoping already merged; net-new = `acrissCode` on `vehicle_classes` + taxonomy seed + i18n. Awaiting reviewer green light.

--- a/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
+++ b/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
@@ -1,0 +1,292 @@
+# Slice 3 — ACRISS + Vehicle CRUD (issue #388)
+
+**Date:** 2026-06-02
+**Status:** Draft v1 — awaiting review before issue/worktree kickoff
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 row 3; §2 "Class taxonomy" / "Class display vs vehicle booking"; §4 business portal item 3; §4 platform item 2; §5 schema-retrofit row; §9 items 8/13; §10 item 13)
+**Companion plan:** `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` (slice 4 sequences after this; 4c reworks the same class/vehicle forms)
+
+---
+
+## 0. What this slice actually is (and is not)
+
+The demo target (proposal §6 row 3) is: *operator adds a Toyota Yaris in class "CCAR"*. Decomposed against the already-merged code, the work splits cleanly:
+
+| Area | New in slice 3? | Why |
+|---|---|---|
+| `vehicle_classes.acriss_code` column + CHECK | **Yes** — the only new schema | Not present in `schema.ts`; §2 "Class taxonomy" makes it canonical |
+| ACRISS taxonomy seed (code → friendly label) | **Yes** | §4 platform item 2; no class records are seeded today (seed only has `SEED_VEHICLES`) |
+| ACRISS i18n labels (en/ja/zh) | **Yes** — new namespace | §4 platform item 2; §8.2 i18n coverage |
+| `acrissCode` in class validator / type / repo / route / `ClassForm` | **Yes** | Thread the new column end-to-end |
+| Vehicle `licensePlate` + `shakenExpiryDate` | **Already merged** (pre-pivot #48/#228) | Columns, validator rules, and i18n keys exist (`schema.ts:121,137`; `validators/vehicle.ts`; `messages/en.json` `business.vehicles.form.licensePlate`/`shakenExpiryDate`) |
+| Vehicle operator-scoping (CRUD only under own operator) | **Already merged in #401/#386** | `DrizzleVehicleRepository` already calls `operatorReadScope` / `requireFleetWriteScope`; `routes/vehicles.ts` resolves `resolveWriteOperatorId` |
+| `vehicles.class_id` references a class | **Already merged** | Composite FK `(operatorId, classId) → vehicle_classes(operatorId, id)` (#395) |
+
+> **Honest scope note.** The proposal lists "operator vehicle CRUD with plate + sha-ken expiry" as slice-3 work, but slices 1 (#386) and 2 (#387) already landed the operator-scoped vehicle repo/route, and plate/shaken predate the pivot. **The net-new deliverable is ACRISS on `vehicle_classes`** plus the regression-proofing that vehicle CRUD enforces tenant isolation. The plan keeps a vehicle-CRUD test pass (§7) to *prove* the acceptance criteria, not to re-implement code that exists. This avoids gold-plating while satisfying #388's acceptance list.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **#386 (slice 1 tenancy) merged to `marketplace-pivot`** | Slice 3 builds on `operators` table, `roleEnum` (`OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicleClasses.operatorId` + `vehicles.operatorId` (NOT NULL FKs), the `vehicle_classes_operatorId_id_unique` composite key (#395), and `CallerContext.operatorId`/`bypassScope`. | `origin/marketplace-pivot` contains the slice-1/operator-scope commits; the local `marketplace-pivot` branch is stale at `main`. Create worktrees from `origin/marketplace-pivot` or fast-forward the local tracking branch before kickoff. |
+| **#401 (drop operator fallback) merged** | The write contract this slice extends: `resolveOperatorIdForWrite(ctx, inputOperatorId, operators)` in `packages/api/src/tenancy.ts` with single-operator inference + `OperatorRequiredError` (→ 422), **no `BEST_CAR_RENTAL` hardcode**. Building on the pre-#401 synchronous resolver bakes in a contract being removed (`memory/project_operator-2-gate`). | On `feat/401-drop-operator-fallback`, not yet merged |
+| **#387 (locations) merged** — for the WEB layer only | Slice-3 web reuses #387's `[operatorSlug]` layout + slug-resolution + `BusinessSidebar` conditional-link pattern. Class/vehicle backend has no #387 dependency. | In progress (`feature/387-locations`) |
+
+If contract names differ at kickoff, this PR adapts — never refactor a landed slice.
+
+---
+
+## 2. The canonical pattern (this slice conforms)
+
+Two *different* established shapes coexist; pick the right one per entity (per AGENTS.md `routes/ → services/ → repositories/`, NOT `modules/`):
+
+- **`vehicle_classes` uses a SERVICE layer** (`services/vehicle-class.ts`): route → `VehicleClassService` → `VehicleClassRepository`. The service owns slug-uniqueness (409, scoped to `SYSTEM_CONTEXT` because slug is globally unique), the "at least one rate" merge-validate, and the archive-with-active-bookings guard (#326). ACRISS work threads through this layer.
+- **`vehicles` is ROUTE → REPOSITORY directly** (no dedicated vehicle service; `MaintenanceService` only for status toggles). `routes/vehicles.ts` does the merge-patch and pricing validation inline. Slice 3 does **not** introduce a vehicle service — that would be gold-plating against the merged shape.
+
+**Operator scoping (already the law, do not weaken):**
+- **Reads** call `operatorReadScope(ctx)` (`tenancy.ts`) → `{kind:'all'|'operator'|'none'}`. `none` ⇒ `sql\`false\`` (fail-closed). `vehicle_classes` reads are *public catalog* (anonymous renters via `PUBLIC_CONTEXT` → `all`), so unlike slice-4 insurance/fees there is **no `requireManagementRead` gate** — the catalog is intentionally world-readable. ACRISS is catalog data and inherits this.
+- **Writes** call `requireFleetWriteScope(ctx)` (admits `FLEET_WRITE_ROLES` = STAFF roles ∪ OPERATOR roles; a tenant caller missing `operatorId` fails closed). The route resolves the target tenant via `resolveWriteOperatorId(ctx, body.operatorId)` *before* the insert so a missing/ambiguous operator surfaces as 403/422, not a DB 500.
+- **Per-repo operator-scoping is ADDITIVE (§6.2).** The class + vehicle repos are *already* operator-scoped (slice 1). This slice keeps them scoped; it never adds an auto-bypass for OPERATOR_* callers. Repos not yet scoped still call `rejectOperatorContextUntilScoped` — irrelevant here since both target repos are scoped.
+
+**Validators** (`packages/shared/src/validators/`): `create<X>Schema` / `update<X>Schema = base.partial()`, cross-field via `.superRefine()`. Platform-admin create variants add `operatorId` (the class validator already extends `operatorId` optional per #401).
+
+**Web**: `packages/web/src/modules/classes/*` (`ClassForm`, `ClassList`, `AddClassDialog`, etc.) + `manage/[operatorSlug]/classes/page.tsx` (post-#387 layout). i18n namespace `business.classes.*`; a new `acriss.*` namespace for the code→label dictionary.
+
+---
+
+## 3. Schema (`packages/shared/src/db/schema.ts`)
+
+### 3.1 The one new column
+
+```ts
+// §2 "Class taxonomy" / §10 item 13: ACRISS 4-letter code is canonical on the
+// CLASS, not the vehicle. Vehicles point at a class via the composite FK; the
+// class carries the OTA-standard taxonomy code. Nullable in MVP so existing /
+// operator-created classes without a mapped code still validate — the friendly
+// i18n label is the renter-facing surface, the code is the integration anchor
+// (future Trip.com sync, §2). Format: exactly 4 chars, A-Z + digit 9 ('9' = the
+// ACRISS "or higher" wildcard slot used in some category/type cells).
+acrissCode: text('acrissCode'),
+```
+
+Table extras add a CHECK (friendly DB seal; the validator rejects earlier):
+
+```ts
+check(
+  'vehicle_classes_acriss_code_format',
+  sql`${table.acrissCode} IS NULL OR ${table.acrissCode} ~ '^[A-Z9][A-Z9][A-Z9][A-Z9]$'`,
+),
+```
+
+**No uniqueness constraint on `acrissCode`.** Multiple classes may legitimately share an ACRISS code (e.g. two "CCAR" compact classes with different photos/branding); ACRISS is a *category*, not an identity. §2 treats it as the grouping layer.
+
+### 3.2 What does NOT change here
+
+- `vehicles.classId`, the composite FK `vehicles_operatorId_classId_fk`, `licensePlate`, `shakenExpiryDate` — all already present (slice 1 + pre-pivot). Untouched.
+- `vehicle_classes.dailyRateJpy`/`hourlyRateJpy` — **left in place.** Their removal is **slice 4c** (`drop_class_level_pricing`), explicitly sequenced *after* #388 (slice-4 plan §5 step 3). Dropping them here would collide with 4c and break the "at least one rate" service path still in use.
+
+### 3.3 Migration
+
+```bash
+bun run db:generate --name add_acriss_code_to_vehicle_classes
+bun run db:migrate
+bun run db:verify   # 3 green checks (schema-snapshot / journal-disk / journal-DB)
+```
+
+Single additive migration (one `ALTER TABLE ADD COLUMN` + one `ADD CONSTRAINT`). **Journal-order trap (CLAUDE.md 2026-04-17):** generate this migration on top of whatever #386/#387/#401 left in `drizzle/meta/_journal.json`. If this branch rebases after another slice merges, **regenerate** rather than hand-editing `when`. CI `db-drift` enforces.
+
+---
+
+## 4. Validators — `packages/shared/src/validators/vehicle-class.ts`
+
+Add `acrissCode` to the shared `vehicleClassObjectSchema` (so both create and `.partial()` update inherit it):
+
+```ts
+// ACRISS code: exactly 4 chars, uppercase A-Z or '9'. Optional in MVP. The
+// regex mirrors the DB CHECK `vehicle_classes_acriss_code_format`. Uppercased
+// at the boundary so 'ccar' from a form submits as 'CCAR'.
+acrissCode: z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z9]{4}$/, 'ACRISS code must be 4 letters (A-Z) or 9')
+  .nullish(),
+```
+
+- `createVehicleClassSchema` / `updateVehicleClassSchema` need **no `.superRefine()` change** — the field is independent of the pricing rule.
+- The existing `operatorId` extend on `createVehicleClassSchema` (#401) is unchanged.
+- **Structural validation is deferred.** A future `validateAcrissStructure()` helper could check each *position* against the ACRISS axis it encodes (category / type / transmission-drive / fuel-air). MVP ships the 4-char-format check only because operators may enter codes the seed dictionary does not list.
+
+Export `ACRISS_CODES` (the seed dictionary keys) as `as const` from a new shared module (§5) so the form can offer a typeahead and tests can assert membership.
+
+---
+
+## 5. ACRISS taxonomy seed + i18n
+
+### 5.1 The dictionary — `packages/shared/src/acriss.ts` (new, runtime-dep-free)
+
+`packages/shared` has **no runtime deps on api/web** (AGENTS.md) — this is a pure const module, importable by seed, validators, api, and web.
+
+```ts
+// ACRISS code → translation KEY (not literal text). Labels live in
+// messages/*.json under the `acriss` namespace so en/ja/zh render per locale
+// (§4 platform item 2, §8.2). MVP subset = the 6-8 codes the demo seed needs
+// (proposal §9 item 9: "6-8 ACRISS codes" is the credibility floor).
+export const ACRISS_CODES = {
+  MCAR: 'acriss.MCAR', // Mini, Car, manual, unspecified fuel
+  ECAR: 'acriss.ECAR', // Economy
+  CCAR: 'acriss.CCAR', // Compact  <-- demo target (Toyota Yaris)
+  ICAR: 'acriss.ICAR', // Intermediate
+  SCAR: 'acriss.SCAR', // Standard
+  FCAR: 'acriss.FCAR', // Fullsize
+  IVAR: 'acriss.IVAR', // Intermediate passenger van (minivan)
+  SUVR: 'acriss.SUVR', // SUV  (note: not strictly ACRISS axis-pure; demo label)
+} as const
+
+export type AcrissCode = keyof typeof ACRISS_CODES
+```
+
+> ACRISS axes for reference (informational; MVP does not enforce positionally):
+> pos1 category, pos2 type, pos3 transmission+drive, pos4 fuel+AC. `CCAR` = Compact / 2-4dr car / manual unspecified / unspecified-fuel-with-AC.
+
+### 5.2 i18n labels — `packages/web/messages/{en,ja,zh}.json`
+
+New top-level `acriss` namespace, one entry per `ACRISS_CODES` key:
+
+```jsonc
+// en.json
+"acriss": { "CCAR": "Compact", "ECAR": "Economy", "IVAR": "Minivan", ... }
+// ja.json
+"acriss": { "CCAR": "コンパクト", "ECAR": "エコノミー", "IVAR": "ミニバン", ... }
+// zh.json
+"acriss": { "CCAR": "紧凑型", "ECAR": "经济型", "IVAR": "商务车", ... }
+```
+
+Plus `business.classes.form.acrissCode` (+ placeholder + hint) in all three. **Restart dev server after adding namespaces** (CLAUDE.md i18n gotcha: `rm -rf packages/web/.next && bun run dev`). **Verify locale parity** — the `lint:i18n` parity check (#375) fails CI on a missing key; conflict resolution silently drops keys (CLAUDE.md).
+
+### 5.3 Class seed — `packages/shared/src/db/seed.ts`
+
+Today the seed inserts only `SEED_VEHICLES` against the Best Car Rental operator; **no `vehicle_classes` rows are seeded**. Add a `SEED_CLASSES` array (operator = Best Car Rental, `operatorId = BEST_CAR_RENTAL_OPERATOR_ID`) with `acrissCode` set per class so the demo "Toyota Yaris in CCAR" works end-to-end, and so seeded vehicles can attach via the composite FK. Keep class `dailyRateJpy`/`hourlyRateJpy` for now (removed in 4c). Idempotent insert (mirror the existing `onConflictDoNothing` pattern).
+
+---
+
+## 6. Repo / Service / Routes / Web — threading `acrissCode`
+
+Pure plumbing; no new interface methods.
+
+| Layer | File | Change |
+|---|---|---|
+| **Type** | `packages/api/src/stores.ts` `VehicleClass` | add `acrissCode: string | null` |
+| **Drizzle columns** | `repositories/drizzle/shared.ts` `vehicleClassColumns` + `toVehicleClass` | add `acrissCode: vehicleClasses.acrissCode` and map it |
+| **Drizzle repo** | `repositories/drizzle/vehicle-class.ts` `create`/`update` | pass `acrissCode` through (operator scoping already present — untouched) |
+| **InMemory repo** | `repositories/in-memory/vehicle-class.ts` | persist/return `acrissCode` |
+| **Repo interface** | `repositories/types.ts` | no signature change (data shape via `VehicleClass`) |
+| **Service** | `services/vehicle-class.ts` | no logic change — `create`/`update` already spread the data object |
+| **Route** | `routes/vehicle-classes.ts` `POST`/`PATCH` | add `acrissCode: d.acrissCode ?? null` to the create object; `PATCH` uses `stripUndefined(parsed.data)` so it flows automatically |
+| **Web type/api** | `modules/classes/api.ts`, `hooks.ts` | type carries through (uses `CreateVehicleClassInput`) |
+| **Web form** | `modules/classes/components/ClassForm.tsx` | add an ACRISS field: a `<select>` of `ACRISS_CODES` keys rendering `t('acriss.<code>')` labels (typeahead/datalist optional), bound via `register('acrissCode')`; label from `t('form.acrissCode')` |
+| **Web display** | `ClassRow.tsx` / `ClassCatalogCard.tsx` / `ClassDetailView.tsx` | render the friendly label `t('acriss.<code>')` next to class name (the renter-facing grouping label, §2) |
+
+**Vehicle CRUD: no code change.** `routes/vehicles.ts`, `validators/vehicle.ts`, `DrizzleVehicleRepository` already handle plate, shaken, operator scope, and `classId` via composite FK. This slice only adds **tests** (§7) proving the acceptance criteria, plus surfacing the class's ACRISS label on the vehicle list (web, read-only, via the already-loaded class).
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant)
+
+Mirror `packages/api/tests/integration/rls-context.test.ts` (seed operator A + operator B + their `OPERATOR_STAFF` users; assert isolation both directions). One failing test → implement → repeat (no horizontal batching, per `~/.claude/rules/testing.md`).
+
+| Layer | New ACRISS work | Vehicle-CRUD acceptance proof (regression) |
+|---|---|---|
+| **Validator** (`packages/shared/test/validators/`) | `'CCAR'` accepted; `'ccar'` accepted and uppercased to `'CCAR'`; `'CCA'` (3) rejected; `'CCARX'` (5) rejected; `'cc-r'` rejected; `null`/omitted accepted (nullish) | existing plate/shaken rules still pass (no change expected) |
+| **InMemory repo** | `create`/`update` round-trips `acrissCode`; op-A staff cannot read/update op-B class (`operatorReadScope`); RENTER/anonymous (`PUBLIC_CONTEXT`) read across operators (catalog is public) but only ACTIVE | op-A staff cannot create/read/update/softDelete op-B vehicle; bypass roles see both |
+| **Drizzle repo** (Neon `test`) | inserting `acrissCode='cc'` (lowercase, len 2) → 23514 check_violation; valid 4-char code persists | composite FK `(operatorId, classId)` rejects a vehicle whose class belongs to another operator → 23503 (already covered by #395/#400 — keep the assertion) |
+| **Service** | class `create`/`update` returns `acrissCode`; slug-uniqueness 409 still holds; archive-with-active-bookings 409 still holds | n/a (no vehicle service) |
+| **Route** | `POST /vehicle-classes` with bad ACRISS → 400 (Zod via `parseBody`); `GET /vehicle-classes` (public) returns `acrissCode` | `POST /vehicles` cross-operator: operator caller's `operatorId` stamped from token, body `operatorId` ignored; missing/ambiguous operator for a bypass caller → 422 (`OperatorRequiredError`); 401/403/404 matrix |
+| **Web** | `ClassForm` renders the ACRISS select with translated labels; submitting selects the code | `ClassRow`/catalog renders `t('acriss.CCAR')` = "Compact" |
+| **i18n** | parity test: every `ACRISS_CODES` key exists in en/ja/zh `acriss` namespace | — |
+
+**E2E:** none required for slice 3 (operator-portal only; renter-facing E2E starts slice 5 per proposal §6.1). The existing #338/#345 mock-API E2E re-seed against the marketplace shape and must stay green (§6.2(b)).
+
+---
+
+## 8. Merge gate (proposal §6.1)
+
+All green before merge:
+`bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` (3 green) · `bun run lint:i18n` parity (#375) · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktrees
+
+```bash
+git worktree add ../kuruma-acriss -b feature/388-acriss-vehicle-crud marketplace-pivot
+cd ../kuruma-acriss && bun install && bunx tsc --noEmit   # fresh-worktree hygiene (CLAUDE.md)
+```
+
+Within the worktree, one vertical RED→GREEN→REFACTOR cycle per row:
+
+1. **Schema** — `acrissCode` column + CHECK; `db:generate --name add_acriss_code_to_vehicle_classes` → `db:migrate` → `db:verify`.
+2. **Shared dictionary** — `acriss.ts` (`ACRISS_CODES`) + validator field (RED validator test first).
+3. **Type + repos** — `VehicleClass.acrissCode`, drizzle columns/mapper, in-memory (RED repo round-trip + isolation tests first).
+4. **Service + route** — thread through (RED route test first); Drizzle integration test against Neon `test`.
+5. **Seed** — `SEED_CLASSES` with ACRISS codes (incl. CCAR for the Yaris).
+6. **i18n** — `acriss` namespace + `business.classes.form.acrissCode` in en/ja/zh; restart dev; parity check.
+7. **Web** — `ClassForm` ACRISS select; class/vehicle list label display.
+8. **Vehicle-CRUD acceptance tests** — prove tenant isolation + plate/shaken (no impl expected).
+9. Review (code-reviewer + architect) → rebase onto `origin/marketplace-pivot` → PR (`Closes #388`).
+
+Conventional commits, small + focused. Never force-push; always rebase (`memory/feedback_no-force-push`).
+
+---
+
+## 10. Cross-slice boundary (what does NOT ship here)
+
+| Concern | Belongs to | Citation |
+|---|---|---|
+| **Drop `vehicle_classes.dailyRateJpy`/`hourlyRateJpy`** + move pricing to vehicle-only | **Slice 4c** (#389c) | slice-4 plan §5; proposal §5.1 step 4. Sequenced *after* #388. Class pricing stays untouched here. |
+| **Insurance options / fee schedules** | **Slice 4a/4b** | proposal §6 row 4 |
+| **Renter storefront search / per-class availability summaries / "from ¥X"** | **Slice 5** (#391) | proposal §6 row 5, §10 item 21 |
+| **Booking with requested/assigned vehicle, fee snapshot, exclusion constraint** | **Slice 6** (#392) | proposal §6 row 6, §10 item 14 |
+| **Locations CRUD + `vehicles.pickupLocationId` operational attach** | **Slice 2** (#387) — already merged | proposal §6 row 2 (column exists; bookings attach in slice 6) |
+| **Structural/positional ACRISS validation, full ACRISS table (~hundreds of codes)** | Post-MVP refinement | §2 reversibility ("rename labels"); MVP needs only the seed subset |
+| **Sha-ken expiry reminder UX** | Post-MVP | proposal §9 item 8 ("data column required now; reminder UX is post-MVP" — column already exists) |
+
+---
+
+## 11. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Branching off a stale local `marketplace-pivot` | Medium | High | §1 precondition: create worktrees from `origin/marketplace-pivot` or fast-forward the local tracking branch before `git worktree add`; confirm #386 + #401 are present |
+| Migration journal `when` collision with concurrent slice-2/4 branches | Medium | Medium | Single additive migration; regenerate (not hand-edit) on rebase; `db:verify` + CI `db-drift` (CLAUDE.md 2026-04-17) |
+| i18n keys dropped in conflict resolution → blank ACRISS labels | Medium | Low | `lint:i18n` parity test (#375) as a merge gate; explicit parity test in §7 |
+| Scope creep into vehicle-CRUD reimplementation | Medium | Medium | §0 honest-scope note: vehicle CRUD + plate/shaken already merged; slice adds tests, not code |
+| ACRISS CHECK regex rejects a legitimately weird code operators enter | Low | Low | MVP regex is permissive (`[A-Z9]{4}`), no positional validation; structural check deferred |
+| Accidentally dropping class pricing here, colliding with 4c | Low | Medium | §3.2 + §10: class pricing explicitly untouched; 4c owns the drop |
+
+---
+
+## 12. Critical files
+
+**New:** `packages/shared/src/acriss.ts`; migration `drizzle/00NN_add_acriss_code_to_vehicle_classes.sql` (+ snapshot/journal).
+**Modify (shared):** `db/schema.ts` (column + CHECK), `validators/vehicle-class.ts` (field), `db/seed.ts` (`SEED_CLASSES`).
+**Modify (api):** `stores.ts` (`VehicleClass.acrissCode`), `repositories/drizzle/shared.ts` (columns + `toVehicleClass`), `repositories/drizzle/vehicle-class.ts`, `repositories/in-memory/vehicle-class.ts`, `routes/vehicle-classes.ts`.
+**Modify (web):** `modules/classes/components/ClassForm.tsx`, `ClassRow.tsx`, `ClassCatalogCard.tsx`, `ClassDetailView.tsx`; `messages/{en,ja,zh}.json` (`acriss.*` + `business.classes.form.acrissCode`).
+**Unchanged (proof-only):** `routes/vehicles.ts`, `validators/vehicle.ts`, `repositories/{drizzle,in-memory}/vehicle.ts`, `tenancy.ts`, `middleware/auth.ts`.
+
+---
+
+## 13. Resolved decisions
+
+1. **ACRISS validation depth.** Defer positional/structural validation. MVP ships 4-char-format only (`[A-Z9]{4}`) so operators can enter codes outside the seed dictionary without false rejects.
+2. **`acrissCode` nullable vs required.** Nullable for operator-created classes; every demo seed class carries a code. This keeps the integration anchor without blocking manual class creation.
+3. **ACRISS seed subset size.** Use the 8-code subset in §5.1. Du can refine ja/zh label wording during discovery without changing the schema/API contract.
+4. **`SUVR` purity.** Keep `SUVR` as a pragmatic demo label. The field is format-validated, not dictionary-gated; a stricter OTA table can replace the subset post-MVP.
+
+---
+
+## 14. Review log
+
+**v1 (2026-06-02)** — initial draft. Grounded against merged `feat/401-drop-operator-fallback` + `feature/387-locations` code (tenancy.ts, vehicle/class repos, routes, validators, seed, ClassForm). Key finding surfaced: plate/shaken/vehicle-operator-scoping already merged; net-new = `acrissCode` on `vehicle_classes` + taxonomy seed + i18n. Awaiting reviewer green light.

--- a/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
+++ b/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
@@ -200,9 +200,9 @@ Mirror `packages/api/tests/integration/rls-context.test.ts` (seed operator A + o
 | Layer | New ACRISS work | Vehicle-CRUD acceptance proof (regression) |
 |---|---|---|
 | **Validator** (`packages/shared/test/validators/`) | `'CCAR'` accepted; `'ccar'` accepted and uppercased to `'CCAR'`; `'CCA'` (3) rejected; `'CCARX'` (5) rejected; `'cc-r'` rejected; `null`/omitted accepted (nullish) | existing plate/shaken rules still pass (no change expected) |
-| **InMemory repo** | `create`/`update` round-trips `acrissCode`; op-A staff cannot read/update op-B class (`operatorReadScope`); RENTER/anonymous (`PUBLIC_CONTEXT`) read across operators (catalog is public) but only ACTIVE | op-A staff cannot create/read/update/softDelete op-B vehicle; bypass roles see both |
+| **InMemory repo** | `create`/`update` round-trips `acrissCode`; op-A staff cannot **read** op-B class (`findById`/`findAll` scoped via `operatorReadScope`) — `update`/`archive` take no `CallerContext`, so mutation isolation is **not** a repo-test concern (proven at the service, below); RENTER/anonymous (`PUBLIC_CONTEXT`) read across operators (catalog is public) but only ACTIVE | op-A staff cannot create/read/update/softDelete op-B vehicle; bypass roles see both |
 | **Drizzle repo** (Neon `test`) | inserting `acrissCode='cc'` (lowercase, len 2) → 23514 check_violation; valid 4-char code persists | composite FK `(operatorId, classId)` rejects a vehicle whose class belongs to another operator → 23503 (already covered by #395/#400 — keep the assertion) |
-| **Service** | class `create`/`update` returns `acrissCode`; slug-uniqueness 409 still holds; archive-with-active-bookings 409 still holds | n/a (no vehicle service) |
+| **Service** | class `create`/`update` returns `acrissCode`; **op-A `update`/`archive` of an op-B class → 404** (caller-scoped `findById(ctx,id)` runs before the unscoped `repo.update(id)`/`archive(id)` — this is the mutation-isolation seal); slug-uniqueness 409 still holds; archive-with-active-bookings 409 still holds | n/a (no vehicle service) |
 | **Route** | `POST /vehicle-classes` with bad ACRISS → 400 (Zod via `parseBody`); `GET /vehicle-classes` (public) returns `acrissCode` | `POST /vehicles` cross-operator: operator caller's `operatorId` stamped from token, body `operatorId` ignored; missing/ambiguous operator for a bypass caller → 422 (`OperatorRequiredError`); 401/403/404 matrix |
 | **Web** | `ClassForm` renders the ACRISS select with translated labels; submitting selects the code | `ClassRow`/catalog renders `t('acriss.CCAR')` = "Compact" |
 | **i18n** | parity test: every `ACRISS_CODES` key exists in en/ja/zh `acriss` namespace | — |
@@ -285,6 +285,7 @@ Conventional commits, small + focused. Never force-push; always rebase (`memory/
 2. **`acrissCode` nullable vs required.** Nullable for operator-created classes; every demo seed class carries a code. This keeps the integration anchor without blocking manual class creation.
 3. **ACRISS seed subset size.** Use the 8-code subset in §5.1. Du can refine ja/zh label wording during discovery without changing the schema/API contract.
 4. **`SUVR` purity.** Keep `SUVR` as a pragmatic demo label. The field is format-validated, not dictionary-gated; a stricter OTA table can replace the subset post-MVP.
+5. **`CallerContext` on class mutations (relayed review note, 2026-06-02).** Keep the repo shape — `VehicleClassRepository.update(id, data)`/`archive(id)` do **not** take `CallerContext`; do not expand the interface. Mutation isolation is proven at the **service**: `VehicleClassService.update(ctx, id)`/`archive(ctx, id)` call caller-scoped `findById(ctx, id)` first → 404 for another operator's class. §7 attributes read-isolation to repo tests and mutation-isolation to service/route tests accordingly. (Option 1 from the review note; matches the implemented shape on `marketplace-pivot`.)
 
 ---
 

--- a/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
+++ b/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
@@ -1,0 +1,280 @@
+# Slice 4 Amendment — Insurance, Pricing & Fees (issue #389)
+
+**Date:** 2026-06-02
+**Status:** Draft v2 — review incorporated (P0 + 3×P1 + P2, 2026-06-02); awaiting final green light to create issues
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 slice 4, §4 business portal items 4-6, §9 items 5/19, §10 items 5/9)
+**Supersedes:** the thin body of #389 (insufficient detail for AFK implementation per review 2026-06-02)
+
+---
+
+## 0. Decision: split #389 into 4a / 4b / 4c
+
+#389 bundles three independent domains. Per review, it is split into three sub-issues under epic #385, each a mergeable vertical slice on its own worktree off `marketplace-pivot`:
+
+| Sub-slice | Domain | New? | Independent of | Effort |
+|---|---|---|---|---|
+| **4a** | Insurance options (per-operator CRUD) | New entity | 4b, 4c | ~1 day |
+| **4b** | Fee schedules (per-operator, optional per-class) | New entity | 4a, 4c | ~1-1.5 days |
+| **4c** | Vehicle pricing finalization (drop legacy class pricing) | Removal/cleanup | 4a, 4b | ~0.5 day |
+
+**4a and 4b run in parallel** (separate worktrees) — they share no business logic, only three merge-surface files (`schema.ts`, `index.ts` DI block, `messages/*.json`). **4c sequences after #388** (ACRISS + vehicle CRUD) because both rework the vehicle/class forms.
+
+**Insurance scope decision:** per-operator CRUD only. No `vehicle_insurance_options` join table in MVP — at booking (slice 6) the renter picks from the operator's full active list and the booking stores the selected option + price snapshot. Per-vehicle applicability is deferred until proven needed.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **#401 merged to `marketplace-pivot`** | Slice 4 repos build on the post-#401 write contract: `resolveOperatorIdForWrite(ctx, input, operators)` with single-operator inference + `OperatorRequiredError`, **no `BEST_CAR_RENTAL_OPERATOR_ID` fallback**. Building on the current pivot branch bakes in a contract actively being removed (`memory/project_operator-2-gate`). | On `feat/401-drop-operator-fallback`, not yet merged |
+| **#387 (locations) merged** — for the WEB layer of 4a/4c only | 4a/4c pages reuse #387's `[operatorSlug]` layout + operator slug-resolution + `BusinessSidebar` conditional-link pattern. Backend repos/services have no #387 dependency and can start earlier. | In progress (`feature/387-locations`) |
+| **#388 (ACRISS + vehicle CRUD)** — for **4c only** | 4c drops legacy class pricing while #388 reworks the class/vehicle forms; landing 4c first would conflict. 4a/4b do not depend on #388. | Not started |
+
+`operators` table, `roleEnum` (incl. `OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicles`/`vehicleClasses.operatorId`, the `(operatorId, id)` composite-unique on `vehicle_classes` (#395), and `CallerContext.operatorId`/`bypassScope` (#401) are all assumed present from slices 1-3.
+
+If the contract names differ at kickoff, each sub-slice adapts its own PR — never refactor a landed slice.
+
+---
+
+## 2. The canonical pattern (all three sub-slices conform)
+
+Established by `vehicles` / `vehicle_classes` (per AGENTS.md API layout `routes/ → services/ → repositories/`, NOT `modules/`):
+
+- **Repo interface** (`repositories/types.ts`): `CallerContext` on every method.
+- **Drizzle repo** reads: insurance/fees are **operator-private config**, so `findAll`/`findById` first call a management-read guard `requireManagementRead(ctx)` that rejects `RENTER` **and** `PARTNER` (unlike vehicles, whose catalog is public). Allowed read roles = `MANAGEMENT_READ_ROLES = STAFF_ROLES ∪ OPERATOR_ROLES` = `{STAFF, ADMIN, PLATFORM_ADMIN, OPERATOR_OWNER, OPERATOR_STAFF}`. **After** the guard, apply `operatorReadScope(ctx)` → `{kind:'all'|'operator'|'none'}` (`kind:'none'` ⇒ `sql\`false\``, fail-closed). Writes call `requireFleetWriteScope(ctx)` then insert with the route-resolved `operatorId`.
+
+> **[P0] Why `operatorReadScope` alone is unsafe here:** it maps every non-operator role — **including `RENTER`** — to `{kind:'all'}` because the vehicle *catalog* is public. Insurance/fees are private; a renter (or `PARTNER` API caller) hitting `findAll` would read every operator's config. `requireManagementRead(ctx)` is the seal; `operatorReadScope` only handles the operator-vs-bypass split *after* renters/partners are rejected. Add `requireManagementRead` to `middleware/auth.ts` alongside `requireFleetWriteScope`.
+- **InMemory repo** mirrors the interface (injected in tests via `createApp(overrides)`).
+- **Service** is auth-agnostic; returns `{ ok: true, ... } | { ok: false, error, status, code? }`.
+- **Route** gates mutations with role check, builds ctx via `toCallerContext(requireUser(c))`, uses `ok()`/`fail()`/`parseBody()` from `routes/helpers.ts`. Mounted at `/` in `index.ts`.
+- **Validators** (`packages/shared/src/validators/<entity>.ts`): `create<X>Schema` / `update<X>Schema` (= `.partial()`), cross-field rules via `.superRefine()`.
+- **Web** module `packages/web/src/modules/<entity>/` (`api.ts`, `hooks.ts`, `components/`) + page under `manage/[operatorSlug]/<entity>/page.tsx`, i18n namespace `business.<entity>`.
+
+**Bypass-caller scoping (every list/create, mirrors #387):** operator callers auto-scope to `ctx.operatorId` and any `?operatorId=` they pass is dropped at the route. **[P1] Gate on `ctx.bypassScope === true`, not on the `PLATFORM_ADMIN` string** — during transition, legacy `STAFF`/`ADMIN` are bypass equivalents and must obey the same rule. A bypass caller's GET requires explicit `?operatorId=<id>` OR `?includeAll=true` (else 400); a bypass caller's POST requires `operatorId` in body (`platformAdmin*` schema variant; missing → 400 via `parseBody`). Cross-operator id on GET/PATCH/DELETE returns **404, not 403** (no tenant-existence leak). Mutations load the row first to capture its tenant before writing.
+
+**[P1] Validation status code = `400` (contract):** every validation failure — Zod via `parseBody()`, missing `operatorId` on a bypass create, and fee-type↔unit coherence — returns **400**, matching the existing `parseBody()` helper. The plan and tests use 400 throughout; do **not** introduce a second validation status (422). If a future caller needs to distinguish "well-formed but semantically invalid," add a `code` field to the error body, not a new HTTP status.
+
+---
+
+## 3. Sub-slice 4a — Insurance options
+
+### Schema (`packages/shared/src/db/schema.ts`)
+
+```ts
+export const insuranceStatusEnum = pgEnum('insurance_status', ['ACTIVE', 'ARCHIVED'])
+
+export const insuranceOptions = pgTable('insurance_options', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  operatorId: text('operatorId').notNull().references(() => operators.id),
+  name: text('name').notNull(),
+  description: text('description'),
+  dailyPriceJpy: integer('dailyPriceJpy').notNull(),
+  deductibleJpy: integer('deductibleJpy'),          // null = no deductible (full cover)
+  status: insuranceStatusEnum('status').notNull().default('ACTIVE'),
+  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index('idx_insurance_options_operatorId').on(t.operatorId),
+  unique('insurance_options_operatorId_id_unique').on(t.operatorId, t.id),
+  unique('insurance_options_operator_name_unique').on(t.operatorId, t.name),
+  check('insurance_options_daily_price_non_negative', sql`${t.dailyPriceJpy} >= 0`),
+  check('insurance_options_deductible_non_negative',
+    sql`${t.deductibleJpy} IS NULL OR ${t.deductibleJpy} >= 0`),
+])
+```
+
+Seed (proposal §2): Best Car Rental gets two options — normal (deductible 150,000) + premium (deductible 250,000); `dailyPriceJpy` operator-set placeholders.
+
+### Validators — `packages/shared/src/validators/insurance-option.ts`
+- `createInsuranceOptionSchema`: name (1-200), description (≤2000, optional), `dailyPriceJpy` int ≥ 0, `deductibleJpy` int ≥ 0 nullish.
+- `updateInsuranceOptionSchema = base.partial()`.
+- `platformAdminCreateInsuranceOptionSchema = createInsuranceOptionSchema.extend({ operatorId: z.string() })`.
+
+### Repo interface — `repositories/types.ts`
+```ts
+export interface InsuranceOptionFilters { status?: 'ACTIVE' | 'ARCHIVED'; includeArchived?: boolean; operatorId?: string }
+export interface InsuranceOptionRepository {
+  findAll(ctx: CallerContext, filters?: InsuranceOptionFilters): Promise<InsuranceOption[]>
+  findById(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined>
+  create(ctx: CallerContext, data: Omit<InsuranceOption, 'id'|'createdAt'|'updatedAt'>): Promise<InsuranceOption>
+  update(ctx: CallerContext, id: string, data: Partial<InsuranceOption>): Promise<InsuranceOption | undefined>
+  archive(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined>
+}
+```
+Drizzle + InMemory pair under `repositories/{drizzle,in-memory}/insurance-option.ts`. Service `services/insurance-option.ts` (name-uniqueness 409, archive sets status). Routes `routes/insurance-options.ts` at `/insurance-options`. DI + mount in `index.ts`.
+
+### Web
+`manage/[operatorSlug]/insurance/page.tsx` + `modules/insurance/` (`InsuranceList`, `InsuranceForm`, `InsuranceArchiveDialog`, `useInsuranceOptions`). i18n `business.insurance.*`. Sidebar link gated on `operatorId`.
+
+---
+
+## 4. Sub-slice 4b — Fee schedules
+
+### Schema
+
+```ts
+export const feeTypeEnum = pgEnum('fee_type', ['OVERTIME_HOURLY', 'CLEANING_FLAT', 'NO_FUEL_FLAT'])
+export const feeUnitEnum = pgEnum('fee_unit', ['PER_HOUR', 'PER_DAY', 'PER_KM', 'FLAT'])
+export const feeScheduleStatusEnum = pgEnum('fee_schedule_status', ['ACTIVE', 'ARCHIVED'])
+
+export const feeSchedules = pgTable('fee_schedules', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  operatorId: text('operatorId').notNull().references(() => operators.id),
+  vehicleClassId: text('vehicleClassId'),            // null = operator-wide
+  feeType: feeTypeEnum('feeType').notNull(),
+  unit: feeUnitEnum('unit').notNull(),
+  amountJpy: integer('amountJpy').notNull(),
+  status: feeScheduleStatusEnum('status').notNull().default('ACTIVE'),
+  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  // [P2] Composite index covering the operator read-scope (leading column) AND the
+  // composite FK source, so lint:fk-indexes + FK maintenance are satisfied. (operatorId)
+  // is a prefix of this, so no separate idx_fee_schedules_operatorId is needed. The
+  // partial UNIQUE indexes below are conditional and do NOT count as FK cover.
+  index('idx_fee_schedules_operator_class').on(t.operatorId, t.vehicleClassId),
+  // Composite FK seal (#395): a per-class fee's class must belong to the SAME operator.
+  // MATCH SIMPLE — when vehicleClassId IS NULL the FK is not enforced (operator-wide row).
+  foreignKey({
+    columns: [t.operatorId, t.vehicleClassId],
+    foreignColumns: [vehicleClasses.operatorId, vehicleClasses.id],
+    name: 'fee_schedules_operator_class_fk',
+  }),
+  check('fee_schedules_amount_non_negative', sql`${t.amountJpy} >= 0`),
+  // Uniqueness: ONE active fee per (operator, type, scope). Two partial indexes because
+  // NULL != NULL in a plain UNIQUE — operator-wide rows would otherwise never dedupe.
+  // Scoped to status='ACTIVE' so archiving frees the slot for a re-created fee.
+  uniqueIndex('fee_schedules_active_class_unique')
+    .on(t.operatorId, t.feeType, t.vehicleClassId)
+    .where(sql`status = 'ACTIVE' AND "vehicleClassId" IS NOT NULL`),
+  uniqueIndex('fee_schedules_active_operatorwide_unique')
+    .on(t.operatorId, t.feeType)
+    .where(sql`status = 'ACTIVE' AND "vehicleClassId" IS NULL`),
+])
+```
+
+### Validators — `packages/shared/src/validators/fee-schedule.ts`
+- `createFeeScheduleSchema`: `feeType` enum, `unit` enum, `amountJpy` int ≥ 0, `vehicleClassId` uuid nullish. `.superRefine()` enforces **fee-type ↔ unit coherence**:
+  - `OVERTIME_HOURLY` ⇒ `unit === 'PER_HOUR'`
+  - `CLEANING_FLAT` ⇒ `unit === 'FLAT'`
+  - `NO_FUEL_FLAT` ⇒ `unit === 'FLAT'`
+- `updateFeeScheduleSchema = base.partial()`. **[P1] The schema cannot fully enforce coherence on patch** — a patch of only `{ unit: 'FLAT' }` against an existing `OVERTIME_HOURLY` row never sees `feeType`, so the `.superRefine()` can't fire. Coherence on update is therefore enforced in the **service** on the merged value (below); the schema's `.superRefine()` stays only as a create-time + both-keys-present fast-path.
+- Platform-admin extend variant adds `operatorId`.
+
+### Repo / Service / Routes / Web
+Same shape as 4a. `FeeScheduleFilters` adds `feeType?` and `vehicleClassId?`. **[P1] Service is the coherence + uniqueness seal:** `update` fetches the existing row, **merges the patch**, then validates (a) fee-type↔unit coherence on the *merged* `feeType`+`unit` (400 on mismatch) and (b) active-uniqueness on the merged `(operatorId, feeType, vehicleClassId)` **excluding the current row id** (409) — so a no-key-change edit (e.g. bumping only `amountJpy`) does not falsely collide with itself. This is the merge-then-validate pattern `VehicleClassService.update` uses for "at least one rate". `create` validates the same on the full payload (no exclusion). The DB partial-unique indexes + the schema `.superRefine()` are backstops, not the only checks. Routes at `/fee-schedules`. Page `manage/[operatorSlug]/fees/page.tsx` + `modules/fees/` — form: feeType select → unit auto-constrained by type, amount, optional class dropdown (operator's classes only). i18n `business.fees.*`.
+
+### Slice-6 boundary (explicit — does NOT ship in 4b)
+4b stores schedules only. **Deferred to slice 6 (#392):** snapshot of applicable `fee_schedules` rows into `bookings.fee_snapshot jsonb` at booking; overtime compute `ceil(overage_hours) * snapshotted_hourly_rate`; the confirmation-page "potential additional charges" block. 4b ships zero renter-facing surface and zero booking coupling.
+
+---
+
+## 5. Sub-slice 4c — Vehicle pricing finalization
+
+Vehicle-level pricing already exists (`vehicles.dailyRateJpy`/`hourlyRateJpy`, `createVehicleSchema` "at least one rate", operator write-scope). 4c finishes the migration to vehicle-only pricing by **removing** class-level pricing. This is a destructive removal — discipline matters more than volume.
+
+### Step 1 — Reader audit (BEFORE any drop)
+Grep and reroute every reader of `vehicleClasses.dailyRateJpy` / `hourlyRateJpy`:
+```
+rg "dailyRateJpy|hourlyRateJpy" packages/api packages/web packages/shared \
+  | rg -i "class" --color=never
+```
+Known readers to resolve first: `VehicleClassService.update` "at least one rate" validation, any `ClassCatalogCard` / renter catalog "from ¥X", booking-by-class pricing. Storefront min-price becomes `min(vehicles.dailyRateJpy)` per storefront (that computation lands in slice 5 — 4c only ensures nothing still *requires* class pricing).
+
+### Step 2 — Migration (dedicated, after readers rerouted)
+Drop in one `db:generate --name drop_class_level_pricing` migration:
+- columns `vehicle_classes.dailyRateJpy`, `vehicle_classes.hourlyRateJpy`
+- CHECK constraints `vehicle_classes_pricing_at_least_one`, `vehicle_classes_daily_rate_non_negative`, `vehicle_classes_hourly_rate_non_negative`
+
+Then remove the fields from `vehicleClassObjectSchema`, the `VehicleClassService` rate validation, and the `ClassForm` price inputs. `db:verify` (3 green) after migrate.
+
+### Step 3 — Sequence
+Land **after #388** merges (it owns the class/vehicle form rework). Coordinate the `schema.ts` migration order to avoid the drizzle journal out-of-order `when` trap (CLAUDE.md 2026-04-17): regenerate 4c's migration on top of whatever #388 added.
+
+No new UI. No new page. Vehicle form already carries price.
+
+---
+
+## 6. Migration ordering across 4a / 4b / 4c (the real parallel hazard)
+
+All three append to `schema.ts` + `drizzle/`. Concurrent worktrees ⇒ journal `when` collisions. Rules:
+- 4a and 4b each generate **additive** table migrations — order between them is irrelevant *except* the journal must stay monotonic. Whichever merges second **regenerates** its migration on the rebased branch (`bun run db:generate` after rebase), never hand-edits `_journal.json` unless cherry-picking (then bump `when` to `max(prev)+1` per CLAUDE.md).
+- 4c is a **drop** — must be the last of the three and after #388. Never interleave a drop migration between two pending additive ones.
+- Every sub-slice runs `bun run db:verify` post-migrate; CI `db-drift` enforces.
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant)
+
+Per sub-slice, mirroring `packages/api/tests/integration/rls-context.test.ts` (seed operator A + operator B + their `OPERATOR_STAFF` users; assert isolation both directions):
+
+| Layer | 4a Insurance | 4b Fees | 4c Pricing |
+|---|---|---|---|
+| **Validator** (`packages/shared/test/validators/`) | reject empty name, negative price, negative deductible; accept null deductible | **fee-type↔unit coherence**: `OVERTIME_HOURLY`+`FLAT` rejected; `CLEANING_FLAT`+`PER_HOUR` rejected; valid combos pass; negative amount rejected | class schema no longer accepts rate fields |
+| **InMemory repo** | CRUD; op-A staff can't see/update/archive op-B rows; **[P0] `RENTER` and `PARTNER` reads → Forbidden (NOT all-operators)**; bypass roles see both | same + filter by feeType/classId; **[P1] merged-patch coherence: patching only `unit` against an existing row is validated against the stored `feeType`** | — |
+| **Drizzle repo** (Neon `test`) | FK on operatorId; unique `(operatorId,name)` → 23505 | **composite FK rejects a fee whose class belongs to another operator → 23503**; **second ACTIVE fee of same (operator,type,scope) → 23505** on the partial index | post-drop: inserting a class with a rate column fails (column gone) |
+| **Service** | name-uniqueness 409; archive sets status; cross-operator id update → 404 | active-uniqueness 409 message; archive frees the slot (re-create succeeds) | `VehicleClassService` has no rate path |
+| **Route** | 401/403/404 matrix; **`RENTER`/`PARTNER` read → 403**; bypass GET w/o operatorId→400, POST w/o operatorId→400; operator `?operatorId=B` dropped | same matrix; unit-coherence + merged-patch coherence → **400** | n/a (no new route) |
+| **Web** | `InsuranceForm` validation surfaces | `FeeScheduleForm` constrains unit by type | `ClassForm` no longer renders rate inputs |
+
+E2E: none required for slice 4 (operator-portal only; renter-facing E2E starts slice 5 per proposal §6.1).
+
+---
+
+## 8. Per-sub-slice merge gate (proposal §6.1)
+
+All green before merge: `bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktrees
+
+```
+git worktree add ../kuruma-insurance -b feature/389a-insurance marketplace-pivot   # 4a
+git worktree add ../kuruma-fees      -b feature/389b-fees      marketplace-pivot   # 4b (parallel)
+# 4c after #388:
+git worktree add ../kuruma-pricing   -b feature/389c-pricing   marketplace-pivot
+```
+Within each: schema migration → validator (RED/GREEN per rule) → InMemory repo → service → routes → DI wire → Drizzle repo (integration) → web → i18n (restart dev) → review → rebase → PR (`Closes #389a` etc.).
+
+**Parallelism:** 4a ∥ 4b from day one (after #401). 4c trails #388. Net wall-clock ≈ max(4a, 4b) + 4c ≈ ~1.5 + 0.5 = **~2 days** vs ~2.5-3 sequential.
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Dropping class pricing breaks renter catalog / booking-by-class | Medium | High | 4c step-1 reader audit + reroute BEFORE the drop migration; integration test asserts no rate column remains |
+| 4a/4b concurrent migrations collide in `_journal.json` | Medium | Medium | Second-to-merge regenerates on rebase; never hand-edit journal; `db:verify` + CI `db-drift` |
+| Fee operator-wide uniqueness silently broken by NULL semantics | Medium | Medium | Two partial unique indexes (not a plain UNIQUE); integration test inserts a duplicate operator-wide fee and asserts 23505 |
+| Per-class fee points at another operator's class | Low | Critical | Composite FK `(operatorId, vehicleClassId) → vehicle_classes(operatorId, id)`; integration test asserts 23503 |
+| Built on pre-#401 fallback contract | Medium | High | Precondition: #401 merged first; repos call `resolveOperatorIdForWrite(ctx, input, operators)` (no hardcoded operator) |
+| 4c lands before #388 and conflicts on class form | Low | Medium | Explicit sequencing: 4c after #388 |
+
+---
+
+## 11. Critical files
+
+**4a:** `validators/insurance-option.ts`, `repositories/{drizzle,in-memory}/insurance-option.ts`, `services/insurance-option.ts`, `routes/insurance-options.ts`, `modules/insurance/*`, `manage/[operatorSlug]/insurance/page.tsx`; modify `schema.ts`, `repositories/types.ts`, `index.ts`, `messages/{en,ja,zh}.json`, `BusinessSidebar.tsx`, `seed.ts`.
+**4b:** same set for `fee-schedule` / `fees`.
+**4c:** modify `schema.ts` (drop columns+checks), `validators/vehicle-class.ts`, `services/vehicle-class.ts`, `modules/classes/components/ClassForm.tsx`; new drop migration.
+
+---
+
+## 12. Open questions — RESOLVED (reviewer 2026-06-02)
+
+1. `insurance_options.dailyPriceJpy` — **required**. (An option with no price is meaningless.)
+2. Keep `PER_DAY` / `PER_KM` in the unit enum now — **yes** (proposal names them; the fee-type↔unit validation prevents misuse).
+3. 4c deletes class pricing — **yes, but only after the reader audit (§5 step 1) AND after #388.**
+
+## 13. Review log
+
+**v2 (2026-06-02)** incorporated reviewer findings:
+- **[P0]** Reads of insurance/fees now gated by `requireManagementRead(ctx)` (rejects `RENTER`/`PARTNER`) before `operatorReadScope` — §2, §7.
+- **[P1]** Fee coherence + active-uniqueness enforced in the **service** on merged existing+patch, not the partial schema — §4, §7.
+- **[P1]** Bypass-caller scoping gates on `ctx.bypassScope` (covers legacy `STAFF`/`ADMIN`), not the `PLATFORM_ADMIN` string — §2.
+- **[P1]** Standardized all validation failures on **400** (matches `parseBody()`); 422 removed — §2, §7.
+- **[P2]** Added composite FK-source index `(operatorId, vehicleClassId)` for `lint:fk-indexes` — §4.

--- a/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
+++ b/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
@@ -10,7 +10,7 @@
 
 ## 0. Decision: split #389 into 4a / 4b / 4c
 
-#389 bundles three independent domains. Per review, it is split into three sub-issues under epic #385, each a mergeable vertical slice on its own worktree off `marketplace-pivot`:
+#389 bundles three independent domains. Per review, it is split into three sub-issues under epic #385, each a mergeable vertical slice on its own worktree off `origin/marketplace-pivot`:
 
 | Sub-slice | Domain | New? | Independent of | Effort |
 |---|---|---|---|---|
@@ -28,8 +28,8 @@
 
 | Precondition | Why | Status 2026-06-02 |
 |---|---|---|
-| **#401 merged to `marketplace-pivot`** | Slice 4 repos build on the post-#401 write contract: `resolveOperatorIdForWrite(ctx, input, operators)` with single-operator inference + `OperatorRequiredError`, **no `BEST_CAR_RENTAL_OPERATOR_ID` fallback**. Building on the current pivot branch bakes in a contract actively being removed (`memory/project_operator-2-gate`). | On `feat/401-drop-operator-fallback`, not yet merged |
-| **#387 (locations) merged** — for the WEB layer of 4a/4c only | 4a/4c pages reuse #387's `[operatorSlug]` layout + operator slug-resolution + `BusinessSidebar` conditional-link pattern. Backend repos/services have no #387 dependency and can start earlier. | In progress (`feature/387-locations`) |
+| **#401 merged to `marketplace-pivot`** | Slice 4 repos build on the post-#401 write contract: `resolveOperatorIdForWrite(ctx, input, operators)` with single-operator inference + `OperatorRequiredError`, **no `BEST_CAR_RENTAL_OPERATOR_ID` fallback**. | Merged to `origin/marketplace-pivot` via PR #408. The local `marketplace-pivot` branch may still be stale; branch from `origin/marketplace-pivot` or fast-forward local before kickoff. |
+| **#387 (locations) merged** — for the WEB layer of 4a/4b only | Routing is **flat & JWT-scoped** (`/manage/insurance`, `/manage/fees`) like every other manage page — **NO `[operatorSlug]` segment** (slice-2 decision: operator derived from JWT, not URL). #387 lands `lib/business-roles.ts` admitting `OPERATOR_*` to the flat `/manage` portal — the 4a/4b pages need that gate. Backend repos/services have no #387 dependency. | In review (PR #414 → `marketplace-pivot`) |
 | **#388 (ACRISS + vehicle CRUD)** — for **4c only** | 4c drops legacy class pricing while #388 reworks the class/vehicle forms; landing 4c first would conflict. 4a/4b do not depend on #388. | Not started |
 
 `operators` table, `roleEnum` (incl. `OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicles`/`vehicleClasses.operatorId`, the `(operatorId, id)` composite-unique on `vehicle_classes` (#395), and `CallerContext.operatorId`/`bypassScope` (#401) are all assumed present from slices 1-3.
@@ -50,7 +50,7 @@ Established by `vehicles` / `vehicle_classes` (per AGENTS.md API layout `routes/
 - **Service** is auth-agnostic; returns `{ ok: true, ... } | { ok: false, error, status, code? }`.
 - **Route** gates mutations with role check, builds ctx via `toCallerContext(requireUser(c))`, uses `ok()`/`fail()`/`parseBody()` from `routes/helpers.ts`. Mounted at `/` in `index.ts`.
 - **Validators** (`packages/shared/src/validators/<entity>.ts`): `create<X>Schema` / `update<X>Schema` (= `.partial()`), cross-field rules via `.superRefine()`.
-- **Web** module `packages/web/src/modules/<entity>/` (`api.ts`, `hooks.ts`, `components/`) + page under `manage/[operatorSlug]/<entity>/page.tsx`, i18n namespace `business.<entity>`.
+- **Web** module `packages/web/src/modules/<entity>/` (`api.ts`, `hooks.ts`, `components/`) + **flat** page `app/[locale]/(business)/manage/<entity>/page.tsx` — JWT-scoped, **no `[operatorSlug]` segment** (mirrors `/manage/locations`); i18n namespace `business.<entity>`; link in `BusinessSidebar.tsx`.
 
 **Bypass-caller scoping (every list/create, mirrors #387):** operator callers auto-scope to `ctx.operatorId` and any `?operatorId=` they pass is dropped at the route. **[P1] Gate on `ctx.bypassScope === true`, not on the `PLATFORM_ADMIN` string** — during transition, legacy `STAFF`/`ADMIN` are bypass equivalents and must obey the same rule. A bypass caller's GET requires explicit `?operatorId=<id>` OR `?includeAll=true` (else 400); a bypass caller's POST requires `operatorId` in body (`platformAdmin*` schema variant; missing → 400 via `parseBody`). Cross-operator id on GET/PATCH/DELETE returns **404, not 403** (no tenant-existence leak). Mutations load the row first to capture its tenant before writing.
 
@@ -78,7 +78,12 @@ export const insuranceOptions = pgTable('insurance_options', {
 }, (t) => [
   index('idx_insurance_options_operatorId').on(t.operatorId),
   unique('insurance_options_operatorId_id_unique').on(t.operatorId, t.id),
-  unique('insurance_options_operator_name_unique').on(t.operatorId, t.name),
+  // Name uniqueness scoped to ACTIVE rows so archiving an option frees its name
+  // for reuse (consistent with fee_schedules active-uniqueness). Two ACTIVE options
+  // can't share a name; an archived one no longer reserves it. PARTIAL index.
+  uniqueIndex('insurance_options_active_name_unique')
+    .on(t.operatorId, t.name)
+    .where(sql`status = 'ACTIVE'`),
   check('insurance_options_daily_price_non_negative', sql`${t.dailyPriceJpy} >= 0`),
   check('insurance_options_deductible_non_negative',
     sql`${t.deductibleJpy} IS NULL OR ${t.deductibleJpy} >= 0`),
@@ -103,10 +108,10 @@ export interface InsuranceOptionRepository {
   archive(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined>
 }
 ```
-Drizzle + InMemory pair under `repositories/{drizzle,in-memory}/insurance-option.ts`. Service `services/insurance-option.ts` (name-uniqueness 409, archive sets status). Routes `routes/insurance-options.ts` at `/insurance-options`. DI + mount in `index.ts`.
+Drizzle + InMemory pair under `repositories/{drizzle,in-memory}/insurance-option.ts`. Service `services/insurance-option.ts`: name-uniqueness 409 **checked against ACTIVE rows only and excluding the current row id on update** (matches the active-name partial index — archiving frees the name, and a no-name-change edit can't self-collide); archive sets status. Routes `routes/insurance-options.ts` at `/insurance-options`. DI + mount in `index.ts`.
 
 ### Web
-`manage/[operatorSlug]/insurance/page.tsx` + `modules/insurance/` (`InsuranceList`, `InsuranceForm`, `InsuranceArchiveDialog`, `useInsuranceOptions`). i18n `business.insurance.*`. Sidebar link gated on `operatorId`.
+Flat `manage/insurance/page.tsx` (JWT-scoped, **no `[operatorSlug]`**) + `modules/insurance/` (`InsuranceList`, `InsuranceForm`, `InsuranceArchiveDialog`, `useInsuranceOptions`). i18n `business.insurance.*`. `BusinessSidebar` link (between Classes/Customers, like Locations).
 
 ---
 
@@ -164,7 +169,7 @@ export const feeSchedules = pgTable('fee_schedules', {
 - Platform-admin extend variant adds `operatorId`.
 
 ### Repo / Service / Routes / Web
-Same shape as 4a. `FeeScheduleFilters` adds `feeType?` and `vehicleClassId?`. **[P1] Service is the coherence + uniqueness seal:** `update` fetches the existing row, **merges the patch**, then validates (a) fee-type↔unit coherence on the *merged* `feeType`+`unit` (400 on mismatch) and (b) active-uniqueness on the merged `(operatorId, feeType, vehicleClassId)` **excluding the current row id** (409) — so a no-key-change edit (e.g. bumping only `amountJpy`) does not falsely collide with itself. This is the merge-then-validate pattern `VehicleClassService.update` uses for "at least one rate". `create` validates the same on the full payload (no exclusion). The DB partial-unique indexes + the schema `.superRefine()` are backstops, not the only checks. Routes at `/fee-schedules`. Page `manage/[operatorSlug]/fees/page.tsx` + `modules/fees/` — form: feeType select → unit auto-constrained by type, amount, optional class dropdown (operator's classes only). i18n `business.fees.*`.
+Same shape as 4a. `FeeScheduleFilters` adds `feeType?` and `vehicleClassId?`. **[P1] Service is the coherence + uniqueness seal:** `update` fetches the existing row, **merges the patch**, then validates (a) fee-type↔unit coherence on the *merged* `feeType`+`unit` (400 on mismatch) and (b) active-uniqueness on the merged `(operatorId, feeType, vehicleClassId)` **excluding the current row id** (409) — so a no-key-change edit (e.g. bumping only `amountJpy`) does not falsely collide with itself. This is the merge-then-validate pattern `VehicleClassService.update` uses for "at least one rate". `create` validates the same on the full payload (no exclusion). The DB partial-unique indexes + the schema `.superRefine()` are backstops, not the only checks. Routes at `/fee-schedules`. **Flat** page `manage/fees/page.tsx` (JWT-scoped, **no `[operatorSlug]`**) + `modules/fees/` — form: feeType select → unit auto-constrained by type, amount, optional class dropdown (operator's classes only). i18n `business.fees.*`.
 
 ### Slice-6 boundary (explicit — does NOT ship in 4b)
 4b stores schedules only. **Deferred to slice 6 (#392):** snapshot of applicable `fee_schedules` rows into `bookings.fee_snapshot jsonb` at booking; overtime compute `ceil(overage_hours) * snapshotted_hourly_rate`; the confirmation-page "potential additional charges" block. 4b ships zero renter-facing surface and zero booking coupling.
@@ -214,9 +219,9 @@ Per sub-slice, mirroring `packages/api/tests/integration/rls-context.test.ts` (s
 |---|---|---|---|
 | **Validator** (`packages/shared/test/validators/`) | reject empty name, negative price, negative deductible; accept null deductible | **fee-type↔unit coherence**: `OVERTIME_HOURLY`+`FLAT` rejected; `CLEANING_FLAT`+`PER_HOUR` rejected; valid combos pass; negative amount rejected | class schema no longer accepts rate fields |
 | **InMemory repo** | CRUD; op-A staff can't see/update/archive op-B rows; **[P0] `RENTER` and `PARTNER` reads → Forbidden (NOT all-operators)**; bypass roles see both | same + filter by feeType/classId; **[P1] merged-patch coherence: patching only `unit` against an existing row is validated against the stored `feeType`** | — |
-| **Drizzle repo** (Neon `test`) | FK on operatorId; unique `(operatorId,name)` → 23505 | **composite FK rejects a fee whose class belongs to another operator → 23503**; **second ACTIVE fee of same (operator,type,scope) → 23505** on the partial index | post-drop: inserting a class with a rate column fails (column gone) |
-| **Service** | name-uniqueness 409; archive sets status; cross-operator id update → 404 | active-uniqueness 409 message; archive frees the slot (re-create succeeds) | `VehicleClassService` has no rate path |
-| **Route** | 401/403/404 matrix; **`RENTER`/`PARTNER` read → 403**; bypass GET w/o operatorId→400, POST w/o operatorId→400; operator `?operatorId=B` dropped | same matrix; unit-coherence + merged-patch coherence → **400** | n/a (no new route) |
+| **Drizzle repo** (Neon `test`) | FK on operatorId; **two ACTIVE options same `(operatorId,name)` → 23505 on the partial index**; **archiving an option then creating a new one with the same name succeeds (name freed)** | **composite FK rejects a fee whose class belongs to another operator → 23503**; **second ACTIVE fee of same (operator,type,scope) → 23505** on the partial index | post-drop: inserting a class with a rate column fails (column gone) |
+| **Service** | name-uniqueness 409 (**ACTIVE-only, excludes current row id on update**); archive sets status; cross-operator id update → 404 | active-uniqueness 409 message (**excludes current row id**); archive frees the slot (re-create succeeds) | `VehicleClassService` has no rate path |
+| **Route** | 401/403/404 matrix; **`RENTER`/`PARTNER` read → 403**. **[Item 4] Bypass-precedence (explicit): GET `?operatorId=A` narrows to A · GET `?includeAll=true` returns all · GET with neither → 400 · POST w/o body operatorId → 400 · operator caller's `?operatorId=B` is dropped (returns own rows only)** | same matrix; **same bypass-precedence cases**; unit-coherence + merged-patch coherence → **400** | n/a (no new route) |
 | **Web** | `InsuranceForm` validation surfaces | `FeeScheduleForm` constrains unit by type | `ClassForm` no longer renders rate inputs |
 
 E2E: none required for slice 4 (operator-portal only; renter-facing E2E starts slice 5 per proposal §6.1).
@@ -232,10 +237,12 @@ All green before merge: `bun run test` · `bun run lint` · `bun run --filter @k
 ## 9. Execution order & worktrees
 
 ```
-git worktree add ../kuruma-insurance -b feature/389a-insurance marketplace-pivot   # 4a
-git worktree add ../kuruma-fees      -b feature/389b-fees      marketplace-pivot   # 4b (parallel)
+# Branch from origin/marketplace-pivot — local marketplace-pivot lags remote (PR #408/#401).
+# `git fetch origin` first; or fast-forward local before branching.
+git worktree add ../kuruma-insurance -b feature/389a-insurance origin/marketplace-pivot   # 4a
+git worktree add ../kuruma-fees      -b feature/389b-fees      origin/marketplace-pivot   # 4b (parallel)
 # 4c after #388:
-git worktree add ../kuruma-pricing   -b feature/389c-pricing   marketplace-pivot
+git worktree add ../kuruma-pricing   -b feature/389c-pricing   origin/marketplace-pivot
 ```
 Within each: schema migration → validator (RED/GREEN per rule) → InMemory repo → service → routes → DI wire → Drizzle repo (integration) → web → i18n (restart dev) → review → rebase → PR (`Closes #389a` etc.).
 
@@ -258,7 +265,7 @@ Within each: schema migration → validator (RED/GREEN per rule) → InMemory re
 
 ## 11. Critical files
 
-**4a:** `validators/insurance-option.ts`, `repositories/{drizzle,in-memory}/insurance-option.ts`, `services/insurance-option.ts`, `routes/insurance-options.ts`, `modules/insurance/*`, `manage/[operatorSlug]/insurance/page.tsx`; modify `schema.ts`, `repositories/types.ts`, `index.ts`, `messages/{en,ja,zh}.json`, `BusinessSidebar.tsx`, `seed.ts`.
+**4a:** `validators/insurance-option.ts`, `repositories/{drizzle,in-memory}/insurance-option.ts`, `services/insurance-option.ts`, `routes/insurance-options.ts`, `modules/insurance/*`, `app/[locale]/(business)/manage/insurance/page.tsx` (flat); modify `schema.ts`, `repositories/types.ts`, `index.ts`, `messages/{en,ja,zh}.json`, `BusinessSidebar.tsx`, `seed.ts`.
 **4b:** same set for `fee-schedule` / `fees`.
 **4c:** modify `schema.ts` (drop columns+checks), `validators/vehicle-class.ts`, `services/vehicle-class.ts`, `modules/classes/components/ClassForm.tsx`; new drop migration.
 

--- a/docs/plans/2026-06-02-slice5-renter-storefront-search.md
+++ b/docs/plans/2026-06-02-slice5-renter-storefront-search.md
@@ -1,0 +1,298 @@
+# Slice 5 — Renter Storefront Search (issue #391)
+
+**Date:** 2026-06-02
+**Status:** Draft v1 — awaiting review/green-light before issue kickoff
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` — §2 (Search result shape, Availability query, Turnaround buffer), §4 renter portal items 1–3, §6 row 5, §6.1 (E2E gate), §6.2 (tenant scoping — RENTER has no operatorId), §9 items 20/21, §10 items 10/12/13.
+**Locked decision (epic #385 body):** *Renter search is storefront-first.* §10 item 12: "storefront cards first, storefront vehicle detail second… flat all-vehicle search is rejected for MVP because it hides the operator/location choice."
+
+This slice is a **read-path** slice. It ships **zero booking writes** (booking = slice 6) and, ideally, **zero new tables** — only two new read endpoints, their repository reads, the renter search UI, and (likely) one or two covering indexes. It is the first **renter-facing** slice, so it is the **first slice that requires a Playwright E2E happy path** (§6.1).
+
+---
+
+## 0. Decision: one slice, two read models (no sub-split)
+
+Unlike slice 4 (three independent entity CRUDs), slice 5 is a single cohesive read feature: a search list and its drill-down detail, both backed by the **same availability computation**. There is nothing to parallelize across worktrees. It ships as **one PR on `feature/391-renter-storefront-search`**.
+
+The two read models (§9 item 21, §10 item 12):
+
+| Read model | Endpoint | Returns |
+|---|---|---|
+| **Storefront search** | `GET /storefronts/search` | Location/storefront cards across all operators, each with `classSummaries[]` (per-ACRISS-class available count), `fromDailyPriceJpy`, and fallback `fromHourlyPriceJpy` |
+| **Storefront detail** | `GET /storefronts/:locationId/vehicles` | The available **individual** vehicles at that storefront for the selected date range, grouped/filterable by class |
+
+**Hard boundary (§10 item 12):** the primary search result is **store cards, never a flat cross-operator vehicle list**. The flat list only ever appears *inside* one storefront's detail.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **Slice 2 (#387 locations) merged to `marketplace-pivot`** | The store card IS a `locations` row. Search reads `locations` (name, address, `operatingHours`, `defaultTurnaroundMinutes`) and joins `vehicles.pickupLocationId → locations.id`. Without it there is no storefront entity to return. | In progress on `feature/387-locations` (locations table + `vehicles.pickupLocationId` composite FK present on that branch; not yet on `marketplace-pivot`) |
+| **Slice 3 (#388 ACRISS + vehicle CRUD) merged** | `classSummaries` group by ACRISS class; the card shows "Compact x4, Minivan x2". Requires `vehicle_classes.acriss_code` + i18n class labels. The current `marketplace-pivot` `vehicle_classes` has **no `acrissCode` column yet** — slice 3 adds it. | Not started |
+| **Slice 4 (#389a/b/c pricing) merged** | Card pricing is computed from `vehicles.dailyRateJpy` / `vehicles.hourlyRateJpy`. §10 item 11 + §5.1: pricing is **vehicle-level only**; slice 4c drops `vehicle_classes.dailyRateJpy`. Slice 5 must read price from `vehicles`, never from the class. | Not started (4a/4b drafted in `2026-06-02-slice4-*`; 4c trails #388) |
+
+`operators`, `locations`, `vehicles.operatorId` + `vehicles.pickupLocationId` (composite FK to `locations`), `vehicle_classes.acriss_code`, `vehicles.dailyRateJpy`/`hourlyRateJpy`, the `bookings` exclusion semantics on `effectiveEndAt`, and `CallerContext` (with `PUBLIC_CONTEXT`, `operatorReadScope`, `bypassScope`) from `packages/api/src/middleware/auth.ts` are all assumed present from slices 1–4.
+
+**If slices 2–4 are not all merged at kickoff,** do not stub their schema — block on them. Slice 5 is genuinely downstream; building against placeholder columns bakes in rework.
+
+---
+
+## 2. The reuse target — DO NOT reinvent availability
+
+The availability computation already exists and already honours the exclusion/turnaround model. Slice 5 **extends its reach to a storefront**, it does not re-derive overlap logic.
+
+### What exists today (cite, reuse)
+
+- **`DrizzleAvailabilityRepository.findAvailableVehicles(from, to)`** — `packages/api/src/repositories/drizzle/availability.ts:10`. Selects `vehicles` where `status='AVAILABLE'` AND `NOT EXISTS` an overlapping `CONFIRMED`/`ACTIVE` booking via `tstzrange(b."startAt", b."effectiveEndAt") && tstzrange(from, to)`. **This is the canonical overlap predicate** (#317). `effectiveEndAt = endAt + turnaround` is already materialized on the booking row, so the turnaround buffer (§2 / §9 item 20) is honoured by reusing this predicate — slice 5 adds **no new range math**.
+- **`VehicleClassAvailabilityService.getAvailabilityForClass(slug, from, to)`** — `packages/api/src/services/vehicle-class-availability.ts`. Already computes `{ totalCars, availableCars, sampleAvailableVehicleIds }` per class by intersecting `findAvailableVehicles` with the class membership (#317). The `classSummaries` aggregation in slice 5 is the **same intersection, grouped by `(locationId, classId)` instead of one class**.
+- **`GET /vehicle-classes/:slug/availability`** route + `cachePublic(c, 10)` — `packages/api/src/routes/vehicle-classes.ts:54`. The 10s edge-cache pattern for time-sensitive availability and the public-catalog per-IP rate limiter (`publicCatalogLimiter`, lines 25–30) are reused verbatim for the new search routes.
+- **`parseDateRange(c, true)`** + `parsePagination`/`parseLimit` — `packages/api/src/routes/helpers.ts`. Date-range parse (both/one/neither, `to>from`, ISO validation) and cursor/offset parsing are done; reuse, do not duplicate.
+- **`PUBLIC_CONTEXT`** — `auth.ts`: `{ userId:'public', role:'RENTER', bypassScope:false }`. The sanctioned caller context for anonymous renter reads. `operatorReadScope(PUBLIC_CONTEXT)` resolves to `{kind:'all'}` (cross-operator marketplace is the point), **without** granting a privilege bypass.
+
+### The one real gap
+
+`AvailabilityRepository.findAvailableVehicles(from, to)` (`repositories/types.ts:181`) takes **no location/operator filter** — it scans the whole fleet. Slice 5 needs availability **scoped to a storefront** and **grouped by class**. Two options, pick the cheaper:
+
+- **(A, preferred)** Add `locationId?: string` (and keep `operatorId` derivable via the join) as an optional filter arg: `findAvailableVehicles(from, to, filters?: { locationId?: string; operatorId?: string; classId?: string })`. Backward-compatible (existing callers pass no filter). The class catalog endpoint keeps working unchanged.
+- (B) Add a dedicated `findAvailableVehiclesByLocation(...)` method. More surface, no benefit over (A).
+
+Go with **(A)**. It is additive to the interface; the InMemory + Drizzle impls both gain the optional predicate; no existing caller changes.
+
+> **Learn: Open/Closed via optional filter arg.** Extending `findAvailableVehicles` with an optional, defaulted filter adds the new storefront-scoped behaviour without editing any existing call site — adding feature N didn't force a rewrite of feature N-1. Heuristic: when a query needs one more axis, add a defaulted filter param, not a parallel method.
+
+---
+
+## 3. Read model 1 — Storefront search
+
+### Endpoint
+
+`GET /storefronts/search` — **public, no auth** (registered before `requireAuth`, behind `publicCatalogLimiter` + `cachePublic(c, 10)`).
+
+Query params (parsed via `parseDateRange(c, true)` + bespoke parse for the rest):
+
+| Param | Required | Notes |
+|---|---|---|
+| `from`, `to` | **yes** | Pickup/return datetime (ISO, JST per existing `parseDateRange`). `to>from` enforced. |
+| `pickupLocationId` | no | If present, narrows to that one storefront (degenerate single-card search). |
+| `class` (ACRISS code, repeatable) | no | Filter to stores that have ≥1 available vehicle in any listed class; the card's `classSummaries` is filtered to the requested classes. |
+| `limit`, `cursor` | no | Cursor pagination (§3.3). Default 25, max 50. |
+
+§4 item 1 lists "pickup location + return location" — MVP UX defaults pickup=return (proposal §2 Locations: "MVP UX defaults equal"); **dropoff filtering does not ship here** (one-way rental is post-MVP, §2). The search form may show a locked return location mirroring pickup, but slice 5 filters on `pickupLocationId` only.
+
+### Response shape
+
+```jsonc
+{
+  "success": true,
+  "data": {
+    "storefronts": [
+      {
+        "locationId": "loc_...",
+        "operatorId": "op_...",
+        "operatorName": "Best Car Rental",
+        "name": "Best Car Rental Osaka — Namba",
+        "address": "…",
+        "operatingHours": { "openTime": "09:00", "closeTime": "20:00" } | null,
+        "classSummaries": [
+          { "acrissCode": "CCAR", "label": "Compact", "availableCount": 4 },
+          { "acrissCode": "MVAR", "label": "Minivan", "availableCount": 2 }
+        ],
+        "fromDailyPriceJpy": 4500,
+        "fromHourlyPriceJpy": 800,
+        "representativePhotos": ["…"]   // up to N from available vehicles' photos
+      }
+    ],
+    "nextCursor": "…" | null
+  }
+}
+```
+
+The demo target string — "Best Car Rental Osaka — Compact x4, Minivan x2, from ¥4,500/day" (§6 row 5) — renders directly from `name` + `classSummaries` + `fromDailyPriceJpy`.
+
+### Aggregation logic (`StorefrontSearchService`)
+
+For the date range `[from, to)`:
+
+1. Resolve candidate `locations` (status `ACTIVE`) across all operators (or the single `pickupLocationId`), honouring `operatorReadScope(PUBLIC_CONTEXT) = {kind:'all'}`.
+2. Compute the set of **available vehicles** via the extended `findAvailableVehicles(from, to, { locationId })` — already filters `status='AVAILABLE'` + no overlapping `CONFIRMED`/`ACTIVE` booking on `effectiveEndAt` (turnaround included). One query per result page, **not** per location (avoid N+1, §8).
+3. Group available vehicles by `(pickupLocationId, classId)` → `availableCount`; join `vehicle_classes` for `acrissCode` + label.
+4. `fromDailyPriceJpy = min(vehicle.dailyRateJpy)` over available daily-priced vehicles and `fromHourlyPriceJpy = min(vehicle.hourlyRateJpy)` over available hourly-priced vehicles. Prefer daily in UI; if no daily price exists, render the hourly fallback. **Never** read class pricing — it's dropped in 4c.
+5. **Drop stores with zero available vehicles** from the result (an empty store is not a useful card).
+6. Apply `class` filter: keep stores with ≥1 available vehicle in a requested class; trim `classSummaries` to requested classes.
+
+> **Learn: Batch the availability scan (N+1 guard).** Computing availability once over all candidate vehicles and grouping in memory — instead of calling `getAvailabilityForClass` per (store × class) — keeps it to ~1 DB round trip per page. The per-class service is fine for one class detail page; looping it across a search result is the N+1 trap. Heuristic: a search list aggregates with one scan + in-memory group-by, never a query per row.
+
+### ACRISS label i18n
+
+`classSummaries[].label` is the **localized** class label. Resolution mirrors the existing class catalog: the API returns the `acrissCode` + raw class `name`; the **web layer** localizes via the `catalog`/ACRISS i18n namespace (server-rendered with `getTranslations`). The API stays locale-agnostic (operator-entered names are single-language per §9 item 4). Decide at impl time whether to send `label` pre-localized (requires `Accept-Language` plumb-through) or send `acrissCode` and localize in web — **default to localize-in-web** (no new API i18n surface).
+
+### 3.3 Pagination
+
+Cursor over `(locationId)` ordered by a stable key (e.g. `operatorName, name, locationId`). Reuse `parseLimit`. The cursor encodes the last `(sortKey, locationId)` — opaque base64. At MVP scale (3 ops × ~3 locations = ~9 stores) pagination is barely exercised, but the contract ships now so the renter list never returns an unbounded set. Default 25 / max 50.
+
+---
+
+## 4. Read model 2 — Storefront detail
+
+### Endpoint
+
+`GET /storefronts/:locationId/vehicles` — **public, no auth**, `publicCatalogLimiter` + `cachePublic(c, 10)`.
+
+Query params: `from`, `to` (required, `parseDateRange`), optional `class` (ACRISS filter), `limit`/`cursor`.
+
+### Response shape
+
+```jsonc
+{
+  "success": true,
+  "data": {
+    "storefront": { "locationId": "…", "name": "…", "address": "…", "operatorName": "…", "operatingHours": {…}|null },
+    "vehicles": [
+      {
+        "id": "veh_...", "name": "Toyota Yaris", "make": "Toyota", "model": "Yaris",
+        "year": 2023, "seats": 5, "transmission": "AUTO",
+        "acrissCode": "CCAR", "classLabel": "Compact",
+        "dailyRateJpy": 4500, "hourlyRateJpy": 800,
+        "photos": ["…"]
+      }
+    ],
+    "nextCursor": "…" | null
+  }
+}
+```
+
+### Logic (`StorefrontDetailService`)
+
+1. Load the `location` by id (404 if missing/`ARCHIVED`).
+2. `findAvailableVehicles(from, to, { locationId, classId? })` → the available individual vehicles for the range (exclusion + turnaround already applied).
+3. Join `vehicle_classes` for `acrissCode` + label; project the renter-safe vehicle fields (no operator-internal fields — no `shakenExpiryDate`, no `insuranceExpiryDate`, no `bufferMinutes`).
+4. Group/sort by class for the grouped-by-ACRISS UI (§4 item 3).
+
+**404 vs empty:** unknown/archived `locationId` → **404**. Known store with no available vehicles for the range → **200 with `vehicles: []`** (the store exists; it's just full).
+
+---
+
+## 5. Architecture & boundaries (AGENTS.md)
+
+Import direction **routes → services → repositories**; web has **no DB access** (calls Hono via `hono/client`).
+
+### API layer (`packages/api`)
+
+| Layer | File(s) | Responsibility |
+|---|---|---|
+| **Repo interface** | `repositories/types.ts` | Extend `AvailabilityRepository.findAvailableVehicles(from, to, filters?)` with optional `{ locationId?, operatorId?, classId? }`. Add a `StorefrontRepository` (or extend `LocationRepository` from #387) read method `findActiveStorefronts(ctx, { pickupLocationId? })` returning location rows with operator name joined. Every method takes `CallerContext`. |
+| **Drizzle repo** | `repositories/drizzle/availability.ts`, `…/storefront.ts` | Add the optional `locationId`/`classId`/`operatorId` predicate to the existing `NOT EXISTS` query (join `vehicles.pickupLocationId`). New storefront read joins `locations ⨝ operators`. Reads use `operatorReadScope(ctx)` → `{kind:'all'}` for `PUBLIC_CONTEXT` (renter sees all operators — this is the marketplace, §6.2). |
+| **InMemory repo** | `repositories/in-memory/availability.ts`, `…/storefront.ts` | Mirror the interface for tests (injected via `createApp(overrides)`). |
+| **Service** | `services/storefront-search.ts`, `services/storefront-detail.ts` | Auth-agnostic; return `{ ok:true, data } | { ok:false, error, status }`. Own the group-by-class aggregation + daily/hourly min-price calculation. **No HTTP, no Hono imports.** |
+| **Routes** | `routes/storefronts.ts` | Public GET routes registered **before** `requireAuth` (like `routes/vehicle-classes.ts:19`). Build ctx as `PUBLIC_CONTEXT` (no JWT needed). Use `ok()`/`fail()`/`parseDateRange()` + `cachePublic(c, 10)`. Mount at `/` in `index.ts`; stack `publicCatalogLimiter`. |
+| **Composition root** | `index.ts` | Construct `StorefrontSearchService`/`StorefrontDetailService` with the storefront + availability + class repos; wire `createStorefrontRoutes(...)`. Only `index.ts` touches concrete classes. |
+
+### Auth/scope model — the renter difference (§6.2)
+
+Search is **public/renter-facing**. This is the inverse of slice 4's operator-private config:
+
+- **No `requireManagementRead` gate.** Insurance/fees (slice 4) reject `RENTER`; the storefront catalog **must admit anonymous renters** — that's the product. Routes register before `requireAuth`.
+- **`operatorReadScope(PUBLIC_CONTEXT) = {kind:'all'}` is correct and intended here** (the exact opposite of why it was unsafe for slice-4 private config). The renter genuinely should see every operator's stores — cross-operator search is the point (§2 Tenant routing: "renter portal = single URL space").
+- **RENTER has no `operatorId`** (§6.2). No tenant predicate is applied to the renter read; the only filters are `status='AVAILABLE'`/`ACTIVE` location + the date-range availability + any explicit `pickupLocationId`/`class` query filter.
+- **Renter-safe projection.** The repo/service must project only renter-visible columns. Never leak operator-internal fields (sha-ken/insurance expiry, buffer minutes, cost). This is the read-side analogue of tenant scoping: a public endpoint over a multi-tenant table must whitelist columns.
+
+> **Learn: Public read ≠ privilege bypass.** `PUBLIC_CONTEXT` resolves to `{kind:'all'}` scope but `bypassScope:false` — it can read the cross-operator catalog but is not an admin. The safety control on a public multi-tenant read is **column projection** (whitelist renter-safe fields), not row scoping. Heuristic: when an endpoint is intentionally cross-tenant, audit the SELECT column list, not the WHERE clause.
+
+### Web layer (`packages/web`)
+
+- New renter route group: `app/[locale]/search/page.tsx` (search form + results) and `app/[locale]/storefronts/[locationId]/page.tsx` (detail). Follows the existing `app/[locale]/vehicles` catalog pattern (server component + `getTranslations`).
+- New module `modules/storefronts/` mirroring `modules/classes/`: `api.ts` (typed `hono/client` calls via `createApiClient` — `packages/web/src/lib/api-client.ts`), `hooks.ts`, `index.ts`, `components/` (`StorefrontSearchForm`, `StorefrontCard`, `ClassSummaryBadges`, `StorefrontDetailView`, `AvailableVehicleCard`).
+- i18n namespace `search.*` (and reuse `catalog.*` for ACRISS labels) across `en`/`ja`/`zh` (renter pages require all three, §8.2). **New namespaces require a dev-server restart** (`rm -rf packages/web/.next && bun run dev`).
+- `StorefrontCard` renders the demo string; `ClassSummaryBadges` reuses the badge consistency rule (named badge component, never ad-hoc colors — `memory/feedback_badge-consistency`).
+- A11y (§8.2 / `~/.claude/rules/react.md`): search form inputs have `<label>`s; date pickers keyboard-navigable; cards are semantic `<a>` links to detail.
+
+---
+
+## 6. What does NOT ship in slice 5 (explicit boundaries)
+
+| Deferred to | Item | Why |
+|---|---|---|
+| **Slice 6 (#392)** | Any booking write; `requested_vehicle_id`/`assigned_vehicle_id` insert; the exclusion-constraint *write*; `booking_code`; selected-insurance snapshot; fee snapshot; vehicle selection → confirm. | Slice 5 is read-only. It surfaces a "select" button that, in slice 5, links to a placeholder/disabled booking route. The availability **read** predicate slice 5 uses is the same one slice 6's write transaction validates against — but the write is slice 6 (§2 Booking write boundary, §10 item 14). |
+| **Slice 6** | Renter contact capture, insurance dropdown wired to operator options, booking submit. | §4 item 4. |
+| **Post-MVP** | One-way rental (dropoff ≠ pickup filtering); distance/area geo-sort; map view; per-weekday operating hours. | §2 Locations; §4 item 2 lists "distance/area" — MVP shows address/area text only, no geo ranking. |
+| **Post-MVP** | Materialized availability view. | §2 Availability query: "Live scan… no materialized view in MVP." Slice 5 uses the live `NOT EXISTS` scan. |
+
+---
+
+## 7. Schema changes (likely indexes only)
+
+Slice 5 ideally adds **no tables and no columns** — it reads slices 1–4's schema. The only candidate change is **covering indexes** for the new query paths, if `bun run lint:fk-indexes` / query plans demand:
+
+- `vehicles.pickupLocationId` — #387 already adds `idx_vehicles_pickupLocationId` (confirmed on `feature/387-locations`); the storefront availability join reuses it. **No new index needed if present.**
+- `bookings(vehicleId, status, startAt, effectiveEndAt)` — the `NOT EXISTS` overlap subquery filters on `vehicleId` + status + range. A composite/GiST index here would help at scale, **but** §8.2 sets search p95 <500ms at MVP scale (3 ops × ~40 vehicles) which the live scan "handles trivially." **Recommendation: ship no new index in slice 5; measure first.** If a plan regression shows up, add the index in a dedicated follow-up — do not speculatively index (YAGNI).
+
+**If** any index is added: `bun run db:generate --name <describe>` → `db:migrate` → `db:verify` (3 green); respect the journal-`when` monotonic rule (CLAUDE.md 2026-04-17) when rebasing onto `marketplace-pivot`. **No hand-written `.sql` in `drizzle/`.**
+
+---
+
+## 8. Tests (TDD vertical-slice, mutation-resistant)
+
+Strict RED→GREEN per behaviour (`~/.claude/rules/testing.md`). Seed two operators (A, B) each with a location + vehicles across ≥2 ACRISS classes + at least one overlapping booking, to prove cross-operator aggregation and exclusion.
+
+| Layer | Coverage |
+|---|---|
+| **Service unit** (`StorefrontSearchService`) | Empty range params rejected (400 upstream). `classSummaries` counts ONLY available vehicles (a vehicle with an overlapping `CONFIRMED` booking is excluded; assert exact count drops by 1). `fromDailyPriceJpy === min(dailyRateJpy)` and hourly-only stores return `fromDailyPriceJpy:null` + exact `fromHourlyPriceJpy`. Store with zero available vehicles omitted. `class` filter trims summaries to requested codes. Cross-operator: stores from A and B both appear (assert both `operatorId`s present). |
+| **Service unit** (`StorefrontDetailService`) | Unknown `locationId` → `{ok:false,status:404}`. Known store, full range → `vehicles:[]` (200). Available vehicles list excludes MAINTENANCE/RETIRED and overlapping-booked ones — assert exact ids. Renter projection omits `shakenExpiryDate`/`bufferMinutes` (assert key absent). |
+| **InMemory repo** | `findAvailableVehicles(from,to,{locationId})` returns only that location's free vehicles; `{classId}` filter narrows correctly; turnaround respected (a booking ending inside `[from,to)` minus turnaround still blocks). |
+| **Drizzle repo** (Neon `test`) | The extended `NOT EXISTS` overlap query returns the right vehicle set for a `locationId` against a seeded overlapping booking on `effectiveEndAt`. Confirms the SQL predicate, not just the in-memory mirror. |
+| **Route** | `GET /storefronts/search` 200 public (no auth). Missing `from`/`to` → 400 (`parseDateRange`). `to<=from` → 400. Response shape matches the contract (assert `storefronts[0].classSummaries` + daily/hourly price fields). `GET /storefronts/:id/vehicles` unknown id → 404. `cachePublic` header present. |
+| **E2E (Playwright)** — REQUIRED (first renter-facing slice, §6.1) | Happy path: renter opens `/en/search`, enters a date range, submits → sees a storefront card containing the store name + a class-summary badge (e.g. "Compact x4") + "from ¥4,500"; clicks the card → lands on `/en/storefronts/:id`, sees grouped available vehicles, sees a (disabled/placeholder) select control. **Mock only HTTP boundaries** (none external here beyond the API; seed the `test` DB). Extend the existing `e2e/browse.spec.ts` pattern + `playwright.config.ts` (#296 infra, #321 renter-browse spec). |
+
+**E2E note:** this is the slice that *introduces* the renter search E2E; slices 6/8 build the full search→book→confirm journey on top. The §6.1 gate "E2E happy-path required green before slice 6 and slice 8 merge" means slice 5's E2E is the seed the later gates extend.
+
+---
+
+## 9. Resolved decisions / cross-slice risks
+
+1. **Slices 2–4 not yet merged.** Slice 5 is the most downstream renter slice and **hard-depends** on `locations` (#387), `acriss_code` (#388), and vehicle-only pricing (#389c-drop). As of 2026-06-02 none are merged to `marketplace-pivot`. **Risk:** kicking off slice 5 early means coding against placeholder columns. **Mitigation:** treat slices 2→3→4 as a strict gate; do not start the schema-touching parts of slice 5 until they land. The web/UI scaffolding *can* start against the documented API contract.
+2. **`AvailabilityRepository` signature change** is a shared interface edit (`repositories/types.ts`) touched by other slices. Making `findAvailableVehicles`' new arg **optional** keeps it backward-compatible, but coordinate so slice 6's booking-availability work and slice 5 don't both edit the method concurrently. Land slice 5's signature extension first if 5 and 6 partially parallelize (§6 "5 and 6 can partially parallelize").
+3. **Dropoff/return location filtering.** Resolved for MVP: pickup=dropoff. The search API filters only `pickupLocationId`; the web may show a locked return-location control mirroring pickup, but no one-way filtering ships here.
+4. **ACRISS label localization placement.** Resolved: API returns `acrissCode` (and raw operator-entered class data); the web localizes labels via the slice-3 `acriss.*` namespace. No `Accept-Language` API surface in this slice.
+5. **Min price when a store has only hourly-priced vehicles.** Resolved: storefront cards prefer the minimum `dailyRateJpy` and render "from ¥X/day". If a store has available vehicles but no daily-priced vehicle, return `fromDailyPriceJpy:null` plus `fromHourlyPriceJpy` and render "from ¥X/hour"; do not derive a fake daily equivalent.
+6. **Index speculation.** §7 recommends shipping no new index and measuring (§8.2 says the live scan handles MVP scale trivially). If a reviewer wants a guard index on `bookings`, it's a one-line additive migration — but YAGNI says wait for a real plan regression.
+
+---
+
+## 10. Per-slice merge gate (§6.1)
+
+All green before merge: `bun run test` (unit + integration) · `bun run test:e2e` (renter happy path — **required this slice**) · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` (if any index migration) · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 11. Execution order & worktree
+
+```
+git worktree add ../kuruma-storefront-search -b feature/391-renter-storefront-search marketplace-pivot
+```
+
+Within the worktree (vertical slice, RED/GREEN per behaviour):
+
+1. Extend `AvailabilityRepository.findAvailableVehicles` interface + InMemory impl (RED test → GREEN).
+2. `StorefrontRepository`/`LocationRepository` read interface + InMemory impl.
+3. `StorefrontSearchService` aggregation (group-by-class, daily/hourly min prices) — unit tests first.
+4. `StorefrontDetailService` — unit tests first.
+5. Drizzle impls (integration tests against Neon `test`).
+6. `routes/storefronts.ts` + mount in `index.ts` (route tests).
+7. Web: `modules/storefronts/` + `app/[locale]/search` + `app/[locale]/storefronts/[locationId]` + i18n (`search.*`, restart dev).
+8. Playwright E2E happy path.
+9. code-reviewer + architect → rebase onto `origin/marketplace-pivot` (never force push) → PR `Closes #391`.
+
+**Effort:** proposal §6 row 5 estimates **2–3 days**. The availability reuse (no new overlap math) keeps it toward the low end; the E2E + renter UI is the bulk of the work.
+
+---
+
+## 12. Critical files
+
+**New (API):** `services/storefront-search.ts`, `services/storefront-detail.ts`, `repositories/{drizzle,in-memory}/storefront.ts`, `routes/storefronts.ts`.
+**Modify (API):** `repositories/types.ts` (`findAvailableVehicles` filter arg + `StorefrontRepository`), `repositories/{drizzle,in-memory}/availability.ts`, `index.ts` (DI + mount).
+**New (Web):** `app/[locale]/search/page.tsx`, `app/[locale]/storefronts/[locationId]/page.tsx`, `modules/storefronts/*`.
+**Modify (Web):** `messages/{en,ja,zh}.json` (`search.*`), renter nav.
+**New (test):** service unit + repo integration + `e2e/storefront-search.spec.ts`.
+**Schema:** none expected (indexes only if a plan regression appears — §7).

--- a/docs/plans/2026-06-02-slice5-renter-storefront-search.md
+++ b/docs/plans/2026-06-02-slice5-renter-storefront-search.md
@@ -29,7 +29,7 @@ The two read models (§9 item 21, §10 item 12):
 
 | Precondition | Why | Status 2026-06-02 |
 |---|---|---|
-| **Slice 2 (#387 locations) merged to `marketplace-pivot`** | The store card IS a `locations` row. Search reads `locations` (name, address, `operatingHours`, `defaultTurnaroundMinutes`) and joins `vehicles.pickupLocationId → locations.id`. Without it there is no storefront entity to return. | In progress on `feature/387-locations` (locations table + `vehicles.pickupLocationId` composite FK present on that branch; not yet on `marketplace-pivot`) |
+| **Slice 2 (#387 locations) merged to `marketplace-pivot`** | The store card IS a `locations` row. Search reads `locations` (name, address, `operatingHours`, `defaultTurnaroundMinutes`) and joins `vehicles.pickupLocationId → locations.id`. Without it there is no storefront entity to return. | In review (PR #414 → `marketplace-pivot`; locations table + `vehicles.pickupLocationId` composite FK present on that branch, not yet on pivot) |
 | **Slice 3 (#388 ACRISS + vehicle CRUD) merged** | `classSummaries` group by ACRISS class; the card shows "Compact x4, Minivan x2". Requires `vehicle_classes.acriss_code` + i18n class labels. The current `marketplace-pivot` `vehicle_classes` has **no `acrissCode` column yet** — slice 3 adds it. | Not started |
 | **Slice 4 (#389a/b/c pricing) merged** | Card pricing is computed from `vehicles.dailyRateJpy` / `vehicles.hourlyRateJpy`. §10 item 11 + §5.1: pricing is **vehicle-level only**; slice 4c drops `vehicle_classes.dailyRateJpy`. Slice 5 must read price from `vehicles`, never from the class. | Not started (4a/4b drafted in `2026-06-02-slice4-*`; 4c trails #388) |
 
@@ -225,7 +225,7 @@ Search is **public/renter-facing**. This is the inverse of slice 4's operator-pr
 
 Slice 5 ideally adds **no tables and no columns** — it reads slices 1–4's schema. The only candidate change is **covering indexes** for the new query paths, if `bun run lint:fk-indexes` / query plans demand:
 
-- `vehicles.pickupLocationId` — #387 already adds `idx_vehicles_pickupLocationId` (confirmed on `feature/387-locations`); the storefront availability join reuses it. **No new index needed if present.**
+- `vehicles.pickupLocationId` — #387 already adds `idx_vehicles_pickupLocationId` (confirmed on PR #414); the storefront availability join reuses it. **No new index needed if present.**
 - `bookings(vehicleId, status, startAt, effectiveEndAt)` — the `NOT EXISTS` overlap subquery filters on `vehicleId` + status + range. A composite/GiST index here would help at scale, **but** §8.2 sets search p95 <500ms at MVP scale (3 ops × ~40 vehicles) which the live scan "handles trivially." **Recommendation: ship no new index in slice 5; measure first.** If a plan regression shows up, add the index in a dedicated follow-up — do not speculatively index (YAGNI).
 
 **If** any index is added: `bun run db:generate --name <describe>` → `db:migrate` → `db:verify` (3 green); respect the journal-`when` monotonic rule (CLAUDE.md 2026-04-17) when rebasing onto `marketplace-pivot`. **No hand-written `.sql` in `drizzle/`.**
@@ -269,7 +269,8 @@ All green before merge: `bun run test` (unit + integration) · `bun run test:e2e
 ## 11. Execution order & worktree
 
 ```
-git worktree add ../kuruma-storefront-search -b feature/391-renter-storefront-search marketplace-pivot
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-storefront-search -b feature/391-renter-storefront-search origin/marketplace-pivot
 ```
 
 Within the worktree (vertical slice, RED/GREEN per behaviour):

--- a/docs/plans/2026-06-02-slice6-booking-event-log.md
+++ b/docs/plans/2026-06-02-slice6-booking-event-log.md
@@ -30,9 +30,9 @@ This is the **booking write-path rework**. It converts the legacy single-insert,
 | **Slice 4a (#389a — insurance options) merged to `marketplace-pivot`** | Slice 6 reads active `insurance_options` so the renter can pick one during booking and the booking can snapshot the selected option's name/price/deductible. | Plan landed (`docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` §3); merge state TBC at kickoff |
 | **Slice 4b (#392 dep — fee schedules) merged to `marketplace-pivot`** | Slice 6 reads `fee_schedules` rows to build `bookings.fee_snapshot`. Without the table + its `feeType`/`unit`/`amountJpy`/`vehicleClassId` columns there is nothing to snapshot. | Plan landed (`docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` §4); merge state TBC at kickoff |
 | **Slice 5 (#391 — storefront search + vehicle selection) merged** | Slice 6 is the **submit** for the vehicle the renter selected in slice 5's storefront-detail screen. Slice 5 owns "renter picks a concrete vehicle"; slice 6 owns "renter confirms that vehicle into a booking." Proposal §6 critical path: "5 and 6 can partially parallelize" — but the submit endpoint needs slice 5's vehicle-selection UI as its caller. | #391 |
-| **Slice 2 (#387 — locations) merged** | `bookings.pickup_location_id` + `dropoff_location_id` FKs (proposal §2 "Locations") and the substitution rule "same-operator, **same-location**" (§9 item 25) both require the `locations` table. Substitution's location check is unimplementable without it. | In progress (`feature/387-locations`); **HARD blocker** for slice 6 |
+| **Slice 2 (#387 — locations) merged** | `bookings.pickup_location_id` + `dropoff_location_id` FKs (proposal §2 "Locations") and the substitution rule "same-operator, **same-location**" (§9 item 25) both require the `locations` table. Substitution's location check is unimplementable without it. | In review (PR #414 → `marketplace-pivot`); **HARD blocker** for slice 6 |
 | **Slice 1 (#386 — tenancy) merged** | `CallerContext.operatorId` / `bypassScope`, `OPERATOR_*` roles, `operators` table. **Confirmed present on `marketplace-pivot`** (`packages/api/src/middleware/auth.ts` already exports `operatorId?`, `bypassScope?`, `OPERATOR_ROLES`, `SCOPE_BYPASS_ROLES`). | Merged |
-| **`#401` (drop operator fallback) merged** | Operator-scoped writes resolve `operatorId` from `ctx`, no `BEST_CAR_RENTAL_OPERATOR_ID` fallback (`memory/project_operator-2-gate`). Substitution + operator booking-list reads must obey this. | `feat/401-drop-operator-fallback`, not yet merged |
+| **`#401` (drop operator fallback) merged** | Operator-scoped writes resolve `operatorId` from `ctx`, no `BEST_CAR_RENTAL_OPERATOR_ID` fallback (`memory/project_operator-2-gate`). Substitution + operator booking-list reads must obey this. | Merged to `origin/marketplace-pivot` via PR #408. Branch from `origin/marketplace-pivot` or fast-forward local before kickoff. |
 
 If a contract name differs at kickoff, slice 6 adapts its own PR — never refactor a landed slice (`CLAUDE.md` "Stay in scope").
 
@@ -296,7 +296,8 @@ All green before merge: `bun run test` · `bun run lint` · `bun run --filter @k
 ## 9. Execution order & worktree
 
 ```
-git worktree add ../kuruma-booking-events -b feature/392-booking-event-log marketplace-pivot
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-booking-events -b feature/392-booking-event-log origin/marketplace-pivot
 ```
 
 Per `CLAUDE.md` Monorepo: fresh `bun install` + verify `tsc --noEmit` in the worktree. Order within the slice (vertical, RED→GREEN per cycle):

--- a/docs/plans/2026-06-02-slice6-booking-event-log.md
+++ b/docs/plans/2026-06-02-slice6-booking-event-log.md
@@ -1,0 +1,338 @@
+# Slice 6 — Booking & Event Log (issue #392)
+
+**Date:** 2026-06-02
+**Status:** Draft v1 — implementation plan for AFK execution; awaiting green light to create worktree
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` — §6 row 6 (slice scope), §6.1 (E2E gate before slice-6 merge), §6.2 (tenant scoping), §10 item 3 (booking_code format), §9 items 19/22/25, §10 items 9/14/17, §2 rows "Record mutation model" / "Booking write boundary" / "Vehicle substitution" / "Vehicle turnaround buffer".
+**Format model:** mirrors `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` structure/depth, adapted to an event-sourced booking write-path slice.
+
+This is the **booking write-path rework**. It converts the legacy single-insert, class-with-optional-vehicle booking (`#308` / `#345`) into a **selected-vehicle, event-sourced** booking whose authoritative lifecycle lives in an append-only `booking_events` log, with the existing `bookings.status` as the write-through projection for fast reads. It is the slice where the proposal's mutation model (§2 "Record mutation model"), exclusion-on-assigned-vehicle (§2), 48h turnaround (§2), `booking_code` (§10 item 3), selected-insurance snapshot, and fee snapshot (§9 item 19) all land together as one transactional submit.
+
+---
+
+## 0. What this slice does NOT ship (boundary fences)
+
+| Deferred to | Item |
+|---|---|
+| **Slice 7 (#393)** | Actual email send. The `EmailSender` interface (`packages/api/src/services/email/`, proposal §9 item 5 / §10 item 2) and `notification_log` table are slice 7. Slice 6 commits the booking and emits the `BOOKING_CREATED` event **only**; no network side effect runs inside or after the transaction here. The post-commit hook seam already exists (`BookingService.ensureThread`, `#335`) — slice 7 extends that seam, slice 6 does not add a second one. |
+| **Slice 7** | `operators.preAuthHandoffUrl` rendering on the confirmation page. The column already exists on `marketplace-pivot` (slice 1 schema), but wiring the link + email is slice 7's "pre-auth handoff" deliverable. Slice 6 renders selected insurance + the **fee-disclosure** block only. |
+| **Post-MVP** | Per-vehicle insurance applicability (`vehicle_insurance_options` join table). Slice 6 lets the renter choose from the operator's active insurance options and snapshots that choice; it does not restrict options per vehicle. |
+| **Slice 4b (#392-dependency, landed)** | `fee_schedules` table + CRUD. Slice 6 **reads** that table to build the snapshot; it does not create or modify it. |
+| **Post-MVP** | Auto-compute / auto-charge of fees at checkout. Slice 6 snapshots rates and **displays informationally** only (§9 item 19: "informational only in MVP"). |
+| **Post-MVP** | Renter cancellation/modification UI (§9 item 7, §10 item 8). Event log makes both trivially addable later; not in this slice. Operator-initiated cancel stays on the existing `cancel` path. |
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **Slice 4a (#389a — insurance options) merged to `marketplace-pivot`** | Slice 6 reads active `insurance_options` so the renter can pick one during booking and the booking can snapshot the selected option's name/price/deductible. | Plan landed (`docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` §3); merge state TBC at kickoff |
+| **Slice 4b (#392 dep — fee schedules) merged to `marketplace-pivot`** | Slice 6 reads `fee_schedules` rows to build `bookings.fee_snapshot`. Without the table + its `feeType`/`unit`/`amountJpy`/`vehicleClassId` columns there is nothing to snapshot. | Plan landed (`docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` §4); merge state TBC at kickoff |
+| **Slice 5 (#391 — storefront search + vehicle selection) merged** | Slice 6 is the **submit** for the vehicle the renter selected in slice 5's storefront-detail screen. Slice 5 owns "renter picks a concrete vehicle"; slice 6 owns "renter confirms that vehicle into a booking." Proposal §6 critical path: "5 and 6 can partially parallelize" — but the submit endpoint needs slice 5's vehicle-selection UI as its caller. | #391 |
+| **Slice 2 (#387 — locations) merged** | `bookings.pickup_location_id` + `dropoff_location_id` FKs (proposal §2 "Locations") and the substitution rule "same-operator, **same-location**" (§9 item 25) both require the `locations` table. Substitution's location check is unimplementable without it. | In progress (`feature/387-locations`); **HARD blocker** for slice 6 |
+| **Slice 1 (#386 — tenancy) merged** | `CallerContext.operatorId` / `bypassScope`, `OPERATOR_*` roles, `operators` table. **Confirmed present on `marketplace-pivot`** (`packages/api/src/middleware/auth.ts` already exports `operatorId?`, `bypassScope?`, `OPERATOR_ROLES`, `SCOPE_BYPASS_ROLES`). | Merged |
+| **`#401` (drop operator fallback) merged** | Operator-scoped writes resolve `operatorId` from `ctx`, no `BEST_CAR_RENTAL_OPERATOR_ID` fallback (`memory/project_operator-2-gate`). Substitution + operator booking-list reads must obey this. | `feat/401-drop-operator-fallback`, not yet merged |
+
+If a contract name differs at kickoff, slice 6 adapts its own PR — never refactor a landed slice (`CLAUDE.md` "Stay in scope").
+
+---
+
+## 2. Grounding in merged code — what exists, what we extend (do NOT reinvent)
+
+The single-tenant booking write path is already mature. Slice 6 **extends** it; it does not rebuild it.
+
+### 2.1 The existing exclusion constraint (KEEP THE PATTERN)
+
+`drizzle/0006_exclusion_constraint.sql` (real, merged):
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_no_overlap"
+  EXCLUDE USING gist (
+    "vehicleId" WITH =,
+    tstzrange("startAt", "effectiveEndAt") WITH &&
+  ) WHERE (status IN ('CONFIRMED', 'ACTIVE'));
+```
+
+- `effectiveEndAt` is a **stored** column (`bookings.effectiveEndAt timestamptz NOT NULL`, `drizzle/0008`), computed by a trigger from `vehicles.bufferMinutes` (`drizzle/0015_effective-end-trigger.sql`, `compute_effective_end_at()`), with a defense-in-depth CHECK `effectiveEndAt >= endAt`.
+- Postgres only excludes rows where **every `=` operand is non-null**, so today's nullable `vehicleId` means unassigned (class-only) bookings never collide. That subtlety is mirrored in `InMemoryBookingRepository.create` (`packages/api/src/repositories/in-memory/booking.ts:127-145`) and `getConflictingBookings`.
+
+**Slice 6 extension — three changes, no reinvention:**
+
+1. **Rename the constrained column** `vehicleId` → `assignedVehicleId` (proposal §2: "exclusion constraint on `(assigned_vehicle_id, time_range)`"). The constraint shape is identical; only the column it keys on changes. **`assignedVehicleId` becomes NOT NULL** for new selected-vehicle bookings (the class-only path is retired this slice), so the "null operand skips exclusion" loophole closes — every confirmed booking now occupies its assigned vehicle atomically.
+2. **Rebind the trigger** to compute `effectiveEndAt` from the **turnaround** value, not the legacy 60-min `bufferMinutes`. See §5.3 — `effective_end_at = end_at + turnaround_minutes` where turnaround resolves `vehicles.turnaroundMinutesOverride ?? locations.defaultTurnaroundMinutes ?? 2880` (48h). Proposal §2 "Vehicle turnaround buffer" + §9 item 20 ("rename/map `bufferMinutes` → `turnaround_minutes`; do not leave the old 60-minute default").
+3. **Add `operatorId` to bookings** (it is absent on `marketplace-pivot` today — see §2.4). The exclusion constraint does **not** need `operatorId` in it: it is per-`assignedVehicleId`, and a vehicle belongs to exactly one operator, so cross-operator collisions are structurally impossible (proposal §8.1 risk row: "adding `operator_id` doesn't change behavior").
+
+### 2.2 The existing booking service / repo (EXTEND, don't replace)
+
+- `BookingService.create(ctx, input, now = new Date())` (`packages/api/src/services/booking.ts:148`) — `now` is **injected** (`#314`) for testability; keep that. It already: validates renter (staff-override path), checks idempotency **scoped to caller** (`#340`, `findByIdempotencyKey(ctx, key)`), resolves class+vehicle, computes server-side price (`#74` — never client-supplied), inserts, catches `EXCLUSION_VIOLATION`→409 / `UNIQUE_VIOLATION`+replay, then runs `ensureThread` (`#335`) **after** the row exists.
+- `BookingRepository` interface (`packages/api/src/repositories/types.ts:141`) — `create(ctx, data)` is a single insert today.
+- `RunInTransaction` (`types.ts:257`) + `createDrizzleTransaction` (`repositories/drizzle/transaction.ts`) **already exist** — used by `MaintenanceService`. Slice 6 reuses this exact pattern to make booking-submit one transaction; it does not invent a new transaction mechanism. The factory's repo bundle is widened to include the booking + event repos (§4.2).
+- `pgErrorCode` / `PG_ERROR` (`packages/api/src/pg-errors.ts`) — `EXCLUSION_VIOLATION = '23P01'`, `UNIQUE_VIOLATION = '23505'`. Slice 6 adds nothing here; `booking_code` collision reuses `UNIQUE_VIOLATION` (§5.4).
+
+### 2.3 The existing route + helpers (REUSE)
+
+- `createBookingRoutes(service)` (`packages/api/src/routes/bookings.ts`) — `POST /bookings` already builds `ctx` via `toCallerContext(requireUser(c))`, parses with `createBookingSchema` via `parseBody()`, forces `source=DIRECT` for non-staff. Slice 6 widens the validator + input, keeps the route shape.
+- `routes/helpers.ts`: `ok()`, `fail()`, `parseBody()`, `parseDateRange()`, `stripUndefined()`. Use them; do not hand-roll `c.json`.
+
+### 2.4 marketplace-pivot bookings table — current shape (what we migrate FROM)
+
+On `origin/marketplace-pivot` the `bookings` table is still the **legacy single-tenant shape**: `renterId`, `classId` (single FK → `vehicleClasses.id`), nullable `vehicleId`, `startAt`/`endAt`/`effectiveEndAt`, `status`, `source`, `idempotencyKey`. It has **no** `operatorId`, **no** `requestedVehicleId`/`assignedVehicleId`, **no** `bookingCode`, **no** `feeSnapshot`, **no** `currentState`. Slices 2-5 did not touch it. **Slice 6 is the booking-table marketplace migration.** (Proposal §5.1 step 4: "replace legacy nullable `bookings.vehicleId` with selected/assigned vehicle semantics.")
+
+---
+
+## 3. Event taxonomy & the write-through model
+
+### 3.1 `booking_events` — append-only log
+
+The booking's lifecycle is a sequence of immutable events. The existing `bookings.status` column is the **projection** (write-through cache) of the latest lifecycle event for fast reads — the events are the source of truth. The proposal names this projection `current_state`; MVP keeps `status` to avoid churning every existing reader.
+
+MVP event types (`bookingEventTypeEnum`):
+
+| Event | Emitted when | `status` after | Payload (jsonb) |
+|---|---|---|---|
+| `BOOKING_CREATED` | Booking submit (this slice's happy path) | `CONFIRMED` | `{ requestedVehicleId, assignedVehicleId, classId, startAt, endAt, totalPrice, insuranceSnapshot, feeSnapshot }` |
+| `VEHICLE_SUBSTITUTED` | Operator swaps the assigned car (§9 item 25) | unchanged (still `CONFIRMED`/`ACTIVE`) | `{ fromVehicleId, toVehicleId, reason }` |
+| `BOOKING_CANCELLED` | Operator cancels (existing `cancel` path, rewired to emit an event) | `CANCELLED` | `{ cancellationFee, cancelledAt }` |
+| `STATUS_CHANGED` | `CONFIRMED→ACTIVE→COMPLETED` transitions (existing `updateStatus`, rewired) | new status | `{ from, to }` |
+
+> **Scope discipline:** Only `BOOKING_CREATED` + `VEHICLE_SUBSTITUTED` are *new* behavior this slice. `BOOKING_CANCELLED` / `STATUS_CHANGED` are the **existing** transitions made to *also append an event* so the log is complete — they reuse `VALID_BOOKING_TRANSITIONS` (`schema.ts:271`). Do not build new cancellation/modification flows (§0).
+
+`status` maps to the existing `bookingStatusEnum` (`CONFIRMED | ACTIVE | COMPLETED | CANCELLED`) and is the write-through projection target. No new `currentState` column ships in MVP.
+
+### 3.2 Invariant
+
+Every booking mutation that changes lifecycle state happens as: **append event → update projection**, in the same transaction. A projection that disagrees with `max(booking_events.createdAt)` is a bug; an integration test asserts the projection equals the last event's resulting state.
+
+---
+
+## 4. The single-transaction submit (the heart of this slice)
+
+Proposal §2 "Booking write boundary" + §9 item 22 + §10 item 14: **booking submit is ONE DB transaction** for (a) selected-vehicle availability validation, (b) booking row insert with requested+assigned vehicle IDs, (c) selected-insurance snapshot, (d) initial `BOOKING_CREATED` event insert, (e) fee snapshot. **Notifications happen after commit (slice 7).**
+
+### 4.1 Transaction sequence (inside `runInTransaction`)
+
+```
+BEGIN
+  1. Resolve class + selected vehicle (must belong to class; vehicle's operator owns it)
+  2. Resolve turnaround_minutes := vehicle.turnaroundMinutesOverride
+                                   ?? location.defaultTurnaroundMinutes
+                                   ?? 2880 (48h)         [§5.3]
+  3. Compute server-side price (calculateBookingPrice, #74 — never client-supplied)
+  4. Resolve selected insurance option from this operator's ACTIVE options and build insurance_snapshot
+  5. Build fee_snapshot from applicable fee_schedules rows  [§6]
+  6. Generate booking_code (8-char no-confusables base32 nanoid)  [§5.4]
+  7. INSERT bookings { requestedVehicleId, assignedVehicleId, operatorId, classId,
+       pickup/dropoffLocationId, startAt, endAt, effectiveEndAt(=trigger), status='CONFIRMED',
+       bookingCode, insuranceOptionId, insuranceSnapshot, feeSnapshot, totalPrice, idempotencyKey }
+       -> exclusion constraint on assignedVehicleId enforces uniqueness ATOMICALLY  [§2.1]
+       -> unique(bookingCode) may collide -> retry generation (bounded)  [§5.4]
+  8. INSERT booking_events { bookingId, type='BOOKING_CREATED', payload, actorId=renterId }
+  9. (status already 'CONFIRMED' from the insert default — projection is consistent)
+COMMIT
+-- AFTER COMMIT (NOT in tx): ensureThread (#335). Slice 7 adds EmailSender here.
+```
+
+**Why one transaction (FC/IS framing):** availability validation + row + event + snapshot are a single atomic *decision-and-record*. If the exclusion constraint fires (step 6), the whole thing rolls back — no orphan event, no orphan snapshot. The thread/email work is an **imperative shell** side effect that must NOT be inside the transaction (network I/O in a DB tx is the `Side Effects in Business Logic` smell). This is exactly why `ensureThread` is already post-insert today.
+
+### 4.2 Repository / transaction wiring (boundaries: AGENTS.md)
+
+- Widen `RunInTransaction`'s repo bundle (`types.ts:257`) to include `bookingRepo` + `bookingEventRepo` (+ read access to `feeScheduleRepo`, `vehicleRepo`, `locationRepo` for in-tx resolution). `createDrizzleTransaction` (`repositories/drizzle/transaction.ts`) constructs the Drizzle repos bound to the `tx` handle; the InMemory equivalent passes its repos through (JS single-threaded — same pattern as today).
+- `BookingService.create` orchestrates: it calls `runInTransaction(async (repos) => { ...steps 1-7... })`. **Orchestration lives in the service**, the multi-row write lives behind the transaction repo — routes never see a transaction (AGENTS.md: routes→services→repositories, never backwards).
+- New `BookingEventRepository` interface (`types.ts`): `append(ctx, event)`, `findByBookingId(ctx, bookingId)`. Drizzle + InMemory pair under `repositories/{drizzle,in-memory}/booking-event.ts`. Concretes wired **only** in `index.ts` (AGENTS.md: "No `new ConcreteRepository()` outside `index.ts`").
+- `index.ts` widens the `createDrizzleTransaction(db)` call and the `new BookingService(...)` constructor args to inject the event repo + transaction runner. Today `BookingService` takes `(bookingRepo, vehicleRepo, userRepo, vehicleClassRepo, threading)` (`index.ts:287`); add `bookingEventRepo`, `runInTransaction`, and the fee/location read deps.
+
+### 4.3 Tenant scoping at the route/service (§6.2)
+
+- **Renter books**: `ctx.role = RENTER`, no `operatorId`; the booking's `operatorId` is derived from the **selected vehicle's** operator (not from the caller). A renter cannot set `operatorId`.
+- **Operator reads** its own bookings: `findAll`/`findById` filter on `ctx.operatorId` for `OPERATOR_*` (NEVER bypass — proposal §6.2 heuristic). This **replaces** the legacy `PRIVILEGED_ROLES`-based scoping in `DrizzleBookingRepository.findAll` (`booking.ts:14-15`) and `InMemoryBookingRepository.scopedValues` (`in-memory/booking.ts:37-41`), which only knew renter-vs-privileged. New scoping is three-way: renter (own rows) / operator (operator's rows) / bypass (all). Gate bypass on `ctx.bypassScope === true`, not on a role string (mirrors slice 4 §2 "[P1]").
+- **Substitution** (§5.5) is an operator-only write, scoped to `ctx.operatorId`; it loads the booking first to confirm tenant ownership (404 not 403 on cross-operator — no existence leak, mirrors slice 4).
+
+---
+
+## 5. Schema, migrations & generation details
+
+All `schema.ts` changes generate via `bun run db:generate --name <change>` → `bun run db:migrate` → `bun run db:verify` (3 green) per `CLAUDE.md` Database Migrations. **The exclusion constraint, the turnaround trigger rebind, and the `btree_gist`-backed rename are NOT expressible in Drizzle's table builder** — they require a **hand-written custom migration**: `bun run db:generate --custom --name booking_exclusion_assigned_vehicle` (`CLAUDE.md`: "never drop raw `.sql` into `drizzle/`"). The additive columns (event table, `booking_code`, `fee_snapshot`, etc.) go in a normal generated migration; sequence the custom SQL migration **after** it.
+
+### 5.1 `bookings` table changes
+
+| Column | Change | Source |
+|---|---|---|
+| `operatorId text NOT NULL → operators.id` | **Add** (absent on pivot, §2.4) | §2 multi-tenancy |
+| `requestedVehicleId text NOT NULL → vehicles.id` | **Add** — what the renter chose | §2, §9 item 25 |
+| `assignedVehicleId text NOT NULL → vehicles.id` | **Rename** from `vehicleId` + make NOT NULL — what the operator fulfills; exclusion keys on this | §2 |
+| `pickupLocationId` / `dropoffLocationId text NOT NULL → locations.id` | **Add** (needs #387) | §2 "Locations" |
+| `bookingCode text NOT NULL UNIQUE` | **Add** | §10 item 3, §9 item 3 |
+| `insuranceOptionId text → insurance_options.id` | **Add nullable** — selected renter insurance option; null only if renter declines coverage / operator has no active option | §4 renter item 4 |
+| `insuranceSnapshot jsonb` | **Add nullable** — `{ name, dailyPriceJpy, deductibleJpy, insuranceOptionId }` locked at booking time | §4 renter item 4 |
+| `feeSnapshot jsonb NOT NULL DEFAULT '[]'` | **Add** | §9 item 19 |
+| `classId` | Keep (discovery/grouping); composite FK `(operatorId, classId) → vehicle_classes(operatorId, id)` to seal class-to-operator (mirrors `vehicles` on pivot, #395) | §2 |
+| `status` | Keep as the write-through projection target (§3.1, §11) | §2 |
+
+Composite FK seal: `(operatorId, requestedVehicleId)` and `(operatorId, assignedVehicleId)` → `vehicles(operatorId, id)` so an assigned vehicle must belong to the booking's operator (same pattern as `vehicles_operatorId_classId_fk` on pivot). Add the same composite seal for `(operatorId, insuranceOptionId)` → `insurance_options(operatorId, id)` where `insuranceOptionId IS NOT NULL`. This makes "operator can only substitute/price against its own records" a DB invariant, not just a service check.
+
+### 5.2 `booking_events` table (new)
+
+```
+booking_events
+  id            text PK (uuid)
+  bookingId     text NOT NULL -> bookings.id
+  type          booking_event_type enum (BOOKING_CREATED | VEHICLE_SUBSTITUTED | BOOKING_CANCELLED | STATUS_CHANGED)
+  payload       jsonb NOT NULL
+  actorId       text -> users.id   (renter for CREATED; operator user for SUBSTITUTED/CANCELLED; null for system)
+  createdAt     timestamptz NOT NULL default now()
+  index idx_booking_events_bookingId (bookingId, createdAt)   -- ordered replay per booking
+```
+
+Append-only: no `update`/`delete` repo methods exist on `BookingEventRepository` (enforced by interface, not just convention).
+
+### 5.3 Turnaround → exclusion range (the math)
+
+`effective_end_at = end_at + turnaround_minutes`, where at booking time:
+
+```
+turnaround_minutes = vehicle.turnaroundMinutesOverride
+                     ?? location.defaultTurnaroundMinutes   -- pickup location; default 2880 on the column
+                     ?? 2880                                 -- 48h hard fallback
+```
+
+- Proposal §2 "Vehicle turnaround buffer", §9 item 20, §10 item 11. `locations.default_turnaround_minutes` defaults to **2880 (48h)** per §5.1 step 4; `vehicles.turnaround_minutes_override` is the optional per-vehicle exception.
+- The existing trigger `compute_effective_end_at()` (`drizzle/0015`) reads `vehicles.bufferMinutes` (default 60). **Rebind it** to resolve `turnaround_minutes` from the override→location→default chain and key off `assignedVehicleId`. Keep the trigger (defense-in-depth) so a direct SQL insert can't bypass the buffer; the service also computes `effectiveEndAt` for the in-memory repo to mirror. CHECK `effectiveEndAt >= endAt` stays.
+- **`bufferMinutes` retirement:** §9 item 20 is explicit — "do not leave the old 60-minute default in place." Map `vehicles.bufferMinutes` → `vehicles.turnaroundMinutesOverride` (nullable, no 60-min default), and add `locations.defaultTurnaroundMinutes` (default 2880). The exclusion range thus widens from "60 min after return" to "48h after return" — that is the intended behavior change.
+
+### 5.4 `booking_code` generation (§10 item 3)
+
+- **Format:** 8-char, no-confusables base32 nanoid. Alphabet excludes `0 O 1 I l` (e.g. `23456789ABCDEFGHJKLMNPQRSTUVWXYZ`), no prefix, pattern like `2J7QXKN4`. Internal `bookings.id` stays UUIDv7 (proposal §2 "Booking ID", `memory/project_architect-review`).
+- **Library:** `nanoid` with `customAlphabet` (~1KB, §10 item 3). **`nanoid` is not yet a dependency** (verified: absent from all `packages/*/package.json`) — add to `@kuruma/api` (the generator runs server-side in the booking service; never client-side, no PII, recitable over phone).
+- **Uniqueness + retry:** `bookingCode` is `UNIQUE NOT NULL`. 8 chars over a 32-symbol alphabet = ~2^40 space; collision is astronomically rare at MVP scale but must be handled. On `UNIQUE_VIOLATION` (`23505`) for `bookingCode` specifically (distinguish from the idempotency-key unique), **regenerate and retry the insert**, bounded to e.g. 3 attempts, then surface a 500. Reuse `pgErrorCode` (`pg-errors.ts`); the retry is in the service around the transaction step. Generation happens **inside** the transaction sequence (§4.1 step 5) so a retry re-runs the whole atomic insert cleanly.
+
+### 5.5 Substitution write path (`VEHICLE_SUBSTITUTED`, §9 item 25 / §10 item 17)
+
+New operator-only endpoint, e.g. `POST /bookings/:id/substitute` (route → service → transaction repo). In one transaction:
+
+1. Load booking scoped to `ctx.operatorId` (404 if not this operator's — no leak).
+2. Validate the replacement vehicle: **same operator, same pickup location, same ACRISS class**. §9 item 25 allows "same-or-better," but no ACRISS rank order is defined; better-class substitution is a follow-up requiring an explicit ordering decision.
+3. `UPDATE bookings SET assignedVehicleId = :new, effectiveEndAt = recomputed` — the exclusion constraint re-checks availability for the **new** assigned vehicle atomically (rolls back if the new car is already booked for the range).
+4. Append `VEHICLE_SUBSTITUTED` event `{ fromVehicleId, toVehicleId, reason, actorId: operatorUserId }`. `requestedVehicleId` is **never** mutated — the audit trail preserves what the renter originally selected (§2 "Vehicle substitution").
+
+This is a vertical sub-slice but small; ships in slice 6 because the proposal lists "substitution event support" in row 6. **UI for substitution is minimal** (operator booking-detail action) — the data path + event are the deliverable.
+
+### 5.6 Migration ordering (the journal trap)
+
+Two migrations: (1) generated additive (`booking_events` table, new `bookings` columns, enum), (2) custom SQL (`assignedVehicleId` rename + exclusion-constraint swap + trigger rebind). Order: additive **then** custom. Per `CLAUDE.md` 2026-04-17 trap: if rebasing onto a `marketplace-pivot` that gained migrations meanwhile, **regenerate** (don't hand-edit `_journal.json`); if cherry-picking, bump `when` to `max(prev)+1`. Run `bun run db:verify` after each; CI `db-drift` enforces.
+
+---
+
+## 6. Insurance + fee snapshot shapes
+
+### 6.1 Selected insurance (`bookings.insurance_snapshot jsonb`)
+
+At booking, the renter may choose one active insurance option from the selected vehicle's operator. The option list is not filtered per vehicle in MVP; per-vehicle applicability is post-MVP. If an option is selected, snapshot it inside the same transaction so later operator edits do not rewrite booked terms:
+
+```jsonc
+{
+  "insuranceOptionId": "...",
+  "name": "Premium",
+  "dailyPriceJpy": 2800,
+  "deductibleJpy": 250000
+}
+```
+
+`totalPrice` includes base vehicle rental + selected insurance daily price for the booking day count. If the renter declines insurance or the operator has no active options, `insuranceOptionId` and `insuranceSnapshot` are null.
+
+### 6.2 Fee schedules (`bookings.fee_snapshot jsonb`)
+
+At booking, snapshot the **applicable** `fee_schedules` rows so the rate is locked at booking time (proposal §9 item 19: "locks rate-at-time-of-booking so post-MVP checkout charges against the locked rate, not the current one"). "Applicable" = active rows for the booking's operator that are either **operator-wide** (`vehicleClassId IS NULL`) or **match the booking's class** (`vehicleClassId = booking.classId`). Slice 4b's two partial-unique indexes guarantee at most one active row per `(operator, type, scope)`.
+
+Snapshot element shape (one per applicable fee):
+
+```jsonc
+{
+  "feeType": "OVERTIME_HOURLY",   // | CLEANING_FLAT | NO_FUEL_FLAT
+  "unit": "PER_HOUR",             // | FLAT (coherence already enforced in slice 4b)
+  "amountJpy": 500,
+  "vehicleClassId": "..." | null  // provenance: class-specific vs operator-wide
+}
+```
+
+- Overtime is **not computed** at booking (no return-overage yet) — the snapshot just locks the hourly rate; the post-MVP rule is `ceil(overage_hours) * snapshotted_hourly_rate` (§9 item 19). MVP displays it as "¥500 / hour over scheduled return."
+- Snapshot reads `fee_schedules` **inside the transaction** (consistent point-in-time) via the fee-schedule repo's read method, scoped to the booking's operator. No write to `fee_schedules`.
+
+### Confirmation page — "potential additional charges" (§4 renter item 5, proposal "informational only")
+
+`packages/web/src/app/[locale]/bookings/confirmation/page.tsx` already exists (renter flow #345). Slice 6 adds the selected-insurance summary plus a **"Potential additional charges"** block rendering `booking.feeSnapshot`: each row as a labelled line (i18n `bookings.confirmation.fees.*`, en/ja/zh), e.g. "Overtime ¥500/hour · Cleaning ¥3,000 · No-fuel return ¥5,000", with a one-line disclaimer that these apply only if incurred. It reads the snapshots off the booking (no separate fetch). Pre-auth link + email are slice 7 (§0).
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant)
+
+Per `~/.claude/rules/testing.md` + proposal §6.1. One failing test → minimal impl → repeat. Mirror `packages/api/tests/integration/rls-context.test.ts` for the tenant-isolation cases (seed operator A + B + their `OPERATOR_STAFF` + renters; assert isolation both directions).
+
+| Layer | Cases |
+|---|---|
+| **Validator** (`shared/test/validators/booking`) | `requestedVehicleId`/`assignedVehicleId` required UUID; optional `insuranceOptionId` UUID; reject end ≤ start (existing `.refine`); pickup/dropoff location ids required UUID; client-supplied `totalPrice`/`bookingCode`/`operatorId`/snapshot fields silently dropped |
+| **booking_code unit** | 8 chars; alphabet excludes `0O1Il`; 10k generations all match `/^[2-9A-HJ-NP-Z]{8}$/` and are unique; collision path retries on injected `UNIQUE_VIOLATION` then succeeds; exhausts retries → 500 |
+| **Turnaround unit** | `effectiveEndAt = endAt + resolve(override ?? locationDefault ?? 2880)`; override wins over location; location wins over 2880; **mutation guard**: a 60-min result must FAIL (proves the 48h default landed, §9 item 20) |
+| **Insurance/fee snapshot unit** | selected active insurance option snapshots `{insuranceOptionId,name,dailyPriceJpy,deductibleJpy}` exactly and contributes to `totalPrice`; another operator's / archived insurance option rejected. Operator-wide + class-specific fee rows both included; another operator's fees excluded; archived fees excluded; fee snapshot element matches `{feeType,unit,amountJpy,vehicleClassId}` exactly |
+| **InMemory booking repo** | CRUD + event-append; exclusion mirror now keys on `assignedVehicleId` (overlapping assigned vehicle → `EXCLUSION_VIOLATION`); renter sees own / operator sees operator's / bypass sees all; `status` projection equals last appended event's state |
+| **Drizzle booking repo** (Neon `test`) | real exclusion: two CONFIRMED bookings, same `assignedVehicleId`, overlapping `[startAt, effectiveEndAt)` → `23P01`; turnaround widens the conflict window (booking B starting 24h after A's `endAt` is rejected when turnaround=48h, accepted when 12h); `bookingCode` unique → `23505`; composite FK rejects assigning a vehicle or insurance option from another operator → `23503` |
+| **Service — submit** | one transaction: on exclusion failure NO `booking_events` row and NO booking row persist (atomicity — query both after the failed call); idempotent replay returns existing booking + emits no second event (`#340`); `ensureThread` runs after commit, its failure does not roll back the booking (`#335`); `now` injected (`#314`) |
+| **Service — substitution** | rejects different-operator vehicle (404); rejects different-location vehicle (400); rejects lower-class vehicle (400); accepts same-operator/location/same-class → updates `assignedVehicleId`, leaves `requestedVehicleId`, appends `VEHICLE_SUBSTITUTED`; new vehicle already booked for range → `EXCLUSION_VIOLATION`→409, no event appended |
+| **Route** | `POST /bookings` 201 with `bookingCode` + `insuranceSnapshot` + `feeSnapshot` in body; renter cannot set `operatorId`; operator booking list scoped (op-A staff cannot read op-B booking → 404); substitution route gated to `OPERATOR_*` (renter → 403) |
+| **Web** | booking form renders active operator insurance options; confirmation page renders selected insurance + each `feeSnapshot` row + disclaimer; empty snapshot renders no block (no empty heading) |
+| **E2E (Playwright) — REQUIRED before merge (§6.1)** | renter search → storefront result → vehicle selection → book → **confirmation shows booking code + vehicle details + selected insurance + potential additional charges**. Mock only HTTP boundaries (OAuth callback); Resend is slice 7 so nothing to mock here. |
+
+**E2E gate (§6.1, §6.2):** green E2E happy-path is a **hard merge gate** for slice 6 (and slice 8). The #345/#338 E2E suites, re-seeded against the marketplace shape (default operator = Best Car Rental Osaka), run in CI throughout and must stay green (proposal §6.2(b), §8.1 regression risk).
+
+---
+
+## 8. Per-slice merge gate (proposal §6.1)
+
+All green before merge: `bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` · **E2E happy-path green** (§6.1, hard gate for slice 6) · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktree
+
+```
+git worktree add ../kuruma-booking-events -b feature/392-booking-event-log marketplace-pivot
+```
+
+Per `CLAUDE.md` Monorepo: fresh `bun install` + verify `tsc --noEmit` in the worktree. Order within the slice (vertical, RED→GREEN per cycle):
+
+1. **Schema** — `bookings` columns + `booking_events` table + enums; generated additive migration; then **custom** migration (rename→`assignedVehicleId`, exclusion swap, trigger rebind) via `db:generate --custom`; `db:migrate`; `db:verify` (3 green).
+2. **Validators** (`shared/validators/booking.ts`) — widen create schema; booking_code generator util (`shared/lib/` or `api` util) with its unit test first.
+3. **InMemory repos** — `BookingEventRepository` + booking-repo changes (exclusion mirror on `assignedVehicleId`, three-way scoping); injected in tests via `createApp(overrides)`.
+4. **Service** — submit transaction orchestration + substitution + insurance snapshot + fee snapshot + turnaround resolution + booking_code retry. `BookingEventRepository` + `RunInTransaction` widened bundle.
+5. **DI wire** — `index.ts`: widen `createDrizzleTransaction`, construct event repo, extend `BookingService` ctor.
+6. **Drizzle repos** — integration tests against Neon `test` (exclusion, FK seal, code uniqueness, turnaround window).
+7. **Routes** — extend `POST /bookings`; add `POST /bookings/:id/substitute`; reuse helpers.
+8. **Web** — booking insurance dropdown + confirmation selected-insurance and "potential additional charges" blocks + i18n (`rm -rf packages/web/.next && bun run dev` to pick up new namespace, `CLAUDE.md` i18n gotcha).
+9. **E2E** — Playwright happy path (hard gate).
+10. **Review** (code-reviewer + architect) → rebase onto `origin/marketplace-pivot` (never force push, `memory/feedback_no-force-push`) → PR `Closes #392`, link epic #385.
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Turnaround rebind leaves the legacy 60-min `bufferMinutes` default live (§9 item 20) | Medium | High | Map `bufferMinutes`→nullable `turnaroundMinutesOverride` (no default); `locations.defaultTurnaroundMinutes` default 2880; mutation-guard test asserts a 60-min result FAILS |
+| Projection (`status`) drifts from the event log | Medium | High | Both writes in one transaction; integration test asserts projection == last event's resulting state; append-only repo (no update/delete) |
+| Exclusion constraint not actually atomic across the rename + NOT NULL flip | Low | Critical | Custom SQL migration keyed on `assignedVehicleId` (proven pattern from `0006`); integration test forces concurrent overlap → `23P01`; per proposal §8.1 "adding operator_id doesn't change behavior" |
+| Email/network side effect leaks into the transaction | Low | High | `ensureThread` stays post-commit (existing #335 seam); slice 7's EmailSender extends the same post-commit hook; explicit §0 fence + atomicity test (no booking row on rolled-back tx) |
+| booking_code collision unhandled → 500 on rare clash | Low | Low | `UNIQUE NOT NULL` + bounded regenerate-on-`23505` retry inside the tx; unit test injects a collision |
+| Substitution assigns another operator's / location's vehicle | Low | Critical | Composite FK `(operatorId, assignedVehicleId)→vehicles(operatorId,id)`; service checks same-operator/location/class; integration asserts 23503 + 404 |
+| #387 (locations) not merged → pickup/dropoff FK + substitution location check unbuildable | Medium | High | Hard precondition (§1); do not start slice 6 web/substitution until #387 lands |
+| Out-of-order journal `when` after rebase onto a moved pivot | Medium | Medium | Regenerate migration on rebase; never hand-edit `_journal.json`; `db:verify` + CI `db-drift` (`CLAUDE.md` 2026-04-17) |
+
+---
+
+## 11. Resolved decisions / cross-slice risks
+
+1. **`status` vs `currentState`.** Resolved: keep existing `bookings.status` as the write-through projection target. The proposal's `current_state` name is documentation intent, not an MVP column rename.
+2. **Slice 5 ↔ 6 boundary on vehicle selection.** Resolved: slice 5 owns storefront search/detail and selecting a concrete vehicle into navigation state; slice 6 owns the booking form, submit endpoint, confirmation page data, and validation. If slice 5 only lands a placeholder select control, slice 6 wires the real submit flow.
+3. **Substitution class rule.** Resolved: MVP substitution requires the same operator, same pickup location, and same ACRISS class. "Better class" remains post-MVP until an explicit ACRISS rank order exists.
+4. **Insurance at booking.** Resolved: renter insurance selection is in slice 6. Add nullable `insuranceOptionId` + `insuranceSnapshot` to `bookings`; snapshot selected active operator option at submit; include selected-insurance price in `totalPrice`. No per-vehicle insurance applicability table in MVP.
+5. **`notification_log` ownership.** Resolved: slice 7 creates `notification_log`. Slice 6 emits `BOOKING_CREATED` and keeps post-commit hooks side-effect-safe, but creates no notification table.

--- a/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
+++ b/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
@@ -20,7 +20,7 @@ This is an **outbound-integration slice**: it adds a generic `EmailSender` port,
 | Not in slice 7 | Owned by | Why it matters |
 |---|---|---|
 | The booking DB transaction (availability validate → insert → first `booking_events` → fee snapshot) | **Slice 6 (#392)**, proposal §2 "Booking write boundary" + §10 item 14 | Slice 7 fires **after commit only**. We do not touch the transaction. |
-| `bookings.booking_code`, `requested_vehicle_id`, `assigned_vehicle_id`, `fee_snapshot`, `bookings.operatorId`, `booking_events` table | **Slice 6 (#392)**, proposal §5.1 step 4 + §9 item 3 | The notification payload reads these. **They are NOT on `marketplace-pivot` yet** (verified: `bookings` still has the legacy single-`vehicleId` shape). See §1 preconditions. |
+| `bookings.booking_code`, `requested_vehicle_id`, `assigned_vehicle_id`, `insurance_option_id`, `insurance_snapshot`, `fee_snapshot`, `bookings.operatorId`, `booking_events` table | **Slice 6 (#392)**, proposal §5.1 step 4 + §9 item 3 | The notification payload reads these. **They are NOT on `marketplace-pivot` yet** (verified: `bookings` still has the legacy single-`vehicleId` shape). See §1 preconditions. |
 | `operators.pre_auth_handoff_url` **column** | **Already merged (slice 1, #386)** | Verified present on `marketplace-pivot`. Slice 7 *consumes* it; does not add it. |
 | Renter cancellation UI / auto-charge of fees | Post-MVP (proposal §9 items 7/19) | Confirmation email lists a cancellation contact + "potential additional charges" informationally only. |
 | Operator-portal "manual resend" button beyond a basic action | This slice ships the API + a minimal portal surface; rich ops UI is slice 8 polish (proposal §8.2: "failed sends visible to operator with manual-resend button") |
@@ -31,7 +31,7 @@ This is an **outbound-integration slice**: it adds a generic `EmailSender` port,
 
 | Precondition | Why | Status 2026-06-02 |
 |---|---|---|
-| **Slice 6 (#392) merged to `marketplace-pivot`** | Slice 7's payload reads `booking_code`, `assigned_vehicle_id`, `fee_snapshot`, `bookings.operatorId`, and fires off the post-commit hook slice 6 introduces. **Hard dependency** (proposal §6 "Depends on Slice 6"). | **Not started.** `bookings` on `marketplace-pivot` is still the legacy shape — no `bookingCode`/`operatorId`/`feeSnapshot`/event log. **This slice cannot start until #392 lands.** |
+| **Slice 6 (#392) merged to `marketplace-pivot`** | Slice 7's payload reads `booking_code`, `assigned_vehicle_id`, selected `insurance_snapshot`, `fee_snapshot`, `bookings.operatorId`, and fires off the post-commit hook slice 6 introduces. **Hard dependency** (proposal §6 "Depends on Slice 6"). | **Not started.** `bookings` on `marketplace-pivot` is still the legacy shape — no `bookingCode`/`operatorId`/`insuranceSnapshot`/`feeSnapshot`/event log. **This slice cannot start until #392 lands.** |
 | `operators` table + `pre_auth_handoff_url` column | Confirmation page + email link out to it. | **Merged** (#386). `OperatorRepository` exists with `create`/`existsBySlug` only — slice 7 **adds `findById`** (§4). |
 | `CallerContext.operatorId` / `bypassScope` (#386/#401) | `notification_log` reads are operator-private (§6.2 scoping). | Merged on pivot. |
 | Resend account + `RESEND_API_KEY` secret provisioned | Adapter needs a key; absent → dev stub / prod sentinel (mirrors `GoogleTranslationProvider`). | Provision before the integration test against the real boundary; unit tests inject a fake `fetchFn`. |
@@ -249,7 +249,8 @@ All green before merge: `bun run test` · `bun run lint` · `bun run --filter @k
 ## 9. Execution order & worktree
 
 ```bash
-git worktree add ../kuruma-notifications -b feature/393-notifications-preauth marketplace-pivot
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-notifications -b feature/393-notifications-preauth origin/marketplace-pivot
 ```
 Within the worktree (TDD RED→GREEN per slice, one behavior at a time):
 1. `notification_log` migration → `db:verify` (3 green).
@@ -262,7 +263,7 @@ Within the worktree (TDD RED→GREEN per slice, one behavior at a time):
 8. `routes/notifications.ts` (list + resend).
 9. Web: confirmation-page selected-insurance summary + pre-auth CTA + potential-charges block + i18n keys (en/ja/zh, verify parity).
 10. E2E happy path.
-11. Review → rebase onto `marketplace-pivot` (regenerate migration if journal moved) → PR (`Closes #393`).
+11. Review → rebase onto `origin/marketplace-pivot` (regenerate migration if journal moved) → PR (`Closes #393`).
 
 ---
 

--- a/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
+++ b/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
@@ -1,0 +1,298 @@
+# Slice 7 — Outbound Notifications & Pre-Auth Handoff (issue #393)
+
+**Date:** 2026-06-02
+**Status:** Draft v1 — awaiting green light to create worktree + start TDD
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 row 7; §4 business item 8 + renter items 5/6; §9 items 2/5/17; §10 item 2; §8.1 Resend/pre-auth risks; §8.2 notification-delivery NFR)
+**Format mirror:** `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md`
+**Supersedes:** the thin body of #393 (insufficient detail for AFK implementation)
+
+---
+
+## 0. What this slice is (and is not)
+
+This is an **outbound-integration slice**: it adds a generic `EmailSender` port, one concrete adapter (Resend), two templated email kinds in three languages, a `notification_log` table, and a confirmation-page link to each operator's pre-auth URL. It is the *first* outbound side-effect to leave the API, so it also pays down the `TODO(#300)` outbox marker already sitting in `BookingService` (`packages/api/src/services/booking.ts:234`).
+
+**Locked design (proposal §9 item 5 + §10 item 2, verbatim):** design `EmailSender` in `packages/api/src/services/email/` with methods like `sendBookingNotification(...)` / `sendBookingConfirmation(...)`; the concrete vendor (Resend for DX) is chosen here but **swap cost = one adapter class** — no vendor lock-in at any call site. Generic-by-design.
+
+### Does NOT ship here (cross-slice boundaries — cite before you build)
+
+| Not in slice 7 | Owned by | Why it matters |
+|---|---|---|
+| The booking DB transaction (availability validate → insert → first `booking_events` → fee snapshot) | **Slice 6 (#392)**, proposal §2 "Booking write boundary" + §10 item 14 | Slice 7 fires **after commit only**. We do not touch the transaction. |
+| `bookings.booking_code`, `requested_vehicle_id`, `assigned_vehicle_id`, `fee_snapshot`, `bookings.operatorId`, `booking_events` table | **Slice 6 (#392)**, proposal §5.1 step 4 + §9 item 3 | The notification payload reads these. **They are NOT on `marketplace-pivot` yet** (verified: `bookings` still has the legacy single-`vehicleId` shape). See §1 preconditions. |
+| `operators.pre_auth_handoff_url` **column** | **Already merged (slice 1, #386)** | Verified present on `marketplace-pivot`. Slice 7 *consumes* it; does not add it. |
+| Renter cancellation UI / auto-charge of fees | Post-MVP (proposal §9 items 7/19) | Confirmation email lists a cancellation contact + "potential additional charges" informationally only. |
+| Operator-portal "manual resend" button beyond a basic action | This slice ships the API + a minimal portal surface; rich ops UI is slice 8 polish (proposal §8.2: "failed sends visible to operator with manual-resend button") |
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **Slice 6 (#392) merged to `marketplace-pivot`** | Slice 7's payload reads `booking_code`, `assigned_vehicle_id`, `fee_snapshot`, `bookings.operatorId`, and fires off the post-commit hook slice 6 introduces. **Hard dependency** (proposal §6 "Depends on Slice 6"). | **Not started.** `bookings` on `marketplace-pivot` is still the legacy shape — no `bookingCode`/`operatorId`/`feeSnapshot`/event log. **This slice cannot start until #392 lands.** |
+| `operators` table + `pre_auth_handoff_url` column | Confirmation page + email link out to it. | **Merged** (#386). `OperatorRepository` exists with `create`/`existsBySlug` only — slice 7 **adds `findById`** (§4). |
+| `CallerContext.operatorId` / `bypassScope` (#386/#401) | `notification_log` reads are operator-private (§6.2 scoping). | Merged on pivot. |
+| Resend account + `RESEND_API_KEY` secret provisioned | Adapter needs a key; absent → dev stub / prod sentinel (mirrors `GoogleTranslationProvider`). | Provision before the integration test against the real boundary; unit tests inject a fake `fetchFn`. |
+| `EMAIL_FROM` / `WEB_PUBLIC_ORIGIN` env | `From:` address + absolute links in emails (emails can't use relative URLs). | Add to `.dev.vars` + GitHub Secrets at kickoff. |
+
+If slice-6 contract names differ at kickoff (e.g. the post-commit hook signature), slice 7 adapts its own PR — never refactor a landed slice (per slice-4 precedent).
+
+---
+
+## 2. The canonical pattern this slice mirrors
+
+The codebase already has the **exact interface → adapter → composition-root DI** shape we need: `TranslationProvider` (port) → `GoogleTranslationProvider` (REST adapter with timeout + retry + injectable `fetchFn`) → wired in `index.ts` with a prod sentinel + dev stub. `EmailSender` is the same shape for a different verb.
+
+| Existing artifact (reference, do not edit) | Slice-7 analog |
+|---|---|
+| `services/translation-provider.ts` — `TranslationProvider` port | `services/email/email-sender.ts` — `EmailSender` port |
+| `services/google-translation-provider.ts` — REST adapter, 3s `AbortSignal.timeout`, single retry on 5xx/network, `fetchFn` injected (`#336`) | `services/email/resend-email-sender.ts` — same resilience shape against Resend's `POST /emails` |
+| `index.ts:206-222` — provider chosen by env key; prod sentinel throws on use, dev stub returns a marker | `index.ts` — `EmailSender` chosen by `RESEND_API_KEY`; prod sentinel + dev console stub |
+| `BookingService.ensureThread` (`#335` auto-thread-on-confirm) + `TODO(#300)` outbox marker | `NotificationDispatcher` — the second post-commit side effect; extract the outbox the TODO predicted |
+| `MessageTranslationService` returns `{ ok: true|false, status }`; route maps to HTTP | `NotificationService` returns the same discriminated result for the resend route |
+
+**Boundary reminder (AGENTS.md):** routes → services → repositories, never backwards. `EmailSender` is an **interface in `services/`** with the concrete `ResendEmailSender` constructed **only in `index.ts`**. `packages/shared` gains **no runtime dep** (templates render in the API, not shared). `packages/web` gets **no DB access** — it reads the operator's pre-auth URL via the booking read model the API already returns.
+
+> **Learn: Hexagonal Boundary / DIP.** `EmailSender` is a port; `ResendEmailSender` is the only adapter; the only `new ResendEmailSender(...)` lives in the composition root. The service layer never imports `resend` or names a vendor. Heuristic: *if a service file says `import { Resend }` or `require('resend')`, the adapter leaked into the core — inject the port instead.*
+
+---
+
+## 3. Schema — `notification_log` (`packages/shared/src/db/schema.ts`)
+
+One table, append-then-update lifecycle. A row is **inserted `QUEUED` before** the send attempt and **updated to `SENT`/`FAILED`** after — so a crash mid-send leaves a durable `QUEUED` row the resend path can pick up (at-least-once, proposal §9 item 17 / §8.2).
+
+```ts
+export const notificationKindEnum = pgEnum('notification_kind', [
+  'OPERATOR_BOOKING_ALERT',   // -> operator: a booking landed
+  'RENTER_BOOKING_CONFIRM',   // -> renter: confirmation + pre-auth link
+])
+export const notificationStatusEnum = pgEnum('notification_status', ['QUEUED', 'SENT', 'FAILED'])
+
+export const notificationLog = pgTable('notification_log', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  bookingId: text('bookingId').notNull().references(() => bookings.id),
+  // Tenant owner — every notification belongs to exactly one operator, so
+  // operator-portal reads can scope by operatorId without a join (§6.2).
+  operatorId: text('operatorId').notNull().references(() => operators.id),
+  kind: notificationKindEnum('kind').notNull(),
+  channel: text('channel').notNull().default('EMAIL'),  // future: SMS/LINE without schema churn
+  recipient: text('recipient').notNull(),               // resolved address at send time
+  locale: text('locale').notNull(),                     // en | ja | zh chosen for this send
+  status: notificationStatusEnum('status').notNull().default('QUEUED'),
+  providerMessageId: text('providerMessageId'),         // Resend id on success (audit / dedupe)
+  error: text('error'),                                 // last failure reason (truncated)
+  attempts: integer('attempts').notNull().default(0),
+  // Idempotency: one logical notification per (booking, kind). The dispatcher
+  // upserts on this key so a post-commit replay never double-sends. Mirrors the
+  // `booking:<id>` thread idempotency key in ensureThread (#335).
+  idempotencyKey: text('idempotencyKey').notNull(),
+  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index('idx_notification_log_bookingId').on(t.bookingId),
+  // operator-portal list scopes on operatorId (§6.2); also covers the operatorId FK.
+  index('idx_notification_log_operatorId').on(t.operatorId),
+  unique('notification_log_idempotency_unique').on(t.idempotencyKey),
+])
+```
+
+**`idempotencyKey` format:** `notify:<bookingId>:<kind>` (e.g. `notify:<uuid>:RENTER_BOOKING_CONFIRM`). One renter-confirm + one operator-alert per booking. A second post-commit dispatch (replay) finds the `SENT` row and no-ops; a `FAILED`/`QUEUED` row is what the manual-resend route re-attempts.
+
+**Migration workflow (CLAUDE.md drizzle rules — non-negotiable):**
+```bash
+bun run db:generate --name add_notification_log
+bun run db:migrate
+bun run db:verify          # 3 green checks
+```
+Regenerate on top of slice-6's migrations after rebase (journal `when` must stay monotonic — CLAUDE.md 2026-04-17 trap). Never hand-edit `_journal.json` unless cherry-picking, then bump `when` to `max(prev)+1`.
+
+**No schema change to `operators`** — `pre_auth_handoff_url` already exists (§1).
+
+---
+
+## 4. API layer
+
+### 4a. `EmailSender` port — `services/email/email-sender.ts`
+
+```ts
+export interface EmailMessage {
+  to: string
+  from: string
+  subject: string
+  html: string
+  text: string          // plain-text fallback; deliverability + screen readers
+  replyTo?: string
+}
+export interface SendResult { providerMessageId: string }
+
+/**
+ * Provider-agnostic outbound email port. Implementations call a vendor
+ * (Resend, SES, Postmark…); the service layer depends on this interface so
+ * the vendor swaps at the composition root. Throws on provider failure —
+ * the dispatcher catches, logs FAILED, and never rolls back the booking.
+ */
+export interface EmailSender {
+  send(message: EmailMessage): Promise<SendResult>
+}
+```
+
+### 4b. `ResendEmailSender` adapter — `services/email/resend-email-sender.ts`
+
+REST against `POST https://api.resend.com/emails` (NOT the npm SDK — keeps the CF Workers bundle lean and matches the REST-over-SDK choice in `GoogleTranslationProvider`). Same resilience contract as `#336`:
+- `AbortSignal.timeout(TIMEOUT_MS)` (start 5000ms — email is less latency-sensitive than translate);
+- single retry on network error / 5xx; 4xx returns immediately (caller error, e.g. bad address);
+- `fetchFn: typeof fetch = fetch` injected so unit tests assert the request without a network call;
+- maps the Resend `{ id }` response to `SendResult.providerMessageId`; throws a typed error with the Resend message on `!ok`.
+
+### 4c. Templates — `services/email/templates/`
+
+`packages/shared` stays runtime-dep-free (AGENTS.md), so **templates live in the API**, not shared. Strategy:
+
+- A pure render function per kind: `renderRenterConfirmation(data, locale)` and `renderOperatorAlert(data, locale)` returning `{ subject, html, text }`.
+- **i18n source:** a single `templates/messages/{en,ja,zh}.ts` map keyed by template + field (subject lines, labels, the "potential additional charges" heading, cancellation-contact line). Keep it co-located and typed — these are *outbound* strings, distinct from the web `next-intl` namespaces, so they do not need a dev-server restart. **Do not** reach into `packages/web/messages/*.json` from the API (boundary violation).
+- Renderers are **pure** (data in → strings out) → unit-testable with zero I/O.
+
+> **Learn: Functional Core / Imperative Shell.** Template rendering is the pure core (deterministic strings); `EmailSender.send` is the imperative shell (network). Keeping them split means template assertions need no mock at all. Heuristic: *if a "render" function awaits anything, a side effect leaked into the core.*
+
+**Locale selection:** renter email uses `users.language` (the renter's stored language, already on the booking's renter); operator email uses the operator's display language (en/ja per §8.2 NFR — zh optional for operator). Fallback chain `requested → en`.
+
+**Payload fields (read from the slice-6 booking read model):** `booking_code`, vehicle make/model/plate (assigned vehicle), pickup/return location + datetimes, operator name, selected `insurance_snapshot`, **operator `pre_auth_handoff_url`** (renter email + confirmation page), and the `fee_snapshot` "potential additional charges" block (proposal §9 item 19 — informational only).
+
+### 4d. `NotificationDispatcher` + `NotificationService`
+
+- **`NotificationDispatcher`** (`services/notification-dispatcher.ts`) is the post-commit hook. It is what the `TODO(#300)` in `BookingService` predicted: *"if a second post-booking side effect appears here, extract an outbox/event dispatcher rather than chaining another inline hook."* That condition is now true (thread + email). It:
+  1. Builds the renter + operator notifications from the committed booking;
+  2. For each: upsert a `QUEUED` `notification_log` row by `notify:<bookingId>:<kind>` (skip if already `SENT`);
+  3. `await emailSender.send(...)`; on success update `SENT` + `providerMessageId`; on throw, `console.error` (structured) + update `FAILED` + `error` + `attempts++`.
+  - **Never throws back into the booking path** — booking is authoritative, exactly like `ensureThread`'s catch-and-log.
+- **`NotificationService`** (`services/notification.ts`) backs the operator-portal **list** (`findAll(ctx, { bookingId? })`, operator-scoped, management-read guarded) + **manual resend** (`resend(ctx, notificationId)` → re-runs the dispatcher for that one row, returns `{ ok, status }`).
+
+**Wiring the post-commit fire (no email inside the transaction — proposal §2 / §10 item 14):** after the booking service returns a committed booking, invoke the dispatcher through slice 6's post-commit seam when present; otherwise invoke it from the booking route via `c.executionCtx.waitUntil(...)`. The response does not wait for Resend, and the booking transaction never contains a network call.
+
+### 4e. `OperatorRepository.findById` (additive)
+
+Current interface (`create`/`existsBySlug` only) can't read `pre_auth_handoff_url`. Add:
+```ts
+findById(ctx: CallerContext, id: string): Promise<Operator | undefined>
+```
+to the interface + Drizzle + InMemory pair. Read-scoped: an operator caller only resolves its own row; bypass roles resolve any (mirrors the §6.2 read-scope split). The dispatcher uses `SYSTEM_CONTEXT` since it runs post-commit on the platform's behalf.
+
+### 4f. Routes — `routes/notifications.ts`
+
+- `GET /notifications?bookingId=` — operator-scoped list (management-read guard rejects `RENTER`/`PARTNER`; bypass callers need explicit `?operatorId=` or `?includeAll=true`, mirroring slice 4 §2). For the operator portal badge (proposal §4 business item 8).
+- `POST /notifications/:id/resend` — manual resend; cross-operator id → **404 not 403** (no tenant-existence leak). Uses `ok()`/`fail()` from `routes/helpers.ts`. Gated on management roles.
+
+Mounted at `/` in `index.ts`.
+
+### 4g. Composition root — `index.ts`
+
+Add, mirroring the `translationProvider` block (`index.ts:206-222`):
+```ts
+const emailSender: EmailSender = (() => {
+  const key = process.env.RESEND_API_KEY
+  if (key) return new ResendEmailSender(key, process.env.EMAIL_FROM ?? '')
+  if (process.env.NODE_ENV === 'production') {
+    return { send: async () => { throw new Error('RESEND_API_KEY not configured') } }
+  }
+  return { send: async (m) => { console.info('[email:dev]', m.to, m.subject); return { providerMessageId: 'dev' } } }
+})()
+```
+Construct `NotificationDispatcher(notificationLogRepo, operatorRepo, vehicleRepo, userRepo, emailSender)` and `NotificationService(notificationLogRepo, emailSender, …)`; wire the dispatcher into the booking post-commit seam; `.route('/', createNotificationRoutes(notificationService))`. Add `notificationLogRepo` to the `overrides` test surface (InMemory) like every other repo.
+
+---
+
+## 5. Web layer — confirmation page links to pre-auth
+
+`packages/web/src/app/[locale]/bookings/confirmation/page.tsx` currently renders booking id (`booking.id.slice(0, 8)` → becomes `booking_code` post-slice-6), class, dates, status. Slice 7 adds (proposal §4 renter item 5):
+
+1. **Pre-auth handoff CTA** — a prominent button linking to the operator's `pre_auth_handoff_url` (absolute, external → plain `<a href target="_blank" rel="noopener noreferrer">`, **not** the i18n `Link`). The URL comes from the booking read model the API returns (web has **no DB access** — AGENTS.md). If the operator has no URL configured, hide the CTA (don't render a dead link).
+2. **"Potential additional charges" block** — render `fee_snapshot` rows (overtime/hour, cleaning, no-fuel) informational only (proposal §9 item 19). Slice 6 surfaces the snapshot; slice 7 ensures the email mirrors the page.
+3. Copy that explains the pre-auth step (risk §8.1: "Pre-auth handoff UX confuses tourists" — confirmation page must explain it).
+
+**i18n:** extend the existing `bookings.confirmation` namespace in `packages/web/messages/{en,ja,zh}.json` with `preAuthTitle`, `preAuthExplain`, `preAuthCta`, `potentialChargesTitle`, `cancellationContact`. New keys in an existing namespace **do not** need a dev-server restart (a *new namespace* would — CLAUDE.md). **Verify all three locales have every key** (CLAUDE.md: merges silently drop keys; `lint` parity check at `chore/i18n-parity-lint` enforces).
+
+---
+
+## 6. Tenant scoping (proposal §6.2)
+
+`notification_log` is **operator-private** — same posture as insurance/fees in slice 4:
+- Reads gated by a **management-read guard** (reject `RENTER` + `PARTNER`) *then* `operatorReadScope`: operator callers see only their `operatorId` rows; bypass callers (`PLATFORM_ADMIN` + legacy `STAFF`/`ADMIN`) see across, gated on `ctx.bypassScope === true` (not the role string).
+- The renter never reads `notification_log` via the portal — the renter sees the confirmation **page/email**, not the log.
+- The dispatcher writes with the booking's `operatorId` (from the slice-6 booking row) — no cross-tenant write possible.
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant; mock only the HTTP boundary to Resend)
+
+Per proposal §6.1: E2E required green for slice 7. Mock **only** the Resend HTTP boundary (inject `fetchFn`); no internal mocks.
+
+| Layer | What it asserts |
+|---|---|
+| **Template renderers** (pure, `packages/api/tests/services/email/`) | `renderRenterConfirmation` includes `booking_code`, selected `insurance_snapshot`, the **exact** `pre_auth_handoff_url`, and each `fee_snapshot` line; `ja`/`zh` produce localized subject lines (specific string match, not "truthy"); `text` fallback non-empty; missing pre-auth URL omits the CTA line. |
+| **`ResendEmailSender`** (inject fake `fetchFn`) | Posts to `https://api.resend.com/emails` with `Authorization: Bearer <key>` + correct JSON body; maps `{ id }` → `providerMessageId`; **retries once on 5xx/network, NOT on 4xx**; `AbortSignal` present (mirror `#336` translate-timeout tests). |
+| **`NotificationDispatcher`** (InMemory log + fake sender) | Inserts `QUEUED` then updates `SENT` with `providerMessageId`; on sender throw → `FAILED` + `error` + `attempts=1`, **booking unaffected**; replay with same booking → idempotent (no second `SENT` row, send not called twice); writes the booking's `operatorId`. |
+| **`OperatorRepository.findById`** (Drizzle on Neon `test` + InMemory) | Operator caller resolves own row only; cross-operator id → `undefined`; bypass resolves any; returns `pre_auth_handoff_url`. |
+| **`NotificationService` + routes** | resend re-sends a `FAILED` row → `SENT`; `RENTER`/`PARTNER` read → 403; cross-operator resend id → 404; bypass list without `operatorId`/`includeAll` → 400. |
+| **Drizzle `notification_log`** (Neon `test`) | FK on `bookingId`/`operatorId`; second insert of same `idempotencyKey` → 23505 (proves idempotency seal). |
+| **E2E (Playwright, proposal §6.1)** | renter search → book → **confirmation page shows selected insurance + pre-auth CTA + potential charges**; operator portal shows a notification row. Resend HTTP boundary mocked. Test viewports per §8.2 (mobile-first). |
+
+---
+
+## 8. Per-slice merge gate (proposal §6.1)
+
+All green before merge: `bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` (port/adapter direction — this slice is the litmus test for it) · `bun run lint:modules` · `bun run db:verify` · E2E happy path · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktree
+
+```bash
+git worktree add ../kuruma-notifications -b feature/393-notifications-preauth marketplace-pivot
+```
+Within the worktree (TDD RED→GREEN per slice, one behavior at a time):
+1. `notification_log` migration → `db:verify` (3 green).
+2. `EmailSender` port + template renderers (RED template tests first — pure, fast).
+3. `ResendEmailSender` adapter (RED: fake `fetchFn` asserts request + retry).
+4. `notificationLog` repo pair (InMemory → Drizzle integration).
+5. `OperatorRepository.findById` (additive).
+6. `NotificationDispatcher` + `NotificationService`.
+7. Wire DI in `index.ts` + post-commit seam into the booking route/service.
+8. `routes/notifications.ts` (list + resend).
+9. Web: confirmation-page selected-insurance summary + pre-auth CTA + potential-charges block + i18n keys (en/ja/zh, verify parity).
+10. E2E happy path.
+11. Review → rebase onto `marketplace-pivot` (regenerate migration if journal moved) → PR (`Closes #393`).
+
+---
+
+## 10. Risks (proposal §8.1)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Slice 6 not merged** — payload fields don't exist | High (today) | Blocking | Hard precondition (§1); do not start until #392 lands; adapt to its actual post-commit seam. |
+| Email side effect leaks into the booking transaction | Low | High | Dispatcher runs **after commit** via `waitUntil`/post-commit callback; proposal §2/§10.14; test asserts booking succeeds when sender throws. |
+| Resend free-tier limit (3k/mo) | Low | Low | Free tier covers MVP + early ops; upgrade $20/mo later (proposal §8.1). |
+| Double-send on post-commit replay | Medium | Medium | `notification_log.idempotencyKey` unique on `notify:<bookingId>:<kind>`; dispatcher skips `SENT`; integration test asserts 23505 + no second send. |
+| Pre-auth handoff UX confuses tourists | Medium | Medium | Confirmation page explains the step (proposal §8.1); email reinforces; copy reviewed with Du. |
+| Vendor lock-in creeps into call sites | Low | Medium | `lint:boundaries` + the port/adapter split; no `resend` import outside `resend-email-sender.ts` + `index.ts`. |
+| i18n key drift across en/ja/zh | Medium | Low | `chore/i18n-parity-lint` parity check; verify all three before merge (CLAUDE.md). |
+| Failed send invisible to operator | Low | Medium | `notification_log` `FAILED` rows surfaced in operator portal + manual-resend route (proposal §8.2 / §9 item 17). |
+
+---
+
+## 11. Critical files
+
+**New (API):** `services/email/email-sender.ts`, `services/email/resend-email-sender.ts`, `services/email/templates/{renter-confirmation,operator-alert}.ts`, `services/email/templates/messages/{en,ja,zh}.ts`, `services/notification-dispatcher.ts`, `services/notification.ts`, `repositories/{drizzle,in-memory}/notification-log.ts`, `routes/notifications.ts`.
+**Modify (API):** `schema.ts` (add `notification_log` + enums), `repositories/types.ts` (`NotificationLogRepository` + `OperatorRepository.findById`), `index.ts` (DI + post-commit seam + route mount + overrides), `repositories/drizzle/operator.ts` + `repositories/in-memory/operator.ts` (`findById`), new migration in `drizzle/`.
+**Modify (web):** `app/[locale]/bookings/confirmation/page.tsx`, `messages/{en,ja,zh}.json` (`bookings.confirmation.*` keys), operator-portal notifications surface (minimal — badge/list; rich UI = slice 8).
+**Env:** `RESEND_API_KEY`, `EMAIL_FROM`, optional `EMAIL_REPLY_TO`, `WEB_PUBLIC_ORIGIN` (`.dev.vars` + GitHub Secrets; never hardcode — security rule).
+
+---
+
+## 12. Resolved decisions
+
+1. **Post-commit seam shape.** Prefer a service-level post-commit dispatcher seam from slice 6. If slice 6 lands without one, invoke `NotificationDispatcher` from the booking route via `c.executionCtx.waitUntil`; do not add a second inline side-effect chain inside `BookingService`.
+2. **Operator alert locale.** Default operator alerts to `ja` with `en` fallback unless a landed operator-language field exists. Do not add `operators.language` in slice 7.
+3. **`waitUntil` vs awaited send.** Use `waitUntil` for Resend sends so booking latency is unaffected. The `QUEUED` row is inserted before the send attempt, and manual resend covers failures.
+4. **Reply-to / cancellation contact.** Use `EMAIL_REPLY_TO` when configured, otherwise `EMAIL_FROM`, as the MVP cancellation-contact/reply-to address. Do not add an operator contact-email column in slice 7.

--- a/docs/plans/2026-06-02-slice8-demo-seed-e2e.md
+++ b/docs/plans/2026-06-02-slice8-demo-seed-e2e.md
@@ -27,7 +27,7 @@ Status snapshot (2026-06-02):
 | Provides | Slice / issue | State | Seed needs it for |
 |---|---|---|---|
 | `operators`, role enum, `CallerContext.operatorId` | #386 (slice 1) | **CLOSED / merged** | operator rows, scoped seed verification |
-| `locations` table + `vehicles.pickup_location_id` | #387 (slice 2) | in progress (`feature/387-locations`) | location rows, vehicle→location FK |
+| `locations` table + `vehicles.pickup_location_id` | #387 (slice 2) | in review (PR #414 → `marketplace-pivot`) | location rows, vehicle→location FK |
 | `vehicle_classes.acriss_code` + vehicle CRUD | #388 (slice 3) | not started | ACRISS distribution across ~40 vehicles |
 | `insurance_options`, `fee_schedules`, vehicle-only pricing | #389 / #404-406 (slice 4) | planned (`2026-06-02-slice4-*.md`) | insurance + fee seed rows |
 | storefront search read models | #391 (slice 5) | **OPEN** | E2E step 1–3 (search → storefront → vehicle) |
@@ -156,7 +156,7 @@ New spec: `e2e/marketplace-happy-path.spec.ts`. **This is the required-green gat
 | 2. Storefront result | Renter clicks the Best Car Rental Osaka card | URL → `/en/storefronts/best-car-rental/<location>`; heading `level:1` = operator+location name; available-vehicle list `toHaveCount(expected)` for the seeded date range | "storefront result" |
 | 3. Vehicle selection | Renter picks the seeded `CCAR` Toyota Yaris | selection panel shows make/model/**license plate** + `dailyRateJpy` formatted as `¥8,000`; **insurance dropdown lists exactly the operator's 2 options** (Normal/Premium) | "vehicle selection" |
 | 4. Booking | Renter selects Premium insurance, confirms dates, enters contact (email/name/phone/lang), submits | confirmation page URL contains `/booking/`; **booking-code matches `/^[2-9A-HJ-NP-Z]{8}$/`** (no-confusables alphabet, §9 item 3); page shows selected vehicle, selected Premium insurance, pre-auth handoff link (`href` = operator pre-auth URL), and a **"potential additional charges"** block listing the snapshotted overtime/cleaning/no-fuel fees | "vehicle selection → booking → confirmation" |
-| 5. Operator-visible notification | Switch to operator session (Best Car Rental owner), open `/manage/best-car-rental/bookings` | new booking row present with the **same booking-code** from step 4; **notification badge count incremented**; `notification_log` row rendered with `status: sent` (or `queued`) | "confirmation notification visible in operator portal" |
+| 5. Operator-visible notification | Switch to operator session (Best Car Rental owner), open flat `/manage/bookings` | new booking row present with the **same booking-code** from step 4; **notification badge count incremented**; `notification_log` row rendered with `status: sent` (or `queued`) | "confirmation notification visible in operator portal" |
 
 `test.step()` per row so the HTML report reads as the acceptance script. A failing step captures screenshot+trace (config already on). Run the renter journey on a mobile viewport variant too (proposal §8.2: iPhone/Android Chrome) — one extra project or `test.use({ viewport })` block.
 
@@ -220,17 +220,18 @@ Bundle measurement runs on the build output, independent of feature merges (§1.
 A `docs/runbooks/` markdown (or runbook section) the operator follows live:
 
 **Cold start**
-1. `git checkout marketplace-pivot && bun install`
-2. Point `.env` + API `.dev.vars` at a fresh Neon branch off `marketplace-pivot` (proposal §5.2).
-3. `bun run db:migrate` → `bun run db:seed` → `bun run db:seed-bookings` → `bun run db:verify` (3 green).
-4. `bun run dev:api` and `bun run dev` (two terminals).
+1. `git fetch origin`
+2. Use a fresh worktree or fast-forwarded local branch from `origin/marketplace-pivot`, then `bun install`.
+3. Point `.env` + API `.dev.vars` at a fresh Neon branch off the fully merged pivot (proposal §5.2).
+4. `bun run db:migrate` → `bun run db:seed` → `bun run db:seed-bookings` → `bun run db:verify` (3 green).
+5. `bun run dev:api` and `bun run dev` (two terminals).
 
 **Walkthrough script (mirrors the E2E journey, §5.1)**
 1. **Renter search** — open renter portal, search Osaka pickup/return + dates + Compact class → storefront cards across all 3 operators with per-class summaries + min price.
 2. **Storefront** — open *Best Car Rental — Namba* → available vehicles for the dates, grouped by ACRISS class.
 3. **Select** — pick the Toyota Yaris (CCAR) → plate + price + insurance options shown.
 4. **Book** — choose Premium insurance, confirm, enter contact → confirmation page with booking-code, selected insurance, pre-auth handoff link, and "potential additional charges".
-5. **Operator view** — log in as the Best Car Rental owner → `/manage/best-car-rental/bookings` shows the new booking + notification badge; show the operator-notification email content.
+5. **Operator view** — log in as the Best Car Rental owner → flat `/manage/bookings` shows the new booking + notification badge; show the operator-notification email content.
 6. **Show range** — switch locale to ja and zh on the renter pages; switch to a second operator portal to show tenant isolation (operator 2 cannot see operator 1's bookings — proposal §6.2).
 
 **Talking points:** multi-tenant isolation, ACRISS-standard taxonomy (Trip.com-ready), 48h turnaround, fee disclosure pattern (NicoNico/Hertz parity), substitution audit trail.
@@ -252,7 +253,8 @@ A `docs/runbooks/` markdown (or runbook section) the operator follows live:
 ## 10. Execution order & worktree
 
 ```bash
-git worktree add ../kuruma-demo-seed -b feature/390-demo-seed-e2e marketplace-pivot
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-demo-seed -b feature/390-demo-seed-e2e origin/marketplace-pivot
 ```
 
 Within the worktree, TDD where applicable (seed builders + booking-code generator are pure → unit-test first; E2E journey is RED via `test.fixme` → GREEN as slice 5/6/7 UI lands):

--- a/docs/plans/2026-06-02-slice8-demo-seed-e2e.md
+++ b/docs/plans/2026-06-02-slice8-demo-seed-e2e.md
@@ -1,0 +1,289 @@
+# Slice 8 — Demo Seed, E2E Happy-Path & Polish (issue #390)
+
+**Date:** 2026-06-02
+**Status:** Draft v1 — awaiting green light to create the worktree
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 row 8, §6.1 E2E gate, §6.2 scoping, §7 NFRs, §8.2, §9 item 9)
+**Slice intent (proposal §6 row 8):** "3 operators × multi-location × ~40 vehicles across ACRISS codes, sample bookings, E2E happy-path test, i18n sweep. Demo: cold-start to Qiao demo."
+
+---
+
+## 0. What this slice is (and is not)
+
+Slice 8 is the **integration / polish** slice — it ships no new domain entity. It (a) replaces the legacy flat vehicle seed with a credible marketplace dataset, (b) lands the **renter happy-path Playwright test** that is the §6.1 merge gate for this slice, (c) runs an **i18n parity + quality sweep**, (d) **verifies the §7 performance budgets**, and (e) produces a **demo runbook** for the Qiao/Du walkthrough.
+
+**Acceptance (epic #385):** the demo shows *renter search → storefront result → vehicle selection → booking → confirmation notification visible in the operator portal*. That exact sentence is both the E2E assertion target (§5) and the runbook script (§8).
+
+**Not in scope:** any schema change, any new repo/service/route, any new feature UI. If the seed needs a column that does not exist, that is a defect in slices 1–7, not a slice-8 task — treat it as an upstream bug, do not patch it here.
+
+---
+
+## 1. The hard dependency (read this first)
+
+> **Slice 8 can only *fully* land after slices 3–7 merge to `marketplace-pivot`.** The seed writes `operators`, `locations`, `vehicle_classes.acriss_code`, `vehicles` (operator/location/class FKs), `insurance_options`, `fee_schedules`, `bookings` (`requested_vehicle_id` / `assigned_vehicle_id` / `booking_code` / `insurance_option_id` / `insurance_snapshot` / `fee_snapshot`), `booking_events`, and `notification_log`. None of those tables/columns exist on `marketplace-pivot` yet for slices 5–7.
+
+Status snapshot (2026-06-02):
+
+| Provides | Slice / issue | State | Seed needs it for |
+|---|---|---|---|
+| `operators`, role enum, `CallerContext.operatorId` | #386 (slice 1) | **CLOSED / merged** | operator rows, scoped seed verification |
+| `locations` table + `vehicles.pickup_location_id` | #387 (slice 2) | in progress (`feature/387-locations`) | location rows, vehicle→location FK |
+| `vehicle_classes.acriss_code` + vehicle CRUD | #388 (slice 3) | not started | ACRISS distribution across ~40 vehicles |
+| `insurance_options`, `fee_schedules`, vehicle-only pricing | #389 / #404-406 (slice 4) | planned (`2026-06-02-slice4-*.md`) | insurance + fee seed rows |
+| storefront search read models | #391 (slice 5) | **OPEN** | E2E step 1–3 (search → storefront → vehicle) |
+| `booking_events`, `bookings.*` marketplace cols, exclusion on `assigned_vehicle_id` | #392 (slice 6) | **OPEN** | sample bookings + E2E step 4 (book) |
+| `EmailSender`, `notification_log`, operator notification badge | #393 (slice 7) | **OPEN** | E2E step 5 (operator-visible notification) |
+
+**Entity shapes are cited from the proposal and resolved slice plans, not invented** — each seed builder consumes whatever the *merged* migration for that slice produced. Concrete shapes confirmed so far: insurance/fee schema in `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` §3–4; booking-code + selected-insurance snapshot in `docs/plans/2026-06-02-slice6-booking-event-log.md` §5–6; turnaround `default_turnaround_minutes = 2880` in proposal §5.1.
+
+### 1.1 What can be drafted before 3–7 merge (de-risking)
+
+To keep slice 8 off the critical path, draft these against the proposal contracts and stub-validate, sequencing the final wire-up after merges:
+
+1. **Seed *data tables* (pure data, no DB writes)** — the operator/location/vehicle/ACRISS/booking arrays as typed `const` fixtures in `packages/shared/src/db/seed-data/`. No schema import, so they compile today. Review for credibility (names, plates, ACRISS spread, prices) with Du early.
+2. **The i18n sweep script invocation + checklist** (§6) — `lint:i18n-parity` already exists and passes (501 keys × en/ja/zh). The renter-facing key audit can start as soon as slice 5/6/7 namespaces land incrementally.
+3. **Playwright journey skeleton** (§5) — `describe`/`test.step` structure with `test.fixme()` placeholders, plus the marketplace mock-API fixtures, drafted against the §6.1 flow. The mock-API extension (storefront/booking/notification endpoints) is the only part that can land before slice 5/6 UI exists.
+4. **Perf-budget harness** (§7) — the build-size assertion and Lighthouse/`@next/bundle-analyzer` step are infra, independent of feature merges.
+
+**The DB-writing seed builders + the real assertions wire up last**, after each slice's migration is merged. Net: slice-8 wall-clock collapses to ~1 day of integration once 5–7 are in, instead of 2–3 days cold.
+
+---
+
+## 2. Current state (grounded in merged code)
+
+| Asset | Path | Slice-8 disposition |
+|---|---|---|
+| Legacy vehicle seed | `packages/shared/src/db/seed.ts` | **Rewritten.** Today inserts 16 flat `SEED_VEHICLES` with `dailyRateJpy`/`hourlyRateJpy`/`bufferMinutes:60`, **no operator/location/class FK**. Marketplace seed supersedes it. |
+| Legacy booking seed | `packages/shared/src/db/seed-bookings.ts` | **Rewritten.** Today writes `bookings` with `vehicleId` + `classId` + `effectiveEndAt`; marketplace schema replaces `vehicleId` with requested/assigned (§5.1) and adds `booking_code` + `booking_events`. |
+| `db:seed` / `db:seed-bookings` commands | `package.json:24-25` | Repointed to the marketplace seed; ordering documented (§4). |
+| Playwright config | `playwright.config.ts` | Reused. `testDir: ./e2e`, mock-API webServer on `:8787`, web dev on `:3001`, `screenshot: only-on-failure`, `trace: on-first-retry`. |
+| Mock API | `e2e/mock-api.ts` | **Extended** with storefront-search / booking-submit / operator-notification fixtures (§5.3). |
+| Existing E2E specs | `e2e/landing.spec.ts`, `e2e/browse.spec.ts` (#296 scaffold, #321 browse) | Kept; the new `marketplace-happy-path.spec.ts` is additive. Existing specs guard against regressions per §6.2. |
+| i18n messages | `packages/web/messages/{en,ja,zh}.json` | 9 namespaces (`common errors auth nav catalog vehicles business messaging bookings landing`), **501 keys each, in parity today**. Sweep adds the slice-5/6/7 namespaces and re-verifies. |
+| Parity lint | `scripts/lint-i18n-parity.ts` + `package.json:18` (`lint:i18n-parity`) | Machine half of the sweep (#375). Quality half is manual (§6). |
+| `test:e2e` command | `package.json:11` (`bunx playwright test`) | The §6.1 gate runner. |
+
+**Boundary note (AGENTS.md):** the seed lives in `@kuruma/shared` and writes through Drizzle directly — that is the one sanctioned non-API DB writer (it is a dev/ops script, not request-path code). The E2E mocks **only HTTP boundaries** (Resend, OAuth) per §6.2; it does not mock internal collaborators.
+
+---
+
+## 3. Demo seed design (proposal §9 item 9: the "credibility floor")
+
+Target: **3 operators × 3 locations each × ~40 vehicles total across 6–8 ACRISS codes**, plus insurance, fees, and a spread of sample bookings/events. Built as typed data fixtures (`seed-data/`) consumed by idempotent builder functions.
+
+### 3.1 Operators (3)
+
+| # | Name | Slug (auto, §9 item 15) | Pre-auth URL (operators col, §9 item 2) | Locale of free-text |
+|---|---|---|---|---|
+| 1 | Best Car Rental | `best-car-rental` | configured Stripe pre-auth site | en/ja mix |
+| 2 | Kansai Drive | `kansai-drive` | placeholder pre-auth URL | ja |
+| 3 | Sakura Mobility | `sakura-mobility` | placeholder pre-auth URL | ja/en |
+
+Each operator gets one `OPERATOR_OWNER` user (`owner@<slug>.example.test`) so the demo can log into each portal. Emails use `@example.test` (matches the existing `seed-bookings.ts` convention so cleanup greps cleanly). One `PLATFORM_ADMIN` seeded from `PLATFORM_ADMIN_EMAILS` (proposal §9 item 23).
+
+### 3.2 Locations (3 per operator = 9)
+
+Real Kansai pickup points for credibility: e.g. Best Car Rental → **Namba**, **Shin-Osaka**, **Kansai Airport (KIX)**; Kansai Drive → **Umeda**, **Tennoji**, **Kobe Sannomiya**; Sakura Mobility → **Kyoto Station**, **Nara**, **Osaka Castle area**. Each carries an address, operating hours, and `default_turnaround_minutes = 2880` (48h, proposal §2/§5.1) — one location overrides to a shorter buffer to demo configurability.
+
+### 3.3 ACRISS classes (6–8 codes) + vehicle distribution (~40)
+
+ACRISS first letter = category; classes live on `vehicle_classes.acriss_code` (proposal §2, §10 item 13). Distribution keeps every storefront searchable across classes:
+
+| ACRISS | Class label (i18n key) | Example models | ~Count |
+|---|---|---|---|
+| `MCAR` | Mini (kei) | Honda N-BOX, Daihatsu Tanto, Suzuki Hustler | 7 |
+| `ECAR` | Economy | Toyota Aqua, Honda Fit | 6 |
+| `CCAR` | Compact | Toyota Yaris, Mazda 2 | 6 |
+| `ICAR` | Intermediate | Toyota Corolla | 5 |
+| `SCAR` | Standard / sedan | Toyota Camry | 4 |
+| `IFAR` | Intermediate SUV | Mazda CX-5, Toyota RAV4, Suzuki Jimny | 6 |
+| `FFAR` | Full-size SUV | Toyota Harrier | 3 |
+| `PVAR` | Premium van (7+) | Toyota Alphard, Sienta, Honda Freed | 4 |
+
+≈ **41 vehicles**, 8 ACRISS codes, spread across all 3 operators and 9 locations (no operator has a single-class fleet — each storefront must return ≥3 distinct class summaries so the search-result card is convincing). Vehicles reuse the existing seed's make/model/photos/seats but **add** `operator_id`, `class_id` (ACRISS), `pickup_location_id`, per-vehicle `dailyRateJpy` (pricing lives on the vehicle now, §5.1), `shaken_expiry_date`, and `turnaround_minutes_override` on one vehicle to demo the override path. Plates are realistic Kansai format (`なにわ 300 あ 12-34`).
+
+### 3.4 Insurance + fees (consume slice-4 schema)
+
+Per `docs/plans/2026-06-02-slice4-*.md` §3–4 and proposal §2/§9 item 19:
+- **Insurance** (`insurance_options`): each operator gets 2 rows — **Normal** (deductible ¥150,000) and **Premium** (deductible ¥250,000) from notes_02 defaults; operator-set `dailyPriceJpy` (e.g. ¥1,500 / ¥2,800).
+- **Fee schedules** (`fee_schedules`): each operator gets the three platform fee types — `OVERTIME_HOURLY` (PER_HOUR, e.g. ¥1,000), `CLEANING_FLAT` (FLAT, e.g. ¥5,000), `NO_FUEL_FLAT` (FLAT, e.g. ¥3,000). At least one operator sets a per-class `OVERTIME_HOURLY` (e.g. higher for `PVAR`) to demo the per-class path and exercise the composite-FK seal.
+
+### 3.5 Sample bookings + events (consume slice-6 schema)
+
+A spread mirroring the current `seed-bookings.ts` time distribution (past COMPLETED, today ACTIVE, future CONFIRMED) but in marketplace shape:
+- `requested_vehicle_id` = `assigned_vehicle_id` initially (proposal §2); **one** booking carries a `VEHICLE_SUBSTITUTED` event (old/new vehicle, reason) to demo the substitution audit trail (§9 item 25).
+- each booking has a generated `booking_code` (8-char no-confusables base32), selected `insurance_option_id` + `insurance_snapshot`, and a `fee_snapshot jsonb` snapshotted from §3.4 fees (proposal §9 item 19).
+- `booking_events` append-only: every booking gets an initial `BOOKING_CREATED` event; the demo "live" booking created during the E2E run produces a fresh event + `notification_log` row.
+- demo renters reuse the `@example.test` personas (`Tanaka Yui`/ja, `Chen Wei`/zh, `Sarah Smith`/en, `Sato Hiroshi`/ja) so all three locales are represented.
+- bookings respect the exclusion constraint on `assigned_vehicle_id` + 48h turnaround — seed times are chosen to avoid self-collision.
+
+### 3.6 Seed structure & idempotency
+
+```
+packages/shared/src/db/
+  seed-data/                # pure typed fixtures (draftable pre-merge, §1.1)
+    operators.ts  locations.ts  vehicles.ts  insurance.ts  fees.ts  bookings.ts
+  seed.ts                   # orchestrator: operators → locations → classes → vehicles → insurance → fees
+  seed-bookings.ts          # bookings + events + notification_log (depends on seed.ts output)
+```
+
+Idempotency: delete-by-`@example.test` / delete-by-seeded-operator-slug before insert (same pattern as today's `seed.ts:307` and `seed-bookings.ts:31-35`). FK order matters — children deleted before parents, inserted parents-first. Run order per CLAUDE.md: `db:generate → db:migrate → db:seed → db:seed-bookings → db:verify`.
+
+---
+
+## 4. Seed execution & ordering
+
+```bash
+bun run db:migrate          # all slices 1-7 migrations applied on marketplace-pivot
+bun run db:seed             # operators, locations, classes(ACRISS), vehicles, insurance, fees
+bun run db:seed-bookings    # sample bookings + events + notification_log rows
+bun run db:verify           # 3 green checks (schema/journal/DB sync)
+```
+
+`db:seed` and `db:seed-bookings` stay as separate `package.json` scripts (already wired: `:24-25`). Document a `db:seed:all` convenience script chaining both for the runbook.
+
+---
+
+## 5. E2E happy-path journey (the §6.1 merge gate)
+
+New spec: `e2e/marketplace-happy-path.spec.ts`. **This is the required-green gate before slice 8 merge** (proposal §6.1: "renter search → storefront result → vehicle selection → book → confirmation email visible in operator portal"). Mutation-resistant assertions only — specific text/URL/role queries, never `toBeVisible()`-truthiness on a bare container.
+
+### 5.1 Journey mapped to acceptance criteria
+
+| Step | User action | Mutation-resistant assertion | Acceptance clause |
+|---|---|---|---|
+| 1. Search | Renter on `/en` fills pickup+return location, start+end datetime, class filter; clicks **Search** | URL → `/en/search?...`; result region has ≥1 storefront card; **`expect(cards.first()).toContainText('Best Car Rental')`** and the per-class summary text (`Compact ×N · from ¥X/day`) | "renter search → storefront result" |
+| 2. Storefront result | Renter clicks the Best Car Rental Osaka card | URL → `/en/storefronts/best-car-rental/<location>`; heading `level:1` = operator+location name; available-vehicle list `toHaveCount(expected)` for the seeded date range | "storefront result" |
+| 3. Vehicle selection | Renter picks the seeded `CCAR` Toyota Yaris | selection panel shows make/model/**license plate** + `dailyRateJpy` formatted as `¥8,000`; **insurance dropdown lists exactly the operator's 2 options** (Normal/Premium) | "vehicle selection" |
+| 4. Booking | Renter selects Premium insurance, confirms dates, enters contact (email/name/phone/lang), submits | confirmation page URL contains `/booking/`; **booking-code matches `/^[2-9A-HJ-NP-Z]{8}$/`** (no-confusables alphabet, §9 item 3); page shows selected vehicle, selected Premium insurance, pre-auth handoff link (`href` = operator pre-auth URL), and a **"potential additional charges"** block listing the snapshotted overtime/cleaning/no-fuel fees | "vehicle selection → booking → confirmation" |
+| 5. Operator-visible notification | Switch to operator session (Best Car Rental owner), open `/manage/best-car-rental/bookings` | new booking row present with the **same booking-code** from step 4; **notification badge count incremented**; `notification_log` row rendered with `status: sent` (or `queued`) | "confirmation notification visible in operator portal" |
+
+`test.step()` per row so the HTML report reads as the acceptance script. A failing step captures screenshot+trace (config already on). Run the renter journey on a mobile viewport variant too (proposal §8.2: iPhone/Android Chrome) — one extra project or `test.use({ viewport })` block.
+
+### 5.2 What is mocked vs real (proposal §6.2)
+
+- **Mocked (HTTP boundaries only):** Resend send (the mock-API records the call and flips `notification_log.status`), OAuth callback (a test session helper sets the renter/operator JWT). **Nothing internal is mocked.**
+- **Real:** the entire web UI render, routing, search/booking/notification API contract via the mock-API fixtures, i18n message resolution. The mock-API mirrors the *real* response envelope (`{ success, data }` per `e2e/mock-api.ts:57-58`).
+
+> Note: the current harness (`playwright.config.ts:42-49`) deliberately uses placeholder `DATABASE_URL` and routes to the mock-API — the spec never touches Postgres. Real-DB booking coverage is the **integration** suite (slice 6), not this E2E. This matches the existing two-track E2E strategy (`memory/project_e2e-strategy`).
+
+### 5.3 Mock-API extension (`e2e/mock-api.ts`)
+
+Add fixture endpoints mirroring the slice-5/6/7 real contracts:
+- `GET /storefronts?from&to&...` → storefront cards with `class_summaries` (proposal §9 item 21).
+- `GET /storefronts/:slug/:locationId/vehicles?from&to&class` → available vehicles for the range.
+- `GET /insurance-options?operatorId=` → the operator's 2 options.
+- `POST /bookings` → returns a fixed booking-code matching the no-confusables regex + `fee_snapshot`.
+- `GET /bookings?operatorId=` (operator portal) → includes the just-created booking.
+- `GET /notifications?operatorId=` → one `sent` row.
+
+Fixtures stay frozen-timestamp (`FROZEN_TIMESTAMP`, mock-api.ts:7) for deterministic assertions.
+
+---
+
+## 6. i18n sweep checklist (#375 parity + quality)
+
+Two halves, per `scripts/lint-i18n-parity.ts` header comment:
+
+**(a) Machine — parity (automatable, CI-enforced):**
+- [ ] `bun run lint:i18n-parity` green — all locales same key set (today: 501 keys × 3).
+- [ ] After each slice 5/6/7 namespace lands, re-run; conflict resolution silently drops keys (CLAUDE.md i18n gotcha) — verify post-merge.
+- [ ] New marketplace namespaces present in **all three** files: `search`/`storefront` (slice 5), `booking`/`confirmation` (slice 6), notification/email strings (slice 7).
+
+**(b) Manual — quality (the #375 manual half the lint does NOT cover):**
+- [ ] **Renter-facing en/ja/zh** (proposal §8.2 hard requirement): search form, storefront card, vehicle selection, booking form, confirmation page incl. selected insurance + "potential additional charges" block, confirmation email body — every value actually translated, not EN copied into JA/ZH.
+- [ ] **Operator portal en/ja minimum** (zh optional per §8.2): locations, vehicles, insurance, fees, bookings list + notification badge.
+- [ ] ACRISS class labels translated in all three (proposal §4 platform item 2).
+- [ ] Outbound email templates (operator notification + renter confirmation) translated en/ja/zh (proposal §4 platform, §8.2 notification row).
+- [ ] **Restart dev server after adding any new namespace** — `rm -rf packages/web/.next && bun run dev` (CLAUDE.md i18n gotcha: new namespaces need a restart).
+- [ ] Operator-entered free-text is single-language per field by design (§9 item 4) — do **not** flag those as "missing translation".
+
+---
+
+## 7. Performance verification (proposal §7 / §8.2 budgets)
+
+These NFRs are **explicitly verified in slice 8** (§7: "Next.js bundle already meets this; verify in slice 8"):
+
+| Budget | Target | How verified in slice 8 |
+|---|---|---|
+| **First-load JS** | **< 500 KB** on renter pages (§7, §8.2) | `bun run --filter @kuruma/web build` → read Next.js per-route "First Load JS" for `/`, `/search`, `/storefronts/*`, `/booking/*`. Record numbers in the runbook. If any renter route exceeds, file a follow-up (do not fix here unless trivial). |
+| **Search perf** | live availability < 500 ms p95 at MVP scale (3 ops × 40 vehicles) (§7, §8.2) | Hit the real search endpoint against the seeded `test`/dev branch; record p95 over ~50 runs. "Not enforced via SLO yet" (§7) — measure + record, do not gate. |
+| **Responsive** | renter portal usable on iPhone + Android Chrome (§8.2) | E2E mobile-viewport variant (§5.1). |
+| **Accessibility** | WCAG 2.1 AA — contrast, keyboard nav, aria on icon-only controls (§8.2) | Spot-audit renter happy-path pages (axe pass + keyboard-only run of the journey). |
+
+Bundle measurement runs on the build output, independent of feature merges (§1.1 item 4) — can be wired early.
+
+---
+
+## 8. Demo runbook (cold-start → Qiao/Du walkthrough)
+
+A `docs/runbooks/` markdown (or runbook section) the operator follows live:
+
+**Cold start**
+1. `git checkout marketplace-pivot && bun install`
+2. Point `.env` + API `.dev.vars` at a fresh Neon branch off `marketplace-pivot` (proposal §5.2).
+3. `bun run db:migrate` → `bun run db:seed` → `bun run db:seed-bookings` → `bun run db:verify` (3 green).
+4. `bun run dev:api` and `bun run dev` (two terminals).
+
+**Walkthrough script (mirrors the E2E journey, §5.1)**
+1. **Renter search** — open renter portal, search Osaka pickup/return + dates + Compact class → storefront cards across all 3 operators with per-class summaries + min price.
+2. **Storefront** — open *Best Car Rental — Namba* → available vehicles for the dates, grouped by ACRISS class.
+3. **Select** — pick the Toyota Yaris (CCAR) → plate + price + insurance options shown.
+4. **Book** — choose Premium insurance, confirm, enter contact → confirmation page with booking-code, selected insurance, pre-auth handoff link, and "potential additional charges".
+5. **Operator view** — log in as the Best Car Rental owner → `/manage/best-car-rental/bookings` shows the new booking + notification badge; show the operator-notification email content.
+6. **Show range** — switch locale to ja and zh on the renter pages; switch to a second operator portal to show tenant isolation (operator 2 cannot see operator 1's bookings — proposal §6.2).
+
+**Talking points:** multi-tenant isolation, ACRISS-standard taxonomy (Trip.com-ready), 48h turnaround, fee disclosure pattern (NicoNico/Hertz parity), substitution audit trail.
+
+---
+
+## 9. Tests & merge gate
+
+| Layer | Slice-8 coverage |
+|---|---|
+| **Unit** | Seed builders: ACRISS distribution covers 6–8 codes; every storefront returns ≥3 class summaries; booking-code generator matches no-confusables regex; idempotent re-seed is a no-op (count stable). Pure-function tests on `seed-data/` fixtures. |
+| **Integration** (Neon `test`/dev) | Run the full seed against a real branch; assert row counts (3 operators, 9 locations, ~41 vehicles, 6 insurance, 9+ fees, N bookings), FK integrity, exclusion-constraint non-violation, `db:verify` green. |
+| **E2E (Playwright)** | `marketplace-happy-path.spec.ts` (§5) — **the required §6.1 gate**. Plus existing `landing`/`browse` specs stay green (regression guard, §6.2). |
+
+**Merge gate (proposal §6.1, all green):** `bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run lint:i18n-parity` · `bun run db:verify` · **`bun run test:e2e` (happy-path green — required for slice 8)** · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 10. Execution order & worktree
+
+```bash
+git worktree add ../kuruma-demo-seed -b feature/390-demo-seed-e2e marketplace-pivot
+```
+
+Within the worktree, TDD where applicable (seed builders + booking-code generator are pure → unit-test first; E2E journey is RED via `test.fixme` → GREEN as slice 5/6/7 UI lands):
+
+1. Draftable-now (§1.1): `seed-data/` fixtures, i18n checklist, Playwright skeleton + mock-API extension, perf harness.
+2. After slices 3–4 merge: wire `seed.ts` (operators→locations→classes→vehicles→insurance→fees); integration row-count tests green.
+3. After slice 6 merge: wire `seed-bookings.ts` (bookings+events+`booking_code`+`fee_snapshot`); E2E steps 1–4 green.
+4. After slice 7 merge: `notification_log` seed + E2E step 5 green; full §6.1 gate green.
+5. i18n sweep (§6) + perf verification (§7) + runbook (§8).
+6. Rebase onto `origin/marketplace-pivot`, review, PR (`Closes #390`).
+
+Always rebase, never force push (CLAUDE.md session protocol).
+
+---
+
+## 11. Resolved decisions / cross-slice risks
+
+| # | Risk / question | Owner | Mitigation |
+|---|---|---|---|
+| 1 | **Slice 8 is gated on 5/6/7, all OPEN.** It cannot fully land until they merge. | sequencing | §1.1 draftable-now work keeps it off the critical path; final wire-up ≈ 1 day post-merge. |
+| 2 | Seed needs a column a slice didn't ship (e.g. `operators.pre_auth_handoff_url`, `vehicles.turnaround_minutes_override`). | slices 2/7 | Treat as a defect in the owning slice; do **not** add schema in slice 8. Proposal §9 items 2 & 20 mandate these — verify present at wire-up. |
+| 3 | Concurrent seed migration is N/A (slice 8 adds no migration) but seed **assumes journal is clean** post-5/6/7. | this slice | `db:verify` before seeding; watch the out-of-order `when` trap (CLAUDE.md 2026-04-17) if slices rebased. |
+| 4 | E2E mock-API contract drifts from real slice-5/6 API. | this slice | Mirror the `{ success, data }` envelope; cross-check fixture shapes against the merged route handlers at wire-up. The integration suite (slice 6) is the real-DB truth; E2E is render/flow. |
+| 5 | i18n quality (vs parity) is manual and easy to skip. | this slice | §6(b) explicit checklist; lint catches parity, human catches EN-copied-into-JA. |
+| 6 | First-load JS may exceed 500 KB once slice-5/6 renter pages land. | slices 5/6 | §7 measures at build; if over, file follow-up — the deploy-bridge (§8 of proposal) bundle concern is separate. |
+| 7 | Booking-code regex must match the real generator alphabet exactly. | slice 6 | Verify the nanoid alphabet (`2-9A-HJ-NP-Z`, excludes `0 O 1 I l`) against slice-6's impl before asserting in E2E. |
+
+---
+
+## 12. Critical files
+
+**New:** `e2e/marketplace-happy-path.spec.ts`, `packages/shared/src/db/seed-data/*.ts`, demo runbook (`docs/runbooks/2026-demo-runbook.md` or runbook section).
+**Modified:** `packages/shared/src/db/seed.ts`, `packages/shared/src/db/seed-bookings.ts`, `e2e/mock-api.ts`, `package.json` (optional `db:seed:all`), `packages/web/messages/{en,ja,zh}.json` (sweep top-ups only — most keys ship in their owning slices).
+**Read-only (verify, never modify):** `playwright.config.ts`, `scripts/lint-i18n-parity.ts`, `packages/shared/src/db/schema.ts`.


### PR DESCRIPTION
Implementation plan docs for the five not-yet-started slices of the marketplace MVP pivot (epic #385). One doc per slice, each also posted as a comment on its issue. **Planning only — no code, schema, migrations, or tests.**

## Docs
| Slice | Issue | Doc |
|------|-------|-----|
| 3 ACRISS + vehicle CRUD | #388 | `docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md` |
| 5 Renter storefront search | #391 | `docs/plans/2026-06-02-slice5-renter-storefront-search.md` |
| 6 Booking + event log | #392 | `docs/plans/2026-06-02-slice6-booking-event-log.md` |
| 7 Notifications + pre-auth | #393 | `docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md` |
| 8 Demo seed + E2E | #390 | `docs/plans/2026-06-02-slice8-demo-seed-e2e.md` |

Each is grounded in the actual merged code and cites the source-of-truth proposal (`docs/plans/2026-05-25-marketplace-mvp-proposal.md`) for any cross-slice contract.

## Key resolution — insurance ownership
The one genuine cross-slice conflict is resolved: **booking (slice 6) owns `insuranceOptionId` + `insuranceSnapshot`**, snapshotted inside the booking transaction alongside `feeSnapshot`. **Slice 4** provides the `(operatorId, id)` composite-unique FK target on `insurance_options`. **Per-vehicle insurance applicability is deferred post-MVP** (no `vehicle_insurance_options` join table).

## Notes
- These are planning artifacts on `main`; **implementation worktrees start from `origin/marketplace-pivot`** (`feature/<n>-<slug>`), per each doc.
- Dependency order is strict: 3 → 5 → 6 → 7 → 8, and 5–8 all gate on #387 (locations) merging first.
- Does not close the slice issues — they track implementation, not planning.