### PR TITLE
fix(#413): edit forms validate with update schema + correct typing

### DIFF
--- a/packages/web/src/modules/classes/components/ClassForm.tsx
+++ b/packages/web/src/modules/classes/components/ClassForm.tsx
@@ -9,30 +9,46 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { ACRISS_CODES } from '@kuruma/shared/acriss'
 import {
   type CreateVehicleClassInput,
+  type UpdateVehicleClassInput,
   createVehicleClassSchema,
+  updateVehicleClassSchema,
 } from '@kuruma/shared/validators/vehicle-class'
 import { useTranslations } from 'next-intl'
 import { useEffect, useRef } from 'react'
-import { useForm } from 'react-hook-form'
+import { type Resolver, useForm } from 'react-hook-form'
 import type { z } from 'zod'
 
 type ClassFormValues = z.input<typeof createVehicleClassSchema>
 type ClassFormOutput = z.output<typeof createVehicleClassSchema>
 
-interface ClassFormProps {
-  onSubmit: (data: CreateVehicleClassInput) => Promise<void>
+// #413: one form, two modes. Create validates with createVehicleClassSchema and
+// emits CreateVehicleClassInput; edit validates with updateVehicleClassSchema
+// (partial, no defaults, no operatorId) and emits UpdateVehicleClassInput. The
+// discriminated union ties each mode to its onSubmit input type and keeps the
+// #407 operator picker create-only — operatorId is not patchable, so edit mode
+// never accepts or renders it.
+type ClassFormBaseProps = {
   onCancel?: () => void
   defaultValues?: Partial<CreateVehicleClassInput>
   isSubmitting?: boolean
-  // #407: operators the caller may create under. Supplied only by the add
-  // dialog (create mode). One operator → hidden + submitted silently; 2+ →
-  // the admin must choose (gate before operator #2).
-  operators?: readonly OperatorOption[] | undefined
-  // #407 P2: set when the server rejected the create with OPERATOR_REQUIRED
-  // (a second operator now exists). Forces the picker open with an inline
-  // prompt even if the still-stale `operators` prop carries a single entry.
-  operatorRequired?: boolean
 }
+type ClassFormProps =
+  | (ClassFormBaseProps & {
+      mode?: 'create'
+      onSubmit: (data: CreateVehicleClassInput) => Promise<void>
+      // #407: operators the caller may create under. Supplied only by the add
+      // dialog. One operator → hidden + submitted silently; 2+ → the admin must
+      // choose (gate before operator #2).
+      operators?: readonly OperatorOption[] | undefined
+      // #407 P2: set when the server rejected the create with OPERATOR_REQUIRED
+      // (a second operator now exists). Forces the picker open with an inline
+      // prompt even if the still-stale `operators` prop carries a single entry.
+      operatorRequired?: boolean
+    })
+  | (ClassFormBaseProps & {
+      mode: 'edit'
+      onSubmit: (data: UpdateVehicleClassInput) => Promise<void>
+    })
 
 // The ACRISS <select>'s "None" option has an empty value. Coerce it to null so
 // the schema's .nullish() accepts it instead of failing the regex on ''.
@@ -42,14 +58,12 @@ function nullableString(v: unknown) {
 
 const ACRISS_CODE_LIST = Object.keys(ACRISS_CODES) as (keyof typeof ACRISS_CODES)[]
 
-export function ClassForm({
-  onSubmit,
-  onCancel,
-  defaultValues,
-  isSubmitting,
-  operators,
-  operatorRequired,
-}: ClassFormProps) {
+export function ClassForm(props: ClassFormProps) {
+  const { onCancel, defaultValues, isSubmitting } = props
+  const mode = props.mode ?? 'create'
+  // #407 picker inputs are create-only; edit mode never shows or syncs them.
+  const operators = props.mode === 'edit' ? undefined : props.operators
+  const operatorRequired = props.mode === 'edit' ? false : props.operatorRequired
   const t = useTranslations('business.classes')
   // ACRISS labels live under the top-level `acriss.*` namespace, not
   // `business.classes`, so resolve them through a separate translator.
@@ -58,9 +72,10 @@ export function ClassForm({
   const showOperatorPicker =
     (operators !== undefined && operators.length > 1) || operatorRequired === true
 
-  // MEDIUM 3: three-type-parameter useForm lets RHF narrow the submit
-  // handler to the schema's OUTPUT type (CreateVehicleClassInput) — no
-  // `as` assertion needed at handleSubmit.
+  // MEDIUM 3: three-type-parameter useForm narrows the submit handler to the
+  // schema's OUTPUT type (CreateVehicleClassInput) — no `as` at handleSubmit.
+  // Edit reuses the same field shape with the partial update resolver; the lone
+  // cast bridges that resolver's value type to the create shape.
   const {
     register,
     handleSubmit,
@@ -68,7 +83,9 @@ export function ClassForm({
     getValues,
     formState: { errors },
   } = useForm<ClassFormValues, unknown, ClassFormOutput>({
-    resolver: zodResolver(createVehicleClassSchema),
+    resolver: zodResolver(
+      mode === 'edit' ? updateVehicleClassSchema : createVehicleClassSchema,
+    ) as Resolver<ClassFormValues, unknown, ClassFormOutput>,
     defaultValues: {
       name: '',
       slug: '',
@@ -121,9 +138,12 @@ export function ClassForm({
         // description" rather than an empty string value.
         const trimmed = data.description?.trim()
         const { description: _drop, ...rest } = data
-        const payload: CreateVehicleClassInput =
-          trimmed && trimmed.length > 0 ? { ...rest, description: trimmed } : rest
-        await onSubmit(payload)
+        const payload = trimmed && trimmed.length > 0 ? { ...rest, description: trimmed } : rest
+        // `payload` is the create OUTPUT shape (a structural superset of the
+        // update input). Narrow on mode to call the correctly-typed onSubmit;
+        // in edit mode the update resolver has already stripped operatorId.
+        if (props.mode === 'edit') await props.onSubmit(payload)
+        else await props.onSubmit(payload)
       })}
       className="space-y-4"
     >

--- a/packages/web/src/modules/classes/components/EditClassDialog.tsx
+++ b/packages/web/src/modules/classes/components/EditClassDialog.tsx
@@ -11,7 +11,7 @@ import { updateClassAction } from '@/modules/classes/actions'
 import type { VehicleClassData } from '@/modules/classes/api'
 import { ClassForm } from '@/modules/classes/components/ClassForm'
 import { useClassMutation } from '@/modules/classes/hooks'
-import type { CreateVehicleClassInput } from '@kuruma/shared/validators/vehicle-class'
+import type { UpdateVehicleClassInput } from '@kuruma/shared/validators/vehicle-class'
 import { useTranslations } from 'next-intl'
 
 interface EditClassDialogProps {
@@ -21,7 +21,9 @@ interface EditClassDialogProps {
 
 export function EditClassDialog({ vehicleClass, onOpenChange }: EditClassDialogProps) {
   const t = useTranslations('business.classes')
-  const { mutateAsync, isPending, error } = useClassMutation<CreateVehicleClassInput>({
+  // #413: an edit is a PATCH — type the mutation with the update input so the
+  // form (mode="edit") and updateClassAction agree on UpdateVehicleClassInput.
+  const { mutateAsync, isPending, error } = useClassMutation<UpdateVehicleClassInput>({
     mutationFn: (data) => updateClassAction(vehicleClass?.id ?? '', data),
     onSuccess: () => onOpenChange(false),
   })
@@ -37,6 +39,7 @@ export function EditClassDialog({ vehicleClass, onOpenChange }: EditClassDialogP
         {vehicleClass && (
           <ClassForm
             key={vehicleClass.id}
+            mode="edit"
             onSubmit={async (data) => {
               await mutateAsync(data)
             }}

--- a/packages/web/src/modules/locations/components/EditLocationDialog.tsx
+++ b/packages/web/src/modules/locations/components/EditLocationDialog.tsx
@@ -11,7 +11,7 @@ import { updateLocationAction } from '@/modules/locations/actions'
 import type { LocationData } from '@/modules/locations/api'
 import { LocationForm } from '@/modules/locations/components/LocationForm'
 import { useLocationMutation } from '@/modules/locations/hooks'
-import type { CreateLocationInput } from '@kuruma/shared/validators/location'
+import type { UpdateLocationInput } from '@kuruma/shared/validators/location'
 import { useTranslations } from 'next-intl'
 
 interface EditLocationDialogProps {
@@ -21,7 +21,9 @@ interface EditLocationDialogProps {
 
 export function EditLocationDialog({ location, onOpenChange }: EditLocationDialogProps) {
   const t = useTranslations('business.locations')
-  const { mutateAsync, isPending, error } = useLocationMutation<CreateLocationInput>({
+  // #413: an edit is a PATCH — type the mutation with the update input so the
+  // form (mode="edit") and updateLocationAction agree on UpdateLocationInput.
+  const { mutateAsync, isPending, error } = useLocationMutation<UpdateLocationInput>({
     mutationFn: (data) => updateLocationAction(location?.id ?? '', data),
     onSuccess: () => onOpenChange(false),
   })
@@ -37,6 +39,7 @@ export function EditLocationDialog({ location, onOpenChange }: EditLocationDialo
         {location && (
           <LocationForm
             key={location.id}
+            mode="edit"
             onSubmit={async (data) => {
               await mutateAsync(data)
             }}

--- a/packages/web/src/modules/locations/components/LocationForm.tsx
+++ b/packages/web/src/modules/locations/components/LocationForm.tsx
@@ -5,42 +5,62 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { type CreateLocationInput, createLocationSchema } from '@kuruma/shared/validators/location'
+import {
+  type CreateLocationInput,
+  type UpdateLocationInput,
+  createLocationSchema,
+  updateLocationSchema,
+} from '@kuruma/shared/validators/location'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { type Resolver, useForm } from 'react-hook-form'
 import type { z } from 'zod'
 
 type LocationFormValues = z.input<typeof createLocationSchema>
 type LocationFormOutput = z.output<typeof createLocationSchema>
 
-interface LocationFormProps {
-  onSubmit: (data: CreateLocationInput) => Promise<void>
+// #413: one form, two modes. Create validates with createLocationSchema and
+// emits CreateLocationInput; edit validates with the no-default
+// updateLocationSchema and emits UpdateLocationInput (a PATCH must not inject
+// defaults). The discriminated union ties each mode to its onSubmit input type,
+// so an edit dialog can't be wired to the create type.
+type LocationFormBaseProps = {
   onCancel?: () => void
   defaultValues?: Partial<CreateLocationInput>
   isSubmitting?: boolean
 }
+type LocationFormProps =
+  | (LocationFormBaseProps & {
+      mode?: 'create'
+      onSubmit: (data: CreateLocationInput) => Promise<void>
+    })
+  | (LocationFormBaseProps & {
+      mode: 'edit'
+      onSubmit: (data: UpdateLocationInput) => Promise<void>
+    })
 
 const DEFAULT_OPEN = '09:00'
 const DEFAULT_CLOSE = '18:00'
 
-export function LocationForm({
-  onSubmit,
-  onCancel,
-  defaultValues,
-  isSubmitting,
-}: LocationFormProps) {
+export function LocationForm(props: LocationFormProps) {
+  const { onCancel, defaultValues, isSubmitting } = props
+  const mode = props.mode ?? 'create'
   const t = useTranslations('business.locations')
 
-  // Three-type-parameter useForm lets RHF narrow the submit handler to the
-  // schema's OUTPUT type (CreateLocationInput) — no `as` at handleSubmit.
+  // Three-type-parameter useForm narrows the submit handler to the schema's
+  // OUTPUT type (CreateLocationInput) — no `as` at handleSubmit. The fields are
+  // identical across modes (update is the same fields, partial + no defaults),
+  // so register/errors stay typed to the create shape and only the resolver
+  // swaps. The lone cast bridges the update resolver's value type to that shape.
   const {
     register,
     handleSubmit,
     setValue,
     formState: { errors },
   } = useForm<LocationFormValues, unknown, LocationFormOutput>({
-    resolver: zodResolver(createLocationSchema),
+    resolver: zodResolver(
+      mode === 'edit' ? updateLocationSchema : createLocationSchema,
+    ) as Resolver<LocationFormValues, unknown, LocationFormOutput>,
     defaultValues: {
       name: '',
       address: '',
@@ -66,7 +86,11 @@ export function LocationForm({
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        await onSubmit(data)
+        // `data` is the create OUTPUT shape (a structural superset). In edit
+        // mode it also satisfies UpdateLocationInput (all-optional), so narrow
+        // on mode to call the correctly-typed onSubmit without a cast.
+        if (props.mode === 'edit') await props.onSubmit(data)
+        else await props.onSubmit(data)
       })}
       className="space-y-4"
     >

--- a/packages/web/tests/modules/classes/ClassForm.test.tsx
+++ b/packages/web/tests/modules/classes/ClassForm.test.tsx
@@ -261,3 +261,59 @@ describe('ClassForm — operator picker', () => {
     expect(screen.getAllByText('form.operatorRequired').length).toBeGreaterThan(0)
   })
 })
+
+// Issue #413: edit mode validates with the update schema and never touches the
+// create-only operator picker (operatorId is not patchable).
+describe('ClassForm — edit mode (#413)', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  const editDefaults = {
+    name: 'Standard',
+    slug: 'standard',
+    seats: 7,
+    luggageCapacity: 3,
+    transmission: 'MANUAL' as const,
+    sortOrder: 5,
+  }
+
+  it('never renders the operator picker in edit mode', () => {
+    render(<ClassForm mode="edit" onSubmit={vi.fn()} defaultValues={editDefaults} />)
+    expect(screen.queryByLabelText('form.operator')).not.toBeInTheDocument()
+  })
+
+  it('submits an edit without an operatorId (not patchable)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<ClassForm mode="edit" onSubmit={onSubmit} defaultValues={editDefaults} />)
+
+    await user.clear(screen.getByLabelText('form.seats'))
+    await user.type(screen.getByLabelText('form.seats'), '8')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    const data = onSubmit.mock.calls[0][0]
+    expect('operatorId' in data).toBe(false)
+    expect(data).toMatchObject({ name: 'Standard', slug: 'standard', seats: 8 })
+  })
+
+  it('still rejects an invalid slug in edit mode', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<ClassForm mode="edit" onSubmit={onSubmit} defaultValues={editDefaults} />)
+
+    const slug = screen.getByLabelText('form.slug')
+    await user.clear(slug)
+    await user.type(slug, 'Not A Slug')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/web/tests/modules/locations/LocationForm.test.tsx
+++ b/packages/web/tests/modules/locations/LocationForm.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+import { LocationForm } from '@/modules/locations/components/LocationForm'
+
+const editDefaults = {
+  name: 'Osaka Namba',
+  address: '1-2-3 Namba, Chuo-ku, Osaka',
+  operatingHours: { openTime: '09:00', closeTime: '18:00' },
+  timezone: 'Asia/Tokyo',
+  defaultTurnaroundMinutes: 2880,
+}
+
+describe('LocationForm', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('create mode: submits the entered values with create defaults', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<LocationForm onSubmit={onSubmit} />)
+
+    await user.type(screen.getByLabelText('form.name'), 'Kyoto Station')
+    await user.type(screen.getByLabelText('form.address'), '1 Karasuma, Kyoto')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      name: 'Kyoto Station',
+      address: '1 Karasuma, Kyoto',
+      operatingHours: null,
+      timezone: 'Asia/Tokyo',
+      defaultTurnaroundMinutes: 2880,
+    })
+  })
+
+  it('edit mode: pre-fills the existing location and submits the edit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(<LocationForm mode="edit" onSubmit={onSubmit} defaultValues={editDefaults} />)
+
+    const name = screen.getByLabelText('form.name')
+    expect(name).toHaveValue('Osaka Namba')
+
+    await user.clear(name)
+    await user.type(name, 'Osaka Umeda')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      name: 'Osaka Umeda',
+      address: '1-2-3 Namba, Chuo-ku, Osaka',
+      operatingHours: { openTime: '09:00', closeTime: '18:00' },
+    })
+  })
+
+  it('edit mode: still rejects an inverted operating-hours range', async () => {
+    // The update schema reuses the shared operatingHours field schema, so the
+    // inverted-range refinement must fire in edit mode too (issue #413 note).
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    render(
+      <LocationForm
+        mode="edit"
+        onSubmit={onSubmit}
+        defaultValues={{
+          ...editDefaults,
+          operatingHours: { openTime: '20:00', closeTime: '08:00' },
+        }}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('closeTime must be after openTime')).toBeInTheDocument()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What & why

Closes #413 (manual close — base is `marketplace-pivot`, a non-default branch, so the keyword won't auto-fire).

`EditLocationDialog` / `EditClassDialog` drive a PATCH but the shared form validated with the **create** schema and typed the mutation `Create*Input`. It worked (the edit form pre-fills every field) but bypassed the partial-update design and the typing was too wide. This parameterizes both forms with a `mode` discriminated union so **edit validates with the `update*` schema and is typed `Update*Input`**.

**No user-facing behavior change** — the edit form always submits all fields, so create vs update validate identically at runtime. This is a typing/intent correctness fix; the guard is at the type level.

## Changes
- **`LocationForm` / `ClassForm`**: `mode?: 'create' | 'edit'` discriminated union. Create → `createSchema` + `Create*Input`; edit → the no-default `update*Schema` + `Update*Input`. One `useForm`; the resolver is selected by mode (single localized cast bridges the update resolver's value type to the shared create field-shape — `register`/`errors`/`handleSubmit` stay cast-free).
- **`EditLocationDialog` / `EditClassDialog`**: type the mutation `Update*Input`, pass `mode="edit"`.
- **`ClassForm` (#407 interaction)**: `operators` / `operatorRequired` are now **create-only** union members. `operatorId` is not patchable, so edit mode never renders/syncs the operator picker and never submits `operatorId`.
- Add/Create dialogs untouched — `mode` defaults to `'create'`.

## How the fix is enforced (review note)
The discriminating guard is **compile-time**, via real consumer types under the existing `typecheck` CI gate — not a synthetic `expectTypeOf` (web vitest has no typecheck mode and `tests/` isn't in the tsc program, so that would be a no-op). With edit-mode `onSubmit: (Update*Input)` and `useXMutation<Update*Input>`, reverting a dialog to `Create*Input` makes `Update*Input` (all-optional) → `Create*Input` (required fields) **fail to compile**. Verified both ways: regression → `tsc` exit 2; correct → green.

## Test plan
- [x] `bun run --filter @kuruma/web test` — **438 passed** (+6: 3 location, 3 class)
- [x] `bun run --filter '*' typecheck` — 0 errors
- [x] `bun run lint` — clean
- [x] Type guard proven to fail on regression (both forms)
- [x] Edit submits no `operatorId`; inverted operating-hours still rejected in edit mode

Plan + accepted review amendments: #413 [plan](https://github.com/jackli921/kuruma-rental/issues/413#issuecomment-4636597560) · [amendments](https://github.com/jackli921/kuruma-rental/issues/413#issuecomment-4636617015)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
