### PR TITLE
ci(api): gate the neon-serverless tx lane via a local proxy — no Neon usage (#496)

### DIFF
--- a/.github/workflows/ci-neon.yml
+++ b/.github/workflows/ci-neon.yml
@@ -12,13 +12,21 @@ on:
   push:
     branches: [marketplace-pivot, main]
   pull_request:
+    branches: [marketplace-pivot, main]
     paths:
       - packages/shared/src/db/**
       - packages/api/src/repositories/drizzle/**
       - packages/api/tests/neon/**
+      - drizzle.config.ts
       - "**/package.json"
       - bun.lock
       - .github/workflows/ci-neon.yml
+
+# Supersede in-flight runs on the same ref: this lane boots Docker containers,
+# so cancelling stale commits saves runner minutes under heavy parallel-PR load.
+concurrency:
+  group: ci-neon-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   BUN_VERSION: "1.2.13"
@@ -46,14 +54,17 @@ jobs:
       - name: Start local postgres + Neon proxy
         run: docker compose -f "$COMPOSE_FILE" up -d --wait
 
+      # Migrations connect directly to postgres (healthy after --wait) and don't
+      # need the proxy. Run them before the proxy-wait so a proxy startup failure
+      # can't mask a migration/postgres problem in the logs.
+      - name: Apply migrations against the local postgres
+        run: bun run db:migrate
+
       - name: Wait for proxy on :4444
         # The proxy image defines no healthcheck, so `--wait` only guarantees the
         # container is running, not accepting connections. Poll the port from the
         # host before the test connects (avoids a startup race).
         run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/4444) 2>/dev/null; do sleep 1; done'
-
-      - name: Apply migrations against the local postgres
-        run: bun run db:migrate
 
       - name: Run the neon-serverless tx lane via the local proxy
         run: bun run --filter @kuruma/api test:neon

--- a/.github/workflows/ci-neon.yml
+++ b/.github/workflows/ci-neon.yml
@@ -1,0 +1,67 @@
+name: CI (neon driver lane)
+
+# Guards the production neon-serverless interactive-transaction wiring (#493)
+# WITHOUT using Neon (#496): a local postgres fronted by a Neon proxy exercises
+# the exact runTx (neon-serverless WebSocket) + getDb (neon-http) code path.
+# Separate workflow so the path filter scopes ONLY this lane (ci.yml untouched).
+#
+# Runs on trunk pushes and on PRs that touch the tx wiring, the drizzle repos,
+# this lane, OR the serverless driver version (a @neondatabase/serverless bump
+# is exactly the #493 regression class, so package.json / bun.lock must trigger).
+on:
+  push:
+    branches: [marketplace-pivot, main]
+  pull_request:
+    paths:
+      - packages/shared/src/db/**
+      - packages/api/src/repositories/drizzle/**
+      - packages/api/tests/neon/**
+      - "**/package.json"
+      - bun.lock
+      - .github/workflows/ci-neon.yml
+
+env:
+  BUN_VERSION: "1.2.13"
+
+jobs:
+  neon-tx:
+    runs-on: ubuntu-latest
+
+    env:
+      COMPOSE_FILE: packages/api/tests/neon/docker-compose.ci.yml
+      # Migrations connect directly (drizzle-kit, standard pg protocol); the test
+      # routes through the proxy via the localhost-host neonConfig override.
+      DATABASE_URL: postgres://kuruma:kuruma@localhost:5432/kuruma_neon
+      NEON_TEST_DATABASE_URL: postgres://kuruma:kuruma@localhost:5432/kuruma_neon
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Start local postgres + Neon proxy
+        run: docker compose -f "$COMPOSE_FILE" up -d --wait
+
+      - name: Wait for proxy on :4444
+        # The proxy image defines no healthcheck, so `--wait` only guarantees the
+        # container is running, not accepting connections. Poll the port from the
+        # host before the test connects (avoids a startup race).
+        run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/4444) 2>/dev/null; do sleep 1; done'
+
+      - name: Apply migrations against the local postgres
+        run: bun run db:migrate
+
+      - name: Run the neon-serverless tx lane via the local proxy
+        run: bun run --filter @kuruma/api test:neon
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f "$COMPOSE_FILE" logs
+
+      - name: Tear down the stack
+        if: always()
+        run: docker compose -f "$COMPOSE_FILE" down -v

--- a/docs/2026-06-12-issue-496-handoff.md
+++ b/docs/2026-06-12-issue-496-handoff.md
@@ -1,0 +1,36 @@
+# #496 — neon CI lane: handoff for next session
+
+## Status: PR #588 OPEN → `marketplace-pivot` (Closes #496). Code-review done + fixes pushed. NOT merged.
+
+- Worktree: `~/Dev/kuruma-496-ci-neon`, branch `chore/496-ci-neon-lane` (off mp, rebased clean).
+- Tip: `aaa1ef8` (review fixes) on top of `8ef8c1e` (initial impl). 2 commits.
+- **First CI pass (commit before review fixes): all 5/5 green** (test-and-build, db-drift, e2e, e2e-real-db, neon-tx). The review-fix push triggered a re-run — **verify it's green before merge** (`gh pr checks 588`).
+
+## What this PR does
+Wires the #493 self-skipping `packages/api/tests/neon` lane into CI **without using Neon** (user constraint: free-tier branch cap). A local `postgres:16` + `local-neon-http-proxy` (digest-pinned) exercises the real `runTx` (neon-serverless WS `/v2`) + `getDb` (neon-http `/sql`) path. Zero Neon usage, no new secrets — same ethos as #445's `e2e-real-db`.
+
+## Files (6)
+- `.github/workflows/ci-neon.yml` (NEW) — separate path-filtered workflow; trunk push + scoped PRs (`db/**`, `repositories/drizzle/**`, `tests/neon/**`, `drizzle.config.ts`, `**/package.json`, `bun.lock`). Has `concurrency` cancel-in-progress. **Not a required check** by design (path-filter + required = stuck-PR gotcha).
+- `packages/api/tests/neon/docker-compose.ci.yml` (NEW) — `postgres:16` + proxy pinned `@sha256:cd2ae14…`. Ports env-overridable (`NEON_PG_PORT`/`NEON_PROXY_PORT`; CI uses 5432/4444).
+- `packages/api/tests/neon/interactive-tx.test.ts` (EDIT) — `localhost` host flips `neonConfig` into local-proxy mode via `NEON_PROXY_PORT`; real-Neon path untouched; documents the un-guarded pooled-endpoint requirement.
+- `scripts/test-neon-local.ts` + `test:neon:local` (NEW) — one-shot local run (free ports 5455/4455).
+- `docs/plans/2026-06-12-issue-496-ci-neon-lane.md` — plan (architect-review folded in).
+
+## Code-review (code-reviewer agent) — all actioned
+Applied: concurrency block; `pull_request.branches`; `drizzle.config.ts` in filter; reorder migrate-before-proxy-wait; single try/finally so a partial `up` can't leak containers; `URL`→`DB_URL`; `AbortSignal.timeout` on the probe; `--remove-orphans`; logs-on-any-failure.
+**Rejected (with reason):** swapping the CI TCP readiness check for `curl -fsS POST /sql` — an empty POST 4xx's and `-f` would loop until timeout. TCP check + `depends_on: service_healthy` is correct.
+
+## Verification done
+- `bun run test:neon:local` → **1 passed** (real tx via proxy, not skipped), teardown ran. Re-verified after the review-fix restructure.
+- `bun run --filter @kuruma/api test:neon` (no env) → **1 skipped**, exit 0 (default lane unaffected).
+- biome clean; `@kuruma/api` typecheck 0; compose config valid; workflow YAML parses (concurrency + pr.branches confirmed).
+
+## GOTCHAS
+- Proxy image healthcheck is `null` → `--wait` only guarantees "running"; the `:4444` poll is required.
+- A fresh worktree needs `bun install` (the `drizzle-kit` binary is per-worktree).
+
+## NEXT (for whoever picks this up)
+1. `gh pr checks 588` — confirm the re-run is green.
+2. Merge squash (auto-merge is OFF on this repo; if "require up-to-date" trips, `gh pr update-branch` → re-wait CI → squash).
+3. **Manual close #496 + drop `in-progress` label** (base ≠ default branch, so `Closes` won't auto-fire).
+4. Teardown: `git worktree remove ~/Dev/kuruma-496-ci-neon` (remote branch lingers per ruleset — fine).

--- a/docs/2026-06-12-issue-496-handoff.md
+++ b/docs/2026-06-12-issue-496-handoff.md
@@ -3,8 +3,9 @@
 ## Status: PR #588 OPEN → `marketplace-pivot` (Closes #496). Code-review done + fixes pushed. NOT merged.
 
 - Worktree: `~/Dev/kuruma-496-ci-neon`, branch `chore/496-ci-neon-lane` (off mp, rebased clean).
-- Tip: `aaa1ef8` (review fixes) on top of `8ef8c1e` (initial impl). 2 commits.
-- **First CI pass (commit before review fixes): all 5/5 green** (test-and-build, db-drift, e2e, e2e-real-db, neon-tx). The review-fix push triggered a re-run — **verify it's green before merge** (`gh pr checks 588`).
+- Tip: `12fa2de` (handoff) / `aaa1ef8` (review fixes) / `8ef8c1e` (impl). 3 commits.
+- **CI is GREEN 5/5 on the latest commit incl. review fixes** (test-and-build, db-drift, e2e, e2e-real-db, neon-tx — re-run `27450582374`/`27450582389`). Re-confirm with `gh pr checks 588` since trunk moves fast.
+- **Branch is ~1 behind trunk** (parallel merges). Left intentionally un-updated to avoid burning CI; run `gh pr update-branch` at merge time if "require up-to-date" trips.
 
 ## What this PR does
 Wires the #493 self-skipping `packages/api/tests/neon` lane into CI **without using Neon** (user constraint: free-tier branch cap). A local `postgres:16` + `local-neon-http-proxy` (digest-pinned) exercises the real `runTx` (neon-serverless WS `/v2`) + `getDb` (neon-http `/sql`) path. Zero Neon usage, no new secrets — same ethos as #445's `e2e-real-db`.

--- a/docs/plans/2026-06-12-issue-496-ci-neon-lane.md
+++ b/docs/plans/2026-06-12-issue-496-ci-neon-lane.md
@@ -1,0 +1,49 @@
+## Implementation Plan — CI-gate the neon real-driver lane (no Neon usage)
+
+### Context
+The `#493` fix added `packages/api/tests/neon/interactive-tx.test.ts`, which exercises an **interactive transaction through the production `getDb()` / `runTx` (neon-serverless) wiring** — the exact path the renter booking-submit hits (`POST /bookings -> ensureThread -> DrizzleThreadRepository.create -> db.transaction`). The neon-**http** driver throws `No transactions support` at runtime; `runTx` (neon-**serverless**) fixes it. That regression currently has **no automated guard**: the lane `describe.skipIf(!NEON_TEST_DATABASE_URL)` self-skips, and CI never sets that env.
+
+### Decision (revised from the original "real Neon branch" framing)
+Do **not** spin Neon branches in CI. The Neon free tier caps branches, and an ephemeral-branch-per-run scheme would *increase* Neon usage and race under this repo's heavy parallel-PR load. Instead, run the lane against a **local Postgres fronted by a local Neon proxy** — the `@neondatabase/serverless` driver supports this via `neonConfig`. This exercises the driver's **interactive-transaction code path** (the thing the test asserts) with **zero Neon usage and no new secrets**, consistent with how `#445` moved `e2e-real-db` onto a disposable `postgres:16`.
+
+What we keep: the neon-serverless transaction semantics (`runTx` opens a real session tx and commits atomically).
+What we knowingly give up: fidelity to Neon's *cloud* proxy/network behaviour — which this test does not assert.
+
+### Changes (all in isolated files — no overlap with the in-flight `vite/*` operator work)
+
+1. **NEW `packages/api/tests/neon/docker-compose.ci.yml`**
+   - `postgres:16` (`kuruma`/`kuruma`/`kuruma_neon`, healthcheck).
+   - `ghcr.io/timowilhelm/local-neon-http-proxy` **pinned by `@sha256:` digest** (not the mutable `:main` tag — reproducibility + supply-chain) on `:4444`, `PG_CONNECTION_STRING` → the postgres service; `depends_on` postgres healthy. This proxy serves both the HTTP `/sql` endpoint (neon-http reads) and the WebSocket `/v2` endpoint (neon-serverless transactions); neon's own `wsproxy` only does WS, so it can't drive `getDb()`'s reads.
+
+2. **EDIT `packages/api/tests/neon/interactive-tx.test.ts`**
+   - Add a local-proxy `neonConfig` block that activates **only** when `new URL(NEON_TEST_DATABASE_URL).hostname === 'localhost'` — no external DNS dependency (was `db.localtest.me`, a public wildcard; we control resolution in CI, so use `localhost` directly):
+     ```ts
+     neonConfig.useSecureWebSocket = false
+     neonConfig.wsProxy = (host) => `${host}:4444/v2`
+     neonConfig.fetchEndpoint = (host) => `http://${host}:4444/sql`
+     ```
+   - The real-Neon path (secure WS, any other host) and the `skipIf(!NEON_TEST_DATABASE_URL)` guard are unchanged.
+   - Add a comment noting the local lane does **not** reproduce prod's pooled-endpoint (`-pooler`) requirement — that is an operational guard, not the driver code-path #493 protects.
+
+3. **NEW `.github/workflows/ci-neon.yml`** (separate workflow so the path filter scopes only this lane; `ci.yml` untouched)
+   - Triggers: `push` to `marketplace-pivot`/`main`; `pull_request` filtered to `packages/shared/src/db/**` (where `runTx`/`getDb` live), `packages/api/src/repositories/drizzle/**`, `packages/api/tests/neon/**`, **`**/package.json` + `bun.lock`** (a `@neondatabase/serverless` bump is exactly the #493 regression class and must trigger the guard), and the workflow file itself.
+   - Steps: checkout → setup-bun → `bun install --frozen-lockfile` → `docker compose -f packages/api/tests/neon/docker-compose.ci.yml up -d --wait` (postgres healthcheck) → **host-side readiness poll on `:4444`** (`until` loop, the proxy image has no shell for a container healthcheck) → `bun run db:migrate` (`DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_neon`, direct) → `bun run --filter @kuruma/api test:neon` (`NEON_TEST_DATABASE_URL=postgres://kuruma:kuruma@localhost:5432/kuruma_neon`) → **`docker compose logs` on `if: failure()`** → `docker compose down -v` with `if: always()`.
+
+4. **NEW `test:neon:local` script** + short note in `docs/runbooks/2026-demo-runbook.md` documenting the one-command local run.
+
+### Verification (real, before pushing)
+Run the compose stack + `db:migrate` + `test:neon` **locally** and confirm the single `interactive transaction` test passes (not skipped). This proves the wiring end-to-end against the local proxy rather than relying on a first CI run. Also confirm `test:neon` with no env still self-skips green (no breakage to the default lane).
+
+### Out of scope / follow-ups
+- **Not** marking `ci-neon` a required branch-protection check: a path-filtered + required check leaves PRs that don't touch the paths stuck on "Expected — waiting for status". Can be revisited if we want it blocking.
+- No schema change, no migration, no new GitHub Secrets, no Neon API key.
+
+### Acceptance criteria
+- [ ] `ci-neon` workflow runs on trunk push and on PRs touching the tx wiring, and goes **green** with the `interactive transaction` test **executed** (not skipped).
+- [ ] No Neon branch is created and no Neon credentials are referenced anywhere in CI.
+- [ ] The real-Neon local path (developer with a real `NEON_TEST_DATABASE_URL`) still works unchanged.
+- [ ] `bun run test:neon` with no env continues to self-skip (exit 0).
+- [ ] A `@neondatabase/serverless` version bump (touches `package.json`/`bun.lock`) triggers the PR lane.
+
+### Revisions after architect review (2026-06-12)
+Folded in: (1) drop the `db.localtest.me` external DNS dependency → trigger on `localhost`; (2) add `**/package.json` + `bun.lock` to the path filter so driver bumps trigger the guard (closing a blind spot at the lane's own purpose); (3) pin the third-party proxy image by `@sha256:` digest, not `:main`; (4) add a host-side `:4444` readiness poll (no flake) + `docker compose logs` on failure; (5) drop the dead `packages/api/src/db/**` filter entry; (6) document the un-guarded pooled-endpoint requirement in the test comment.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e:ui": "bunx playwright test --ui",
     "test:e2e:real-db": "bunx playwright test --config playwright.real-db.config.ts",
     "test:e2e:real-db:local": "bun run scripts/e2e-real-db-local.ts",
+    "test:neon:local": "bun run scripts/test-neon-local.ts",
     "lint": "bunx biome check . && bun run lint:size && bun run lint:modules",
     "lint:fix": "bunx biome check --write .",
     "lint:size": "bun run scripts/lint-file-size.ts",

--- a/packages/api/tests/neon/docker-compose.ci.yml
+++ b/packages/api/tests/neon/docker-compose.ci.yml
@@ -1,0 +1,36 @@
+# Local Neon-proxy stack for the neon-serverless transaction lane (#493/#496).
+#
+# Exercises the production runTx (neon-serverless WebSocket) AND getDb
+# (neon-http) code paths against a LOCAL postgres — zero Neon usage, no secrets
+# (same ethos as the #445 e2e-real-db lane). The proxy serves BOTH the HTTP
+# `/sql` endpoint (neon-http reads) and the WebSocket `/v2` endpoint
+# (neon-serverless transactions); Neon's own wsproxy only does WS, so it cannot
+# drive getDb()'s reads — hence this combined proxy.
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: kuruma
+      POSTGRES_PASSWORD: kuruma
+      POSTGRES_DB: kuruma_neon
+    ports:
+      # CI uses the 5432 default (clean runner); local runs override to dodge a
+      # busy port (see scripts/test-neon-local.ts).
+      - "${NEON_PG_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kuruma -d kuruma_neon"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  neon-proxy:
+    # Pinned by digest (not the mutable `:main` tag) for reproducibility and
+    # supply-chain safety. Tag at pin time: local-neon-http-proxy:main.
+    image: ghcr.io/timowilhelm/local-neon-http-proxy@sha256:cd2ae14edf2feafbc3330492de5c80506f77274c3bd013154cdef697bdeb768a
+    environment:
+      PG_CONNECTION_STRING: postgres://kuruma:kuruma@postgres:5432/kuruma_neon
+    ports:
+      - "${NEON_PROXY_PORT:-4444}:4444"
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/packages/api/tests/neon/interactive-tx.test.ts
+++ b/packages/api/tests/neon/interactive-tx.test.ts
@@ -7,10 +7,12 @@ import { threadParticipants, threads, users } from '@kuruma/shared/db/schema'
 // at runtime -> 500 on CF Workers. This test exercises that exact write
 // through the SAME getDb() wiring production uses (no harness override).
 //
-// Requires a NON-PROD Neon branch in NEON_TEST_DATABASE_URL (never production
-// — see reference_neon-branches). Self-skips otherwise, so it stays out of the
-// unit lane and the docker-Postgres integration lane (neon-serverless can't
-// speak to local Postgres).
+// Set NEON_TEST_DATABASE_URL to run it; self-skips otherwise, so it stays out
+// of the unit lane and the docker-Postgres integration lane. Two ways to run:
+//   - CI (#496): a localhost URL + the local Neon proxy in docker-compose.ci.yml
+//     — exercises this exact serverless driver path with ZERO Neon usage.
+//   - Real Neon: a NON-PROD branch URL (never production — see
+//     reference_neon-branches), driven over secure WebSocket.
 import { neonConfig } from '@neondatabase/serverless'
 import { eq, inArray } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -23,6 +25,20 @@ const NEON_URL = process.env.NEON_TEST_DATABASE_URL
 // Node/vitest has no global WebSocket (verified on Node 20); the serverless
 // driver needs one. Production runs on CF Workers where WebSocket is global.
 neonConfig.webSocketConstructor = ws
+
+// Local-proxy mode (#496): when NEON_TEST_DATABASE_URL points at localhost, the
+// CI stack (docker-compose.ci.yml) fronts a local postgres with a Neon proxy on
+// :4444, so this lane exercises the production neon-serverless tx path with ZERO
+// Neon usage and no secrets. Any other host = a real Neon branch over secure WS.
+// NOTE: the local lane does NOT reproduce prod's pooled-endpoint (`-pooler`)
+// requirement — that is an operational guard, not the driver code-path #493
+// protects.
+if (NEON_URL && new URL(NEON_URL).hostname === 'localhost') {
+  const proxyPort = process.env.NEON_PROXY_PORT ?? '4444'
+  neonConfig.useSecureWebSocket = false
+  neonConfig.wsProxy = (host) => `${host}:${proxyPort}/v2`
+  neonConfig.fetchEndpoint = (host) => `http://${host}:${proxyPort}/sql`
+}
 
 const ctx = (userId: string): CallerContext => ({ userId, role: 'RENTER' })
 

--- a/scripts/test-neon-local.ts
+++ b/scripts/test-neon-local.ts
@@ -1,0 +1,60 @@
+import { $ } from 'bun'
+
+/**
+ * One-shot local run of the neon-serverless transaction lane (#493/#496):
+ * boots a disposable `postgres:16` + local Neon proxy via the SAME compose file
+ * CI uses, applies migrations, and runs the lane through the proxy — with NO
+ * Neon branch and no secrets.
+ *
+ * The proxy serves the production driver's /sql (neon-http reads) and /v2
+ * (neon-serverless transactions) endpoints, so `runTx` is exercised exactly as
+ * in production. The localhost host in NEON_TEST_DATABASE_URL flips the test's
+ * neonConfig into local-proxy mode (see interactive-tx.test.ts).
+ *
+ *   bun run test:neon:local
+ *
+ * The stack is torn down on exit (even on failure).
+ */
+const COMPOSE = 'packages/api/tests/neon/docker-compose.ci.yml'
+// Default to non-standard ports so a busy local 5432/4444 doesn't break the run;
+// override with NEON_PG_PORT / NEON_PROXY_PORT. CI uses the 5432/4444 defaults.
+const PG_PORT = process.env.NEON_PG_PORT ?? '5455'
+const PROXY_PORT = process.env.NEON_PROXY_PORT ?? '4455'
+const URL = `postgres://kuruma:kuruma@localhost:${PG_PORT}/kuruma_neon`
+const PROXY_TIMEOUT_S = 60
+
+const env = {
+  ...process.env,
+  NEON_PG_PORT: PG_PORT,
+  NEON_PROXY_PORT: PROXY_PORT,
+  DATABASE_URL: URL,
+  NEON_TEST_DATABASE_URL: URL,
+}
+
+console.log(`[neon] starting local postgres (:${PG_PORT}) + Neon proxy (:${PROXY_PORT})`)
+await $`docker compose -f ${COMPOSE} up -d --wait`.env(env)
+
+console.log(`[neon] waiting for the proxy on :${PROXY_PORT}`)
+for (let attempt = 1; ; attempt++) {
+  const up = await fetch(`http://localhost:${PROXY_PORT}/sql`, { method: 'POST' })
+    .then(() => true)
+    .catch(() => false)
+  if (up) break
+  if (attempt > PROXY_TIMEOUT_S) {
+    await $`docker compose -f ${COMPOSE} logs`.env(env).nothrow()
+    await $`docker compose -f ${COMPOSE} down -v`.env(env).nothrow()
+    throw new Error(`proxy not reachable on :${PROXY_PORT} after ${PROXY_TIMEOUT_S}s`)
+  }
+  await Bun.sleep(1000)
+}
+
+try {
+  console.log('[neon] applying migrations')
+  await $`bun run db:migrate`.env(env)
+
+  console.log('[neon] running the neon-serverless tx lane via the local proxy')
+  await $`bun run --filter @kuruma/api test:neon`.env(env)
+} finally {
+  console.log('[neon] tearing down the stack')
+  await $`docker compose -f ${COMPOSE} down -v`.env(env).nothrow()
+}

--- a/scripts/test-neon-local.ts
+++ b/scripts/test-neon-local.ts
@@ -20,41 +20,49 @@ const COMPOSE = 'packages/api/tests/neon/docker-compose.ci.yml'
 // override with NEON_PG_PORT / NEON_PROXY_PORT. CI uses the 5432/4444 defaults.
 const PG_PORT = process.env.NEON_PG_PORT ?? '5455'
 const PROXY_PORT = process.env.NEON_PROXY_PORT ?? '4455'
-const URL = `postgres://kuruma:kuruma@localhost:${PG_PORT}/kuruma_neon`
+const DB_URL = `postgres://kuruma:kuruma@localhost:${PG_PORT}/kuruma_neon`
 const PROXY_TIMEOUT_S = 60
 
 const env = {
   ...process.env,
   NEON_PG_PORT: PG_PORT,
   NEON_PROXY_PORT: PROXY_PORT,
-  DATABASE_URL: URL,
-  NEON_TEST_DATABASE_URL: URL,
+  DATABASE_URL: DB_URL,
+  NEON_TEST_DATABASE_URL: DB_URL,
 }
 
-console.log(`[neon] starting local postgres (:${PG_PORT}) + Neon proxy (:${PROXY_PORT})`)
-await $`docker compose -f ${COMPOSE} up -d --wait`.env(env)
-
-console.log(`[neon] waiting for the proxy on :${PROXY_PORT}`)
-for (let attempt = 1; ; attempt++) {
-  const up = await fetch(`http://localhost:${PROXY_PORT}/sql`, { method: 'POST' })
-    .then(() => true)
-    .catch(() => false)
-  if (up) break
-  if (attempt > PROXY_TIMEOUT_S) {
-    await $`docker compose -f ${COMPOSE} logs`.env(env).nothrow()
-    await $`docker compose -f ${COMPOSE} down -v`.env(env).nothrow()
-    throw new Error(`proxy not reachable on :${PROXY_PORT} after ${PROXY_TIMEOUT_S}s`)
-  }
-  await Bun.sleep(1000)
-}
-
+// Everything after the first `up` is inside one try/finally so a failure at any
+// point (including a partial `up`) still tears the stack down — a leaked stack
+// would wedge the next run on the same ports.
 try {
+  console.log(`[neon] starting local postgres (:${PG_PORT}) + Neon proxy (:${PROXY_PORT})`)
+  await $`docker compose -f ${COMPOSE} up -d --wait --remove-orphans`.env(env)
+
+  console.log(`[neon] waiting for the proxy on :${PROXY_PORT}`)
+  for (let attempt = 1; ; attempt++) {
+    // AbortSignal bounds each probe so a hung fetch can't stretch the timeout.
+    const up = await fetch(`http://localhost:${PROXY_PORT}/sql`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(1000),
+    })
+      .then(() => true)
+      .catch(() => false)
+    if (up) break
+    if (attempt > PROXY_TIMEOUT_S) {
+      throw new Error(`proxy not reachable on :${PROXY_PORT} after ${PROXY_TIMEOUT_S}s`)
+    }
+    await Bun.sleep(1000)
+  }
+
   console.log('[neon] applying migrations')
   await $`bun run db:migrate`.env(env)
 
   console.log('[neon] running the neon-serverless tx lane via the local proxy')
   await $`bun run --filter @kuruma/api test:neon`.env(env)
+} catch (err) {
+  await $`docker compose -f ${COMPOSE} logs`.env(env).nothrow()
+  throw err
 } finally {
   console.log('[neon] tearing down the stack')
-  await $`docker compose -f ${COMPOSE} down -v`.env(env).nothrow()
+  await $`docker compose -f ${COMPOSE} down -v --remove-orphans`.env(env).nothrow()
 }


### PR DESCRIPTION
Closes #496.

## What
The `#493` interactive-transaction lane (`packages/api/tests/neon`) self-skipped without `NEON_TEST_DATABASE_URL`, so the **production neon-serverless `runTx` path** (renter booking-submit `POST /bookings` opens an interactive tx) had **no automated guard** — including the `as unknown as NeonHttpDb` cast in `runTx`.

This runs that exact lane in CI against a **local `postgres:16` fronted by a local Neon proxy** — exercising the real `runTx` (neon-serverless WebSocket) + `getDb` (neon-http) code path with **zero Neon usage and no secrets**, consistent with how #445 moved `e2e-real-db` off Neon.

## Changes
- **`.github/workflows/ci-neon.yml`** (new) — separate, path-filtered workflow. Triggers on trunk push + PRs touching `packages/shared/src/db/**`, `packages/api/src/repositories/drizzle/**`, the lane, and **`**/package.json` + `bun.lock`** (a `@neondatabase/serverless` bump is the #493 regression class). Steps: compose up → `:4444` readiness poll → `db:migrate` (direct) → `test:neon` (via proxy) → logs-on-failure → teardown. **Not** marked a required check (path-filter + required = stuck-PR gotcha).
- **`packages/api/tests/neon/docker-compose.ci.yml`** (new) — `postgres:16` + `local-neon-http-proxy` **pinned by `@sha256:` digest** (serves both `/sql` HTTP reads and `/v2` WS tx; neon's own wsproxy can't drive the reads). Ports env-overridable.
- **`packages/api/tests/neon/interactive-tx.test.ts`** — `localhost` host flips `neonConfig` into local-proxy mode; real-Neon path unchanged. Documents that the local lane does **not** reproduce prod's pooled-endpoint (`-pooler`) requirement.
- **`test:neon:local`** (new script) — one-command local run via the same compose file.

## Verification (local)
- `bun run test:neon:local` → **1 passed** — the real `commits a thread + both participants atomically` test ran through the neon-serverless WebSocket via the proxy (not skipped), zero Neon used.
- `bun run --filter @kuruma/api test:neon` with no env → **1 skipped**, exit 0 (default lane unaffected).
- biome clean, `@kuruma/api` typecheck exit 0, `docker compose config` valid, workflow YAML parses.

## Reviews folded in (architect-review on the plan)
External DNS dep dropped (`localhost`, not `db.localtest.me`); driver-bump trigger added to the path filter; proxy pinned by digest; readiness poll + logs-on-failure; pooled-endpoint gap documented.

## Notes
- No schema change, no migration, **no new GitHub Secrets**, no Neon API key.
- Free-tier-friendly: never creates a Neon branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)