### PR TITLE
feat(operator): mount fleet CRUD into OperatorFleetView (#560)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -496,6 +496,7 @@
       },
       "bulk": {
         "selectAll": "Select all",
+        "selectRow": "Select {name}",
         "deselectAll": "Deselect all",
         "selectedCount": "{count, plural, one {# vehicle selected} other {# vehicles selected}}",
         "setAvailable": "Set Available",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -496,6 +496,7 @@
       },
       "bulk": {
         "selectAll": "すべて選択",
+        "selectRow": "{name}を選択",
         "deselectAll": "選択解除",
         "selectedCount": "{count}台選択中",
         "setAvailable": "利用可能にする",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -496,6 +496,7 @@
       },
       "bulk": {
         "selectAll": "全选",
+        "selectRow": "选择{name}",
         "deselectAll": "取消全选",
         "selectedCount": "已选择{count}辆车",
         "setAvailable": "设为可用",

--- a/packages/web/src/routes/$locale/_business/manage/fleet.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fleet.tsx
@@ -20,7 +20,6 @@ export const Route = createFileRoute('/$locale/_business/manage/fleet')({
 
 function OperatorFleetRoute() {
   const t = useTranslations('business.vehicles.fleet')
-  const { locale } = Route.useParams()
   const { data: vehicles } = useSuspenseQuery(operatorFleetQueryOptions())
 
   return (
@@ -30,7 +29,7 @@ function OperatorFleetRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        <OperatorFleetView vehicles={vehicles} locale={locale} />
+        <OperatorFleetView vehicles={vehicles} />
       </div>
     </main>
   )

--- a/packages/web/src/vite/operator-fleet/EditVehicleSheet.tsx
+++ b/packages/web/src/vite/operator-fleet/EditVehicleSheet.tsx
@@ -1,0 +1,51 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { PhotoUpload } from '@/vite/operator-fleet/PhotoUpload'
+import { VehicleForm } from '@/vite/operator-fleet/VehicleForm'
+import {
+  type OperatorFleetVehicle,
+  vehicleClassOptionsQueryOptions,
+} from '@/vite/operator-fleet/api'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslations } from 'use-intl'
+
+interface EditVehicleSheetProps {
+  /** Whether the sheet is open. */
+  readonly open: boolean
+  /** The vehicle being edited, or `null` for create mode. */
+  readonly vehicle: OperatorFleetVehicle | null
+  /** Controlled open/close handler (the parent owns the sheet state). */
+  readonly onOpenChange: (open: boolean) => void
+  /** Called after a create/update succeeds (parent closes the sheet). */
+  readonly onSaved: () => void
+}
+
+// Slide-over host that composes the add/edit form with photo management (#560).
+// It owns no fleet state — the parent passes the target vehicle (null = create)
+// and the open flag. Class options are fetched lazily (only while open) and the
+// dropdown is hidden when empty, so a failed/absent class list never blocks the
+// form. PhotoUpload renders in both modes: in create mode it shows its own
+// "save the vehicle first" hint, since photos attach to a persisted vehicle id.
+export function EditVehicleSheet({ open, vehicle, onOpenChange, onSaved }: EditVehicleSheetProps) {
+  const t = useTranslations('business.vehicles')
+  const { data: classOptions } = useQuery({ ...vehicleClassOptionsQueryOptions(), enabled: open })
+  const isEdit = vehicle != null
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>{isEdit ? t('editVehicle') : t('addVehicle')}</SheetTitle>
+        </SheetHeader>
+        <div className="space-y-6 p-4 pt-0">
+          <VehicleForm
+            vehicle={vehicle}
+            classOptions={classOptions ?? []}
+            onSaved={onSaved}
+            onCancel={() => onOpenChange(false)}
+          />
+          <PhotoUpload vehicleId={vehicle?.id ?? null} photos={vehicle?.photos ?? []} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -1,7 +1,9 @@
 import { formatVehicleRate } from '@/lib/format'
+import { BulkActionBar } from '@/vite/operator-fleet/BulkActionBar'
 import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
 import { type ExpiryStatus, computeExpiryStatus } from '@kuruma/shared/lib/expiry'
 import { CarFront } from 'lucide-react'
+import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 
 interface OperatorFleetViewProps {
@@ -9,15 +11,22 @@ interface OperatorFleetViewProps {
   readonly locale: string
 }
 
-// Presentational fleet table + empty state. The route owns the loader /
-// useSuspenseQuery and the pending/error boundaries; this stays a pure function
-// of the resolved rows so it is unit-testable (FC/IS — the shell does I/O, this
-// renders). The CRUD / filters / bulk / photo affordances land as separate
-// controlled components in follow-up slices (#526) and are mounted here at
-// integration; this foundation ships the read-only list only.
+// Stateful fleet management container. The route owns the loader /
+// useSuspenseQuery and the pending/error boundaries; this owns the interaction
+// state (selection, filters, the edit sheet) and mounts the controlled CRUD /
+// bulk / photo / filter slices (#526). Decision logic stays in the pure
+// fleet-filters lib (FC/IS); this is the imperative shell that holds UI state.
 export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetViewProps) {
   const t = useTranslations('business.vehicles.fleet')
+  const tBulk = useTranslations('business.vehicles.bulk')
   const todayIso = new Date().toISOString().slice(0, 10)
+  const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
+
+  const clearSelection = () => setSelectedIds([])
+  const allSelected = vehicles.length > 0 && selectedIds.length === vehicles.length
+  const toggleAll = () => setSelectedIds(allSelected ? [] : vehicles.map((v) => v.id))
+  const toggleOne = (id: string) =>
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
 
   if (vehicles.length === 0) {
     return (
@@ -29,57 +38,80 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
   }
 
   return (
-    <div className="overflow-x-auto rounded-xl border border-border">
-      <table className="w-full text-left text-sm">
-        <thead className="border-b border-border bg-muted/40 text-muted-foreground">
-          <tr>
-            <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
-            <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
-            <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
-            <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
-            <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
-            <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {vehicles.map((v) => (
-            <tr
-              key={v.id}
-              className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
-            >
-              <td className="px-4 py-3">
-                <div className="font-medium">{v.name}</div>
-                <div className="text-xs text-muted-foreground">
-                  <span>{v.licensePlate ?? t('none')}</span>
-                  {v.make != null && (
-                    <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
-                  )}
-                </div>
-              </td>
-              <td className="px-4 py-3">
-                <StatusPill status={v.status} label={t(`status.${v.status}`)} />
-              </td>
-              <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
-              <td className="px-4 py-3 text-right tabular-nums">
-                {v.luggageCapacity ?? t('none')}
-              </td>
-              <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
-              <td className="px-4 py-3">
-                <ExpiryPill
-                  status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
-                  labels={{
-                    OK: t('expiry.OK'),
-                    EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
-                    EXPIRED: t('expiry.EXPIRED'),
-                    UNKNOWN: t('expiry.UNKNOWN'),
-                  }}
+    <>
+      <div className="overflow-x-auto rounded-xl border border-border">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b border-border bg-muted/40 text-muted-foreground">
+            <tr>
+              <th className="w-10 px-4 py-3">
+                <input
+                  type="checkbox"
+                  aria-label={tBulk('selectAll')}
+                  checked={allSelected}
+                  onChange={toggleAll}
                 />
-              </td>
+              </th>
+              <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
+              <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
+              <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
+              <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
+              <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
+              <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {vehicles.map((v) => (
+              <tr
+                key={v.id}
+                className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
+              >
+                <td className="px-4 py-3">
+                  <input
+                    type="checkbox"
+                    aria-label={tBulk('selectRow', { name: v.name })}
+                    checked={selectedIds.includes(v.id)}
+                    onChange={() => toggleOne(v.id)}
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <div className="font-medium">{v.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    <span>{v.licensePlate ?? t('none')}</span>
+                    {v.make != null && (
+                      <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <StatusPill status={v.status} label={t(`status.${v.status}`)} />
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
+                <td className="px-4 py-3 text-right tabular-nums">
+                  {v.luggageCapacity ?? t('none')}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
+                <td className="px-4 py-3">
+                  <ExpiryPill
+                    status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
+                    labels={{
+                      OK: t('expiry.OK'),
+                      EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
+                      EXPIRED: t('expiry.EXPIRED'),
+                      UNKNOWN: t('expiry.UNKNOWN'),
+                    }}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BulkActionBar
+        selectedIds={[...selectedIds]}
+        onDone={clearSelection}
+        onClear={clearSelection}
+      />
+    </>
   )
 }
 

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -1,5 +1,7 @@
+import { type FleetFilterState, filterVehicles } from '@/lib/fleet-filters'
 import { formatVehicleRate } from '@/lib/format'
 import { BulkActionBar } from '@/vite/operator-fleet/BulkActionBar'
+import { FleetFilters } from '@/vite/operator-fleet/FleetFilters'
 import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
 import { type ExpiryStatus, computeExpiryStatus } from '@kuruma/shared/lib/expiry'
 import { CarFront } from 'lucide-react'
@@ -21,10 +23,13 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
   const tBulk = useTranslations('business.vehicles.bulk')
   const todayIso = new Date().toISOString().slice(0, 10)
   const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
+  const [filters, setFilters] = useState<FleetFilterState>({})
 
+  const visibleVehicles = filterVehicles([...vehicles], filters)
+  const visibleIds = visibleVehicles.map((v) => v.id)
   const clearSelection = () => setSelectedIds([])
-  const allSelected = vehicles.length > 0 && selectedIds.length === vehicles.length
-  const toggleAll = () => setSelectedIds(allSelected ? [] : vehicles.map((v) => v.id))
+  const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.includes(id))
+  const toggleAll = () => setSelectedIds(allSelected ? [] : visibleIds)
   const toggleOne = (id: string) =>
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
 
@@ -38,8 +43,11 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
   }
 
   return (
-    <>
-      <div className="overflow-x-auto rounded-xl border border-border">
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <aside className="lg:w-64 lg:shrink-0">
+        <FleetFilters vehicles={vehicles} value={filters} onChange={setFilters} />
+      </aside>
+      <div className="min-w-0 flex-1 overflow-x-auto rounded-xl border border-border">
         <table className="w-full text-left text-sm">
           <thead className="border-b border-border bg-muted/40 text-muted-foreground">
             <tr>
@@ -60,7 +68,7 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
             </tr>
           </thead>
           <tbody>
-            {vehicles.map((v) => (
+            {visibleVehicles.map((v) => (
               <tr
                 key={v.id}
                 className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
@@ -111,7 +119,7 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
         onDone={clearSelection}
         onClear={clearSelection}
       />
-    </>
+    </div>
   )
 }
 

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -13,7 +13,6 @@ import { useTranslations } from 'use-intl'
 
 interface OperatorFleetViewProps {
   readonly vehicles: readonly OperatorFleetVehicle[]
-  readonly locale: string
 }
 
 // Stateful fleet management container. The route owns the loader /
@@ -21,7 +20,7 @@ interface OperatorFleetViewProps {
 // state (selection, filters, the edit sheet) and mounts the controlled CRUD /
 // bulk / photo / filter slices (#526). Decision logic stays in the pure
 // fleet-filters lib (FC/IS); this is the imperative shell that holds UI state.
-export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetViewProps) {
+export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
   const t = useTranslations('business.vehicles.fleet')
   const tBulk = useTranslations('business.vehicles.bulk')
   const todayIso = new Date().toISOString().slice(0, 10)
@@ -31,8 +30,13 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
 
   const visibleVehicles = filterVehicles([...vehicles], filters)
   const visibleIds = visibleVehicles.map((v) => v.id)
+  // Selection is reconciled against the visible rows: a row hidden by a filter
+  // drops out of the effective selection so a bulk action can never touch a row
+  // the operator can't see.
+  const effectiveSelectedIds = visibleIds.filter((id) => selectedIds.includes(id))
   const clearSelection = () => setSelectedIds([])
-  const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.includes(id))
+  const allSelected = visibleIds.length > 0 && effectiveSelectedIds.length === visibleIds.length
+  const someSelected = effectiveSelectedIds.length > 0 && !allSelected
   const toggleAll = () => setSelectedIds(allSelected ? [] : visibleIds)
   const toggleOne = (id: string) =>
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
@@ -63,6 +67,9 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
                   <th className="w-10 px-4 py-3">
                     <input
                       type="checkbox"
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected
+                      }}
                       aria-label={tBulk('selectAll')}
                       checked={allSelected}
                       onChange={toggleAll}
@@ -131,7 +138,7 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
       )}
 
       <BulkActionBar
-        selectedIds={[...selectedIds]}
+        selectedIds={effectiveSelectedIds}
         onDone={clearSelection}
         onClear={clearSelection}
       />

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -1,10 +1,13 @@
+import { Button } from '@/components/ui/button'
 import { type FleetFilterState, filterVehicles } from '@/lib/fleet-filters'
 import { formatVehicleRate } from '@/lib/format'
 import { BulkActionBar } from '@/vite/operator-fleet/BulkActionBar'
+import { EditVehicleSheet } from '@/vite/operator-fleet/EditVehicleSheet'
 import { FleetFilters } from '@/vite/operator-fleet/FleetFilters'
+import { FleetRowActions } from '@/vite/operator-fleet/FleetRowActions'
 import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
 import { type ExpiryStatus, computeExpiryStatus } from '@kuruma/shared/lib/expiry'
-import { CarFront } from 'lucide-react'
+import { CarFront, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 
@@ -24,6 +27,7 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
   const todayIso = new Date().toISOString().slice(0, 10)
   const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
   const [filters, setFilters] = useState<FleetFilterState>({})
+  const [sheet, setSheet] = useState<{ vehicle: OperatorFleetVehicle | null } | null>(null)
 
   const visibleVehicles = filterVehicles([...vehicles], filters)
   const visibleIds = visibleVehicles.map((v) => v.id)
@@ -33,91 +37,111 @@ export function OperatorFleetView({ vehicles, locale: _locale }: OperatorFleetVi
   const toggleOne = (id: string) =>
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
 
-  if (vehicles.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center rounded-xl border border-border py-20">
-        <CarFront className="mb-4 size-12 text-muted-foreground/30" />
-        <p className="text-lg text-muted-foreground">{t('empty')}</p>
-      </div>
-    )
-  }
-
   return (
-    <div className="flex flex-col gap-6 lg:flex-row">
-      <aside className="lg:w-64 lg:shrink-0">
-        <FleetFilters vehicles={vehicles} value={filters} onChange={setFilters} />
-      </aside>
-      <div className="min-w-0 flex-1 overflow-x-auto rounded-xl border border-border">
-        <table className="w-full text-left text-sm">
-          <thead className="border-b border-border bg-muted/40 text-muted-foreground">
-            <tr>
-              <th className="w-10 px-4 py-3">
-                <input
-                  type="checkbox"
-                  aria-label={tBulk('selectAll')}
-                  checked={allSelected}
-                  onChange={toggleAll}
-                />
-              </th>
-              <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
-              <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
-              <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
-              <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
-              <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
-              <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visibleVehicles.map((v) => (
-              <tr
-                key={v.id}
-                className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
-              >
-                <td className="px-4 py-3">
-                  <input
-                    type="checkbox"
-                    aria-label={tBulk('selectRow', { name: v.name })}
-                    checked={selectedIds.includes(v.id)}
-                    onChange={() => toggleOne(v.id)}
-                  />
-                </td>
-                <td className="px-4 py-3">
-                  <div className="font-medium">{v.name}</div>
-                  <div className="text-xs text-muted-foreground">
-                    <span>{v.licensePlate ?? t('none')}</span>
-                    {v.make != null && (
-                      <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
-                    )}
-                  </div>
-                </td>
-                <td className="px-4 py-3">
-                  <StatusPill status={v.status} label={t(`status.${v.status}`)} />
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
-                <td className="px-4 py-3 text-right tabular-nums">
-                  {v.luggageCapacity ?? t('none')}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
-                <td className="px-4 py-3">
-                  <ExpiryPill
-                    status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
-                    labels={{
-                      OK: t('expiry.OK'),
-                      EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
-                      EXPIRED: t('expiry.EXPIRED'),
-                      UNKNOWN: t('expiry.UNKNOWN'),
-                    }}
-                  />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+    <div className="space-y-6">
+      <div className="flex justify-end">
+        <Button onClick={() => setSheet({ vehicle: null })}>
+          <Plus className="size-4" />
+          {t('addVehicle')}
+        </Button>
       </div>
+
+      {vehicles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-border py-20">
+          <CarFront className="mb-4 size-12 text-muted-foreground/30" />
+          <p className="text-lg text-muted-foreground">{t('empty')}</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <aside className="lg:w-64 lg:shrink-0">
+            <FleetFilters vehicles={vehicles} value={filters} onChange={setFilters} />
+          </aside>
+          <div className="min-w-0 flex-1 overflow-x-auto rounded-xl border border-border">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-border bg-muted/40 text-muted-foreground">
+                <tr>
+                  <th className="w-10 px-4 py-3">
+                    <input
+                      type="checkbox"
+                      aria-label={tBulk('selectAll')}
+                      checked={allSelected}
+                      onChange={toggleAll}
+                    />
+                  </th>
+                  <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
+                  <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
+                  <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
+                  <th className="px-4 py-3 text-right font-medium">{t('columns.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleVehicles.map((v) => (
+                  <tr
+                    key={v.id}
+                    className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
+                  >
+                    <td className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        aria-label={tBulk('selectRow', { name: v.name })}
+                        checked={selectedIds.includes(v.id)}
+                        onChange={() => toggleOne(v.id)}
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="font-medium">{v.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        <span>{v.licensePlate ?? t('none')}</span>
+                        {v.make != null && (
+                          <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusPill status={v.status} label={t(`status.${v.status}`)} />
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      {v.luggageCapacity ?? t('none')}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
+                    <td className="px-4 py-3">
+                      <ExpiryPill
+                        status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
+                        labels={{
+                          OK: t('expiry.OK'),
+                          EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
+                          EXPIRED: t('expiry.EXPIRED'),
+                          UNKNOWN: t('expiry.UNKNOWN'),
+                        }}
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <FleetRowActions vehicle={v} onEdit={() => setSheet({ vehicle: v })} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
       <BulkActionBar
         selectedIds={[...selectedIds]}
         onDone={clearSelection}
         onClear={clearSelection}
+      />
+      <EditVehicleSheet
+        open={sheet !== null}
+        vehicle={sheet?.vehicle ?? null}
+        onOpenChange={(next) => {
+          if (!next) setSheet(null)
+        }}
+        onSaved={() => setSheet(null)}
       />
     </div>
   )

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -5,13 +5,31 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
+
+// The edit sheet lazily loads vehicle-class options; stub the query so it never
+// hits the network and resolves to an empty list (the form's class dropdown is
+// then simply hidden — out of scope here).
+vi.mock('@/vite/operator-fleet/api', async () => {
+  const actual = await vi.importActual<typeof import('@/vite/operator-fleet/api')>(
+    '@/vite/operator-fleet/api',
+  )
+  return {
+    ...actual,
+    vehicleClassOptionsQueryOptions: () => ({
+      queryKey: ['operator-fleet', 'class-options'],
+      queryFn: async () => [],
+    }),
+  }
+})
 
 const en = enMessages.business.vehicles.fleet
 const bulk = enMessages.business.vehicles.bulk
 const filter = enMessages.business.vehicles.filter
 const statusLabels = enMessages.business.vehicles.status
+const form = enMessages.business.vehicles.form
+const editVehicleLabel = enMessages.business.vehicles.editVehicle
 
 function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
   return {
@@ -145,5 +163,25 @@ describe('OperatorFleetView', () => {
 
     expect(screen.getByText('Retired Car')).toBeInTheDocument()
     expect(screen.queryByText('Available Car')).not.toBeInTheDocument()
+  })
+
+  it('opens an empty create sheet when Add vehicle is clicked', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Toyota Aqua' })])
+    expect(screen.queryByLabelText(form.name)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: en.addVehicle }))
+
+    expect(await screen.findByLabelText(form.name)).toHaveValue('')
+  })
+
+  it('opens the edit sheet prefilled when a row Edit action is used', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Toyota Aqua' })])
+
+    await user.click(screen.getByRole('button', { name: en.columns.actions }))
+    await user.click(screen.getByRole('menuitem', { name: editVehicleLabel }))
+
+    expect(await screen.findByLabelText(form.name)).toHaveValue('Toyota Aqua')
   })
 })

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -74,7 +74,7 @@ function renderView(vehicles: OperatorFleetVehicle[]) {
   return render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
-        <OperatorFleetView vehicles={vehicles} locale="en" />
+        <OperatorFleetView vehicles={vehicles} />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -163,6 +163,18 @@ describe('OperatorFleetView', () => {
 
     expect(screen.getByText('Retired Car')).toBeInTheDocument()
     expect(screen.queryByText('Available Car')).not.toBeInTheDocument()
+  })
+
+  it('drops hidden rows from the bulk selection when a filter excludes them', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Toyota Aqua' }), vehicle({ id: 'b', name: 'Honda Fit' })])
+
+    await user.click(screen.getByRole('checkbox', { name: bulk.selectAll }))
+    expect(screen.getByText('2 vehicles selected')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText(filter.searchPlaceholder), 'Aqua')
+
+    expect(screen.getByText('1 vehicle selected')).toBeInTheDocument()
   })
 
   it('opens an empty create sheet when Add vehicle is clicked', async () => {

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -10,6 +10,8 @@ import enMessages from '../../../messages/en.json'
 
 const en = enMessages.business.vehicles.fleet
 const bulk = enMessages.business.vehicles.bulk
+const filter = enMessages.business.vehicles.filter
+const statusLabels = enMessages.business.vehicles.status
 
 function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
   return {
@@ -119,5 +121,29 @@ describe('OperatorFleetView', () => {
     await user.click(screen.getByRole('button', { name: bulk.deselectAll }))
 
     expect(screen.queryByText('2 vehicles selected')).not.toBeInTheDocument()
+  })
+
+  it('filters the table to rows matching the search query', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Toyota Aqua' }), vehicle({ id: 'b', name: 'Honda Fit' })])
+    expect(screen.getByText('Honda Fit')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText(filter.searchPlaceholder), 'Aqua')
+
+    expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+    expect(screen.queryByText('Honda Fit')).not.toBeInTheDocument()
+  })
+
+  it('filters the table by status when a status facet is toggled', async () => {
+    const user = userEvent.setup()
+    renderView([
+      vehicle({ id: 'a', name: 'Available Car', status: 'AVAILABLE' }),
+      vehicle({ id: 'b', name: 'Retired Car', status: 'RETIRED' }),
+    ])
+
+    await user.click(screen.getByRole('button', { name: new RegExp(`^${statusLabels.RETIRED}`) }))
+
+    expect(screen.getByText('Retired Car')).toBeInTheDocument()
+    expect(screen.queryByText('Available Car')).not.toBeInTheDocument()
   })
 })

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -1,12 +1,15 @@
 import { formatVehicleRate } from '@/lib/format'
 import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 const en = enMessages.business.vehicles.fleet
+const bulk = enMessages.business.vehicles.bulk
 
 function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
   return {
@@ -47,10 +50,13 @@ function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVe
 }
 
 function renderView(vehicles: OperatorFleetVehicle[]) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <IntlProvider locale="en" messages={enMessages}>
-      <OperatorFleetView vehicles={vehicles} locale="en" />
-    </IntlProvider>,
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorFleetView vehicles={vehicles} locale="en" />
+      </IntlProvider>
+    </QueryClientProvider>,
   )
 }
 
@@ -84,5 +90,34 @@ describe('OperatorFleetView', () => {
     renderView([vehicle({ id: 'a', name: 'Car A' }), vehicle({ id: 'b', name: 'Car B' })])
     expect(screen.getByText('Car A')).toBeInTheDocument()
     expect(screen.getByText('Car B')).toBeInTheDocument()
+  })
+
+  it('reveals the bulk action bar with a count when a row is selected', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Car A' }), vehicle({ id: 'b', name: 'Car B' })])
+
+    expect(screen.queryByText('1 vehicle selected')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('checkbox', { name: 'Select Car A' }))
+
+    expect(screen.getByText('1 vehicle selected')).toBeInTheDocument()
+  })
+
+  it('select-all checkbox selects every visible row', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Car A' }), vehicle({ id: 'b', name: 'Car B' })])
+
+    await user.click(screen.getByRole('checkbox', { name: bulk.selectAll }))
+
+    expect(screen.getByText('2 vehicles selected')).toBeInTheDocument()
+  })
+
+  it('deselect-all from the bulk bar clears the selection', async () => {
+    const user = userEvent.setup()
+    renderView([vehicle({ id: 'a', name: 'Car A' }), vehicle({ id: 'b', name: 'Car B' })])
+
+    await user.click(screen.getByRole('checkbox', { name: bulk.selectAll }))
+    await user.click(screen.getByRole('button', { name: bulk.deselectAll }))
+
+    expect(screen.queryByText('2 vehicles selected')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #560. Completes #526 (with the already-merged #555–#559); part of epic #523.

## What
Mounts the five merged, self-contained operator-fleet components into `OperatorFleetView`, which becomes a **stateful container** (the route still owns the loader + `useSuspenseQuery`):

- **Selection** — native checkbox column + select-all (over the *filtered* rows, with an indeterminate state on partial selection) → drives `BulkActionBar`.
- **Filters** — `FleetFilters` aside; visible rows derived via the pure `filterVehicles([...vehicles], filters)`.
- **CRUD** — `FleetRowActions` per row (edit / maintenance / retire) + an "Add vehicle" toolbar button → new `EditVehicleSheet` host composing `VehicleForm` + `PhotoUpload`. Class options load lazily (`enabled: open`).

No API / schema / migration changes. No new dependency. Added one i18n key (`business.vehicles.bulk.selectRow`) across en/ja/zh.

## Commits
- selection + BulkActionBar
- FleetFilters sidebar
- row actions + Add + EditVehicleSheet
- review fixes

## Review
code-reviewer + architect agents — no CRITICAL/HIGH. **Fixed:**
- **Bug:** stale `selectedIds` survived filtering, so a bulk action could touch rows hidden by a filter. Now the bar/select-all operate on `effectiveSelectedIds = visibleIds ∩ selectedIds`, with a regression test.
- Added indeterminate select-all; removed a dead `locale` prop (view + route).

Deliberately deferred (rationale in the handoff doc): onDone/onClear seam (YAGNI — `BulkActionBar` self-invalidates), widening shared `filterVehicles` to `readonly` (scope), extracting a presentational `FleetTable` (file is well under the size cap).

## Gates
- web suite **913/913** (152 files); fleet subset 49
- `tsc --noEmit` 0; biome clean; i18n parity **813 keys × 3 locales**

## Test plan
- [x] Unit/RTL: selection reveals bar with count; select-all; deselect-all; search + status filtering narrow rows; filter prunes hidden rows from the bulk selection; Add opens an empty create sheet; row Edit opens a prefilled sheet
- [ ] Manual browser smoke of the live CRUD flow — **skipped by decision**, relying on the green suite above