### PR TITLE
test(api): cover pickup-location FK → 422 on vehicle write path (#412 part 3)

### DIFF
--- a/packages/api/tests/integration/vehicles-route-fk.test.ts
+++ b/packages/api/tests/integration/vehicles-route-fk.test.ts
@@ -1,4 +1,4 @@
-import { operators, users, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
+import { locations, operators, users, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
@@ -10,12 +10,14 @@ import {
 } from '../../src/repositories/drizzle'
 import type { VehicleClass } from '../../src/stores'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
-import { db } from './setup'
+import { db, seedLocation } from './setup'
 
 // #400: the composite FK vehicles(operatorId,classId) -> vehicle_classes(operatorId,id)
 // (#395) rejects a cross-tenant classId at the DB with 23503. The vehicles route
 // must map that to 422 rather than surfacing a raw 500. In-memory repos cannot
 // exercise the DB-only FK, so this drives the full HTTP app against real Postgres.
+// #412 part 3 extends the same contract to the third composite FK,
+// vehicles(operatorId,pickupLocationId) -> locations (#387/#435).
 describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () => {
   const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const opAId = `op_route_a_${uniq}`
@@ -23,6 +25,8 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
   const staffUserId = crypto.randomUUID()
   let classA: VehicleClass
   let classB: VehicleClass
+  let locationA: { id: string }
+  let locationB: { id: string }
   let app: ReturnType<typeof createApp>
   let headers: Record<string, string>
 
@@ -45,7 +49,7 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
 
   // A non-operator (STAFF) caller names the target operator explicitly via the
   // body, so resolution is unambiguous; the classId is what the DB FK rejects.
-  const vehicleBody = (operatorId: string, classId: string) => ({
+  const vehicleBody = (operatorId: string, classId: string, pickupLocationId?: string) => ({
     operatorId,
     classId,
     name: 'Route FK Vehicle',
@@ -53,6 +57,7 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
     transmission: 'AUTO' as const,
     licensePlate: null,
     dailyRateJpy: 8000,
+    ...(pickupLocationId ? { pickupLocationId } : {}),
   })
 
   beforeAll(async () => {
@@ -63,6 +68,8 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
     ])
     classA = await makeClass(opAId, 'a')
     classB = await makeClass(opBId, 'b')
+    locationA = await seedLocation('route-fk-a', 2880, opAId)
+    locationB = await seedLocation('route-fk-b', 2880, opBId)
     await db.insert(users).values({
       id: staffUserId,
       email: `route-fk-${uniq}@kuruma-test.com`,
@@ -81,6 +88,7 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
   afterAll(async () => {
     await db.delete(vehicles).where(inArray(vehicles.operatorId, [opAId, opBId]))
     await db.delete(vehicleClasses).where(inArray(vehicleClasses.operatorId, [opAId, opBId]))
+    await db.delete(locations).where(inArray(locations.operatorId, [opAId, opBId]))
     await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
     await db.delete(users).where(inArray(users.id, [staffUserId]))
   })
@@ -129,5 +137,31 @@ describe('POST/PATCH /vehicles maps a cross-operator classId to 422 (#400)', () 
     })
     expect(res.status).toBe(422)
     expect((await res.json()).error).toBe('Invalid operator')
+  })
+
+  // #412 part 3: vehicles(operatorId, pickupLocationId) -> locations is a third
+  // composite FK. A cross-tenant pickupLocationId trips it with 23503; the route
+  // must report "Invalid pickup location" — not the misleading class/operator copy.
+  it('POST returns 422 "Invalid pickup location" for a cross-operator pickupLocationId', async () => {
+    const res = await post(vehicleBody(opAId, classA.id, locationB.id))
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid pickup location')
+  })
+
+  it('POST returns 201 for the operator’s own pickup location', async () => {
+    const res = await post(vehicleBody(opAId, classA.id, locationA.id))
+    expect(res.status).toBe(201)
+    expect((await res.json()).data.pickupLocationId).toBe(locationA.id)
+  })
+
+  it('PATCH returns 422 "Invalid pickup location" when reassigning to another operator’s location', async () => {
+    const created = await (await post(vehicleBody(opAId, classA.id, locationA.id))).json()
+    const res = await app.request(`/vehicles/${created.data.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pickupLocationId: locationB.id }),
+    })
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid pickup location')
   })
 })


### PR DESCRIPTION
## What

Adds route-level regression coverage for **#412 part 3** — mapping a cross-tenant/missing \`pickupLocationId\` to **422 "Invalid pickup location"** on the vehicle write path.

The production mapping already exists: \`fkViolationMessage()\` in \`routes/vehicles.ts\` switches on the violated constraint name and translates a Postgres 23503 on the composite FK \`vehicles(operatorId, pickupLocationId) → locations\` to 422 (shipped earlier with #435). But \`vehicles-route-fk.test.ts\` only exercised the **classId** and **operatorId** branches of that switch — the **pickupLocationId** branch had no test.

This PR closes that gap with three cases (reusing the existing \`seedLocation\` helper):
- `POST /vehicles` with a cross-operator \`pickupLocationId\` → **422 "Invalid pickup location"**
- `POST /vehicles` with the operator's own location → **201** (asserts \`pickupLocationId\` persisted)
- `PATCH /vehicles/:id` reassigning to another operator's location → **422**

## Scope

- **Test-only.** No production code changed.
- Part of #412 (**part 3 only**). **Part 1** shipped in #491. **Part 2** (hide ARCHIVED-pickup vehicles from renter search) stays deferred until #458 lands — #412 remains open.

## Test plan

- [x] `biome check` clean; pre-commit hooks (file-size, module-boundaries, tsc web+api) pass
- [x] Full \`vehicles-route-fk.test.ts\` integration suite run against a real Postgres branch: **7/7 pass** (4 existing + 3 new)
- [x] Rebased on latest \`marketplace-pivot\`

> Note: the api \`tsc\` only type-checks \`src/**\` and the integration vitest config has no typecheck step, so this file is verified solely by running the integration lane (which CI gates) — done above against an ephemeral Neon branch.