### PR TITLE
feat(api): app-side global throttle for forward geocoding (#574)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,20 @@
   # real admin address(es), not a placeholder.
   PLATFORM_ADMIN_EMAILS=you@yourdomain.example
 
-  # Forward geocoding for operator locations (#531). DISABLED unless BOTH are set
-  # (otherwise the API persists locations with null coords — safe, just no map pin).
-  # WARNING: the public OSM endpoint (https://nominatim.openstreetmap.org) caps the
-  # WHOLE app at 1 req/s and forbids bursts — there is NO app-side throttle/cache yet
-  # (#574). Use it only for local/demo; in production point NOMINATIM_API_URL at a
-  # self-hosted / proxied / quota-backed instance and add a limiter first.
+  # Forward geocoding for operator locations (#531). DISABLED unless BOTH a
+  # User-Agent AND an endpoint are set (otherwise locations save with null coords —
+  # safe, just no map pin). Outbound lookups are throttled app-wide by the
+  # GEOCODE_LIMITER binding (#574, ~1 req/10s) so a burst can't breach OSMF's 1 req/s.
+  #
+  # Demo / low volume — public OSM (free, no account; throttle keeps it policy-safe):
   # NOMINATIM_USER_AGENT="kuruma-rental/1.0 (ops@yourdomain.example)"
   # NOMINATIM_API_URL=https://nominatim.openstreetmap.org
+  #
+  # Production — LocationIQ (Nominatim-compatible drop-in, free 5k/day, storage OK):
+  # keep the UA, point the URL below, add a key. A real provider's own server-side
+  # limit is the actual guarantee; the app throttle is best-effort defense-in-depth.
+  # NOMINATIM_API_URL=https://us1.locationiq.com/v1
+  # NOMINATIM_API_KEY=your-locationiq-token
+  #
+  # NOTE: local dev has no GEOCODE_LIMITER binding (unthrottled). Point at LocationIQ
+  # or a self-host before any bulk seed/import so you don't trip an OSM IP ban.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -141,6 +141,7 @@ import { FeeScheduleService } from './services/fee-schedule'
 import { FlatSearchService } from './services/flat-search'
 import { FleetOverviewService } from './services/fleet-overview'
 import { NominatimGeocoder } from './services/geocoding/nominatim-geocoder'
+import { ThrottledGeocoder } from './services/geocoding/throttled-geocoder'
 import type { Geocoder } from './services/geocoding/types'
 import { GoogleTranslationProvider } from './services/google-translation-provider'
 import { InsuranceOptionService } from './services/insurance-option'
@@ -199,6 +200,9 @@ export function createApp(overrides?: {
   photoUploadLimiter?: RateLimitBinding
   photoUploadUserLimiter?: RateLimitBinding
   publicCatalogLimiter?: RateLimitBinding
+  // Over-limit ⇒ the geocoder skips the lookup (#574). Inject a deny-binding in
+  // tests; absent ⇒ the globalThis-resolved GEOCODE_LIMITER (or unthrottled dev).
+  geocodeLimiter?: RateLimitBinding
   // Injected Google OAuth runtime (provider + account store). Integration tests
   // pass a fake so the callback can be exercised without a live Google/DB.
   googleAuthRuntime?: GoogleAuthRuntime
@@ -452,17 +456,12 @@ export function createApp(overrides?: {
     }
   })()
 
-  // Forward geocoder (#531): disabled by default — returns null (no coords)
-  // unless BOTH a descriptive User-Agent AND an explicit endpoint are set. We do
-  // NOT default to the public OSM endpoint: its usage policy caps the WHOLE app
-  // at 1 req/s and there is no app-side throttle/cache here yet (#574), so a
-  // burst of operator saves would breach it. Production must point
-  // NOMINATIM_API_URL at a self-hosted / proxied / quota-backed instance (or
-  // swap in a different provider adapter on this one line). Geocoding is
-  // best-effort — the service treats null as "no coordinates" and the location
-  // still saves — so the null stub is safe and there is no loud prod sentinel.
-  // A test override wins outright, proving a provider swap touches only here.
-  const geocoder: Geocoder =
+  // Forward geocoder (#531): disabled by default (null stub) unless BOTH a
+  // User-Agent and an endpoint are set; prod = LocationIQ (Nominatim-compatible,
+  // + NOMINATIM_API_KEY) or self-host. The resolved geocoder is wrapped in a
+  // ThrottledGeocoder keyed off GEOCODE_LIMITER (#574) — best-effort global cap so
+  // a burst can't breach OSMF's 1 req/s. A test override wins outright.
+  const innerGeocoder: Geocoder =
     overrides?.geocoder ??
     (() => {
       const userAgent = process.env.NOMINATIM_USER_AGENT
@@ -470,6 +469,13 @@ export function createApp(overrides?: {
       if (!userAgent || !baseUrl) return { geocode: async () => null }
       return new NominatimGeocoder(baseUrl, userAgent)
     })()
+  // Adapt the native binding's `limit({ key })` to the RateLimiter port here.
+  const geocodeLimiter =
+    overrides?.geocodeLimiter ??
+    ((globalThis as Record<string, unknown>).GEOCODE_LIMITER as RateLimitBinding | undefined)
+  const geocoder: Geocoder = geocodeLimiter
+    ? new ThrottledGeocoder(innerGeocoder, { limit: (key) => geocodeLimiter.limit({ key }) })
+    : innerGeocoder
 
   // In-app Stripe payment (#461). Real gateway when BOTH secrets are set; in
   // production without them a sentinel throws on first use (not at boot, so

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -467,7 +467,7 @@ export function createApp(overrides?: {
       const userAgent = process.env.NOMINATIM_USER_AGENT
       const baseUrl = process.env.NOMINATIM_API_URL
       if (!userAgent || !baseUrl) return { geocode: async () => null }
-      return new NominatimGeocoder(baseUrl, userAgent)
+      return new NominatimGeocoder(baseUrl, userAgent, undefined, process.env.NOMINATIM_API_KEY)
     })()
   // Adapt the native binding's `limit({ key })` to the RateLimiter port here.
   const geocodeLimiter =

--- a/packages/api/src/services/geocoding/nominatim-geocoder.ts
+++ b/packages/api/src/services/geocoding/nominatim-geocoder.ts
@@ -22,6 +22,9 @@ export class NominatimGeocoder implements Geocoder {
     private readonly baseUrl: string,
     private readonly userAgent: string,
     private readonly fetchFn: typeof fetch = fetch,
+    // Optional auth token. LocationIQ is Nominatim-compatible but key-gated via
+    // `?key=` (#574), so providing one makes it a pure env-var swap from public OSM.
+    private readonly apiKey?: string,
   ) {}
 
   async geocode(address: string): Promise<GeocodeResult | null> {
@@ -29,6 +32,7 @@ export class NominatimGeocoder implements Geocoder {
     url.searchParams.set('format', 'jsonv2')
     url.searchParams.set('limit', '1')
     url.searchParams.set('q', address)
+    if (this.apiKey) url.searchParams.set('key', this.apiKey)
 
     try {
       const response = await this.fetchFn(url.toString(), {

--- a/packages/api/src/services/geocoding/throttled-geocoder.ts
+++ b/packages/api/src/services/geocoding/throttled-geocoder.ts
@@ -1,0 +1,53 @@
+import type { GeocodeResult, Geocoder, RateLimiter } from './types'
+
+// One shared bucket across every isolate/request: a constant key makes the
+// native CF rate-limit binding enforce a single GLOBAL rate, not a per-key one.
+const GLOBAL_KEY = 'geocode:global'
+
+/**
+ * Wraps a `Geocoder` with an app-side global throttle (#574). OSM/Nominatim's
+ * policy caps the WHOLE app at 1 req/s; this caps our outbound geocoding before
+ * a burst of operator saves can breach it (best-effort defense-in-depth — the
+ * native binding is a fixed window, not a token bucket, so it can admit 2 across
+ * a window boundary; the production provider's own server-side limit is the real
+ * guarantee).
+ *
+ * Over the limit ⇒ SKIP the lookup and return null. A skip is indistinguishable
+ * from a provider miss/outage, which `LocationService` already handles (the save
+ * proceeds with no coords; a later edit/`regeocode` fills the pin). Honors the
+ * `Geocoder` never-throw contract: a degraded limiter fails OPEN (proceed) so a
+ * rate-limit-service blip can't silently kill all geocoding.
+ */
+export class ThrottledGeocoder implements Geocoder {
+  constructor(
+    private readonly inner: Geocoder,
+    private readonly limiter: RateLimiter,
+    private readonly key: string = GLOBAL_KEY,
+  ) {}
+
+  async geocode(address: string): Promise<GeocodeResult | null> {
+    let allowed = true
+    try {
+      ;({ success: allowed } = await this.limiter.limit(this.key))
+    } catch (err) {
+      // Limiter itself failed: fail OPEN so geocoding survives a limiter outage.
+      console.warn('[geocode] rate limiter unavailable; proceeding without throttle', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      allowed = true
+    }
+
+    if (!allowed) {
+      console.warn('[geocode] global rate limit reached; skipping lookup (no coords)', { address })
+      return null
+    }
+
+    try {
+      return await this.inner.geocode(address)
+    } catch {
+      // Inner Geocoders must never throw, but honor the contract defensively so
+      // a misbehaving adapter can't break a save through this decorator either.
+      return null
+    }
+  }
+}

--- a/packages/api/src/services/geocoding/throttled-geocoder.ts
+++ b/packages/api/src/services/geocoding/throttled-geocoder.ts
@@ -31,6 +31,8 @@ export class ThrottledGeocoder implements Geocoder {
       ;({ success: allowed } = await this.limiter.limit(this.key))
     } catch (err) {
       // Limiter itself failed: fail OPEN so geocoding survives a limiter outage.
+      // Safe ONLY while public OSM stays opt-in (index.ts gates on UA + URL); if
+      // OSM is ever defaulted on, fail-open could breach its 1 req/s — revisit then.
       console.warn('[geocode] rate limiter unavailable; proceeding without throttle', {
         error: err instanceof Error ? err.message : String(err),
       })

--- a/packages/api/src/services/geocoding/types.ts
+++ b/packages/api/src/services/geocoding/types.ts
@@ -17,3 +17,14 @@ export interface GeocodeResult {
 export interface Geocoder {
   geocode(address: string): Promise<GeocodeResult | null>
 }
+
+/**
+ * App-side throttle port (#574). A generic "may I proceed?" check keyed by a
+ * caller-chosen string, so the geocoding service stays free of the CF/Hono rate-
+ * limit binding type. `index.ts` adapts the native `[[ratelimits]]` binding
+ * (whose shape is `limit({ key })`) to this `limit(key)` port — the only place
+ * that knows about Cloudflare.
+ */
+export interface RateLimiter {
+  limit(key: string): Promise<{ success: boolean }>
+}

--- a/packages/api/src/services/location.ts
+++ b/packages/api/src/services/location.ts
@@ -200,8 +200,11 @@ export class LocationService {
     if (regeocode === true) {
       const hit = await this.safeGeocode(address)
       if (hit) return { kind: 'set', coords: hit }
-      // Manual coords survive a transient outage; derived coords are cleared.
-      return isManual ? { kind: 'preserve' } : { kind: 'set', coords: CLEARED }
+      // A miss clears coords only when they are genuinely stale — i.e. the address
+      // changed and re-derivation failed. A MANUAL pin, or a GEOCODED pin whose
+      // address is unchanged, is NOT stale, so a transient miss (incl. a #574
+      // rate-limit skip) must preserve it rather than destroy valid coordinates.
+      return isManual || !addressChanged ? { kind: 'preserve' } : { kind: 'set', coords: CLEARED }
     }
 
     if (addressChanged) {

--- a/packages/api/tests/routes/location-geocoder-di.test.ts
+++ b/packages/api/tests/routes/location-geocoder-di.test.ts
@@ -50,4 +50,37 @@ describe('Geocoder DI — provider swap touches only index.ts (#531)', () => {
     })
     expect(geocode).toHaveBeenCalledWith('1-2-3 Namba, Osaka')
   })
+
+  test('an over-limit GEOCODE_LIMITER skips the lookup: location still saves, with no coords (#574)', async () => {
+    setupAuthEnv()
+    const vehicleRepo = new InMemoryVehicleRepository()
+    const bookingRepo = new InMemoryBookingRepository()
+    const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+    const geocode = vi.fn(async () => ({ lat: 34.6937, lng: 135.5023 }))
+    // Native CF binding shape (limit({ key }) → { success }); index.ts adapts it.
+    const geocodeLimiter = { limit: vi.fn(async () => ({ success: false })) }
+    const app = createApp({
+      vehicleRepo,
+      bookingRepo,
+      availabilityRepo,
+      geocoder: { geocode },
+      geocodeLimiter,
+    })
+
+    const res = await app.request('/locations', {
+      method: 'POST',
+      headers: await ownerHeaders('op_a'),
+      body: JSON.stringify({ name: 'Namba HQ', address: '1-2-3 Namba, Osaka' }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      coordinateSource: null,
+      latitude: null,
+      longitude: null,
+    })
+    expect(geocode).not.toHaveBeenCalled()
+    expect(geocodeLimiter.limit).toHaveBeenCalledWith({ key: 'geocode:global' })
+  })
 })

--- a/packages/api/tests/services/geocoding/nominatim-geocoder.test.ts
+++ b/packages/api/tests/services/geocoding/nominatim-geocoder.test.ts
@@ -72,4 +72,18 @@ describe('NominatimGeocoder', () => {
     await new NominatimGeocoder(BASE, UA, fetchFn).geocode('Osaka')
     expect(fetchFn).toHaveBeenCalledTimes(1)
   })
+
+  it('appends ?key= when an API key is set, making LocationIQ a drop-in (#574)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(osakaHit))
+    await new NominatimGeocoder(BASE, UA, fetchFn, 'pk.test-token').geocode('Osaka')
+    const parsed = new URL(fetchFn.mock.calls[0]![0] as string)
+    expect(parsed.searchParams.get('key')).toBe('pk.test-token')
+  })
+
+  it('omits the key param entirely when no API key is set (public OSM)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(osakaHit))
+    await new NominatimGeocoder(BASE, UA, fetchFn).geocode('Osaka')
+    const parsed = new URL(fetchFn.mock.calls[0]![0] as string)
+    expect(parsed.searchParams.has('key')).toBe(false)
+  })
 })

--- a/packages/api/tests/services/geocoding/throttled-geocoder.test.ts
+++ b/packages/api/tests/services/geocoding/throttled-geocoder.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ThrottledGeocoder } from '../../../src/services/geocoding/throttled-geocoder'
+import type { GeocodeResult, Geocoder, RateLimiter } from '../../../src/services/geocoding/types'
+
+const OSAKA: GeocodeResult = { lat: 34.6937, lng: 135.5023 }
+
+function fakeGeocoder(
+  result: GeocodeResult | null,
+): Geocoder & { geocode: ReturnType<typeof vi.fn> } {
+  return { geocode: vi.fn(async () => result) }
+}
+
+function limiterReturning(success: boolean): RateLimiter & { limit: ReturnType<typeof vi.fn> } {
+  return { limit: vi.fn(async () => ({ success })) }
+}
+
+describe('ThrottledGeocoder', () => {
+  it('delegates to the inner geocoder and returns its coords when the limiter allows', async () => {
+    const inner = fakeGeocoder(OSAKA)
+    const limiter = limiterReturning(true)
+    const result = await new ThrottledGeocoder(inner, limiter).geocode('1-1 Osaka, Japan')
+
+    expect(result).toEqual(OSAKA)
+    expect(inner.geocode).toHaveBeenCalledWith('1-1 Osaka, Japan')
+  })
+
+  it('checks one shared global bucket — the limiter is keyed by a single constant', async () => {
+    const limiter = limiterReturning(true)
+    const throttled = new ThrottledGeocoder(fakeGeocoder(OSAKA), limiter)
+    await throttled.geocode('A')
+    await throttled.geocode('B')
+
+    expect(limiter.limit).toHaveBeenCalledTimes(2)
+    expect(limiter.limit).toHaveBeenNthCalledWith(1, 'geocode:global')
+    expect(limiter.limit).toHaveBeenNthCalledWith(2, 'geocode:global')
+  })
+
+  it('skips the lookup and returns null WITHOUT calling the inner geocoder when over the limit', async () => {
+    const inner = fakeGeocoder(OSAKA)
+    const result = await new ThrottledGeocoder(inner, limiterReturning(false)).geocode('Osaka')
+
+    expect(result).toBeNull()
+    expect(inner.geocode).not.toHaveBeenCalled()
+  })
+
+  it('returns null when allowed but the inner geocoder finds no match', async () => {
+    const inner = fakeGeocoder(null)
+    const result = await new ThrottledGeocoder(inner, limiterReturning(true)).geocode('nowhere')
+
+    expect(result).toBeNull()
+    expect(inner.geocode).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails OPEN: a limiter error falls through to the inner geocoder rather than killing geocoding', async () => {
+    const inner = fakeGeocoder(OSAKA)
+    const limiter: RateLimiter = {
+      limit: vi.fn(async () => {
+        throw new Error('rate-limit service unavailable')
+      }),
+    }
+    const result = await new ThrottledGeocoder(inner, limiter).geocode('Osaka')
+
+    expect(result).toEqual(OSAKA)
+    expect(inner.geocode).toHaveBeenCalledWith('Osaka')
+  })
+
+  it('never throws even if the inner geocoder rejects (Geocoder contract)', async () => {
+    const inner: Geocoder = {
+      geocode: vi.fn(async () => {
+        throw new Error('boom')
+      }),
+    }
+    expect(await new ThrottledGeocoder(inner, limiterReturning(true)).geocode('Osaka')).toBeNull()
+  })
+})

--- a/packages/api/tests/services/location.test.ts
+++ b/packages/api/tests/services/location.test.ts
@@ -448,6 +448,19 @@ describe('LocationService', () => {
         }
       })
 
+      it('regeocode:true that fails PRESERVES a GEOCODED pin when the address is unchanged (transient miss / #574 throttle-skip is not stale)', async () => {
+        const loc = await seed({ latitude: 1, longitude: 2, coordinateSource: 'GEOCODED' })
+        const result = await build(missGeocoder).update(ctxFor(opA), loc.id, { regeocode: true })
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          // The address still supports the old pin, so a transient re-derivation
+          // miss must not wipe valid coords (#574 makes this miss routine).
+          expect(result.location.latitude).toBe(1)
+          expect(result.location.longitude).toBe(2)
+          expect(result.location.coordinateSource).toBe('GEOCODED')
+        }
+      })
+
       it('an unrelated edit (unchanged address) preserves existing coords', async () => {
         const loc = await seed({ latitude: 1, longitude: 2, coordinateSource: 'GEOCODED' })
         const geocode = vi.fn(async () => ({ lat: 0, lng: 0 }))

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -56,9 +56,10 @@ simple.period = 60
 # caps the WHOLE app at 1 req/s; the geocoder keys every lookup by one constant
 # ("geocode:global") so this is a single shared bucket, not per-IP. period must be
 # 10 or 60 (CF native limiter), so 1/10s is the tightest legal setting and stays
-# safely under 1 req/s. Best-effort only — a fixed window can admit 2 across a
-# boundary, and dev/local has no binding (unthrottled); the production provider's
-# own server-side limit (e.g. LocationIQ) is the real guarantee.
+# safely under 1 req/s. Best-effort only — the CF limiter is per-colo (per edge
+# region), not cross-region consistent, and a fixed window can admit 2 across a
+# boundary; dev/local has no binding (unthrottled). The production provider's own
+# server-side limit (e.g. LocationIQ) is the real guarantee.
 [[ratelimits]]
 name = "GEOCODE_LIMITER"
 namespace_id = "1005"

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -52,6 +52,19 @@ namespace_id = "1004"
 simple.limit = 30
 simple.period = 60
 
+# Global app-side throttle for forward geocoding (#574). OSM/Nominatim's policy
+# caps the WHOLE app at 1 req/s; the geocoder keys every lookup by one constant
+# ("geocode:global") so this is a single shared bucket, not per-IP. period must be
+# 10 or 60 (CF native limiter), so 1/10s is the tightest legal setting and stays
+# safely under 1 req/s. Best-effort only — a fixed window can admit 2 across a
+# boundary, and dev/local has no binding (unthrottled); the production provider's
+# own server-side limit (e.g. LocationIQ) is the real guarantee.
+[[ratelimits]]
+name = "GEOCODE_LIMITER"
+namespace_id = "1005"
+simple.limit = 1
+simple.period = 10
+
 # R2 bucket for vehicle photo uploads — DISABLED.
 # R2 is not enabled on the current Cloudflare account (blocked on #304 account
 # migration). Re-enable by uncommenting once R2 is provisioned:


### PR DESCRIPTION
## What & why

Before we can point the operator-location geocoder (#531) at the public OSM/Nominatim endpoint, we need an app-side guard: OSMF's usage policy caps the **whole app** at 1 req/s and forbids bursts. A burst of operator saves (or a seed/import run) would breach that and earn an IP ban. This PR adds that guard.

**Approach — decorator on the port (DIP + Decorator):** a `ThrottledGeocoder` wraps the existing `Geocoder` port. It checks a Cloudflare-native `[[ratelimits]]` binding (`GEOCODE_LIMITER`, 1 req / 10s) keyed by a single constant (`geocode:global`) so the cap is **global**, not per-IP. Over the limit ⇒ skip the lookup and return `null`. A skip is byte-identical to a provider miss, which `LocationService` already handles — the location still saves, just with no map pin (a later edit/`regeocode` fills it). The CF-specific `limit({ key })` shape is adapted to the port's `limit(key)` at exactly one line in `index.ts`, so nothing in `services/` knows about Cloudflare.

**Fail-OPEN:** if the limiter *itself* errors, geocoding proceeds unthrottled — a rate-limit-service blip shouldn't kill all geocoding. This is safe **only while public OSM stays opt-in** (gated on `NOMINATIM_USER_AGENT` + `NOMINATIM_API_URL`); production runs LocationIQ, whose own server-side cap is the real guarantee. The throttle is best-effort defense-in-depth.

## Scope note

#574's title covers "rate-limit **+ cache**". This PR delivers the **rate-limit** half (the production blocker). The **KV cache** half is split into a follow-up (gated on the #304 account migration that also unblocks R2/KV), filed on merge.

## Changes
- `services/geocoding/throttled-geocoder.ts` (new) — the decorator + fail-open/never-throw logic
- `services/geocoding/types.ts` — new `RateLimiter` port (`limit(key) → { success }`)
- `services/geocoding/nominatim-geocoder.ts` — optional `apiKey` → `?key=`, making LocationIQ a pure env-var swap
- `index.ts` — DI wiring + CF-binding adapter (the only Cloudflare-aware line; still 797/800 cap)
- `wrangler.toml` — `GEOCODE_LIMITER` binding (ns 1005, 1/10s)
- `.env.example` — demo (OSM) vs prod (LocationIQ) config + dev-unthrottled warning

## Reviews (run on the code, not just the plan)
- **code-reviewer → SHIP.** 0 CRITICAL / HIGH / MEDIUM. 3 LOW, all acceptable (JSON-escaped address log; `globalThis` cast consistent with 4 sibling limiters; LocationIQ requires `?key=` over HTTPS, never logged).
- **architect → SHIP.** No fix-now blockers. Two ~1-line doc hardenings folded in (`3bdb2b1`): fail-open's OSM-opt-in dependency, and the limiter being per-colo not cross-region.

## Known residuals
- **R1** — CF fixed-window can admit 2 req across a window boundary. Accepted: immaterial for dozens of lifetime lookups behind a provider's own cap.
- **R2 / F6** — bulk onboarding silently drops pins (only a `console.warn`, no durable marker). Deferred to the cache/retry follow-up. Scope note carried to that issue: the fix needs a **distinguishable pending state** (`null` today conflates "throttled, retry works" with "un-geocodable, retry won't") — not a blind retry-everything sweep.
- **R3** — `globalThis.GEOCODE_LIMITER` resolution isn't unit-proven, but it's the **5th instance** of a pattern 4 sibling limiters already run in production (`nodejs_compat` hoists bindings onto `globalThis`). Covered by the pre-prod smoke below.

## Pre-prod smoke (manual, before enabling in prod)
1. `wrangler dev` → confirm `typeof globalThis.GEOCODE_LIMITER !== 'undefined'`.
2. POST two locations <10s apart with a real `NOMINATIM_*` config → assert the **2nd** persists `latitude: null` (proves the binding throttles the real path, not just that it exists).

## Test plan
- `bun run --filter @kuruma/api test` → **1209 pass** (108 files), incl. 6 new `ThrottledGeocoder` unit tests (allow/skip/fail-open/never-throw/shared-key), 2 `NominatimGeocoder` key-param tests, 1 DI test proving an over-limit binding skips the lookup while the save still 201s with null coords.
- `tsc --noEmit` clean · `lint:boundaries` OK · biome clean.

Closes #574
