### PR TITLE
ci: authenticated real-DB e2e gate (#445)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,78 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  e2e-real-db:
+    # Authenticated real-DB e2e gate (#445): runs the REAL Hono API + Vite web
+    # against a fresh, seeded postgres:16 — no Neon branch, no external secrets.
+    # The harness (#488) mints the API's kuruma_session cookie and drives the
+    # marketplace happy path (search -> book -> confirmation -> operator portal).
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: kuruma
+          POSTGRES_PASSWORD: kuruma
+          POSTGRES_DB: kuruma_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kuruma -d kuruma_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://kuruma:kuruma@localhost:5432/kuruma_e2e
+      # Static, non-secret signing key: the harness mints the session cookie and
+      # the API verifies it with the SAME value — both read this env. No GitHub
+      # Secret needed; the DB is disposable and never leaves the runner.
+      AUTH_SECRET: ci-real-db-e2e-static-secret-0123456789
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Apply all migrations against fresh Postgres
+        run: bun run db:migrate
+
+      - name: Verify no schema drift
+        run: bun run db:verify
+
+      - name: Seed the marketplace fixture over TCP
+        # db:seed:tcp uses postgres-js (TCP); the production neon-http getDb()
+        # cannot reach a plain postgres:16 container.
+        run: bun run db:seed:tcp
+
+      - name: Run authenticated real-DB E2E
+        run: bun run test:e2e:real-db
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-real-db
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/real-db/pg-connect-options.test.ts
+++ b/e2e/real-db/pg-connect-options.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { pgConnectOptions } from './pg-connect-options'
+
+// The whole reason this helper exists: a GitHub `postgres:16` service container
+// speaks plaintext on localhost, so the harness's hard-coded `ssl: 'require'`
+// would refuse to connect. Remote (Neon) hosts must still get TLS.
+describe('pgConnectOptions', () => {
+  test('disables TLS for a localhost container (plaintext postgres:16)', () => {
+    const opts = pgConnectOptions('postgresql://kuruma:kuruma@localhost:5432/kuruma_test')
+    expect(opts.ssl).toBe(false)
+    expect(opts).toMatchObject({
+      host: 'localhost',
+      port: 5432,
+      database: 'kuruma_test',
+      username: 'kuruma',
+      password: 'kuruma',
+    })
+  })
+
+  test('disables TLS for 127.0.0.1 too', () => {
+    expect(pgConnectOptions('postgresql://u:p@127.0.0.1:5432/db').ssl).toBe(false)
+  })
+
+  test('requires TLS for a remote Neon host', () => {
+    const opts = pgConnectOptions('postgresql://owner:secret@ep-cool-pooler.eu.neon.tech/maindb')
+    expect(opts.ssl).toBe('require')
+    expect(opts.host).toBe('ep-cool-pooler.eu.neon.tech')
+  })
+
+  test('defaults the port to 5432 when the URL omits it', () => {
+    expect(pgConnectOptions('postgresql://u:p@ep-x.neon.tech/db').port).toBe(5432)
+  })
+
+  test('url-decodes credentials and drops libpq-only query params', () => {
+    const opts = pgConnectOptions(
+      'postgresql://us%40er:p%3Ass@ep-x.neon.tech/db?channel_binding=require',
+    )
+    expect(opts.username).toBe('us@er')
+    expect(opts.password).toBe('p:ss')
+    expect(opts).not.toHaveProperty('channel_binding')
+  })
+})

--- a/e2e/real-db/pg-connect-options.ts
+++ b/e2e/real-db/pg-connect-options.ts
@@ -1,0 +1,32 @@
+/**
+ * postgres-js connection options parsed from a Postgres connection URL.
+ * Built from URL *parts* (not the raw string) so libpq-only query params such as
+ * `channel_binding` never reach postgres-js, which doesn't understand them.
+ */
+export interface PgConnectOptions {
+  host: string
+  port: number
+  database: string
+  username: string
+  password: string
+  /** TLS for remote hosts; off for a localhost container (it speaks plaintext). */
+  ssl: 'require' | false
+}
+
+// A GitHub `postgres:16` service container listens on localhost without TLS, so
+// `ssl: 'require'` would refuse the connection. Neon (and any remote host) keeps
+// TLS. `verify-full` is intentionally not used — fine for a disposable test DB.
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+export function pgConnectOptions(url: string): PgConnectOptions {
+  const u = new URL(url)
+  const host = u.hostname
+  return {
+    host,
+    port: u.port ? Number(u.port) : 5432,
+    database: u.pathname.replace(/^\//, ''),
+    username: decodeURIComponent(u.username),
+    password: decodeURIComponent(u.password),
+    ssl: LOCAL_HOSTS.has(host) ? false : 'require',
+  }
+}

--- a/e2e/real-db/pg.ts
+++ b/e2e/real-db/pg.ts
@@ -1,23 +1,14 @@
 import postgres from 'postgres'
+import { pgConnectOptions } from './pg-connect-options'
 
 /**
- * A short-lived postgres-js client for the e2e Neon branch, built from
- * DATABASE_URL's parts so libpq-only params (e.g. `channel_binding`) don't reach
- * postgres-js. ssl is forced to `require` (TLS, but not `verify-full`) — fine
- * for a disposable test branch; do not copy this into app code that needs full
- * certificate verification. Caller must `await sql.end()`.
+ * A short-lived postgres-js client for the e2e DB, built from DATABASE_URL's
+ * parts (see `pgConnectOptions`) so libpq-only params don't reach postgres-js
+ * and TLS is required for remote hosts but off for a localhost container. Caller
+ * must `await sql.end()`.
  */
 export function testSql(): postgres.Sql {
   const url = process.env.DATABASE_URL
   if (!url) throw new Error('DATABASE_URL is required for the real-DB e2e track')
-  const u = new URL(url)
-  return postgres({
-    host: u.hostname,
-    port: u.port ? Number(u.port) : 5432,
-    database: u.pathname.replace(/^\//, ''),
-    username: decodeURIComponent(u.username),
-    password: decodeURIComponent(u.password),
-    ssl: 'require',
-    max: 1,
-  })
+  return postgres({ ...pgConnectOptions(url), max: 1 })
 }

--- a/e2e/real-db/real-api-server.ts
+++ b/e2e/real-db/real-api-server.ts
@@ -24,6 +24,7 @@ import {
   DrizzleVehicleDetailRepository,
   DrizzleVehicleRepository,
 } from '../../packages/api/src/repositories/drizzle'
+import { pgConnectOptions } from './pg-connect-options'
 
 // Driver note: production's getDb() uses @neondatabase/serverless (HTTP), whose
 // drizzle adapter THROWS on db.transaction() ("No transactions support in
@@ -40,20 +41,10 @@ const port = Number(process.env.REAL_API_PORT ?? 8788)
 const url = process.env.DATABASE_URL
 if (!url) throw new Error('DATABASE_URL is required for the real-DB e2e API server')
 
-// Build from URL parts so libpq-only params (channel_binding) never reach
-// postgres-js; prepare:false keeps interactive transactions safe over the Neon
-// transaction-mode pooler. Mirrors e2e/real-db/pg.ts.
-const u = new URL(url)
-const client = postgres({
-  host: u.hostname,
-  port: u.port ? Number(u.port) : 5432,
-  database: u.pathname.replace(/^\//, ''),
-  username: decodeURIComponent(u.username),
-  password: decodeURIComponent(u.password),
-  ssl: 'require',
-  prepare: false,
-  max: 5,
-})
+// Build from URL parts (see pg-connect-options) so libpq-only params never reach
+// postgres-js and TLS is off for a localhost container; prepare:false keeps
+// interactive transactions safe over the Neon transaction-mode pooler.
+const client = postgres({ ...pgConnectOptions(url), prepare: false, max: 5 })
 const db = drizzle(client, { schema }) as unknown as Db
 
 // #493: thread/message create take an injected interactive-tx runner (DIP).

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "bun run packages/shared/src/db/seed.ts",
-    "db:seed-bookings": "bun run packages/shared/src/db/seed-bookings.ts",
+    "db:seed": "bun run scripts/seed.ts",
+    "db:seed-bookings": "bun run scripts/seed-bookings.ts",
+    "db:seed:tcp": "bun run scripts/seed-tcp.ts",
     "db:verify": "bun run scripts/db-verify.ts",
     "prepare": "husky"
   },

--- a/packages/shared/src/db/seed-bookings.ts
+++ b/packages/shared/src/db/seed-bookings.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
-import { getDb } from './index'
+import type { getDb } from './index'
 import {
   type BookingCreatedPayload,
   type FeeSnapshotItem,
@@ -76,9 +76,7 @@ function feeSnapshotFor(operatorId: string, classId: string): FeeSnapshotItem[] 
 
 type SeededVehicle = { id: string; pickupLocationId: string }
 
-async function seed() {
-  const db = getDb()
-
+export async function seedBookings(db: ReturnType<typeof getDb>) {
   // --- Idempotent cleanup (FK-safe), scoped to demo-renter personas. ---
   console.log('Clearing demo bookings, events, notifications, renters...')
   const renterEmails = DEMO_RENTERS.map((r) => r.email)
@@ -238,10 +236,4 @@ async function seed() {
     `\nSeeded ${DEMO_RENTERS.length} renters, ${bookingValues.length} bookings, ` +
       `${eventValues.length} events, ${notificationValues.length} notifications.`,
   )
-  process.exit(0)
 }
-
-seed().catch((err) => {
-  console.error('Seed bookings failed:', err)
-  process.exit(1)
-})

--- a/packages/shared/src/db/seed.test.ts
+++ b/packages/shared/src/db/seed.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+import { seed } from './seed'
+import { seedBookings } from './seed-bookings'
+
+// The DIP seam (#445): the seed modules are now pure libraries — they used to
+// call getDb() + process.exit() at module scope, which made them unusable from a
+// CI runner that injects a postgres-js client to seed a local container. The
+// Neon CLI entries moved to scripts/seed*.ts; seed/seedBookings take the db as an
+// argument, so importing them must be side-effect free.
+describe('seed injection seam', () => {
+  test('exposes seed(db) as a one-argument injectable function', () => {
+    expect(typeof seed).toBe('function')
+    expect(seed.length).toBe(1)
+  })
+
+  test('exposes seedBookings(db) as a one-argument injectable function', () => {
+    expect(typeof seedBookings).toBe('function')
+    expect(seedBookings.length).toBe(1)
+  })
+})

--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -1,4 +1,4 @@
-import { getDb } from './index'
+import type { getDb } from './index'
 import { parsePlatformAdminEmails } from './platform-admins'
 import {
   feeSchedules,
@@ -45,8 +45,7 @@ function demoShakenExpiry(): string {
   return expiry.toISOString().slice(0, 10)
 }
 
-async function seed() {
-  const db = getDb()
+export async function seed(db: ReturnType<typeof getDb>) {
   const now = new Date()
 
   // 1. Operators (tenant roots). vehicles/classes/locations all FK to these, so
@@ -267,10 +266,4 @@ async function seed() {
       `${DEMO_VEHICLE_CLASSES.length} classes, ${DEMO_VEHICLES.length} vehicles, ` +
       `${DEMO_INSURANCE_OPTIONS.length} insurance options, ${DEMO_FEE_SCHEDULES.length} fee schedules.`,
   )
-  process.exit(0)
 }
-
-seed().catch((err) => {
-  console.error('Seed failed:', err)
-  process.exit(1)
-})

--- a/scripts/seed-bookings.ts
+++ b/scripts/seed-bookings.ts
@@ -1,0 +1,11 @@
+import { getDb } from '../packages/shared/src/db'
+import { seedBookings } from '../packages/shared/src/db/seed-bookings'
+
+// CLI entry for `bun run db:seed-bookings` — run AFTER db:seed (needs the seeded
+// fleet). Seeds the Neon DATABASE_URL; CI uses scripts/seed-tcp.ts for a local DB.
+seedBookings(getDb())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Seed bookings failed:', err)
+    process.exit(1)
+  })

--- a/scripts/seed-tcp.ts
+++ b/scripts/seed-tcp.ts
@@ -1,0 +1,32 @@
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { pgConnectOptions } from '../e2e/real-db/pg-connect-options'
+import type { getDb } from '../packages/shared/src/db'
+import * as schema from '../packages/shared/src/db/schema'
+import { seed } from '../packages/shared/src/db/seed'
+import { seedBookings } from '../packages/shared/src/db/seed-bookings'
+
+/**
+ * Seed a local (or any TCP-reachable) Postgres for the real-DB e2e gate (#445).
+ *
+ * The shared `seed`/`seedBookings` are injectable (DIP), so we feed them a
+ * postgres-js client instead of the production neon-http `getDb()` — neon-http
+ * speaks Neon's HTTP protocol and cannot talk to a plain `postgres:16` container.
+ * `pgConnectOptions` turns TLS off for localhost. Runs `seed` then `seedBookings`
+ * (CLAUDE.md ordering: the fleet must exist before bookings resolve vehicles).
+ */
+const url = process.env.DATABASE_URL
+if (!url) throw new Error('DATABASE_URL is required for db:seed:tcp')
+
+const client = postgres({ ...pgConnectOptions(url), max: 1 })
+// The postgres-js handle exposes the same query-builder surface the seeds are
+// typed against (neon-http); the drivers differ only in their result HKT, so a
+// single cast bridges them — the same seam real-api-server.ts uses.
+const db = drizzle(client, { schema }) as unknown as ReturnType<typeof getDb>
+
+try {
+  await seed(db)
+  await seedBookings(db)
+} finally {
+  await client.end()
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,12 @@
+import { getDb } from '../packages/shared/src/db'
+import { seed } from '../packages/shared/src/db/seed'
+
+// CLI entry for `bun run db:seed` — seeds the Neon DATABASE_URL via the
+// production neon-http getDb(). The seeding logic is the pure, injectable seed()
+// in @kuruma/shared; CI seeds a local container instead via scripts/seed-tcp.ts.
+seed(getDb())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Seed failed:', err)
+    process.exit(1)
+  })


### PR DESCRIPTION
Supersedes **#545** (which was stacked on `feat/488-demo-e2e` so GitHub never ran its checks). #488 (#544) has since merged into `marketplace-pivot`, so this is **rebased directly onto `marketplace-pivot`** — the two now-redundant #488 commits dropped — and the `e2e-real-db` CI job runs here for real. (#545's branch couldn't be force-pushed per repo policy, hence a fresh branch/PR.)

## What this adds (2 commits)
- **`498c397` Slice A** — localhost-capable DB plumbing: `pgConnectOptions` (TLS off for localhost), injectable `seed()`/`seedBookings()`, `scripts/seed-tcp.ts` + `db:seed:tcp`. Production's neon-http `getDb()` can't reach a plain `postgres:16`; postgres-js (TCP) can.
- **`9da142f` Slice D** — new `e2e-real-db` CI job: postgres:16 service + Playwright chromium → `db:migrate → db:verify → db:seed:tcp → test:e2e:real-db`. Static `AUTH_SECRET` signs+verifies the minted cookie; DB is disposable.

## Proof (local, docker postgres:16)
- `db:verify` 4/4; `test:e2e:real-db` **3 passed** (2 session mints + marketplace happy path search → storefront → vehicle → booking → confirmation → operator portal).

## Prior review (on #545)
No blocking code findings. The only item was the verification gap (checks not running while stacked) — fixed by this retarget. Shared 416 / api 1076 / web 722 / typecheck / lint all green per reviewer.

## Remaining
- [ ] `e2e-real-db` green here in CI
- [ ] **Slice E** (repo-admin): add `e2e-real-db` to `marketplace-pivot` branch-protection required checks

Refs #445