### PR TITLE
docs(plans): fold 2026-06-05 scope update into proposal + archive handoff notes

### DIFF
--- a/docs/2026-06-04-gate-pair-396-407-handoff.md
+++ b/docs/2026-06-04-gate-pair-396-407-handoff.md
@@ -1,0 +1,81 @@
+# Gate pair #396 + #407 — Session Handoff (2026-06-04)
+
+> Written so you can `/clear` and resume cold. The real progress signal is the
+> **worktree git logs + PR #426**, not this doc.
+
+## What this work is
+The two "hard gates before operator #2" from the MVP backlog triage (see
+`docs/2026-06-02-marketplace-handoff-next.md` + milestone **MVP Demo / #2**):
+- **#396** operator-scope UserRepository — *tenant-isolation*
+- **#407** GET /operators + web operator picker — *the 422 has no UI affordance yet*
+
+Both branch off **`origin/marketplace-pivot`** (local `main` predates the pivot —
+do NOT read marketplace code from the main checkout; it will look "missing").
+
+## Status
+
+| Issue | State | Where |
+|---|---|---|
+| **#396** | ✅ **DONE — in review** | PR **#426** → `marketplace-pivot` (2 commits). Worktree `/Users/jack/Dev/kuruma-396-users`, branch `feature/396-operator-scope-users`. |
+| **#407** | ⬜ **NOT STARTED** | Worktree already exists: `/Users/jack/Dev/kuruma-operator-picker`, branch `feat/operator-picker`, has an **untracked plan doc** `docs/plans/2026-06-04-operator-picker.md` (honor it). No code yet. |
+
+### #396 — what shipped (decision: minimal fail-closed, NOT a retrofit)
+Investigation showed **no `OPERATOR_*` path reaches `UserRepository`** today, so
+this slice **proves + locks the closures** instead of threading `CallerContext`.
+Renters are **shared marketplace customers** (`users.operatorId` nullable) — do
+NOT filter users by operator. Real per-operator customer access = **slice 6**.
+- `tests/routes/operator-user-isolation.test.ts` — 6 regression locks
+- `repositories/types.ts` — documenting comment on `UserRepository`
+- Review fix (`c22a6af`): `/users` was resolving thread co-participants for any
+  non-privileged caller via a synthetic `RENTER` context → an operator sharing a
+  thread could resolve another user. Now **operators are self-only before the
+  thread lookup** (`routes/users.ts`, `isOperatorRole` guard). Fail-closed until
+  operator messaging (slice 7).
+- **On merge: close #396 manually** (targets non-default branch → `Closes` won't fire).
+
+## #407 — scope (from the issue body; bring to AFK depth before coding)
+- `GET /operators` API route — list operators (bypass roles see all; `OPERATOR_*`
+  sees only its own). Returns id + name + slug. (Operators route/repo already
+  exist on trunk — `routes/operators.ts`, `repositories/drizzle/operator.ts`,
+  `OperatorRepository.findById/findBySlug/findSoleId`.)
+- Web: operator **picker** on vehicle-create + class-create forms; send chosen
+  `operatorId` in POST body. **Hidden when exactly one operator exists** (keep
+  today's one-click flow).
+- Map the **422 `OperatorRequiredError`** to an **inline form error** (not a raw
+  toast) prompting operator selection.
+- Retire sole-operator inference once op #2 exists (require explicit `operatorId`
+  for non-operator writes — closes the LOW TOCTOU from #401 review).
+- (optional) Observability log when `findSoleId()` is null/ambiguous.
+- **Find first:** `resolveOperatorIdForWrite` / `findSoleId` call site (the write
+  resolver). `OperatorRequiredError` lives in `packages/api/src/middleware/auth.ts`
+  (→ 422). `tenancy.ts` does NOT exist as a file — the resolver is elsewhere; grep.
+- Sequencing: independent of #396 (no shared files) → can PR in parallel.
+
+## How to resume after /clear
+1. `gh pr view 426` — is #396 merged? If yes, `gh issue close 396` + clean worktree.
+2. `git -C /Users/jack/Dev/kuruma-operator-picker log --oneline origin/marketplace-pivot..HEAD` — #407 progress (none yet).
+3. Read `docs/plans/2026-06-04-operator-picker.md` in that worktree.
+4. `git -C /Users/jack/Dev/kuruma-operator-picker fetch origin && git -C ... rebase origin/marketplace-pivot` (trunk moves fast — slice 4a/4b already merged).
+5. Fresh worktree → `bun install` + `bunx tsc --noEmit` before coding.
+
+## Per-slice merge gate (run IN the worktree, all green)
+`bun run --filter @kuruma/api test` · `bun run lint` (whole repo, not file-scoped)
+· `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` ·
+`db:verify` only if `schema.ts`/`drizzle/` changed (#407 likely no schema change).
+
+## Gotchas hit this session
+- **Wrong-branch trap:** an Explore agent read `main` and reported the entire
+  marketplace foundation as "missing." Always explore in a worktree off
+  `origin/marketplace-pivot`.
+- Test harness: `createApp({ ...inMemoryRepos })` + JWT via `SignJWT` (issuer
+  `kuruma-web`, aud `kuruma-api`, `TEST_AUTH_SECRET`); `testAuthMiddleware(id,
+  role, operatorId)` for direct-mount route tests. Pattern: `tests/routes/
+  operator-user-isolation.test.ts`, `tenancy-context.test.ts`, `manual-booking.test.ts`.
+- `db:seed` is **Neon-HTTP only** (can't target docker pg).
+- Other live worktrees — do NOT touch: `kuruma-fees`, `kuruma-insurance`,
+  `kuruma-pricing` (slices 4b/4a/4c), `kuruma-operator-picker` (#407, yours next).
+
+## GitHub bookkeeping done
+- Milestones created: **MVP Demo (#2)** (17 open / 4 done), **Pre-launch (#3)**.
+- Triage ordering: `docs/2026-06-02-marketplace-handoff-next.md` + chat. Of the
+  non-slice issues, the only **must-do-before-demo** were #407 + #396.

--- a/docs/2026-06-04-operator-picker-collision-handoff.md
+++ b/docs/2026-06-04-operator-picker-collision-handoff.md
@@ -1,0 +1,64 @@
+# Operator Picker (#407) — Session Handoff + Collision Report
+
+**Date:** 2026-06-04
+**This session's log:** `e9b03659` (`~/.claude/projects/-Users-jack-Dev-kuruma-rental/`)
+**Epic:** #385 · **Issue:** #407 (P1, `in-progress`)
+
+---
+
+## TL;DR
+
+- ✅ **#388 closed.** ✅ **Slice 4b (#405) merged** to `marketplace-pivot` (PR #424, squash `9e33403`), #405 closed.
+- ⚠️ **#407 is being built by TWO Claude sessions in the SAME worktree at once** (`/Users/jack/Dev/kuruma-rental`'s sibling `../kuruma-operator-picker`). Resolve the collision **before** resuming. My work is safe (3 copies — see below).
+
+---
+
+## Done this session (no action needed — fully landed)
+
+1. **#388** — was already closed (PR #418); confirmed + `in-progress` label cleared.
+2. **Slice 4b fee schedules (#405)** — branch `feature/389b-fees` was already rebased + had an open PR #424. I:
+   - Found CI failing on **export drift** (`./validators/fee-schedule` missing from `packages/shared/package.json`); the fix commit `56ec248` was on the branch but the failed run was on the older `c12680f`. The HEAD run (`56ec248`) was green.
+   - Verified full local gate: 402 unit + 15 integration (`fee-schedule`) + typecheck ×3 + full `bun run lint` + `db:verify` (34 migrations).
+   - **Merged PR #424 (squash → `9e33403`)**, closed #405, removed `in-progress`/`AFK` labels.
+   - Removed merged worktrees `kuruma-insurance` + `kuruma-fees` (+ deleted their local branches).
+
+---
+
+## #407 collision — what's going on
+
+**Two live sessions share `../kuruma-operator-picker` (branch `feat/operator-picker`).** They share one working dir + one git index, so edits cross-contaminate.
+
+- **THIS session (log `e9b03659`):** built the **WEB half** — `packages/web/src/modules/operators/{api,actions,hooks,index}.ts` + operator picker in `VehicleForm.tsx` & `ClassForm.tsx` (shown when 2+ operators, hidden+defaulted when 1; vehicle form scopes class options to the picked operator for the composite FK) + i18n (en/ja/zh) + form tests — **all green in isolation**. Plus the API **`GET /operators` list endpoint** (committed cleanly as **`f0fd29a`**). **Scope decision (user, confirmed): FOCUSED gate — DEFER retire-inference.**
+- **OTHER session (logs `ee58b55e` / `d24a0e3b`, last active ~00:05):** building the **FULL plan incl. retire-inference** (pure `resolveOperatorIdForWrite`, `findSoleId` deleted from interface + both repos + `tenancy.ts` + test helper). At 00:02 it ran `git add -A && git commit`, sweeping up **my uncommitted web work + its API changes together** into **`cfad142`** ("wip slices 3b-3e"). It is now driving a **conflicted merge** (26 `UU`/`AA` files) onto `origin/marketplace-pivot`.
+
+**Branch state at handoff:** `feat/operator-picker` = `9e33403` ← `f0fd29a` (mine) ← `d52d56c` (docs) ← `cfad142` (combined wip), `[ahead 3, behind 1]`, **conflicted merge in progress** (volatile — snapshot may be stale).
+
+**Root cause:** #407 was already `in-progress` (another session had claimed it; the plan doc was its handoff). This session doubled up in the same directory.
+
+---
+
+## Where my work is (durable — 3 copies)
+
+1. **`f0fd29a`** — `GET /operators` API list endpoint (clean, isolated, recoverable via cherry-pick).
+2. **`cfad142`** — my full web work + the other session's retire-inference (entangled). Extract web-only: `git show cfad142 -- packages/web` or `git checkout cfad142 -- packages/web/src/modules/operators ...`.
+3. **`/tmp/op-picker-backup/`** — `web-changes.patch` + `operators-module/` (⚠️ ephemeral; re-copy from `cfad142` if `/tmp` is cleared).
+
+---
+
+## RESUME — in order
+
+1. **Pick ONE session to own #407.** Stop the other (check `~/.claude/projects/.../*.jsonl` mtimes + `ps` for live `claude`/VS Code-extension processes). Two agents in one worktree WILL keep colliding.
+2. **Resolve the contended worktree first** (`cd ../kuruma-operator-picker`):
+   - `git status`; if a merge/rebase is in progress, decide `git merge --abort` / `git rebase --abort` (returns to `cfad142`) vs finishing it. Do this only once no other session is live there.
+3. **Decide scope** (events have overtaken the original "defer" call):
+   - **Likely cheapest = FINISH THE FULL PLAN** — the other session already wrote the retire-inference into `cfad142`. Remaining work per plan §5 step 5: add `operatorId` to the **~8 route test files** that POST vehicle/class without it (now required since inference is retired): `vehicles`, `vehicle-classes`, `locations`, `insurance-options`, `fee-schedules`, `maintenance-logs`, `bulk-vehicle-status`, `stats`. Then full green gate → PR `Closes #407`.
+   - **OR FOCUSED** (revert retire-inference): reset branch to `f0fd29a`, re-apply `/tmp/op-picker-backup/web-changes.patch` + `operators-module/`, keep inference, open a follow-up issue "Retire sole-operator inference + 422→inline picker error (#407 follow-up)".
+4. **Full merge gate** (in the worktree): `bun run test`; `bun run lint` (whole repo); typecheck ×3; `DATABASE_URL=... bun run --filter @kuruma/api test:integration`; PR → `marketplace-pivot` (non-default → won't auto-close; close #407 manually).
+
+---
+
+## Key refs
+
+- **Plan (full TDD design):** `docs/plans/2026-06-04-operator-picker.md` (lives in the worktree, in `cfad142`).
+- Issue **#407**, Epic **#385**. Prior gates: #401/#400/#397 (operator write-scope, fallback drop).
+- Scope rationale: gate (operator #2 onboarding) is satisfied additively; retire-inference is hardening that touches ~8 other slices' tests.

--- a/docs/2026-06-04-slice4-handoff.md
+++ b/docs/2026-06-04-slice4-handoff.md
@@ -1,0 +1,127 @@
+# Slice 4 (Insurance + Fees) — Session Handoff
+
+**Date:** 2026-06-04
+**Epic:** #385 · **Index:** #389 · **Plan:** `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md`
+**Staging trunk:** `marketplace-pivot` (NOT `main` — see gotcha #1).
+
+---
+
+## TL;DR — resume point
+
+| Sub-slice | Status |
+|---|---|
+| **4a insurance (#404)** | ✅ **DONE** — merged to `marketplace-pivot` via PR #421 (squash `c439883`). #404 closed, `in-progress` label removed. |
+| **4b fees (#405)** | ⏳ **Built, reviewed, fixed, all-green — needs REBASE + PR.** Squashed to ONE clean commit `e71e332` on branch `feature/389b-fees` (worktree `/Users/jack/Dev/kuruma-fees`). I attempted the rebase, resolved most conflicts, then **aborted to leave a clean state** — redo via the recipe below. |
+| **4c pricing (#406)** | ⏸ **Deferred to another session** (user's call). Now unblocked (slice 3 #388 merged). |
+
+**Immediate next action:** execute the "4b rebase recipe" below, then open PR `Closes #405`.
+
+---
+
+## Repo state
+
+- `origin/marketplace-pivot` tip = `c439883` (slice 4a). Contains slices 1, 2, 3, 4a.
+- `feature/389b-fees` @ `e71e332` = the entire 4b implementation squashed into one commit, **on the old base `3a6a5c0`** (pre-slice-3/4a). Pre-commit hooks passed on it. Includes ALL review fixes (FK→400, DRY enums, schema comment).
+- Worktrees:
+  - `/Users/jack/Dev/kuruma-insurance` — `feature/389a-insurance` (MERGED; safe to `git worktree remove ../kuruma-insurance`).
+  - `/Users/jack/Dev/kuruma-fees` — `feature/389b-fees` @ `e71e332` (clean). **Work here.**
+  - `kuruma-acriss` (#388, merged), `kuruma-knip`, `kuruma-smoke414` — pre-existing, not part of slice 4.
+- Test DB: docker container `kuruma-test-pg` on `localhost:5432`, user/pass `kuruma`/`kuruma`. Per-worktree DBs: `kuruma_test_insurance` (4a), `kuruma_test_fees` (4b). Recreate fresh before each integration run.
+
+---
+
+## 4b rebase recipe (lands #405)
+
+```bash
+cd /Users/jack/Dev/kuruma-fees
+git fetch origin
+git rebase origin/marketplace-pivot      # conflicts expected (4a's parallel additions vs 4b's)
+```
+
+Resolve conflicts (4a is now in the base; 4b added parallel siblings → mostly "keep both"):
+
+1. **drizzle migration (collision: slice-3 `0030_acriss`, 4a `0031_insurance`, 4b wants `0030_fees`):**
+   ```bash
+   git rm -f drizzle/0030_add_fee_schedules.sql
+   git checkout --ours -- drizzle/meta/_journal.json drizzle/meta/0030_snapshot.json
+   ```
+   (Regenerate as `0032` AFTER the rebase — step 6. Never hand-edit `_journal.json`.)
+
+2. **`packages/api/src/middleware/auth.ts` — SILENT DUPLICATE:** git auto-merges (no conflict markers) but keeps BOTH copies of `MANAGEMENT_READ_ROLES` + `requireManagementRead` (4a + 4b added them identically). Delete the SECOND copy. Verify:
+   ```bash
+   rg -c "export function requireManagementRead" packages/api/src/middleware/auth.ts   # MUST be 1
+   ```
+
+3. **Keep-both unions — safe to marker-strip** (each hunk is distinct single lines, ours then theirs):
+   `packages/api/src/index.ts`, `repositories/drizzle/index.ts`, `repositories/in-memory/index.ts`, `repositories/types.ts`, `packages/web/src/components/nav/BusinessSidebar.tsx`.
+   ```bash
+   perl -i -ne 'print unless /^(<<<<<<<|=======|>>>>>>>)/' <file>
+   ```
+
+4. **Shared-tail unions — MANUAL** (both blocks share a trailing `status/createdAt/updatedAt/}` or closing `}`; a blind strip merges them into one broken block — give each block its OWN closing):
+   - `packages/api/src/stores.ts` — `InsuranceOption` + `FeeSchedule` interfaces (each full).
+   - `packages/api/src/repositories/drizzle/shared.ts` — 5 hunks: schema import + type import (strip-safe); `insuranceOptionColumns` + `feeScheduleColumns` objects, `InsuranceOptionRow`/`FeeScheduleRow` aliases (strip-safe), `toInsuranceOption` + `toFeeSchedule` mappers (manual — close each fn).
+   - `packages/shared/src/db/schema.ts` — keep BOTH full tables: `insuranceOptions` (from base) and `feeSchedules` (4b: 3 enums `fee_type`/`fee_unit`/`fee_schedule_status`, the no-DB-coherence-CHECK comment above `feeType`, composite FK `fee_schedules_operator_class_fk`, 2 partial unique indexes).
+   - `packages/web/messages/{en,ja,zh}.json` — keep BOTH `business.insurance` + `business.fees` blocks AND `nav.insurance` + `nav.fees`. Mind JSON commas. (en structure: `business.fees` has `type{}`, `unit{}`, `form{}`, `row{}` + the archive/list keys.)
+
+5. `git add -A && git rebase --continue`
+
+6. **Regenerate fee migration as 0032:**
+   ```bash
+   bun run db:generate --name add_fee_schedules     # -> drizzle/0032_add_fee_schedules.sql (fee DDL only)
+   git add drizzle && git commit -m "chore: regenerate fee migration as 0032 (rebased onto 4a)"
+   ```
+
+7. **Fresh DB + verify (33 migrations, monotonic):**
+   ```bash
+   docker exec kuruma-test-pg psql -U kuruma -d postgres -c 'DROP DATABASE IF EXISTS kuruma_test_fees WITH (FORCE);'
+   docker exec kuruma-test-pg psql -U kuruma -d postgres -c 'CREATE DATABASE kuruma_test_fees;'
+   export DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test_fees
+   bun run db:migrate && bun run db:verify
+   ```
+
+8. **Full merge gate (all green):**
+   ```bash
+   bun run test
+   bun run lint                                   # only the 4 pre-existing lint:size WARNs are OK
+   bun run --filter @kuruma/api lint:boundaries
+   bun run lint:modules
+   bun run --filter @kuruma/shared typecheck && bun run --filter @kuruma/api typecheck && bun run --filter @kuruma/web typecheck
+   DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_test_fees bun run --filter @kuruma/api test:integration fee-schedule   # expect 15/15
+   ```
+   If lint flags a `seed.ts`-style multi-line import format, run `bunx biome check --write <file>` and re-commit.
+
+9. **Push + PR:**
+   ```bash
+   git push -u origin feature/389b-fees
+   gh pr create --base marketplace-pivot --head feature/389b-fees \
+     --title "feat(marketplace): slice 4b — fee schedules (per-operator, optional per-class) (#405)" \
+     --body "...Closes #405..."
+   ```
+
+10. **After CI green (db-drift + test-and-build + e2e), merge + close manually:**
+    ```bash
+    gh pr merge <PR#> --squash
+    gh issue close 405 --comment "Landed via PR #<PR#> (squash -> marketplace-pivot)."
+    gh issue edit 405 --remove-label in-progress
+    ```
+
+---
+
+## Gotchas learned this session (IMPORTANT)
+
+1. **Non-default base = NO auto-close.** PRs merged into `marketplace-pivot` do NOT auto-close `Closes #N` (GitHub only auto-closes on merge to the default branch `main`). **Always manually `gh issue close` + remove `in-progress` after merge.** → This is why **#388 is still OPEN** despite PR #418 being merged — **close #388 too.**
+2. **3-way migration `0030` collision.** slice-3 = `0030_add_acriss_code`, 4a = `0031_add_insurance_options`, 4b = `0032_add_fee_schedules` (after rebase). Always regenerate the migration after a rebase; `db:verify` (journal-count vs applied-count) is the real signal, not the migrate "success" line.
+3. **`requireManagementRead` duplicates silently on the 4b rebase** (both slices add the identical symbol; git keeps both with no conflict marker). Dedup + verify count == 1.
+4. **`bun run test` = unit only** (no DB). Drizzle integration is `test:integration` and needs `DATABASE_URL` → the docker `kuruma-test-pg`.
+5. **`db:seed` is Neon-only** (pre-existing project gotcha) — don't run it against the docker test DB.
+
+---
+
+## Reviews (for the record — both slices passed)
+
+- **4a:** code-reviewer APPROVE (no Crit/High/Med-blocking); architect "ship-ready".
+- **4b:** code-reviewer (1 MEDIUM — DRY `FeeType`/`FeeUnit`, FIXED); architect (1 HIGH — FK violation → 500, FIXED to **400 + `INVALID_VEHICLE_CLASS`** via `FEE_SCHEDULES_CLASS_FK` constraint-name match in `FeeScheduleService`, user-approved status choice). Both otherwise clean. All fixes are baked into `e71e332`.
+
+## 4b contents (in `e71e332`)
+schema (3 enums + `fee_schedules` table, composite FK, 2 partial active-unique indexes, amount check) · validators (`fee-schedule.ts`, coherence superRefine) · repos drizzle+in-memory (requireManagementRead before operatorReadScope) · service (merge-then-validate coherence + active-uniqueness + FK→400) · routes `/fee-schedules` (bypass-precedence, code surfaced via `fail` extras) · DI in `index.ts` · web `modules/fees/*` + flat `manage/fees/page.tsx` + sidebar + i18n `business.fees.*` · tests at every layer.

--- a/docs/2026-06-04-slice4b-ci-handoff.md
+++ b/docs/2026-06-04-slice4b-ci-handoff.md
@@ -1,0 +1,73 @@
+# Slice 4b — landed + CI lessons — Session Handoff
+
+**Date:** 2026-06-04 (session 2) · **Epic:** #385 · **Staging trunk:** `marketplace-pivot`
+
+Continues `docs/2026-06-04-slice4-handoff.md`. This session pushed 4b, opened its PR, fixed the real CI blockers — and 4b **merged** (a parallel session did the final merge while this one was running).
+
+---
+
+## TL;DR — current state
+
+| Item | Status |
+|---|---|
+| **Slice 4b (#405)** | ✅ **DONE.** Merged to `marketplace-pivot` via PR #424 (squash `9e33403`, 03:31Z). #405 CLOSED, `in-progress` removed. |
+| **PR #425** (`fix/drop-dead-insurance-export`) | OPEN, green, but **OPTIONAL.** Removes dead 4a export `fetchInsuranceOptionById`. Was made to "unblock lint:deps" — but lint:deps is `continue-on-error` (never blocked). **Decision: merge as cleanup, or close.** |
+| **Slice 4c (#406)** | Not started. Worktree `kuruma-pricing` (`feature/389c-pricing`). Next marketplace slice. |
+
+**No urgent action.** 4b is shipped. Optionally resolve #425. Then start 4c.
+
+---
+
+## What actually mattered (the 4b CI fixes, in merged commit `56ec248`)
+
+CI's `test-and-build` failed on two **blocking** steps the session-1 local gate never ran:
+1. **export-drift** — `packages/shared/package.json` had no `exports` entry for `./validators/fee-schedule`. Added it. Every new shared subpath needs one.
+2. **fk-indexes** — `fee_schedules.vehicleClassId` was only the TRAILING column of `idx_fee_schedules_operator_class`; `lint:fk-indexes` doesn't count trailing columns as FK cover. Added a dedicated leading index → migration **`0033_add_fee_schedule_class_index.sql`**. (Schema author's "composite covers it" comment was wrong; corrected.)
+
+These two are what unblocked the merge.
+
+## The lint:deps red herring (→ PR #425)
+
+`lint:deps` (knip) flagged `fetchInsuranceOptionById`, a dead 4a export with no callers. I treated it as a blocker and (per your call) opened a separate base PR #425 to remove it. **It was not a blocker:** `lint:deps` is `continue-on-error: true` in ci.yml, and it's flaky locally (errors loading `playwright.config.ts`). #425 is therefore optional dead-code cleanup. The export removal itself is legit (the function truly has no callers).
+
+---
+
+## The COMPLETE local gate (mirror ci.yml `test-and-build` exactly)
+
+The session-1 recipe was incomplete. Run ALL of these before claiming a marketplace branch green — and check `continue-on-error` before treating any failing step as a blocker:
+
+```bash
+bun run lint                                   # biome + lint:size (WARN only) + lint:modules
+bun run scripts/lint-export-drift.ts           # BLOCKING — missed in session 1
+bun run lint:fk-indexes                         # BLOCKING — missed in session 1
+bun run lint:i18n-parity                         # BLOCKING — missed in session 1
+bun run lint:deps                                # continue-on-error in CI (informational), flaky locally — NOT a blocker
+bun run test                                     # unit only — run with DATABASE_URL UNSET (gotcha 2)
+bun run --filter @kuruma/shared typecheck && bun run --filter @kuruma/api typecheck && bun run --filter @kuruma/web typecheck
+bun run --filter @kuruma/api lint:boundaries && bun run lint:modules
+DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/<db> bun run --filter @kuruma/api test:integration <name>
+bun run db:verify
+```
+
+---
+
+## Gotchas learned this session (candidates for CLAUDE.md)
+
+1. **Local gate must mirror `ci.yml`.** export-drift / fk-indexes / i18n-parity are CI-only and block; they were absent from the session-1 recipe. **Before treating a failing CI step as a blocker, grep ci.yml for `continue-on-error`** (lint:deps has it).
+2. **`bun run test` FAILS if `DATABASE_URL` is exported** — a unit test connects to the real DB and hits a `unique_idempotency_key` violation. Run unit tests with the var UNSET; integration WITH it. CI runs `bun run test` with no DB URL.
+3. **Never force-push (even feature branches).** To pull a moved base into an already-pushed branch, `git merge origin/<base>` — not rebase + force. Squash-merge flattens it.
+4. **Composite-FK trailing columns need their own leading index** for `lint:fk-indexes`.
+5. **Each new `@kuruma/shared` subpath export** needs a `package.json` "exports" entry (export-drift).
+6. **`rm` is shell-aliased in this env** (rejects `-f`). Use `git checkout HEAD -- <path>` to restore. A failed `rm` during migration regen left a broken delta-only migration; recovered via `git checkout HEAD -- drizzle/` then generated a separate `0033`.
+7. **Parallel sessions move fast.** 4b was merged and `kuruma-fees` removed by another session mid-task. `git fetch` + `gh pr view` before assuming local state.
+
+---
+
+## Worktree state (2026-06-04)
+
+- `origin/marketplace-pivot` tip = `9e33403` (slices 1–4b).
+- `kuruma-deadexport` @ `1ec20bf` — PR #425 (optional). Removable after you close/merge it.
+- `kuruma-pricing` @ `feature/389c-pricing` — 4c, not started.
+- `kuruma-fees`, `kuruma-insurance` — removed by parallel sessions.
+- New (other sessions): `kuruma-396-users`, `kuruma-operator-picker`.
+- Test DB: docker `kuruma-test-pg` on localhost:5432, `kuruma`/`kuruma`.

--- a/docs/plans/2026-05-25-marketplace-mvp-proposal.md
+++ b/docs/plans/2026-05-25-marketplace-mvp-proposal.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-25
 **Status:** Accepted for MVP implementation (Jack, 2026-05-27)
-**Scope update (2026-06-05):** `docs/plans/2026-06-05-scope-update-du-kaku.md` (Du + Kaku alignment) amends §1/§2/§9/§10 — adds in-app payment, document upload + verification, a dual (map/flat-list + storefront) search model, paid add-ons, and a platform-admin revenue portal. MVP-vs-later triage pending.
+**Scope update (2026-06-05):** `docs/plans/2026-06-05-scope-update-du-kaku.md` (Du + Kaku alignment) amends §1/§2/§6/§9/§10 — adds in-app payment, document upload + manual verification, a dual (map/flat-list + storefront) search model, paid add-ons, luggage attributes, and a platform-admin revenue portal. MVP-vs-later triage is resolved in that addendum's §5.
 **Supersedes:** 2026-04-28 email-hub pivot
 **Anchored in:** `docs/internal/2026-05-24-qiao-du-meeting.md`, `docs/meeting_notes/2026_05_24_notes_02.txt`, Du follow-up notes from 2026-05-27
 
@@ -14,7 +14,7 @@ A multi-tenant Airbnb-style car rental marketplace. Partner operators register s
 
 **First operator:** Best Car Rental (Osaka), 30–40 cars. **Second wave:** Mr. Qiao's partner operators (count TBD).
 
-**Out of MVP** (deferred, designed-for): online payment, pre-auth (lives on separate Stripe site), license/IDP/photo upload, calendar dashboards, cancellation/modification UI, OTA email parsing, Trip.com sync (Du's parallel work — integration boundary designed but not built).
+**Out of MVP / fast-follow after 2026-06-05 triage** (deferred, designed-for): class-combo deals with inventory-count availability, automated document verification, richer admin portal workflows, calendar dashboards, cancellation/modification UI, OTA email parsing, Trip.com sync (Du's parallel work — integration boundary designed but not built). In-app Stripe payment, paid add-ons, document upload + manual verification, luggage attributes, map/list search over specific vehicles, and the platform revenue tab are now MVP/MVP-lite per the addendum.
 
 ---
 
@@ -22,7 +22,7 @@ A multi-tenant Airbnb-style car rental marketplace. Partner operators register s
 
 | Decision | Choice | Reversibility |
 |---|---|---|
-| **Search result shape** | NicoNico-style storefront-first flow: search form filters by pickup/return datetime, pickup/return location, and class; results show storefront cards with per-class availability summaries; clicking a storefront shows available individual vehicles at that storefront for selection. | Storefront-first mirrors the reference UX and makes partner/location choice explicit |
+| **Search result shape** | Dual model: keep the NicoNico-style storefront-first flow, and add a map + left-side flat list across operators/locations for specific vehicles. Class-combo deals are designed-for now but fast-follow after demo. | Lets us demo cross-operator discovery without throwing away storefront-first partner/location context |
 | **Class display vs vehicle booking** | ACRISS class is the discovery/filtering/grouping layer; a concrete vehicle is selected before booking submit. Persist both `requested_vehicle_id` (what the renter chose) and `assigned_vehicle_id` (what the operator will fulfill). Initially they are the same. Postgres exclusion constraint on `(assigned_vehicle_id, time_range)` enforces uniqueness atomically. | Class-only booking would have a check-then-act race; selected-vehicle booking lets the DB constraint enforce uniqueness atomically while preserving a path for real-world substitutions |
 | **Class taxonomy** | ACRISS 4-letter codes live on `vehicle_classes.acriss_code`; vehicles reference a class via `vehicles.class_id`; i18n friendly labels render in UI | Reversible (rename labels); adopting ACRISS aligns with OTA standard for future Trip.com sync |
 | **Tenant routing** | Business portal under `/manage/<operator_slug>/...`; renter portal = single URL space (cross-operator search is the point) | Reversible via 301 + URL rewrites; subdomain swap is future post-MVP if white-label needed |
@@ -33,7 +33,7 @@ A multi-tenant Airbnb-style car rental marketplace. Partner operators register s
 | **Vehicle turnaround buffer** | Default 48-hour cooldown after return before the same vehicle is bookable again. Storefront/location default is operator-adjustable; vehicle-level override is allowed for exceptions. Availability and exclusion ranges use `effective_end_at = end_at + turnaround_minutes`. | Prevents immediate re-rental after return and preserves the existing exclusion-constraint model |
 | **Booking write boundary** | Booking submit runs in one DB transaction: validate selected-vehicle availability, insert booking with `requested_vehicle_id` + `assigned_vehicle_id`, insert initial `booking_events`, snapshot applicable fees. Notification work happens after commit via `notification_log`. | Keeps atomic business state in Postgres while avoiding email/network side effects inside the transaction |
 | **Vehicle substitution** | If the selected car becomes unavailable after booking, an operator may substitute another available vehicle from the same operator/location and same-or-better ACRISS class. Substitution updates `assigned_vehicle_id` in a transaction, rechecks availability/exclusion, and appends a `VEHICLE_SUBSTITUTED` booking event with old/new vehicle IDs and reason. | Handles normal rental-ops reality without reverting to vague class-only reservations; audit trail preserves what the renter originally selected |
-| **Additive fees** | `fee_schedules` per operator (optionally per `vehicle_class_id`); platform-defined fee-type enum starts with `OVERTIME_HOURLY` + `CLEANING_FLAT` + `NO_FUEL_FLAT`. Overtime is charged as `ceil(overtime_hours) * hourly_rate_for_class`. At booking: snapshot applicable rows into `bookings.fee_snapshot jsonb` (locks rate-at-time-of-booking). MVP displays informationally on confirmation; no auto-compute/charge. | Snapshot pattern lets post-MVP checkout flow apply actual fees against locked rates without retroactive surprises |
+| **Additive costs** | Two buckets: selectable paid add-ons chosen during booking (baby seat, etc.) and potential post-rental `fee_schedules` (`OVERTIME_HOURLY`, `CLEANING_FLAT`, `NO_FUEL_FLAT`) snapshotted for disclosure. | Keeps paid checkout add-ons separate from later/manual incident fees |
 | **Insurance** | Per-operator `insurance_options`; operator picks which apply per vehicle; seed defaults from notes_02 (150k normal / 250k premium) | Per-operator from start; platform-standard could overlay later |
 | **Locations** | First-class entity, `operator_id` FK, N per operator; bookings carry `pickup_location_id` + `dropoff_location_id` (separate FKs; MVP UX defaults equal) | One-way rental unlocks without schema change |
 | **Booking ID** | UUIDv7 internal + short alphanumeric `booking_code` for human/email reference | UUIDv7 keeps existing pattern (`project_architect-review`) |
@@ -94,12 +94,17 @@ None of the above will paint us into a corner. The two that *touch the most code
 
 ### Renter portal
 
-1. Search — pickup location + return location + start datetime + end datetime + class filters → storefront cards across all operators
-2. Storefront result card — operator/location name, address, distance/area, operating hours, per-class availability summary, min price, and representative photos
+1. Search — pickup location + return location + start datetime + end datetime + class filters → storefront cards plus map/list results over specific vehicles across all operators
+2. Result cards — operator/location, address/area, operating hours, per-class availability or selected vehicle, min price, representative photos, seats, and luggage count/size
 3. Storefront detail — available individual vehicles at that storefront for the selected date range, grouped/filterable by ACRISS class
-4. Booking flow — select vehicle, select insurance, confirm pickup/return locations + dates, enter renter contact (email, name, phone, language)
-5. Booking confirmation page — booking code, selected vehicle details (make/model/license plate), pickup details, **link to pre-auth handoff site** (operator's configured URL), and **"potential additional charges"** block listing snapshotted fees (overtime/hour, cleaning, no-fuel return) — informational only
-6. Confirmation email — booking details + pre-auth link + potential additional charges + cancellation contact
+4. Booking flow — select vehicle, upload document(s), wait for manual verification gate, select paid add-ons, select insurance, confirm pickup/return locations + dates, enter renter contact
+5. Stripe payment — platform account collects the shown price; webhook records `payment_events` with partner-business attribution and 4% platform fee
+6. Booking confirmation page/email — booking code, selected vehicle details, pickup details, pre-auth handoff link, paid selections, and potential additional charges
+
+### Platform admin portal
+
+1. Revenue tab — read-only successful-payment aggregates per partner business
+2. Manual document review — approve/reject uploaded IDP/passport documents before booking can proceed
 
 ### Platform / shared
 
@@ -110,6 +115,7 @@ None of the above will paint us into a corner. The two that *touch the most code
 5. Outbound email via `EmailSender` interface (concrete vendor chosen at slice 7; Resend likely for DX) — see §10 item 2
 6. Operator-scoped query enforcement via `CallerContext`
 7. Operator onboarding for MVP — env-gated admin invite endpoint + seed script; no public self-serve
+8. `payment_events` as Stripe webhook source-of-truth for revenue reporting
 
 ---
 
@@ -126,7 +132,7 @@ None of the above will paint us into a corner. The two that *touch the most code
 | **Demo seed data** — 3+ operators, 30+ vehicles, varied ACRISS codes, multiple locations, sample bookings | New | ~0.5 day |
 | **Integration + i18n keys + polish** | — | 2–3 days |
 | **E2E happy path** — renter search → book → notification email → operator sees it | New | 1–2 days |
-| **Total** | | **~18–23 focused dev days** |
+| **Total** | | **~18–23 focused dev days before 2026-06-05 scope expansion; re-estimate after slice 6 lands** |
 
 Migration epic #378 is **not** in this estimate.
 
@@ -168,7 +174,7 @@ Formalize three long-lived environments + short-lived feature branches:
 
 ## 6. Vertical-slice execution plan (ordered)
 
-Each slice = DB → API → UI → test → mergeable. Slices listed in dependency order; each is shippable.
+Each slice = DB → API → UI → test → mergeable. Slices listed in dependency order; each is shippable. After 2026-06-05 triage, the order after slice 6 is re-baselined to: **7 notifications + pre-auth → luggage + map/list view → doc upload + manual verify → payment + add-ons + `payment_events` → admin revenue tab → 8 demo seed + E2E**.
 
 | # | Slice | What ships | Days |
 |---|---|---|---|
@@ -303,12 +309,12 @@ These are either resolved defaults or implementation notes that should stay visi
 13. **Currency** — JPY only. No conversion in MVP. Trip.com integration will surface multi-currency later, not now.
 14. **Trip.com / Du integration boundary** — beyond #6, design `bookings.source` enum already includes `TRIP_COM` per current schema; honor that.
 15. **Operator slug strategy** — auto-generated from operator name on creation (kebab-case, ASCII, max 32 chars). Collisions append numeric suffix (`acme-2`). Editable only by platform admin (env-gated endpoint), not by operator. Stored as `operators.slug text unique not null`. Used in `/manage/<slug>/...`.
-16. **KANATA / three-party structure** — KANATA STUDIO is platform owner, **implicit** in the data model (no row, no entity). `operators` table holds rental businesses; Best Car Rental is operator #1. Kaku is a business-arrangement concern (sourcing + payment intermediary per `memory/project_business-structure.md`), not a system entity. Commission / revenue-share is **post-MVP** — no money flows through the platform yet (payment is at-store). When that lands, design a `commission_terms` table per-operator.
+16. **KANATA / three-party structure + commission** — KANATA STUDIO is platform owner, **implicit** in the data model (no row, no entity). `operators` table holds rental businesses; Best Car Rental is operator #1. Kaku is a business-arrangement concern, not a system entity. Per 2026-06-05 scope update, money flows through the platform in MVP: Stripe collects the full amount, `payment_events` records partner-business attribution, platform retains 4%, and partner remittance is computed manually at month-end.
 17. **Notification reliability** — at-least-once delivery via Resend's built-in retry. Persist a `notification_log` row per send (`status: queued | sent | failed`). Failed sends visible in operator portal with manual-resend button. No DLQ for MVP.
 18. **Platform brand on renter portal** — renter portal is **platform-neutral** (multi-operator marketplace). Per-card operator name shows as a label, not as branding. Domain near-term is `bestcarrental.jp` per `memory/project_company-identity.md`, with cross-operator listings on it (the brand becomes the marketplace name, not exclusively Mr. Qiao's business).
-19. **Additive fees / potential charges** — `fee_schedules` table per-operator, optionally per-class via nullable `vehicle_class_id` FK. Platform-defined fee-type enum starts with `OVERTIME_HOURLY` + `CLEANING_FLAT` + `NO_FUEL_FLAT` for MVP. Operator sets `amount_jpy` + `unit` (`PER_HOUR` / `PER_DAY` / `PER_KM` / `FLAT`) per row. Overtime calculation rule from Du: `ceil(actual_return_overage_hours) * snapshotted_overtime_hourly_rate_for_class`. At booking, applicable rows snapshot into `bookings.fee_snapshot jsonb` — locks rate-at-time-of-booking so post-MVP checkout charges against the locked rate, not the current one. Confirmation page + email display them as "potential additional charges" — informational only in MVP. Auto-application at checkout is post-MVP (needs damage-assessment + final-charge flow). Pattern matches NicoNico / Hertz fee disclosure.
+19. **Add-ons vs potential charges** — paid add-ons are selected in the booking wizard and charged through Stripe in MVP. `fee_schedules` remain the separate potential-charge model for overtime/cleaning/no-fuel disclosures; applicable rows snapshot into `bookings.fee_snapshot jsonb` and stay informational until a later final-charge workflow exists.
 20. **Turnaround buffer** — default cooldown is 48 hours after scheduled return before the same vehicle appears as available again. Operators can adjust at storefront/location level; individual vehicles can override when needed. Existing `bufferMinutes` concept should be renamed or mapped to `turnaround_minutes` so implementers do not leave the old 60-minute default in place.
-21. **Search API contract** — use two renter-facing read models: storefront search returns location/storefront cards with `class_summaries`; storefront detail returns available vehicles for the selected date range + class filters. Do not return a flat cross-operator vehicle list as the primary search result.
+21. **Search API contract** — use renter-facing read models for both storefront search and map/list vehicle search. Storefront search returns location cards with `class_summaries`; storefront detail returns available vehicles; map/list search returns available specific vehicles across operators/locations. Class-combo results are designed-for but not demo scope.
 22. **Booking transaction boundary** — selected-vehicle booking is one DB transaction for availability validation, booking insert with requested/assigned vehicle IDs, first event insert, and fee snapshot. Email/notification side effects are queued/logged after commit only.
 23. **Platform admin bootstrap** — seed the first platform admin from `PLATFORM_ADMIN_EMAILS`; expose only env-gated admin endpoints for operator creation/invite during MVP. Public operator signup is post-MVP.
 24. **Issue/worktree policy** — create one GitHub epic for the marketplace MVP, then one GitHub issue per vertical slice. Implementation agents work from one issue at a time on `feature/<issue-number>-<slug>` branches/worktrees off `marketplace-pivot`.
@@ -328,10 +334,10 @@ Initial walkthrough decisions from 2026-05-25 plus Du follow-up decisions from 2
 6. **Du discovery session** — still relevant; schedule during slices 2–3 (before slice 4 starts). Targeted at his daily workflow + operator-portal information architecture. Output may surface follow-up work in slice 7–8 polish.
 7. **Operator approval workflow** — invite-only via env-gated admin endpoint for MVP. Matches "partners register as they come" framing — when a partner says yes, Jack creates the operator account. Self-serve signup form is post-MVP.
 8. **Booking modification UI** — none in MVP. Event log makes modification trivially addable post-MVP without schema change.
-9. **Additive cost model** — `fee_schedules` per-operator (optionally per-class) with platform-defined fee-type enum: `OVERTIME_HOURLY` + `CLEANING_FLAT` + `NO_FUEL_FLAT` for MVP. At booking, applicable fees snapshot to `bookings.fee_snapshot jsonb` locking rate-at-time-of-booking. Overtime is later computed as rounded-up overage hours times the snapshotted hourly class rate. Confirmation page + email show informationally; auto-charge at checkout is post-MVP. See §9 item 19 for full schema sketch.
+9. **Additive cost model** — paid add-ons are selected and charged during the MVP booking wizard. Potential post-rental fees still use `fee_schedules`, snapshot into `bookings.fee_snapshot jsonb`, and render informationally until a later final-charge workflow exists.
 10. **NicoNico-style renter flow from Du follow-up** — landing/search collects pickup/return datetime, pickup/return location, and class filters; results are storefront cards with class availability summaries; storefront detail shows available individual vehicles; booking reserves the selected vehicle.
 11. **Turnaround buffer** — default 48 hours after return; configurable by storefront/location with optional vehicle override. Availability and booking conflict ranges use the chosen turnaround.
-12. **Search contract** — storefront cards first, storefront vehicle detail second. This is the primary renter search model; flat all-vehicle search is rejected for MVP because it hides the operator/location choice.
+12. **Search contract** — storefront-first remains supported, but the 2026-06-05 update adds a map + left-side flat list over specific vehicles as MVP-lite. Both flows are first-class; class-combo results are fast-follow.
 13. **ACRISS placement** — `vehicle_classes.acriss_code` is canonical; vehicles point to classes. Rejected: duplicating ACRISS on vehicles unless a future integration proves class records cannot express the needed variance.
 14. **Booking transaction boundary** — booking submit is one DB transaction for selected vehicle availability, booking row with requested/assigned vehicle IDs, initial event, and fee snapshot; notifications happen after commit through `notification_log`.
 15. **Platform admin bootstrap** — seed + env-gated admin endpoint for MVP operator onboarding. Public self-serve registration is post-MVP.


### PR DESCRIPTION
Saves two pieces of in-progress doc work:
1. Folds the 2026-06-05 Du+Kaku scope update into the **proposal body** (§2, §9, §10, renter flow, new platform-admin section, payment_events) so the source-of-truth matches the addendum.
2. Archives the 2026-06-04 slice handoff notes into the repo.

Docs-only. Ref #385.