### PR TITLE
test(e2e): one-shot local-Postgres run for the real-DB lane + runbook (#542)

### DIFF
--- a/docs/runbooks/2026-demo-runbook.md
+++ b/docs/runbooks/2026-demo-runbook.md
@@ -16,7 +16,8 @@
 
 ## 1. What is seeded
 
-After `db:seed` + `db:seed-bookings` against a fresh Neon branch:
+After the marketplace fixture is seeded (`db:seed:tcp` against local Postgres, or
+`db:seed` + `db:seed-bookings` against a Neon branch):
 
 - **3 operators** · **9 locations** · **12 ACRISS classes** · **41 vehicles** · **6 insurance options** · **10 fee schedules**
 - **4 renters** · **10 bookings** (+ booking_events + notification_log rows), **0 FK orphans**
@@ -36,13 +37,18 @@ git fetch origin
 # fresh worktree or fast-forwarded local branch off origin/marketplace-pivot
 bun install
 
-# Point DATABASE_URL at a fresh Neon branch off the merged pivot (NOT production).
-# The lane needs Neon today because db:seed runs through the neon-http driver — a
-# local-Postgres path is tracked in #542.
+# Local Postgres — no Neon branch (#542). Spin up a disposable container:
+docker run -d --name kuruma-e2e-pg \
+  -e POSTGRES_USER=kuruma -e POSTGRES_PASSWORD=kuruma -e POSTGRES_DB=kuruma_e2e \
+  -p 5433:5432 postgres:16
+export DATABASE_URL='postgresql://kuruma:kuruma@localhost:5433/kuruma_e2e'
 bun run db:migrate
-bun run db:seed
-bun run db:seed-bookings
+bun run db:seed:tcp          # seeds over postgres-js/TCP; the neon-http getDb() can't reach a local container
 bun run db:verify            # must show 4 green checks
+
+# Alternatively, against a fresh Neon branch off the merged pivot (NOT production):
+#   export DATABASE_URL=<neon-branch-pooled-url>
+#   bun run db:migrate && bun run db:seed && bun run db:seed-bookings && bun run db:verify
 ```
 
 For local Google login through the Vite shell (only needed for the **manual**
@@ -69,11 +75,18 @@ bun run dev
 
 The honest proof of the journey. It runs the real **Vite** web (`vite --port 3002`,
 proxying `/api` + `/auth` to the Hono API) → real Hono API (postgres-js) → the
-seeded Neon branch, authenticated with a minted **`kuruma_session`** HS256 cookie
-(`e2e/real-db/mint-session.ts`, mirroring the API's `mintSessionToken` contract).
+seeded **local Postgres** (or a Neon branch), authenticated with a minted
+**`kuruma_session`** HS256 cookie (`e2e/real-db/mint-session.ts`, mirroring the
+API's `mintSessionToken` contract).
 
 ```bash
-AUTH_SECRET=<any 32+ char secret> DATABASE_URL=<neon-branch-pooled-url> bun run test:e2e:real-db
+# One-shot against local Postgres — boots a throwaway postgres:16, migrates,
+# seeds (TCP), and runs the lane. No Neon branch, no manual env (#542):
+bun run test:e2e:real-db:local
+#   docker rm -f kuruma-e2e-pg    # tear the container down afterwards
+
+# Or point it at an already-seeded DB yourself (local container or Neon pooled URL):
+AUTH_SECRET=<any 32+ char secret> DATABASE_URL=<postgres-url> bun run test:e2e:real-db
 ```
 
 Expected: **3 passed** (2 session-mint + the marketplace happy-path). The
@@ -90,8 +103,9 @@ renter search → Best Car Rental KIX storefront → vehicle → the 5-step wiza
 > **Why the lane uses a postgres-js API server.** The booking → thread-creation path opens an
 > interactive transaction. Production runs these via `runTx` (neon-serverless) since **#493**,
 > but the lane keeps `e2e/real-db/real-api-server.ts` on postgres-js (TCP) to exercise the real
-> path without opening a WebSocket per transaction. `DATABASE_URL` should be the Neon **pooled**
-> endpoint (`-pooler`).
+> path without opening a WebSocket per transaction. `pgConnectOptions` turns TLS off for a
+> localhost container and keeps `ssl: 'require'` for remote hosts; with a Neon `DATABASE_URL`,
+> use the **pooled** endpoint (`-pooler`).
 
 ---
 
@@ -114,6 +128,6 @@ operator `/manage/bookings`.
 ## 5. Known gaps / follow-ups
 
 - **Out of Path A scope:** the Stripe *pay* step and the admin *partner-revenue 4%* tab — #461 (live Stripe) / #462 (Vite admin portal).
-- **Local Postgres for this lane — #542.** `db:seed`/`db:seed-bookings` use the neon-http driver and `pg.ts`/`real-api-server.ts` hardcode `ssl: 'require'`, so the lane needs a Neon branch today. #542 moves it to local Postgres (Neon local proxy or a postgres-js seed path) to drop the Neon-branch dependency.
-- **CI gate — #445.** Wiring this lane into CI with a managed Neon-branch lifecycle.
+- **Local Postgres for this lane — #542 (done).** `db:seed:tcp` seeds over postgres-js/TCP and `pgConnectOptions` turns TLS off for localhost, so the lane runs against a disposable `postgres:16` with no Neon branch — `bun run test:e2e:real-db:local` (§3).
+- **CI gate — #445 (done).** The `e2e-real-db` job runs this lane against a fresh `postgres:16` service container (no Neon branch, no external secrets) and is a required check on `marketplace-pivot`.
 - **Operator locations port — #529.** Re-enables `locations.auth.spec.ts` in this lane.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui",
     "test:e2e:real-db": "bunx playwright test --config playwright.real-db.config.ts",
+    "test:e2e:real-db:local": "bun run scripts/e2e-real-db-local.ts",
     "lint": "bunx biome check . && bun run lint:size && bun run lint:modules",
     "lint:fix": "bunx biome check --write .",
     "lint:size": "bun run scripts/lint-file-size.ts",

--- a/scripts/e2e-real-db-local.ts
+++ b/scripts/e2e-real-db-local.ts
@@ -1,0 +1,50 @@
+import { $ } from 'bun'
+
+/**
+ * One-shot local real-DB e2e (#542): boots a disposable `postgres:16`, applies
+ * every migration, seeds the marketplace fixture over TCP, and runs the
+ * authenticated happy-path lane — with NO Neon branch.
+ *
+ * The seed goes through `db:seed:tcp` (postgres-js), not the production
+ * neon-http `getDb()`, which can't reach a plain local container. This mirrors
+ * the CI `e2e-real-db` job exactly, but manages the throwaway DB for you.
+ *
+ *   bun run test:e2e:real-db:local                    # full run
+ *   E2E_PG_PORT=5455 bun run test:e2e:real-db:local   # override port on collision
+ *   docker rm -f kuruma-e2e-pg                         # tear down when done
+ *
+ * The container is recreated each run so the DB is pristine (matching CI); it is
+ * left running afterwards so you can inspect it or re-run the Playwright UI.
+ */
+const PORT = process.env.E2E_PG_PORT ?? '5433'
+const CONTAINER = process.env.E2E_PG_CONTAINER ?? 'kuruma-e2e-pg'
+const HEALTH_TIMEOUT_S = 30
+
+const env = {
+  ...process.env,
+  DATABASE_URL: `postgresql://kuruma:kuruma@localhost:${PORT}/kuruma_e2e`,
+  // Any 32+ char string: the harness mints the session cookie and the API
+  // verifies it with the SAME value. Not a secret — the DB is local + disposable.
+  AUTH_SECRET: process.env.AUTH_SECRET ?? 'local-real-db-e2e-static-secret-0123456789',
+}
+
+console.log(`[e2e] (re)creating disposable postgres:16 (${CONTAINER}) on :${PORT}`)
+await $`docker rm -f ${CONTAINER}`.nothrow().quiet()
+await $`docker run -d --name ${CONTAINER} -e POSTGRES_USER=kuruma -e POSTGRES_PASSWORD=kuruma -e POSTGRES_DB=kuruma_e2e -p ${PORT}:5432 postgres:16`.quiet()
+
+console.log('[e2e] waiting for postgres to accept connections...')
+for (let attempt = 1; ; attempt++) {
+  const ready = await $`docker exec ${CONTAINER} pg_isready -U kuruma -d kuruma_e2e`
+    .nothrow()
+    .quiet()
+  if (ready.exitCode === 0) break
+  if (attempt > HEALTH_TIMEOUT_S) throw new Error(`postgres not ready after ${HEALTH_TIMEOUT_S}s`)
+  await Bun.sleep(1000)
+}
+
+console.log('[e2e] applying migrations + seeding marketplace fixture (TCP)')
+await $`bun run db:migrate`.env(env)
+await $`bun run db:seed:tcp`.env(env)
+
+console.log('[e2e] running authenticated real-DB lane')
+await $`bun run test:e2e:real-db`.env(env)


### PR DESCRIPTION
## Why

The authenticated real-DB e2e lane (`playwright.real-db.config.ts` / `e2e/real-db/*`) needed a seeded **Neon branch**. #542 wanted it on local Postgres to drop that dependency.

## Finding: both blockers were already solved

#445 (merged) shipped the postgres-js/TCP path:
- **Seed (Blocker #1)** → `db:seed:tcp` (`scripts/seed-tcp.ts`) seeds via postgres-js, not the neon-http `getDb()`.
- **TLS (Blocker #2)** → `pgConnectOptions` turns `ssl` off for localhost, keeps `require` for remote.

The CI `e2e-real-db` job already runs the whole lane green against a fresh `postgres:16` with **no Neon branch**. So AC#1 is met in CI; this PR closes the loop for **local dev** + doc accuracy.

## Changes

- **`bun run test:e2e:real-db:local`** (`scripts/e2e-real-db-local.ts`) — boots a disposable `postgres:16`, migrates, seeds over TCP, runs the lane. No Neon branch, no manual env. Recreates the container each run (pristine, mirrors CI), leaves it up for inspection. Port override via `E2E_PG_PORT`; teardown `docker rm -f kuruma-e2e-pg`.
- **Runbook rewrite** (`docs/runbooks/2026-demo-runbook.md`) — local-Postgres-first; Neon branch demoted to documented alternative. Marks #542/#445 done; fixes the stale "needs Neon today" notes.

## Verification

Lane run **3/3 green against a local container**, both ways:
- Manual: `docker run postgres:16` → `db:migrate` → `db:seed:tcp` → `test:e2e:real-db`
- One-shot: `bun run test:e2e:real-db:local` → `3 passed (6.8s)`

Pre-commit gate (biome, lint:size, lint:modules, tsc web+api) green.

## Acceptance

- [x] `bun run test:e2e:real-db` passes against local docker Postgres, no Neon branch
- [x] The demo runbook documents the local flow

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)