### PR TITLE
fix(operator): read-only classes for bypass roles (#583)

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/classes.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/classes.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorSession } from '@/vite/guards'
 import { AddClassDialog } from '@/vite/operator-classes/AddClassDialog'
 import { DeleteClassDialog } from '@/vite/operator-classes/DeleteClassDialog'
 import { EditClassDialog } from '@/vite/operator-classes/EditClassDialog'
 import { OperatorClassesView } from '@/vite/operator-classes/OperatorClassesView'
 import { type OperatorClass, operatorClassesQueryOptions } from '@/vite/operator-classes/api'
+import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
@@ -26,12 +28,19 @@ export const Route = createFileRoute('/$locale/_business/manage/classes')({
   component: OperatorClassesRoute,
 })
 
-function OperatorClassesRoute() {
+export function OperatorClassesRoute() {
   const t = useTranslations('business.classes')
   const { data: classes } = useSuspenseQuery(classesQuery)
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
   const [showAdd, setShowAdd] = useState(false)
   const [editing, setEditing] = useState<OperatorClass | null>(null)
   const [deleting, setDeleting] = useState<OperatorClass | null>(null)
+
+  // Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) read the
+  // operator-scoped list for oversight but cannot write: a create needs a single
+  // target tenant they don't carry, and the portal has no operator picker. So the
+  // page is read-only for them, mirroring locations (#583, #529 review pattern).
+  const canWrite = isOperatorSession(session)
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -41,19 +50,32 @@ function OperatorClassesRoute() {
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
             <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
           </div>
-          <Button onClick={() => setShowAdd(true)}>
-            <Plus className="mr-1.5 size-4" />
-            {t('addClass')}
-          </Button>
+          {canWrite && (
+            <Button onClick={() => setShowAdd(true)}>
+              <Plus className="mr-1.5 size-4" />
+              {t('addClass')}
+            </Button>
+          )}
         </header>
-        <OperatorClassesView classes={classes} onEdit={setEditing} onDelete={setDeleting} />
+        <OperatorClassesView
+          classes={classes}
+          onEdit={canWrite ? setEditing : undefined}
+          onDelete={canWrite ? setDeleting : undefined}
+        />
       </div>
-      <AddClassDialog open={showAdd} onOpenChange={setShowAdd} />
-      <EditClassDialog vehicleClass={editing} onOpenChange={(open) => !open && setEditing(null)} />
-      <DeleteClassDialog
-        vehicleClass={deleting}
-        onOpenChange={(open) => !open && setDeleting(null)}
-      />
+      {canWrite && (
+        <>
+          <AddClassDialog open={showAdd} onOpenChange={setShowAdd} />
+          <EditClassDialog
+            vehicleClass={editing}
+            onOpenChange={(open) => !open && setEditing(null)}
+          />
+          <DeleteClassDialog
+            vehicleClass={deleting}
+            onOpenChange={(open) => !open && setDeleting(null)}
+          />
+        </>
+      )}
     </main>
   )
 }

--- a/packages/web/src/vite/operator-classes/OperatorClassesView.tsx
+++ b/packages/web/src/vite/operator-classes/OperatorClassesView.tsx
@@ -7,12 +7,13 @@ import { useTranslations } from 'use-intl'
 
 interface OperatorClassesViewProps {
   readonly classes: readonly OperatorClass[]
-  /** Opens the edit dialog for a class. Omitted -> no edit affordance (e.g. in
-   * isolation tests). */
-  readonly onEdit?: (vehicleClass: OperatorClass) => void
+  /** Opens the edit dialog for a class. Omitted -> no edit affordance: read-only
+   * for bypass roles (#583), and in isolation tests. `| undefined` is explicit so
+   * the route can pass `canWrite ? setX : undefined` under exactOptionalPropertyTypes. */
+  readonly onEdit?: ((vehicleClass: OperatorClass) => void) | undefined
   /** Opens the archive (delete) dialog for a class. Disabled on already-archived
-   * rows. */
-  readonly onDelete?: (vehicleClass: OperatorClass) => void
+   * rows. Omitted -> no delete affordance (read-only / isolation tests). */
+  readonly onDelete?: ((vehicleClass: OperatorClass) => void) | undefined
 }
 
 // Presentational list + empty state (FC/IS): a pure function of the resolved

--- a/packages/web/tests/vite/operator-classes/OperatorClassesRoute.test.tsx
+++ b/packages/web/tests/vite/operator-classes/OperatorClassesRoute.test.tsx
@@ -1,0 +1,77 @@
+import { OperatorClassesRoute } from '@/routes/$locale/_business/manage/classes'
+import { type OperatorClass, operatorClassesQueryOptions } from '@/vite/operator-classes/api'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const en = enMessages.business.classes
+
+function vehicleClass(): OperatorClass {
+  return {
+    id: 'cls_1',
+    operatorId: 'op_1',
+    name: 'Compact',
+    slug: 'compact',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    acrissCode: null,
+    sortOrder: 0,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+const operatorSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
+  csrfToken: 't',
+}
+
+const bypassSession: Session = {
+  user: { id: 'u', role: 'PLATFORM_ADMIN' },
+  csrfToken: 't',
+}
+
+// Seed both queries the route reads via useSuspenseQuery so they resolve from cache
+// (no fetch, no router needed). staleTime=Infinity suppresses a background refetch.
+function renderRoute(session: Session) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
+  })
+  queryClient.setQueryData(['session'], session)
+  queryClient.setQueryData(operatorClassesQueryOptions({ includeArchived: true }).queryKey, [
+    vehicleClass(),
+  ])
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorClassesRoute />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('OperatorClassesRoute write-affordance gating (#583)', () => {
+  it('shows Add + row Edit/Delete for a tenant-scoped operator session', () => {
+    renderRoute(operatorSession)
+    expect(screen.getByRole('button', { name: en.addClass })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.editClass })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.deleteAction })).toBeInTheDocument()
+  })
+
+  it('hides Add + row actions for a bypass role with no operatorId, but still lists rows (read-only oversight)', () => {
+    renderRoute(bypassSession)
+    expect(screen.queryByRole('button', { name: en.addClass })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.editClass })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: en.deleteAction })).not.toBeInTheDocument()
+    expect(screen.getByText('Compact')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #583. Follow-up to #581 (which fixed the same bug on the operator **locations** page).

## Problem

The `_business` guard admits bypass-scope roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no `operatorId`). The operator **classes** page (`/manage/classes`) rendered an **ungated** Add button and passed `onEdit`/`onDelete` unconditionally, so those users saw Add/Edit/Delete affordances — but the API requires bypass writes to name an `operatorId` the no-picker form never sends, so every create fails.

## Fix — read-only for bypass roles

- Route: gate the Add button, the row `onEdit`/`onDelete` callbacks, and the create/edit/delete dialogs on `canWrite = isOperatorSession(session)` (the pure helper added in #581).
- `OperatorClassesView` already supported optional `onEdit?`/`onDelete?` with conditional row rendering — only made them explicit `| undefined` for `exactOptionalPropertyTypes`. No other view change.

Cross-operator oversight **read stays**. No backend change, no operator picker (consistent with the #526/#528 decision).

## Scope note

Fleet (#526) has the same latent issue but its CRUD affordances aren't mounted yet — that lands in #560, where the gating should be built in. This PR covers classes only (the live case).

## Tests

`OperatorClassesRoute.test.tsx` (new): operator session → Add + Edit + Delete present; bypass session → none, but rows still list.

## Verification

- tsc web+api — 0 · biome · i18n-parity 812×3
- classes suite — 28 passed · full web suite — 956 passed