### PR TITLE
fix(api): #517 reject oversized uploads early on Content-Length (413)

### DIFF
--- a/packages/api/src/routes/documents.ts
+++ b/packages/api/src/routes/documents.ts
@@ -1,8 +1,22 @@
-import { uploadDocumentSchema, verifyDocumentSchema } from '@kuruma/shared/validators/document'
+import {
+  MAX_DOCUMENT_BYTES,
+  uploadDocumentSchema,
+  verifyDocumentSchema,
+} from '@kuruma/shared/validators/document'
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { RenterDocumentService } from '../services/renter-document'
-import { fail, ok, parseBody, parsePagination } from './helpers'
+import {
+  MULTIPART_OVERHEAD_BYTES,
+  fail,
+  ok,
+  parseBody,
+  parsePagination,
+  rejectOversizedBody,
+} from './helpers'
+
+// One file per request; cap the request at the per-file limit plus multipart slack.
+const MAX_DOCUMENT_REQUEST_BYTES = MAX_DOCUMENT_BYTES + MULTIPART_OVERHEAD_BYTES
 
 export function createDocumentRoutes(service: RenterDocumentService) {
   const app = new Hono()
@@ -11,6 +25,9 @@ export function createDocumentRoutes(service: RenterDocumentService) {
     .post('/documents', async (c) => {
       const user = requireUser(c)
       const ctx = toCallerContext(user)
+
+      const oversized = rejectOversizedBody(c, MAX_DOCUMENT_REQUEST_BYTES)
+      if (oversized) return oversized
 
       const body = await c.req.parseBody()
       const file = body.file

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -81,6 +81,34 @@ export function parsePagination(c: Context, opts?: LimitOptions): PaginationSucc
   return { ok: true, limit: limitResult.limit, offset }
 }
 
+// --- Upload size guard ---
+
+/**
+ * Pure decision: does the `Content-Length` header declare a body strictly
+ * larger than `maxBytes`? Returns false for an absent, empty, or malformed
+ * header — we only reject on a value we can trust. The per-file size check in
+ * the service is the precise backstop; this is the cheap early gate that lets
+ * a route reject an abusive body before buffering it into memory.
+ */
+export function exceedsContentLength(header: string | null | undefined, maxBytes: number): boolean {
+  if (!header) return false
+  const declared = parseNonNegativeInt(header)
+  return declared !== undefined && declared > maxBytes
+}
+
+/**
+ * Reject an oversized multipart/body request early (413) based on its
+ * `Content-Length`, before `parseBody()` buffers the bytes. Returns the 413
+ * response to short-circuit, or `undefined` to continue. Call at the top of
+ * an upload handler: `return rejectOversizedBody(c, MAX) ?? (await handle())`.
+ */
+export function rejectOversizedBody(c: Context, maxBytes: number): Response | undefined {
+  if (exceedsContentLength(c.req.header('content-length'), maxBytes)) {
+    return fail(c, 'Request body too large', 413)
+  }
+  return undefined
+}
+
 // --- Cache headers ---
 
 /**

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -84,6 +84,13 @@ export function parsePagination(c: Context, opts?: LimitOptions): PaginationSucc
 // --- Upload size guard ---
 
 /**
+ * Slack added to a route's payload budget to cover multipart framing (boundary
+ * lines, Content-Disposition headers, extra form fields) so a legitimately
+ * max-sized file isn't false-rejected by a few hundred bytes of envelope. The
+ * service's exact per-file check enforces the real limit. */
+export const MULTIPART_OVERHEAD_BYTES = 64 * 1024
+
+/**
  * Pure decision: does the `Content-Length` header declare a body strictly
  * larger than `maxBytes`? Returns false for an absent, empty, or malformed
  * header — we only reject on a value we can trust. The per-file size check in

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,8 +1,16 @@
 import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
 import { type Context, Hono } from 'hono'
 import { STAFF_ROLES, requireUser, toCallerContext } from '../middleware/auth'
-import type { VehiclePhotoService } from '../services/vehicle-photo'
-import { fail, ok } from './helpers'
+import {
+  MAX_FILE_SIZE,
+  MAX_PHOTOS_PER_VEHICLE,
+  type VehiclePhotoService,
+} from '../services/vehicle-photo'
+import { MULTIPART_OVERHEAD_BYTES, fail, ok, rejectOversizedBody } from './helpers'
+
+// Up to MAX_PHOTOS_PER_VEHICLE files per request; cap the whole multipart body
+// at that many max-sized files plus framing slack.
+const MAX_PHOTOS_REQUEST_BYTES = MAX_PHOTOS_PER_VEHICLE * MAX_FILE_SIZE + MULTIPART_OVERHEAD_BYTES
 
 export function createVehiclePhotoRoutes(
   service: VehiclePhotoService,
@@ -28,6 +36,9 @@ export function createVehiclePhotoRoutes(
       const user = requireUser(c)
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
+
+      const oversized = rejectOversizedBody(c, MAX_PHOTOS_REQUEST_BYTES)
+      if (oversized) return oversized
 
       const body = await c.req.parseBody({ all: true })
       const rawFiles = body.file

--- a/packages/api/src/services/vehicle-photo.ts
+++ b/packages/api/src/services/vehicle-photo.ts
@@ -2,8 +2,8 @@ import { detectImageType } from '../lib/image-signature'
 import type { CallerContext } from '../middleware/auth'
 import type { PhotoStorage, VehicleRepository } from '../repositories/types'
 
-const MAX_PHOTOS_PER_VEHICLE = 10
-const MAX_FILE_SIZE = 5 * 1024 * 1024
+export const MAX_PHOTOS_PER_VEHICLE = 10
+export const MAX_FILE_SIZE = 5 * 1024 * 1024
 const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif'])
 
 export type UploadResult =

--- a/packages/api/tests/routes/documents.test.ts
+++ b/packages/api/tests/routes/documents.test.ts
@@ -93,6 +93,16 @@ describe('POST /documents', () => {
     const res = await app.request('/documents', { method: 'POST', body: uploadForm('IDP') })
     expect(res.status).toBe(401)
   })
+
+  it('rejects an oversized body early with 413 before buffering it', async () => {
+    const res = await app.request('/documents', {
+      method: 'POST',
+      headers: { ...(await authHeaders(RENTER)), 'content-length': String(50 * 1024 * 1024) },
+    })
+
+    expect(res.status).toBe(413)
+    expect((await res.json()).error).toBe('Request body too large')
+  })
 })
 
 describe('GET /documents/me', () => {

--- a/packages/api/tests/routes/helpers.test.ts
+++ b/packages/api/tests/routes/helpers.test.ts
@@ -2,13 +2,17 @@ import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
+  exceedsContentLength,
   fail,
   ok,
   parseBody,
   parseDateRange,
   parseLimit,
   parsePagination,
+  rejectOversizedBody,
 } from '../../src/routes/helpers'
+
+const GUARD_MAX_BYTES = 100
 
 // Tiny Hono app that uses the helpers so we can test through real HTTP.
 function createTestApp() {
@@ -63,8 +67,67 @@ function createTestApp() {
     return ok(c, { from: result.from?.toISOString() ?? null, to: result.to?.toISOString() ?? null })
   })
 
+  app.post('/guarded', (c) => rejectOversizedBody(c, GUARD_MAX_BYTES) ?? ok(c, { passed: true }))
+
   return app
 }
+
+describe('exceedsContentLength()', () => {
+  it('is true only when a valid length is strictly above the max', () => {
+    expect(exceedsContentLength('101', GUARD_MAX_BYTES)).toBe(true)
+  })
+
+  it('is false at the exact boundary (equal is allowed)', () => {
+    expect(exceedsContentLength('100', GUARD_MAX_BYTES)).toBe(false)
+  })
+
+  it('is false below the max', () => {
+    expect(exceedsContentLength('99', GUARD_MAX_BYTES)).toBe(false)
+  })
+
+  it('is false when the header is absent (cannot pre-check; service backstops)', () => {
+    expect(exceedsContentLength(undefined, GUARD_MAX_BYTES)).toBe(false)
+    expect(exceedsContentLength(null, GUARD_MAX_BYTES)).toBe(false)
+    expect(exceedsContentLength('', GUARD_MAX_BYTES)).toBe(false)
+  })
+
+  it('is false for a malformed header rather than trusting a partial parse', () => {
+    expect(exceedsContentLength('999abc', GUARD_MAX_BYTES)).toBe(false)
+    expect(exceedsContentLength('1.5', GUARD_MAX_BYTES)).toBe(false)
+    expect(exceedsContentLength('-1', GUARD_MAX_BYTES)).toBe(false)
+  })
+})
+
+describe('rejectOversizedBody()', () => {
+  const app = createTestApp()
+
+  it('returns 413 with an error envelope when Content-Length exceeds the max', async () => {
+    const res = await app.request('/guarded', {
+      method: 'POST',
+      headers: { 'content-length': '101' },
+    })
+
+    expect(res.status).toBe(413)
+    expect(await res.json()).toEqual({ success: false, error: 'Request body too large' })
+  })
+
+  it('passes through when Content-Length is within the max', async () => {
+    const res = await app.request('/guarded', {
+      method: 'POST',
+      headers: { 'content-length': '100' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, data: { passed: true } })
+  })
+
+  it('passes through when Content-Length is absent (chunked/streamed bodies)', async () => {
+    const res = await app.request('/guarded', { method: 'POST' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, data: { passed: true } })
+  })
+})
 
 describe('ok()', () => {
   const app = createTestApp()

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -102,6 +102,16 @@ describe('POST /vehicles/:id/photos', () => {
     expect(updated?.photos).toHaveLength(1)
   })
 
+  it('rejects an oversized body early with 413 before buffering it', async () => {
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers: { ...(await authHeaders()), 'content-length': String(100 * 1024 * 1024) },
+    })
+
+    expect(res.status).toBe(413)
+    expect((await res.json()).error).toBe('Request body too large')
+  })
+
   it('rejects non-image MIME type with 400', async () => {
     const headers = await authHeaders()
     const form = makeFormData('doc.pdf', 'application/pdf', 1024)


### PR DESCRIPTION
## What & why
Hardening follow-up from #459. Both multipart upload handlers buffered the whole body via \`c.req.parseBody()\` before any size check — the per-file limit was only enforced *after* buffering. An abusive caller could force the Worker to buffer hundreds of MiB. This adds an early \`Content-Length\` gate that returns **413** before buffering.

## Approach (FC/IS)
- **Pure decision** \`exceedsContentLength(header, maxBytes)\` — true only for a valid positive integer header strictly above the cap; false for absent/empty/malformed (we only reject on a value we can trust; chunked uploads with no \`Content-Length\` pass through and the service per-file check remains the precise backstop).
- **Thin shell** \`rejectOversizedBody(c, maxBytes)\` → 413 \`{ success: false, error: 'Request body too large' }\` or \`undefined\`.
- **Per-route caps** derived from the *existing* per-file limits + 64 KiB multipart slack:
  - \`POST /documents\` → \`MAX_DOCUMENT_BYTES\` (10 MiB) + slack.
  - \`POST /vehicles/:id/photos\` → \`MAX_PHOTOS_PER_VEHICLE × MAX_FILE_SIZE\` (10 × 5 MiB) + slack.
- Guard runs **after auth** (cheap, no buffering) and **before** \`parseBody\`.

## Tests (TDD, 3 vertical slices)
- \`helpers.test.ts\`: 8 cases on the pure fn + shell (boundary, absent, malformed, 413 envelope, pass-through).
- \`documents.test.ts\` / \`vehicle-photos.test.ts\`: oversized \`Content-Length\` → 413 before buffering.
- Full API suite green: **1062 passed**; boundaries OK; tsc 0; lint clean.

Closes #517.