### PR TITLE
fix(operator): read-only locations for bypass roles (#529 review round 2)

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/locations.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/locations.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorSession } from '@/vite/guards'
 import { AddLocationDialog } from '@/vite/operator-locations/AddLocationDialog'
 import { ArchiveLocationDialog } from '@/vite/operator-locations/ArchiveLocationDialog'
 import { EditLocationDialog } from '@/vite/operator-locations/EditLocationDialog'
 import { OperatorLocationsView } from '@/vite/operator-locations/OperatorLocationsView'
 import { type OperatorLocation, operatorLocationsQueryOptions } from '@/vite/operator-locations/api'
+import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
@@ -24,14 +26,21 @@ export const Route = createFileRoute('/$locale/_business/manage/locations')({
   component: OperatorLocationsRoute,
 })
 
-function OperatorLocationsRoute() {
+export function OperatorLocationsRoute() {
   const t = useTranslations('business.locations')
   const { data: locations } = useSuspenseQuery(operatorLocationsQueryOptions())
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
   const [addOpen, setAddOpen] = useState(false)
   // Edit/archive open against a selected row; null = closed. Distinct state per
   // dialog so a stale edit can't bleed into an archive prompt.
   const [editing, setEditing] = useState<OperatorLocation | null>(null)
   const [archiving, setArchiving] = useState<OperatorLocation | null>(null)
+
+  // Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) get the
+  // cross-operator read for oversight (#387) but cannot write: a create needs a
+  // single target tenant they don't carry here, and the portal deliberately has no
+  // operator picker (#526/#528). So the page is read-only for them (#529 review P1).
+  const canWrite = isOperatorSession(session)
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -41,18 +50,31 @@ function OperatorLocationsRoute() {
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
             <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
           </div>
-          <Button onClick={() => setAddOpen(true)} className="shrink-0">
-            <Plus className="size-4" />
-            {t('addLocation')}
-          </Button>
+          {canWrite && (
+            <Button onClick={() => setAddOpen(true)} className="shrink-0">
+              <Plus className="size-4" />
+              {t('addLocation')}
+            </Button>
+          )}
         </header>
-        <OperatorLocationsView locations={locations} onEdit={setEditing} onArchive={setArchiving} />
-        <AddLocationDialog open={addOpen} onOpenChange={setAddOpen} />
-        <EditLocationDialog location={editing} onOpenChange={(open) => !open && setEditing(null)} />
-        <ArchiveLocationDialog
-          location={archiving}
-          onOpenChange={(open) => !open && setArchiving(null)}
+        <OperatorLocationsView
+          locations={locations}
+          onEdit={canWrite ? setEditing : undefined}
+          onArchive={canWrite ? setArchiving : undefined}
         />
+        {canWrite && (
+          <>
+            <AddLocationDialog open={addOpen} onOpenChange={setAddOpen} />
+            <EditLocationDialog
+              location={editing}
+              onOpenChange={(open) => !open && setEditing(null)}
+            />
+            <ArchiveLocationDialog
+              location={archiving}
+              onOpenChange={(open) => !open && setArchiving(null)}
+            />
+          </>
+        )}
       </div>
     </main>
   )

--- a/packages/web/src/vite/guards.ts
+++ b/packages/web/src/vite/guards.ts
@@ -27,6 +27,16 @@ export function manageGuard(session: Session | null, operatorSlug: string): Guar
   return session?.user.operatorSlug === operatorSlug ? { type: 'allow' } : { type: 'forbidden' }
 }
 
+// A *tenant-scoped* operator session carries an operatorId (#521); bypass business
+// roles (PLATFORM_ADMIN, legacy STAFF/ADMIN) do not. This is the exact mirror of the
+// API's non-bypass write branch — `operatorReadScope(ctx).kind !== 'all'` — so it gates
+// the operator-portal write affordances (Add/Edit/Archive): a write needs a single
+// target tenant, which only an operator session supplies. Bypass roles still read
+// cross-operator (#387 oversight), so the page renders read-only for them (#529 review).
+export function isOperatorSession(session: Session | null): boolean {
+  return Boolean(session?.user.operatorId)
+}
+
 export function adminGuard(session: Session | null): GuardResult {
   if (!session) return { type: 'login' }
   // Narrower than businessGuard: tenant-scoped OPERATOR_* roles clear the business

--- a/packages/web/src/vite/operator-locations/OperatorLocationsView.tsx
+++ b/packages/web/src/vite/operator-locations/OperatorLocationsView.tsx
@@ -6,8 +6,12 @@ import { useTranslations } from 'use-intl'
 
 interface OperatorLocationsViewProps {
   readonly locations: readonly OperatorLocation[]
-  readonly onEdit: (l: OperatorLocation) => void
-  readonly onArchive: (l: OperatorLocation) => void
+  // Optional: omitted in read-only mode (bypass roles get cross-operator oversight
+  // but cannot write — a write needs a single target tenant they lack here, #529).
+  // `| undefined` is explicit: the route passes `canWrite ? setX : undefined`
+  // (exactOptionalPropertyTypes distinguishes absent from an explicit undefined).
+  readonly onEdit?: ((l: OperatorLocation) => void) | undefined
+  readonly onArchive?: ((l: OperatorLocation) => void) | undefined
 }
 
 const MINUTES_PER_HOUR = 60
@@ -43,8 +47,8 @@ export function OperatorLocationsView({
 
 interface LocationRowProps {
   location: OperatorLocation
-  onEdit: (l: OperatorLocation) => void
-  onArchive: (l: OperatorLocation) => void
+  onEdit?: ((l: OperatorLocation) => void) | undefined
+  onArchive?: ((l: OperatorLocation) => void) | undefined
 }
 
 function LocationRow({ location: l, onEdit, onArchive }: LocationRowProps) {
@@ -78,25 +82,31 @@ function LocationRow({ location: l, onEdit, onArchive }: LocationRowProps) {
         </div>
       </div>
 
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t('editLocation')}
-          onClick={() => onEdit(l)}
-        >
-          <Pencil className="size-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t('archiveAction')}
-          onClick={() => onArchive(l)}
-          disabled={l.status === 'ARCHIVED'}
-        >
-          <Trash2 className="size-4" />
-        </Button>
-      </div>
+      {(onEdit || onArchive) && (
+        <div className="flex shrink-0 items-center gap-1">
+          {onEdit && (
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t('editLocation')}
+              onClick={() => onEdit(l)}
+            >
+              <Pencil className="size-4" />
+            </Button>
+          )}
+          {onArchive && (
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t('archiveAction')}
+              onClick={() => onArchive(l)}
+              disabled={l.status === 'ARCHIVED'}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/web/tests/vite/guards.test.ts
+++ b/packages/web/tests/vite/guards.test.ts
@@ -1,8 +1,19 @@
-import { adminGuard, businessGuard, manageGuard, renterGuard } from '@/vite/guards'
+import {
+  adminGuard,
+  businessGuard,
+  isOperatorSession,
+  manageGuard,
+  renterGuard,
+} from '@/vite/guards'
 import type { Session } from '@/vite/session'
 import { describe, expect, it } from 'vitest'
 
 const session = (role: string): Session => ({ user: { id: 'u', role }, csrfToken: 't' })
+
+const tenantSession = (role: string): Session => ({
+  user: { id: 'u', role, operatorId: 'op_1' },
+  csrfToken: 't',
+})
 
 const operatorSession = (role: string, operatorSlug?: string): Session => ({
   user: { id: 'u', role, ...(operatorSlug ? { operatorSlug } : {}) },
@@ -55,6 +66,23 @@ describe('manageGuard', () => {
 
   it('redirects signed-out users to login', () => {
     expect(manageGuard(null, 'acme')).toEqual({ type: 'login' })
+  })
+})
+
+describe('isOperatorSession', () => {
+  it('is true for a tenant-scoped operator session (carries an operatorId)', () => {
+    expect(isOperatorSession(tenantSession('OPERATOR_OWNER'))).toBe(true)
+    expect(isOperatorSession(tenantSession('OPERATOR_STAFF'))).toBe(true)
+  })
+
+  it('is false for bypass business roles with no operatorId — they can read but cannot write', () => {
+    expect(isOperatorSession(session('PLATFORM_ADMIN'))).toBe(false)
+    expect(isOperatorSession(session('STAFF'))).toBe(false)
+    expect(isOperatorSession(session('ADMIN'))).toBe(false)
+  })
+
+  it('is false for a signed-out session', () => {
+    expect(isOperatorSession(null)).toBe(false)
   })
 })
 

--- a/packages/web/tests/vite/operator-locations/OperatorLocationsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-locations/OperatorLocationsRoute.test.tsx
@@ -1,0 +1,69 @@
+import { OperatorLocationsRoute } from '@/routes/$locale/_business/manage/locations'
+import { LOCATIONS_QUERY_KEY, type OperatorLocation } from '@/vite/operator-locations/api'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const en = enMessages.business.locations
+
+function location(): OperatorLocation {
+  return {
+    id: 'loc_1',
+    operatorId: 'op_1',
+    name: 'Namba Branch',
+    address: '1-2-3 Namba, Chuo-ku, Osaka',
+    operatingHours: { openTime: '09:00', closeTime: '20:00' },
+    timezone: 'Asia/Tokyo',
+    defaultTurnaroundMinutes: 2880,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+const operatorSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
+  csrfToken: 't',
+}
+
+const bypassSession: Session = {
+  user: { id: 'u', role: 'PLATFORM_ADMIN' },
+  csrfToken: 't',
+}
+
+// Seed both queries the route reads via useSuspenseQuery so they resolve from cache
+// (no fetch, no router needed). staleTime=Infinity suppresses a background refetch.
+function renderRoute(session: Session) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
+  })
+  queryClient.setQueryData(['session'], session)
+  queryClient.setQueryData(LOCATIONS_QUERY_KEY, [location()])
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorLocationsRoute />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('OperatorLocationsRoute write-affordance gating (#529 review P1)', () => {
+  it('shows Add + row Edit/Archive for a tenant-scoped operator session', () => {
+    renderRoute(operatorSession)
+    expect(screen.getByRole('button', { name: en.addLocation })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.editLocation })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.archiveAction })).toBeInTheDocument()
+  })
+
+  it('hides Add + row actions for a bypass role with no operatorId, but still lists rows (read-only oversight)', () => {
+    renderRoute(bypassSession)
+    expect(screen.queryByRole('button', { name: en.addLocation })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.editLocation })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.archiveAction })).not.toBeInTheDocument()
+    expect(screen.getByTestId('location-row')).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-locations/OperatorLocationsView.test.tsx
+++ b/packages/web/tests/vite/operator-locations/OperatorLocationsView.test.tsx
@@ -98,4 +98,15 @@ describe('OperatorLocationsView', () => {
     renderView([location({ id: 'l4', status: 'ARCHIVED' })])
     expect(screen.getByRole('button', { name: en.archiveAction })).toBeDisabled()
   })
+
+  it('omits the edit/archive row actions in read-only mode (no handlers — bypass roles)', () => {
+    render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorLocationsView locations={[location()]} />
+      </IntlProvider>,
+    )
+    expect(screen.getByTestId('location-row')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.editLocation })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.archiveAction })).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Why

Round-2 review fix for #529 that **missed the #575 squash-merge** (the PR was merged at the pre-fix tip while this was being finished). The bug is currently **live on `marketplace-pivot`**.

#529's round-1 fix added `includeAll=true` so bypass-scope roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no `operatorId`) can load the operator locations page for cross-operator oversight (#387). But the `_business` guard admits those roles and the page's **Add location** button was ungated — while the API requires bypass creates to name an `operatorId` via `platformAdminCreateLocationSchema`, which the no-picker form never sends. Result: bypass roles open the page, click Add, and **every create fails**.

## Fix — read-only for bypass roles

- `guards.ts`: pure `isOperatorSession(session) = !!session.user.operatorId` — the exact mirror of the API's non-bypass write branch (`operatorReadScope(ctx).kind !== 'all'`).
- `OperatorLocationsView`: `onEdit?`/`onArchive?` now optional → per-row Edit/Archive omitted in read-only mode.
- Route: gates the Add button, row callbacks, and the create/edit/archive dialogs on `canWrite = isOperatorSession(session)`.

The cross-operator oversight **read stays** (#387). No backend change, no operator picker (consistent with the #526/#528 decision to drop it — a write needs a single target tenant only an operator session carries).

## Tests (TDD, 3 cycles)

- `guards.test.ts`: `isOperatorSession` true for operator sessions, false for bypass roles / signed-out.
- `OperatorLocationsView.test.tsx`: read-only mode (no handlers) omits row actions.
- `OperatorLocationsRoute.test.tsx` (new): operator session → Add + Edit + Archive; bypass session → none, but rows still list.

## Verification

- `bun run --filter @kuruma/web typecheck` — 0
- `bun run --filter @kuruma/api typecheck` — 0
- operator-locations + guards suites — 38 passed
- full web suite (pre-cherry-pick, on the merged tree) — 911 passed

Refs #529 (closed slice).