### PR TITLE
refactor: address LOW review nits from #433 (shared unwrap + stale comment)

### DIFF
--- a/packages/api/tests/helpers/operator.ts
+++ b/packages/api/tests/helpers/operator.ts
@@ -18,8 +18,9 @@ export function testResolveWriteOperatorId(): ResolveWriteOperatorId {
 
 /**
  * An in-memory operator repo seeded with exactly one operator, for
- * `createApp`-based tests whose non-operator creates rely on sole-operator
- * inference (#401).
+ * `createApp`-based tests. Non-operator creates now send an explicit
+ * `operatorId` (sole-operator inference was retired in #407); this just
+ * provides the operator row their writes reference.
  */
 export function seededOperatorRepo(id: string = TEST_OPERATOR_ID): InMemoryOperatorRepository {
   const now = new Date()

--- a/packages/web/src/modules/operators/api.ts
+++ b/packages/web/src/modules/operators/api.ts
@@ -1,5 +1,5 @@
 import { createApiClient } from '@/lib/api-client'
-import type { ApiResponse } from '@kuruma/shared/types/api-response'
+import { unwrap } from '@/lib/api-error'
 
 // JSON-serialized operator option for the admin picker (#407). The list
 // endpoint returns only the fields the picker needs (id + display name + slug).
@@ -7,19 +7,6 @@ export interface OperatorOption {
   id: string
   name: string
   slug: string
-}
-
-async function unwrap<T>(res: Response): Promise<T> {
-  const body = (await res.json().catch(() => ({
-    success: false as const,
-    error: `Non-JSON response (HTTP ${res.status})`,
-  }))) as ApiResponse<T>
-
-  if (!body.success) {
-    throw new Error(body.error ?? `HTTP ${res.status}`)
-  }
-
-  return body.data
 }
 
 // Lists the operators the caller may write under. Bypass roles see all


### PR DESCRIPTION
Knocks out the two LOW, non-blocking findings from the #433 (operator picker) code review.

## Changes
- **`modules/operators/api.ts`** — import the shared `unwrap` from `@/lib/api-error` instead of a local copy that threw a plain `Error` and discarded the HTTP status. Behavior-identical on success; the shared one throws `ApiError` (carrying status) on failure, which is strictly better. Drops the now-unused `ApiResponse` import.
- **`tests/helpers/operator.ts`** — the `seededOperatorRepo` docblock claimed non-operator creates "rely on sole-operator inference (#401)". Inference was retired in #407; updated to reflect that creates now pass an explicit `operatorId`.

## Verification
typecheck ×3 green · web 432 tests green · `bun run lint` exit 0. No-op for runtime behavior on the operators GET path (no 422 recovery consumer there).

Follow-up to #407 / PR #433. Won't auto-close anything (base is `marketplace-pivot`).