### PR TITLE
test(api): fix midnight-boundary flake in vehicle-detail utilization test

### DIFF
--- a/packages/api/tests/integration/vehicle-detail.test.ts
+++ b/packages/api/tests/integration/vehicle-detail.test.ts
@@ -25,10 +25,18 @@ const detailRepo = new DrizzleVehicleDetailRepository(db)
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
 
-// Anchor all relative dates to a fixed "now" captured at suite start so
-// day-boundary calculations are deterministic even if the clock ticks
-// across midnight mid-suite.
-const NOW = new Date()
+// Anchor all relative dates to LOCAL NOON of the current day. The utilization
+// window buckets [todayStart-29d, todayStart+1d) with no bucket for tomorrow
+// (see vehicle-detail repo dayStart()), so an ACTIVE booking spanning NOW±1h
+// loses its post-midnight slice when the suite runs within ~1h of midnight —
+// the source of the flaky `expected 3.44 to be close to 4`. Pinning to noon
+// keeps the ±1h window far from any day boundary in both UTC (CI) and local
+// dev timezones, making the result deterministic regardless of wall-clock.
+const NOW = (() => {
+  const d = new Date()
+  d.setHours(12, 0, 0, 0)
+  return d
+})()
 const TODAY_START = (() => {
   const d = new Date(NOW)
   d.setHours(0, 0, 0, 0)


### PR DESCRIPTION
## Problem

`packages/api/tests/integration/vehicle-detail.test.ts` anchored its relative dates to `new Date()` (real wall-clock). The utilization query buckets `[todayStart-29d, todayStart+1d)` — no bucket for tomorrow — so the ACTIVE booking that spans `NOW±1h` loses its post-midnight slice whenever the suite **starts within ~1h of UTC midnight**. The utilization total drops 4h → ~3.5h and `toBeCloseTo(4)` fails.

This is a **flaky test**, not a product bug. It surfaced as a red `db-drift` check (which runs the integration suite) reading `expected 3.46 to be close to 4`, and **blocked an unrelated docs PR (#489)** until a re-run cleared it.

## Fix

Pin `NOW` to **local noon** — the same fix already proven on `marketplace-pivot` (whose copy of this file carries the noon-pin + comment). Keeps the `±1h` window far from any day boundary in both UTC (CI) and local dev timezones. Both trunks now handle the clock identically.

One line of logic; the rest is the explanatory comment.

## Proof (TZ=UTC, real Postgres)

- **RED:** pinning `NOW` to `2026-06-15T23:30:00Z` reproduces the failure deterministically — `expected 3.5 to be close to 4`.
- **GREEN:** with the noon-pin, all **10/10** `vehicle-detail` tests pass.

## Test plan
- [x] biome + pre-commit hooks (file-size, module-boundaries, tsc web+api) clean
- [x] RED/GREEN verified against an ephemeral Neon branch
- [x] Based on latest `main`