### PR TITLE
fix(api): map location FK 23503 -> 422 on platform-admin create (#411)

### DIFF
--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -6,6 +6,7 @@ import {
 } from '@kuruma/shared/validators/location'
 import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { LocationFilters } from '../repositories/types'
 import type { LocationService } from '../services/location'
 import type { Location } from '../stores'
@@ -82,17 +83,29 @@ export function createLocationRoutes(
         operatorId = await resolveWriteOperatorId(ctx)
       }
 
-      const result = await service.create(ctx, {
-        operatorId,
-        name: d.name,
-        address: d.address,
-        operatingHours: d.operatingHours,
-        timezone: d.timezone,
-        defaultTurnaroundMinutes: d.defaultTurnaroundMinutes,
-        status: 'ACTIVE',
-      })
-      if (!result.ok) return fail(c, result.error, result.status)
-      return ok(c, result.location, 201)
+      try {
+        const result = await service.create(ctx, {
+          operatorId,
+          name: d.name,
+          address: d.address,
+          operatingHours: d.operatingHours,
+          timezone: d.timezone,
+          defaultTurnaroundMinutes: d.defaultTurnaroundMinutes,
+          status: 'ACTIVE',
+        })
+        if (!result.ok) return fail(c, result.error, result.status)
+        return ok(c, result.location, 201)
+      } catch (err) {
+        // operatorId is the only client-supplied FK on this write, so an
+        // unknown one trips locations_operatorId_operators_id_fk (23503) — a
+        // client error, not a server fault. Map to 422, mirroring the #400
+        // vehicle/class FK->422 contract. No constraint-name disambiguation
+        // needed here: a single FK means a static message is unambiguous.
+        if (pgErrorCode(err) === PG_ERROR.FOREIGN_KEY_VIOLATION) {
+          return fail(c, 'Invalid operator', 422)
+        }
+        throw err
+      }
     })
     .patch('/locations/:id', async (c) => {
       const user = requireUser(c)

--- a/packages/api/tests/integration/locations-route-fk.test.ts
+++ b/packages/api/tests/integration/locations-route-fk.test.ts
@@ -1,0 +1,76 @@
+import { locations, operators, users } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleLocationRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+import { db } from './setup'
+
+// #411: a PLATFORM_ADMIN/STAFF (bypass) create names the target operator in the
+// body. A non-existent operatorId clears Zod + the duplicate-name pre-check, then
+// violates locations_operatorId_operators_id_fk (23503) at the DB. The route must
+// map that to 422 "Invalid operator" — the FK->422 contract #400 standardized for
+// vehicle/class writes — not surface a raw 500. In-memory repos can't exercise the
+// DB-only FK, so this drives the full HTTP app against real Postgres.
+describe('POST /locations maps a non-existent operatorId to 422 (#411)', () => {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opId = `op_loc_fk_${uniq}`
+  const staffUserId = crypto.randomUUID()
+  let app: ReturnType<typeof createApp>
+  let headers: Record<string, string>
+
+  // Bypass caller (STAFF) names the operator explicitly via the body.
+  const locationBody = (operatorId: string, name: string) => ({
+    operatorId,
+    name,
+    address: '1-1 Namba, Chuo-ku, Osaka',
+  })
+
+  beforeAll(async () => {
+    setupAuthEnv()
+    await db.insert(operators).values({ id: opId, slug: `loc-fk-${uniq}`, name: 'Loc FK Operator' })
+    await db.insert(users).values({
+      id: staffUserId,
+      email: `loc-fk-${uniq}@kuruma-test.com`,
+      role: 'STAFF',
+      language: 'en',
+    })
+    app = createApp({
+      vehicleRepo: new DrizzleVehicleRepository(db),
+      bookingRepo: new DrizzleBookingRepository(db),
+      availabilityRepo: new DrizzleAvailabilityRepository(db),
+      locationRepo: new DrizzleLocationRepository(db),
+    })
+    headers = await authHeaders({ sub: staffUserId, role: 'STAFF' })
+  })
+
+  afterAll(async () => {
+    await db.delete(locations).where(inArray(locations.operatorId, [opId]))
+    await db.delete(operators).where(inArray(operators.id, [opId]))
+    await db.delete(users).where(inArray(users.id, [staffUserId]))
+  })
+
+  const post = (body: unknown) =>
+    app.request('/locations', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+  it('returns 422 "Invalid operator" for a non-existent operatorId', async () => {
+    const res = await post(locationBody(`op_missing_${uniq}`, 'Namba FK'))
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid operator')
+  })
+
+  it('returns 201 for an existing operator (catch does not break valid creates)', async () => {
+    const res = await post(locationBody(opId, 'Namba OK'))
+    expect(res.status).toBe(201)
+    expect((await res.json()).data.operatorId).toBe(opId)
+  })
+})


### PR DESCRIPTION
## What

A `PLATFORM_ADMIN`/`STAFF` (bypass) create of a location with a non-existent `operatorId` cleared Zod **and** the duplicate-name pre-check, then violated `locations_operatorId_operators_id_fk` (Postgres `23503`) and surfaced as a raw **500**.

This wraps `service.create` in the `POST /locations` handler and maps the FK violation to **422 `Invalid operator`**, mirroring the FK->422 contract #400 standardized for vehicle/class writes (`routes/vehicles.ts`). The `pg-errors.ts` helpers it relies on were merged in #408.

Unlike `vehicles` (two FKs -> needs `fkViolationMessage`/constraint-name disambiguation), `locations` has exactly **one** client-supplied FK (`operatorId`), so a static message is unambiguous.

## Scope notes
- `PATCH /locations` is intentionally untouched: it never accepts `operatorId`, so there is no client-supplied FK path to map.

## Test plan
- New real-Postgres integration test `tests/integration/locations-route-fk.test.ts` (in-memory repos can't exercise a DB-only FK):
  - `422 "Invalid operator"` for a non-existent operatorId (RED before fix: returned 500)
  - `201` happy path for an existing operator (proves the catch doesn't break valid creates)
- Full local gate green: integration **164 passed**, unit **790 passed**, `tsc --noEmit` clean, `lint:boundaries` OK, biome clean.

Follow-up from #387 (slice 2) review. Epic #385.

Closes #411