### PR TITLE
feat(operator): read-only booking detail drawer (#512 follow-up)

### DIFF
--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -74,13 +74,18 @@ async function seed() {
 
   // 2. One OPERATOR_OWNER login per operator so the demo can sign into each
   // portal. Upsert on email re-asserts role + tenant rather than duplicating.
+  // DEMO_OWNER_EMAIL (optional) rebinds the first operator's owner login to your
+  // own email, so a single Google account can both book as a renter and view the
+  // operator portal in a local demo. No-op when unset (cf. PLATFORM_ADMIN_EMAILS).
+  const demoOwnerEmail = process.env.DEMO_OWNER_EMAIL?.trim()
   console.log('Seeding operator owners...')
-  for (const op of DEMO_OPERATORS) {
+  for (const [index, op] of DEMO_OPERATORS.entries()) {
+    const email = demoOwnerEmail && index === 0 ? demoOwnerEmail : op.owner.email
     await db
       .insert(users)
       .values({
         name: op.owner.name,
-        email: op.owner.email,
+        email,
         role: 'OPERATOR_OWNER',
         operatorId: seedId(op.id),
       })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -779,6 +779,24 @@
         "ACTIVE": "Active",
         "COMPLETED": "Completed",
         "CANCELLED": "Cancelled"
+      },
+      "viewAria": "View details for booking {code}",
+      "detail": {
+        "heading": "Booking details",
+        "status": "Status",
+        "vehicle": "Vehicle",
+        "renter": "Renter",
+        "pickup": "Pick-up",
+        "return": "Return",
+        "insurance": "Insurance",
+        "deductible": "Deductible",
+        "addOns": "Add-ons",
+        "charges": "Potential charges",
+        "notes": "Notes",
+        "total": "Total",
+        "loading": "Loading booking…",
+        "loadError": "Couldn't load this booking",
+        "missing": "Booking not found"
       }
     }
   },

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -779,6 +779,24 @@
         "ACTIVE": "利用中",
         "COMPLETED": "完了",
         "CANCELLED": "キャンセル済み"
+      },
+      "viewAria": "予約 {code} の詳細を表示",
+      "detail": {
+        "heading": "予約の詳細",
+        "status": "ステータス",
+        "vehicle": "車両",
+        "renter": "利用者",
+        "pickup": "受取",
+        "return": "返却",
+        "insurance": "保険",
+        "deductible": "免責額",
+        "addOns": "オプション",
+        "charges": "発生し得る追加料金",
+        "notes": "備考",
+        "total": "合計",
+        "loading": "予約を読み込み中…",
+        "loadError": "この予約を読み込めませんでした",
+        "missing": "予約が見つかりません"
       }
     }
   },

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -779,6 +779,24 @@
         "ACTIVE": "进行中",
         "COMPLETED": "已完成",
         "CANCELLED": "已取消"
+      },
+      "viewAria": "查看预订 {code} 的详情",
+      "detail": {
+        "heading": "预订详情",
+        "status": "状态",
+        "vehicle": "车辆",
+        "renter": "租客",
+        "pickup": "取车",
+        "return": "还车",
+        "insurance": "保险",
+        "deductible": "免赔额",
+        "addOns": "附加项",
+        "charges": "可能产生的费用",
+        "notes": "备注",
+        "total": "合计",
+        "loading": "正在加载预订…",
+        "loadError": "无法加载此预订",
+        "missing": "未找到预订"
       }
     }
   },

--- a/packages/web/src/routes/$locale/_business/manage/bookings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings.tsx
@@ -1,8 +1,10 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { OperatorBookingDetailSheet } from '@/vite/operator-bookings/OperatorBookingDetailSheet'
 import { OperatorBookingsView } from '@/vite/operator-bookings/OperatorBookingsView'
-import { operatorBookingsQueryOptions } from '@/vite/operator-bookings/api'
+import { type OperatorBookingRow, operatorBookingsQueryOptions } from '@/vite/operator-bookings/api'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 
 // Operator booking list (#512). URL `/<locale>/manage/bookings` — the renter
@@ -23,6 +25,7 @@ function OperatorBookingsRoute() {
   const t = useTranslations('bookings.operator')
   const { locale } = Route.useParams()
   const { data: bookings } = useSuspenseQuery(operatorBookingsQueryOptions())
+  const [selected, setSelected] = useState<OperatorBookingRow | null>(null)
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -31,8 +34,13 @@ function OperatorBookingsRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        <OperatorBookingsView bookings={bookings} locale={locale} />
+        <OperatorBookingsView bookings={bookings} locale={locale} onSelectBooking={setSelected} />
       </div>
+      <OperatorBookingDetailSheet
+        row={selected}
+        locale={locale}
+        onClose={() => setSelected(null)}
+      />
     </main>
   )
 }

--- a/packages/web/src/vite/operator-bookings/OperatorBookingDetail.tsx
+++ b/packages/web/src/vite/operator-bookings/OperatorBookingDetail.tsx
@@ -1,0 +1,105 @@
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { BookingDto } from '@/vite/bookings/api'
+import type { OperatorBookingRow } from '@/vite/operator-bookings/api'
+import type { ReactNode } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface OperatorBookingDetailProps {
+  readonly row: OperatorBookingRow
+  readonly booking: BookingDto
+  readonly locale: string
+}
+
+// Read-only operator booking detail (#512 follow-up). Pure presentation (FC/IS):
+// the Sheet wrapper does the fetch; this renders. Vehicle + renter come from the
+// already-expanded list `row` (GET /bookings/:id does NOT expand them), while the
+// snapshots/total/notes come from the single-booking read. Mirrors the renter
+// confirmation breakdown (insurance + fee snapshots), minus its renter CTAs, and
+// reuses the `bookings.confirmation.fees.*` labels rather than duplicating them.
+export function OperatorBookingDetail({ row, booking, locale }: OperatorBookingDetailProps) {
+  const t = useTranslations('bookings.operator')
+  const tc = useTranslations('bookings.confirmation')
+  const dash = t('none')
+  const ins = booking.insuranceSnapshot
+
+  return (
+    <div className="space-y-6 px-4 pb-6 text-sm">
+      <p className="font-mono text-lg font-semibold tracking-tight">{booking.bookingCode}</p>
+
+      <dl className="space-y-3">
+        <DetailRow label={t('detail.status')}>{t(`status.${booking.status}`)}</DetailRow>
+        <DetailRow label={t('detail.vehicle')}>{row.vehicleName ?? dash}</DetailRow>
+        <DetailRow label={t('detail.renter')}>
+          {row.renter?.name ?? row.renter?.email ?? dash}
+        </DetailRow>
+        <DetailRow label={t('detail.pickup')}>{formatDateTime(booking.startAt, locale)}</DetailRow>
+        <DetailRow label={t('detail.return')}>{formatDateTime(booking.endAt, locale)}</DetailRow>
+        <DetailRow label={t('detail.insurance')}>
+          {ins
+            ? `${ins.name} · ${formatJpy(ins.dailyPriceJpy)}${tc('perDay')}`
+            : tc('insuranceDeclined')}
+        </DetailRow>
+        {ins?.deductibleJpy != null && (
+          <DetailRow label={t('detail.deductible')}>{formatJpy(ins.deductibleJpy)}</DetailRow>
+        )}
+      </dl>
+
+      {booking.addOnSnapshot.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="font-semibold">{t('detail.addOns')}</h3>
+          <ul className="space-y-1">
+            {booking.addOnSnapshot.map((addOn) => (
+              <li key={addOn.addOnId} className="flex justify-between gap-4">
+                <span className="text-muted-foreground">{addOn.name}</span>
+                <span className="tabular-nums">{formatJpy(addOn.priceJpy)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {booking.feeSnapshot.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="font-semibold">{t('detail.charges')}</h3>
+          <ul className="space-y-1">
+            {booking.feeSnapshot.map((fee) => (
+              <li
+                key={`${fee.feeType}-${fee.vehicleClassId ?? 'all'}`}
+                className="flex justify-between gap-4"
+              >
+                <span className="text-muted-foreground">{tc(`fees.type.${fee.feeType}`)}</span>
+                <span className="tabular-nums">
+                  {formatJpy(fee.amountJpy)} {tc(`fees.unit.${fee.unit}`)}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-muted-foreground">{tc('fees.disclaimer')}</p>
+        </section>
+      )}
+
+      {booking.notes != null && booking.notes !== '' && (
+        <section className="space-y-1">
+          <h3 className="font-semibold">{t('detail.notes')}</h3>
+          <p className="whitespace-pre-wrap text-muted-foreground">{booking.notes}</p>
+        </section>
+      )}
+
+      <div className="flex justify-between border-t border-border pt-3 font-semibold">
+        <span>{t('detail.total')}</span>
+        <span className="tabular-nums">
+          {booking.totalPrice == null ? dash : formatJpy(booking.totalPrice)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="text-right font-medium">{children}</dd>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/OperatorBookingDetailSheet.tsx
+++ b/packages/web/src/vite/operator-bookings/OperatorBookingDetailSheet.tsx
@@ -1,0 +1,57 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { bookingByIdQueryOptions } from '@/vite/bookings/api'
+import { OperatorBookingDetail } from '@/vite/operator-bookings/OperatorBookingDetail'
+import type { OperatorBookingRow } from '@/vite/operator-bookings/api'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslations } from 'use-intl'
+
+interface OperatorBookingDetailSheetProps {
+  /** The row whose details to show, or null when the drawer is closed. */
+  readonly row: OperatorBookingRow | null
+  readonly locale: string
+  readonly onClose: () => void
+}
+
+// Imperative shell for the read-only detail drawer (#512 follow-up). Owns the
+// Sheet open/close and the single-booking fetch; delegates rendering to the pure
+// OperatorBookingDetail. The body only mounts while a row is selected, so the
+// query (and its hook) never runs with a null id.
+export function OperatorBookingDetailSheet({
+  row,
+  locale,
+  onClose,
+}: OperatorBookingDetailSheetProps) {
+  const t = useTranslations('bookings.operator.detail')
+
+  return (
+    <Sheet
+      open={row != null}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{t('heading')}</SheetTitle>
+        </SheetHeader>
+        {row != null && <DetailBody row={row} locale={locale} />}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function DetailBody({ row, locale }: { row: OperatorBookingRow; locale: string }) {
+  const t = useTranslations('bookings.operator.detail')
+  const { data, isPending, isError } = useQuery(bookingByIdQueryOptions(row.id))
+
+  if (isPending) {
+    return <p className="px-4 pb-6 text-muted-foreground">{t('loading')}</p>
+  }
+  if (isError) {
+    return <p className="px-4 pb-6 text-destructive">{t('loadError')}</p>
+  }
+  if (data == null) {
+    return <p className="px-4 pb-6 text-muted-foreground">{t('missing')}</p>
+  }
+  return <OperatorBookingDetail row={row} booking={data} locale={locale} />
+}

--- a/packages/web/src/vite/operator-bookings/OperatorBookingsView.tsx
+++ b/packages/web/src/vite/operator-bookings/OperatorBookingsView.tsx
@@ -6,12 +6,19 @@ import { useTranslations } from 'use-intl'
 interface OperatorBookingsViewProps {
   readonly bookings: readonly OperatorBookingRow[]
   readonly locale: string
+  /** Opens the read-only detail drawer for a row. Optional + no-op default keeps
+   * the table usable in isolation (and in tests that only assert rendering). */
+  readonly onSelectBooking?: (booking: OperatorBookingRow) => void
 }
 
 // Presentational table + empty state. The route owns the loader/useSuspenseQuery
 // and the pending/error boundaries; this stays a pure function of the resolved
 // rows so it is unit-testable (FC/IS — the shell does I/O, this renders).
-export function OperatorBookingsView({ bookings, locale }: OperatorBookingsViewProps) {
+export function OperatorBookingsView({
+  bookings,
+  locale,
+  onSelectBooking,
+}: OperatorBookingsViewProps) {
   const t = useTranslations('bookings.operator')
   const dash = t('none')
 
@@ -39,8 +46,20 @@ export function OperatorBookingsView({ bookings, locale }: OperatorBookingsViewP
         </thead>
         <tbody>
           {bookings.map((booking) => (
-            <tr key={booking.id} className="border-b border-border last:border-0">
-              <td className="px-4 py-3 font-mono font-medium">{booking.bookingCode}</td>
+            <tr
+              key={booking.id}
+              className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
+            >
+              <td className="px-4 py-3 font-mono font-medium">
+                <button
+                  type="button"
+                  onClick={() => onSelectBooking?.(booking)}
+                  aria-label={t('viewAria', { code: booking.bookingCode })}
+                  className="rounded text-left underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  {booking.bookingCode}
+                </button>
+              </td>
               <td className="px-4 py-3">{booking.vehicleName ?? dash}</td>
               <td className="px-4 py-3">{booking.renter?.name ?? booking.renter?.email ?? dash}</td>
               <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingDetail.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingDetail.test.tsx
@@ -1,0 +1,124 @@
+import type { BookingDto } from '@/vite/bookings/api'
+import { OperatorBookingDetail } from '@/vite/operator-bookings/OperatorBookingDetail'
+import type { OperatorBookingRow } from '@/vite/operator-bookings/api'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+function makeRow(over: Partial<OperatorBookingRow> = {}): OperatorBookingRow {
+  return {
+    id: 'bk-1',
+    bookingCode: 'H7K2M9PQ',
+    status: 'CONFIRMED',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    totalPrice: 18000,
+    vehicleName: 'Toyota Camry',
+    renter: { id: 'r-1', name: 'Jane Renter', email: 'jane@example.com' },
+    ...over,
+  }
+}
+
+function makeBooking(over: Partial<BookingDto> = {}): BookingDto {
+  return {
+    id: 'bk-1',
+    bookingCode: 'H7K2M9PQ',
+    renterId: 'r-1',
+    classId: 'cls-1',
+    requestedVehicleId: 'v-1',
+    assignedVehicleId: 'v-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    effectiveEndAt: '2026-07-03T01:00:00.000Z',
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    insuranceOptionId: 'ins-1',
+    insuranceSnapshot: {
+      insuranceOptionId: 'ins-1',
+      name: 'Premium',
+      dailyPriceJpy: 2000,
+      deductibleJpy: 50000,
+    },
+    feeSnapshot: [
+      { feeType: 'CLEANING_FLAT', unit: 'FLAT', amountJpy: 5000, vehicleClassId: null },
+    ],
+    addOnSnapshot: [{ addOnId: 'ao-1', name: 'Baby seat', priceJpy: 1500 }],
+    totalPrice: 18000,
+    notes: 'Late arrival expected',
+    createdAt: '2026-06-20T00:00:00.000Z',
+    updatedAt: '2026-06-20T00:00:00.000Z',
+    ...over,
+  }
+}
+
+function renderDetail(row: OperatorBookingRow, booking: BookingDto) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <OperatorBookingDetail row={row} booking={booking} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('OperatorBookingDetail', () => {
+  it('shows the booking code and status label', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('H7K2M9PQ')).toBeInTheDocument()
+    expect(screen.getByText('Confirmed')).toBeInTheDocument()
+  })
+
+  it('shows the assigned vehicle and renter from the row', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('Toyota Camry')).toBeInTheDocument()
+    expect(screen.getByText('Jane Renter')).toBeInTheDocument()
+  })
+
+  it('shows the JST pick-up and return datetimes', () => {
+    renderDetail(makeRow(), makeBooking())
+    // Asia/Tokyo: 01:00Z -> Jul 1 10:00; 03 Jul 01:00Z -> Jul 3 10:00
+    expect(screen.getByText(/Jul 1, 2026/)).toBeInTheDocument()
+    expect(screen.getByText(/Jul 3, 2026/)).toBeInTheDocument()
+  })
+
+  it('shows the insurance name, daily price, and deductible', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText(/Premium/)).toBeInTheDocument()
+    expect(screen.getByText(/￥2,000/)).toBeInTheDocument()
+    expect(screen.getByText('￥50,000')).toBeInTheDocument()
+  })
+
+  it('shows "Declined" when there is no insurance snapshot', () => {
+    renderDetail(makeRow(), makeBooking({ insuranceSnapshot: null, insuranceOptionId: null }))
+    expect(screen.getByText('Declined')).toBeInTheDocument()
+  })
+
+  it('lists each potential charge with its amount and unit', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('Cleaning')).toBeInTheDocument()
+    expect(screen.getByText(/￥5,000/)).toBeInTheDocument()
+    expect(screen.getByText(/flat/)).toBeInTheDocument()
+  })
+
+  it('lists each paid add-on with its name and price', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('Baby seat')).toBeInTheDocument()
+    expect(screen.getByText('￥1,500')).toBeInTheDocument()
+  })
+
+  it('shows operator notes when present', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('Late arrival expected')).toBeInTheDocument()
+  })
+
+  it('omits the notes block when notes is null', () => {
+    renderDetail(makeRow(), makeBooking({ notes: null }))
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument()
+  })
+
+  it('shows the total price', () => {
+    renderDetail(makeRow(), makeBooking())
+    expect(screen.getByText('￥18,000')).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingDetailSheet.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingDetailSheet.test.tsx
@@ -1,0 +1,119 @@
+import type { BookingDto } from '@/vite/bookings/api'
+import { OperatorBookingDetailSheet } from '@/vite/operator-bookings/OperatorBookingDetailSheet'
+import type { OperatorBookingRow } from '@/vite/operator-bookings/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// The base-ui Sheet is a portal-backed dialog that is flaky to open in happy-dom,
+// so replace it with a passthrough (mirrors MobileMenu.test). The drawer's own
+// `{row != null && <DetailBody/>}` gate still controls whether the body mounts.
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+// Control the single-booking fetch per test without touching the network.
+const queryFn = vi.fn()
+vi.mock('@/vite/bookings/api', () => ({
+  bookingByIdQueryOptions: (id: string) => ({ queryKey: ['bookings', id], queryFn }),
+}))
+
+function makeRow(over: Partial<OperatorBookingRow> = {}): OperatorBookingRow {
+  return {
+    id: 'bk-1',
+    bookingCode: 'H7K2M9PQ',
+    status: 'CONFIRMED',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    totalPrice: 18000,
+    vehicleName: 'Toyota Camry',
+    renter: { id: 'r-1', name: 'Jane Renter', email: 'jane@example.com' },
+    ...over,
+  }
+}
+
+function makeBooking(): BookingDto {
+  return {
+    id: 'bk-1',
+    bookingCode: 'H7K2M9PQ',
+    renterId: 'r-1',
+    classId: 'cls-1',
+    requestedVehicleId: 'v-1',
+    assignedVehicleId: 'v-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    effectiveEndAt: '2026-07-03T01:00:00.000Z',
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    insuranceOptionId: 'ins-1',
+    insuranceSnapshot: {
+      insuranceOptionId: 'ins-1',
+      name: 'Premium',
+      dailyPriceJpy: 2000,
+      deductibleJpy: 50000,
+    },
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    totalPrice: 18000,
+    notes: null,
+    createdAt: '2026-06-20T00:00:00.000Z',
+    updatedAt: '2026-06-20T00:00:00.000Z',
+  }
+}
+
+function renderSheet(row: OperatorBookingRow | null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        <OperatorBookingDetailSheet row={row} locale="en" onClose={() => {}} />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('OperatorBookingDetailSheet', () => {
+  beforeEach(() => {
+    queryFn.mockReset()
+  })
+
+  it('shows a loading message while the booking is being fetched', () => {
+    queryFn.mockReturnValue(new Promise(() => {})) // never resolves -> stays pending
+    renderSheet(makeRow())
+    expect(screen.getByText('Loading booking…')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the fetch rejects', async () => {
+    queryFn.mockRejectedValue(new Error('boom'))
+    renderSheet(makeRow())
+    await waitFor(() => expect(screen.getByText("Couldn't load this booking")).toBeInTheDocument())
+  })
+
+  it('shows a not-found message when the booking resolves to null', async () => {
+    queryFn.mockResolvedValue(null)
+    renderSheet(makeRow())
+    await waitFor(() => expect(screen.getByText('Booking not found')).toBeInTheDocument())
+  })
+
+  it('renders the detail panel once the booking loads', async () => {
+    queryFn.mockResolvedValue(makeBooking())
+    renderSheet(makeRow())
+    await waitFor(() => expect(screen.getByText('H7K2M9PQ')).toBeInTheDocument())
+    expect(screen.getByText(/Premium/)).toBeInTheDocument()
+    expect(screen.getByText('Toyota Camry')).toBeInTheDocument()
+  })
+
+  it('does not fetch when no row is selected (drawer closed)', () => {
+    renderSheet(null)
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(screen.queryByText('Loading booking…')).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsView.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsView.test.tsx
@@ -1,8 +1,8 @@
 import { OperatorBookingsView } from '@/vite/operator-bookings/OperatorBookingsView'
 import type { OperatorBookingRow } from '@/vite/operator-bookings/api'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 function makeRow(over: Partial<OperatorBookingRow> = {}): OperatorBookingRow {
@@ -67,5 +67,20 @@ describe('OperatorBookingsView', () => {
     renderView([])
     expect(screen.getByText('No bookings yet')).toBeInTheDocument()
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('calls onSelectBooking with the row when the booking code button is clicked', () => {
+    const onSelectBooking = vi.fn()
+    const row = makeRow()
+    render(
+      <IntlProvider locale="en" messages={en}>
+        <OperatorBookingsView bookings={[row]} locale="en" onSelectBooking={onSelectBooking} />
+      </IntlProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /View details for booking ABCD2345/ }))
+
+    expect(onSelectBooking).toHaveBeenCalledTimes(1)
+    expect(onSelectBooking).toHaveBeenCalledWith(row)
   })
 })


### PR DESCRIPTION
## What

The operator bookings list (#512) shipped as a flat, read-only table — no way to drill into a reservation. This adds a **read-only detail drawer**: clicking a booking code opens a right-side Sheet showing the full breakdown that the renter confirmation page shows.

Shown: status, vehicle, renter, pick-up/return (JST), insurance (name · daily price) + deductible, paid add-ons, potential charges (fee snapshot + disclaimer), operator notes, and total.

**No API or DB changes** — reuses the already-tenant-scoped `GET /bookings/:id` (IDOR-sealed, #396) and the renter booking DTO + `formatJpy`/`formatDateTime` helpers.

## How
- `OperatorBookingDetail.tsx` — pure presentational panel (FC/IS), fully unit-tested (10 tests).
- `OperatorBookingDetailSheet.tsx` — imperative shell: owns Sheet open/close, fetches by id, handles loading/error/missing.
- `OperatorBookingsView.tsx` — booking code is now a focusable `<button>` calling `onSelectBooking` (keyboard-accessible; avoids the clickable-`<tr>` a11y anti-pattern Biome flags).
- Route owns the selected-row state; `en`/`ja`/`zh` keys added.

Also includes a small **`DEMO_OWNER_EMAIL` seed knob** (separate commit) that binds one demo operator's owner login to your own email so a single Google account can both book and view the operator portal locally. No-op when unset; mirrors `PLATFORM_ADMIN_EMAILS`.

## Test plan
- [x] web typecheck 0
- [x] web vitest **752 passed** (incl. 17 new operator-bookings tests)
- [x] i18n parity (en/ja/zh) passes
- [x] vite build 0 · biome clean · lint:modules clean

## Deferred
- **Event timeline** (created / vehicle-substituted / cancelled history) needs a new `GET /bookings/:id/events` endpoint — the repo read exists, but no route exposes it. Left out to keep this a clean web-only slice.