### PR TITLE
test(e2e): authenticated real-DB track + locations P1/P2/CRUD (#416)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ next-env.d.ts
 /blob-report/
 /playwright/.cache/
 e2e/.auth/
-/playwright/.cache/
 
 # internal / private docs — not for owner or public repo
 docs/internal/

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ next-env.d.ts
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+e2e/.auth/
+/playwright/.cache/
 
 # internal / private docs — not for owner or public repo
 docs/internal/

--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,8 @@
       "next-env.d.ts",
       "test-results",
       "playwright-report",
-      "blob-report"
+      "blob-report",
+      "e2e/.auth"
     ]
   }
 }

--- a/e2e/real-db/auth.setup.ts
+++ b/e2e/real-db/auth.setup.ts
@@ -1,0 +1,21 @@
+import { test as setup } from '@playwright/test'
+import { STORAGE_STATE } from './constants'
+import { SESSION_COOKIE_NAME, mintOperatorSessionToken } from './mint-session'
+
+const ONE_HOUR_S = 60 * 60
+
+setup('mint operator session cookie', async ({ context }) => {
+  const value = await mintOperatorSessionToken()
+  await context.addCookies([
+    {
+      name: SESSION_COOKIE_NAME,
+      value,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+      expires: Math.floor(Date.now() / 1000) + ONE_HOUR_S,
+    },
+  ])
+  await context.storageState({ path: STORAGE_STATE })
+})

--- a/e2e/real-db/constants.ts
+++ b/e2e/real-db/constants.ts
@@ -1,0 +1,3 @@
+// Dependency-free so playwright.real-db.config.ts can import the storageState
+// path without pulling the minting chain (postgres, next-auth) into config load.
+export const STORAGE_STATE = 'e2e/.auth/operator.json'

--- a/e2e/real-db/locations.auth.spec.ts
+++ b/e2e/real-db/locations.auth.spec.ts
@@ -15,4 +15,54 @@ test.describe('operator locations (authenticated, real DB)', () => {
     await expect(page.getByText('Umeda Store')).toBeVisible()
     await expect(page.getByText('Kansai Airport Counter')).toBeVisible()
   })
+
+  test('invalid hours show the error under Closes, not Opens (P2)', async ({ page }) => {
+    await page.goto('/en/manage/locations')
+    await page.getByRole('button', { name: 'Add location' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.locator('#location-name').fill('E2E Hours Store')
+    await dialog.locator('#location-address').fill('1-1 Test, Osaka')
+    await dialog.getByLabel('Set operating hours').check()
+    await dialog.locator('#location-openTime').fill('20:00')
+    await dialog.locator('#location-closeTime').fill('08:00')
+    await dialog.getByRole('button', { name: 'Save location' }).click()
+
+    // Refine attaches to closeTime (validators/location.ts path: ['closeTime']),
+    // so the message must render under the Closes field — not Opens, not silent.
+    const closeField = dialog.locator('#location-closeTime').locator('xpath=..')
+    const openField = dialog.locator('#location-openTime').locator('xpath=..')
+    await expect(closeField).toContainText('closeTime must be after openTime')
+    await expect(openField).not.toContainText('closeTime must be after openTime')
+  })
+
+  test('add -> edit -> archive a location writes through to the DB (CRUD)', async ({ page }) => {
+    const name = `E2E Store ${Date.now()}`
+    const renamed = `${name} edited`
+    await page.goto('/en/manage/locations')
+
+    // ADD
+    await page.getByRole('button', { name: 'Add location' }).click()
+    const addDialog = page.getByRole('dialog')
+    await addDialog.locator('#location-name').fill(name)
+    await addDialog.locator('#location-address').fill('1-1 Test, Osaka')
+    await addDialog.getByRole('button', { name: 'Save location' }).click()
+    await expect(page.getByRole('heading', { name, exact: true })).toBeVisible()
+
+    // EDIT
+    const row = page.locator('div.rounded-lg').filter({ hasText: name })
+    await row.getByRole('button', { name: 'Edit location' }).click()
+    const editDialog = page.getByRole('dialog')
+    await editDialog.locator('#location-name').fill(renamed)
+    await editDialog.getByRole('button', { name: 'Save location' }).click()
+    await expect(page.getByRole('heading', { name: renamed, exact: true })).toBeVisible()
+
+    // ARCHIVE
+    const editedRow = page.locator('div.rounded-lg').filter({ hasText: renamed })
+    await editedRow.getByRole('button', { name: 'Archive location' }).click()
+    await page.getByRole('dialog').getByRole('button', { name: 'Archive', exact: true }).click()
+    // Status flips to Archived and the archive control disables on that row.
+    await expect(editedRow.getByText('Archived')).toBeVisible()
+    await expect(editedRow.getByRole('button', { name: 'Archive location' })).toBeDisabled()
+  })
 })

--- a/e2e/real-db/locations.auth.spec.ts
+++ b/e2e/real-db/locations.auth.spec.ts
@@ -1,9 +1,24 @@
 import { expect, test } from '@playwright/test'
+import { testSql } from './pg'
+
+// Names this spec creates; cleaned up in afterAll so a reused local branch
+// doesn't accrete rows (a per-run CI branch is disposable, so this is belt-and-
+// braces). The '%' makes the timestamped CRUD name match too.
+const TEST_LOCATION_PREFIX = 'E2E '
 
 // #416: authenticated, real-DB coverage for operator locations. The minted
 // session cookie (auth.setup.ts) carries OPERATOR_OWNER + operatorId, so these
 // flows exercise the real web -> real Hono API -> seeded Neon branch end to end.
 test.describe('operator locations (authenticated, real DB)', () => {
+  test.afterAll(async () => {
+    const sql = testSql()
+    try {
+      await sql`DELETE FROM locations WHERE name LIKE ${`${TEST_LOCATION_PREFIX}%`}`
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+
   test('owner reaches /manage/locations and sees the seeded storefronts (P1)', async ({ page }) => {
     await page.goto('/en/manage/locations')
 
@@ -50,7 +65,7 @@ test.describe('operator locations (authenticated, real DB)', () => {
     await expect(page.getByRole('heading', { name, exact: true })).toBeVisible()
 
     // EDIT
-    const row = page.locator('div.rounded-lg').filter({ hasText: name })
+    const row = page.getByTestId('location-row').filter({ hasText: name })
     await row.getByRole('button', { name: 'Edit location' }).click()
     const editDialog = page.getByRole('dialog')
     await editDialog.locator('#location-name').fill(renamed)
@@ -58,7 +73,7 @@ test.describe('operator locations (authenticated, real DB)', () => {
     await expect(page.getByRole('heading', { name: renamed, exact: true })).toBeVisible()
 
     // ARCHIVE
-    const editedRow = page.locator('div.rounded-lg').filter({ hasText: renamed })
+    const editedRow = page.getByTestId('location-row').filter({ hasText: renamed })
     await editedRow.getByRole('button', { name: 'Archive location' }).click()
     await page.getByRole('dialog').getByRole('button', { name: 'Archive', exact: true }).click()
     // Status flips to Archived and the archive control disables on that row.

--- a/e2e/real-db/locations.auth.spec.ts
+++ b/e2e/real-db/locations.auth.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+// #416: authenticated, real-DB coverage for operator locations. The minted
+// session cookie (auth.setup.ts) carries OPERATOR_OWNER + operatorId, so these
+// flows exercise the real web -> real Hono API -> seeded Neon branch end to end.
+test.describe('operator locations (authenticated, real DB)', () => {
+  test('owner reaches /manage/locations and sees the seeded storefronts (P1)', async ({ page }) => {
+    await page.goto('/en/manage/locations')
+
+    // No redirect to sign-in: the operator session is honoured by middleware.
+    await expect(page).toHaveURL(/\/en\/manage\/locations\/?$/)
+
+    // The three seeded Best Car Rental storefronts render.
+    await expect(page.getByText('Namba Store')).toBeVisible()
+    await expect(page.getByText('Umeda Store')).toBeVisible()
+    await expect(page.getByText('Kansai Airport Counter')).toBeVisible()
+  })
+})

--- a/e2e/real-db/mint-session.ts
+++ b/e2e/real-db/mint-session.ts
@@ -1,4 +1,4 @@
-import postgres from 'postgres'
+import { testSql } from './pg'
 
 // On http/localhost Auth.js uses the unprefixed cookie name (no `__Secure-`).
 // The `encode` salt MUST equal this name or the web's `auth()` cannot decrypt
@@ -13,19 +13,8 @@ const OWNER_NAME = 'Best Car Rental Owner'
 const OPERATOR_ID = 'op_best_car_rental'
 
 /** Look up the seeded owner's auto-generated id by its stable seed email. */
-async function findOwnerId(databaseUrl: string): Promise<string> {
-  const u = new URL(databaseUrl)
-  // Build from URL parts so libpq-only params (e.g. channel_binding) don't reach
-  // postgres-js; the Neon `-pooler` host accepts TCP with ssl=require.
-  const sql = postgres({
-    host: u.hostname,
-    port: u.port ? Number(u.port) : 5432,
-    database: u.pathname.replace(/^\//, ''),
-    username: decodeURIComponent(u.username),
-    password: decodeURIComponent(u.password),
-    ssl: 'require',
-    max: 1,
-  })
+async function findOwnerId(): Promise<string> {
+  const sql = testSql()
   try {
     const rows = await sql<{ id: string }[]>`
       SELECT id FROM users WHERE email = ${OWNER_EMAIL} LIMIT 1
@@ -50,11 +39,9 @@ async function findOwnerId(databaseUrl: string): Promise<string> {
  */
 export async function mintOperatorSessionToken(): Promise<string> {
   const secret = process.env.AUTH_SECRET
-  const databaseUrl = process.env.DATABASE_URL
   if (!secret) throw new Error('AUTH_SECRET is required to mint an e2e session')
-  if (!databaseUrl) throw new Error('DATABASE_URL is required to resolve the owner id')
 
-  const sub = await findOwnerId(databaseUrl)
+  const sub = await findOwnerId()
 
   // next-auth/jwt is ESM-only; dynamic import so Playwright's CJS transform of
   // this file doesn't ERR_REQUIRE_ESM at load time.

--- a/e2e/real-db/mint-session.ts
+++ b/e2e/real-db/mint-session.ts
@@ -1,0 +1,78 @@
+import postgres from 'postgres'
+
+// On http/localhost Auth.js uses the unprefixed cookie name (no `__Secure-`).
+// The `encode` salt MUST equal this name or the web's `auth()` cannot decrypt
+// the session JWE. See issue #416 proven reference.
+export const SESSION_COOKIE_NAME = 'authjs.session-token'
+
+// Seed identity, mirrored from @kuruma/shared/db/constants. Duplicated on
+// purpose: Playwright require()s this file as CJS, and importing the shared
+// workspace package's TS source there breaks. Update both if the seed changes.
+const OWNER_EMAIL = 'owner@best-car-rental.local'
+const OWNER_NAME = 'Best Car Rental Owner'
+const OPERATOR_ID = 'op_best_car_rental'
+
+/** Look up the seeded owner's auto-generated id by its stable seed email. */
+async function findOwnerId(databaseUrl: string): Promise<string> {
+  const u = new URL(databaseUrl)
+  // Build from URL parts so libpq-only params (e.g. channel_binding) don't reach
+  // postgres-js; the Neon `-pooler` host accepts TCP with ssl=require.
+  const sql = postgres({
+    host: u.hostname,
+    port: u.port ? Number(u.port) : 5432,
+    database: u.pathname.replace(/^\//, ''),
+    username: decodeURIComponent(u.username),
+    password: decodeURIComponent(u.password),
+    ssl: 'require',
+    max: 1,
+  })
+  try {
+    const rows = await sql<{ id: string }[]>`
+      SELECT id FROM users WHERE email = ${OWNER_EMAIL} LIMIT 1
+    `
+    const owner = rows[0]
+    if (!owner) {
+      throw new Error(
+        `Owner ${OWNER_EMAIL} not found — run db:seed against the e2e Neon branch first`,
+      )
+    }
+    return owner.id
+  } finally {
+    await sql.end({ timeout: 5 })
+  }
+}
+
+/**
+ * Mint an Auth.js v5 session-cookie value for the seeded Best Car Rental owner,
+ * using the app's own `encode` so the JWE format matches what `auth()` expects.
+ * The browser receives only this cookie; the web mints the downstream HS256 API
+ * token itself (`lib/api-token.ts`) from the same secret.
+ */
+export async function mintOperatorSessionToken(): Promise<string> {
+  const secret = process.env.AUTH_SECRET
+  const databaseUrl = process.env.DATABASE_URL
+  if (!secret) throw new Error('AUTH_SECRET is required to mint an e2e session')
+  if (!databaseUrl) throw new Error('DATABASE_URL is required to resolve the owner id')
+
+  const sub = await findOwnerId(databaseUrl)
+
+  // next-auth/jwt is ESM-only; dynamic import so Playwright's CJS transform of
+  // this file doesn't ERR_REQUIRE_ESM at load time.
+  const { encode } = await import('next-auth/jwt')
+
+  // roleRefreshedAt = now keeps the token self-sufficient: the jwt callback's
+  // `else if (token.sub)` branch skips its DB role re-fetch for 5 minutes
+  // (packages/web/src/auth.ts), so the session needs no live DB to stay valid.
+  return encode({
+    salt: SESSION_COOKIE_NAME,
+    secret,
+    token: {
+      sub,
+      name: OWNER_NAME,
+      email: OWNER_EMAIL,
+      role: 'OPERATOR_OWNER',
+      operatorId: OPERATOR_ID,
+      roleRefreshedAt: Date.now(),
+    },
+  })
+}

--- a/e2e/real-db/pg.ts
+++ b/e2e/real-db/pg.ts
@@ -1,0 +1,23 @@
+import postgres from 'postgres'
+
+/**
+ * A short-lived postgres-js client for the e2e Neon branch, built from
+ * DATABASE_URL's parts so libpq-only params (e.g. `channel_binding`) don't reach
+ * postgres-js. ssl is forced to `require` (TLS, but not `verify-full`) — fine
+ * for a disposable test branch; do not copy this into app code that needs full
+ * certificate verification. Caller must `await sql.end()`.
+ */
+export function testSql(): postgres.Sql {
+  const url = process.env.DATABASE_URL
+  if (!url) throw new Error('DATABASE_URL is required for the real-DB e2e track')
+  const u = new URL(url)
+  return postgres({
+    host: u.hostname,
+    port: u.port ? Number(u.port) : 5432,
+    database: u.pathname.replace(/^\//, ''),
+    username: decodeURIComponent(u.username),
+    password: decodeURIComponent(u.password),
+    ssl: 'require',
+    max: 1,
+  })
+}

--- a/e2e/real-db/real-api-server.ts
+++ b/e2e/real-db/real-api-server.ts
@@ -1,0 +1,15 @@
+// Serves the real Hono API (Drizzle repos against the e2e Neon branch) for the
+// authenticated real-DB Playwright track. Mirrors how the integration suite
+// runs `createApp()` against real Postgres — no `wrangler dev`, fast boot.
+//
+// `createApp()` with no overrides + `DATABASE_URL` set routes to the Drizzle
+// branch (packages/api/src/index.ts), so the service/repo tenant-scoping layer
+// (#395/#402) is exercised for real. AUTH_SECRET verifies the web's HS256 token.
+import { createApp } from '../../packages/api/src/index'
+
+const port = Number(process.env.REAL_API_PORT ?? 8788)
+const app = createApp()
+
+Bun.serve({ port, fetch: app.fetch })
+// biome-ignore lint/suspicious/noConsole: webServer readiness signal for Playwright
+console.log(`[e2e] real API listening on http://localhost:${port}`)

--- a/e2e/real-db/real-api-server.ts
+++ b/e2e/real-db/real-api-server.ts
@@ -11,5 +11,4 @@ const port = Number(process.env.REAL_API_PORT ?? 8788)
 const app = createApp()
 
 Bun.serve({ port, fetch: app.fetch })
-// biome-ignore lint/suspicious/noConsole: webServer readiness signal for Playwright
 console.log(`[e2e] real API listening on http://localhost:${port}`)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "bun run --filter '*' test",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui",
+    "test:e2e:real-db": "bunx playwright test --config playwright.real-db.config.ts",
     "lint": "bunx biome check . && bun run lint:size && bun run lint:modules",
     "lint:fix": "bunx biome check --write .",
     "lint:size": "bun run scripts/lint-file-size.ts",

--- a/packages/web/src/modules/locations/components/LocationRow.tsx
+++ b/packages/web/src/modules/locations/components/LocationRow.tsx
@@ -22,7 +22,10 @@ export function LocationRow({ location: l, onEdit, onArchive }: LocationRowProps
   const turnaroundHours = Math.round(l.defaultTurnaroundMinutes / MINUTES_PER_HOUR)
 
   return (
-    <div className="border border-border rounded-lg p-4 flex items-start gap-4 hover:bg-accent/30 transition-colors">
+    <div
+      data-testid="location-row"
+      className="border border-border rounded-lg p-4 flex items-start gap-4 hover:bg-accent/30 transition-colors"
+    >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-lg font-medium truncate">{l.name}</h3>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,10 @@ const MOCK_API_URL = `http://localhost:${MOCK_API_PORT}`
 
 export default defineConfig({
   testDir: './e2e',
+  // The authenticated real-DB track has its own config (playwright.real-db.config.ts)
+  // with real servers + a seeded Neon branch. Exclude it here so the mock track
+  // never tries to run those specs against the unauthenticated mock API.
+  testIgnore: '**/real-db/**',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -1,0 +1,72 @@
+import { defineConfig, devices } from '@playwright/test'
+import { STORAGE_STATE } from './e2e/real-db/constants'
+
+// Authenticated, real-DB e2e track (#416). Distinct from the mock track in
+// playwright.config.ts: it runs the REAL Hono API + web against a seeded Neon
+// branch, with a minted Auth.js session cookie. Own ports so it never collides
+// with the mock track's servers (web 3001 / mock-api 8787).
+const WEB_PORT = 3002
+const API_PORT = 8788
+const BASE_URL = `http://localhost:${WEB_PORT}`
+const API_URL = `http://localhost:${API_PORT}`
+
+const AUTH_SECRET = process.env.AUTH_SECRET
+const DATABASE_URL = process.env.DATABASE_URL
+if (!AUTH_SECRET || !DATABASE_URL) {
+  throw new Error(
+    'The real-DB e2e track needs AUTH_SECRET + DATABASE_URL (a seeded Neon branch). ' +
+      'Run: AUTH_SECRET=<secret> DATABASE_URL=<neon-branch-url> bun run test:e2e:real-db',
+  )
+}
+
+export default defineConfig({
+  testDir: './e2e/real-db',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'authenticated-real-db',
+      testMatch: /.*\.auth\.spec\.ts/,
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+    },
+  ],
+
+  webServer: [
+    {
+      command: 'bun run e2e/real-db/real-api-server.ts',
+      url: `${API_URL}/vehicle-classes`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+      env: {
+        REAL_API_PORT: String(API_PORT),
+        DATABASE_URL,
+        AUTH_SECRET,
+        WEB_ORIGIN: BASE_URL,
+      },
+    },
+    {
+      command: 'bun run next dev -p 3002',
+      cwd: 'packages/web',
+      url: BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        AUTH_SECRET,
+        DATABASE_URL,
+        NEXT_PUBLIC_API_URL: API_URL,
+      },
+    },
+  ],
+})


### PR DESCRIPTION
**Slice 1 of #416.** Stands up an authenticated, real-DB Playwright track and operator-locations coverage, verified locally against a disposable Neon branch. CI gating (Slice 2) is tracked in #445 (blocked on `NEON_API_KEY`).

## What

A second e2e track (own config, own ports) that runs the **real** Hono API + Next.js web against a **seeded Neon branch**, authenticated by a **minted Auth.js session cookie** — no OAuth. This is the write-track #390 (slice 8) needs.

The auth model (verified against the code):
- Minted **session cookie (JWE)** authenticates browser→web (salt = cookie name; `roleRefreshedAt` skips the jwt DB re-fetch).
- The web mints its own **HS256 API token** (`lib/api-token.ts`) for web→API; the API verifies it unchanged. The harness adds no new trust path.

## Files
- `e2e/real-db/mint-session.ts` — mint the operator session JWE (owner id resolved by stable seed email).
- `e2e/real-db/real-api-server.ts` — serve `createApp()` (Drizzle branch) under Bun, no wrangler.
- `e2e/real-db/auth.setup.ts` + `constants.ts` + `pg.ts` — setup project (cookie→storageState) + helpers.
- `e2e/real-db/locations.auth.spec.ts` — P1 (owner reaches /manage/locations, sees storefronts, no redirect), P2 (hours error renders under Closes not Opens), CRUD (add→edit→archive write-through).
- `playwright.real-db.config.ts` + `test:e2e:real-db` script.
- `playwright.config.ts` — `testIgnore: '**/real-db/**'` so the mock track never runs these.
- `LocationRow.tsx` — `data-testid="location-row"` (stable selector).

## Test plan
- [x] Local run against a disposable Neon branch (forked from marketplace-pivot, migrated+seeded): **4/4 pass** (setup + P1 + P2 + CRUD).
- [x] Mock track unaffected — `playwright test --list` shows only the 3 original specs.
- [x] `bun run lint` (biome + size + modules) clean; pre-commit tsc green.
- [x] Code-reviewed (security pass on cookie minting): no secrets committed, minting confined to `e2e/`, config throws without env. Rebased to clear a stale-base diff artifact.

## Not in scope (→ #445)
CI `e2e-real-db` job with Neon branch create/destroy — needs `NEON_API_KEY` in GitHub Secrets.