### PR TITLE
chore(seed): backfill acrissCode on reseed via coalesce upsert (#420)

### DIFF
--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -529,7 +529,16 @@ async function seed() {
   await db
     .insert(vehicleClasses)
     .values(SEED_CLASSES.map((c) => ({ ...c, operatorId: BEST_CAR_RENTAL_OPERATOR_ID })))
-    .onConflictDoNothing({ target: vehicleClasses.slug })
+    // Reseed-repair for the one column slice 3 (#388) added after these classes
+    // were first seeded: backfill acrissCode where it is still NULL. coalesce
+    // keeps any existing code, so this repairs the gap (#420) without clobbering
+    // an operator's later edit, and the id stays put as the composite-FK target.
+    .onConflictDoUpdate({
+      target: vehicleClasses.slug,
+      set: {
+        acrissCode: sql`coalesce(${vehicleClasses.acrissCode}, excluded.${sql.identifier('acrissCode')})`,
+      },
+    })
 
   // Resolve slug -> id for the just-seeded (or pre-existing) classes so each
   // vehicle can attach by classId. Scoped to this operator's classes.


### PR DESCRIPTION
Closes #420.

## What
`SEED_CLASSES` used `onConflictDoNothing(slug)`, so a class seeded **before** slice 3 (#388) added `acrissCode` stays `NULL` after a reseed. Switch to `onConflictDoUpdate` that **coalesces** the code:

```ts
set: { acrissCode: sql`coalesce(${vehicleClasses.acrissCode}, excluded."acrissCode")` }
```

- Backfills `acrissCode` only when currently NULL (repairs the gap).
- `coalesce` keeps any existing value → operator edits are never clobbered.
- `id` is untouched, preserving the composite-FK target (#388's reason for DoNothing).

## Test plan (verified on a fresh Neon branch)
- [x] NULL `kei.acrissCode` → reseed → backfilled to `MCAR`, **id unchanged**.
- [x] Edit `kei.acrissCode` to `SUVR` → reseed → stays `SUVR` (no clobber).
- [x] Reseed twice → idempotent, counts flat.
- [x] `bun run lint` clean; pre-commit tsc green.

Stacked on #449/#450 (the seed had to run at all first); rebased onto marketplace-pivot post-merge.