### PR TITLE
docs: sync marketplace-pivot docs with shipped Vite/marketplace code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nextjs-agent-rules -->
-# This is NOT the Next.js you know
+# Web is Vite + TanStack Router (NOT Next.js)
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+`packages/web` was migrated off Next.js to **Vite + TanStack Router** on Cloudflare Pages (epic #378). The live shell lives under `packages/web/src/vite/` + `packages/web/src/routes/`. A **frozen** Next.js tree (`src/app/`, `middleware.ts`, `next.config.ts`, `open-next.config.ts`) is still present but is NOT the build path and is slated for deletion at cut-over — **do not extend it**. Adding a route requires `vite build` to regenerate `routeTree.gen.ts` before typecheck.
 <!-- END:nextjs-agent-rules -->
 
 # Monorepo Architecture
@@ -9,7 +9,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 This is a Bun workspace monorepo with three packages:
 
 - `packages/api` — Hono REST API (deploys to CF Workers). All business logic lives here.
-- `packages/web` — Next.js frontend (deploys to CF Pages). UI only, no direct DB access.
+- `packages/web` — Vite + TanStack Router SPA (deploys to CF Pages). UI only, no direct DB access.
 - `packages/shared` — Drizzle schema, Zod validators, shared types. No runtime deps on api or web.
 
 **Key rules:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ Airbnb-style car rental platform for a Japan-based company (Osaka) serving inter
 
 > **Rule: Self-document gotchas.** When you hit a surprise, add it here immediately.
 
-## Next.js 16 + shadcn (base-ui)
+## Next.js 16 + shadcn (base-ui) — FROZEN Next.js tree only
+
+> The live web shell is **Vite + TanStack Router** (`packages/web/src/vite/`). The notes below apply only to the frozen Next.js tree (`src/app/`), which is not the build path and is slated for deletion at cut-over. Do not apply them to new Vite work.
 
 - **No `asChild` prop.** Use `buttonVariants()` on `<Link>`, or `render` prop on triggers. See code examples in `packages/web/src/components/`.
 - **Use `middleware.ts`, NOT `proxy.ts`.** `proxy.ts` forces Node.js runtime; `@opennextjs/cloudflare` is Edge only. The deprecation warning is cosmetic.
@@ -71,7 +73,9 @@ Critical rules:
 6. **Shared secrets (AUTH_SECRET, DATABASE_URL) must match between API and Web workers.** GitHub Secrets is the source of truth. `deploy.yml` no longer re-asserts secrets every deploy — wrangler 4's gradual deployments refuse `secret put` when a pending version exists (cloudflare/workers-sdk#6763) and the old pattern locked up deploys. Instead: `deploy.yml` runs a read-only `wrangler secret list` presence check; `rotate-secrets.yml` (workflow_dispatch) re-asserts values. Rotate after changing a GitHub Secret, whenever the presence check fails, or if "Unauthorized" starts appearing silently.
 7. **`getDb()` (neon-http) CANNOT run interactive transactions** — `db.transaction(cb)` throws `"No transactions support in neon-http driver"` at runtime (tsc does NOT catch it → it 500s in prod). The HTTP driver is stateless fetch-per-query, safe to reuse across requests. For interactive transactions use **`runTx(fn)`** from `@kuruma/shared/db` (#493): it opens a short-lived **neon-serverless (WebSocket) Pool** per call, runs the tx, closes it — the only Workers-safe lifecycle (a WebSocket Pool can't cross requests: "Cannot perform I/O on behalf of a different request"). Repos take the runner via constructor injection; the composition root wires `runTx`. **`DATABASE_URL` must be the Neon POOLED endpoint** (`-pooler` host) — per-call connections against a direct endpoint exhaust Postgres backends under load.
 
-## i18n (next-intl v4)
+## i18n (next-intl v4) — FROZEN Next.js tree only
+
+> The live Vite shell uses **use-intl** with TanStack Router (`$locale` route param, `IntlProvider`, `messages/` served by Vite). The next-intl notes below apply only to the frozen Next.js tree.
 
 - Import navigation helpers from `@/i18n/routing`, not `next/link`.
 - Business routes use `/manage/` prefix. `/dashboard` has no prefix.

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -4,7 +4,7 @@
 
 - [Bun](https://bun.sh/) v1.1+
 - PostgreSQL (or [Neon](https://neon.tech/) serverless Postgres)
-- Node.js 20+ (Vite toolchain; see `.nvmrc`)
+- Node.js 20+ (Vite toolchain)
 
 ## Environment Setup
 

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -4,7 +4,7 @@
 
 - [Bun](https://bun.sh/) v1.1+
 - PostgreSQL (or [Neon](https://neon.tech/) serverless Postgres)
-- Node.js 20+ (for Next.js compatibility)
+- Node.js 20+ (Vite toolchain; see `.nvmrc`)
 
 ## Environment Setup
 
@@ -25,7 +25,7 @@
    | `AUTH_SECRET` | Yes | Random secret for Auth.js session signing (`bunx auth secret`) |
    | `AUTH_GOOGLE_ID` | Yes | Google OAuth client ID |
    | `AUTH_GOOGLE_SECRET` | Yes | Google OAuth client secret |
-   | `NEXT_PUBLIC_API_URL` | No | API base URL (defaults to `http://localhost:8787`) |
+   | _(none)_ | — | The Vite shell calls the API via a same-origin `/api` proxy (dev: `vite.config.mts` `server.proxy`; prod: Pages Functions) — no public API-URL env var. |
 
 3. Run database migrations and seed:
    ```sh
@@ -39,7 +39,7 @@
 kuruma-rental/
   packages/
     api/      @kuruma/api     Hono REST API (CF Workers)
-    web/      @kuruma/web     Next.js 16 frontend (CF Pages)
+    web/      @kuruma/web     Vite + TanStack Router SPA (CF Pages)
     shared/   @kuruma/shared  Drizzle schema, Zod validators, shared types
 ```
 
@@ -51,7 +51,7 @@ kuruma-rental/
 
 | Script | Command | Description |
 |--------|---------|-------------|
-| `dev` | `bun run dev` | Start Next.js dev server (port 3001) |
+| `dev` | `bun run dev` | Start Vite dev server (port 3001; proxies /api + /auth) |
 | `dev:api` | `bun run dev:api` | Start Hono API dev server (Wrangler, port 8787) |
 | `build` | `bun run build` | Build all packages |
 | `test` | `bun run test` | Run all tests across packages |
@@ -66,7 +66,7 @@ kuruma-rental/
 
 | Package | Script | Description |
 |---------|--------|-------------|
-| `@kuruma/web` | `bun run --filter @kuruma/web dev` | Next.js dev server |
+| `@kuruma/web` | `bun run --filter @kuruma/web dev` | Vite dev server |
 | `@kuruma/web` | `bun run --filter @kuruma/web typecheck` | TypeScript check (no DB needed) |
 | `@kuruma/api` | `bun run --filter @kuruma/api dev` | Wrangler dev server |
 | `@kuruma/api` | `bun run --filter @kuruma/api test` | API tests (Vitest) |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -3,13 +3,13 @@
 ## Architecture
 
 ```
-User -> CF Pages (Next.js) -> CF Workers (Hono API) -> Neon Postgres
+User -> CF Pages (Vite SPA + proxy Functions) -> CF Workers (Hono API) -> Neon Postgres
 ```
 
-- **Web**: Next.js 16 on Cloudflare Pages
+- **Web**: Vite + TanStack Router SPA on Cloudflare Pages. Same-origin `/api` + `/auth` proxy via Pages Functions (`packages/web/functions/`).
 - **API**: Hono on Cloudflare Workers
 - **DB**: Neon serverless Postgres
-- **Auth**: Auth.js v5 (Google + Apple OAuth, JWT strategy)
+- **Auth**: Google OAuth on the API, cookie session (Apple was dropped).
 
 ## Deployment
 
@@ -17,9 +17,11 @@ User -> CF Pages (Next.js) -> CF Workers (Hono API) -> Neon Postgres
 
 ```sh
 cd packages/web
-bun run build:worker    # Build with OpenNext for CF
-bun run deploy          # Deploy to Cloudflare Pages
+bun run build           # vite build -> dist/
+bun run deploy:pages    # wrangler pages deploy dist (project: kuruma-web-pages)
 ```
+
+> Web deploy is gated in CI on `WEB_PAGES_DEPLOY_ENABLED=true` and the CF account migration (#304). See `docs/plans/2026-06-09-378-pages-cutover.md` §8.
 
 ### API (Cloudflare Workers)
 

--- a/docs/cloudflare-developer-guide.md
+++ b/docs/cloudflare-developer-guide.md
@@ -1,5 +1,7 @@
 # Cloudflare Developer Guide
 
+> **HISTORICAL (pre-Vite).** This guide documents the **Next.js 16 + OpenNext on CF Workers** web stack, which has been replaced by **Vite + TanStack Router on CF Pages** (epic #378). The API-side lessons (neon-http vs neon-serverless, secrets, the two-runtimes problem) still hold; the web/OpenNext/middleware sections are kept for history. For the current web deploy see `docs/plans/2026-06-09-378-pages-cutover.md` and `docs/cloudflare-account-migration.md`.
+
 A plain-English guide for developers working on this project. Covers the gotchas, workarounds, and patterns we discovered deploying Next.js 16 + Auth.js + Drizzle/Neon to Cloudflare Workers.
 
 If you're new to this codebase, read this before touching anything deployment-related.

--- a/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
+++ b/docs/plans/2026-06-02-slice3-acriss-vehicle-crud.md
@@ -1,0 +1,294 @@
+# Slice 3 — ACRISS + Vehicle CRUD (issue #388)
+
+**Date:** 2026-06-02
+**Status:** MERGED 2026-06-03 (#388, `f4cd0bf`) — ACRISS taxonomy + operator vehicle-class CRUD on `marketplace-pivot`. Plan retained for history.
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 row 3; §2 "Class taxonomy" / "Class display vs vehicle booking"; §4 business portal item 3; §4 platform item 2; §5 schema-retrofit row; §9 items 8/13; §10 item 13)
+**Companion plan:** `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` (slice 4 sequences after this; 4c reworks the same class/vehicle forms)
+
+---
+
+## 0. What this slice actually is (and is not)
+
+The demo target (proposal §6 row 3) is: *operator adds a Toyota Yaris in class "CCAR"*. Decomposed against the already-merged code, the work splits cleanly:
+
+| Area | New in slice 3? | Why |
+|---|---|---|
+| `vehicle_classes.acriss_code` column + CHECK | **Yes** — the only new schema | Not present in `schema.ts`; §2 "Class taxonomy" makes it canonical |
+| ACRISS taxonomy seed (code → friendly label) | **Yes** | §4 platform item 2; no class records are seeded today (seed only has `SEED_VEHICLES`) |
+| ACRISS i18n labels (en/ja/zh) | **Yes** — new namespace | §4 platform item 2; §8.2 i18n coverage |
+| `acrissCode` in class validator / type / repo / route / `ClassForm` | **Yes** | Thread the new column end-to-end |
+| Vehicle `licensePlate` + `shakenExpiryDate` | **Already merged** (pre-pivot #48/#228) | Columns, validator rules, and i18n keys exist (`schema.ts:121,137`; `validators/vehicle.ts`; `messages/en.json` `business.vehicles.form.licensePlate`/`shakenExpiryDate`) |
+| Vehicle operator-scoping (CRUD only under own operator) | **Already merged in #401/#386** | `DrizzleVehicleRepository` already calls `operatorReadScope` / `requireFleetWriteScope`; `routes/vehicles.ts` resolves `resolveWriteOperatorId` |
+| `vehicles.class_id` references a class | **Already merged** | Composite FK `(operatorId, classId) → vehicle_classes(operatorId, id)` (#395) |
+
+> **Honest scope note.** The proposal lists "operator vehicle CRUD with plate + sha-ken expiry" as slice-3 work, but slices 1 (#386) and 2 (#387) already landed the operator-scoped vehicle repo/route, and plate/shaken predate the pivot. **The net-new deliverable is ACRISS on `vehicle_classes`** plus the regression-proofing that vehicle CRUD enforces tenant isolation. The plan keeps a vehicle-CRUD test pass (§7) to *prove* the acceptance criteria, not to re-implement code that exists. This avoids gold-plating while satisfying #388's acceptance list.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **#386 (slice 1 tenancy) merged to `marketplace-pivot`** | Slice 3 builds on `operators` table, `roleEnum` (`OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicleClasses.operatorId` + `vehicles.operatorId` (NOT NULL FKs), the `vehicle_classes_operatorId_id_unique` composite key (#395), and `CallerContext.operatorId`/`bypassScope`. | `origin/marketplace-pivot` contains the slice-1/operator-scope commits; the local `marketplace-pivot` branch is stale at `main`. Create worktrees from `origin/marketplace-pivot` or fast-forward the local tracking branch before kickoff. |
+| **#401 (drop operator fallback) merged** | The write contract this slice extends: `resolveOperatorIdForWrite(ctx, inputOperatorId, operators)` in `packages/api/src/tenancy.ts` with single-operator inference + `OperatorRequiredError` (→ 422), **no `BEST_CAR_RENTAL` hardcode**. | Merged to `origin/marketplace-pivot` via PR #408. The local `marketplace-pivot` branch may still be stale; branch from `origin/marketplace-pivot` or fast-forward local before kickoff. |
+| **#387 (locations) merged** — for the WEB layer only | Slice-3 web reuses #387's flat `/manage/*` business portal gate + `BusinessSidebar` link pattern. Routing is JWT-scoped (`/manage/classes`) with **no `[operatorSlug]` segment**. Class/vehicle backend has no #387 dependency. | In review (PR #414 → `marketplace-pivot`) |
+
+If contract names differ at kickoff, this PR adapts — never refactor a landed slice.
+
+---
+
+## 2. The canonical pattern (this slice conforms)
+
+Two *different* established shapes coexist; pick the right one per entity (per AGENTS.md `routes/ → services/ → repositories/`, NOT `modules/`):
+
+- **`vehicle_classes` uses a SERVICE layer** (`services/vehicle-class.ts`): route → `VehicleClassService` → `VehicleClassRepository`. The service owns slug-uniqueness (409, scoped to `SYSTEM_CONTEXT` because slug is globally unique), the "at least one rate" merge-validate, and the archive-with-active-bookings guard (#326). ACRISS work threads through this layer.
+- **`vehicles` is ROUTE → REPOSITORY directly** (no dedicated vehicle service; `MaintenanceService` only for status toggles). `routes/vehicles.ts` does the merge-patch and pricing validation inline. Slice 3 does **not** introduce a vehicle service — that would be gold-plating against the merged shape.
+
+**Operator scoping (already the law, do not weaken):**
+- **Reads** call `operatorReadScope(ctx)` (`tenancy.ts`) → `{kind:'all'|'operator'|'none'}`. `none` ⇒ `sql\`false\`` (fail-closed). `vehicle_classes` reads are *public catalog* (anonymous renters via `PUBLIC_CONTEXT` → `all`), so unlike slice-4 insurance/fees there is **no `requireManagementRead` gate** — the catalog is intentionally world-readable. ACRISS is catalog data and inherits this.
+- **Writes** call `requireFleetWriteScope(ctx)` (admits `FLEET_WRITE_ROLES` = STAFF roles ∪ OPERATOR roles; a tenant caller missing `operatorId` fails closed). The route resolves the target tenant via `resolveWriteOperatorId(ctx, body.operatorId)` *before* the insert so a missing/ambiguous operator surfaces as 403/422, not a DB 500.
+- **Per-repo operator-scoping is ADDITIVE (§6.2).** The class + vehicle repos are *already* operator-scoped (slice 1). This slice keeps them scoped; it never adds an auto-bypass for OPERATOR_* callers. Repos not yet scoped still call `rejectOperatorContextUntilScoped` — irrelevant here since both target repos are scoped.
+
+**Validators** (`packages/shared/src/validators/`): `create<X>Schema` / `update<X>Schema = base.partial()`, cross-field via `.superRefine()`. Platform-admin create variants add `operatorId` (the class validator already extends `operatorId` optional per #401).
+
+**Web**: `packages/web/src/modules/classes/*` (`ClassForm`, `ClassList`, `AddClassDialog`, etc.) + flat `app/[locale]/(business)/manage/classes/page.tsx` (JWT-scoped, no `[operatorSlug]`). i18n namespace `business.classes.*`; a new `acriss.*` namespace for the code→label dictionary.
+
+---
+
+## 3. Schema (`packages/shared/src/db/schema.ts`)
+
+### 3.1 The one new column
+
+```ts
+// §2 "Class taxonomy" / §10 item 13: ACRISS 4-letter code is canonical on the
+// CLASS, not the vehicle. Vehicles point at a class via the composite FK; the
+// class carries the OTA-standard taxonomy code. Nullable in MVP so existing /
+// operator-created classes without a mapped code still validate — the friendly
+// i18n label is the renter-facing surface, the code is the integration anchor
+// (future Trip.com sync, §2). Format: exactly 4 chars, A-Z + digit 9 ('9' = the
+// ACRISS "or higher" wildcard slot used in some category/type cells).
+acrissCode: text('acrissCode'),
+```
+
+Table extras add a CHECK (friendly DB seal; the validator rejects earlier):
+
+```ts
+check(
+  'vehicle_classes_acriss_code_format',
+  sql`${table.acrissCode} IS NULL OR ${table.acrissCode} ~ '^[A-Z9][A-Z9][A-Z9][A-Z9]$'`,
+),
+```
+
+**No uniqueness constraint on `acrissCode`.** Multiple classes may legitimately share an ACRISS code (e.g. two "CCAR" compact classes with different photos/branding); ACRISS is a *category*, not an identity. §2 treats it as the grouping layer.
+
+### 3.2 What does NOT change here
+
+- `vehicles.classId`, the composite FK `vehicles_operatorId_classId_fk`, `licensePlate`, `shakenExpiryDate` — all already present (slice 1 + pre-pivot). Untouched.
+- `vehicle_classes.dailyRateJpy`/`hourlyRateJpy` — **left in place.** Their removal is **slice 4c** (`drop_class_level_pricing`), explicitly sequenced *after* #388 (slice-4 plan §5 step 3). Dropping them here would collide with 4c and break the "at least one rate" service path still in use.
+
+### 3.3 Migration
+
+```bash
+bun run db:generate --name add_acriss_code_to_vehicle_classes
+bun run db:migrate
+bun run db:verify   # 3 green checks (schema-snapshot / journal-disk / journal-DB)
+```
+
+Single additive migration (one `ALTER TABLE ADD COLUMN` + one `ADD CONSTRAINT`). **Journal-order trap (CLAUDE.md 2026-04-17):** generate this migration on top of whatever #386/#387/#401 left in `drizzle/meta/_journal.json`. If this branch rebases after another slice merges, **regenerate** rather than hand-editing `when`. CI `db-drift` enforces.
+
+---
+
+## 4. Validators — `packages/shared/src/validators/vehicle-class.ts`
+
+Add `acrissCode` to the shared `vehicleClassObjectSchema` (so both create and `.partial()` update inherit it):
+
+```ts
+// ACRISS code: exactly 4 chars, uppercase A-Z or '9'. Optional in MVP. The
+// regex mirrors the DB CHECK `vehicle_classes_acriss_code_format`. Uppercased
+// at the boundary so 'ccar' from a form submits as 'CCAR'.
+acrissCode: z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z9]{4}$/, 'ACRISS code must be 4 letters (A-Z) or 9')
+  .nullish(),
+```
+
+- `createVehicleClassSchema` / `updateVehicleClassSchema` need **no `.superRefine()` change** — the field is independent of the pricing rule.
+- The existing `operatorId` extend on `createVehicleClassSchema` (#401) is unchanged.
+- **Structural validation is deferred.** A future `validateAcrissStructure()` helper could check each *position* against the ACRISS axis it encodes (category / type / transmission-drive / fuel-air). MVP ships the 4-char-format check only because operators may enter codes the seed dictionary does not list.
+
+Export `ACRISS_CODES` (the seed dictionary keys) as `as const` from a new shared module (§5) so the form can offer a typeahead and tests can assert membership.
+
+---
+
+## 5. ACRISS taxonomy seed + i18n
+
+### 5.1 The dictionary — `packages/shared/src/acriss.ts` (new, runtime-dep-free)
+
+`packages/shared` has **no runtime deps on api/web** (AGENTS.md) — this is a pure const module, importable by seed, validators, api, and web.
+
+```ts
+// ACRISS code → translation KEY (not literal text). Labels live in
+// messages/*.json under the `acriss` namespace so en/ja/zh render per locale
+// (§4 platform item 2, §8.2). MVP subset = the 6-8 codes the demo seed needs
+// (proposal §9 item 9: "6-8 ACRISS codes" is the credibility floor).
+export const ACRISS_CODES = {
+  MCAR: 'acriss.MCAR', // Mini, Car, manual, unspecified fuel
+  ECAR: 'acriss.ECAR', // Economy
+  CCAR: 'acriss.CCAR', // Compact  <-- demo target (Toyota Yaris)
+  ICAR: 'acriss.ICAR', // Intermediate
+  SCAR: 'acriss.SCAR', // Standard
+  FCAR: 'acriss.FCAR', // Fullsize
+  IVAR: 'acriss.IVAR', // Intermediate passenger van (minivan)
+  SUVR: 'acriss.SUVR', // SUV  (note: not strictly ACRISS axis-pure; demo label)
+} as const
+
+export type AcrissCode = keyof typeof ACRISS_CODES
+```
+
+> ACRISS axes for reference (informational; MVP does not enforce positionally):
+> pos1 category, pos2 type, pos3 transmission+drive, pos4 fuel+AC. `CCAR` = Compact / 2-4dr car / manual unspecified / unspecified-fuel-with-AC.
+
+### 5.2 i18n labels — `packages/web/messages/{en,ja,zh}.json`
+
+New top-level `acriss` namespace, one entry per `ACRISS_CODES` key:
+
+```jsonc
+// en.json
+"acriss": { "CCAR": "Compact", "ECAR": "Economy", "IVAR": "Minivan", ... }
+// ja.json
+"acriss": { "CCAR": "コンパクト", "ECAR": "エコノミー", "IVAR": "ミニバン", ... }
+// zh.json
+"acriss": { "CCAR": "紧凑型", "ECAR": "经济型", "IVAR": "商务车", ... }
+```
+
+Plus `business.classes.form.acrissCode` (+ placeholder + hint) in all three. **Restart dev server after adding namespaces** (CLAUDE.md i18n gotcha: `rm -rf packages/web/.next && bun run dev`). **Verify locale parity** — the `lint:i18n` parity check (#375) fails CI on a missing key; conflict resolution silently drops keys (CLAUDE.md).
+
+### 5.3 Class seed — `packages/shared/src/db/seed.ts`
+
+Today the seed inserts only `SEED_VEHICLES` against the Best Car Rental operator; **no `vehicle_classes` rows are seeded**. Add a `SEED_CLASSES` array (operator = Best Car Rental, `operatorId = BEST_CAR_RENTAL_OPERATOR_ID`) with `acrissCode` set per class so the demo "Toyota Yaris in CCAR" works end-to-end, and so seeded vehicles can attach via the composite FK. Keep class `dailyRateJpy`/`hourlyRateJpy` for now (removed in 4c). Idempotent insert (mirror the existing `onConflictDoNothing` pattern).
+
+---
+
+## 6. Repo / Service / Routes / Web — threading `acrissCode`
+
+Pure plumbing; no new interface methods.
+
+| Layer | File | Change |
+|---|---|---|
+| **Type** | `packages/api/src/stores.ts` `VehicleClass` | add `acrissCode: string | null` |
+| **Drizzle columns** | `repositories/drizzle/shared.ts` `vehicleClassColumns` + `toVehicleClass` | add `acrissCode: vehicleClasses.acrissCode` and map it |
+| **Drizzle repo** | `repositories/drizzle/vehicle-class.ts` `create`/`update` | pass `acrissCode` through (operator scoping already present — untouched) |
+| **InMemory repo** | `repositories/in-memory/vehicle-class.ts` | persist/return `acrissCode` |
+| **Repo interface** | `repositories/types.ts` | no signature change (data shape via `VehicleClass`) |
+| **Service** | `services/vehicle-class.ts` | no logic change — `create`/`update` already spread the data object |
+| **Route** | `routes/vehicle-classes.ts` `POST`/`PATCH` | add `acrissCode: d.acrissCode ?? null` to the create object; `PATCH` uses `stripUndefined(parsed.data)` so it flows automatically |
+| **Web type/api** | `modules/classes/api.ts`, `hooks.ts` | type carries through (uses `CreateVehicleClassInput`) |
+| **Web form** | `modules/classes/components/ClassForm.tsx` | add an ACRISS field: a `<select>` of `ACRISS_CODES` keys rendering `t('acriss.<code>')` labels (typeahead/datalist optional), bound via `register('acrissCode')`; label from `t('form.acrissCode')` |
+| **Web display** | `ClassRow.tsx` / `ClassCatalogCard.tsx` / `ClassDetailView.tsx` | render the friendly label `t('acriss.<code>')` next to class name (the renter-facing grouping label, §2) |
+
+**Vehicle CRUD: no code change.** `routes/vehicles.ts`, `validators/vehicle.ts`, `DrizzleVehicleRepository` already handle plate, shaken, operator scope, and `classId` via composite FK. This slice only adds **tests** (§7) proving the acceptance criteria, plus surfacing the class's ACRISS label on the vehicle list (web, read-only, via the already-loaded class).
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant)
+
+Mirror `packages/api/tests/integration/rls-context.test.ts` (seed operator A + operator B + their `OPERATOR_STAFF` users; assert isolation both directions). One failing test → implement → repeat (no horizontal batching, per `~/.claude/rules/testing.md`).
+
+| Layer | New ACRISS work | Vehicle-CRUD acceptance proof (regression) |
+|---|---|---|
+| **Validator** (`packages/shared/test/validators/`) | `'CCAR'` accepted; `'ccar'` accepted and uppercased to `'CCAR'`; `'CCA'` (3) rejected; `'CCARX'` (5) rejected; `'cc-r'` rejected; `null`/omitted accepted (nullish) | existing plate/shaken rules still pass (no change expected) |
+| **InMemory repo** | `create`/`update` round-trips `acrissCode`; op-A staff cannot **read** op-B class (`findById`/`findAll` scoped via `operatorReadScope`) — `update`/`archive` take no `CallerContext`, so mutation isolation is **not** a repo-test concern (proven at the service, below); RENTER/anonymous (`PUBLIC_CONTEXT`) read across operators (catalog is public) but only ACTIVE | op-A staff cannot create/read/update/softDelete op-B vehicle; bypass roles see both |
+| **Drizzle repo** (Neon `test`) | inserting `acrissCode='cc'` (lowercase, len 2) → 23514 check_violation; valid 4-char code persists | composite FK `(operatorId, classId)` rejects a vehicle whose class belongs to another operator → 23503 (already covered by #395/#400 — keep the assertion) |
+| **Service** | class `create`/`update` returns `acrissCode`; **op-A `update`/`archive` of an op-B class → 404** (caller-scoped `findById(ctx,id)` runs before the unscoped `repo.update(id)`/`archive(id)` — this is the mutation-isolation seal); slug-uniqueness 409 still holds; archive-with-active-bookings 409 still holds | n/a (no vehicle service) |
+| **Route** | `POST /vehicle-classes` with bad ACRISS → 400 (Zod via `parseBody`); `GET /vehicle-classes` (public) returns `acrissCode` | `POST /vehicles` cross-operator: operator caller's `operatorId` stamped from token, body `operatorId` ignored; missing/ambiguous operator for a bypass caller → 422 (`OperatorRequiredError`); 401/403/404 matrix |
+| **Web** | `ClassForm` renders the ACRISS select with translated labels; submitting selects the code | `ClassRow`/catalog renders `t('acriss.CCAR')` = "Compact" |
+| **i18n** | parity test: every `ACRISS_CODES` key exists in en/ja/zh `acriss` namespace | — |
+
+**E2E:** none required for slice 3 (operator-portal only; renter-facing E2E starts slice 5 per proposal §6.1). The existing #338/#345 mock-API E2E re-seed against the marketplace shape and must stay green (§6.2(b)).
+
+---
+
+## 8. Merge gate (proposal §6.1)
+
+All green before merge:
+`bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` (3 green) · `bun run lint:i18n` parity (#375) · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktrees
+
+```bash
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-acriss -b feature/388-acriss-vehicle-crud origin/marketplace-pivot
+cd ../kuruma-acriss && bun install && bunx tsc --noEmit   # fresh-worktree hygiene (CLAUDE.md)
+```
+
+Within the worktree, one vertical RED→GREEN→REFACTOR cycle per row:
+
+1. **Schema** — `acrissCode` column + CHECK; `db:generate --name add_acriss_code_to_vehicle_classes` → `db:migrate` → `db:verify`.
+2. **Shared dictionary** — `acriss.ts` (`ACRISS_CODES`) + validator field (RED validator test first).
+3. **Type + repos** — `VehicleClass.acrissCode`, drizzle columns/mapper, in-memory (RED repo round-trip + isolation tests first).
+4. **Service + route** — thread through (RED route test first); Drizzle integration test against Neon `test`.
+5. **Seed** — `SEED_CLASSES` with ACRISS codes (incl. CCAR for the Yaris).
+6. **i18n** — `acriss` namespace + `business.classes.form.acrissCode` in en/ja/zh; restart dev; parity check.
+7. **Web** — `ClassForm` ACRISS select; class/vehicle list label display.
+8. **Vehicle-CRUD acceptance tests** — prove tenant isolation + plate/shaken (no impl expected).
+9. Review (code-reviewer + architect) → rebase onto `origin/marketplace-pivot` → PR (`Closes #388`).
+
+Conventional commits, small + focused. Never force-push; always rebase (`memory/feedback_no-force-push`).
+
+---
+
+## 10. Cross-slice boundary (what does NOT ship here)
+
+| Concern | Belongs to | Citation |
+|---|---|---|
+| **Drop `vehicle_classes.dailyRateJpy`/`hourlyRateJpy`** + move pricing to vehicle-only | **Slice 4c** (#389c) | slice-4 plan §5; proposal §5.1 step 4. Sequenced *after* #388. Class pricing stays untouched here. |
+| **Insurance options / fee schedules** | **Slice 4a/4b** | proposal §6 row 4 |
+| **Renter storefront search / per-class availability summaries / "from ¥X"** | **Slice 5** (#391) | proposal §6 row 5, §10 item 21 |
+| **Booking with requested/assigned vehicle, fee snapshot, exclusion constraint** | **Slice 6** (#392) | proposal §6 row 6, §10 item 14 |
+| **Locations CRUD + `vehicles.pickupLocationId` operational attach** | **Slice 2** (#387) — PR #414 in review | proposal §6 row 2 (column exists on the slice-2 branch; bookings attach in slice 6) |
+| **Structural/positional ACRISS validation, full ACRISS table (~hundreds of codes)** | Post-MVP refinement | §2 reversibility ("rename labels"); MVP needs only the seed subset |
+| **Sha-ken expiry reminder UX** | Post-MVP | proposal §9 item 8 ("data column required now; reminder UX is post-MVP" — column already exists) |
+
+---
+
+## 11. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Branching off a stale local `marketplace-pivot` | Medium | High | §1 precondition: create worktrees from `origin/marketplace-pivot` or fast-forward the local tracking branch before `git worktree add`; confirm #386 + #401 are present |
+| Migration journal `when` collision with concurrent slice-2/4 branches | Medium | Medium | Single additive migration; regenerate (not hand-edit) on rebase; `db:verify` + CI `db-drift` (CLAUDE.md 2026-04-17) |
+| i18n keys dropped in conflict resolution → blank ACRISS labels | Medium | Low | `lint:i18n` parity test (#375) as a merge gate; explicit parity test in §7 |
+| Scope creep into vehicle-CRUD reimplementation | Medium | Medium | §0 honest-scope note: vehicle CRUD + plate/shaken already merged; slice adds tests, not code |
+| ACRISS CHECK regex rejects a legitimately weird code operators enter | Low | Low | MVP regex is permissive (`[A-Z9]{4}`), no positional validation; structural check deferred |
+| Accidentally dropping class pricing here, colliding with 4c | Low | Medium | §3.2 + §10: class pricing explicitly untouched; 4c owns the drop |
+
+---
+
+## 12. Critical files
+
+**New:** `packages/shared/src/acriss.ts`; migration `drizzle/00NN_add_acriss_code_to_vehicle_classes.sql` (+ snapshot/journal).
+**Modify (shared):** `db/schema.ts` (column + CHECK), `validators/vehicle-class.ts` (field), `db/seed.ts` (`SEED_CLASSES`).
+**Modify (api):** `stores.ts` (`VehicleClass.acrissCode`), `repositories/drizzle/shared.ts` (columns + `toVehicleClass`), `repositories/drizzle/vehicle-class.ts`, `repositories/in-memory/vehicle-class.ts`, `routes/vehicle-classes.ts`.
+**Modify (web):** `modules/classes/components/ClassForm.tsx`, `ClassRow.tsx`, `ClassCatalogCard.tsx`, `ClassDetailView.tsx`; `messages/{en,ja,zh}.json` (`acriss.*` + `business.classes.form.acrissCode`).
+**Unchanged (proof-only):** `routes/vehicles.ts`, `validators/vehicle.ts`, `repositories/{drizzle,in-memory}/vehicle.ts`, `tenancy.ts`, `middleware/auth.ts`.
+
+---
+
+## 13. Resolved decisions
+
+1. **ACRISS validation depth.** Defer positional/structural validation. MVP ships 4-char-format only (`[A-Z9]{4}`) so operators can enter codes outside the seed dictionary without false rejects.
+2. **`acrissCode` nullable vs required.** Nullable for operator-created classes; every demo seed class carries a code. This keeps the integration anchor without blocking manual class creation.
+3. **ACRISS seed subset size.** Use the 8-code subset in §5.1. Du can refine ja/zh label wording during discovery without changing the schema/API contract.
+4. **`SUVR` purity.** Keep `SUVR` as a pragmatic demo label. The field is format-validated, not dictionary-gated; a stricter OTA table can replace the subset post-MVP.
+5. **`CallerContext` on class mutations (relayed review note, 2026-06-02).** Keep the repo shape — `VehicleClassRepository.update(id, data)`/`archive(id)` do **not** take `CallerContext`; do not expand the interface. Mutation isolation is proven at the **service**: `VehicleClassService.update(ctx, id)`/`archive(ctx, id)` call caller-scoped `findById(ctx, id)` first → 404 for another operator's class. §7 attributes read-isolation to repo tests and mutation-isolation to service/route tests accordingly. (Option 1 from the review note; matches the implemented shape on `marketplace-pivot`.)
+
+---
+
+## 14. Review log
+
+**v1 (2026-06-02)** — initial draft. Grounded against `origin/marketplace-pivot` + PR #414 slice-2 code (tenancy.ts, vehicle/class repos, routes, validators, seed, ClassForm). Key finding surfaced: plate/shaken/vehicle-operator-scoping already merged; net-new = `acrissCode` on `vehicle_classes` + taxonomy seed + i18n. Awaiting reviewer green light.

--- a/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
+++ b/docs/plans/2026-06-02-slice4-insurance-pricing-fees.md
@@ -1,0 +1,287 @@
+# Slice 4 Amendment — Insurance, Pricing & Fees (issue #389)
+
+**Date:** 2026-06-02
+**Status:** MERGED — 4a insurance options (#404, `c439883`), 4b fee schedules (#405, `9e33403`), 4c drop legacy class pricing (#406, `605d089`) on `marketplace-pivot`. Plan retained for history.
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 slice 4, §4 business portal items 4-6, §9 items 5/19, §10 items 5/9)
+**Supersedes:** the thin body of #389 (insufficient detail for AFK implementation per review 2026-06-02)
+
+---
+
+## 0. Decision: split #389 into 4a / 4b / 4c
+
+#389 bundles three independent domains. Per review, it is split into three sub-issues under epic #385, each a mergeable vertical slice on its own worktree off `origin/marketplace-pivot`:
+
+| Sub-slice | Domain | New? | Independent of | Effort |
+|---|---|---|---|---|
+| **4a** | Insurance options (per-operator CRUD) | New entity | 4b, 4c | ~1 day |
+| **4b** | Fee schedules (per-operator, optional per-class) | New entity | 4a, 4c | ~1-1.5 days |
+| **4c** | Vehicle pricing finalization (drop legacy class pricing) | Removal/cleanup | 4a, 4b | ~0.5 day |
+
+**4a and 4b run in parallel** (separate worktrees) — they share no business logic, only three merge-surface files (`schema.ts`, `index.ts` DI block, `messages/*.json`). **4c sequences after #388** (ACRISS + vehicle CRUD) because both rework the vehicle/class forms.
+
+**Insurance scope decision:** per-operator CRUD only. No `vehicle_insurance_options` join table in MVP — at booking (slice 6) the renter picks from the operator's full active list and the booking stores the selected option + price snapshot. Per-vehicle applicability is deferred until proven needed.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **#401 merged to `marketplace-pivot`** | Slice 4 repos build on the post-#401 write contract: `resolveOperatorIdForWrite(ctx, input, operators)` with single-operator inference + `OperatorRequiredError`, **no `BEST_CAR_RENTAL_OPERATOR_ID` fallback**. | Merged to `origin/marketplace-pivot` via PR #408. The local `marketplace-pivot` branch may still be stale; branch from `origin/marketplace-pivot` or fast-forward local before kickoff. |
+| **#387 (locations) merged** — for the WEB layer of 4a/4b only | Routing is **flat & JWT-scoped** (`/manage/insurance`, `/manage/fees`) like every other manage page — **NO `[operatorSlug]` segment** (slice-2 decision: operator derived from JWT, not URL). #387 lands `lib/business-roles.ts` admitting `OPERATOR_*` to the flat `/manage` portal — the 4a/4b pages need that gate. Backend repos/services have no #387 dependency. | In review (PR #414 → `marketplace-pivot`) |
+| **#388 (ACRISS + vehicle CRUD)** — for **4c only** | 4c drops legacy class pricing while #388 reworks the class/vehicle forms; landing 4c first would conflict. 4a/4b do not depend on #388. | Not started |
+
+`operators` table, `roleEnum` (incl. `OPERATOR_OWNER`/`OPERATOR_STAFF`/`PLATFORM_ADMIN`), `vehicles`/`vehicleClasses.operatorId`, the `(operatorId, id)` composite-unique on `vehicle_classes` (#395), and `CallerContext.operatorId`/`bypassScope` (#401) are all assumed present from slices 1-3.
+
+If the contract names differ at kickoff, each sub-slice adapts its own PR — never refactor a landed slice.
+
+---
+
+## 2. The canonical pattern (all three sub-slices conform)
+
+Established by `vehicles` / `vehicle_classes` (per AGENTS.md API layout `routes/ → services/ → repositories/`, NOT `modules/`):
+
+- **Repo interface** (`repositories/types.ts`): `CallerContext` on every method.
+- **Drizzle repo** reads: insurance/fees are **operator-private config**, so `findAll`/`findById` first call a management-read guard `requireManagementRead(ctx)` that rejects `RENTER` **and** `PARTNER` (unlike vehicles, whose catalog is public). Allowed read roles = `MANAGEMENT_READ_ROLES = STAFF_ROLES ∪ OPERATOR_ROLES` = `{STAFF, ADMIN, PLATFORM_ADMIN, OPERATOR_OWNER, OPERATOR_STAFF}`. **After** the guard, apply `operatorReadScope(ctx)` → `{kind:'all'|'operator'|'none'}` (`kind:'none'` ⇒ `sql\`false\``, fail-closed). Writes call `requireFleetWriteScope(ctx)` then insert with the route-resolved `operatorId`.
+
+> **[P0] Why `operatorReadScope` alone is unsafe here:** it maps every non-operator role — **including `RENTER`** — to `{kind:'all'}` because the vehicle *catalog* is public. Insurance/fees are private; a renter (or `PARTNER` API caller) hitting `findAll` would read every operator's config. `requireManagementRead(ctx)` is the seal; `operatorReadScope` only handles the operator-vs-bypass split *after* renters/partners are rejected. Add `requireManagementRead` to `middleware/auth.ts` alongside `requireFleetWriteScope`.
+- **InMemory repo** mirrors the interface (injected in tests via `createApp(overrides)`).
+- **Service** is auth-agnostic; returns `{ ok: true, ... } | { ok: false, error, status, code? }`.
+- **Route** gates mutations with role check, builds ctx via `toCallerContext(requireUser(c))`, uses `ok()`/`fail()`/`parseBody()` from `routes/helpers.ts`. Mounted at `/` in `index.ts`.
+- **Validators** (`packages/shared/src/validators/<entity>.ts`): `create<X>Schema` / `update<X>Schema` (= `.partial()`), cross-field rules via `.superRefine()`.
+- **Web** module `packages/web/src/modules/<entity>/` (`api.ts`, `hooks.ts`, `components/`) + **flat** page `app/[locale]/(business)/manage/<entity>/page.tsx` — JWT-scoped, **no `[operatorSlug]` segment** (mirrors `/manage/locations`); i18n namespace `business.<entity>`; link in `BusinessSidebar.tsx`.
+
+**Bypass-caller scoping (every list/create, mirrors #387):** operator callers auto-scope to `ctx.operatorId` and any `?operatorId=` they pass is dropped at the route. **[P1] Gate on `ctx.bypassScope === true`, not on the `PLATFORM_ADMIN` string** — during transition, legacy `STAFF`/`ADMIN` are bypass equivalents and must obey the same rule. A bypass caller's GET requires explicit `?operatorId=<id>` OR `?includeAll=true` (else 400); a bypass caller's POST requires `operatorId` in body (`platformAdmin*` schema variant; missing → 400 via `parseBody`). Cross-operator id on GET/PATCH/DELETE returns **404, not 403** (no tenant-existence leak). Mutations load the row first to capture its tenant before writing.
+
+**[P1] Validation status code = `400` (contract):** every validation failure — Zod via `parseBody()`, missing `operatorId` on a bypass create, and fee-type↔unit coherence — returns **400**, matching the existing `parseBody()` helper. The plan and tests use 400 throughout; do **not** introduce a second validation status (422). If a future caller needs to distinguish "well-formed but semantically invalid," add a `code` field to the error body, not a new HTTP status.
+
+---
+
+## 3. Sub-slice 4a — Insurance options
+
+### Schema (`packages/shared/src/db/schema.ts`)
+
+```ts
+export const insuranceStatusEnum = pgEnum('insurance_status', ['ACTIVE', 'ARCHIVED'])
+
+export const insuranceOptions = pgTable('insurance_options', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  operatorId: text('operatorId').notNull().references(() => operators.id),
+  name: text('name').notNull(),
+  description: text('description'),
+  dailyPriceJpy: integer('dailyPriceJpy').notNull(),
+  deductibleJpy: integer('deductibleJpy'),          // null = no deductible (full cover)
+  status: insuranceStatusEnum('status').notNull().default('ACTIVE'),
+  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index('idx_insurance_options_operatorId').on(t.operatorId),
+  unique('insurance_options_operatorId_id_unique').on(t.operatorId, t.id),
+  // Name uniqueness scoped to ACTIVE rows so archiving an option frees its name
+  // for reuse (consistent with fee_schedules active-uniqueness). Two ACTIVE options
+  // can't share a name; an archived one no longer reserves it. PARTIAL index.
+  uniqueIndex('insurance_options_active_name_unique')
+    .on(t.operatorId, t.name)
+    .where(sql`status = 'ACTIVE'`),
+  check('insurance_options_daily_price_non_negative', sql`${t.dailyPriceJpy} >= 0`),
+  check('insurance_options_deductible_non_negative',
+    sql`${t.deductibleJpy} IS NULL OR ${t.deductibleJpy} >= 0`),
+])
+```
+
+Seed (proposal §2): Best Car Rental gets two options — normal (deductible 150,000) + premium (deductible 250,000); `dailyPriceJpy` operator-set placeholders.
+
+### Validators — `packages/shared/src/validators/insurance-option.ts`
+- `createInsuranceOptionSchema`: name (1-200), description (≤2000, optional), `dailyPriceJpy` int ≥ 0, `deductibleJpy` int ≥ 0 nullish.
+- `updateInsuranceOptionSchema = base.partial()`.
+- `platformAdminCreateInsuranceOptionSchema = createInsuranceOptionSchema.extend({ operatorId: z.string() })`.
+
+### Repo interface — `repositories/types.ts`
+```ts
+export interface InsuranceOptionFilters { status?: 'ACTIVE' | 'ARCHIVED'; includeArchived?: boolean; operatorId?: string }
+export interface InsuranceOptionRepository {
+  findAll(ctx: CallerContext, filters?: InsuranceOptionFilters): Promise<InsuranceOption[]>
+  findById(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined>
+  create(ctx: CallerContext, data: Omit<InsuranceOption, 'id'|'createdAt'|'updatedAt'>): Promise<InsuranceOption>
+  update(ctx: CallerContext, id: string, data: Partial<InsuranceOption>): Promise<InsuranceOption | undefined>
+  archive(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined>
+}
+```
+Drizzle + InMemory pair under `repositories/{drizzle,in-memory}/insurance-option.ts`. Service `services/insurance-option.ts`: name-uniqueness 409 **checked against ACTIVE rows only and excluding the current row id on update** (matches the active-name partial index — archiving frees the name, and a no-name-change edit can't self-collide); archive sets status. Routes `routes/insurance-options.ts` at `/insurance-options`. DI + mount in `index.ts`.
+
+### Web
+Flat `manage/insurance/page.tsx` (JWT-scoped, **no `[operatorSlug]`**) + `modules/insurance/` (`InsuranceList`, `InsuranceForm`, `InsuranceArchiveDialog`, `useInsuranceOptions`). i18n `business.insurance.*`. `BusinessSidebar` link (between Classes/Customers, like Locations).
+
+---
+
+## 4. Sub-slice 4b — Fee schedules
+
+### Schema
+
+```ts
+export const feeTypeEnum = pgEnum('fee_type', ['OVERTIME_HOURLY', 'CLEANING_FLAT', 'NO_FUEL_FLAT'])
+export const feeUnitEnum = pgEnum('fee_unit', ['PER_HOUR', 'PER_DAY', 'PER_KM', 'FLAT'])
+export const feeScheduleStatusEnum = pgEnum('fee_schedule_status', ['ACTIVE', 'ARCHIVED'])
+
+export const feeSchedules = pgTable('fee_schedules', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  operatorId: text('operatorId').notNull().references(() => operators.id),
+  vehicleClassId: text('vehicleClassId'),            // null = operator-wide
+  feeType: feeTypeEnum('feeType').notNull(),
+  unit: feeUnitEnum('unit').notNull(),
+  amountJpy: integer('amountJpy').notNull(),
+  status: feeScheduleStatusEnum('status').notNull().default('ACTIVE'),
+  createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  // [P2] Composite index covering the operator read-scope (leading column) AND the
+  // composite FK source, so lint:fk-indexes + FK maintenance are satisfied. (operatorId)
+  // is a prefix of this, so no separate idx_fee_schedules_operatorId is needed. The
+  // partial UNIQUE indexes below are conditional and do NOT count as FK cover.
+  index('idx_fee_schedules_operator_class').on(t.operatorId, t.vehicleClassId),
+  // Composite FK seal (#395): a per-class fee's class must belong to the SAME operator.
+  // MATCH SIMPLE — when vehicleClassId IS NULL the FK is not enforced (operator-wide row).
+  foreignKey({
+    columns: [t.operatorId, t.vehicleClassId],
+    foreignColumns: [vehicleClasses.operatorId, vehicleClasses.id],
+    name: 'fee_schedules_operator_class_fk',
+  }),
+  check('fee_schedules_amount_non_negative', sql`${t.amountJpy} >= 0`),
+  // Uniqueness: ONE active fee per (operator, type, scope). Two partial indexes because
+  // NULL != NULL in a plain UNIQUE — operator-wide rows would otherwise never dedupe.
+  // Scoped to status='ACTIVE' so archiving frees the slot for a re-created fee.
+  uniqueIndex('fee_schedules_active_class_unique')
+    .on(t.operatorId, t.feeType, t.vehicleClassId)
+    .where(sql`status = 'ACTIVE' AND "vehicleClassId" IS NOT NULL`),
+  uniqueIndex('fee_schedules_active_operatorwide_unique')
+    .on(t.operatorId, t.feeType)
+    .where(sql`status = 'ACTIVE' AND "vehicleClassId" IS NULL`),
+])
+```
+
+### Validators — `packages/shared/src/validators/fee-schedule.ts`
+- `createFeeScheduleSchema`: `feeType` enum, `unit` enum, `amountJpy` int ≥ 0, `vehicleClassId` uuid nullish. `.superRefine()` enforces **fee-type ↔ unit coherence**:
+  - `OVERTIME_HOURLY` ⇒ `unit === 'PER_HOUR'`
+  - `CLEANING_FLAT` ⇒ `unit === 'FLAT'`
+  - `NO_FUEL_FLAT` ⇒ `unit === 'FLAT'`
+- `updateFeeScheduleSchema = base.partial()`. **[P1] The schema cannot fully enforce coherence on patch** — a patch of only `{ unit: 'FLAT' }` against an existing `OVERTIME_HOURLY` row never sees `feeType`, so the `.superRefine()` can't fire. Coherence on update is therefore enforced in the **service** on the merged value (below); the schema's `.superRefine()` stays only as a create-time + both-keys-present fast-path.
+- Platform-admin extend variant adds `operatorId`.
+
+### Repo / Service / Routes / Web
+Same shape as 4a. `FeeScheduleFilters` adds `feeType?` and `vehicleClassId?`. **[P1] Service is the coherence + uniqueness seal:** `update` fetches the existing row, **merges the patch**, then validates (a) fee-type↔unit coherence on the *merged* `feeType`+`unit` (400 on mismatch) and (b) active-uniqueness on the merged `(operatorId, feeType, vehicleClassId)` **excluding the current row id** (409) — so a no-key-change edit (e.g. bumping only `amountJpy`) does not falsely collide with itself. This is the merge-then-validate pattern `VehicleClassService.update` uses for "at least one rate". `create` validates the same on the full payload (no exclusion). The DB partial-unique indexes + the schema `.superRefine()` are backstops, not the only checks. Routes at `/fee-schedules`. **Flat** page `manage/fees/page.tsx` (JWT-scoped, **no `[operatorSlug]`**) + `modules/fees/` — form: feeType select → unit auto-constrained by type, amount, optional class dropdown (operator's classes only). i18n `business.fees.*`.
+
+### Slice-6 boundary (explicit — does NOT ship in 4b)
+4b stores schedules only. **Deferred to slice 6 (#392):** snapshot of applicable `fee_schedules` rows into `bookings.fee_snapshot jsonb` at booking; overtime compute `ceil(overage_hours) * snapshotted_hourly_rate`; the confirmation-page "potential additional charges" block. 4b ships zero renter-facing surface and zero booking coupling.
+
+---
+
+## 5. Sub-slice 4c — Vehicle pricing finalization
+
+Vehicle-level pricing already exists (`vehicles.dailyRateJpy`/`hourlyRateJpy`, `createVehicleSchema` "at least one rate", operator write-scope). 4c finishes the migration to vehicle-only pricing by **removing** class-level pricing. This is a destructive removal — discipline matters more than volume.
+
+### Step 1 — Reader audit (BEFORE any drop)
+Grep and reroute every reader of `vehicleClasses.dailyRateJpy` / `hourlyRateJpy`:
+```
+rg "dailyRateJpy|hourlyRateJpy" packages/api packages/web packages/shared \
+  | rg -i "class" --color=never
+```
+Known readers to resolve first: `VehicleClassService.update` "at least one rate" validation, any `ClassCatalogCard` / renter catalog "from ¥X", booking-by-class pricing. Storefront min-price becomes `min(vehicles.dailyRateJpy)` per storefront (that computation lands in slice 5 — 4c only ensures nothing still *requires* class pricing).
+
+### Step 2 — Migration (dedicated, after readers rerouted)
+Drop in one `db:generate --name drop_class_level_pricing` migration:
+- columns `vehicle_classes.dailyRateJpy`, `vehicle_classes.hourlyRateJpy`
+- CHECK constraints `vehicle_classes_pricing_at_least_one`, `vehicle_classes_daily_rate_non_negative`, `vehicle_classes_hourly_rate_non_negative`
+
+Then remove the fields from `vehicleClassObjectSchema`, the `VehicleClassService` rate validation, and the `ClassForm` price inputs. `db:verify` (3 green) after migrate.
+
+### Step 3 — Sequence
+Land **after #388** merges (it owns the class/vehicle form rework). Coordinate the `schema.ts` migration order to avoid the drizzle journal out-of-order `when` trap (CLAUDE.md 2026-04-17): regenerate 4c's migration on top of whatever #388 added.
+
+No new UI. No new page. Vehicle form already carries price.
+
+---
+
+## 6. Migration ordering across 4a / 4b / 4c (the real parallel hazard)
+
+All three append to `schema.ts` + `drizzle/`. Concurrent worktrees ⇒ journal `when` collisions. Rules:
+- 4a and 4b each generate **additive** table migrations — order between them is irrelevant *except* the journal must stay monotonic. Whichever merges second **regenerates** its migration on the rebased branch (`bun run db:generate` after rebase), never hand-edits `_journal.json` unless cherry-picking (then bump `when` to `max(prev)+1` per CLAUDE.md).
+- 4c is a **drop** — must be the last of the three and after #388. Never interleave a drop migration between two pending additive ones.
+- Every sub-slice runs `bun run db:verify` post-migrate; CI `db-drift` enforces.
+
+---
+
+## 7. Tests (TDD vertical-slice, mutation-resistant)
+
+Per sub-slice, mirroring `packages/api/tests/integration/rls-context.test.ts` (seed operator A + operator B + their `OPERATOR_STAFF` users; assert isolation both directions):
+
+| Layer | 4a Insurance | 4b Fees | 4c Pricing |
+|---|---|---|---|
+| **Validator** (`packages/shared/test/validators/`) | reject empty name, negative price, negative deductible; accept null deductible | **fee-type↔unit coherence**: `OVERTIME_HOURLY`+`FLAT` rejected; `CLEANING_FLAT`+`PER_HOUR` rejected; valid combos pass; negative amount rejected | class schema no longer accepts rate fields |
+| **InMemory repo** | CRUD; op-A staff can't see/update/archive op-B rows; **[P0] `RENTER` and `PARTNER` reads → Forbidden (NOT all-operators)**; bypass roles see both | same + filter by feeType/classId; **[P1] merged-patch coherence: patching only `unit` against an existing row is validated against the stored `feeType`** | — |
+| **Drizzle repo** (Neon `test`) | FK on operatorId; **two ACTIVE options same `(operatorId,name)` → 23505 on the partial index**; **archiving an option then creating a new one with the same name succeeds (name freed)** | **composite FK rejects a fee whose class belongs to another operator → 23503**; **second ACTIVE fee of same (operator,type,scope) → 23505** on the partial index | post-drop: inserting a class with a rate column fails (column gone) |
+| **Service** | name-uniqueness 409 (**ACTIVE-only, excludes current row id on update**); archive sets status; cross-operator id update → 404 | active-uniqueness 409 message (**excludes current row id**); archive frees the slot (re-create succeeds) | `VehicleClassService` has no rate path |
+| **Route** | 401/403/404 matrix; **`RENTER`/`PARTNER` read → 403**. **[Item 4] Bypass-precedence (explicit): GET `?operatorId=A` narrows to A · GET `?includeAll=true` returns all · GET with neither → 400 · POST w/o body operatorId → 400 · operator caller's `?operatorId=B` is dropped (returns own rows only)** | same matrix; **same bypass-precedence cases**; unit-coherence + merged-patch coherence → **400** | n/a (no new route) |
+| **Web** | `InsuranceForm` validation surfaces | `FeeScheduleForm` constrains unit by type | `ClassForm` no longer renders rate inputs |
+
+E2E: none required for slice 4 (operator-portal only; renter-facing E2E starts slice 5 per proposal §6.1).
+
+---
+
+## 8. Per-sub-slice merge gate (proposal §6.1)
+
+All green before merge: `bun run test` · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 9. Execution order & worktrees
+
+```
+# Branch from origin/marketplace-pivot — local marketplace-pivot lags remote (PR #408/#401).
+# `git fetch origin` first; or fast-forward local before branching.
+git worktree add ../kuruma-insurance -b feature/389a-insurance origin/marketplace-pivot   # 4a
+git worktree add ../kuruma-fees      -b feature/389b-fees      origin/marketplace-pivot   # 4b (parallel)
+# 4c after #388:
+git worktree add ../kuruma-pricing   -b feature/389c-pricing   origin/marketplace-pivot
+```
+Within each: schema migration → validator (RED/GREEN per rule) → InMemory repo → service → routes → DI wire → Drizzle repo (integration) → web → i18n (restart dev) → review → rebase → PR (`Closes #389a` etc.).
+
+**Parallelism:** 4a ∥ 4b from day one (after #401). 4c trails #388. Net wall-clock ≈ max(4a, 4b) + 4c ≈ ~1.5 + 0.5 = **~2 days** vs ~2.5-3 sequential.
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Dropping class pricing breaks renter catalog / booking-by-class | Medium | High | 4c step-1 reader audit + reroute BEFORE the drop migration; integration test asserts no rate column remains |
+| 4a/4b concurrent migrations collide in `_journal.json` | Medium | Medium | Second-to-merge regenerates on rebase; never hand-edit journal; `db:verify` + CI `db-drift` |
+| Fee operator-wide uniqueness silently broken by NULL semantics | Medium | Medium | Two partial unique indexes (not a plain UNIQUE); integration test inserts a duplicate operator-wide fee and asserts 23505 |
+| Per-class fee points at another operator's class | Low | Critical | Composite FK `(operatorId, vehicleClassId) → vehicle_classes(operatorId, id)`; integration test asserts 23503 |
+| Built on pre-#401 fallback contract | Medium | High | Precondition: #401 merged first; repos call `resolveOperatorIdForWrite(ctx, input, operators)` (no hardcoded operator) |
+| 4c lands before #388 and conflicts on class form | Low | Medium | Explicit sequencing: 4c after #388 |
+
+---
+
+## 11. Critical files
+
+**4a:** `validators/insurance-option.ts`, `repositories/{drizzle,in-memory}/insurance-option.ts`, `services/insurance-option.ts`, `routes/insurance-options.ts`, `modules/insurance/*`, `app/[locale]/(business)/manage/insurance/page.tsx` (flat); modify `schema.ts`, `repositories/types.ts`, `index.ts`, `messages/{en,ja,zh}.json`, `BusinessSidebar.tsx`, `seed.ts`.
+**4b:** same set for `fee-schedule` / `fees`.
+**4c:** modify `schema.ts` (drop columns+checks), `validators/vehicle-class.ts`, `services/vehicle-class.ts`, `modules/classes/components/ClassForm.tsx`; new drop migration.
+
+---
+
+## 12. Open questions — RESOLVED (reviewer 2026-06-02)
+
+1. `insurance_options.dailyPriceJpy` — **required**. (An option with no price is meaningless.)
+2. Keep `PER_DAY` / `PER_KM` in the unit enum now — **yes** (proposal names them; the fee-type↔unit validation prevents misuse).
+3. 4c deletes class pricing — **yes, but only after the reader audit (§5 step 1) AND after #388.**
+
+## 13. Review log
+
+**v2 (2026-06-02)** incorporated reviewer findings:
+- **[P0]** Reads of insurance/fees now gated by `requireManagementRead(ctx)` (rejects `RENTER`/`PARTNER`) before `operatorReadScope` — §2, §7.
+- **[P1]** Fee coherence + active-uniqueness enforced in the **service** on merged existing+patch, not the partial schema — §4, §7.
+- **[P1]** Bypass-caller scoping gates on `ctx.bypassScope` (covers legacy `STAFF`/`ADMIN`), not the `PLATFORM_ADMIN` string — §2.
+- **[P1]** Standardized all validation failures on **400** (matches `parseBody()`); 422 removed — §2, §7.
+- **[P2]** Added composite FK-source index `(operatorId, vehicleClassId)` for `lint:fk-indexes` — §4.

--- a/docs/plans/2026-06-02-slice5-renter-storefront-search.md
+++ b/docs/plans/2026-06-02-slice5-renter-storefront-search.md
@@ -1,0 +1,303 @@
+# Slice 5 — Renter Storefront Search (issue #391)
+
+**Date:** 2026-06-02
+**Status:** Reviewed + green-lit 2026-06-05 — all citations verified against merged slices 2–4 on `marketplace-pivot`; ready for `feature/391` kickoff. Review fixes folded in (see §9 items 7–10).
+**Parent epic:** #385
+**Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` — §2 (Search result shape, Availability query, Turnaround buffer), §4 renter portal items 1–3, §6 row 5, §6.1 (E2E gate), §6.2 (tenant scoping — RENTER has no operatorId), §9 items 20/21, §10 items 10/12/13.
+**Locked decision (epic #385 body):** *Renter search is storefront-first.* §10 item 12: "storefront cards first, storefront vehicle detail second… flat all-vehicle search is rejected for MVP because it hides the operator/location choice."
+
+This slice is a **read-path** slice. It ships **zero booking writes** (booking = slice 6) and, ideally, **zero new tables** — only two new read endpoints, their repository reads, the renter search UI, and (likely) one or two covering indexes. It is the first **renter-facing** slice, so it is the **first slice that requires a Playwright E2E happy path** (§6.1).
+
+---
+
+## 0. Decision: one slice, two read models (no sub-split)
+
+Unlike slice 4 (three independent entity CRUDs), slice 5 is a single cohesive read feature: a search list and its drill-down detail, both backed by the **same availability computation**. There is nothing to parallelize across worktrees. It ships as **one PR on `feature/391-renter-storefront-search`**.
+
+The two read models (§9 item 21, §10 item 12):
+
+| Read model | Endpoint | Returns |
+|---|---|---|
+| **Storefront search** | `GET /storefronts/search` | Location/storefront cards across all operators, each with `classSummaries[]` (per-ACRISS-class available count), `fromDailyPriceJpy`, and fallback `fromHourlyPriceJpy` |
+| **Storefront detail** | `GET /storefronts/:locationId/vehicles` | The available **individual** vehicles at that storefront for the selected date range, grouped/filterable by class |
+
+**Hard boundary (§10 item 12):** the primary search result is **store cards, never a flat cross-operator vehicle list**. The flat list only ever appears *inside* one storefront's detail.
+
+---
+
+## 1. Preconditions (MUST hold before kickoff)
+
+| Precondition | Why | Status 2026-06-02 |
+|---|---|---|
+| **Slice 2 (#387 locations) merged to `marketplace-pivot`** | The store card IS a `locations` row. Search reads `locations` (name, address, `operatingHours`, `defaultTurnaroundMinutes`) and joins `vehicles.pickupLocationId → locations.id`. Without it there is no storefront entity to return. | In review (PR #414 → `marketplace-pivot`; locations table + `vehicles.pickupLocationId` composite FK present on that branch, not yet on pivot) |
+| **Slice 3 (#388 ACRISS + vehicle CRUD) merged** | `classSummaries` group by ACRISS class; the card shows "Compact x4, Minivan x2". Requires `vehicle_classes.acriss_code` + i18n class labels. The current `marketplace-pivot` `vehicle_classes` has **no `acrissCode` column yet** — slice 3 adds it. | Not started |
+| **Slice 4 (#389a/b/c pricing) merged** | Card pricing is computed from `vehicles.dailyRateJpy` / `vehicles.hourlyRateJpy`. §10 item 11 + §5.1: pricing is **vehicle-level only**; slice 4c drops `vehicle_classes.dailyRateJpy`. Slice 5 must read price from `vehicles`, never from the class. | Not started (4a/4b drafted in `2026-06-02-slice4-*`; 4c trails #388) |
+
+`operators`, `locations`, `vehicles.operatorId` + `vehicles.pickupLocationId` (composite FK to `locations`), `vehicle_classes.acriss_code`, `vehicles.dailyRateJpy`/`hourlyRateJpy`, the `bookings` exclusion semantics on `effectiveEndAt`, `CallerContext`/`PUBLIC_CONTEXT`/`bypassScope` from `packages/api/src/middleware/auth.ts`, and `operatorReadScope` from `packages/api/src/tenancy.ts:43` (verified 2026-06-05 — `operatorReadScope` is **not** in `auth.ts`) are all assumed present from slices 1–4.
+
+**If slices 2–4 are not all merged at kickoff,** do not stub their schema — block on them. Slice 5 is genuinely downstream; building against placeholder columns bakes in rework.
+
+---
+
+## 2. The reuse target — DO NOT reinvent availability
+
+The availability computation already exists and already honours the exclusion/turnaround model. Slice 5 **extends its reach to a storefront**, it does not re-derive overlap logic.
+
+### What exists today (cite, reuse)
+
+- **`DrizzleAvailabilityRepository.findAvailableVehicles(from, to)`** — `packages/api/src/repositories/drizzle/availability.ts:10`. Selects `vehicles` where `status='AVAILABLE'` AND `NOT EXISTS` an overlapping `CONFIRMED`/`ACTIVE` booking via `tstzrange(b."startAt", b."effectiveEndAt") && tstzrange(from, to)`. **This is the canonical overlap predicate** (#317). `effectiveEndAt = endAt + turnaround` is already materialized on the booking row, so the turnaround buffer (§2 / §9 item 20) is honoured by reusing this predicate — slice 5 adds **no new range math**.
+- **`VehicleClassAvailabilityService.getAvailabilityForClass(slug, from, to)`** — `packages/api/src/services/vehicle-class-availability.ts`. Already computes `{ totalCars, availableCars, sampleAvailableVehicleIds }` per class by intersecting `findAvailableVehicles` with the class membership (#317). The `classSummaries` aggregation in slice 5 is the **same intersection, grouped by `(locationId, classId)` instead of one class**.
+- **`GET /vehicle-classes/:slug/availability`** route + `cachePublic(c, 10)` — `packages/api/src/routes/vehicle-classes.ts:54`. The 10s edge-cache pattern for time-sensitive availability and the public-catalog per-IP rate limiter (`publicCatalogLimiter`, lines 25–30) are reused verbatim for the new search routes.
+- **`parseDateRange(c, true)`** + `parsePagination`/`parseLimit` — `packages/api/src/routes/helpers.ts`. Date-range parse (both/one/neither, `to>from`, ISO validation) and cursor/offset parsing are done; reuse, do not duplicate.
+- **`PUBLIC_CONTEXT`** — `auth.ts` (`{ userId:'public', role:'RENTER', bypassScope:false }`) — the sanctioned caller context for anonymous renter reads. **`operatorReadScope` lives in `tenancy.ts:43`** (not `auth.ts`); `operatorReadScope(PUBLIC_CONTEXT)` resolves to `{kind:'all'}` (cross-operator marketplace is the point), **without** granting a privilege bypass.
+
+### The one real gap
+
+`AvailabilityRepository.findAvailableVehicles(from, to)` (interface `repositories/types.ts:256`; Drizzle impl `availability.ts:10`) takes **no location/operator filter** — it scans the whole fleet. Slice 5 needs availability **scoped to a storefront** and **grouped by class**. Two options, pick the cheaper:
+
+- **(A, preferred)** Add `locationId?: string` (and keep `operatorId` derivable via the join) as an optional filter arg: `findAvailableVehicles(from, to, filters?: { locationId?: string; operatorId?: string; classId?: string })`. Backward-compatible (existing callers pass no filter). The class catalog endpoint keeps working unchanged.
+- (B) Add a dedicated `findAvailableVehiclesByLocation(...)` method. More surface, no benefit over (A).
+
+Go with **(A)**. It is additive to the interface; the InMemory + Drizzle impls both gain the optional predicate; no existing caller changes.
+
+> **Learn: Open/Closed via optional filter arg.** Extending `findAvailableVehicles` with an optional, defaulted filter adds the new storefront-scoped behaviour without editing any existing call site — adding feature N didn't force a rewrite of feature N-1. Heuristic: when a query needs one more axis, add a defaulted filter param, not a parallel method.
+
+---
+
+## 3. Read model 1 — Storefront search
+
+### Endpoint
+
+`GET /storefronts/search` — **public, no auth** (registered before `requireAuth`, behind `publicCatalogLimiter` + `cachePublic(c, 10)`).
+
+Query params (parsed via `parseDateRange(c, true)` + bespoke parse for the rest):
+
+| Param | Required | Notes |
+|---|---|---|
+| `from`, `to` | **yes** | Pickup/return datetime (ISO, JST per existing `parseDateRange`). `to>from` enforced. |
+| `pickupLocationId` | no | If present, narrows to that one storefront (degenerate single-card search). |
+| `class` (ACRISS code, repeatable) | no | Filter to stores that have ≥1 available vehicle in any listed class; the card's `classSummaries` is filtered to the requested classes. |
+| `limit`, `cursor` | no | Cursor pagination (§3.3). Default 25, max 50. |
+
+§4 item 1 lists "pickup location + return location" — MVP UX defaults pickup=return (proposal §2 Locations: "MVP UX defaults equal"); **dropoff filtering does not ship here** (one-way rental is post-MVP, §2). The search form may show a locked return location mirroring pickup, but slice 5 filters on `pickupLocationId` only.
+
+### Response shape
+
+```jsonc
+{
+  "success": true,
+  "data": {
+    "storefronts": [
+      {
+        "locationId": "loc_...",
+        "operatorId": "op_...",
+        "operatorName": "Best Car Rental",
+        "name": "Best Car Rental Osaka — Namba",
+        "address": "…",
+        "operatingHours": { "openTime": "09:00", "closeTime": "20:00" } | null,
+        "classSummaries": [
+          { "acrissCode": "CCAR", "label": "Compact", "availableCount": 4 },
+          { "acrissCode": "MVAR", "label": "Minivan", "availableCount": 2 }
+        ],
+        "fromDailyPriceJpy": 4500,
+        "fromHourlyPriceJpy": 800,
+        "representativePhotos": ["…"]   // up to N from available vehicles' photos
+      }
+    ],
+    "nextCursor": "…" | null
+  }
+}
+```
+
+The demo target string — "Best Car Rental Osaka — Compact x4, Minivan x2, from ¥4,500/day" (§6 row 5) — renders directly from `name` + `classSummaries` + `fromDailyPriceJpy`.
+
+### Aggregation logic (`StorefrontSearchService`)
+
+For the date range `[from, to)`:
+
+1. Resolve candidate `locations` (status `ACTIVE`) across all operators (or the single `pickupLocationId`), honouring `operatorReadScope(PUBLIC_CONTEXT) = {kind:'all'}`.
+2. Compute the set of **available vehicles** via the extended `findAvailableVehicles(from, to, { locationId })` — already filters `status='AVAILABLE'` + no overlapping `CONFIRMED`/`ACTIVE` booking on `effectiveEndAt` (turnaround included). One query per result page, **not** per location (avoid N+1, §8).
+3. Group available vehicles by `(pickupLocationId, classId)` → `availableCount`; join `vehicle_classes` for `acrissCode` + label. **`acrissCode` is nullable** (schema CHECK `^[A-Z9]{4}$` applies only when set; seed backfill is non-corrective, #420) — key the group on `classId`, and when `acrissCode` is NULL fall back to the class `name` for the label. Never drop a vehicle for a missing ACRISS code (§9 item 7).
+4. `fromDailyPriceJpy = min(vehicle.dailyRateJpy)` over available daily-priced vehicles and `fromHourlyPriceJpy = min(vehicle.hourlyRateJpy)` over available hourly-priced vehicles. Prefer daily in UI; if no daily price exists, render the hourly fallback. **Never** read class pricing — it's dropped in 4c.
+5. **Drop stores with zero available vehicles** from the result (an empty store is not a useful card).
+6. Apply `class` filter: keep stores with ≥1 available vehicle in a requested class; trim `classSummaries` to requested classes.
+
+> **Learn: Batch the availability scan (N+1 guard).** Computing availability once over all candidate vehicles and grouping in memory — instead of calling `getAvailabilityForClass` per (store × class) — keeps it to ~1 DB round trip per page. The per-class service is fine for one class detail page; looping it across a search result is the N+1 trap. Heuristic: a search list aggregates with one scan + in-memory group-by, never a query per row.
+
+### ACRISS label i18n
+
+`classSummaries[].label` is the **localized** class label. Resolution mirrors the existing class catalog: the API returns the `acrissCode` + raw class `name`; the **web layer** localizes via the `catalog`/ACRISS i18n namespace (server-rendered with `getTranslations`). The API stays locale-agnostic (operator-entered names are single-language per §9 item 4). Decide at impl time whether to send `label` pre-localized (requires `Accept-Language` plumb-through) or send `acrissCode` and localize in web — **default to localize-in-web** (no new API i18n surface).
+
+### 3.3 Pagination
+
+Cursor over `(locationId)` ordered by a stable key (e.g. `operatorName, name, locationId`). Reuse `parseLimit`. The cursor encodes the last `(sortKey, locationId)` — opaque base64. At MVP scale (3 ops × ~3 locations = ~9 stores) pagination is barely exercised, but the contract ships now so the renter list never returns an unbounded set. Default 25 / max 50.
+
+---
+
+## 4. Read model 2 — Storefront detail
+
+### Endpoint
+
+`GET /storefronts/:locationId/vehicles` — **public, no auth**, `publicCatalogLimiter` + `cachePublic(c, 10)`.
+
+Query params: `from`, `to` (required, `parseDateRange`), optional `class` (ACRISS filter), `limit`/`cursor`.
+
+### Response shape
+
+```jsonc
+{
+  "success": true,
+  "data": {
+    "storefront": { "locationId": "…", "name": "…", "address": "…", "operatorName": "…", "operatingHours": {…}|null },
+    "vehicles": [
+      {
+        "id": "veh_...", "name": "Toyota Yaris", "make": "Toyota", "model": "Yaris",
+        "year": 2023, "seats": 5, "transmission": "AUTO",
+        "acrissCode": "CCAR", "classLabel": "Compact",
+        "dailyRateJpy": 4500, "hourlyRateJpy": 800,
+        "photos": ["…"]
+      }
+    ],
+    "nextCursor": "…" | null
+  }
+}
+```
+
+### Logic (`StorefrontDetailService`)
+
+1. Load the `location` by id (404 if missing/`ARCHIVED`).
+2. `findAvailableVehicles(from, to, { locationId, classId? })` → the available individual vehicles for the range (exclusion + turnaround already applied).
+3. Join `vehicle_classes` for `acrissCode` + label; project the renter-safe vehicle fields (no operator-internal fields — no `shakenExpiryDate`, no `insuranceExpiryDate`, no `bufferMinutes`).
+4. Group/sort by class for the grouped-by-ACRISS UI (§4 item 3).
+
+**404 vs empty:** unknown/archived `locationId` → **404**. Known store with no available vehicles for the range → **200 with `vehicles: []`** (the store exists; it's just full).
+
+---
+
+## 5. Architecture & boundaries (AGENTS.md)
+
+Import direction **routes → services → repositories**; web has **no DB access** (calls Hono via `hono/client`).
+
+### API layer (`packages/api`)
+
+| Layer | File(s) | Responsibility |
+|---|---|---|
+| **Repo interface** | `repositories/types.ts` | Extend `AvailabilityRepository.findAvailableVehicles(from, to, filters?)` with optional `{ locationId?, operatorId?, classId? }`. Add a `StorefrontRepository` (or extend `LocationRepository` from #387) read method `findActiveStorefronts(ctx, { pickupLocationId? })` returning location rows with operator name joined. Every method takes `CallerContext`. |
+| **Drizzle repo** | `repositories/drizzle/availability.ts`, `…/storefront.ts` | Add the optional `locationId`/`classId`/`operatorId` predicate to the existing `NOT EXISTS` query. The `locationId` filter is an **INNER** match on `vehicles.pickupLocationId` (nullable) — vehicles with no assigned location are correctly invisible to storefront search (§9 item 8). **Scope the new arg to `findAvailableVehicles` only**: `availability.ts` has a second `tstzrange` block (the single-vehicle `isAvailable` check at ~L52) that must stay unchanged. New storefront read joins `locations ⨝ operators`. Reads use `operatorReadScope(ctx)` → `{kind:'all'}` for `PUBLIC_CONTEXT` (renter sees all operators — this is the marketplace, §6.2). |
+| **InMemory repo** | `repositories/in-memory/availability.ts`, `…/storefront.ts` | Mirror the interface for tests (injected via `createApp(overrides)`). |
+| **Service** | `services/storefront-search.ts`, `services/storefront-detail.ts` | Auth-agnostic; return `{ ok:true, data } | { ok:false, error, status }`. Own the group-by-class aggregation + daily/hourly min-price calculation. **No HTTP, no Hono imports.** |
+| **Routes** | `routes/storefronts.ts` | Public GET routes registered **before** `requireAuth` (like `routes/vehicle-classes.ts:19`). Build ctx as `PUBLIC_CONTEXT` (no JWT needed). Use `ok()`/`fail()`/`parseDateRange()` + `cachePublic(c, 10)`. Mount at `/` in `index.ts`; stack `publicCatalogLimiter`. |
+| **Composition root** | `index.ts` | Construct `StorefrontSearchService`/`StorefrontDetailService` with the storefront + availability + class repos; wire `createStorefrontRoutes(...)`. Only `index.ts` touches concrete classes. |
+
+### Auth/scope model — the renter difference (§6.2)
+
+Search is **public/renter-facing**. This is the inverse of slice 4's operator-private config:
+
+- **No `requireManagementRead` gate.** Insurance/fees (slice 4) reject `RENTER`; the storefront catalog **must admit anonymous renters** — that's the product. Routes register before `requireAuth`.
+- **`operatorReadScope(PUBLIC_CONTEXT) = {kind:'all'}` is correct and intended here** (the exact opposite of why it was unsafe for slice-4 private config). The renter genuinely should see every operator's stores — cross-operator search is the point (§2 Tenant routing: "renter portal = single URL space").
+- **RENTER has no `operatorId`** (§6.2). No tenant predicate is applied to the renter read; the only filters are `status='AVAILABLE'`/`ACTIVE` location + the date-range availability + any explicit `pickupLocationId`/`class` query filter.
+- **Renter-safe projection.** The repo/service must project only renter-visible columns. Never leak operator-internal fields (sha-ken/insurance expiry, buffer minutes, cost). This is the read-side analogue of tenant scoping: a public endpoint over a multi-tenant table must whitelist columns.
+
+> **Learn: Public read ≠ privilege bypass.** `PUBLIC_CONTEXT` resolves to `{kind:'all'}` scope but `bypassScope:false` — it can read the cross-operator catalog but is not an admin. The safety control on a public multi-tenant read is **column projection** (whitelist renter-safe fields), not row scoping. Heuristic: when an endpoint is intentionally cross-tenant, audit the SELECT column list, not the WHERE clause.
+
+### Web layer (`packages/web`)
+
+- New renter route group: `app/[locale]/search/page.tsx` (search form + results) and `app/[locale]/storefronts/[locationId]/page.tsx` (detail). Follows the existing `app/[locale]/vehicles` catalog pattern (server component + `getTranslations`).
+- New module `modules/storefronts/` mirroring `modules/classes/`: `api.ts` (typed `hono/client` calls via `createApiClient` — `packages/web/src/lib/api-client.ts`), `hooks.ts`, `index.ts`, `components/` (`StorefrontSearchForm`, `StorefrontCard`, `ClassSummaryBadges`, `StorefrontDetailView`, `AvailableVehicleCard`).
+- i18n namespace `search.*` (and reuse `catalog.*` for ACRISS labels) across `en`/`ja`/`zh` (renter pages require all three, §8.2). **New namespaces require a dev-server restart** (`rm -rf packages/web/.next && bun run dev`).
+- `StorefrontCard` renders the demo string; `ClassSummaryBadges` reuses the badge consistency rule (named badge component, never ad-hoc colors — `memory/feedback_badge-consistency`).
+- A11y (§8.2 / `~/.claude/rules/react.md`): search form inputs have `<label>`s; date pickers keyboard-navigable; cards are semantic `<a>` links to detail.
+
+---
+
+## 6. What does NOT ship in slice 5 (explicit boundaries)
+
+| Deferred to | Item | Why |
+|---|---|---|
+| **Slice 6 (#392)** | Any booking write; `requested_vehicle_id`/`assigned_vehicle_id` insert; the exclusion-constraint *write*; `booking_code`; selected-insurance snapshot; fee snapshot; vehicle selection → confirm. | Slice 5 is read-only. It surfaces a "select" button that, in slice 5, links to a placeholder/disabled booking route. The availability **read** predicate slice 5 uses is the same one slice 6's write transaction validates against — but the write is slice 6 (§2 Booking write boundary, §10 item 14). |
+| **Slice 6** | Renter contact capture, insurance dropdown wired to operator options, booking submit. | §4 item 4. |
+| **Post-MVP** | One-way rental (dropoff ≠ pickup filtering); distance/area geo-sort; map view; per-weekday operating hours. | §2 Locations; §4 item 2 lists "distance/area" — MVP shows address/area text only, no geo ranking. |
+| **Post-MVP** | Materialized availability view. | §2 Availability query: "Live scan… no materialized view in MVP." Slice 5 uses the live `NOT EXISTS` scan. |
+
+---
+
+## 7. Schema changes (likely indexes only)
+
+Slice 5 ideally adds **no tables and no columns** — it reads slices 1–4's schema. The only candidate change is **covering indexes** for the new query paths, if `bun run lint:fk-indexes` / query plans demand:
+
+- `vehicles.pickupLocationId` — #387 already adds `idx_vehicles_pickupLocationId` (confirmed on PR #414); the storefront availability join reuses it. **No new index needed if present.**
+- `bookings(vehicleId, status, startAt, effectiveEndAt)` — the `NOT EXISTS` overlap subquery filters on `vehicleId` + status + range. A composite/GiST index here would help at scale, **but** §8.2 sets search p95 <500ms at MVP scale (3 ops × ~40 vehicles) which the live scan "handles trivially." **Recommendation: ship no new index in slice 5; measure first.** If a plan regression shows up, add the index in a dedicated follow-up — do not speculatively index (YAGNI).
+
+**If** any index is added: `bun run db:generate --name <describe>` → `db:migrate` → `db:verify` (3 green); respect the journal-`when` monotonic rule (CLAUDE.md 2026-04-17) when rebasing onto `marketplace-pivot`. **No hand-written `.sql` in `drizzle/`.**
+
+---
+
+## 8. Tests (TDD vertical-slice, mutation-resistant)
+
+Strict RED→GREEN per behaviour (`~/.claude/rules/testing.md`). Seed two operators (A, B) each with a location + vehicles across ≥2 ACRISS classes + at least one overlapping booking, to prove cross-operator aggregation and exclusion.
+
+| Layer | Coverage |
+|---|---|
+| **Service unit** (`StorefrontSearchService`) | Empty range params rejected (400 upstream). `classSummaries` counts ONLY available vehicles (a vehicle with an overlapping `CONFIRMED` booking is excluded; assert exact count drops by 1). `fromDailyPriceJpy === min(dailyRateJpy)` and hourly-only stores return `fromDailyPriceJpy:null` + exact `fromHourlyPriceJpy`. Store with zero available vehicles omitted. `class` filter trims summaries to requested codes. Cross-operator: stores from A and B both appear (assert both `operatorId`s present). |
+| **Service unit** (`StorefrontDetailService`) | Unknown `locationId` → `{ok:false,status:404}`. Known store, full range → `vehicles:[]` (200). Available vehicles list excludes MAINTENANCE/RETIRED and overlapping-booked ones — assert exact ids. Renter projection omits `shakenExpiryDate`/`bufferMinutes` (assert key absent). |
+| **InMemory repo** | `findAvailableVehicles(from,to,{locationId})` returns only that location's free vehicles; `{classId}` filter narrows correctly; turnaround respected (a booking ending inside `[from,to)` minus turnaround still blocks). |
+| **Drizzle repo** (Neon `test`) | The extended `NOT EXISTS` overlap query returns the right vehicle set for a `locationId` against a seeded overlapping booking on `effectiveEndAt`. Confirms the SQL predicate, not just the in-memory mirror. |
+| **Route** | `GET /storefronts/search` 200 public (no auth). Missing `from`/`to` → 400 (`parseDateRange`). `to<=from` → 400. Response shape matches the contract (assert `storefronts[0].classSummaries` + daily/hourly price fields). `GET /storefronts/:id/vehicles` unknown id → 404. `cachePublic` header present. |
+| **E2E (Playwright)** — REQUIRED (first renter-facing slice, §6.1) | Happy path: renter opens `/en/search`, enters a date range, submits → sees a storefront card containing the store name + a class-summary badge (e.g. "Compact x4") + "from ¥4,500"; clicks the card → lands on `/en/storefronts/:id`, sees grouped available vehicles, sees a (disabled/placeholder) select control. Runs on the **mock-API read track** (the established renter-browse track), **not** the real-DB write track which is still pending (#416) — see §9 item 9. Stub the two storefront endpoints' HTTP responses; the gate does not depend on a seeded `test` DB. Extend the existing `e2e/browse.spec.ts` pattern + `playwright.config.ts` (#296 infra, #321 renter-browse spec). |
+
+**E2E note:** this is the slice that *introduces* the renter search E2E; slices 6/8 build the full search→book→confirm journey on top. The §6.1 gate "E2E happy-path required green before slice 6 and slice 8 merge" means slice 5's E2E is the seed the later gates extend.
+
+---
+
+## 9. Resolved decisions / cross-slice risks
+
+1. **Slices 2–4 not yet merged.** Slice 5 is the most downstream renter slice and **hard-depends** on `locations` (#387), `acriss_code` (#388), and vehicle-only pricing (#389c-drop). As of 2026-06-02 none are merged to `marketplace-pivot`. **Risk:** kicking off slice 5 early means coding against placeholder columns. **Mitigation:** treat slices 2→3→4 as a strict gate; do not start the schema-touching parts of slice 5 until they land. The web/UI scaffolding *can* start against the documented API contract.
+2. **`AvailabilityRepository` signature change** is a shared interface edit (`repositories/types.ts`) touched by other slices. Making `findAvailableVehicles`' new arg **optional** keeps it backward-compatible, but coordinate so slice 6's booking-availability work and slice 5 don't both edit the method concurrently. Land slice 5's signature extension first if 5 and 6 partially parallelize (§6 "5 and 6 can partially parallelize").
+3. **Dropoff/return location filtering.** Resolved for MVP: pickup=dropoff. The search API filters only `pickupLocationId`; the web may show a locked return-location control mirroring pickup, but no one-way filtering ships here.
+4. **ACRISS label localization placement.** Resolved: API returns `acrissCode` (and raw operator-entered class data); the web localizes labels via the slice-3 `acriss.*` namespace. No `Accept-Language` API surface in this slice.
+5. **Min price when a store has only hourly-priced vehicles.** Resolved: storefront cards prefer the minimum `dailyRateJpy` and render "from ¥X/day". If a store has available vehicles but no daily-priced vehicle, return `fromDailyPriceJpy:null` plus `fromHourlyPriceJpy` and render "from ¥X/hour"; do not derive a fake daily equivalent.
+6. **Index speculation.** §7 recommends shipping no new index and measuring (§8.2 says the live scan handles MVP scale trivially). If a reviewer wants a guard index on `bookings`, it's a one-line additive migration — but YAGNI says wait for a real plan regression.
+7. **Nullable `acrissCode`.** Resolved (review 2026-06-05): classes may have a NULL `acrissCode` (slice-3 column is nullable; seed backfill non-corrective, #420). `classSummaries` groups by `classId`; the label is the localized ACRISS label when `acrissCode` is set, else the operator-entered class `name`. A NULL ACRISS never drops the vehicle from the count.
+8. **Nullable `pickupLocationId`.** Resolved: the storefront availability filter INNER-joins `vehicles.pickupLocationId`, so a vehicle with no assigned location appears in no storefront. **Action for slice 8:** the demo seed must set `pickupLocationId` on every demo vehicle, or stores render with empty `classSummaries`.
+9. **E2E track.** Resolved: slice 5's required-green Playwright happy path runs on the **mock-API read track** (stub the storefront endpoints), matching the existing `e2e/browse.spec.ts`. It does **not** block on the real-DB authenticated E2E track (#416, still pending). The Drizzle SQL predicate is proven by the repo integration test against Neon `test` (§8), not by E2E.
+10. **`operatorReadScope` location.** Resolved: import from `packages/api/src/tenancy.ts:43`, not `auth.ts` (which holds `PUBLIC_CONTEXT`/`CallerContext`).
+
+---
+
+## 10. Per-slice merge gate (§6.1)
+
+All green before merge: `bun run test` (unit + integration) · `bun run test:e2e` (renter happy path — **required this slice**) · `bun run lint` · `bun run --filter @kuruma/api lint:boundaries` · `bun run lint:modules` · `bun run db:verify` (if any index migration) · code-reviewer + architect agents (`memory/feedback_review-before-ship`).
+
+---
+
+## 11. Execution order & worktree
+
+```
+# Branch from the remote pivot; local marketplace-pivot is known to lag.
+git worktree add ../kuruma-storefront-search -b feature/391-renter-storefront-search origin/marketplace-pivot
+```
+
+Within the worktree (vertical slice, RED/GREEN per behaviour):
+
+1. Extend `AvailabilityRepository.findAvailableVehicles` interface + InMemory impl (RED test → GREEN).
+2. `StorefrontRepository`/`LocationRepository` read interface + InMemory impl.
+3. `StorefrontSearchService` aggregation (group-by-class, daily/hourly min prices) — unit tests first.
+4. `StorefrontDetailService` — unit tests first.
+5. Drizzle impls (integration tests against Neon `test`).
+6. `routes/storefronts.ts` + mount in `index.ts` (route tests).
+7. Web: `modules/storefronts/` + `app/[locale]/search` + `app/[locale]/storefronts/[locationId]` + i18n (`search.*`, restart dev).
+8. Playwright E2E happy path.
+9. code-reviewer + architect → rebase onto `origin/marketplace-pivot` (never force push) → PR `Closes #391`.
+
+**Effort:** proposal §6 row 5 estimates **2–3 days**. The availability reuse (no new overlap math) keeps it toward the low end; the E2E + renter UI is the bulk of the work.
+
+---
+
+## 12. Critical files
+
+**New (API):** `services/storefront-search.ts`, `services/storefront-detail.ts`, `repositories/{drizzle,in-memory}/storefront.ts`, `routes/storefronts.ts`.
+**Modify (API):** `repositories/types.ts` (`findAvailableVehicles` filter arg + `StorefrontRepository`), `repositories/{drizzle,in-memory}/availability.ts`, `index.ts` (DI + mount).
+**New (Web):** `app/[locale]/search/page.tsx`, `app/[locale]/storefronts/[locationId]/page.tsx`, `modules/storefronts/*`.
+**Modify (Web):** `messages/{en,ja,zh}.json` (`search.*`), renter nav.
+**New (test):** service unit + repo integration + `e2e/storefront-search.spec.ts`.
+**Schema:** none expected (indexes only if a plan regression appears — §7).

--- a/docs/plans/2026-06-02-slice6-booking-event-log.md
+++ b/docs/plans/2026-06-02-slice6-booking-event-log.md
@@ -1,7 +1,7 @@
 # Slice 6 — Booking & Event Log (issue #392)
 
 **Date:** 2026-06-02
-**Status:** Draft v2 — refreshed 2026-06-04 against landed slices 3/4a/4b/4c; awaiting green light to create worktree
+**Status:** MERGED 2026-06-06 (#392, PR #469, `3f04b2b`) — booking write-path + event log landed on `marketplace-pivot`. Plan retained for history.
 **Parent epic:** #385
 **Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` — §6 row 6 (slice scope), §6.1 (E2E gate before slice-6 merge), §6.2 (tenant scoping), §10 item 3 (booking_code format), §9 items 19/22/25, §10 items 9/14/17, §2 rows "Record mutation model" / "Booking write boundary" / "Vehicle substitution" / "Vehicle turnaround buffer".
 **Format model:** mirrors `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md` structure/depth, adapted to an event-sourced booking write-path slice.

--- a/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
+++ b/docs/plans/2026-06-02-slice7-notifications-preauth-handoff.md
@@ -1,7 +1,7 @@
 # Slice 7 — Outbound Notifications & Pre-Auth Handoff (issue #393)
 
 **Date:** 2026-06-02 (rev. 2026-06-06)
-**Status:** Draft v2.1 — second architect-review pass applied; awaiting green light to create worktree + start TDD
+**Status:** MERGED 2026-06-06 (#393, PR #482, `fd67030`) — outbound notifications + pre-auth handoff landed on `marketplace-pivot`. Plan retained for history.
 **Parent epic:** #385
 **Source of truth:** `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (§6 row 7; §4 business item 8 + renter items 5/6; §9 items 2/5/17; §10 item 2; §8.1 Resend/pre-auth risks; §8.2 notification-delivery NFR)
 **Format mirror:** `docs/plans/2026-06-02-slice4-insurance-pricing-fees.md`

--- a/docs/plans/2026-06-06-admin-portal-shell.md
+++ b/docs/plans/2026-06-06-admin-portal-shell.md
@@ -5,7 +5,7 @@
 **Branch:** `feat/462-admin-portal-shell` (off `marketplace-pivot`)
 **Worktree:** `/Users/jack/Dev/kuruma-admin-portal`
 **Source of truth:** `docs/plans/2026-06-05-scope-update-du-kaku.md` §1.5, §2, §5
-**Status:** MERGED 2026-06-06 (#462, PR #481, `4c15833`) on the **Next.js** shell. NOT yet ported to the Vite shell — the revenue tab is unreachable on the live CF Pages deploy until ported (tracked separately; unblocks #515 and #501).
+**Status:** MERGED 2026-06-06 (#462, PR #481, `4c15833`) on the **Next.js** shell. NOT yet ported to the Vite shell — the revenue tab is unreachable on the live CF Pages deploy until ported (tracked by #541; unblocks #515 and #501).
 
 ---
 

--- a/docs/plans/2026-06-06-admin-portal-shell.md
+++ b/docs/plans/2026-06-06-admin-portal-shell.md
@@ -5,7 +5,7 @@
 **Branch:** `feat/462-admin-portal-shell` (off `marketplace-pivot`)
 **Worktree:** `/Users/jack/Dev/kuruma-admin-portal`
 **Source of truth:** `docs/plans/2026-06-05-scope-update-du-kaku.md` §1.5, §2, §5
-**Status:** Design artifact — no code written yet. Decisions approved 2026-06-06 (§6); ready to implement.
+**Status:** MERGED 2026-06-06 (#462, PR #481, `4c15833`) on the **Next.js** shell. NOT yet ported to the Vite shell — the revenue tab is unreachable on the live CF Pages deploy until ported (tracked separately; unblocks #515 and #501).
 
 ---
 

--- a/docs/plans/2026-06-06-deploy-blocker-analysis.md
+++ b/docs/plans/2026-06-06-deploy-blocker-analysis.md
@@ -1,0 +1,94 @@
+# Deploy blocker — situation analysis & options (for senior-eng evaluation)
+
+**Date:** 2026-06-06
+**Context:** Marketplace MVP proposal §8; epic #385; deploy red since 2026-04-19.
+**Related:** #378 (Vite migration epic), #423 (bundle dry-run), #372 (CSRF), #373 (domain), #377 (i18n).
+**Status:** **DECIDED 2026-06-06 — Option B now** (see §0).
+
+---
+
+## 0. Decision (confirmed by senior eng, 2026-06-06)
+
+**Do B now** (Vite + CF Pages migration, #378) — unless a committed demo lands inside the next ~3 business days. The constraint is structural: the handler alone already exceeds the paid Worker cap, so trimming (C) is ritual motion and deferral (D) compounds migration cost while deploy stays red. **C and D rejected.**
+
+**Auth front-load — reframed.** Do **not** relocate auth in-place inside the old Next app. Instead stand up a **minimal CF Pages shell + Pages Functions proxy + API auth proof**. The same-origin proxy is itself part of proving cookie auth.
+- **First risk-retirement milestone:** Google + Apple OAuth green on a **CF Pages preview**, cookie `SameSite=Lax`, CSRF enforced, Apple form-POST carve-out tested.
+
+**Checkpoint (pinned 2026-06-06):** end of **migration day 2**, counted from when Slice 0 starts *with required secrets/access available*.
+- **Pass criteria:** CF Pages preview exists; `/api/*` and `/auth/*` proxy through Pages Functions; Google + Apple OAuth green on the preview; session cookie `SameSite=Lax`; CSRF rejects missing/bad tokens; Apple callback carve-out has a test.
+- **Fail criteria:** if the proof is not green by the checkpoint, trigger **A the next morning** as a one-day bridge — freeze non-demo Next.js feature work — then return to B.
+
+**A = contingency only.** Triggered solely by (a) a committed demo date inside the migration window, or (b) the checkpoint failing per above. A is one timeboxed day; it never becomes the plan.
+
+**Doc correction applied:** the migration spec's stray `SameSite=None` (endpoint bullet §5.1) is fixed to `Lax`; `Lax` is the source of truth.
+
+---
+
+## 1. The situation (grounded in measurements)
+
+The web package deploys as a single Cloudflare Worker via `@opennextjs/cloudflare`. Measured bundle:
+
+| Component | Size |
+|---|---|
+| Next.js handler (runtime + React 19 RSC + Auth.js + DrizzleAdapter + postgres driver) | **10.5 MiB** |
+| `@vercel/og` (pulled in by the Next runtime — **not** imported in our app code) | 2.2 MiB |
+| Middleware | 0.9 MiB |
+| **Total** | **~13.6 MiB** |
+
+Cloudflare Worker size caps: **3 MiB free**, **10 MiB paid** (gzipped). We exceed both. Deploys fail on size — this is why production has been red since 2026-04-19.
+
+**Root cause:** `@opennextjs/cloudflare` packages the entire Next.js server runtime into one Worker. The Next runtime alone is ~4–5 MiB *before* any app code. This is structural to "Next.js SSR on Workers," not a function of our app being heavy.
+
+**Why it only gets worse:** every web feature slice (waves A–C: notifications UI, search views, wizard, payment, admin portal) adds to the handler. We're at 10.5 MiB on the handler today; the marketplace slices will push it further. The size pressure is monotonic.
+
+## 2. Why the cheap fixes don't work
+
+- **Paid tier ($5/mo) alone:** buys headroom only to 10 MiB. The handler is *already* 10.5. Doesn't fit even before shedding nothing else.
+- **Trimming under 10 MiB:** even if we fully remove `@vercel/og` (2.2) and shrink middleware (0.9), the **10.5 MiB handler remains over the 10 MiB cap** — and it grows with each slice. Trimming buys, at best, a few weeks of denial. Not a path to a stable MVP.
+- `@vercel/og` is reachable to remove (we don't use `ImageResponse`/OG routes), but removing it doesn't clear the binding constraint.
+
+## 3. The options
+
+### A. Stopgap host for the demo (non-CF) — sidestep
+Host the Next.js web app on a Node-capable platform (Vercel / Railway / Fly / a container) for the demo; keep the Hono API on CF Workers (tiny, unaffected).
+- **Effort:** ~0.5–1 day to wire a second deploy target.
+- **Unblocks:** a *hosted demo* immediately, on the current stack, with zero migration risk.
+- **Costs / risks:** (1) demo runs on infra that is **not** the production target — "works in the demo" doesn't prove production; (2) two deploy setups to maintain meanwhile; (3) #378 still must happen later, by which point **every marketplace slice has been built on Next.js and must be ported** — larger migration surface; (4) doesn't resolve the auth-relocation work, just defers it.
+- **Reversibility:** fully reversible (throwaway host).
+
+### B. Do the #378 Vite + CF Pages migration now — the real fix
+Migrate `packages/web` to Vite + TanStack Router on CF Pages (static, **no size limit**), relocate Auth.js from web into the Hono API (cookie session instead of Bearer), rename `next-intl` → `use-intl`.
+- **Effort:** **3–5 focused days** (per the approved design doc `2026-04-18-migrate-web-off-nextjs-design.md`). Design is done, with a decision-razor/defaults table for every small fork.
+- **Unblocks:** production-grade hosting permanently; size limit becomes a non-issue forever; the demo runs on the real production infra.
+- **Costs / risks:** (1) auth relocation (web→API, Bearer→HttpOnly cookie) is the genuine-risk piece — touches OAuth (Google + Apple), CSRF (#372), and SameSite/domain (#373); (2) router rewrite + data-fetching refactor is mechanical but broad (~79 i18n call sites, all routes); (3) could surface hidden coupling (timeline spec's pessimistic case).
+- **Reversibility:** the auth-model change is the one semi-one-way door; the rest is reversible. Mitigation: land auth relocation behind the existing API on a branch, E2E the OAuth flow on staging before cutover.
+- **Sequencing note:** migration surface grows with every Next.js slice we ship. Doing B **earlier** is strictly cheaper than doing it later.
+
+### C. Trim under the 10 MiB paid tier — buy time
+Remove `@vercel/og`, shrink middleware, lazy-load, code-split.
+- **Effort:** 1–2 days of bundle archaeology.
+- **Unblocks:** nothing durably — handler is already 10.5 and climbing. See §2.
+- **Verdict:** not a real option on its own; at best a bridge if B is chosen but can't land before a hard demo date.
+
+### D. Defer — keep building features, decide later
+- **Effort:** 0 now.
+- **Risk:** deploy stays red; demo-readiness unproven; migration surface keeps growing; we discover integration problems at the worst time (right before the demo). Highest-risk option despite lowest immediate cost.
+
+## 4. Rationale & recommendation
+
+The decision hinges on separating **demo-ready** from **production-ready**, and on one fact that flips the usual "stopgap now, real fix later" instinct: **the real fix is only 3–5 days and already designed.**
+
+When the real fix is cheap and designed, the stopgap (A) mostly buys *risk*, not time: you stand up throwaway infra, keep shipping slices onto the framework you're about to abandon (growing the port), and still owe the auth-relocation work later. The migration's cost is monotonically increasing in the number of Next.js slices shipped — so the cheapest moment to do #378 is **now, before waves A–C**, or as early as possible alongside them.
+
+**Recommendation (for the reviewer to confirm or override):**
+1. **Schedule #378 as the immediate next engineering block** — ideally before/parallel to Wave A, so later slices are built on the target stack and don't need porting. It's 3–5 days, already designed.
+2. **Front-load the risky piece:** do the Auth.js web→API relocation (#372) first on a branch and prove Google+Apple OAuth on staging before touching routing. That retires the only semi-one-way door early.
+3. **Keep option A in the back pocket** purely as a contingency: if a hard demo date lands inside the 3–5 day window, or if auth relocation surfaces hidden coupling, deploy the demo to a Node host as a bridge while B finishes.
+4. **Reject C and D as primary strategies** — C doesn't clear the constraint; D lets the problem compound.
+
+**The one input that changes this recommendation:** if there is a demo commitment in the next ~3 business days, flip to A-now-then-B. Otherwise B-now dominates.
+
+## 5. Open questions for the reviewer
+- Is there a fixed demo date? (Decides A-bridge vs straight-B.)
+- Appetite for the auth-model change (Bearer→cookie) now vs. after the demo? (It's the real risk; everything else is mechanical.)
+- Domain/DNS readiness for #373 (parent-domain cutover) — owner decision, can lag behind B's main work.

--- a/docs/plans/2026-06-06-search-map-list-view.md
+++ b/docs/plans/2026-06-06-search-map-list-view.md
@@ -3,7 +3,7 @@
 **Issue:** #458 — `feat(marketplace): map + flat-list search results (specific vehicles)`
 **Branch / worktree:** `feat/458-search-map-list` @ `/Users/jack/Dev/kuruma-search-mapview` (based on `marketplace-pivot`)
 **Date:** 2026-06-06
-**Status:** DESIGN ARTIFACT — APPROVED decisions applied (see §6: D1 swappable map via DIP, D2 add lat/lng migration now, D3 no plate string to renters). No code written yet.
+**Status:** MERGED 2026-06-10 (#458, PR #513, `8509103`) — cross-operator map + flat-list search landed on `marketplace-pivot`. Plan retained for history; the §0 "Re-grounding" section reflects the live Vite shell.
 **Source of truth:** `docs/plans/2026-06-05-scope-update-du-kaku.md` §1.1, §5; context in `docs/plans/2026-05-25-marketplace-mvp-proposal.md` §2 / §10 items 12 & 21.
 **Epic:** #385. **Refs:** #463 (`fulfillment_mode` affordance), #464 (class-combo, fast-follow), #457 (luggage), #439 (DB-seek paging follow-up), #392 (slice 6 — **MERGED**; held the migration lock, now released — see §3.3 Migration coordination).
 

--- a/docs/plans/2026-06-08-slice457-vehicle-luggage.md
+++ b/docs/plans/2026-06-08-slice457-vehicle-luggage.md
@@ -1,6 +1,6 @@
 # Plan — #457: Vehicle luggage capacity (count + size) + result-card display
 
-> Status: **DRAFT — awaiting review.** No code until D1–D5 confirmed.
+> Status: **MERGED 2026-06-09** (#457, PR #503, `f8d7e97`) — landed on `marketplace-pivot`. Plan retained for history.
 > Issue: #457 (epic #385). Source: `docs/plans/2026-06-05-scope-update-du-kaku.md` §1.2.
 > Branch: `feat/457-luggage` off `origin/marketplace-pivot`. Worktree: `~/Dev/kuruma-457-luggage`.
 


### PR DESCRIPTION
## Why
A docs↔code sync audit of `marketplace-pivot` found the planning/architecture docs had drifted from the code they describe. This brings them back in sync. **Docs-only — no code touched.**

## What changed
**Stale architecture docs (web is Vite now, not Next.js — #378):**
- `AGENTS.md` — header guardrail + `packages/web` description → Vite + TanStack Router
- `CLAUDE.md` — tagged the "Next.js 16" and "i18n (next-intl)" gotcha sections as **frozen Next.js tree only**; pointed to the live use-intl/Vite shell
- `docs/RUNBOOK.md` — architecture diagram + web deploy commands (`vite build` / `deploy:pages`)
- `docs/CONTRIB.md` — stack lines, dev-server description, dropped obsolete `NEXT_PUBLIC_API_URL`
- `docs/cloudflare-developer-guide.md` — HISTORICAL (pre-Vite) banner

**Merged slice plans still marked Draft/awaiting → flipped to MERGED:**
- #457 luggage, #458 search map+list, #462 admin shell, slice 6 (#392), slice 7 (#393)

**Propagated 4 plan docs that existed only on `main`:**
- slice 3/4/5 plans + `2026-06-06-deploy-blocker-analysis.md`; flipped slice 3/4 statuses to MERGED.

## Notes
- #462 admin portal shipped on the **frozen Next.js tree** and is **not yet ported to the Vite shell** — filed a follow-up issue to track (it unblocks #515 and #501).
- The two add/add doc conflicts seen when merging pivot→main (slice 6 / slice 8 plans) are deliberately left for the eventual cut-over merge.
- Targets `marketplace-pivot` (the trunk that carries the Vite code); flows to `main` at the documented cut-over.