### PR TITLE
fix(api): guard location archive against active bookings (#412 part 1)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -444,7 +444,7 @@ export function createApp(overrides?: {
   // inference is retired, so it no longer needs an operator lookup.
   const resolveWriteOperatorId: ResolveWriteOperatorId = (ctx, inputOperatorId) =>
     resolveOperatorIdForWrite(ctx, inputOperatorId)
-  const locationService = new LocationService(locationRepo)
+  const locationService = new LocationService(locationRepo, bookingRepo)
   const insuranceOptionService = new InsuranceOptionService(insuranceOptionRepo)
   const feeScheduleService = new FeeScheduleService(feeScheduleRepo)
   const storefrontSearchService = new StorefrontSearchService(

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -113,6 +113,22 @@ export class DrizzleBookingRepository implements BookingRepository {
     return row?.value ?? 0
   }
 
+  async countActiveForLocation(locationId: string): Promise<number> {
+    const [row] = await this.db
+      .select({ value: count() })
+      .from(bookings)
+      .where(
+        and(
+          or(
+            eq(bookings.pickupLocationId, locationId),
+            eq(bookings.dropoffLocationId, locationId),
+          ),
+          inArray(bookings.status, ['CONFIRMED', 'ACTIVE'] as const),
+        ),
+      )
+    return row?.value ?? 0
+  }
+
   async create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -130,6 +130,16 @@ export class InMemoryBookingRepository implements BookingRepository {
     return count
   }
 
+  async countActiveForLocation(locationId: string): Promise<number> {
+    let count = 0
+    for (const booking of this.store.values()) {
+      const referencesLocation =
+        booking.pickupLocationId === locationId || booking.dropoffLocationId === locationId
+      if (referencesLocation && BLOCKING_STATUSES.has(booking.status)) count++
+    }
+    return count
+  }
+
   async create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -297,6 +297,10 @@ export interface BookingRepository {
    *  vehicle set. Used to guard operations that assume no live bookings exist
    *  for those vehicles — e.g. archiving a vehicle class. */
   countActiveForVehicles(vehicleIds: string[]): Promise<number>
+  /** Counts bookings in BLOCKING_STATUSES (CONFIRMED, ACTIVE) that reference the
+   *  given location as pickup OR dropoff. Guards archiving a location still in
+   *  live use (#412). */
+  countActiveForLocation(locationId: string): Promise<number>
   create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -127,7 +127,16 @@ export function createLocationRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const result = await service.archive(toCallerContext(user), c.req.param('id'))
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) {
+        // Surface the active-bookings discriminator so the portal can prompt the
+        // owner to reassign/cancel first instead of showing a generic 409 (#412).
+        const extras: Record<string, unknown> = {}
+        if (result.code) extras.code = result.code
+        if (result.activeBookingsCount !== undefined) {
+          extras.activeBookingsCount = result.activeBookingsCount
+        }
+        return fail(c, result.error, result.status, extras)
+      }
       return ok(c, result.location)
     })
 }

--- a/packages/api/src/services/location.ts
+++ b/packages/api/src/services/location.ts
@@ -1,10 +1,25 @@
 import type { CallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
-import type { Location, LocationFilters, LocationRepository } from '../repositories/types'
+import type {
+  BookingRepository,
+  Location,
+  LocationFilters,
+  LocationRepository,
+} from '../repositories/types'
 
 export type LocationResult =
   | { ok: true; location: Location }
   | { ok: false; error: string; status: number }
+
+export type LocationArchiveResult =
+  | { ok: true; location: Location }
+  | {
+      ok: false
+      error: string
+      status: number
+      code?: 'LOCATION_HAS_ACTIVE_BOOKINGS'
+      activeBookingsCount?: number
+    }
 
 const DUPLICATE_NAME_MESSAGE = 'A location with this name already exists'
 const NOT_FOUND_MESSAGE = 'Location not found'
@@ -12,7 +27,10 @@ const NOT_FOUND_MESSAGE = 'Location not found'
 const isDuplicateName = (err: unknown): boolean => pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION
 
 export class LocationService {
-  constructor(private readonly repo: LocationRepository) {}
+  constructor(
+    private readonly repo: LocationRepository,
+    private readonly bookingRepo: BookingRepository,
+  ) {}
 
   async findAll(ctx: CallerContext, filters?: LocationFilters): Promise<Location[]> {
     return this.repo.findAll(ctx, filters)
@@ -72,12 +90,26 @@ export class LocationService {
     }
   }
 
-  async archive(ctx: CallerContext, id: string): Promise<LocationResult> {
+  async archive(ctx: CallerContext, id: string): Promise<LocationArchiveResult> {
     // Same caller-scoped guard as update — load before mutate so a cross-tenant
-    // id can never be archived. No active-booking guard in slice 2 (locations
-    // aren't on bookings until slice 6).
+    // id can never be archived.
     const existing = await this.repo.findById(ctx, id)
     if (!existing) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
+
+    // Guard (#412): a location still referenced as pickup OR dropoff by a live
+    // (CONFIRMED/ACTIVE) booking cannot be archived — the owner must reassign or
+    // cancel those bookings first. Mirrors VehicleClassService.archive. The DB
+    // FK keeps the row referenceable; this is the friendly app-level seal.
+    const activeBookingsCount = await this.bookingRepo.countActiveForLocation(id)
+    if (activeBookingsCount > 0) {
+      return {
+        ok: false,
+        error: 'Cannot archive a location with active bookings',
+        status: 409,
+        code: 'LOCATION_HAS_ACTIVE_BOOKINGS',
+        activeBookingsCount,
+      }
+    }
 
     const archived = await this.repo.archive(id)
     if (!archived) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }

--- a/packages/api/tests/integration/locations.test.ts
+++ b/packages/api/tests/integration/locations.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { pgErrorCode } from '../../src/pg-errors'
 import { DrizzleLocationRepository } from '../../src/repositories/drizzle'
+import { DrizzleBookingRepository } from '../../src/repositories/drizzle/booking'
 import { LocationService } from '../../src/services/location'
 import type { Location } from '../../src/stores'
 import { db } from './setup'
@@ -174,7 +175,7 @@ describe('archiving a location frees its name for re-creation (#410)', () => {
 // Resolves to 404 (no cross-tenant existence leak), leaving the row untouched.
 describe('cross-operator location WRITE denial (service seal, #387)', () => {
   const repo = new DrizzleLocationRepository(db)
-  const service = new LocationService(repo)
+  const service = new LocationService(repo, new DrizzleBookingRepository(db))
   const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const opAId = `op_locw_a_${uniq}`
   const opBId = `op_locw_b_${uniq}`

--- a/packages/api/tests/repositories/booking.test.ts
+++ b/packages/api/tests/repositories/booking.test.ts
@@ -139,3 +139,55 @@ describe('InMemoryBookingRepository — three-way read scope', () => {
     ).rejects.toThrow(/another user/)
   })
 })
+
+describe('InMemoryBookingRepository — countActiveForLocation (#412)', () => {
+  it('counts active bookings referencing the location as pickup OR dropoff, ignoring non-active', async () => {
+    const repo = new InMemoryBookingRepository()
+    // pickup = loc-1, CONFIRMED -> counts
+    await repo.create(
+      SYSTEM_CONTEXT,
+      bookingData({
+        bookingCode: 'LOC00001',
+        assignedVehicleId: 'veh-1',
+        pickupLocationId: 'loc-1',
+        dropoffLocationId: 'loc-9',
+      }),
+    )
+    // dropoff = loc-1, ACTIVE -> counts (distinct vehicle avoids the exclusion)
+    await repo.create(
+      SYSTEM_CONTEXT,
+      bookingData({
+        bookingCode: 'LOC00002',
+        assignedVehicleId: 'veh-2',
+        status: 'ACTIVE',
+        pickupLocationId: 'loc-9',
+        dropoffLocationId: 'loc-1',
+      }),
+    )
+    // pickup = loc-1 but CANCELLED -> ignored
+    await repo.create(
+      SYSTEM_CONTEXT,
+      bookingData({
+        bookingCode: 'LOC00003',
+        assignedVehicleId: 'veh-3',
+        status: 'CANCELLED',
+        pickupLocationId: 'loc-1',
+        dropoffLocationId: 'loc-1',
+      }),
+    )
+    // active but a different location -> ignored
+    await repo.create(
+      SYSTEM_CONTEXT,
+      bookingData({
+        bookingCode: 'LOC00004',
+        assignedVehicleId: 'veh-4',
+        pickupLocationId: 'loc-2',
+        dropoffLocationId: 'loc-2',
+      }),
+    )
+
+    expect(await repo.countActiveForLocation('loc-1')).toBe(2)
+    expect(await repo.countActiveForLocation('loc-2')).toBe(1)
+    expect(await repo.countActiveForLocation('loc-unknown')).toBe(0)
+  })
+})

--- a/packages/api/tests/routes/locations.test.ts
+++ b/packages/api/tests/routes/locations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
 import type { UserRole } from '../../src/middleware/auth'
 import { InMemoryLocationRepository } from '../../src/repositories/in-memory'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { createLocationRoutes } from '../../src/routes/locations'
 import { LocationService } from '../../src/services/location'
 import { testAuthMiddleware } from '../helpers/auth'
@@ -11,11 +12,19 @@ import { testResolveWriteOperatorId } from '../helpers/operator'
 const OP_A = 'operator-aaaaaaaa'
 const OP_B = 'operator-bbbbbbbb'
 
-function mountFor(repo: InMemoryLocationRepository, role: UserRole, operatorId?: string) {
+function mountFor(
+  repo: InMemoryLocationRepository,
+  role: UserRole,
+  operatorId?: string,
+  bookingRepo: InMemoryBookingRepository = new InMemoryBookingRepository(),
+) {
   const app = new Hono()
   setupGlobalHandlers(app)
   app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
-  app.route('/', createLocationRoutes(new LocationService(repo), testResolveWriteOperatorId()))
+  app.route(
+    '/',
+    createLocationRoutes(new LocationService(repo, bookingRepo), testResolveWriteOperatorId()),
+  )
   return app
 }
 
@@ -36,7 +45,7 @@ describe('Location routes — auth', () => {
     app.route(
       '/',
       createLocationRoutes(
-        new LocationService(new InMemoryLocationRepository()),
+        new LocationService(new InMemoryLocationRepository(), new InMemoryBookingRepository()),
         testResolveWriteOperatorId(),
       ),
     )

--- a/packages/api/tests/services/location.test.ts
+++ b/packages/api/tests/services/location.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CallerContext } from '../../src/middleware/auth'
 import { PG_ERROR } from '../../src/pg-errors'
 import { InMemoryLocationRepository } from '../../src/repositories/in-memory'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { LocationService } from '../../src/services/location'
+import type { Booking } from '../../src/stores'
 
 const uniqueViolation = () =>
   Object.assign(new Error('duplicate key value violates unique constraint'), {
@@ -31,13 +33,48 @@ function createInput(operatorId: string, name: string) {
   }
 }
 
+function seedBooking(store: Map<string, Booking>, overrides: Partial<Booking>): void {
+  const now = new Date('2026-07-01T00:00:00Z')
+  const booking: Booking = {
+    id: crypto.randomUUID(),
+    operatorId: opA,
+    renterId: 'renter-1',
+    classId: 'cls-1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'loc-x',
+    dropoffLocationId: 'loc-x',
+    startAt: now,
+    endAt: now,
+    effectiveEndAt: now,
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    bookingCode: `BK${store.size}`,
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 12000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+  store.set(booking.id, booking)
+}
+
 describe('LocationService', () => {
   let repo: InMemoryLocationRepository
+  let bookingStore: Map<string, Booking>
   let service: LocationService
 
   beforeEach(() => {
     repo = new InMemoryLocationRepository()
-    service = new LocationService(repo)
+    bookingStore = new Map()
+    service = new LocationService(repo, new InMemoryBookingRepository(bookingStore))
   })
 
   describe('create', () => {
@@ -170,6 +207,47 @@ describe('LocationService', () => {
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(404)
       expect(archiveSpy).not.toHaveBeenCalled()
+    })
+
+    it('refuses to archive a location with active bookings (409 + code, #412)', async () => {
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Namba'))
+      if (!created.ok) throw new Error('seed failed')
+      seedBooking(bookingStore, { pickupLocationId: created.location.id, status: 'CONFIRMED' })
+
+      const archiveSpy = vi.spyOn(repo, 'archive')
+      const result = await service.archive(ctxFor(opA), created.location.id)
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.status).toBe(409)
+        expect(result.code).toBe('LOCATION_HAS_ACTIVE_BOOKINGS')
+        expect(result.activeBookingsCount).toBe(1)
+      }
+      expect(archiveSpy).not.toHaveBeenCalled()
+    })
+
+    it('counts a booking that references the location only as DROPOFF (#412)', async () => {
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Namba'))
+      if (!created.ok) throw new Error('seed failed')
+      seedBooking(bookingStore, {
+        pickupLocationId: 'other-loc',
+        dropoffLocationId: created.location.id,
+        status: 'ACTIVE',
+      })
+
+      const result = await service.archive(ctxFor(opA), created.location.id)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.status).toBe(409)
+    })
+
+    it('archives when only non-active (CANCELLED) bookings reference the location (#412)', async () => {
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Namba'))
+      if (!created.ok) throw new Error('seed failed')
+      seedBooking(bookingStore, { pickupLocationId: created.location.id, status: 'CANCELLED' })
+
+      const result = await service.archive(ctxFor(opA), created.location.id)
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.location.status).toBe('ARCHIVED')
     })
   })
 })


### PR DESCRIPTION
## Problem
`LocationService.archive` archived unconditionally — fine in slice 2 (locations weren't on bookings), but since slice 6 (#392/#435) bookings carry `pickupLocationId`/`dropoffLocationId`. Archiving a location still in live use stranded CONFIRMED/ACTIVE bookings pointing at an archived row.

## Fix (mirrors `VehicleClassService.archive`)
- New `BookingRepository.countActiveForLocation(locationId)` — counts BLOCKING (CONFIRMED/ACTIVE) bookings referencing the location as **pickup OR dropoff** (in-memory + drizzle).
- `LocationService` takes `bookingRepo`; `archive()` returns a 409 with a `LOCATION_HAS_ACTIVE_BOOKINGS` code + `activeBookingsCount` when any exist.
- The DELETE route surfaces `code` + `activeBookingsCount` (verbatim mirror of the class route) so the portal can prompt the owner to reassign/cancel first.

## Tests (TDD, RED→GREEN)
- Service: refuses archive with an active pickup booking (409 + code + count); counts a **dropoff-only** reference; **allows** archive when only CANCELLED bookings reference it.
- Repo: `countActiveForLocation` counts pickup OR dropoff, ignores non-active, 0 for unknown.
- Fixed the route-test harness to inject `bookingRepo`.

Gate: api **893** unit · typecheck · boundaries · biome · web typecheck — all green. No schema change.

## Scope
Part 1 (the archive guard) of #412. **Remaining:** part 2 (hide ARCHIVED-pickup vehicles from renter search — deferred to avoid colliding with in-flight #458) and part 3 (map `23503` → 422 on the vehicle write path). #412 stays open for those.