### PR TITLE
feat(web): renter "My Bookings" list + lean renter top nav (#543)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -51,7 +51,10 @@
     "close": "Close menu",
     "switchToRenter": "Switch to renter view",
     "switchToBusiness": "Switch to business view",
-    "search": "Search"
+    "search": "Search",
+    "browse": "Browse",
+    "myBookings": "My Bookings",
+    "documents": "Documents"
   },
   "acriss": {
     "MCAR": "Mini",
@@ -745,13 +748,16 @@
       "title": "My bookings",
       "subtitle": "Your upcoming and past reservations",
       "empty": "You haven't made any bookings yet.",
+      "browseCars": "Browse cars",
       "pickup": "Pickup",
       "return": "Return",
       "viewDetails": "View details",
       "confirmed": "Confirmed",
       "active": "Active",
       "completed": "Completed",
-      "cancelled": "Cancelled"
+      "cancelled": "Cancelled",
+      "loadError": "Couldn't load your bookings",
+      "retry": "Try again"
     },
     "operator": {
       "title": "Bookings",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -51,7 +51,10 @@
     "close": "メニューを閉じる",
     "switchToRenter": "利用者ビューに切替",
     "switchToBusiness": "管理者ビューに切替",
-    "search": "検索"
+    "search": "検索",
+    "browse": "車を探す",
+    "myBookings": "予約一覧",
+    "documents": "書類"
   },
   "acriss": {
     "MCAR": "ミニ",
@@ -745,13 +748,16 @@
       "title": "予約一覧",
       "subtitle": "今後の予約と過去の予約",
       "empty": "まだ予約がありません。",
+      "browseCars": "車を探す",
       "pickup": "乗車",
       "return": "返却",
       "viewDetails": "詳細を見る",
       "confirmed": "確定済み",
       "active": "利用中",
       "completed": "完了",
-      "cancelled": "キャンセル済み"
+      "cancelled": "キャンセル済み",
+      "loadError": "予約を読み込めませんでした",
+      "retry": "再試行"
     },
     "operator": {
       "title": "予約",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -51,7 +51,10 @@
     "close": "关闭菜单",
     "switchToRenter": "切换到租客视图",
     "switchToBusiness": "切换到管理视图",
-    "search": "搜索"
+    "search": "搜索",
+    "browse": "浏览车辆",
+    "myBookings": "我的预订",
+    "documents": "证件"
   },
   "acriss": {
     "MCAR": "微型车",
@@ -745,13 +748,16 @@
       "title": "我的预订",
       "subtitle": "您的即将到来和过去的预订",
       "empty": "您还没有任何预订。",
+      "browseCars": "浏览车辆",
       "pickup": "取车",
       "return": "还车",
       "viewDetails": "查看详情",
       "confirmed": "已确认",
       "active": "进行中",
       "completed": "已完成",
-      "cancelled": "已取消"
+      "cancelled": "已取消",
+      "loadError": "无法加载您的预订",
+      "retry": "重试"
     },
     "operator": {
       "title": "预订",

--- a/packages/web/src/routes/$locale/_renter/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_renter/bookings/index.tsx
@@ -1,7 +1,77 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { MyBookingsView } from '@/vite/bookings/MyBookingsView'
+import { myBookingsQueryOptions } from '@/vite/bookings/api'
+import { sessionQueryOptions } from '@/vite/session'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import {
+  type ErrorComponentProps,
+  createFileRoute,
+  redirect,
+  useRouter,
+} from '@tanstack/react-router'
+import { useTranslations } from 'use-intl'
 
-// Placeholder so `/<locale>/bookings` stays reachable; the real renter bookings
-// list ports in a later slice.
+// Renter "My Bookings" (#543). Gated by `_renter` (session required). The loader
+// reads the caller's own id from the cached session and prefetches their bookings
+// with renterId=self — a principal-identical query (vite/bookings/api): it means
+// "bookings where I am the renter" for any caller, so an operator-in-renter-view
+// who reaches this URL never sees tenant rows. The component reads the same options
+// via useSuspenseQuery (no FOUC). Mirrors the operator route at manage/bookings.
 export const Route = createFileRoute('/$locale/_renter/bookings/')({
-  component: () => <main>Bookings (port pending)</main>,
+  loader: async ({ context, params, location }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
+    // The parent `_renter` guard redirects an anonymous caller before this runs;
+    // re-checking keeps the type honest and is a defensive backstop.
+    if (!session) {
+      throw redirect({
+        to: '/$locale/login',
+        params: { locale: params.locale },
+        search: { returnTo: location.pathname },
+      })
+    }
+    await context.queryClient.ensureQueryData(myBookingsQueryOptions(session.user.id))
+    return { renterId: session.user.id }
+  },
+  pendingComponent: PageSkeleton,
+  errorComponent: MyBookingsError,
+  component: MyBookingsRoute,
 })
+
+function MyBookingsRoute() {
+  const t = useTranslations('bookings.list')
+  const { locale } = Route.useParams()
+  const { renterId } = Route.useLoaderData()
+  const { data: bookings } = useSuspenseQuery(myBookingsQueryOptions(renterId))
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
+          <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
+        </header>
+        <MyBookingsView bookings={bookings} locale={locale} />
+      </div>
+    </main>
+  )
+}
+
+function MyBookingsError(_props: ErrorComponentProps) {
+  const t = useTranslations('bookings.list')
+  const router = useRouter()
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl py-20 text-center">
+        <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+        <button
+          type="button"
+          onClick={() => router.invalidate()}
+          className="mt-4 rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/packages/web/src/vite/bookings/MyBookingsView.tsx
+++ b/packages/web/src/vite/bookings/MyBookingsView.tsx
@@ -1,0 +1,67 @@
+import { buttonVariants } from '@/components/ui/button'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import type { MyBookingRow } from '@/vite/bookings/api'
+import { Link } from '@tanstack/react-router'
+import { CalendarX } from 'lucide-react'
+import { useTranslations } from 'use-intl'
+
+interface MyBookingsViewProps {
+  readonly bookings: readonly MyBookingRow[]
+  readonly locale: string
+}
+
+// Presentational list + empty state for the renter's own bookings (#543). The
+// route owns the loader/useSuspenseQuery and the renterId; this stays a pure
+// function of the resolved rows so it is unit-testable (FC/IS — the shell does
+// I/O, this renders). Each card links to the booking's confirmation/detail page.
+export function MyBookingsView({ bookings, locale }: MyBookingsViewProps) {
+  const t = useTranslations('bookings.list')
+
+  if (bookings.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-border py-20 text-center">
+        <CalendarX className="mb-4 size-12 text-muted-foreground/30" />
+        <p className="mb-6 text-lg text-muted-foreground">{t('empty')}</p>
+        <Link
+          to="/$locale/search"
+          params={{ locale }}
+          className={cn(buttonVariants({ size: 'lg' }))}
+        >
+          {t('browseCars')}
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {bookings.map((booking) => (
+        <li key={booking.id}>
+          <Link
+            to="/$locale/bookings/confirmation"
+            params={{ locale }}
+            search={{ bookingId: booking.id }}
+            className="flex flex-col gap-2 rounded-xl border border-border p-4 transition-colors hover:bg-muted/40 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-3">
+                <span className="font-mono font-medium">{booking.bookingCode}</span>
+                <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+                  {t(booking.status.toLowerCase())}
+                </span>
+              </div>
+              <span className="text-sm text-muted-foreground">{booking.vehicleName ?? '—'}</span>
+              <span className="text-sm whitespace-nowrap text-muted-foreground">
+                {`${formatDateTime(booking.startAt, locale)} – ${formatDateTime(booking.endAt, locale)}`}
+              </span>
+            </div>
+            <span className="text-right text-lg font-semibold tabular-nums">
+              {booking.totalPrice == null ? '—' : formatJpy(booking.totalPrice)}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -95,3 +95,64 @@ export function bookingByIdQueryOptions(id: string) {
     queryFn: () => fetchBookingById(id),
   })
 }
+
+// "My Bookings" (#543). The full BookingDto has no vehicle name, so the list view
+// reads a leaner row shape from `GET /bookings?expand=vehicle`: the assigned car's
+// display name flattened in, dates as ISO strings. Mirrors operator-bookings/api
+// `OperatorBookingRow`/`toRow`, but renter-scoped and without the renter block.
+export type MyBookingStatus = 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+
+export interface MyBookingRow {
+  id: string
+  bookingCode: string
+  status: MyBookingStatus
+  startAt: string
+  endAt: string
+  totalPrice: number | null
+  // The assigned car's name (#392 — there is no `vehicleId`; the server resolves
+  // it via `expand=vehicle`). Null when the expansion is absent (vehicle deleted).
+  vehicleName: string | null
+}
+
+interface RawMyBooking {
+  id: string
+  bookingCode: string
+  status: MyBookingStatus
+  startAt: string
+  endAt: string
+  totalPrice: number | null
+  vehicle?: { name: string; photos: string[] } | undefined
+}
+
+function toMyRow(b: RawMyBooking): MyBookingRow {
+  return {
+    id: b.id,
+    bookingCode: b.bookingCode,
+    status: b.status,
+    startAt: b.startAt,
+    endAt: b.endAt,
+    totalPrice: b.totalPrice,
+    vehicleName: b.vehicle?.name ?? null,
+  }
+}
+
+// Principal-identical read: `renterId=self` means "bookings where I am the renter"
+// for any caller, so an operator-in-renter-view never sees tenant rows mislabeled
+// as personal (#543 P1). Server ownership scoping (CallerContext) is the real
+// boundary; this filter guarantees the page means the same thing for every caller.
+// First page only — `nextCursor` is intentionally discarded (no pagination yet).
+export async function fetchMyBookings(renterId: string): Promise<MyBookingRow[]> {
+  const sp = new URLSearchParams({ expand: 'vehicle', renterId })
+  const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
+    credentials: 'include',
+  })
+  const data = await unwrap<RawMyBooking[]>(res)
+  return data.map(toMyRow)
+}
+
+export function myBookingsQueryOptions(renterId: string) {
+  return queryOptions({
+    queryKey: ['bookings', 'mine', renterId],
+    queryFn: () => fetchMyBookings(renterId),
+  })
+}

--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -10,8 +10,14 @@ import { useState } from 'react'
 import { useLocale, useTranslations } from 'use-intl'
 
 // `to` is a literal union of real routes so the typed TanStack <Link> compiles;
-// a plain `string` here would fail typecheck (added routes land in 5d-2/5d-3).
-export type NavTo = '/$locale/dashboard' | '/$locale/bookings' | '/$locale/manage/bookings'
+// a plain `string` here would fail typecheck. Renter nav (#543) adds Browse
+// (-> public search) and Documents alongside My Bookings.
+export type NavTo =
+  | '/$locale/dashboard'
+  | '/$locale/bookings'
+  | '/$locale/manage/bookings'
+  | '/$locale/search'
+  | '/$locale/documents'
 
 export interface NavItem {
   readonly to: NavTo

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -10,8 +10,10 @@ import { Car } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 // Client navbar (the SPA reads the session via useSession, not server auth()).
-// Public/renter destinations beyond bookings (search/vehicles/messages/manage)
-// have no route yet — they arrive in 5d-2/5d-3 — so they are omitted here.
+// Renter nav (#543): Browse is public (any renter-view session); My Bookings and
+// Documents are personal "my data" pages, so they are gated on the actual RENTER
+// role — NOT viewMode. An operator who switches to renter view must not see them,
+// or they would drift to tenant data (view state is not authorization state).
 export function Navbar() {
   const { data: session } = useSession()
   const t = useTranslations('nav')
@@ -20,6 +22,14 @@ export function Navbar() {
   const role = session?.user?.role
   const canSwitchView = isBusiness(role)
   const viewMode = getViewMode(role)
+  const isRenter = role === 'RENTER'
+
+  const renterNavItems: readonly NavItem[] = isRenter
+    ? [
+        { to: '/$locale/bookings', label: t('myBookings') },
+        { to: '/$locale/documents', label: t('documents') },
+      ]
+    : []
 
   const navItems: readonly NavItem[] =
     viewMode === 'business'
@@ -28,7 +38,7 @@ export function Navbar() {
           { to: '/$locale/manage/bookings', label: t('bookings') },
         ]
       : session?.user
-        ? [{ to: '/$locale/bookings', label: t('bookings') }]
+        ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]
         : []
 
   return (

--- a/packages/web/tests/vite/bookings/MyBookingsView.test.tsx
+++ b/packages/web/tests/vite/bookings/MyBookingsView.test.tsx
@@ -1,0 +1,82 @@
+import { MyBookingsView } from '@/vite/bookings/MyBookingsView'
+import type { MyBookingRow } from '@/vite/bookings/api'
+import { render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// The view renders typed <Link>s (each row -> confirmation, empty-state CTA ->
+// search); stub the router so we assert the destination + search params, not the
+// portal/router internals.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    search,
+    children,
+  }: {
+    to: string
+    params?: unknown
+    search?: { bookingId?: string }
+    children: ReactNode
+  }) => (
+    <a data-to={to} data-booking-id={search?.bookingId} href={to}>
+      {children}
+    </a>
+  ),
+}))
+
+function makeRow(over: Partial<MyBookingRow> = {}): MyBookingRow {
+  return {
+    id: 'bk-1',
+    bookingCode: 'ABCD2345',
+    status: 'CONFIRMED',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    totalPrice: 24000,
+    vehicleName: 'Toyota Aqua',
+    ...over,
+  }
+}
+
+function renderView(bookings: MyBookingRow[]) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <MyBookingsView bookings={bookings} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('MyBookingsView', () => {
+  it('renders one row per booking with code, vehicle name, status, range, and total', () => {
+    renderView([makeRow()])
+
+    const row = screen.getByRole('listitem')
+    expect(within(row).getByText('ABCD2345')).toBeInTheDocument()
+    expect(within(row).getByText('Toyota Aqua')).toBeInTheDocument()
+    expect(within(row).getByText('Confirmed')).toBeInTheDocument()
+    expect(within(row).getByText('￥24,000')).toBeInTheDocument()
+    // medium dateStyle, Asia/Tokyo: 01:00Z -> Jul 1; 03 Jul 01:00Z -> Jul 3
+    expect(within(row).getByText(/Jul 1, 2026.*Jul 3, 2026/)).toBeInTheDocument()
+  })
+
+  it('links each row to its confirmation page carrying the bookingId', () => {
+    renderView([makeRow({ id: 'bk-9' })])
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('data-to', '/$locale/bookings/confirmation')
+    expect(link).toHaveAttribute('data-booking-id', 'bk-9')
+  })
+
+  it('renders the per-status label for a cancelled booking', () => {
+    renderView([makeRow({ status: 'CANCELLED' })])
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
+
+  it('shows a friendly empty state with a Browse-cars CTA to search when there are none', () => {
+    renderView([])
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+    expect(screen.getByText("You haven't made any bookings yet.")).toBeInTheDocument()
+    const cta = screen.getByRole('link', { name: 'Browse cars' })
+    expect(cta).toHaveAttribute('data-to', '/$locale/search')
+  })
+})

--- a/packages/web/tests/vite/bookings/api.test.ts
+++ b/packages/web/tests/vite/bookings/api.test.ts
@@ -1,4 +1,10 @@
-import { createBooking, fetchBookingById } from '@/vite/bookings/api'
+import { ApiError } from '@/lib/api-error'
+import {
+  createBooking,
+  fetchBookingById,
+  fetchMyBookings,
+  myBookingsQueryOptions,
+} from '@/vite/bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -140,5 +146,89 @@ describe('fetchBookingById', () => {
       vi.fn(async () => jsonResponse({ success: false, error: 'boom' }, 500)),
     )
     await expect(fetchBookingById('b-1')).rejects.toMatchObject({ status: 500 })
+  })
+})
+
+// "My Bookings" (#543): the caller's own bookings, expanded with the assigned
+// vehicle. The query is principal-identical — `renterId=self` means "bookings
+// where I am the renter" for any caller, not "bookings in my tenant".
+const rawMyBooking = (over: Record<string, unknown> = {}) => ({
+  id: 'bk-1',
+  bookingCode: 'ABCD2345',
+  status: 'CONFIRMED',
+  startAt: '2026-07-01T01:00:00.000Z',
+  endAt: '2026-07-03T01:00:00.000Z',
+  totalPrice: 24000,
+  vehicle: { name: 'Toyota Aqua', photos: ['a.jpg'] },
+  ...over,
+})
+
+describe('fetchMyBookings', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('GETs /api/bookings?expand=vehicle&renterId=<self> with credentials', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [], nextCursor: null }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchMyBookings('me-42')
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const parsed = new URL(url, 'http://x')
+    expect(parsed.pathname).toBe('/api/bookings')
+    expect(parsed.searchParams.get('expand')).toBe('vehicle')
+    expect(parsed.searchParams.get('renterId')).toBe('me-42')
+    expect(init.credentials).toBe('include')
+  })
+
+  it('maps the envelope to rows, flattening the expanded vehicle name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [rawMyBooking()], nextCursor: null })),
+    )
+
+    const rows = await fetchMyBookings('me-42')
+
+    expect(rows).toEqual([
+      {
+        id: 'bk-1',
+        bookingCode: 'ABCD2345',
+        status: 'CONFIRMED',
+        startAt: '2026-07-01T01:00:00.000Z',
+        endAt: '2026-07-03T01:00:00.000Z',
+        totalPrice: 24000,
+        vehicleName: 'Toyota Aqua',
+      },
+    ])
+  })
+
+  it('normalizes a missing vehicle expansion to null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [rawMyBooking({ vehicle: undefined })],
+          nextCursor: null,
+        }),
+      ),
+    )
+
+    const [row] = await fetchMyBookings('me-42')
+    expect(row!.vehicleName).toBeNull()
+  })
+
+  it('throws ApiError on a failure envelope', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'Unauthorized' }, 401)),
+    )
+
+    await expect(fetchMyBookings('me-42')).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('myBookingsQueryOptions', () => {
+  it('keys by the renter so two principals never collide on cache', () => {
+    expect(myBookingsQueryOptions('me-42').queryKey).toEqual(['bookings', 'mine', 'me-42'])
   })
 })

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -101,15 +101,34 @@ describe('Navbar', () => {
     expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '2')
   })
 
-  it('shows the bookings link and no business markers for a signed-in renter', () => {
+  it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {
     const { container } = renderNavbar(renter)
-    expect(screen.getByText('Bookings').closest('a')).toHaveAttribute(
+    expect(screen.getByText('Browse').closest('a')).toHaveAttribute('data-to', '/$locale/search')
+    expect(screen.getByText('My Bookings').closest('a')).toHaveAttribute(
       'data-to',
       '/$locale/bookings',
+    )
+    expect(screen.getByText('Documents').closest('a')).toHaveAttribute(
+      'data-to',
+      '/$locale/documents',
     )
     expect(container.querySelector('nav')?.hasAttribute('data-business-nav')).toBe(false)
     const client = screen.getByTestId('navbar-client')
     expect(client).toHaveAttribute('data-view-mode', 'renter')
     expect(client).toHaveAttribute('data-can-switch', 'false')
+    // Desktop + mobile share the same derived navItems (Browse + 2 renter-only).
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '3')
+  })
+
+  it('hides My Bookings/Documents for an operator in renter view — gating is by role, not view (P1, AC6)', () => {
+    // Operator switched to renter view: viewMode is renter, but role is not RENTER,
+    // so the personal "my data" nav must not appear (it would otherwise drift to
+    // tenant data). Browse stays — it is public and role-agnostic.
+    document.cookie = 'kuruma-view=renter; path=/'
+    renderNavbar(business)
+    expect(screen.getByText('Browse')).toBeInTheDocument()
+    expect(screen.queryByText('My Bookings')).toBeNull()
+    expect(screen.queryByText('Documents')).toBeNull()
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '1')
   })
 })


### PR DESCRIPTION
Closes #543

## What
Completes the renter core-path demo — **search → book → confirmation → see it in "My Bookings"** — and gives renters a clear nav to reach it. Vite + TanStack Router shell; data flows through the Hono API. No new API endpoint, no new route file (no `routeTree.gen.ts` regen).

## Changes
- **`vite/bookings/api.ts`** — `MyBookingRow` DTO + `fetchMyBookings(renterId)` → `GET /bookings?expand=vehicle&renterId=<self>` (credentials included, envelope unwrapped, first page only — `nextCursor` intentionally discarded), flattening the assigned-vehicle name. `myBookingsQueryOptions` keyed `['bookings','mine',renterId]`. Mirrors `operator-bookings/api.ts`.
- **`vite/bookings/MyBookingsView.tsx`** (new) — presentational list (code · status · date range · vehicle · total) with each row linking to its confirmation page; friendly empty state + "Browse cars" CTA → `/search`.
- **`routes/$locale/_renter/bookings/index.tsx`** — replaces the stub: loader reads the caller's own id from the cached session and prefetches `myBookingsQueryOptions(self)`; component reads the same options via `useSuspenseQuery`. Mirrors the operator route.
- **`vite/nav/Navbar.tsx` + `MobileMenu.tsx`** — renter nav: **Browse** (public), **My Bookings**, **Documents**. My Bookings/Documents are gated on the actual `role === 'RENTER'` (NOT viewMode); widened `NavTo`.
- **i18n** — `nav.browse/myBookings/documents` + `bookings.list.browseCars/loadError/retry` in en/ja/zh (real translations).

## Why the query is `renterId=self` (P1)
View state is not authorization state. Server scope is role-derived; `renterId=self` makes the page *principal-identical* — it means "bookings where I am the renter" for any caller. An operator who switches to renter view sees **no** My Bookings/Documents nav, and if they reach `/bookings` by URL the `renterId=self` filter narrows to their own (empty) set — never tenant bookings.

## Tests (TDD)
- `bookings/api.test.ts` — `fetchMyBookings` hits the right URL with both params + credentials; flattens vehicle name; normalizes missing expansion to null; throws on failure envelope; queryKey collision guard.
- `MyBookingsView.test.tsx` — rows render code/status/range/vehicle/total; each links to confirmation w/ bookingId; empty state + Browse CTA → `/search`.
- `Navbar.test.tsx` — RENTER shows Browse/My Bookings/Documents; **OPERATOR_OWNER in renter view shows neither My Bookings nor Documents** (P1, AC6); business view unchanged.

## Gates (all green locally)
typecheck (default + frozen) · web vitest **751 passed** · biome · `vite build` · `lint:i18n-parity` (748 keys × 3) · `lint:dist-size` (12.9%). Code-reviewer: SHIP, no CRIT/HIGH/MEDIUM.

> Base is `marketplace-pivot` (non-default), so GitHub won't auto-close #543 on merge — close manually.