### PR TITLE
fix(api): fail-closed rateLimitByIp across remaining public limiters (#563 follow-up)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,4 @@
-import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
 import { getDb, runTx } from '@kuruma/shared/db'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
@@ -119,6 +119,7 @@ import { createNotificationRoutes } from './routes/notifications'
 import { createOperatorRoutes } from './routes/operators'
 import { createPaymentRoutes } from './routes/payments'
 import { createProviderInviteRoutes } from './routes/provider-invites'
+import { rateLimitByIp } from './routes/rate-limit'
 import { createFlatSearchRoutes } from './routes/search'
 import { createStatsRoutes } from './routes/stats'
 import { createStorefrontRoutes } from './routes/storefronts'
@@ -557,14 +558,13 @@ export function createApp(overrides?: {
 
   // Rate limiting via Cloudflare's native rate limit binding. Atomic counters
   // with sub-ms latency, no KV race conditions. Gracefully skipped in local
-  // dev (binding absent → key returns "" → bypass).
+  // dev (binding absent). When present it fails closed on an unresolvable IP
+  // (#580) rather than bypassing via a shared "" key.
   const rateLimiter = (globalThis as Record<string, unknown>).RATE_LIMITER as
     | RateLimitBinding
     | undefined
   if (rateLimiter) {
-    app.use('*', (c, next) =>
-      rateLimit(rateLimiter, (c) => c.req.header('cf-connecting-ip') ?? '')(c, next),
-    )
+    app.use('*', rateLimitByIp(rateLimiter))
   }
 
   // CSRF guard for the cookie session (design spec §5.4). Must run before the

--- a/packages/api/src/routes/rate-limit.ts
+++ b/packages/api/src/routes/rate-limit.ts
@@ -3,16 +3,16 @@ import type { Context, MiddlewareHandler } from 'hono'
 import { fail } from './helpers'
 
 /**
- * Resolve the caller's IP: Cloudflare's `cf-connecting-ip` first, then the
- * `x-forwarded-for` lead hop, then `x-real-ip`. Returns null when none is
- * present so callers can decide policy rather than silently coalescing to ''.
+ * Resolve the caller's IP from Cloudflare's edge-injected `cf-connecting-ip`,
+ * or null when absent so callers can decide policy rather than silently
+ * coalescing to ''. We deliberately do NOT fall back to `x-forwarded-for` /
+ * `x-real-ip`: those are client-controlled, so trusting them as a limiter key
+ * would let a caller forge a fresh bucket per request and evade the limit. On
+ * the real CF edge `cf-connecting-ip` is always present; its absence means the
+ * caller is unidentifiable, and a rate limiter should fail closed on that.
  */
 export function clientIp(c: Context): string | null {
-  const cf = c.req.header('cf-connecting-ip')
-  if (cf) return cf
-  const xff = c.req.header('x-forwarded-for')
-  if (xff) return xff.split(',')[0]?.trim() || null
-  return c.req.header('x-real-ip') ?? null
+  return c.req.header('cf-connecting-ip') ?? null
 }
 
 /**

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -1,8 +1,9 @@
-import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
-import { type Context, Hono } from 'hono'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { Hono } from 'hono'
 import { PUBLIC_CONTEXT } from '../middleware/auth'
 import type { FlatSearchService } from '../services/flat-search'
 import { cachePublic, fail, ok, parseDateRange, parseLimit } from './helpers'
+import { rateLimitByIp } from './rate-limit'
 
 const DEFAULT_LIMIT = 25
 const MAX_LIMIT = 50
@@ -25,9 +26,9 @@ export function createFlatSearchRoutes(
 
   // Stricter per-IP budget on the unauthenticated search path — the public
   // endpoints are the most attractive scraping target (mirrors storefronts).
+  // Fails closed on an unresolvable IP (#580).
   if (publicCatalogLimiter) {
-    const ipKey = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
-    app.use('/search/*', rateLimit(publicCatalogLimiter, ipKey))
+    app.use('/search/*', rateLimitByIp(publicCatalogLimiter))
   }
 
   return app.get('/search/vehicles', async (c) => {

--- a/packages/api/src/routes/storefronts.ts
+++ b/packages/api/src/routes/storefronts.ts
@@ -1,9 +1,10 @@
-import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
-import { type Context, Hono } from 'hono'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { Hono } from 'hono'
 import { PUBLIC_CONTEXT } from '../middleware/auth'
 import type { StorefrontDetailService } from '../services/storefront-detail'
 import type { StorefrontSearchService } from '../services/storefront-search'
 import { cachePublic, fail, ok, parseDateRange, parseLimit } from './helpers'
+import { rateLimitByIp } from './rate-limit'
 
 const DEFAULT_LIMIT = 25
 const MAX_LIMIT = 50
@@ -28,9 +29,9 @@ export function createStorefrontRoutes(
 
   // Stricter per-IP budget on the unauthenticated catalog paths — the public
   // endpoints are the most attractive scraping target (mirrors vehicle-classes).
+  // Fails closed on an unresolvable IP (#580).
   if (publicCatalogLimiter) {
-    const ipKey = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
-    app.use('/storefronts/*', rateLimit(publicCatalogLimiter, ipKey))
+    app.use('/storefronts/*', rateLimitByIp(publicCatalogLimiter))
   }
 
   return app

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -1,9 +1,9 @@
-import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
 import {
   createVehicleClassSchema,
   updateVehicleClassSchema,
 } from '@kuruma/shared/validators/vehicle-class'
-import { type Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import {
   FLEET_WRITE_ROLES,
   PUBLIC_CONTEXT,
@@ -17,6 +17,7 @@ import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import { cachePublic, fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
+import { rateLimitByIp } from './rate-limit'
 
 export function createVehicleClassRoutes(
   service: VehicleClassService,
@@ -32,11 +33,12 @@ export function createVehicleClassRoutes(
   // public endpoints are the only unauthenticated data paths and are the
   // most attractive scraping target, so they need a tighter budget than
   // the shared global one.
+  // Fails closed on an unresolvable IP (#580).
   if (publicCatalogLimiter) {
-    const ipKey = (c: Context) => c.req.header('cf-connecting-ip') ?? ''
-    app.use('/vehicle-classes', rateLimit(publicCatalogLimiter, ipKey))
-    app.use('/vehicle-classes/by-slug/*', rateLimit(publicCatalogLimiter, ipKey))
-    app.use('/vehicle-classes/:slug/availability', rateLimit(publicCatalogLimiter, ipKey))
+    const limiter = rateLimitByIp(publicCatalogLimiter)
+    app.use('/vehicle-classes', limiter)
+    app.use('/vehicle-classes/by-slug/*', limiter)
+    app.use('/vehicle-classes/:slug/availability', limiter)
   }
 
   return (

--- a/packages/api/tests/routes/rate-limit-helper.test.ts
+++ b/packages/api/tests/routes/rate-limit-helper.test.ts
@@ -12,28 +12,19 @@ function ctxWithHeaders(headers: Record<string, string>) {
 }
 
 describe('clientIp', () => {
-  it('prefers cf-connecting-ip over the proxy fallbacks', () => {
-    const ip = clientIp(
-      ctxWithHeaders({
-        'cf-connecting-ip': '203.0.113.7',
-        'x-forwarded-for': '198.51.100.1',
-        'x-real-ip': '192.0.2.5',
-      }),
-    )
-    expect(ip).toBe('203.0.113.7')
+  it('resolves the Cloudflare-injected cf-connecting-ip header', () => {
+    expect(clientIp(ctxWithHeaders({ 'cf-connecting-ip': '203.0.113.7' }))).toBe('203.0.113.7')
   })
 
-  it('falls back to the first x-forwarded-for hop, trimmed', () => {
-    expect(clientIp(ctxWithHeaders({ 'x-forwarded-for': ' 198.51.100.1 , 10.0.0.1 ' }))).toBe(
-      '198.51.100.1',
-    )
+  it('IGNORES client-controlled x-forwarded-for / x-real-ip (spoof-proof key)', () => {
+    // Only the edge-injected header is trusted; forged proxy headers must not
+    // mint a fresh limiter bucket. With no cf-connecting-ip, the IP is null.
+    expect(
+      clientIp(ctxWithHeaders({ 'x-forwarded-for': '198.51.100.1', 'x-real-ip': '192.0.2.5' })),
+    ).toBeNull()
   })
 
-  it('falls back to x-real-ip when no cf/xff header is present', () => {
-    expect(clientIp(ctxWithHeaders({ 'x-real-ip': '192.0.2.5' }))).toBe('192.0.2.5')
-  })
-
-  it('returns null when no IP header is present', () => {
+  it('returns null when cf-connecting-ip is absent', () => {
     expect(clientIp(ctxWithHeaders({}))).toBeNull()
   })
 })

--- a/packages/api/tests/routes/rate-limit.test.ts
+++ b/packages/api/tests/routes/rate-limit.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+const fakeLimiter = () => ({ limit: vi.fn(async () => ({ success: true })) })
 
 describe('rate limiting wiring', () => {
   it('app starts without rate limit binding (local dev)', async () => {
@@ -19,5 +27,50 @@ describe('rate limiting wiring', () => {
 
     const health = await app.request('/health')
     expect(health.status).toBe(200)
+  })
+})
+
+// #580: every public limiter must fail CLOSED on an unresolvable IP. The
+// underlying limiter bypasses entirely on an empty key, so a missing IP must
+// 429 rather than fall through to a shared '' bucket (#563 generalized).
+describe('fail-closed rate limiting (#580)', () => {
+  function appWithCatalogLimiter(limiter: RateLimitBinding) {
+    const vehicleRepo = new InMemoryVehicleRepository()
+    const bookingRepo = new InMemoryBookingRepository()
+    const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+    return createApp({ vehicleRepo, bookingRepo, availabilityRepo, publicCatalogLimiter: limiter })
+  }
+
+  it('public catalog route 429s when no client IP resolves — limiter never consulted', async () => {
+    const limiter = fakeLimiter()
+    const res = await appWithCatalogLimiter(limiter).request('/search/vehicles')
+    expect(res.status).toBe(429)
+    // An empty key would be silently bypassed — proving we never reach it.
+    expect(limiter.limit).not.toHaveBeenCalled()
+  })
+
+  it('public catalog route consults the limiter on the resolved IP', async () => {
+    const limiter = fakeLimiter()
+    const res = await appWithCatalogLimiter(limiter).request(
+      '/search/vehicles?from=2026-07-01T00:00:00Z&to=2026-07-02T00:00:00Z',
+      { headers: { 'cf-connecting-ip': '203.0.113.9' } },
+    )
+    expect(limiter.limit).toHaveBeenCalledWith({ key: '203.0.113.9' })
+    expect(res.status).toBe(200)
+  })
+
+  describe('global limiter', () => {
+    afterEach(() => {
+      // createApp gates on truthiness, so clearing to undefined disables it.
+      ;(globalThis as Record<string, unknown>).RATE_LIMITER = undefined
+    })
+
+    it('429s every path when no client IP resolves', async () => {
+      const limiter = fakeLimiter()
+      ;(globalThis as Record<string, unknown>).RATE_LIMITER = limiter
+      const res = await createApp().request('/health')
+      expect(res.status).toBe(429)
+      expect(limiter.limit).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Generalizes the fail-closed per-IP limiter from #563/PR #579 to the rest of the public limiters. The underlying `@elithrar/workers-hono-rate-limit` middleware **bypasses limiting entirely on an empty key**, so the old `cf-connecting-ip ?? ''` pattern gave these endpoints *zero* brute-force protection whenever the IP was absent.

Migrated all four IP-keyed sites onto `rateLimitByIp` (429s an unresolvable IP):
- `routes/search.ts` (`/search/*`)
- `routes/storefronts.ts` (`/storefronts/*`)
- `routes/vehicle-classes.ts` (3 public mounts)
- `index.ts` — the global `app.use('*')` `RATE_LIMITER`

**Out of scope:** `vehicle-photos.ts` limiters are keyed on user/vehicle (authenticated, never empty), not IP — correctly left as-is.

## Code review applied
An independent review (no CRITICAL/HIGH; global fail-closed confirmed safe — all prod traffic transits the CF edge where `cf-connecting-ip` is guaranteed) raised one **MEDIUM**: `clientIp`'s `x-forwarded-for` / `x-real-ip` fallbacks are client-controlled and spoofable — a caller could forge them to mint a fresh limiter bucket per request. On the CF edge they never fire (cf-connecting-ip always wins), so they were dead weight in prod and pure latent evasion surface. Fixed: `clientIp` now trusts **only** `cf-connecting-ip` (→ null → fail closed). Commit `040e0e5`.

## Testing
- `tests/routes/rate-limit.test.ts`: fail-closed integration coverage — a public catalog route and the global limiter both **429 with the limiter binding never consulted** when no IP resolves, and consult it on the resolved IP otherwise.
- `tests/routes/rate-limit-helper.test.ts`: `clientIp` resolves cf-connecting-ip and **ignores** forged x-forwarded-for / x-real-ip.
- Full gate: api suite green, `tsc` clean, biome lint clean, module-boundaries OK. No schema/migration.

Closes #580