### PR TITLE
ci: authenticated real-DB e2e gate (#445) [stacked on #488]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,78 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  e2e-real-db:
+    # Authenticated real-DB e2e gate (#445): runs the REAL Hono API + Vite web
+    # against a fresh, seeded postgres:16 — no Neon branch, no external secrets.
+    # The harness (#488) mints the API's kuruma_session cookie and drives the
+    # marketplace happy path (search -> book -> confirmation -> operator portal).
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: kuruma
+          POSTGRES_PASSWORD: kuruma
+          POSTGRES_DB: kuruma_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kuruma -d kuruma_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://kuruma:kuruma@localhost:5432/kuruma_e2e
+      # Static, non-secret signing key: the harness mints the session cookie and
+      # the API verifies it with the SAME value — both read this env. No GitHub
+      # Secret needed; the DB is disposable and never leaves the runner.
+      AUTH_SECRET: ci-real-db-e2e-static-secret-0123456789
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Apply all migrations against fresh Postgres
+        run: bun run db:migrate
+
+      - name: Verify no schema drift
+        run: bun run db:verify
+
+      - name: Seed the marketplace fixture over TCP
+        # db:seed:tcp uses postgres-js (TCP); the production neon-http getDb()
+        # cannot reach a plain postgres:16 container.
+        run: bun run db:seed:tcp
+
+      - name: Run authenticated real-DB E2E
+        run: bun run test:e2e:real-db
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-real-db
+          path: playwright-report/
+          retention-days: 7

--- a/docs/runbooks/2026-demo-runbook.md
+++ b/docs/runbooks/2026-demo-runbook.md
@@ -1,12 +1,16 @@
-# Slice 8 — Core-Path Runbook (issue #390, interim milestone)
+# Marketplace Demo Runbook — renter books, operator sees it (Path A)
 
-> **Scope.** This runbook verifies the **interim core-path** that slice 8 (#390) delivers:
-> *renter search → storefront → vehicle → booking → confirmation → operator sees it.*
-> The full customer-facing Qiao/Du demo (pay → partner-revenue) is **#488** and is gated on #457–#462.
+> **Scope.** Verifies the shipped marketplace happy path end to end on the real
+> stack: *renter search → storefront → vehicle → instant-book → confirmation →
+> operator sees it*. This is the **#488** final demo, scoped to **Path A**
+> (instant-book / pay-at-pickup — no online Stripe charge) to match what ships in
+> the Vite app (#511). It began as the #390 interim core-path and was re-pointed
+> to the Vite UI when the web app moved off Next.js (#378).
 >
-> The authoritative proof of the core path is the **automated real-DB E2E lane** (§3). The
-> manual click-through (§4) is for narration. (Live booking submit now works on the
-> neon-serverless API — **#493 is fixed**; see §4.)
+> **Deferred — not in this runbook:** the Stripe *pay* step (#461 backend exists;
+> the renter flow is intentionally instant-book) and the admin *partner-revenue
+> 4%* tab (#462). The authoritative proof is the automated real-DB E2E lane (§3);
+> the manual click-through (§4) is for narration.
 
 ---
 
@@ -19,7 +23,7 @@ After `db:seed` + `db:seed-bookings` against a fresh Neon branch:
 - Key identities for the walkthrough:
   - Renter: `sarah@example.test` (role `RENTER`)
   - Operator: `owner@best-car-rental.local` (role `OPERATOR_OWNER`, Best Car Rental)
-  - `Kansai Airport (KIX)` storefront carries 4 vehicles.
+  - `Kansai Airport (KIX)` storefront carries 4 vehicles (the happy-path run consumes one for a far-future window).
 
 All seed ids are deterministic UUIDs (`seedId(slug)` — `packages/shared/src/db/seed-id.ts`); fixtures keep readable slugs.
 
@@ -33,24 +37,26 @@ git fetch origin
 bun install
 
 # Point DATABASE_URL at a fresh Neon branch off the merged pivot (NOT production).
+# The lane needs Neon today because db:seed runs through the neon-http driver — a
+# local-Postgres path is tracked in #542.
 bun run db:migrate
 bun run db:seed
 bun run db:seed-bookings
-bun run db:verify            # must show 3 green checks
+bun run db:verify            # must show 4 green checks
 ```
 
-For local Google login through the Vite shell, the API's OAuth callback must use
-the web dev origin so the browser returns through Vite's `/auth` proxy:
+For local Google login through the Vite shell (only needed for the **manual**
+walkthrough in §4, on the normal `bun run dev` web at :3001), the API's OAuth
+callback must use the web dev origin so the browser returns through Vite's
+`/auth` proxy:
 
 ```bash
 AUTH_URL=http://localhost:3001
 WEB_POST_LOGIN_URL=http://localhost:3001/en
 ```
 
-Register this redirect URI in the Google OAuth client used for local demos:
-`http://localhost:3001/auth/google/callback`.
-
-Then, in two terminals:
+Register `http://localhost:3001/auth/google/callback` in the local-demo Google
+OAuth client, then run the web + API in two terminals:
 
 ```bash
 bun --env-file=.env run dev:api
@@ -61,24 +67,31 @@ bun run dev
 
 ## 3. Verify the core path (automated — the merge gate)
 
-This is the §6.1 acceptance gate and the honest proof of the journey. It runs the real Next.js
-web → real Hono API → seeded Neon branch with a minted Auth.js session.
+The honest proof of the journey. It runs the real **Vite** web (`vite --port 3002`,
+proxying `/api` + `/auth` to the Hono API) → real Hono API (postgres-js) → the
+seeded Neon branch, authenticated with a minted **`kuruma_session`** HS256 cookie
+(`e2e/real-db/mint-session.ts`, mirroring the API's `mintSessionToken` contract).
 
 ```bash
-set -a; source /tmp/slice8-db.env; set +a   # or export DATABASE_URL for your branch
-AUTH_SECRET=ci-placeholder-secret-not-real bun run test:e2e:real-db
+AUTH_SECRET=<any 32+ char secret> DATABASE_URL=<neon-branch-pooled-url> bun run test:e2e:real-db
 ```
 
-Expected: **6 passed** (2 session-mint + 3 operator-locations + the marketplace happy-path).
-The happy-path spec (`e2e/real-db/marketplace-happy-path.auth.spec.ts`) drives:
-renter search → Best Car Rental KIX storefront → vehicle → book → confirmation code
-(`/^[2-9A-HJ-NP-Z]{8}$/`) → operator sees the booking on `/manage/bookings?view=month`
-+ an `OPERATOR_BOOKING_ALERT` row in `notification_log`.
+Expected: **3 passed** (2 session-mint + the marketplace happy-path). The
+happy-path spec (`e2e/real-db/marketplace-happy-path.auth.spec.ts`) drives:
+renter search → Best Car Rental KIX storefront → vehicle → the 5-step wizard
+(Continue ×3 → Continue to payment → **Reserve now**) → confirmation code
+(`/^[2-9A-HJ-NP-Z]{8}$/`) → operator sees the booking in the **list** at
+`/manage/bookings` (asserted by the booking-code cell) + an
+`OPERATOR_BOOKING_ALERT` row in `notification_log`.
+
+> `locations.auth.spec.ts` is quarantined in the config — the operator
+> `/manage/locations` page is the retired Next.js one; its Vite port is **#529**.
 
 > **Why the lane uses a postgres-js API server.** The booking → thread-creation path opens an
-> interactive transaction. Production now runs these via `runTx` (neon-serverless) since **#493**,
+> interactive transaction. Production runs these via `runTx` (neon-serverless) since **#493**,
 > but the lane keeps `e2e/real-db/real-api-server.ts` on postgres-js (TCP) to exercise the real
-> path without opening a WebSocket connection per transaction.
+> path without opening a WebSocket per transaction. `DATABASE_URL` should be the Neon **pooled**
+> endpoint (`-pooler`).
 
 ---
 
@@ -86,19 +99,21 @@ renter search → Best Car Rental KIX storefront → vehicle → book → confir
 
 Routes (locale-prefixed, e.g. `/en`): `/search` → `/storefronts/[locationId]?from&to`
 → `/bookings/new?vehicleId&locationId&from&to` → `/bookings/confirmation?bookingId`;
-operator `/manage/bookings?view=month`.
+operator `/manage/bookings`.
 
 1. **Renter search** — open `/search`, pick Osaka pickup + dates → storefront cards across all 3 operators with per-class min price.
 2. **Storefront** — open *Best Car Rental — Kansai Airport (KIX)* → available vehicles grouped by ACRISS class.
-3. **Select** — pick a vehicle → plate, price, insurance options shown. (`/bookings/new` requires a logged-in renter; it redirects to `/login` otherwise.)
-4. **Book** — choose insurance, confirm.
-   - ✅ **#493 fixed.** Live booking submit works: thread creation runs through `runTx` (neon-serverless), not the HTTP driver. Requires the API's `DATABASE_URL` to be the Neon **pooled** endpoint (`-pooler`); on a deployed Worker / `wrangler dev` it commits and returns a confirmation code. (Confirm once via the manual deploy smoke — AC bullet 1 of #493.)
-5. **Operator view** — log in as `owner@best-car-rental.local` → `/manage/bookings?view=month` shows the seeded bookings on the calendar (event title = renter name) + notification badge. Operator-2 portal cannot see operator-1 bookings (tenant isolation).
-6. **Range** — switch locale to `ja` / `zh` on the renter pages.
+3. **Select** — "Book this car" → `/bookings/new` carries `vehicleId` + `locationId` + dates. (Requires a logged-in renter; redirects to `/login` otherwise.)
+4. **Book (5-step wizard)** — Dates (pre-filled, read-only) → Extras (optional) → Insurance (default **No insurance**) → Review → Payment. Click **Reserve now**. Instant-book: **no online charge** — you pay at pickup via the operator's pre-authorization link.
+5. **Confirmation** — reservation code + status **Confirmed** + the pre-auth handoff card (the operator's payment link; hidden if the operator set none).
+6. **Operator view** — log in as `owner@best-car-rental.local` → `/manage/bookings` lists the booking (newest first; renter name + code) + notification badge. Tenant isolation: the operator-2 portal cannot see operator-1 bookings.
+7. **Range** — switch locale to `ja` / `zh` on the renter pages.
 
 ---
 
-## 5. Known gaps (interim)
+## 5. Known gaps / follow-ups
 
-- Full customer demo (pay → partner revenue, pre-auth handoff narration) is **#488**.
-- First-load JS baseline 554.9 kB > 500 kB target — signed exception, see plan §7.1 (resolved by #378).
+- **Out of Path A scope:** the Stripe *pay* step and the admin *partner-revenue 4%* tab — #461 (live Stripe) / #462 (Vite admin portal).
+- **Local Postgres for this lane — #542.** `db:seed`/`db:seed-bookings` use the neon-http driver and `pg.ts`/`real-api-server.ts` hardcode `ssl: 'require'`, so the lane needs a Neon branch today. #542 moves it to local Postgres (Neon local proxy or a postgres-js seed path) to drop the Neon-branch dependency.
+- **CI gate — #445.** Wiring this lane into CI with a managed Neon-branch lifecycle.
+- **Operator locations port — #529.** Re-enables `locations.auth.spec.ts` in this lane.

--- a/e2e/real-db/marketplace-happy-path.auth.spec.ts
+++ b/e2e/real-db/marketplace-happy-path.auth.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from '@playwright/test'
 import { RENTER_STORAGE_STATE } from './constants'
 import { testSql } from './pg'
 
-// Slice 8 (#390) interim core-path milestone — the merge gate (plan §5/§6.1).
-// Proves the acceptance sentence end to end on the REAL web -> Hono API ->
-// seeded Neon branch stack (lane #416), across TWO authenticated actors:
+// #488 final marketplace demo (Path A: instant-book, no Stripe). Ported from the
+// #390 interim spec to the shipped Vite UI. Proves the acceptance sentence end to
+// end on the REAL Vite web -> Hono API -> seeded Postgres stack, across TWO
+// authenticated actors:
 //
 //   "renter search -> storefront result -> vehicle selection -> booking ->
 //    confirmation notification visible in the operator portal".
@@ -13,8 +14,9 @@ import { testSql } from './pg'
 // ctx.userId for non-staff, so the booking must be made AS the renter). Step 6
 // reuses the project-default OPERATOR_OWNER `page` to read the operator portal.
 //
-// Selectors are grounded in the merged slice-5/6/7 UI (not the mock skeleton in
-// e2e/marketplace-happy-path.spec.ts, whose fixtures predate the real pages).
+// Selectors are grounded in the shipped Vite UI (#458 search / #460 5-step
+// wizard / #511 confirmation / #512 operator list) — not the mock skeleton in
+// e2e/marketplace-happy-path.spec.ts, and not the retired Next.js pages.
 
 // Booking-code alphabet (api/lib/booking-code.ts BOOKING_CODE_PATTERN). Inlined:
 // @kuruma/api TS can't be required from this CJS-transformed Playwright file.
@@ -35,11 +37,10 @@ const OPERATOR_NAME = 'Best Car Rental'
 const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 // A far-future window, clear of the seeded bookings (which span demo-time-relative
-// ~-5..+7 days). Keeps a fleet of vehicles available and isolates the new booking
-// on the operator's July calendar. `datetime-local` wall-clock (parsed as JST).
+// ~-5..+7 days). Keeps a fleet of vehicles available and isolates the new booking.
+// `datetime-local` wall-clock (parsed as JST).
 const FROM = '2026-07-15T10:00'
 const TO = '2026-07-17T10:00'
-const BOOKING_MONTH = '2026-07-15' // operator calendar ?date — month view spans it
 
 // KIX seeds only 4 vehicles, so every run consumes one for the window. afterAll
 // deletes the bookings this spec created (+ their RESTRICT children, in FK order:
@@ -53,7 +54,7 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
     browser,
     baseURL,
   }) => {
-    test.setTimeout(120_000) // cold Next dev compiles each route on first hit
+    test.setTimeout(120_000) // Vite builds each route on first hit; real-DB round-trips
 
     const renterContext = await browser.newContext({ storageState: RENTER_STORAGE_STATE, baseURL })
     const renter = await renterContext.newPage()
@@ -75,21 +76,39 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
 
       await expect(renter).toHaveURL(new RegExp(`/storefronts/${UUID}\\?from=.+&to=.+`))
       await expect(renter.getByRole('heading', { name: STOREFRONT_NAME })).toBeVisible()
-      await expect(renter.getByText(OPERATOR_NAME)).toBeVisible()
+      // Operator name appears in several places on the detail page (header, vehicle
+      // cards) — first() keeps the assertion out of strict-mode multi-match.
+      await expect(renter.getByText(OPERATOR_NAME).first()).toBeVisible()
     })
 
-    await test.step('3. vehicle selection carries vehicle + location + dates into the form', async () => {
+    await test.step('3. vehicle selection carries vehicle + location + dates into the wizard', async () => {
+      // "Book this car" is a styled Link → /bookings/new with vehicleId + locationId
+      // + the search dates (so the wizard's first step is pre-filled, read-only).
       await renter.getByRole('link', { name: 'Book this car' }).first().click()
       await expect(renter).toHaveURL(
         new RegExp(`/bookings/new\\?vehicleId=${UUID}&locationId=${UUID}`),
       )
-      await expect(renter.getByRole('heading', { name: 'Confirm your booking' })).toBeVisible()
+      // The wizard opens on the read-only Dates step; its Continue button proves it loaded.
+      await expect(renter.getByRole('button', { name: 'Continue', exact: true })).toBeVisible()
     })
 
     let bookingCode = ''
-    await test.step('4-5. booking confirms with a no-confusables reservation code', async () => {
-      // Default insurance = decline (optional coverage); the renter just confirms.
-      await renter.getByRole('button', { name: 'Confirm booking' }).click()
+    await test.step('4-5. step through the wizard; booking confirms with a no-confusables code', async () => {
+      // 5-step wizard (#460): dates → addOns → insurance → confirm → payment.
+      // Dates are pre-filled & read-only; add-ons are optional (skip); insurance
+      // defaults to "No insurance" (decline). Each step gates on its own marker so
+      // we never click Continue before the next step has rendered.
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // dates → addOns
+      await expect(renter.getByText('Add optional extras')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // addOns → insurance
+      await expect(renter.getByText('No insurance')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // insurance → confirm
+      await expect(renter.getByText('Review your booking')).toBeVisible()
+
+      await renter.getByRole('button', { name: 'Continue to payment' }).click() // confirm → payment
+      await renter.getByRole('button', { name: 'Reserve now' }).click() // instant-book submit
 
       await expect(renter).toHaveURL(/\/bookings\/confirmation\?bookingId=.+/)
       await expect(renter.getByRole('heading', { name: 'Booking confirmed' })).toBeVisible()
@@ -99,13 +118,15 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
       await expect(renter.getByText('Confirmed', { exact: true })).toBeVisible()
     })
 
-    await test.step('6a. operator portal shows the new booking on the calendar', async () => {
-      // `page` is the project-default OPERATOR_OWNER session. Month view spans the
-      // booking day regardless of the runner timezone; the calendar event title is
-      // the renter name (BookingsCalendar.toCalendarEvents).
-      await page.goto(`/en/manage/bookings?view=month&date=${BOOKING_MONTH}`)
+    await test.step('6a. operator portal lists the new booking', async () => {
+      // `page` is the project-default OPERATOR_OWNER session. The Vite operator view
+      // (#512) is a table ordered desc(createdAt) (repositories/drizzle/booking.ts),
+      // so this just-created booking is the FIRST row. Assert the exact reservation
+      // code cell (ties the row to THIS run) plus the renter's name.
+      await page.goto('/en/manage/bookings')
       await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
-      await expect(page.getByText(RENTER_NAME).first()).toBeVisible({ timeout: 20_000 })
+      await expect(page.getByRole('cell', { name: bookingCode })).toBeVisible({ timeout: 20_000 })
+      await expect(page.getByRole('cell', { name: RENTER_NAME }).first()).toBeVisible()
     })
 
     await test.step('6b. slice-7 wrote the operator notification for this booking', async () => {

--- a/e2e/real-db/mint-session.ts
+++ b/e2e/real-db/mint-session.ts
@@ -1,14 +1,24 @@
 import { testSql } from './pg'
 
-// On http/localhost Auth.js uses the unprefixed cookie name (no `__Secure-`).
-// The `encode` salt MUST equal this name or the web's `auth()` cannot decrypt
-// the session JWE. See issue #416 proven reference.
-export const SESSION_COOKIE_NAME = 'authjs.session-token'
-
-// Seed identities, mirrored from @kuruma/shared seed data. Duplicated on purpose:
-// Playwright require()s this file as CJS, and importing the shared workspace
-// package's TS source here breaks. Update both if the seed changes.
+// The Vite/CF-Pages stack (#378) authenticates the browser with the API's own
+// `kuruma_session` HS256 JWT — NOT an Auth.js JWE (the retired Next.js path). We
+// mint it here with the SAME contract as packages/api/src/middleware/auth.ts
+// `mintSessionToken` (iss/aud/alg/exp + a `csrf` claim) — keep the two in sync.
+// GET /auth/session echoes the `csrf` claim as `csrfToken`; the wizard's
+// Reserve-now POST sends it back through the API's CSRF middleware, so a session
+// minted without it would pass auth but fail every mutation.
 //
+// Why inline `jose` instead of importing the API helper: Playwright runs these
+// specs under Node with its own loader, which transpiles files in the test dir
+// but NOT an arbitrary `packages/api/**.ts` reached via dynamic import. `jose` is
+// a published package, so importing IT is safe (mirrors the prior next-auth/jwt use).
+export const SESSION_COOKIE_NAME = 'kuruma_session'
+
+// Mirror of packages/api/src/middleware/auth.ts (API_TOKEN_ISSUER/AUDIENCE, TTL).
+const API_TOKEN_ISSUER = 'kuruma-web'
+const API_TOKEN_AUDIENCE = 'kuruma-api'
+const SESSION_TTL = '7d'
+
 // Best Car Rental owner — db/constants.ts BEST_CAR_RENTAL_OWNER_EMAIL. operatorId
 // is NOT hard-coded: the demo seed mints UUID ids (db/seed-id.ts), so we read the
 // owner's actual operatorId off the user row below. A stale slug here would scope
@@ -48,49 +58,49 @@ async function findUser(email: string): Promise<{ id: string; operatorId: string
 interface SessionIdentity {
   email: string
   name: string
-  role: string
+  role: 'RENTER' | 'OPERATOR_OWNER'
 }
 
 /**
- * Mint an Auth.js v5 session-cookie value for a seeded user, using the app's own
- * `encode` so the JWE format matches what `auth()` expects. The browser receives
- * only this cookie; the web mints the downstream HS256 API token itself
- * (`lib/api-token.ts`) from the same secret. The DB-resolved operatorId becomes
- * the token's tenant claim (omitted for an unscoped RENTER).
+ * Mint a `kuruma_session` JWT for a seeded user, signed with AUTH_SECRET — the
+ * same secret the API verifies with (middleware/auth.ts verifyAndMap). The
+ * DB-resolved operatorId becomes the tenant claim (omitted for an unscoped RENTER).
  */
-async function mintSessionToken(identity: SessionIdentity): Promise<string> {
+async function mintSession(identity: SessionIdentity): Promise<string> {
   const secret = process.env.AUTH_SECRET
   if (!secret) throw new Error('AUTH_SECRET is required to mint an e2e session')
 
   const user = await findUser(identity.email)
 
-  // next-auth/jwt is ESM-only; dynamic import so Playwright's CJS transform of
-  // this file doesn't ERR_REQUIRE_ESM at load time.
-  const { encode } = await import('next-auth/jwt')
+  // jose is ESM-only; dynamic import so Playwright's CJS transform of this file
+  // doesn't ERR_REQUIRE_ESM at load time.
+  const { SignJWT } = await import('jose')
+  const key = new TextEncoder().encode(secret)
 
-  // roleRefreshedAt = now keeps the token self-sufficient: the jwt callback's
-  // `else if (token.sub)` branch skips its DB role re-fetch for 5 minutes
-  // (packages/web/src/auth.ts), so the session needs no live DB to stay valid.
-  return encode({
-    salt: SESSION_COOKIE_NAME,
-    secret,
-    token: {
-      sub: user.id,
-      name: identity.name,
-      email: identity.email,
-      role: identity.role,
-      ...(user.operatorId ? { operatorId: user.operatorId } : {}),
-      roleRefreshedAt: Date.now(),
-    },
-  })
+  const payload: Record<string, unknown> = {
+    role: identity.role,
+    csrf: crypto.randomUUID(),
+    name: identity.name,
+    email: identity.email,
+  }
+  if (user.operatorId) payload.operatorId = user.operatorId
+
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(user.id)
+    .setIssuedAt()
+    .setIssuer(API_TOKEN_ISSUER)
+    .setAudience(API_TOKEN_AUDIENCE)
+    .setExpirationTime(SESSION_TTL)
+    .sign(key)
 }
 
 /** Session cookie value for the seeded Best Car Rental OPERATOR_OWNER. */
 export function mintOperatorSessionToken(): Promise<string> {
-  return mintSessionToken(OPERATOR)
+  return mintSession(OPERATOR)
 }
 
 /** Session cookie value for the seeded RENTER persona (Sarah Smith). */
 export function mintRenterSessionToken(): Promise<string> {
-  return mintSessionToken(RENTER)
+  return mintSession(RENTER)
 }

--- a/e2e/real-db/pg-connect-options.test.ts
+++ b/e2e/real-db/pg-connect-options.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { pgConnectOptions } from './pg-connect-options'
+
+// The whole reason this helper exists: a GitHub `postgres:16` service container
+// speaks plaintext on localhost, so the harness's hard-coded `ssl: 'require'`
+// would refuse to connect. Remote (Neon) hosts must still get TLS.
+describe('pgConnectOptions', () => {
+  test('disables TLS for a localhost container (plaintext postgres:16)', () => {
+    const opts = pgConnectOptions('postgresql://kuruma:kuruma@localhost:5432/kuruma_test')
+    expect(opts.ssl).toBe(false)
+    expect(opts).toMatchObject({
+      host: 'localhost',
+      port: 5432,
+      database: 'kuruma_test',
+      username: 'kuruma',
+      password: 'kuruma',
+    })
+  })
+
+  test('disables TLS for 127.0.0.1 too', () => {
+    expect(pgConnectOptions('postgresql://u:p@127.0.0.1:5432/db').ssl).toBe(false)
+  })
+
+  test('requires TLS for a remote Neon host', () => {
+    const opts = pgConnectOptions('postgresql://owner:secret@ep-cool-pooler.eu.neon.tech/maindb')
+    expect(opts.ssl).toBe('require')
+    expect(opts.host).toBe('ep-cool-pooler.eu.neon.tech')
+  })
+
+  test('defaults the port to 5432 when the URL omits it', () => {
+    expect(pgConnectOptions('postgresql://u:p@ep-x.neon.tech/db').port).toBe(5432)
+  })
+
+  test('url-decodes credentials and drops libpq-only query params', () => {
+    const opts = pgConnectOptions(
+      'postgresql://us%40er:p%3Ass@ep-x.neon.tech/db?channel_binding=require',
+    )
+    expect(opts.username).toBe('us@er')
+    expect(opts.password).toBe('p:ss')
+    expect(opts).not.toHaveProperty('channel_binding')
+  })
+})

--- a/e2e/real-db/pg-connect-options.ts
+++ b/e2e/real-db/pg-connect-options.ts
@@ -1,0 +1,32 @@
+/**
+ * postgres-js connection options parsed from a Postgres connection URL.
+ * Built from URL *parts* (not the raw string) so libpq-only query params such as
+ * `channel_binding` never reach postgres-js, which doesn't understand them.
+ */
+export interface PgConnectOptions {
+  host: string
+  port: number
+  database: string
+  username: string
+  password: string
+  /** TLS for remote hosts; off for a localhost container (it speaks plaintext). */
+  ssl: 'require' | false
+}
+
+// A GitHub `postgres:16` service container listens on localhost without TLS, so
+// `ssl: 'require'` would refuse the connection. Neon (and any remote host) keeps
+// TLS. `verify-full` is intentionally not used — fine for a disposable test DB.
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+export function pgConnectOptions(url: string): PgConnectOptions {
+  const u = new URL(url)
+  const host = u.hostname
+  return {
+    host,
+    port: u.port ? Number(u.port) : 5432,
+    database: u.pathname.replace(/^\//, ''),
+    username: decodeURIComponent(u.username),
+    password: decodeURIComponent(u.password),
+    ssl: LOCAL_HOSTS.has(host) ? false : 'require',
+  }
+}

--- a/e2e/real-db/pg.ts
+++ b/e2e/real-db/pg.ts
@@ -1,23 +1,14 @@
 import postgres from 'postgres'
+import { pgConnectOptions } from './pg-connect-options'
 
 /**
- * A short-lived postgres-js client for the e2e Neon branch, built from
- * DATABASE_URL's parts so libpq-only params (e.g. `channel_binding`) don't reach
- * postgres-js. ssl is forced to `require` (TLS, but not `verify-full`) — fine
- * for a disposable test branch; do not copy this into app code that needs full
- * certificate verification. Caller must `await sql.end()`.
+ * A short-lived postgres-js client for the e2e DB, built from DATABASE_URL's
+ * parts (see `pgConnectOptions`) so libpq-only params don't reach postgres-js
+ * and TLS is required for remote hosts but off for a localhost container. Caller
+ * must `await sql.end()`.
  */
 export function testSql(): postgres.Sql {
   const url = process.env.DATABASE_URL
   if (!url) throw new Error('DATABASE_URL is required for the real-DB e2e track')
-  const u = new URL(url)
-  return postgres({
-    host: u.hostname,
-    port: u.port ? Number(u.port) : 5432,
-    database: u.pathname.replace(/^\//, ''),
-    username: decodeURIComponent(u.username),
-    password: decodeURIComponent(u.password),
-    ssl: 'require',
-    max: 1,
-  })
+  return postgres({ ...pgConnectOptions(url), max: 1 })
 }

--- a/e2e/real-db/real-api-server.ts
+++ b/e2e/real-db/real-api-server.ts
@@ -24,6 +24,7 @@ import {
   DrizzleVehicleDetailRepository,
   DrizzleVehicleRepository,
 } from '../../packages/api/src/repositories/drizzle'
+import { pgConnectOptions } from './pg-connect-options'
 
 // Driver note: production's getDb() uses @neondatabase/serverless (HTTP), whose
 // drizzle adapter THROWS on db.transaction() ("No transactions support in
@@ -40,20 +41,10 @@ const port = Number(process.env.REAL_API_PORT ?? 8788)
 const url = process.env.DATABASE_URL
 if (!url) throw new Error('DATABASE_URL is required for the real-DB e2e API server')
 
-// Build from URL parts so libpq-only params (channel_binding) never reach
-// postgres-js; prepare:false keeps interactive transactions safe over the Neon
-// transaction-mode pooler. Mirrors e2e/real-db/pg.ts.
-const u = new URL(url)
-const client = postgres({
-  host: u.hostname,
-  port: u.port ? Number(u.port) : 5432,
-  database: u.pathname.replace(/^\//, ''),
-  username: decodeURIComponent(u.username),
-  password: decodeURIComponent(u.password),
-  ssl: 'require',
-  prepare: false,
-  max: 5,
-})
+// Build from URL parts (see pg-connect-options) so libpq-only params never reach
+// postgres-js and TLS is off for a localhost container; prepare:false keeps
+// interactive transactions safe over the Neon transaction-mode pooler.
+const client = postgres({ ...pgConnectOptions(url), prepare: false, max: 5 })
 const db = drizzle(client, { schema }) as unknown as Db
 
 // #493: thread/message create take an injected interactive-tx runner (DIP).

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "bun run packages/shared/src/db/seed.ts",
-    "db:seed-bookings": "bun run packages/shared/src/db/seed-bookings.ts",
+    "db:seed": "bun run scripts/seed.ts",
+    "db:seed-bookings": "bun run scripts/seed-bookings.ts",
+    "db:seed:tcp": "bun run scripts/seed-tcp.ts",
     "db:verify": "bun run scripts/db-verify.ts",
     "prepare": "husky"
   },

--- a/packages/shared/src/db/seed-bookings.ts
+++ b/packages/shared/src/db/seed-bookings.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
-import { getDb } from './index'
+import type { getDb } from './index'
 import {
   type BookingCreatedPayload,
   type FeeSnapshotItem,
@@ -76,9 +76,7 @@ function feeSnapshotFor(operatorId: string, classId: string): FeeSnapshotItem[] 
 
 type SeededVehicle = { id: string; pickupLocationId: string }
 
-async function seed() {
-  const db = getDb()
-
+export async function seedBookings(db: ReturnType<typeof getDb>) {
   // --- Idempotent cleanup (FK-safe), scoped to demo-renter personas. ---
   console.log('Clearing demo bookings, events, notifications, renters...')
   const renterEmails = DEMO_RENTERS.map((r) => r.email)
@@ -238,10 +236,4 @@ async function seed() {
     `\nSeeded ${DEMO_RENTERS.length} renters, ${bookingValues.length} bookings, ` +
       `${eventValues.length} events, ${notificationValues.length} notifications.`,
   )
-  process.exit(0)
 }
-
-seed().catch((err) => {
-  console.error('Seed bookings failed:', err)
-  process.exit(1)
-})

--- a/packages/shared/src/db/seed.test.ts
+++ b/packages/shared/src/db/seed.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+import { seed } from './seed'
+import { seedBookings } from './seed-bookings'
+
+// The DIP seam (#445): the seed modules are now pure libraries — they used to
+// call getDb() + process.exit() at module scope, which made them unusable from a
+// CI runner that injects a postgres-js client to seed a local container. The
+// Neon CLI entries moved to scripts/seed*.ts; seed/seedBookings take the db as an
+// argument, so importing them must be side-effect free.
+describe('seed injection seam', () => {
+  test('exposes seed(db) as a one-argument injectable function', () => {
+    expect(typeof seed).toBe('function')
+    expect(seed.length).toBe(1)
+  })
+
+  test('exposes seedBookings(db) as a one-argument injectable function', () => {
+    expect(typeof seedBookings).toBe('function')
+    expect(seedBookings.length).toBe(1)
+  })
+})

--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -1,4 +1,4 @@
-import { getDb } from './index'
+import type { getDb } from './index'
 import { parsePlatformAdminEmails } from './platform-admins'
 import {
   feeSchedules,
@@ -45,8 +45,7 @@ function demoShakenExpiry(): string {
   return expiry.toISOString().slice(0, 10)
 }
 
-async function seed() {
-  const db = getDb()
+export async function seed(db: ReturnType<typeof getDb>) {
   const now = new Date()
 
   // 1. Operators (tenant roots). vehicles/classes/locations all FK to these, so
@@ -267,10 +266,4 @@ async function seed() {
       `${DEMO_VEHICLE_CLASSES.length} classes, ${DEMO_VEHICLES.length} vehicles, ` +
       `${DEMO_INSURANCE_OPTIONS.length} insurance options, ${DEMO_FEE_SCHEDULES.length} fee schedules.`,
   )
-  process.exit(0)
 }
-
-seed().catch((err) => {
-  console.error('Seed failed:', err)
-  process.exit(1)
-})

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
     {
       name: 'authenticated-real-db',
       testMatch: /.*\.auth\.spec\.ts/,
+      // locations.auth.spec.ts drives the operator /manage/locations page, which
+      // only exists in the retired Next.js app — the Vite operator-locations port
+      // is #529 (epic #523). Re-enable it there. Until then this lane proves the
+      // #488 marketplace happy path against the shipped Vite UI.
+      testIgnore: ['**/locations.auth.spec.ts'],
       dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
     },
@@ -57,15 +62,17 @@ export default defineConfig({
       },
     },
     {
-      command: 'bun run next dev -p 3002',
+      // The web app is Vite now (#378), not Next. Vite is a pure SPA dev server:
+      // it needs no AUTH_SECRET/DATABASE_URL — it proxies /api (strip prefix) and
+      // /auth (verbatim) to the real Hono API via VITE_DEV_API_PROXY, so the
+      // browser talks to the API same-origin and the minted session cookie rides.
+      command: 'bunx vite --port 3002',
       cwd: 'packages/web',
       url: BASE_URL,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
-        AUTH_SECRET,
-        DATABASE_URL,
-        NEXT_PUBLIC_API_URL: API_URL,
+        VITE_DEV_API_PROXY: API_URL,
       },
     },
   ],

--- a/scripts/seed-bookings.ts
+++ b/scripts/seed-bookings.ts
@@ -1,0 +1,11 @@
+import { getDb } from '../packages/shared/src/db'
+import { seedBookings } from '../packages/shared/src/db/seed-bookings'
+
+// CLI entry for `bun run db:seed-bookings` — run AFTER db:seed (needs the seeded
+// fleet). Seeds the Neon DATABASE_URL; CI uses scripts/seed-tcp.ts for a local DB.
+seedBookings(getDb())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Seed bookings failed:', err)
+    process.exit(1)
+  })

--- a/scripts/seed-tcp.ts
+++ b/scripts/seed-tcp.ts
@@ -1,0 +1,32 @@
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { pgConnectOptions } from '../e2e/real-db/pg-connect-options'
+import type { getDb } from '../packages/shared/src/db'
+import * as schema from '../packages/shared/src/db/schema'
+import { seed } from '../packages/shared/src/db/seed'
+import { seedBookings } from '../packages/shared/src/db/seed-bookings'
+
+/**
+ * Seed a local (or any TCP-reachable) Postgres for the real-DB e2e gate (#445).
+ *
+ * The shared `seed`/`seedBookings` are injectable (DIP), so we feed them a
+ * postgres-js client instead of the production neon-http `getDb()` — neon-http
+ * speaks Neon's HTTP protocol and cannot talk to a plain `postgres:16` container.
+ * `pgConnectOptions` turns TLS off for localhost. Runs `seed` then `seedBookings`
+ * (CLAUDE.md ordering: the fleet must exist before bookings resolve vehicles).
+ */
+const url = process.env.DATABASE_URL
+if (!url) throw new Error('DATABASE_URL is required for db:seed:tcp')
+
+const client = postgres({ ...pgConnectOptions(url), max: 1 })
+// The postgres-js handle exposes the same query-builder surface the seeds are
+// typed against (neon-http); the drivers differ only in their result HKT, so a
+// single cast bridges them — the same seam real-api-server.ts uses.
+const db = drizzle(client, { schema }) as unknown as ReturnType<typeof getDb>
+
+try {
+  await seed(db)
+  await seedBookings(db)
+} finally {
+  await client.end()
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,12 @@
+import { getDb } from '../packages/shared/src/db'
+import { seed } from '../packages/shared/src/db/seed'
+
+// CLI entry for `bun run db:seed` — seeds the Neon DATABASE_URL via the
+// production neon-http getDb(). The seeding logic is the pure, injectable seed()
+// in @kuruma/shared; CI seeds a local container instead via scripts/seed-tcp.ts.
+seed(getDb())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Seed failed:', err)
+    process.exit(1)
+  })


### PR DESCRIPTION
**Draft + stacked on #488.** Adds the CI job that runs the authenticated real-DB e2e track against a fresh, seeded `postgres:16` — no Neon branch, no external secrets — plus the local-pg plumbing it needs.

## Why stacked on #488
The real-DB harness re-port (mint `kuruma_session` cookie, Vite proxy, happy-path spec) is owned by **#488** (already pushed, green on Neon). This branch drops #445's duplicate harness work and builds only the #445-unique pieces on top. **Base = `feat/488-demo-e2e`; blocked until #488 merges** (GitHub auto-retargets to `marketplace-pivot` then).

## What this adds (on top of #488)
- **Slice A — `dae0217`** localhost-capable DB plumbing: `pgConnectOptions` (TLS off for localhost), injectable `seed()`/`seedBookings()`, `seed-tcp.ts` + `db:seed:tcp`. Production's neon-http `getDb()` can't reach a plain `postgres:16` container; postgres-js (TCP) can.
- **Slice D — `2720c6d`** new `e2e-real-db` CI job: postgres:16 service + Playwright chromium, then `db:migrate → db:verify → db:seed:tcp → test:e2e:real-db`. A static `AUTH_SECRET` signs + verifies the minted cookie (both harness and API read the same job env; the DB never leaves the runner).

## Proof (local, docker postgres:16)
- `db:verify` **4/4** (schema↔snapshot, journal↔disk, monotonic, journal↔DB = 48)
- `test:e2e:real-db` **3 passed**: 2 session mints + marketplace happy path (search → storefront → vehicle → booking → confirmation → operator portal)

## Test plan
- [ ] CI `e2e-real-db` job green on this PR
- [ ] After #488 merges: retarget/rebase onto `marketplace-pivot`, re-run CI
- [ ] **Slice E** (separate, repo-admin): add `e2e-real-db` to `marketplace-pivot` branch-protection required checks

Refs #445