### PR TITLE
fix(api): disambiguate resend no-ops from real re-sends (#485)

### DIFF
--- a/packages/api/src/routes/notifications.ts
+++ b/packages/api/src/routes/notifications.ts
@@ -54,6 +54,8 @@ export function createNotificationRoutes(service: NotificationService) {
       // tenant-existence leak. The atomic claim makes a double-click send once.
       const result = await service.resend(toCallerContext(user), c.req.param('id'))
       if (!result.ok) return fail(c, result.error, result.status)
-      return ok(c, { status: result.status })
+      // `outcome` lets the portal distinguish a real re-send from a no-op
+      // ("already in progress" / "already sent") instead of a blanket green (#485).
+      return ok(c, { status: result.status, outcome: result.outcome })
     })
 }

--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -28,6 +28,20 @@ interface Resolved {
 }
 
 /**
+ * Explicit result of one processOne attempt, so callers (notably the operator
+ * resend) never have to re-derive "did a send actually happen?" from a status
+ * that conflates a fresh send with a no-op. `claim()` returns null only for a
+ * terminal SENT row or a live (non-expired) SENDING lease, which is exactly the
+ * already_sent / in_progress split.
+ */
+export type DispatchOutcome =
+  | { result: 'sent'; row: NotificationLog }
+  | { result: 'failed'; row: NotificationLog }
+  | { result: 'already_sent'; row: NotificationLog }
+  | { result: 'in_progress'; row: NotificationLog }
+  | { result: 'no_recipient' }
+
+/**
  * Turns a committed booking into outbound email. Owns the upsert -> atomic claim
  * -> render -> send -> mark unit (processOne), reused by both the post-commit
  * dispatch and the operator-portal resend. Never throws to its caller — a send
@@ -52,15 +66,16 @@ export class NotificationDispatcher {
 
   /**
    * Idempotent send unit for one (booking, kind). Upserts a QUEUED row, atomically
-   * claims it, renders + sends, and records the terminal state. A null claim (live
-   * lease or terminal SENT) is a no-op. Returns the row's resulting state, or
-   * undefined when there is no resolvable recipient.
+   * claims it, renders + sends, and records the terminal state. A null claim is a
+   * no-op — already_sent (terminal SENT) or in_progress (a live SENDING lease held
+   * by another sender). Returns an explicit DispatchOutcome so callers don't infer
+   * "did we send?" from a status.
    */
-  async processOne(booking: Booking, kind: Kind): Promise<NotificationLog | undefined> {
+  async processOne(booking: Booking, kind: Kind): Promise<DispatchOutcome> {
     const resolved = await this.resolveRecipient(booking, kind)
     if (!resolved) {
       console.error('[notification] no recipient', { bookingId: booking.id, kind })
-      return undefined
+      return { result: 'no_recipient' }
     }
 
     const row = await this.notificationLogRepo.upsertQueued({
@@ -73,18 +88,25 @@ export class NotificationDispatcher {
     })
 
     const claimed = await this.notificationLogRepo.claim(row.id)
-    if (!claimed) return row // live lease or already SENT — skip
+    if (!claimed) {
+      // claim() only declines a terminal SENT row or a live (non-expired) SENDING
+      // lease — QUEUED/FAILED/expired-SENDING are always claimable. So the un-claimed
+      // status disambiguates "already done" from "in flight elsewhere".
+      return row.status === 'SENT'
+        ? { result: 'already_sent', row }
+        : { result: 'in_progress', row }
+    }
 
     try {
       const message = await this.buildMessage(booking, kind, claimed.recipient, claimed.locale)
       const { providerMessageId } = await this.emailSender.send(message)
       await this.notificationLogRepo.markSent(claimed.id, providerMessageId)
-      return { ...claimed, status: 'SENT', providerMessageId }
+      return { result: 'sent', row: { ...claimed, status: 'SENT', providerMessageId } }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
       console.error('[notification] send failed', { id: claimed.id, kind, reason })
       await this.notificationLogRepo.markFailed(claimed.id, reason.slice(0, 500))
-      return { ...claimed, status: 'FAILED', error: reason }
+      return { result: 'failed', row: { ...claimed, status: 'FAILED', error: reason } }
     }
   }
 

--- a/packages/api/src/services/notification.ts
+++ b/packages/api/src/services/notification.ts
@@ -9,7 +9,11 @@ import type { NotificationLog } from '../stores'
 import type { NotificationDispatcher } from './notification-dispatcher'
 
 export type ResendResult =
-  | { ok: true; status: NotificationLog['status'] }
+  | {
+      ok: true
+      status: NotificationLog['status']
+      outcome: 'resent' | 'already_sent' | 'in_progress'
+    }
   | { ok: false; status: number; error: string }
 
 /**
@@ -38,11 +42,18 @@ export class NotificationService {
     const booking = await this.bookingRepo.findById(SYSTEM_CONTEXT, row.bookingId)
     if (!booking) return { ok: false, status: 404, error: 'Booking not found' }
 
-    const result = await this.dispatcher.processOne(booking, row.kind)
-    if (!result) return { ok: false, status: 422, error: 'No resolvable recipient' }
-    if (result.status === 'FAILED') {
-      return { ok: false, status: 502, error: result.error ?? 'Send failed' }
+    const outcome = await this.dispatcher.processOne(booking, row.kind)
+    switch (outcome.result) {
+      case 'no_recipient':
+        return { ok: false, status: 422, error: 'No resolvable recipient' }
+      case 'failed':
+        return { ok: false, status: 502, error: outcome.row.error ?? 'Send failed' }
+      case 'sent':
+        return { ok: true, status: 'SENT', outcome: 'resent' }
+      case 'already_sent':
+        return { ok: true, status: 'SENT', outcome: 'already_sent' }
+      case 'in_progress':
+        return { ok: true, status: 'SENDING', outcome: 'in_progress' }
     }
-    return { ok: true, status: result.status }
   }
 }

--- a/packages/api/tests/services/notification-service.test.ts
+++ b/packages/api/tests/services/notification-service.test.ts
@@ -165,7 +165,44 @@ describe('NotificationService', () => {
     await logRepo.claim(seeded.id)
     await logRepo.markFailed(seeded.id, 'earlier failure')
     const result = await service.resend(op1Ctx, seeded.id)
-    expect(result).toEqual({ ok: true, status: 'SENT' })
+    expect(result).toEqual({ ok: true, status: 'SENT', outcome: 'resent' })
+  })
+
+  it('reports a live SENDING lease as in_progress without re-sending (#485)', async () => {
+    // Another sender holds a fresh (non-expired) lease: resend must NOT report a
+    // green "sent" — the portal needs to say "already in progress".
+    const sender = { send: vi.fn(async () => ({ providerMessageId: 'msg-1' })) }
+    const { service, logRepo, booking } = build(sender)
+    const seeded = await logRepo.upsertQueued({
+      bookingId: booking.id,
+      operatorId: OP1,
+      kind: 'RENTER_BOOKING_CONFIRM',
+      recipient: 'jane@example.com',
+      locale: 'en',
+      idempotencyKey: `notify:${booking.id}:RENTER_BOOKING_CONFIRM`,
+    })
+    await logRepo.claim(seeded.id) // live lease held elsewhere
+    const result = await service.resend(op1Ctx, seeded.id)
+    expect(result).toEqual({ ok: true, status: 'SENDING', outcome: 'in_progress' })
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('reports an already-SENT row as already_sent without re-sending (#485)', async () => {
+    const sender = { send: vi.fn(async () => ({ providerMessageId: 'msg-1' })) }
+    const { service, logRepo, booking } = build(sender)
+    const seeded = await logRepo.upsertQueued({
+      bookingId: booking.id,
+      operatorId: OP1,
+      kind: 'RENTER_BOOKING_CONFIRM',
+      recipient: 'jane@example.com',
+      locale: 'en',
+      idempotencyKey: `notify:${booking.id}:RENTER_BOOKING_CONFIRM`,
+    })
+    await logRepo.claim(seeded.id)
+    await logRepo.markSent(seeded.id, 'msg-earlier')
+    const result = await service.resend(op1Ctx, seeded.id)
+    expect(result).toEqual({ ok: true, status: 'SENT', outcome: 'already_sent' })
+    expect(sender.send).not.toHaveBeenCalled()
   })
 
   it('two concurrent resends of one row invoke the sender exactly once (atomic claim)', async () => {


### PR DESCRIPTION
## Problem
`NotificationDispatcher.processOne` returned the un-claimed row whenever `claim()` declined, so `NotificationService.resend` reported **both** an already-SENT row **and** a live SENDING lease (another sender holds it) as `{ ok: true }` → HTTP 200. The operator saw a green result when **nothing was sent**.

## Fix
`processOne` now returns an explicit `DispatchOutcome`: `sent | failed | already_sent | in_progress | no_recipient`. `claim()` declines **only** a terminal SENT row or a live (non-expired) lease — exactly the `already_sent` / `in_progress` split — so the caller no longer infers "did we send?" from a conflated status. `resend` maps these to a discriminated `ResendResult` carrying an `outcome` the route surfaces (`'resent' | 'already_sent' | 'in_progress'`), so the portal can say "already in progress" / "already sent" instead of a blanket success.

## Tests (TDD, RED→GREEN)
- live SENDING lease → `{ ok: true, status: 'SENDING', outcome: 'in_progress' }`, sender **not** called
- already-SENT row → `{ ok: true, status: 'SENT', outcome: 'already_sent' }`, sender **not** called
- genuine re-send (FAILED→SENT) → `outcome: 'resent'` (updated existing exact-match test)

Gate: api **888** unit · api typecheck · boundaries · biome · web typecheck — all green. No schema change.

Closes #485 (manual close — base is non-default `marketplace-pivot`). Slice-7 follow-up, epic #385.