### PR TITLE
test(e2e): marketplace demo real-DB E2E on the Vite stack + runbook (#488)

### DIFF
--- a/docs/runbooks/2026-demo-runbook.md
+++ b/docs/runbooks/2026-demo-runbook.md
@@ -1,12 +1,16 @@
-# Slice 8 — Core-Path Runbook (issue #390, interim milestone)
+# Marketplace Demo Runbook — renter books, operator sees it (Path A)
 
-> **Scope.** This runbook verifies the **interim core-path** that slice 8 (#390) delivers:
-> *renter search → storefront → vehicle → booking → confirmation → operator sees it.*
-> The full customer-facing Qiao/Du demo (pay → partner-revenue) is **#488** and is gated on #457–#462.
+> **Scope.** Verifies the shipped marketplace happy path end to end on the real
+> stack: *renter search → storefront → vehicle → instant-book → confirmation →
+> operator sees it*. This is the **#488** final demo, scoped to **Path A**
+> (instant-book / pay-at-pickup — no online Stripe charge) to match what ships in
+> the Vite app (#511). It began as the #390 interim core-path and was re-pointed
+> to the Vite UI when the web app moved off Next.js (#378).
 >
-> The authoritative proof of the core path is the **automated real-DB E2E lane** (§3). The
-> manual click-through (§4) is for narration. (Live booking submit now works on the
-> neon-serverless API — **#493 is fixed**; see §4.)
+> **Deferred — not in this runbook:** the Stripe *pay* step (#461 backend exists;
+> the renter flow is intentionally instant-book) and the admin *partner-revenue
+> 4%* tab (#462). The authoritative proof is the automated real-DB E2E lane (§3);
+> the manual click-through (§4) is for narration.
 
 ---
 
@@ -19,7 +23,7 @@ After `db:seed` + `db:seed-bookings` against a fresh Neon branch:
 - Key identities for the walkthrough:
   - Renter: `sarah@example.test` (role `RENTER`)
   - Operator: `owner@best-car-rental.local` (role `OPERATOR_OWNER`, Best Car Rental)
-  - `Kansai Airport (KIX)` storefront carries 4 vehicles.
+  - `Kansai Airport (KIX)` storefront carries 4 vehicles (the happy-path run consumes one for a far-future window).
 
 All seed ids are deterministic UUIDs (`seedId(slug)` — `packages/shared/src/db/seed-id.ts`); fixtures keep readable slugs.
 
@@ -33,24 +37,26 @@ git fetch origin
 bun install
 
 # Point DATABASE_URL at a fresh Neon branch off the merged pivot (NOT production).
+# The lane needs Neon today because db:seed runs through the neon-http driver — a
+# local-Postgres path is tracked in #542.
 bun run db:migrate
 bun run db:seed
 bun run db:seed-bookings
-bun run db:verify            # must show 3 green checks
+bun run db:verify            # must show 4 green checks
 ```
 
-For local Google login through the Vite shell, the API's OAuth callback must use
-the web dev origin so the browser returns through Vite's `/auth` proxy:
+For local Google login through the Vite shell (only needed for the **manual**
+walkthrough in §4, on the normal `bun run dev` web at :3001), the API's OAuth
+callback must use the web dev origin so the browser returns through Vite's
+`/auth` proxy:
 
 ```bash
 AUTH_URL=http://localhost:3001
 WEB_POST_LOGIN_URL=http://localhost:3001/en
 ```
 
-Register this redirect URI in the Google OAuth client used for local demos:
-`http://localhost:3001/auth/google/callback`.
-
-Then, in two terminals:
+Register `http://localhost:3001/auth/google/callback` in the local-demo Google
+OAuth client, then run the web + API in two terminals:
 
 ```bash
 bun --env-file=.env run dev:api
@@ -61,24 +67,31 @@ bun run dev
 
 ## 3. Verify the core path (automated — the merge gate)
 
-This is the §6.1 acceptance gate and the honest proof of the journey. It runs the real Next.js
-web → real Hono API → seeded Neon branch with a minted Auth.js session.
+The honest proof of the journey. It runs the real **Vite** web (`vite --port 3002`,
+proxying `/api` + `/auth` to the Hono API) → real Hono API (postgres-js) → the
+seeded Neon branch, authenticated with a minted **`kuruma_session`** HS256 cookie
+(`e2e/real-db/mint-session.ts`, mirroring the API's `mintSessionToken` contract).
 
 ```bash
-set -a; source /tmp/slice8-db.env; set +a   # or export DATABASE_URL for your branch
-AUTH_SECRET=ci-placeholder-secret-not-real bun run test:e2e:real-db
+AUTH_SECRET=<any 32+ char secret> DATABASE_URL=<neon-branch-pooled-url> bun run test:e2e:real-db
 ```
 
-Expected: **6 passed** (2 session-mint + 3 operator-locations + the marketplace happy-path).
-The happy-path spec (`e2e/real-db/marketplace-happy-path.auth.spec.ts`) drives:
-renter search → Best Car Rental KIX storefront → vehicle → book → confirmation code
-(`/^[2-9A-HJ-NP-Z]{8}$/`) → operator sees the booking on `/manage/bookings?view=month`
-+ an `OPERATOR_BOOKING_ALERT` row in `notification_log`.
+Expected: **3 passed** (2 session-mint + the marketplace happy-path). The
+happy-path spec (`e2e/real-db/marketplace-happy-path.auth.spec.ts`) drives:
+renter search → Best Car Rental KIX storefront → vehicle → the 5-step wizard
+(Continue ×3 → Continue to payment → **Reserve now**) → confirmation code
+(`/^[2-9A-HJ-NP-Z]{8}$/`) → operator sees the booking in the **list** at
+`/manage/bookings` (asserted by the booking-code cell) + an
+`OPERATOR_BOOKING_ALERT` row in `notification_log`.
+
+> `locations.auth.spec.ts` is quarantined in the config — the operator
+> `/manage/locations` page is the retired Next.js one; its Vite port is **#529**.
 
 > **Why the lane uses a postgres-js API server.** The booking → thread-creation path opens an
-> interactive transaction. Production now runs these via `runTx` (neon-serverless) since **#493**,
+> interactive transaction. Production runs these via `runTx` (neon-serverless) since **#493**,
 > but the lane keeps `e2e/real-db/real-api-server.ts` on postgres-js (TCP) to exercise the real
-> path without opening a WebSocket connection per transaction.
+> path without opening a WebSocket per transaction. `DATABASE_URL` should be the Neon **pooled**
+> endpoint (`-pooler`).
 
 ---
 
@@ -86,19 +99,21 @@ renter search → Best Car Rental KIX storefront → vehicle → book → confir
 
 Routes (locale-prefixed, e.g. `/en`): `/search` → `/storefronts/[locationId]?from&to`
 → `/bookings/new?vehicleId&locationId&from&to` → `/bookings/confirmation?bookingId`;
-operator `/manage/bookings?view=month`.
+operator `/manage/bookings`.
 
 1. **Renter search** — open `/search`, pick Osaka pickup + dates → storefront cards across all 3 operators with per-class min price.
 2. **Storefront** — open *Best Car Rental — Kansai Airport (KIX)* → available vehicles grouped by ACRISS class.
-3. **Select** — pick a vehicle → plate, price, insurance options shown. (`/bookings/new` requires a logged-in renter; it redirects to `/login` otherwise.)
-4. **Book** — choose insurance, confirm.
-   - ✅ **#493 fixed.** Live booking submit works: thread creation runs through `runTx` (neon-serverless), not the HTTP driver. Requires the API's `DATABASE_URL` to be the Neon **pooled** endpoint (`-pooler`); on a deployed Worker / `wrangler dev` it commits and returns a confirmation code. (Confirm once via the manual deploy smoke — AC bullet 1 of #493.)
-5. **Operator view** — log in as `owner@best-car-rental.local` → `/manage/bookings?view=month` shows the seeded bookings on the calendar (event title = renter name) + notification badge. Operator-2 portal cannot see operator-1 bookings (tenant isolation).
-6. **Range** — switch locale to `ja` / `zh` on the renter pages.
+3. **Select** — "Book this car" → `/bookings/new` carries `vehicleId` + `locationId` + dates. (Requires a logged-in renter; redirects to `/login` otherwise.)
+4. **Book (5-step wizard)** — Dates (pre-filled, read-only) → Extras (optional) → Insurance (default **No insurance**) → Review → Payment. Click **Reserve now**. Instant-book: **no online charge** — you pay at pickup via the operator's pre-authorization link.
+5. **Confirmation** — reservation code + status **Confirmed** + the pre-auth handoff card (the operator's payment link; hidden if the operator set none).
+6. **Operator view** — log in as `owner@best-car-rental.local` → `/manage/bookings` lists the booking (newest first; renter name + code) + notification badge. Tenant isolation: the operator-2 portal cannot see operator-1 bookings.
+7. **Range** — switch locale to `ja` / `zh` on the renter pages.
 
 ---
 
-## 5. Known gaps (interim)
+## 5. Known gaps / follow-ups
 
-- Full customer demo (pay → partner revenue, pre-auth handoff narration) is **#488**.
-- First-load JS baseline 554.9 kB > 500 kB target — signed exception, see plan §7.1 (resolved by #378).
+- **Out of Path A scope:** the Stripe *pay* step and the admin *partner-revenue 4%* tab — #461 (live Stripe) / #462 (Vite admin portal).
+- **Local Postgres for this lane — #542.** `db:seed`/`db:seed-bookings` use the neon-http driver and `pg.ts`/`real-api-server.ts` hardcode `ssl: 'require'`, so the lane needs a Neon branch today. #542 moves it to local Postgres (Neon local proxy or a postgres-js seed path) to drop the Neon-branch dependency.
+- **CI gate — #445.** Wiring this lane into CI with a managed Neon-branch lifecycle.
+- **Operator locations port — #529.** Re-enables `locations.auth.spec.ts` in this lane.

--- a/e2e/real-db/marketplace-happy-path.auth.spec.ts
+++ b/e2e/real-db/marketplace-happy-path.auth.spec.ts
@@ -108,6 +108,7 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
       await expect(renter.getByText('Review your booking')).toBeVisible()
 
       await renter.getByRole('button', { name: 'Continue to payment' }).click() // confirm → payment
+      await expect(renter.getByRole('heading', { name: 'Confirm and reserve' })).toBeVisible()
       await renter.getByRole('button', { name: 'Reserve now' }).click() // instant-book submit
 
       await expect(renter).toHaveURL(/\/bookings\/confirmation\?bookingId=.+/)
@@ -120,9 +121,8 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
 
     await test.step('6a. operator portal lists the new booking', async () => {
       // `page` is the project-default OPERATOR_OWNER session. The Vite operator view
-      // (#512) is a table ordered desc(createdAt) (repositories/drizzle/booking.ts),
-      // so this just-created booking is the FIRST row. Assert the exact reservation
-      // code cell (ties the row to THIS run) plus the renter's name.
+      // is #512. Assert the exact reservation code cell — a per-run unique token, so
+      // it ties the row to THIS run regardless of table ordering — plus Sarah's name.
       await page.goto('/en/manage/bookings')
       await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
       await expect(page.getByRole('cell', { name: bookingCode })).toBeVisible({ timeout: 20_000 })

--- a/e2e/real-db/marketplace-happy-path.auth.spec.ts
+++ b/e2e/real-db/marketplace-happy-path.auth.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from '@playwright/test'
 import { RENTER_STORAGE_STATE } from './constants'
 import { testSql } from './pg'
 
-// Slice 8 (#390) interim core-path milestone — the merge gate (plan §5/§6.1).
-// Proves the acceptance sentence end to end on the REAL web -> Hono API ->
-// seeded Neon branch stack (lane #416), across TWO authenticated actors:
+// #488 final marketplace demo (Path A: instant-book, no Stripe). Ported from the
+// #390 interim spec to the shipped Vite UI. Proves the acceptance sentence end to
+// end on the REAL Vite web -> Hono API -> seeded Postgres stack, across TWO
+// authenticated actors:
 //
 //   "renter search -> storefront result -> vehicle selection -> booking ->
 //    confirmation notification visible in the operator portal".
@@ -13,8 +14,9 @@ import { testSql } from './pg'
 // ctx.userId for non-staff, so the booking must be made AS the renter). Step 6
 // reuses the project-default OPERATOR_OWNER `page` to read the operator portal.
 //
-// Selectors are grounded in the merged slice-5/6/7 UI (not the mock skeleton in
-// e2e/marketplace-happy-path.spec.ts, whose fixtures predate the real pages).
+// Selectors are grounded in the shipped Vite UI (#458 search / #460 5-step
+// wizard / #511 confirmation / #512 operator list) — not the mock skeleton in
+// e2e/marketplace-happy-path.spec.ts, and not the retired Next.js pages.
 
 // Booking-code alphabet (api/lib/booking-code.ts BOOKING_CODE_PATTERN). Inlined:
 // @kuruma/api TS can't be required from this CJS-transformed Playwright file.
@@ -35,11 +37,10 @@ const OPERATOR_NAME = 'Best Car Rental'
 const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 // A far-future window, clear of the seeded bookings (which span demo-time-relative
-// ~-5..+7 days). Keeps a fleet of vehicles available and isolates the new booking
-// on the operator's July calendar. `datetime-local` wall-clock (parsed as JST).
+// ~-5..+7 days). Keeps a fleet of vehicles available and isolates the new booking.
+// `datetime-local` wall-clock (parsed as JST).
 const FROM = '2026-07-15T10:00'
 const TO = '2026-07-17T10:00'
-const BOOKING_MONTH = '2026-07-15' // operator calendar ?date — month view spans it
 
 // KIX seeds only 4 vehicles, so every run consumes one for the window. afterAll
 // deletes the bookings this spec created (+ their RESTRICT children, in FK order:
@@ -53,7 +54,7 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
     browser,
     baseURL,
   }) => {
-    test.setTimeout(120_000) // cold Next dev compiles each route on first hit
+    test.setTimeout(120_000) // Vite builds each route on first hit; real-DB round-trips
 
     const renterContext = await browser.newContext({ storageState: RENTER_STORAGE_STATE, baseURL })
     const renter = await renterContext.newPage()
@@ -75,21 +76,39 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
 
       await expect(renter).toHaveURL(new RegExp(`/storefronts/${UUID}\\?from=.+&to=.+`))
       await expect(renter.getByRole('heading', { name: STOREFRONT_NAME })).toBeVisible()
-      await expect(renter.getByText(OPERATOR_NAME)).toBeVisible()
+      // Operator name appears in several places on the detail page (header, vehicle
+      // cards) — first() keeps the assertion out of strict-mode multi-match.
+      await expect(renter.getByText(OPERATOR_NAME).first()).toBeVisible()
     })
 
-    await test.step('3. vehicle selection carries vehicle + location + dates into the form', async () => {
+    await test.step('3. vehicle selection carries vehicle + location + dates into the wizard', async () => {
+      // "Book this car" is a styled Link → /bookings/new with vehicleId + locationId
+      // + the search dates (so the wizard's first step is pre-filled, read-only).
       await renter.getByRole('link', { name: 'Book this car' }).first().click()
       await expect(renter).toHaveURL(
         new RegExp(`/bookings/new\\?vehicleId=${UUID}&locationId=${UUID}`),
       )
-      await expect(renter.getByRole('heading', { name: 'Confirm your booking' })).toBeVisible()
+      // The wizard opens on the read-only Dates step; its Continue button proves it loaded.
+      await expect(renter.getByRole('button', { name: 'Continue', exact: true })).toBeVisible()
     })
 
     let bookingCode = ''
-    await test.step('4-5. booking confirms with a no-confusables reservation code', async () => {
-      // Default insurance = decline (optional coverage); the renter just confirms.
-      await renter.getByRole('button', { name: 'Confirm booking' }).click()
+    await test.step('4-5. step through the wizard; booking confirms with a no-confusables code', async () => {
+      // 5-step wizard (#460): dates → addOns → insurance → confirm → payment.
+      // Dates are pre-filled & read-only; add-ons are optional (skip); insurance
+      // defaults to "No insurance" (decline). Each step gates on its own marker so
+      // we never click Continue before the next step has rendered.
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // dates → addOns
+      await expect(renter.getByText('Add optional extras')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // addOns → insurance
+      await expect(renter.getByText('No insurance')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // insurance → confirm
+      await expect(renter.getByText('Review your booking')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue to payment' }).click() // confirm → payment
+      await renter.getByRole('button', { name: 'Reserve now' }).click() // instant-book submit
 
       await expect(renter).toHaveURL(/\/bookings\/confirmation\?bookingId=.+/)
       await expect(renter.getByRole('heading', { name: 'Booking confirmed' })).toBeVisible()
@@ -99,13 +118,15 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
       await expect(renter.getByText('Confirmed', { exact: true })).toBeVisible()
     })
 
-    await test.step('6a. operator portal shows the new booking on the calendar', async () => {
-      // `page` is the project-default OPERATOR_OWNER session. Month view spans the
-      // booking day regardless of the runner timezone; the calendar event title is
-      // the renter name (BookingsCalendar.toCalendarEvents).
-      await page.goto(`/en/manage/bookings?view=month&date=${BOOKING_MONTH}`)
+    await test.step('6a. operator portal lists the new booking', async () => {
+      // `page` is the project-default OPERATOR_OWNER session. The Vite operator view
+      // (#512) is a table ordered desc(createdAt) (repositories/drizzle/booking.ts),
+      // so this just-created booking is the FIRST row. Assert the exact reservation
+      // code cell (ties the row to THIS run) plus the renter's name.
+      await page.goto('/en/manage/bookings')
       await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
-      await expect(page.getByText(RENTER_NAME).first()).toBeVisible({ timeout: 20_000 })
+      await expect(page.getByRole('cell', { name: bookingCode })).toBeVisible({ timeout: 20_000 })
+      await expect(page.getByRole('cell', { name: RENTER_NAME }).first()).toBeVisible()
     })
 
     await test.step('6b. slice-7 wrote the operator notification for this booking', async () => {

--- a/e2e/real-db/mint-session.ts
+++ b/e2e/real-db/mint-session.ts
@@ -1,14 +1,24 @@
 import { testSql } from './pg'
 
-// On http/localhost Auth.js uses the unprefixed cookie name (no `__Secure-`).
-// The `encode` salt MUST equal this name or the web's `auth()` cannot decrypt
-// the session JWE. See issue #416 proven reference.
-export const SESSION_COOKIE_NAME = 'authjs.session-token'
-
-// Seed identities, mirrored from @kuruma/shared seed data. Duplicated on purpose:
-// Playwright require()s this file as CJS, and importing the shared workspace
-// package's TS source here breaks. Update both if the seed changes.
+// The Vite/CF-Pages stack (#378) authenticates the browser with the API's own
+// `kuruma_session` HS256 JWT — NOT an Auth.js JWE (the retired Next.js path). We
+// mint it here with the SAME contract as packages/api/src/middleware/auth.ts
+// `mintSessionToken` (iss/aud/alg/exp + a `csrf` claim) — keep the two in sync.
+// GET /auth/session echoes the `csrf` claim as `csrfToken`; the wizard's
+// Reserve-now POST sends it back through the API's CSRF middleware, so a session
+// minted without it would pass auth but fail every mutation.
 //
+// Why inline `jose` instead of importing the API helper: Playwright runs these
+// specs under Node with its own loader, which transpiles files in the test dir
+// but NOT an arbitrary `packages/api/**.ts` reached via dynamic import. `jose` is
+// a published package, so importing IT is safe (mirrors the prior next-auth/jwt use).
+export const SESSION_COOKIE_NAME = 'kuruma_session'
+
+// Mirror of packages/api/src/middleware/auth.ts (API_TOKEN_ISSUER/AUDIENCE, TTL).
+const API_TOKEN_ISSUER = 'kuruma-web'
+const API_TOKEN_AUDIENCE = 'kuruma-api'
+const SESSION_TTL = '7d'
+
 // Best Car Rental owner — db/constants.ts BEST_CAR_RENTAL_OWNER_EMAIL. operatorId
 // is NOT hard-coded: the demo seed mints UUID ids (db/seed-id.ts), so we read the
 // owner's actual operatorId off the user row below. A stale slug here would scope
@@ -48,49 +58,49 @@ async function findUser(email: string): Promise<{ id: string; operatorId: string
 interface SessionIdentity {
   email: string
   name: string
-  role: string
+  role: 'RENTER' | 'OPERATOR_OWNER'
 }
 
 /**
- * Mint an Auth.js v5 session-cookie value for a seeded user, using the app's own
- * `encode` so the JWE format matches what `auth()` expects. The browser receives
- * only this cookie; the web mints the downstream HS256 API token itself
- * (`lib/api-token.ts`) from the same secret. The DB-resolved operatorId becomes
- * the token's tenant claim (omitted for an unscoped RENTER).
+ * Mint a `kuruma_session` JWT for a seeded user, signed with AUTH_SECRET — the
+ * same secret the API verifies with (middleware/auth.ts verifyAndMap). The
+ * DB-resolved operatorId becomes the tenant claim (omitted for an unscoped RENTER).
  */
-async function mintSessionToken(identity: SessionIdentity): Promise<string> {
+async function mintSession(identity: SessionIdentity): Promise<string> {
   const secret = process.env.AUTH_SECRET
   if (!secret) throw new Error('AUTH_SECRET is required to mint an e2e session')
 
   const user = await findUser(identity.email)
 
-  // next-auth/jwt is ESM-only; dynamic import so Playwright's CJS transform of
-  // this file doesn't ERR_REQUIRE_ESM at load time.
-  const { encode } = await import('next-auth/jwt')
+  // jose is ESM-only; dynamic import so Playwright's CJS transform of this file
+  // doesn't ERR_REQUIRE_ESM at load time.
+  const { SignJWT } = await import('jose')
+  const key = new TextEncoder().encode(secret)
 
-  // roleRefreshedAt = now keeps the token self-sufficient: the jwt callback's
-  // `else if (token.sub)` branch skips its DB role re-fetch for 5 minutes
-  // (packages/web/src/auth.ts), so the session needs no live DB to stay valid.
-  return encode({
-    salt: SESSION_COOKIE_NAME,
-    secret,
-    token: {
-      sub: user.id,
-      name: identity.name,
-      email: identity.email,
-      role: identity.role,
-      ...(user.operatorId ? { operatorId: user.operatorId } : {}),
-      roleRefreshedAt: Date.now(),
-    },
-  })
+  const payload: Record<string, unknown> = {
+    role: identity.role,
+    csrf: crypto.randomUUID(),
+    name: identity.name,
+    email: identity.email,
+  }
+  if (user.operatorId) payload.operatorId = user.operatorId
+
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(user.id)
+    .setIssuedAt()
+    .setIssuer(API_TOKEN_ISSUER)
+    .setAudience(API_TOKEN_AUDIENCE)
+    .setExpirationTime(SESSION_TTL)
+    .sign(key)
 }
 
 /** Session cookie value for the seeded Best Car Rental OPERATOR_OWNER. */
 export function mintOperatorSessionToken(): Promise<string> {
-  return mintSessionToken(OPERATOR)
+  return mintSession(OPERATOR)
 }
 
 /** Session cookie value for the seeded RENTER persona (Sarah Smith). */
 export function mintRenterSessionToken(): Promise<string> {
-  return mintSessionToken(RENTER)
+  return mintSession(RENTER)
 }

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
     {
       name: 'authenticated-real-db',
       testMatch: /.*\.auth\.spec\.ts/,
+      // locations.auth.spec.ts drives the operator /manage/locations page, which
+      // only exists in the retired Next.js app — the Vite operator-locations port
+      // is #529 (epic #523). Re-enable it there. Until then this lane proves the
+      // #488 marketplace happy path against the shipped Vite UI.
+      testIgnore: ['**/locations.auth.spec.ts'],
       dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
     },
@@ -57,15 +62,17 @@ export default defineConfig({
       },
     },
     {
-      command: 'bun run next dev -p 3002',
+      // The web app is Vite now (#378), not Next. Vite is a pure SPA dev server:
+      // it needs no AUTH_SECRET/DATABASE_URL — it proxies /api (strip prefix) and
+      // /auth (verbatim) to the real Hono API via VITE_DEV_API_PROXY, so the
+      // browser talks to the API same-origin and the minted session cookie rides.
+      command: 'bunx vite --port 3002',
       cwd: 'packages/web',
       url: BASE_URL,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
-        AUTH_SECRET,
-        DATABASE_URL,
-        NEXT_PUBLIC_API_URL: API_URL,
+        VITE_DEV_API_PROXY: API_URL,
       },
     },
   ],


### PR DESCRIPTION
## What

Capstone of umbrella #509 / epic #385: the **final marketplace demo as a real-DB Playwright E2E lane**, ported from the retired Next.js app to the **shipped Vite app**, plus a refreshed demo runbook.

The full renter→operator journey runs against a real Postgres + real API: search → storefront → vehicle → 5-step reservation wizard → instant-book → confirmation → operator booking list → slice-7 operator notification.

## Scope — Path A (instant-book, no Stripe)

The issue title reads "discover→book→pay→partner-revenue", but the demo covers **what is actually shipped on Vite**:

- **Instant-book / pay-at-pickup** (#511) — the renter flow is instant-book by design; there is no Stripe checkout step to drive.
- **Stripe pay step DEFERRED** — backend exists (#461) but the renter wizard doesn't gate on it.
- **Admin partner-revenue tab DEFERRED** — not yet ported to Vite (#462).

Path A was the maintainer-confirmed scope for this slice. The deferred pieces are tracked on their own issues.

## How it works (the porting crux)

- **Vite/API auth = `kuruma_session` HS256 JWT** (the #378 session), not an Auth.js JWE. `mint-session.ts` mints it with the same contract as `packages/api`'s `mintSessionToken` (iss `kuruma-web` / aud `kuruma-api` / 7d + a `csrf` claim), inlining `jose` because Playwright's Node loader won't transpile a `packages/api/**.ts` import.
- **CSRF round-trip is real:** the minted `csrf` claim is echoed by `GET /auth/session` as `csrfToken`, which the wizard sends back on the Reserve-now POST — so a token minted without it would auth but fail every mutation.
- **`operatorId` is DB-resolved**, never hard-coded (seed mints UUIDs), so the operator token is scoped to the right tenant.
- **Config:** web server `next dev` → `bunx vite --port 3002`; `locations.auth.spec.ts` quarantined via `testIgnore` (operator locations not yet on Vite → #529).

## Reconciliation with #445 (real-DB CI gate)

#445 independently re-ported the same harness (`mint-session.ts` + `playwright.real-db.config.ts`) for its CI-gate work, importing the API helper directly + adding a unit-tested `sessionClaims` seam. Per maintainer decision, **#488 lands the harness now** (it's pushed, Playwright-proven green, 1 slice from done); **#445 rebases** onto it — its DB-plumbing and CI-gate (`e2e-real-db` job) are additive, and its session re-port resolves on rebase. "Whoever lands first wins; the other rebases."

## Verification

- **E2E lane proven green: 3 passed** (2 session-mint + the full happy path) against a seeded Neon branch, pre-rebase tip.
- code-reviewer + architect-review: **no CRITICAL/HIGH**; SHIP-WITH-NITS. Applied the two cheap nits (gate the payment step on its `Confirm and reserve` heading; trim a misleading ordering comment).
- Post-rebase: `bun run lint` clean, per-package `tsc --noEmit` (shared/api/web) all exit 0.

## Test plan

- [x] `bun run lint` — clean (only pre-existing file-size soft-warnings)
- [x] `tsc --noEmit` — shared / api / web app all 0
- [x] code-reviewer + architect-review — no HIGH+
- [ ] Re-run `bun run test:e2e:real-db` — **needs a freshly-seeded Neon branch** (the prior one was deleted to free capacity). Delta since the proven-green run is a clean rebase + one added visible-assertion + a comment, so this is low-risk re-verification, deferred until the #445 local-pg lane (#542) removes the Neon dependency.

Closes #488. Part of umbrella #509 / epic #385.
