### PR TITLE
ci: gate marketplace-pivot + clear inherited red gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, marketplace-pivot]
   pull_request:
-    branches: [main]
+    branches: [main, marketplace-pivot]
 
 env:
   BUN_VERSION: "1.2.13"

--- a/packages/api/tests/integration/vehicle-detail.test.ts
+++ b/packages/api/tests/integration/vehicle-detail.test.ts
@@ -26,10 +26,18 @@ const detailRepo = new DrizzleVehicleDetailRepository(db)
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
 
-// Anchor all relative dates to a fixed "now" captured at suite start so
-// day-boundary calculations are deterministic even if the clock ticks
-// across midnight mid-suite.
-const NOW = new Date()
+// Anchor all relative dates to LOCAL NOON of the current day. The utilization
+// window buckets [todayStart-29d, todayStart+1d) with no bucket for tomorrow
+// (see vehicle-detail repo dayStart()), so an ACTIVE booking spanning NOW±1h
+// loses its post-midnight slice when the suite runs within ~1h of midnight —
+// the source of the flaky `expected 3.44 to be close to 4`. Pinning to noon
+// keeps the ±1h window far from any day boundary in both UTC (CI) and local
+// dev timezones, making the result deterministic regardless of wall-clock.
+const NOW = (() => {
+  const d = new Date()
+  d.setHours(12, 0, 0, 0)
+  return d
+})()
 const TODAY_START = (() => {
   const d = new Date(NOW)
   d.setHours(0, 0, 0, 0)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,6 +27,7 @@
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",
     "./validators/location": "./src/validators/location.ts",
     "./validators/customer": "./src/validators/customer.ts",
+    "./validators/operator": "./src/validators/operator.ts",
     "./validators/translation": "./src/validators/translation.ts"
   },
   "scripts": {


### PR DESCRIPTION
## Why

The MVP slices (3–8) all target \`marketplace-pivot\`, but CI (\`ci.yml\`) only triggers on \`main\`. As a result, inherited debt has shipped to the base branch ungated — discovered while verifying Slice 2 (#414). This PR makes CI **visible and green** on \`marketplace-pivot\` so every future slice gets a real gate instead of rediscovering the same debt.

Base-branch hygiene only — **separate from Slice 2**, which is already merged.

## Changes (3)

1. **`ci.yml` triggers** — add \`marketplace-pivot\` to \`push\` + \`pull_request\`. Lights up the full pipeline (lint, typecheck, boundaries, export-drift, fk-indexes, i18n, test, web build, **db-drift + integration**) on MVP PRs.
2. **`fix(shared)` export drift** — \`validators/operator.ts\` is imported by the operator service + admin routes but was missing from \`package.json\` \`exports\` (landed via #408). One-line fix; clears the hard \`export-drift\` CI gate.
3. **`test(api)` de-flake** — \`vehicle-detail.test.ts\` used \`new Date()\`, so an ACTIVE booking spanning \`NOW±1h\` lost its post-midnight slice when run within ~1h of midnight (\`expected 3.44 to be close to 4\`). Pin \`NOW\` to local noon → deterministic in UTC (CI) and local dev.

**Left separate (intentional):** the knip / \`lint:deps\` "Error loading wrangler.toml" failure. It's \`continue-on-error: true\` in CI (never blocks the signal), so it's environmental cleanup for another PR.

## Verification (local, against docker \`kuruma-test-pg\`)

- whole-repo \`bun run lint\`, \`typecheck ×3\`, boundaries, **export-drift now PASSES** (22 paths)
- \`bun run test\`: api 616 / web 384 / shared 211
- full integration: **129/129** (was 128/1-fail)
- de-flake proof: under \`TZ=Pacific/Auckland\` (23:07 local) the **old** code fails (\`3.86\`), the **new** code passes 10/10 — same TZ, isolating the fix.

## Rollout (status-checks-first)

Merge this once green, **then** enable branch protection / required checks for \`marketplace-pivot\`. Don't make checks mandatory before they exist and are green.