### PR TITLE
refactor(shared): extract MIN_TURNAROUND_MINUTES constant (#551 follow-up)

### DIFF
--- a/packages/shared/src/validators/location.ts
+++ b/packages/shared/src/validators/location.ts
@@ -53,10 +53,18 @@ const timezoneSchema = z
 // 60-min floor (#551): guarantees a real servicing gap between rentals. This is
 // a service-quality minimum, not overlap-safety — overlap is already impossible
 // at any turnaround via the bookings_no_overlap exclusion constraint.
+/**
+ * Minimum servicing gap between rentals, in minutes (#551). Single app-layer
+ * source for the floor — shared by this Zod schema and the LocationForm input.
+ * The DB CHECK `locations_turnaround_min_60` (schema.ts + the 0050 migration SQL)
+ * stays a literal `60` on purpose: regenerating it to interpolate the constant
+ * would churn the migration snapshot for no behavioural change.
+ */
+export const MIN_TURNAROUND_MINUTES = 60
 const turnaroundSchema = z
   .number()
   .int('Turnaround must be a whole number of minutes')
-  .min(60, 'Turnaround must be at least 60 minutes')
+  .min(MIN_TURNAROUND_MINUTES, `Turnaround must be at least ${MIN_TURNAROUND_MINUTES} minutes`)
 
 export const createLocationSchema = z.object({
   name: nameSchema,

--- a/packages/web/src/modules/locations/components/LocationForm.tsx
+++ b/packages/web/src/modules/locations/components/LocationForm.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
   type CreateLocationInput,
+  MIN_TURNAROUND_MINUTES,
   type UpdateLocationInput,
   createLocationSchema,
   updateLocationSchema,
@@ -164,7 +165,7 @@ export function LocationForm(props: LocationFormProps) {
           <Input
             id="location-turnaround"
             type="number"
-            min={60}
+            min={MIN_TURNAROUND_MINUTES}
             {...register('defaultTurnaroundMinutes', { valueAsNumber: true })}
           />
           <p className="text-xs text-muted-foreground mt-1">{t('form.turnaroundHint')}</p>


### PR DESCRIPTION
Closes #576

From the #551/#572 review (MEDIUM): de-duplicate the 60-min turnaround floor magic number.

- Add exported `MIN_TURNAROUND_MINUTES = 60` in `@kuruma/shared/validators/location`; reference it in `turnaroundSchema.min(...)` (message templated) and the renter `LocationForm` `min` attr.
- DB CHECK + 0050 migration SQL stay literal 60 by design (avoid snapshot churn).

## Verify
- shared 420 pass · web LocationForm 4 pass · typecheck shared+web+api clean · pre-commit (biome/size/modules/tsc) green.
- No migration, no behavioural change (templated message resolves to the identical string).