### PR TITLE
fix(provider-invites): fail-closed IP rate-limit + 404 on unknown operatorId (#563)

### DIFF
--- a/docs/2026-06-12-issue-563-invite-hardening-handoff.md
+++ b/docs/2026-06-12-issue-563-invite-hardening-handoff.md
@@ -1,0 +1,100 @@
+# Handoff — #563 provider-invite hardening (PR #550 follow-up)
+
+**Status:** Claimed + scoped + fully designed. **No code written yet.** Pick up at the TDD RED step below.
+
+## Setup (already done)
+- Issue **#563** labeled `in-progress`.
+- Worktree `~/Dev/kuruma-563-invite-hardening`, branch `fix/563-invite-hardening`, off `origin/marketplace-pivot @ 84a03b3` (includes #571 FleetFilters). `bun install` done. Tree clean.
+- Pure unit-test work: **no DB / no migration / no docker.**
+
+## The two fixes (both LOW, from /code-review of #550)
+
+### Fix 1 — rate-limit IP fails closed
+`packages/api/src/routes/provider-invites.ts:27` keys the limiter on `c.req.header('cf-connecting-ip') ?? ''`. If the IP is ever absent, every anonymous caller shares one `''` bucket (over-throttle, or no protection) on a brute-forceable token endpoint.
+
+**Create `packages/api/src/routes/rate-limit.ts`** (does NOT exist yet — safe to create):
+```ts
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
+import type { Context, MiddlewareHandler } from 'hono'
+import { fail } from './helpers'
+
+/** Client IP from CF's header, then proxy fallbacks. null when none present. */
+export function clientIp(c: Context): string | null {
+  const cf = c.req.header('cf-connecting-ip')
+  if (cf) return cf
+  const xff = c.req.header('x-forwarded-for')
+  if (xff) return xff.split(',')[0]?.trim() || null
+  return c.req.header('x-real-ip') ?? null
+}
+
+/** Per-IP limit that FAILS CLOSED: indeterminate IP -> 429, never the shared ''
+ *  bucket (#563). Only bites when the limiter binding is wired (CF) AND no IP is
+ *  resolvable — a misconfig; on real CF, cf-connecting-ip is always present. */
+export function rateLimitByIp(limiter: RateLimitBinding): MiddlewareHandler {
+  const limited = rateLimit(limiter, (c) => clientIp(c) ?? '')
+  return async (c, next) => {
+    if (clientIp(c) === null) return fail(c, 'Too many requests', 429)
+    return limited(c, next)
+  }
+}
+```
+Then in `provider-invites.ts` replace the inline `ipKey` + `rateLimit(...)` with:
+```ts
+import { rateLimitByIp } from './rate-limit'
+// ...
+if (publicCatalogLimiter) app.use('/provider-invites/*', rateLimitByIp(publicCatalogLimiter))
+```
+**Scope:** the identical `?? ''` pattern is also in `index.ts:566`, `routes/search.ts:29`, `routes/storefronts.ts:32`, `routes/vehicle-classes.ts:36`. **Leave them** (out of #563 scope); mention in the PR as a trivial follow-up that can adopt `rateLimitByIp`.
+
+### Fix 2 — bad operatorId -> 404 (not 500)
+`packages/api/src/services/provider-invite.ts` `createInvite` inserts directly; a non-existent `operatorId` hits the FK -> 500. It already holds `this.operatorRepo`.
+
+- Add to `provider-invite.ts`:
+```ts
+export class OperatorNotFoundError extends Error {
+  constructor(readonly operatorId: string) {
+    super(`Operator not found: ${operatorId}`)
+    this.name = 'OperatorNotFoundError'
+  }
+}
+```
+- In `createInvite`, before `this.repo.create(...)`:
+```ts
+const operator = await this.operatorRepo.findById(input.operatorId)
+if (!operator) throw new OperatorNotFoundError(input.operatorId)
+```
+- In `packages/api/src/routes/admin.ts` (the `.post('/admin/provider-invites', ...)` handler, ~line 35), wrap the call:
+```ts
+try {
+  const created = await providerInviteService.createInvite(parsed.data, requireUser(c).id)
+  return ok(c, created, 201)
+} catch (e) {
+  if (e instanceof OperatorNotFoundError) return fail(c, 'Operator not found', 404)
+  throw e
+}
+```
+(Localized catch chosen over a global-handler mapping — YAGNI for one call site. `fail` already imported in admin.ts.)
+
+## TDD plan (RED -> GREEN, one at a time)
+
+**GOTCHA:** `packages/api/tests/routes/rate-limit.test.ts` ALREADY EXISTS (pre-existing app-level wiring tests — do NOT overwrite). Put the `clientIp`/`rateLimitByIp` unit tests in a **new file** `packages/api/tests/routes/rate-limit-helper.test.ts` (or append to the existing one). The ready-to-use test body I drafted is below — use it verbatim:
+
+- `clientIp`: prefers cf-connecting-ip; first x-forwarded-for hop trimmed; x-real-ip fallback; null when none.
+- `rateLimitByIp`: no IP -> `c.json({success:false,error:'Too many requests'},429)`, `next` NOT called, `binding.limit` NOT called (the key assertion — proves no `''` bucketing); IP present -> `binding.limit` called with `{ key: '<ip>' }` and `next` called once.
+- Context double: `{ req: { header: name => headers[name.toLowerCase()] }, header: vi.fn(), json: vi.fn((b,s)=>({body:b,status:s})) }`. Fake binding: `{ limit: vi.fn(async () => ({ success: true })) }`.
+
+For Fix 2 tests:
+- `tests/services/provider-invite.test.ts` (existing — mirror its `beforeEach`; operatorRepo seeded with `op_1`): add `it('throws OperatorNotFoundError for an operatorId that does not exist', ...)` calling `createInvite({ ...INPUT, operatorId: 'op_missing' }, INVITED_BY)` -> `await expect(...).rejects.toThrow(OperatorNotFoundError)`. Happy path already covered (operator exists).
+- `tests/routes/provider-invites.test.ts` (existing — `makeApp` seeds operator `op_1`, `bearer({role:'PLATFORM_ADMIN'})`): add `test('bad operatorId -> 404', ...)` posting `{ ...validBody, operatorId: 'op_missing' }` -> `expect(res.status).toBe(404)`.
+
+## Remaining steps
+1. Write the failing tests (above), confirm RED.
+2. Create `rate-limit.ts`, edit `provider-invites.ts`, edit `provider-invite.ts` + `admin.ts`. Confirm GREEN.
+3. Gate: `bun run --filter @kuruma/api test`, `bunx tsc -p packages/api/tsconfig.json --noEmit`, `bun run lint` (biome auto-sorts imports — re-read before further edits), `bun run --filter @kuruma/api lint:boundaries`.
+4. Commit (`fix(provider-invites): fail-closed IP rate-limit + 404 on unknown operatorId (#563)`), end with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer.
+5. Rebase onto `origin/marketplace-pivot`, push `-u`, `gh pr create --base marketplace-pivot` with `Closes #563`.
+6. Base ≠ default branch -> after merge, **close #563 manually** + drop `in-progress` + remove worktree/branch. Remote branch will linger (ruleset blocks deletion).
+
+## Notes
+- Architecture: routes -> services -> repos. `rate-limit.ts` lives in `routes/` and imports `routes/helpers` (`fail`) — same layer, allowed.
+- `OperatorRepository.findById` returns operator-or-null (see `preview` at provider-invite.ts:90 for the existing usage pattern).

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3,7 +3,7 @@ import { createProviderInviteSchema } from '@kuruma/shared/validators/provider-i
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { OperatorService } from '../services/operator'
-import type { ProviderInviteService } from '../services/provider-invite'
+import { OperatorNotFoundError, type ProviderInviteService } from '../services/provider-invite'
 import { fail, ok, parseBody } from './helpers'
 
 export function createAdminRoutes(
@@ -33,8 +33,13 @@ export function createAdminRoutes(
         const parsed = await parseBody(c, createProviderInviteSchema)
         if (!parsed.ok) return parsed.response
 
-        const created = await providerInviteService.createInvite(parsed.data, requireUser(c).id)
-        return ok(c, created, 201)
+        try {
+          const created = await providerInviteService.createInvite(parsed.data, requireUser(c).id)
+          return ok(c, created, 201)
+        } catch (e) {
+          if (e instanceof OperatorNotFoundError) return fail(c, 'Operator not found', 404)
+          throw e
+        }
       })
   )
 }

--- a/packages/api/src/routes/provider-invites.ts
+++ b/packages/api/src/routes/provider-invites.ts
@@ -1,7 +1,8 @@
-import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
-import { type Context, Hono } from 'hono'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { Hono } from 'hono'
 import type { ProviderInviteService } from '../services/provider-invite'
 import { ok } from './helpers'
+import { rateLimitByIp } from './rate-limit'
 
 /**
  * Public provider-invite preview (#521 §7). Anonymous by design — the invite
@@ -22,10 +23,9 @@ export function createProviderInviteRoutes(
 
   // Per-IP budget on the unauthenticated preview path — an invite token is a
   // guessable-shaped public endpoint, so cap brute-force probing (mirrors the
-  // storefront catalog limiter).
+  // storefront catalog limiter). Fails closed on an unresolvable IP (#563).
   if (publicCatalogLimiter) {
-    const ipKey = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
-    app.use('/provider-invites/*', rateLimit(publicCatalogLimiter, ipKey))
+    app.use('/provider-invites/*', rateLimitByIp(publicCatalogLimiter))
   }
 
   return app.get('/provider-invites/:token/preview', async (c) => {

--- a/packages/api/src/routes/rate-limit.ts
+++ b/packages/api/src/routes/rate-limit.ts
@@ -1,0 +1,31 @@
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
+import type { Context, MiddlewareHandler } from 'hono'
+import { fail } from './helpers'
+
+/**
+ * Resolve the caller's IP: Cloudflare's `cf-connecting-ip` first, then the
+ * `x-forwarded-for` lead hop, then `x-real-ip`. Returns null when none is
+ * present so callers can decide policy rather than silently coalescing to ''.
+ */
+export function clientIp(c: Context): string | null {
+  const cf = c.req.header('cf-connecting-ip')
+  if (cf) return cf
+  const xff = c.req.header('x-forwarded-for')
+  if (xff) return xff.split(',')[0]?.trim() || null
+  return c.req.header('x-real-ip') ?? null
+}
+
+/**
+ * Per-IP rate limit that FAILS CLOSED (#563). The underlying limiter bypasses
+ * rate limiting entirely on an empty key, so an indeterminate IP must 429 here
+ * rather than fall through to a shared '' bucket on a brute-forceable endpoint.
+ * On real Cloudflare `cf-connecting-ip` is always present; a null IP signals a
+ * misconfiguration, and refusing is the safe default.
+ */
+export function rateLimitByIp(limiter: RateLimitBinding): MiddlewareHandler {
+  const limited = rateLimit(limiter, (c) => clientIp(c) ?? '')
+  return async (c, next) => {
+    if (clientIp(c) === null) return fail(c, 'Too many requests', 429)
+    return limited(c, next)
+  }
+}

--- a/packages/api/src/services/provider-invite.ts
+++ b/packages/api/src/services/provider-invite.ts
@@ -7,6 +7,16 @@ import type { OperatorRepository, ProviderInviteRepository } from '../repositori
 // recipient is expected to accept promptly during onboarding.
 export const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
+/** Raised when an invite is minted against an operatorId with no matching row.
+ *  The route maps this to a 404 so a bad target reads as a client error, not a
+ *  500 from the FK violation (#563). */
+export class OperatorNotFoundError extends Error {
+  constructor(readonly operatorId: string) {
+    super(`Operator not found: ${operatorId}`)
+    this.name = 'OperatorNotFoundError'
+  }
+}
+
 export interface ProviderInviteAuditEvent {
   readonly type: 'PROVIDER_INVITE_CREATED'
   readonly invitedByUserId: string
@@ -58,6 +68,11 @@ export class ProviderInviteService {
     input: CreateProviderInviteInput,
     invitedByUserId: string,
   ): Promise<CreatedInvite> {
+    // Validate the target exists before the insert so an unknown operatorId is a
+    // clean 404 rather than a 500 from the FK constraint (#563).
+    const operator = await this.operatorRepo.findById(input.operatorId)
+    if (!operator) throw new OperatorNotFoundError(input.operatorId)
+
     const token = randomToken(32)
     const expiresAt = new Date(Date.now() + (this.config.ttlMs ?? INVITE_TTL_MS))
     await this.repo.create({

--- a/packages/api/tests/routes/provider-invites.test.ts
+++ b/packages/api/tests/routes/provider-invites.test.ts
@@ -136,6 +136,16 @@ describe('POST /admin/provider-invites', () => {
     expect(res.status).toBe(400)
   })
 
+  test('returns 404 when the target operator does not exist', async () => {
+    const res = await app.request('/admin/provider-invites', {
+      method: 'POST',
+      headers: await bearer({ sub: 'admin-1', role: 'PLATFORM_ADMIN' }),
+      body: JSON.stringify({ ...validBody, operatorId: 'op_missing' }),
+    })
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ success: false, error: 'Operator not found' })
+  })
+
   test('rejects an unknown operator role (400)', async () => {
     const res = await app.request('/admin/provider-invites', {
       method: 'POST',

--- a/packages/api/tests/routes/rate-limit-helper.test.ts
+++ b/packages/api/tests/routes/rate-limit-helper.test.ts
@@ -1,0 +1,85 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import { clientIp, rateLimitByIp } from '../../src/routes/rate-limit'
+
+// Minimal Context double: clientIp only reads request headers (case-insensitive).
+function ctxWithHeaders(headers: Record<string, string>) {
+  const lower = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
+  return { req: { header: (name: string) => lower[name.toLowerCase()] } } as unknown as Parameters<
+    typeof clientIp
+  >[0]
+}
+
+describe('clientIp', () => {
+  it('prefers cf-connecting-ip over the proxy fallbacks', () => {
+    const ip = clientIp(
+      ctxWithHeaders({
+        'cf-connecting-ip': '203.0.113.7',
+        'x-forwarded-for': '198.51.100.1',
+        'x-real-ip': '192.0.2.5',
+      }),
+    )
+    expect(ip).toBe('203.0.113.7')
+  })
+
+  it('falls back to the first x-forwarded-for hop, trimmed', () => {
+    expect(clientIp(ctxWithHeaders({ 'x-forwarded-for': ' 198.51.100.1 , 10.0.0.1 ' }))).toBe(
+      '198.51.100.1',
+    )
+  })
+
+  it('falls back to x-real-ip when no cf/xff header is present', () => {
+    expect(clientIp(ctxWithHeaders({ 'x-real-ip': '192.0.2.5' }))).toBe('192.0.2.5')
+  })
+
+  it('returns null when no IP header is present', () => {
+    expect(clientIp(ctxWithHeaders({}))).toBeNull()
+  })
+})
+
+function makeApp(binding: RateLimitBinding) {
+  const app = new Hono()
+  app.use('/guarded/*', rateLimitByIp(binding))
+  return app.get('/guarded/ping', (c) => c.json({ ok: true }))
+}
+
+describe('rateLimitByIp', () => {
+  it('fails closed with 429 when no client IP resolves — never the shared "" bucket', async () => {
+    const binding = { limit: vi.fn(async () => ({ success: true })) }
+    const app = makeApp(binding)
+
+    const res = await app.request('/guarded/ping')
+
+    expect(res.status).toBe(429)
+    expect(await res.json()).toEqual({ success: false, error: 'Too many requests' })
+    // The crux of #563: an absent IP must NOT fall through to the limiter, where
+    // an empty key bypasses rate limiting entirely.
+    expect(binding.limit).not.toHaveBeenCalled()
+  })
+
+  it('rate-limits on the resolved IP key and passes the request through when allowed', async () => {
+    const binding = { limit: vi.fn(async () => ({ success: true })) }
+    const app = makeApp(binding)
+
+    const res = await app.request('/guarded/ping', {
+      headers: { 'cf-connecting-ip': '203.0.113.7' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(binding.limit).toHaveBeenCalledWith({ key: '203.0.113.7' })
+  })
+
+  it('returns 429 when the limiter rejects the resolved IP', async () => {
+    const binding = { limit: vi.fn(async () => ({ success: false })) }
+    const app = makeApp(binding)
+
+    const res = await app.request('/guarded/ping', {
+      headers: { 'cf-connecting-ip': '203.0.113.7' },
+    })
+
+    expect(res.status).toBe(429)
+    expect(binding.limit).toHaveBeenCalledWith({ key: '203.0.113.7' })
+  })
+})

--- a/packages/api/tests/services/provider-invite.test.ts
+++ b/packages/api/tests/services/provider-invite.test.ts
@@ -4,6 +4,7 @@ import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/ope
 import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
 import {
   INVITE_TTL_MS,
+  OperatorNotFoundError,
   type ProviderInviteAuditEvent,
   ProviderInviteService,
 } from '../../src/services/provider-invite'
@@ -69,6 +70,14 @@ describe('ProviderInviteService.createInvite', () => {
     const after = Date.now()
     expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + INVITE_TTL_MS)
     expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + INVITE_TTL_MS)
+  })
+
+  it('throws OperatorNotFoundError for an unknown operatorId, before any write or audit', async () => {
+    await expect(
+      service.createInvite({ ...INPUT, operatorId: 'op_missing' }, INVITED_BY),
+    ).rejects.toThrow(OperatorNotFoundError)
+    // The guard runs before the insert + audit — no partial side effects leak out.
+    expect(audits).toEqual([])
   })
 
   it('emits a privilege-grant audit event that does not leak the token', async () => {


### PR DESCRIPTION
## Summary

Two LOW-severity follow-ups from the `/code-review` of #550 (provider login + invites).

### 1. Per-IP rate limit fails closed
`provider-invites.ts` keyed its public invite-preview limiter on `cf-connecting-ip ?? ''`. The underlying limiter treats an **empty key as "no key" and bypasses rate limiting entirely** — so an absent/indeterminate IP gave a brute-forceable token endpoint *no* protection.

New `packages/api/src/routes/rate-limit.ts`:
- `clientIp(c)` — resolves `cf-connecting-ip` → first `x-forwarded-for` hop → `x-real-ip` → `null`.
- `rateLimitByIp(limiter)` — returns **429** when no IP resolves, otherwise delegates to the real limiter keyed on the IP. On real Cloudflare `cf-connecting-ip` is always present; a null IP is a misconfig, and refusing is the safe default.

### 2. Unknown `operatorId` → 404, not 500
`createInvite` inserted directly, so a non-existent `operatorId` hit the FK and surfaced as a 500. It now pre-checks `operatorRepo.findById` and throws a typed `OperatorNotFoundError`; the admin route maps that to a **404**.

## Out of scope (trivial follow-up)
The identical `?? ''` fallback also lives in `index.ts`, `routes/search.ts`, `routes/storefronts.ts`, `routes/vehicle-classes.ts`. Left untouched here; they can adopt `rateLimitByIp` in a small sweep.

## Testing
- New `tests/routes/rate-limit-helper.test.ts`: `clientIp` precedence/fallback/null; `rateLimitByIp` fails closed on no IP (asserts the limiter is **not** called — proving no `''` bucketing), keys on the IP when present, and 429s on limiter reject.
- `provider-invite` service test: throws `OperatorNotFoundError` for an unknown operator, before any write or audit.
- `provider-invites` route test: bad `operatorId` → 404.
- Full gate: api suite **1198 passing**, `tsc` clean, biome lint clean, module-boundary lint OK. No schema/migration.

Closes #563