### PR TITLE
feat(operator): fleet management foundation + read-only list (#526)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -450,6 +450,35 @@
         "noMaintenanceHistory": "No maintenance records yet"
       },
       "fleet": {
+        "title": "Fleet",
+        "subtitle": "Every vehicle across your storefronts",
+        "addVehicle": "Add vehicle",
+        "empty": "No vehicles yet. Add your first car to start renting.",
+        "loadError": "Couldn't load your fleet",
+        "retry": "Try again",
+        "none": "—",
+        "perDay": "/day",
+        "perHour": "/hr",
+        "columns": {
+          "vehicle": "Vehicle",
+          "status": "Status",
+          "seats": "Seats",
+          "luggage": "Luggage",
+          "price": "Price",
+          "shaken": "Sha-ken",
+          "actions": "Actions"
+        },
+        "status": {
+          "AVAILABLE": "Available",
+          "MAINTENANCE": "Maintenance",
+          "RETIRED": "Retired"
+        },
+        "expiry": {
+          "OK": "Valid",
+          "EXPIRING_SOON": "Expiring soon",
+          "EXPIRED": "Expired",
+          "UNKNOWN": "—"
+        },
         "rowView": "Row view",
         "gridView": "Grid view",
         "moreActions": "More actions",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -450,6 +450,35 @@
         "noMaintenanceHistory": "メンテナンス記録なし"
       },
       "fleet": {
+        "title": "車両",
+        "subtitle": "全店舗の車両",
+        "addVehicle": "車両を追加",
+        "empty": "車両がまだありません。最初の車両を追加して貸出を始めましょう。",
+        "loadError": "車両の読み込みに失敗しました",
+        "retry": "再試行",
+        "none": "—",
+        "perDay": "/日",
+        "perHour": "/時間",
+        "columns": {
+          "vehicle": "車両",
+          "status": "ステータス",
+          "seats": "座席",
+          "luggage": "荷物",
+          "price": "料金",
+          "shaken": "車検",
+          "actions": "操作"
+        },
+        "status": {
+          "AVAILABLE": "利用可能",
+          "MAINTENANCE": "整備中",
+          "RETIRED": "廃車"
+        },
+        "expiry": {
+          "OK": "有効",
+          "EXPIRING_SOON": "まもなく期限切れ",
+          "EXPIRED": "期限切れ",
+          "UNKNOWN": "—"
+        },
         "rowView": "リスト表示",
         "gridView": "グリッド表示",
         "moreActions": "その他の操作",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -450,6 +450,35 @@
         "noMaintenanceHistory": "还没有维修记录"
       },
       "fleet": {
+        "title": "车队",
+        "subtitle": "所有门店的车辆",
+        "addVehicle": "添加车辆",
+        "empty": "暂无车辆。添加第一辆车开始出租。",
+        "loadError": "无法加载车队",
+        "retry": "重试",
+        "none": "—",
+        "perDay": "/天",
+        "perHour": "/小时",
+        "columns": {
+          "vehicle": "车辆",
+          "status": "状态",
+          "seats": "座位",
+          "luggage": "行李",
+          "price": "价格",
+          "shaken": "车检",
+          "actions": "操作"
+        },
+        "status": {
+          "AVAILABLE": "可用",
+          "MAINTENANCE": "维护中",
+          "RETIRED": "已停用"
+        },
+        "expiry": {
+          "OK": "有效",
+          "EXPIRING_SOON": "即将到期",
+          "EXPIRED": "已过期",
+          "UNKNOWN": "—"
+        },
         "rowView": "列表视图",
         "gridView": "网格视图",
         "moreActions": "更多操作",

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as LocaleProviderInviteTokenRouteImport } from './routes/$locale/
 import { Route as LocaleManageOperatorSlugDashboardRouteImport } from './routes/$locale/manage/$operatorSlug/dashboard'
 import { Route as LocaleRenterBookingsNewRouteImport } from './routes/$locale/_renter/bookings/new'
 import { Route as LocaleRenterBookingsConfirmationRouteImport } from './routes/$locale/_renter/bookings/confirmation'
+import { Route as LocaleBusinessManageFleetRouteImport } from './routes/$locale/_business/manage/fleet'
 import { Route as LocaleBusinessManageBookingsRouteImport } from './routes/$locale/_business/manage/bookings'
 import { Route as LocaleAdminAdminRevenueRouteImport } from './routes/$locale/_admin/admin/revenue'
 
@@ -154,6 +155,12 @@ const LocaleRenterBookingsConfirmationRoute =
     path: '/confirmation',
     getParentRoute: () => LocaleRenterBookingsRoute,
   } as any)
+const LocaleBusinessManageFleetRoute =
+  LocaleBusinessManageFleetRouteImport.update({
+    id: '/manage/fleet',
+    path: '/manage/fleet',
+    getParentRoute: () => LocaleBusinessRoute,
+  } as any)
 const LocaleBusinessManageBookingsRoute =
   LocaleBusinessManageBookingsRouteImport.update({
     id: '/manage/bookings',
@@ -182,6 +189,7 @@ export interface FileRoutesByFullPath {
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/bookings': typeof LocaleBusinessManageBookingsRoute
+  '/$locale/manage/fleet': typeof LocaleBusinessManageFleetRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/manage/$operatorSlug/dashboard': typeof LocaleManageOperatorSlugDashboardRoute
@@ -204,6 +212,7 @@ export interface FileRoutesByTo {
   '/$locale/vehicles': typeof LocaleVehiclesIndexRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/bookings': typeof LocaleBusinessManageBookingsRoute
+  '/$locale/manage/fleet': typeof LocaleBusinessManageFleetRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/manage/$operatorSlug/dashboard': typeof LocaleManageOperatorSlugDashboardRoute
@@ -232,6 +241,7 @@ export interface FileRoutesById {
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
   '/$locale/_admin/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/_business/manage/bookings': typeof LocaleBusinessManageBookingsRoute
+  '/$locale/_business/manage/fleet': typeof LocaleBusinessManageFleetRoute
   '/$locale/_renter/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/_renter/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/manage/$operatorSlug/dashboard': typeof LocaleManageOperatorSlugDashboardRoute
@@ -258,6 +268,7 @@ export interface FileRouteTypes {
     | '/$locale/vehicles/'
     | '/$locale/admin/revenue'
     | '/$locale/manage/bookings'
+    | '/$locale/manage/fleet'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/manage/$operatorSlug/dashboard'
@@ -280,6 +291,7 @@ export interface FileRouteTypes {
     | '/$locale/vehicles'
     | '/$locale/admin/revenue'
     | '/$locale/manage/bookings'
+    | '/$locale/manage/fleet'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/manage/$operatorSlug/dashboard'
@@ -307,6 +319,7 @@ export interface FileRouteTypes {
     | '/$locale/vehicles/'
     | '/$locale/_admin/admin/revenue'
     | '/$locale/_business/manage/bookings'
+    | '/$locale/_business/manage/fleet'
     | '/$locale/_renter/bookings/confirmation'
     | '/$locale/_renter/bookings/new'
     | '/$locale/manage/$operatorSlug/dashboard'
@@ -485,6 +498,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleRenterBookingsConfirmationRouteImport
       parentRoute: typeof LocaleRenterBookingsRoute
     }
+    '/$locale/_business/manage/fleet': {
+      id: '/$locale/_business/manage/fleet'
+      path: '/manage/fleet'
+      fullPath: '/$locale/manage/fleet'
+      preLoaderRoute: typeof LocaleBusinessManageFleetRouteImport
+      parentRoute: typeof LocaleBusinessRoute
+    }
     '/$locale/_business/manage/bookings': {
       id: '/$locale/_business/manage/bookings'
       path: '/manage/bookings'
@@ -519,11 +539,13 @@ const LocaleAdminRouteWithChildren = LocaleAdminRoute._addFileChildren(
 interface LocaleBusinessRouteChildren {
   LocaleBusinessDashboardRoute: typeof LocaleBusinessDashboardRoute
   LocaleBusinessManageBookingsRoute: typeof LocaleBusinessManageBookingsRoute
+  LocaleBusinessManageFleetRoute: typeof LocaleBusinessManageFleetRoute
 }
 
 const LocaleBusinessRouteChildren: LocaleBusinessRouteChildren = {
   LocaleBusinessDashboardRoute: LocaleBusinessDashboardRoute,
   LocaleBusinessManageBookingsRoute: LocaleBusinessManageBookingsRoute,
+  LocaleBusinessManageFleetRoute: LocaleBusinessManageFleetRoute,
 }
 
 const LocaleBusinessRouteWithChildren = LocaleBusinessRoute._addFileChildren(

--- a/packages/web/src/routes/$locale/_business/manage/fleet.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fleet.tsx
@@ -1,0 +1,57 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
+import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useTranslations } from 'use-intl'
+
+// Operator fleet management (#526). URL `/<locale>/manage/fleet` — behind the
+// `_business` guard, so only business roles reach it; tenant scoping is
+// server-side (CallerContext), the client passes no operatorId. The loader
+// prefetches into the query cache (no FOUC); the component reads the same
+// options via useSuspenseQuery. This foundation ships the read-only list; the
+// CRUD / filters / bulk / photo slices are mounted here at integration (#526).
+export const Route = createFileRoute('/$locale/_business/manage/fleet')({
+  loader: ({ context }) => context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+  pendingComponent: PageSkeleton,
+  errorComponent: OperatorFleetError,
+  component: OperatorFleetRoute,
+})
+
+function OperatorFleetRoute() {
+  const t = useTranslations('business.vehicles.fleet')
+  const { locale } = Route.useParams()
+  const { data: vehicles } = useSuspenseQuery(operatorFleetQueryOptions())
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
+          <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
+        </header>
+        <OperatorFleetView vehicles={vehicles} locale={locale} />
+      </div>
+    </main>
+  )
+}
+
+function OperatorFleetError(_props: ErrorComponentProps) {
+  const t = useTranslations('business.vehicles.fleet')
+  const router = useRouter()
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl py-20 text-center">
+        <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+        <button
+          type="button"
+          onClick={() => router.invalidate()}
+          className="mt-4 rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -16,6 +16,7 @@ export type NavTo =
   | '/$locale/dashboard'
   | '/$locale/bookings'
   | '/$locale/manage/bookings'
+  | '/$locale/manage/fleet'
   | '/$locale/search'
   | '/$locale/documents'
 

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -36,6 +36,7 @@ export function Navbar() {
       ? [
           { to: '/$locale/dashboard', label: t('dashboard') },
           { to: '/$locale/manage/bookings', label: t('bookings') },
+          { to: '/$locale/manage/fleet', label: t('fleet') },
         ]
       : session?.user
         ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -1,0 +1,126 @@
+import { formatVehicleRate } from '@/lib/format'
+import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
+import { type ExpiryStatus, computeExpiryStatus } from '@kuruma/shared/lib/expiry'
+import { CarFront } from 'lucide-react'
+import { useTranslations } from 'use-intl'
+
+interface OperatorFleetViewProps {
+  readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly locale: string
+}
+
+// Presentational fleet table + empty state. The route owns the loader /
+// useSuspenseQuery and the pending/error boundaries; this stays a pure function
+// of the resolved rows so it is unit-testable (FC/IS — the shell does I/O, this
+// renders). The CRUD / filters / bulk / photo affordances land as separate
+// controlled components in follow-up slices (#526) and are mounted here at
+// integration; this foundation ships the read-only list only.
+export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetViewProps) {
+  const t = useTranslations('business.vehicles.fleet')
+  const todayIso = new Date().toISOString().slice(0, 10)
+
+  if (vehicles.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-border py-20">
+        <CarFront className="mb-4 size-12 text-muted-foreground/30" />
+        <p className="text-lg text-muted-foreground">{t('empty')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border">
+      <table className="w-full text-left text-sm">
+        <thead className="border-b border-border bg-muted/40 text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
+            <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
+            <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vehicles.map((v) => (
+            <tr
+              key={v.id}
+              className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
+            >
+              <td className="px-4 py-3">
+                <div className="font-medium">{v.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  <span>{v.licensePlate ?? t('none')}</span>
+                  {v.make != null && (
+                    <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
+                  )}
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <StatusPill status={v.status} label={t(`status.${v.status}`)} />
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {v.luggageCapacity ?? t('none')}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
+              <td className="px-4 py-3">
+                <ExpiryPill
+                  status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
+                  labels={{
+                    OK: t('expiry.OK'),
+                    EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
+                    EXPIRED: t('expiry.EXPIRED'),
+                    UNKNOWN: t('expiry.UNKNOWN'),
+                  }}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function priceLabel(v: OperatorFleetVehicle, t: (k: string) => string) {
+  return (
+    formatVehicleRate(v.dailyRateJpy, v.hourlyRateJpy, {
+      perDay: t('perDay'),
+      perHour: t('perHour'),
+    }) ?? t('none')
+  )
+}
+
+const STATUS_PILL: Record<VehicleStatus, string> = {
+  AVAILABLE: 'border-transparent bg-muted text-foreground',
+  MAINTENANCE: 'border-amber-300 text-amber-700 dark:text-amber-400',
+  RETIRED: 'border-transparent bg-muted text-muted-foreground',
+}
+
+function StatusPill({ status, label }: { status: VehicleStatus; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_PILL[status]}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+const EXPIRY_PILL: Record<ExpiryStatus, string> = {
+  OK: 'text-muted-foreground',
+  EXPIRING_SOON: 'text-amber-700 dark:text-amber-400',
+  EXPIRED: 'text-destructive font-medium',
+  UNKNOWN: 'text-muted-foreground',
+}
+
+function ExpiryPill({
+  status,
+  labels,
+}: {
+  status: ExpiryStatus
+  labels: Record<ExpiryStatus, string>
+}) {
+  return <span className={`text-xs ${EXPIRY_PILL[status]}`}>{labels[status]}</span>
+}

--- a/packages/web/src/vite/operator-fleet/api.ts
+++ b/packages/web/src/vite/operator-fleet/api.ts
@@ -1,0 +1,189 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import type { LuggageSize } from '@kuruma/shared/lib/luggage'
+import type {
+  BulkVehicleStatus,
+  CreateVehicleInput,
+  UpdateVehicleInput,
+  VehicleStatus,
+} from '@kuruma/shared/validators/vehicle'
+import { queryOptions } from '@tanstack/react-query'
+
+// #526: operator fleet management. The Vite shell owns this read projection (it
+// never imports the frozen Next module's `vehicle-api.ts`, which is hono-client +
+// Bearer-token) so it stays self-contained and cookie-based like the rest of the
+// shell. The list endpoint is operator-scoped server-side via the session cookie
+// (CallerContext), so this client passes NO operatorId — a cross-tenant read is
+// impossible from here by construction. Canonical write types come from
+// @kuruma/shared so the (#526 follow-up) forms stay in lockstep with the Zod
+// validators rather than drifting a parallel copy.
+
+export type { BulkVehicleStatus, CreateVehicleInput, UpdateVehicleInput, VehicleStatus }
+
+/** A booking touching a fleet vehicle, as the overview needs it. ISO strings. */
+export interface FleetBookingSummary {
+  startAt: string
+  endAt: string
+  renterName: string | null
+}
+
+/**
+ * One fleet row from `GET /vehicles/fleet-overview`. Mirrors
+ * `@kuruma/shared/types/fleet.FleetVehicleOverview` with dates as ISO strings
+ * (JSON-serialized). If a field is added there, add it here too.
+ */
+export interface OperatorFleetVehicle {
+  id: string
+  operatorId: string
+  classId: string | null
+  pickupLocationId: string | null
+  name: string
+  description: string | null
+  photos: string[]
+  seats: number
+  luggageCapacity: number | null
+  luggageSize: LuggageSize | null
+  transmission: 'AUTO' | 'MANUAL'
+  fuelType: string | null
+  licensePlate: string | null
+  status: VehicleStatus
+  minRentalHours: number | null
+  maxRentalHours: number | null
+  advanceBookingHours: number | null
+  make: string | null
+  model: string | null
+  year: number | null
+  color: string | null
+  dailyRateJpy: number | null
+  hourlyRateJpy: number | null
+  shakenExpiryDate: string | null
+  insuranceExpiryDate: string | null
+  createdAt: string
+  updatedAt: string
+  utilization: number
+  bookingCountLast30Days: number
+  currentBooking: FleetBookingSummary | null
+  nextBooking: FleetBookingSummary | null
+  activeMaintenanceReason: string | null
+}
+
+export const FLEET_QUERY_KEY = ['operator-fleet'] as const
+
+export async function fetchOperatorFleet(): Promise<OperatorFleetVehicle[]> {
+  const res = await fetch(`${getApiBaseUrl()}/vehicles/fleet-overview`, {
+    credentials: 'include',
+  })
+  return unwrap<OperatorFleetVehicle[]>(res)
+}
+
+export function operatorFleetQueryOptions() {
+  return queryOptions({
+    queryKey: FLEET_QUERY_KEY,
+    queryFn: fetchOperatorFleet,
+  })
+}
+
+// --- Mutations (cookie-based; consumed by the #526 follow-up slices) ----------
+// All write paths are operator-scoped server-side; the client never names a
+// tenant. Each unwraps the ok() envelope and throws ApiError on failure so the
+// caller's useMutation onError can surface it.
+
+async function writeJson<T>(path: string, method: 'POST' | 'PATCH', body: unknown): Promise<T> {
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method,
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return unwrap<T>(res)
+}
+
+export function createVehicle(data: CreateVehicleInput): Promise<OperatorFleetVehicle> {
+  return writeJson<OperatorFleetVehicle>('/vehicles', 'POST', data)
+}
+
+export function updateVehicle(id: string, data: UpdateVehicleInput): Promise<OperatorFleetVehicle> {
+  return writeJson<OperatorFleetVehicle>(`/vehicles/${encodeURIComponent(id)}`, 'PATCH', data)
+}
+
+export function updateVehicleStatus(
+  id: string,
+  status: VehicleStatus,
+  reason?: string,
+): Promise<OperatorFleetVehicle> {
+  const body = reason != null ? { status, reason } : { status }
+  return writeJson<OperatorFleetVehicle>(
+    `/vehicles/${encodeURIComponent(id)}/status`,
+    'PATCH',
+    body,
+  )
+}
+
+export function bulkUpdateVehicleStatus(
+  vehicleIds: string[],
+  status: BulkVehicleStatus,
+): Promise<OperatorFleetVehicle[]> {
+  return writeJson<OperatorFleetVehicle[]>('/vehicles/bulk-status', 'PATCH', { vehicleIds, status })
+}
+
+export async function retireVehicle(id: string): Promise<OperatorFleetVehicle> {
+  const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  })
+  return unwrap<OperatorFleetVehicle>(res)
+}
+
+export interface PhotoUploadResult {
+  uploaded: string[]
+  total: number
+}
+
+export interface PhotoDeleteResult {
+  deleted: string
+  remaining: number
+}
+
+export async function uploadVehiclePhotos(
+  vehicleId: string,
+  files: readonly File[],
+): Promise<PhotoUploadResult> {
+  const formData = new FormData()
+  for (const file of files) formData.append('file', file)
+  const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/photos`, {
+    method: 'POST',
+    credentials: 'include',
+    body: formData,
+  })
+  return unwrap<PhotoUploadResult>(res)
+}
+
+export async function deleteVehiclePhoto(
+  vehicleId: string,
+  photoUrl: string,
+): Promise<PhotoDeleteResult> {
+  const url = `${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/photos?url=${encodeURIComponent(photoUrl)}`
+  const res = await fetch(url, { method: 'DELETE', credentials: 'include' })
+  return unwrap<PhotoDeleteResult>(res)
+}
+
+// Minimal class list for the Add/Edit form's class dropdown — kept here so the
+// form slice (#526 follow-up) reads it without touching the classes feature
+// (#528). Operator-scoped server-side.
+export interface VehicleClassOption {
+  id: string
+  name: string
+}
+
+export async function fetchVehicleClassOptions(): Promise<VehicleClassOption[]> {
+  const res = await fetch(`${getApiBaseUrl()}/vehicle-classes`, { credentials: 'include' })
+  const data = await unwrap<Array<{ id: string; name: string }>>(res)
+  return data.map((c) => ({ id: c.id, name: c.name }))
+}
+
+export function vehicleClassOptionsQueryOptions() {
+  return queryOptions({
+    queryKey: ['operator-fleet', 'class-options'],
+    queryFn: fetchVehicleClassOptions,
+  })
+}

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -82,7 +82,7 @@ describe('Navbar', () => {
     expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '0')
   })
 
-  it('shows the dashboard + operator bookings links and business markers for a business user', () => {
+  it('shows the dashboard, operator bookings + fleet links and business markers for a business user', () => {
     const { container } = renderNavbar(business)
     expect(screen.getByText('Dashboard').closest('a')).toHaveAttribute(
       'data-to',
@@ -94,11 +94,16 @@ describe('Navbar', () => {
       'data-to',
       '/$locale/manage/bookings',
     )
+    // #526: the operator fleet management view lives at /manage/fleet.
+    expect(screen.getByText('Fleet').closest('a')).toHaveAttribute(
+      'data-to',
+      '/$locale/manage/fleet',
+    )
     expect(container.querySelector('nav')?.hasAttribute('data-business-nav')).toBe(true)
     const client = screen.getByTestId('navbar-client')
     expect(client).toHaveAttribute('data-view-mode', 'business')
     expect(client).toHaveAttribute('data-can-switch', 'true')
-    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '2')
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '3')
   })
 
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -1,0 +1,88 @@
+import { formatVehicleRate } from '@/lib/format'
+import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const en = enMessages.business.vehicles.fleet
+
+function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'v1',
+    operatorId: 'op_1',
+    classId: null,
+    pickupLocationId: null,
+    name: 'Toyota Aqua',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'なにわ 300 あ 12-34',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: 'Toyota',
+    model: 'Aqua',
+    year: 2022,
+    color: null,
+    dailyRateJpy: 6800,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-01-01',
+    insuranceExpiryDate: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+function renderView(vehicles: OperatorFleetVehicle[]) {
+  return render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <OperatorFleetView vehicles={vehicles} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('OperatorFleetView', () => {
+  it('shows the empty state when there are no vehicles', () => {
+    renderView([])
+    expect(screen.getByText(en.empty)).toBeInTheDocument()
+  })
+
+  it('renders a vehicle row with name, plate, status, seats, luggage and price', () => {
+    renderView([vehicle()])
+    expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+    expect(screen.getByText('なにわ 300 あ 12-34')).toBeInTheDocument()
+    expect(screen.getByText(en.status.AVAILABLE)).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    const price = formatVehicleRate(6800, null, { perDay: en.perDay, perHour: en.perHour })
+    expect(screen.getByText(price as string)).toBeInTheDocument()
+  })
+
+  it('flags an expired sha-ken certificate', () => {
+    renderView([vehicle({ id: 'v2', shakenExpiryDate: '2020-01-01' })])
+    expect(screen.getByText(en.expiry.EXPIRED)).toBeInTheDocument()
+  })
+
+  it('shows the maintenance status label for a vehicle under maintenance', () => {
+    renderView([vehicle({ id: 'v3', status: 'MAINTENANCE' })])
+    expect(screen.getByText(en.status.MAINTENANCE)).toBeInTheDocument()
+  })
+
+  it('renders one row per vehicle', () => {
+    renderView([vehicle({ id: 'a', name: 'Car A' }), vehicle({ id: 'b', name: 'Car B' })])
+    expect(screen.getByText('Car A')).toBeInTheDocument()
+    expect(screen.getByText('Car B')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Foundation slice of **#526** (port operator fleet to Vite, epic #523). Delivers the complete data layer + a read-only fleet list, and is structured so the remaining CRUD/photo/filter/bulk work can be built as **conflict-free parallel single-file slices**.

This PR owns all four shared-file conflict surfaces (`routeTree.gen.ts`, `messages/*.json`, `operator-fleet/api.ts`, `OperatorFleetView.tsx`) so the follow-up slices add NEW files only and never collide.

## What's included

- **`vite/operator-fleet/api.ts`** — complete cookie-based data layer (`credentials:'include'`, `unwrap()`, `getApiBaseUrl()`):
  - reads: `fetchOperatorFleet` / `operatorFleetQueryOptions` / `FLEET_QUERY_KEY`, `fetchVehicleClassOptions` / `vehicleClassOptionsQueryOptions`
  - writes: `createVehicle`, `updateVehicle`, `updateVehicleStatus`, `bulkUpdateVehicleStatus`, `retireVehicle`, `uploadVehiclePhotos`, `deleteVehiclePhoto`
  - canonical write types re-exported from `@kuruma/shared/validators/vehicle`
- **`OperatorFleetView.tsx`** — read-only table: status pill, sha-ken expiry pill, seats, luggage, price (via `formatVehicleRate`), empty state.
- **Route** `routes/$locale/_business/manage/fleet.tsx` (behind `_business` guard) + nav wiring (`Navbar`, `MobileMenu` `NavTo` union).
- **i18n** namespace `business.vehicles.fleet` (en/ja/zh).

## The remaining work (filed as parallel slices under #523)

5 controlled, single-file components (`VehicleForm`, `FleetRowActions`, `PhotoUpload`, `FleetFilters`, `BulkActionBar`) + 1 deferred grouping toggle, then a small sequential integration PR mounting them into the view. New-files-only = no merge conflicts when run in parallel.

## Test plan

- [x] `tsc --noEmit` (app + node) — 0 errors
- [x] `biome check` — clean
- [x] `vite build` — 0 errors (fleet chunk emitted)
- [x] i18n parity (en/ja/zh) — passing
- [x] full web suite — **801 passed, 0 failed**

Advances #526 (does not close — CRUD slices remain).