### PR TITLE
fix(seed): db:seed broken by #410 partial index — select-then-insert locations (#449)

### DIFF
--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, ne, sql } from 'drizzle-orm'
 import {
   BEST_CAR_RENTAL_NAME,
   BEST_CAR_RENTAL_OPERATOR_ID,
@@ -495,18 +495,30 @@ async function seed() {
     }
   }
 
-  // Best Car Rental storefronts (#387). Idempotent on (operatorId, name): a
-  // reseed leaves existing rows untouched, preserving each row's id so the
-  // vehicles->locations composite FK target stays stable across reseeds.
+  // Best Car Rental storefronts (#387). Since #410 (migration 0035) the
+  // (operatorId, name) uniqueness is a PARTIAL index (WHERE status <> 'ARCHIVED'),
+  // which onConflict can't target — mirror the insurance-options pattern below:
+  // insert each location only when no non-archived row of that name exists.
+  // Idempotent across reseeds and preserves each row's id as the
+  // vehicles->locations composite-FK target.
   console.log('Seeding locations...')
-  const insertedLocations = await db
-    .insert(locations)
-    .values(SEED_LOCATIONS.map((l) => ({ ...l, operatorId: BEST_CAR_RENTAL_OPERATOR_ID })))
-    .onConflictDoNothing({ target: [locations.operatorId, locations.name] })
-    .returning({ id: locations.id, name: locations.name })
-  console.log(`  seeded ${insertedLocations.length} new location(s)`)
-  for (const l of insertedLocations) {
-    console.log(`  + ${l.name} (${l.id})`)
+  for (const loc of SEED_LOCATIONS) {
+    const [existing] = await db
+      .select({ id: locations.id })
+      .from(locations)
+      .where(
+        and(
+          eq(locations.operatorId, BEST_CAR_RENTAL_OPERATOR_ID),
+          eq(locations.name, loc.name),
+          ne(locations.status, 'ARCHIVED'),
+        ),
+      )
+    if (existing) continue
+    const [inserted] = await db
+      .insert(locations)
+      .values({ ...loc, operatorId: BEST_CAR_RENTAL_OPERATOR_ID })
+      .returning({ id: locations.id, name: locations.name })
+    if (inserted) console.log(`  + ${inserted.name} (${inserted.id})`)
   }
 
   // Vehicle classes MUST exist before vehicles: vehicles.(operatorId, classId)


### PR DESCRIPTION
Closes #449.

## Problem
`bun run db:seed` aborts on any DB at migration `0035`+:
> NeonDbError: there is no unique or exclusion constraint matching the ON CONFLICT specification

`0035` (#410) replaced the full `locations_operatorId_name_unique` constraint with a **partial** unique index (`WHERE status <> 'ARCHIVED'`). Postgres can't use a partial index as an `ON CONFLICT` target, but `seed.ts` still did `onConflictDoNothing({ target: [operatorId, name] })`. Regression from #410 — the seed wasn't updated.

## Fix
Mirror the insurance-options pattern already in the same file (which uses select-then-insert *precisely because* its uniqueness is partial): insert each seed location only when no non-archived row of that name exists. Idempotent; preserves each row's id as the vehicles→locations composite-FK target.

## Why it matters
Unblocks fresh demo-DB setup, the #445 CI real-DB e2e job, and #420.

## Test plan
- [x] `db:seed` against a fresh Neon branch at `0035`: completes fully (3 locations, 5 classes, 15 vehicles) — previously aborted at locations.
- [x] Reseed: 0 errors, counts unchanged (3 locations / 5 classes) — idempotent, no dupes.
- [x] `bun run lint` clean; pre-commit tsc green.