### PR TITLE
feat(operator): fleet row/grid view toggle — Vite (#561)

### DIFF
--- a/packages/web/src/lib/fleet-grouping.ts
+++ b/packages/web/src/lib/fleet-grouping.ts
@@ -13,7 +13,10 @@ export interface FleetClassGroup<T> {
   readonly vehicles: readonly T[]
 }
 
-const UNASSIGNED_KEY = '__unassigned__'
+// Stable key for the trailing "no class / archived class" group. Exported so
+// consumers (e.g. the grid's collapse state) key on the same literal the
+// grouping uses, rather than re-typing it and risking silent drift.
+export const UNASSIGNED_KEY = '__unassigned__'
 
 export function groupVehiclesByClassId<T extends { classId: string | null }>(
   vehicles: readonly T[],

--- a/packages/web/src/lib/fleet-grouping.ts
+++ b/packages/web/src/lib/fleet-grouping.ts
@@ -1,0 +1,45 @@
+// Pure grouping for the operator fleet grid view (#561). Buckets vehicles by
+// their `classId`, resolving the display name from a caller-supplied
+// id -> name map (the operator-scoped class options query). Vehicles whose
+// classId is null — or names a class no longer in the map (archived, FK
+// dropped) — fall into a trailing "Unassigned" group so the owner can spot
+// and reassign them. Empty classes are dropped (the fleet page manages
+// vehicles, not classes). The map's iteration order is the display order;
+// the server returns classes already sortOrder-ordered.
+
+export interface FleetClassGroup<T> {
+  readonly classId: string | null
+  readonly className: string
+  readonly vehicles: readonly T[]
+}
+
+const UNASSIGNED_KEY = '__unassigned__'
+
+export function groupVehiclesByClassId<T extends { classId: string | null }>(
+  vehicles: readonly T[],
+  classNames: ReadonlyMap<string, string>,
+  unassignedLabel: string,
+): FleetClassGroup<T>[] {
+  const buckets = new Map<string, T[]>()
+  for (const vehicle of vehicles) {
+    const key =
+      vehicle.classId != null && classNames.has(vehicle.classId) ? vehicle.classId : UNASSIGNED_KEY
+    const bucket = buckets.get(key) ?? []
+    buckets.set(key, [...bucket, vehicle])
+  }
+
+  const groups: FleetClassGroup<T>[] = []
+  for (const [classId, className] of classNames) {
+    const bucket = buckets.get(classId)
+    if (bucket && bucket.length > 0) {
+      groups.push({ classId, className, vehicles: bucket })
+    }
+  }
+
+  const unassigned = buckets.get(UNASSIGNED_KEY)
+  if (unassigned && unassigned.length > 0) {
+    groups.push({ classId: null, className: unassignedLabel, vehicles: unassigned })
+  }
+
+  return groups
+}

--- a/packages/web/src/routes/$locale/_business/manage/fleet.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fleet.tsx
@@ -1,6 +1,9 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
-import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
+import {
+  operatorFleetQueryOptions,
+  vehicleClassOptionsQueryOptions,
+} from '@/vite/operator-fleet/api'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
@@ -11,8 +14,16 @@ import { useTranslations } from 'use-intl'
 // prefetches into the query cache (no FOUC); the component reads the same
 // options via useSuspenseQuery. This foundation ships the read-only list; the
 // CRUD / filters / bulk / photo slices are mounted here at integration (#526).
+// The loader also prefetches the operator's vehicle-class options so the grid
+// view (#561) can group by class with no "Unassigned" flash, and so the edit
+// sheet's class dropdown is a warm-cache read — both behind this route's
+// pendingComponent rather than each component owning its own loading state.
 export const Route = createFileRoute('/$locale/_business/manage/fleet')({
-  loader: ({ context }) => context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+      context.queryClient.ensureQueryData(vehicleClassOptionsQueryOptions()),
+    ]),
   pendingComponent: PageSkeleton,
   errorComponent: OperatorFleetError,
   component: OperatorFleetRoute,
@@ -21,6 +32,7 @@ export const Route = createFileRoute('/$locale/_business/manage/fleet')({
 function OperatorFleetRoute() {
   const t = useTranslations('business.vehicles.fleet')
   const { data: vehicles } = useSuspenseQuery(operatorFleetQueryOptions())
+  const { data: classOptions } = useSuspenseQuery(vehicleClassOptionsQueryOptions())
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -29,7 +41,7 @@ function OperatorFleetRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        <OperatorFleetView vehicles={vehicles} />
+        <OperatorFleetView vehicles={vehicles} classOptions={classOptions} />
       </div>
     </main>
   )

--- a/packages/web/src/vite/operator-fleet/FleetGrid.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetGrid.tsx
@@ -1,14 +1,13 @@
-import { groupVehiclesByClassId } from '@/lib/fleet-grouping'
+import { UNASSIGNED_KEY, groupVehiclesByClassId } from '@/lib/fleet-grouping'
 import { FleetVehicleCard } from '@/vite/operator-fleet/FleetVehicleCard'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
-import { vehicleClassOptionsQueryOptions } from '@/vite/operator-fleet/api'
-import { useQuery } from '@tanstack/react-query'
+import type { OperatorFleetVehicle, VehicleClassOption } from '@/vite/operator-fleet/api'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
 
 interface FleetGridProps {
   readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly classOptions: readonly VehicleClassOption[]
   readonly selectedIds: readonly string[]
   readonly onToggleSelect: (id: string) => void
   readonly onEdit: (vehicle: OperatorFleetVehicle) => void
@@ -16,22 +15,23 @@ interface FleetGridProps {
 }
 
 // Grid mode for the operator fleet (#561): vehicles grouped by class into
-// collapsible sections of cards. Class display names come from the same
-// operator-scoped options query the edit form uses (#528); a vehicle with no
-// class — or one whose class is gone — lands in a trailing "Unassigned"
+// collapsible sections of cards. Class display names are supplied by the
+// container (the route prefetches the operator-scoped options, #528), so this
+// stays presentational with no fetch of its own and no loading flash. A vehicle
+// with no class — or one whose class is gone — lands in a trailing "Unassigned"
 // section. Collapse state is per-group and client-local.
 export function FleetGrid({
   vehicles,
+  classOptions,
   selectedIds,
   onToggleSelect,
   onEdit,
   todayIso,
 }: FleetGridProps) {
   const t = useTranslations('business.vehicles.group')
-  const { data: classOptions } = useQuery(vehicleClassOptionsQueryOptions())
 
   const groups = useMemo(() => {
-    const classNames = new Map((classOptions ?? []).map((c) => [c.id, c.name]))
+    const classNames = new Map(classOptions.map((c) => [c.id, c.name]))
     return groupVehiclesByClassId(vehicles, classNames, t('unassigned'))
   }, [vehicles, classOptions, t])
 
@@ -49,7 +49,7 @@ export function FleetGrid({
   return (
     <div className="min-w-0 flex-1 space-y-6">
       {groups.map((group) => {
-        const key = group.classId ?? '__unassigned__'
+        const key = group.classId ?? UNASSIGNED_KEY
         const isCollapsed = collapsed.has(key)
         return (
           <section key={key} aria-label={group.className}>

--- a/packages/web/src/vite/operator-fleet/FleetGrid.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetGrid.tsx
@@ -1,0 +1,91 @@
+import { groupVehiclesByClassId } from '@/lib/fleet-grouping'
+import { FleetVehicleCard } from '@/vite/operator-fleet/FleetVehicleCard'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { vehicleClassOptionsQueryOptions } from '@/vite/operator-fleet/api'
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface FleetGridProps {
+  readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly selectedIds: readonly string[]
+  readonly onToggleSelect: (id: string) => void
+  readonly onEdit: (vehicle: OperatorFleetVehicle) => void
+  readonly todayIso: string
+}
+
+// Grid mode for the operator fleet (#561): vehicles grouped by class into
+// collapsible sections of cards. Class display names come from the same
+// operator-scoped options query the edit form uses (#528); a vehicle with no
+// class — or one whose class is gone — lands in a trailing "Unassigned"
+// section. Collapse state is per-group and client-local.
+export function FleetGrid({
+  vehicles,
+  selectedIds,
+  onToggleSelect,
+  onEdit,
+  todayIso,
+}: FleetGridProps) {
+  const t = useTranslations('business.vehicles.group')
+  const { data: classOptions } = useQuery(vehicleClassOptionsQueryOptions())
+
+  const groups = useMemo(() => {
+    const classNames = new Map((classOptions ?? []).map((c) => [c.id, c.name]))
+    return groupVehiclesByClassId(vehicles, classNames, t('unassigned'))
+  }, [vehicles, classOptions, t])
+
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+  const toggle = (key: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
+  if (groups.length === 0) return null
+
+  return (
+    <div className="min-w-0 flex-1 space-y-6">
+      {groups.map((group) => {
+        const key = group.classId ?? '__unassigned__'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <section key={key} aria-label={group.className}>
+            <button
+              type="button"
+              onClick={() => toggle(key)}
+              aria-expanded={!isCollapsed}
+              className="-mx-1 mb-4 flex w-full items-center gap-2 rounded-sm border-border border-b px-1 pb-2 text-left transition-colors hover:bg-muted/30"
+            >
+              {isCollapsed ? (
+                <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+              )}
+              <h2 className="flex-1 font-semibold text-lg tracking-tight">{group.className}</h2>
+              <span className="text-muted-foreground text-sm tabular-nums">
+                {t('vehicleCount', { count: group.vehicles.length })}
+              </span>
+            </button>
+            {!isCollapsed && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {group.vehicles.map((vehicle) => (
+                  <FleetVehicleCard
+                    key={vehicle.id}
+                    vehicle={vehicle}
+                    selected={selectedIds.includes(vehicle.id)}
+                    onToggleSelect={onToggleSelect}
+                    onEdit={() => onEdit(vehicle)}
+                    todayIso={todayIso}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/FleetSummaryBar.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetSummaryBar.tsx
@@ -1,0 +1,50 @@
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { computeExpiryStatus } from '@kuruma/shared/lib/expiry'
+import { useTranslations } from 'use-intl'
+
+interface FleetSummaryBarProps {
+  readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly todayIso: string
+}
+
+// Fleet-wide counts strip (#561). "On rental" reflects operational state
+// (there is a currentBooking) not the status column — a vehicle can be
+// AVAILABLE and currently rented at once (#52). Counts the whole fleet, not
+// the filtered view, so it stays a stable snapshot as filters change.
+export function FleetSummaryBar({ vehicles, todayIso }: FleetSummaryBarProps) {
+  const t = useTranslations('business.vehicles.fleet.summary')
+
+  const total = vehicles.length
+  const onRental = vehicles.filter((v) => v.currentBooking !== null).length
+  const available = vehicles.filter((v) => v.status === 'AVAILABLE').length
+  const maintenance = vehicles.filter((v) => v.status === 'MAINTENANCE').length
+  const expiring = vehicles.filter((v) => {
+    const s = computeExpiryStatus(v.shakenExpiryDate, todayIso)
+    const i = computeExpiryStatus(v.insuranceExpiryDate, todayIso)
+    return s === 'EXPIRING_SOON' || s === 'EXPIRED' || i === 'EXPIRING_SOON' || i === 'EXPIRED'
+  }).length
+
+  const dot = (
+    <span className="hidden text-muted-foreground sm:inline" aria-hidden>
+      ·
+    </span>
+  )
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-xl border border-border bg-card px-4 py-3 text-sm">
+      <span className="font-medium text-foreground">{t('total', { n: total })}</span>
+      {dot}
+      <span className="text-foreground">{t('onRental', { n: onRental })}</span>
+      {dot}
+      <span className="text-foreground">{t('available', { n: available })}</span>
+      {dot}
+      <span className="text-foreground">{t('maintenance', { n: maintenance })}</span>
+      {expiring > 0 && (
+        <>
+          {dot}
+          <span className="text-destructive">{t('expiring', { n: expiring })}</span>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/FleetTable.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetTable.tsx
@@ -18,7 +18,9 @@ interface FleetTableProps {
 // Row mode for the operator fleet (#561): the original table, extracted from
 // OperatorFleetView so the container can swap it for FleetGrid. Purely
 // presentational — selection state and the edit handler are injected by the
-// parent, identical to the cards' contract so behaviour matches in both views.
+// parent. Per-row affordances (checkbox + FleetRowActions + onEdit) match the
+// grid cards; the header select-all / indeterminate control is row-view only
+// (grid per-group select-all is a #561 follow-up).
 export function FleetTable({
   vehicles,
   selectedIds,

--- a/packages/web/src/vite/operator-fleet/FleetTable.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetTable.tsx
@@ -1,0 +1,111 @@
+import { FleetRowActions } from '@/vite/operator-fleet/FleetRowActions'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { ExpiryPill, StatusPill, priceLabel } from '@/vite/operator-fleet/cells'
+import { computeExpiryStatus } from '@kuruma/shared/lib/expiry'
+import { useTranslations } from 'use-intl'
+
+interface FleetTableProps {
+  readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly selectedIds: readonly string[]
+  readonly allSelected: boolean
+  readonly someSelected: boolean
+  readonly onToggleAll: () => void
+  readonly onToggleOne: (id: string) => void
+  readonly onEdit: (vehicle: OperatorFleetVehicle) => void
+  readonly todayIso: string
+}
+
+// Row mode for the operator fleet (#561): the original table, extracted from
+// OperatorFleetView so the container can swap it for FleetGrid. Purely
+// presentational — selection state and the edit handler are injected by the
+// parent, identical to the cards' contract so behaviour matches in both views.
+export function FleetTable({
+  vehicles,
+  selectedIds,
+  allSelected,
+  someSelected,
+  onToggleAll,
+  onToggleOne,
+  onEdit,
+  todayIso,
+}: FleetTableProps) {
+  const t = useTranslations('business.vehicles.fleet')
+  const tBulk = useTranslations('business.vehicles.bulk')
+
+  return (
+    <div className="min-w-0 flex-1 overflow-x-auto rounded-xl border border-border">
+      <table className="w-full text-left text-sm">
+        <thead className="border-border border-b bg-muted/40 text-muted-foreground">
+          <tr>
+            <th className="w-10 px-4 py-3">
+              <input
+                type="checkbox"
+                ref={(el) => {
+                  if (el) el.indeterminate = someSelected
+                }}
+                aria-label={tBulk('selectAll')}
+                checked={allSelected}
+                onChange={onToggleAll}
+              />
+            </th>
+            <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
+            <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
+            <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
+            <th className="px-4 py-3 text-right font-medium">{t('columns.actions')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vehicles.map((v) => (
+            <tr
+              key={v.id}
+              className="border-border border-b transition-colors last:border-0 hover:bg-muted/40"
+            >
+              <td className="px-4 py-3">
+                <input
+                  type="checkbox"
+                  aria-label={tBulk('selectRow', { name: v.name })}
+                  checked={selectedIds.includes(v.id)}
+                  onChange={() => onToggleOne(v.id)}
+                />
+              </td>
+              <td className="px-4 py-3">
+                <div className="font-medium">{v.name}</div>
+                <div className="text-muted-foreground text-xs">
+                  <span>{v.licensePlate ?? t('none')}</span>
+                  {v.make != null && (
+                    <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
+                  )}
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <StatusPill status={v.status} label={t(`status.${v.status}`)} />
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {v.luggageCapacity ?? t('none')}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
+              <td className="px-4 py-3">
+                <ExpiryPill
+                  status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
+                  labels={{
+                    OK: t('expiry.OK'),
+                    EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
+                    EXPIRED: t('expiry.EXPIRED'),
+                    UNKNOWN: t('expiry.UNKNOWN'),
+                  }}
+                />
+              </td>
+              <td className="px-4 py-3 text-right">
+                <FleetRowActions vehicle={v} onEdit={() => onEdit(v)} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
@@ -1,0 +1,80 @@
+import { FleetRowActions } from '@/vite/operator-fleet/FleetRowActions'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { ExpiryPill, StatusPill, priceLabel } from '@/vite/operator-fleet/cells'
+import { computeExpiryStatus } from '@kuruma/shared/lib/expiry'
+import { Car } from 'lucide-react'
+import { useTranslations } from 'use-intl'
+
+interface FleetVehicleCardProps {
+  readonly vehicle: OperatorFleetVehicle
+  readonly selected: boolean
+  readonly onToggleSelect: (id: string) => void
+  readonly onEdit: () => void
+  readonly todayIso: string
+}
+
+// Grid-mode card for one fleet vehicle (#561). Carries the exact same
+// affordances as a table row — a selection checkbox, the per-row actions
+// menu and Edit — so selection and bulk actions behave identically in both
+// views. Presentation (status / expiry / price) comes from the shared cells.
+export function FleetVehicleCard({
+  vehicle,
+  selected,
+  onToggleSelect,
+  onEdit,
+  todayIso,
+}: FleetVehicleCardProps) {
+  const t = useTranslations('business.vehicles.fleet')
+  const tBulk = useTranslations('business.vehicles.bulk')
+  const photo = vehicle.photos[0]
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-3">
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          aria-label={tBulk('selectRow', { name: vehicle.name })}
+          checked={selected}
+          onChange={() => onToggleSelect(vehicle.id)}
+          className="mt-1 shrink-0"
+        />
+        <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-muted">
+          {photo ? (
+            <img src={photo} alt={vehicle.name} className="h-full w-full object-cover" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <Car className="size-6 text-muted-foreground/30" />
+            </div>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium">{vehicle.name}</div>
+          <div className="truncate text-xs text-muted-foreground">
+            {vehicle.licensePlate ?? t('none')}
+          </div>
+          <div className="mt-1">
+            <StatusPill status={vehicle.status} label={t(`status.${vehicle.status}`)} />
+          </div>
+        </div>
+        <FleetRowActions vehicle={vehicle} onEdit={onEdit} />
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <span className="tabular-nums text-muted-foreground">
+          {`${vehicle.seats} · ${vehicle.luggageCapacity ?? t('none')}`}
+        </span>
+        <span className="font-medium tabular-nums">{priceLabel(vehicle, t)}</span>
+      </div>
+
+      <ExpiryPill
+        status={computeExpiryStatus(vehicle.shakenExpiryDate, todayIso)}
+        labels={{
+          OK: t('expiry.OK'),
+          EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
+          EXPIRED: t('expiry.EXPIRED'),
+          UNKNOWN: t('expiry.UNKNOWN'),
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
@@ -13,10 +13,11 @@ interface FleetVehicleCardProps {
   readonly todayIso: string
 }
 
-// Grid-mode card for one fleet vehicle (#561). Carries the exact same
-// affordances as a table row — a selection checkbox, the per-row actions
-// menu and Edit — so selection and bulk actions behave identically in both
-// views. Presentation (status / expiry / price) comes from the shared cells.
+// Grid-mode card for one fleet vehicle (#561). Carries the same per-row
+// affordances as a table row — a selection checkbox, the per-row actions menu
+// and Edit — so per-vehicle selection and bulk actions behave identically in
+// both views. (Header select-all is row-view only; see FleetTable.) Presentation
+// (status / expiry / price) comes from the shared cells.
 export function FleetVehicleCard({
   vehicle,
   selected,

--- a/packages/web/src/vite/operator-fleet/FleetViewToggle.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetViewToggle.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { FleetViewMode } from '@/vite/operator-fleet/useFleetViewMode'
+import { LayoutGrid, Rows3 } from 'lucide-react'
+import { useTranslations } from 'use-intl'
+
+interface FleetViewToggleProps {
+  readonly value: FleetViewMode
+  readonly onChange: (next: FleetViewMode) => void
+}
+
+// Row/grid switch for the operator fleet (#561). A pair of pressed-state
+// buttons; the parent owns the mode (via useFleetViewMode) so the table/grid
+// branch and this control never drift.
+export function FleetViewToggle({ value, onChange }: FleetViewToggleProps) {
+  const t = useTranslations('business.vehicles.fleet')
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-card p-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={t('rowView')}
+        aria-pressed={value === 'row'}
+        className={cn('h-7 px-2', value === 'row' && 'bg-muted')}
+        onClick={() => onChange('row')}
+      >
+        <Rows3 className="size-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={t('gridView')}
+        aria-pressed={value === 'grid'}
+        className={cn('h-7 px-2', value === 'grid' && 'bg-muted')}
+        onClick={() => onChange('grid')}
+      >
+        <LayoutGrid className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -7,7 +7,7 @@ import { FleetGrid } from '@/vite/operator-fleet/FleetGrid'
 import { FleetSummaryBar } from '@/vite/operator-fleet/FleetSummaryBar'
 import { FleetTable } from '@/vite/operator-fleet/FleetTable'
 import { FleetViewToggle } from '@/vite/operator-fleet/FleetViewToggle'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { OperatorFleetVehicle, VehicleClassOption } from '@/vite/operator-fleet/api'
 import { useFleetViewMode } from '@/vite/operator-fleet/useFleetViewMode'
 import { CarFront, Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -15,6 +15,7 @@ import { useTranslations } from 'use-intl'
 
 interface OperatorFleetViewProps {
   readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly classOptions: readonly VehicleClassOption[]
 }
 
 // Stateful fleet management container. The route owns the loader /
@@ -23,7 +24,7 @@ interface OperatorFleetViewProps {
 // (FleetTable) or grid (FleetGrid) presentation (#561). Decision logic stays in
 // the pure fleet-filters / fleet-grouping libs (FC/IS); this is the imperative
 // shell that holds UI state.
-export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
+export function OperatorFleetView({ vehicles, classOptions }: OperatorFleetViewProps) {
   const t = useTranslations('business.vehicles.fleet')
   const todayIso = new Date().toISOString().slice(0, 10)
   const [view, setView] = useFleetViewMode()
@@ -70,6 +71,7 @@ export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
             {view === 'grid' ? (
               <FleetGrid
                 vehicles={visibleVehicles}
+                classOptions={classOptions}
                 selectedIds={selectedIds}
                 onToggleSelect={toggleOne}
                 onEdit={openEdit}

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -1,12 +1,14 @@
 import { Button } from '@/components/ui/button'
 import { type FleetFilterState, filterVehicles } from '@/lib/fleet-filters'
-import { formatVehicleRate } from '@/lib/format'
 import { BulkActionBar } from '@/vite/operator-fleet/BulkActionBar'
 import { EditVehicleSheet } from '@/vite/operator-fleet/EditVehicleSheet'
 import { FleetFilters } from '@/vite/operator-fleet/FleetFilters'
-import { FleetRowActions } from '@/vite/operator-fleet/FleetRowActions'
-import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
-import { type ExpiryStatus, computeExpiryStatus } from '@kuruma/shared/lib/expiry'
+import { FleetGrid } from '@/vite/operator-fleet/FleetGrid'
+import { FleetSummaryBar } from '@/vite/operator-fleet/FleetSummaryBar'
+import { FleetTable } from '@/vite/operator-fleet/FleetTable'
+import { FleetViewToggle } from '@/vite/operator-fleet/FleetViewToggle'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { useFleetViewMode } from '@/vite/operator-fleet/useFleetViewMode'
 import { CarFront, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
@@ -17,13 +19,14 @@ interface OperatorFleetViewProps {
 
 // Stateful fleet management container. The route owns the loader /
 // useSuspenseQuery and the pending/error boundaries; this owns the interaction
-// state (selection, filters, the edit sheet) and mounts the controlled CRUD /
-// bulk / photo / filter slices (#526). Decision logic stays in the pure
-// fleet-filters lib (FC/IS); this is the imperative shell that holds UI state.
+// state (selection, filters, view mode, the edit sheet) and picks the row
+// (FleetTable) or grid (FleetGrid) presentation (#561). Decision logic stays in
+// the pure fleet-filters / fleet-grouping libs (FC/IS); this is the imperative
+// shell that holds UI state.
 export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
   const t = useTranslations('business.vehicles.fleet')
-  const tBulk = useTranslations('business.vehicles.bulk')
   const todayIso = new Date().toISOString().slice(0, 10)
+  const [view, setView] = useFleetViewMode()
   const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
   const [filters, setFilters] = useState<FleetFilterState>({})
   const [sheet, setSheet] = useState<{ vehicle: OperatorFleetVehicle | null } | null>(null)
@@ -40,10 +43,12 @@ export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
   const toggleAll = () => setSelectedIds(allSelected ? [] : visibleIds)
   const toggleOne = (id: string) =>
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  const openEdit = (vehicle: OperatorFleetVehicle) => setSheet({ vehicle })
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between gap-3">
+        <FleetViewToggle value={view} onChange={setView} />
         <Button onClick={() => setSheet({ vehicle: null })}>
           <Plus className="size-4" />
           {t('addVehicle')}
@@ -56,85 +61,34 @@ export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
           <p className="text-lg text-muted-foreground">{t('empty')}</p>
         </div>
       ) : (
-        <div className="flex flex-col gap-6 lg:flex-row">
-          <aside className="lg:w-64 lg:shrink-0">
-            <FleetFilters vehicles={vehicles} value={filters} onChange={setFilters} />
-          </aside>
-          <div className="min-w-0 flex-1 overflow-x-auto rounded-xl border border-border">
-            <table className="w-full text-left text-sm">
-              <thead className="border-b border-border bg-muted/40 text-muted-foreground">
-                <tr>
-                  <th className="w-10 px-4 py-3">
-                    <input
-                      type="checkbox"
-                      ref={(el) => {
-                        if (el) el.indeterminate = someSelected
-                      }}
-                      aria-label={tBulk('selectAll')}
-                      checked={allSelected}
-                      onChange={toggleAll}
-                    />
-                  </th>
-                  <th className="px-4 py-3 font-medium">{t('columns.vehicle')}</th>
-                  <th className="px-4 py-3 font-medium">{t('columns.status')}</th>
-                  <th className="px-4 py-3 text-right font-medium">{t('columns.seats')}</th>
-                  <th className="px-4 py-3 text-right font-medium">{t('columns.luggage')}</th>
-                  <th className="px-4 py-3 text-right font-medium">{t('columns.price')}</th>
-                  <th className="px-4 py-3 font-medium">{t('columns.shaken')}</th>
-                  <th className="px-4 py-3 text-right font-medium">{t('columns.actions')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {visibleVehicles.map((v) => (
-                  <tr
-                    key={v.id}
-                    className="border-b border-border transition-colors last:border-0 hover:bg-muted/40"
-                  >
-                    <td className="px-4 py-3">
-                      <input
-                        type="checkbox"
-                        aria-label={tBulk('selectRow', { name: v.name })}
-                        checked={selectedIds.includes(v.id)}
-                        onChange={() => toggleOne(v.id)}
-                      />
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="font-medium">{v.name}</div>
-                      <div className="text-xs text-muted-foreground">
-                        <span>{v.licensePlate ?? t('none')}</span>
-                        {v.make != null && (
-                          <span>{` · ${[v.make, v.model, v.year].filter(Boolean).join(' ')}`}</span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <StatusPill status={v.status} label={t(`status.${v.status}`)} />
-                    </td>
-                    <td className="px-4 py-3 text-right tabular-nums">{v.seats}</td>
-                    <td className="px-4 py-3 text-right tabular-nums">
-                      {v.luggageCapacity ?? t('none')}
-                    </td>
-                    <td className="px-4 py-3 text-right tabular-nums">{priceLabel(v, t)}</td>
-                    <td className="px-4 py-3">
-                      <ExpiryPill
-                        status={computeExpiryStatus(v.shakenExpiryDate, todayIso)}
-                        labels={{
-                          OK: t('expiry.OK'),
-                          EXPIRING_SOON: t('expiry.EXPIRING_SOON'),
-                          EXPIRED: t('expiry.EXPIRED'),
-                          UNKNOWN: t('expiry.UNKNOWN'),
-                        }}
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <FleetRowActions vehicle={v} onEdit={() => setSheet({ vehicle: v })} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        <>
+          <FleetSummaryBar vehicles={vehicles} todayIso={todayIso} />
+          <div className="flex flex-col gap-6 lg:flex-row">
+            <aside className="lg:w-64 lg:shrink-0">
+              <FleetFilters vehicles={vehicles} value={filters} onChange={setFilters} />
+            </aside>
+            {view === 'grid' ? (
+              <FleetGrid
+                vehicles={visibleVehicles}
+                selectedIds={selectedIds}
+                onToggleSelect={toggleOne}
+                onEdit={openEdit}
+                todayIso={todayIso}
+              />
+            ) : (
+              <FleetTable
+                vehicles={visibleVehicles}
+                selectedIds={selectedIds}
+                allSelected={allSelected}
+                someSelected={someSelected}
+                onToggleAll={toggleAll}
+                onToggleOne={toggleOne}
+                onEdit={openEdit}
+                todayIso={todayIso}
+              />
+            )}
           </div>
-        </div>
+        </>
       )}
 
       <BulkActionBar
@@ -152,46 +106,4 @@ export function OperatorFleetView({ vehicles }: OperatorFleetViewProps) {
       />
     </div>
   )
-}
-
-function priceLabel(v: OperatorFleetVehicle, t: (k: string) => string) {
-  return (
-    formatVehicleRate(v.dailyRateJpy, v.hourlyRateJpy, {
-      perDay: t('perDay'),
-      perHour: t('perHour'),
-    }) ?? t('none')
-  )
-}
-
-const STATUS_PILL: Record<VehicleStatus, string> = {
-  AVAILABLE: 'border-transparent bg-muted text-foreground',
-  MAINTENANCE: 'border-amber-300 text-amber-700 dark:text-amber-400',
-  RETIRED: 'border-transparent bg-muted text-muted-foreground',
-}
-
-function StatusPill({ status, label }: { status: VehicleStatus; label: string }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_PILL[status]}`}
-    >
-      {label}
-    </span>
-  )
-}
-
-const EXPIRY_PILL: Record<ExpiryStatus, string> = {
-  OK: 'text-muted-foreground',
-  EXPIRING_SOON: 'text-amber-700 dark:text-amber-400',
-  EXPIRED: 'text-destructive font-medium',
-  UNKNOWN: 'text-muted-foreground',
-}
-
-function ExpiryPill({
-  status,
-  labels,
-}: {
-  status: ExpiryStatus
-  labels: Record<ExpiryStatus, string>
-}) {
-  return <span className={`text-xs ${EXPIRY_PILL[status]}`}>{labels[status]}</span>
 }

--- a/packages/web/src/vite/operator-fleet/cells.tsx
+++ b/packages/web/src/vite/operator-fleet/cells.tsx
@@ -1,0 +1,49 @@
+import { formatVehicleRate } from '@/lib/format'
+import type { OperatorFleetVehicle, VehicleStatus } from '@/vite/operator-fleet/api'
+import type { ExpiryStatus } from '@kuruma/shared/lib/expiry'
+
+// Presentational cells shared by the fleet table rows and the grid cards
+// (#561). Extracted from OperatorFleetView so both view modes render status,
+// expiry and price identically without duplicating the colour maps.
+
+export function priceLabel(v: OperatorFleetVehicle, t: (k: string) => string): string {
+  return (
+    formatVehicleRate(v.dailyRateJpy, v.hourlyRateJpy, {
+      perDay: t('perDay'),
+      perHour: t('perHour'),
+    }) ?? t('none')
+  )
+}
+
+const STATUS_PILL: Record<VehicleStatus, string> = {
+  AVAILABLE: 'border-transparent bg-muted text-foreground',
+  MAINTENANCE: 'border-amber-300 text-amber-700 dark:text-amber-400',
+  RETIRED: 'border-transparent bg-muted text-muted-foreground',
+}
+
+export function StatusPill({ status, label }: { status: VehicleStatus; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_PILL[status]}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+const EXPIRY_PILL: Record<ExpiryStatus, string> = {
+  OK: 'text-muted-foreground',
+  EXPIRING_SOON: 'text-amber-700 dark:text-amber-400',
+  EXPIRED: 'text-destructive font-medium',
+  UNKNOWN: 'text-muted-foreground',
+}
+
+export function ExpiryPill({
+  status,
+  labels,
+}: {
+  status: ExpiryStatus
+  labels: Record<ExpiryStatus, string>
+}) {
+  return <span className={`text-xs ${EXPIRY_PILL[status]}`}>{labels[status]}</span>
+}

--- a/packages/web/src/vite/operator-fleet/useFleetViewMode.ts
+++ b/packages/web/src/vite/operator-fleet/useFleetViewMode.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+export type FleetViewMode = 'row' | 'grid'
+
+const STORAGE_KEY = 'kuruma-fleet-view-mode'
+
+function isViewMode(v: unknown): v is FleetViewMode {
+  return v === 'row' || v === 'grid'
+}
+
+// localStorage-backed persistence for the operator's preferred fleet layout
+// (#561). Defaults to 'row' on first paint and hydrates from storage in an
+// effect so SSR/initial render stays deterministic. Returns a [value, setter]
+// tuple like useState; the setter writes through to storage.
+export function useFleetViewMode(): readonly [FleetViewMode, (next: FleetViewMode) => void] {
+  const [mode, setMode] = useState<FleetViewMode>('row')
+
+  useEffect(() => {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (isViewMode(raw)) setMode(raw)
+  }, [])
+
+  const update = (next: FleetViewMode) => {
+    setMode(next)
+    window.localStorage.setItem(STORAGE_KEY, next)
+  }
+
+  return [mode, update] as const
+}

--- a/packages/web/src/vite/operator-fleet/useFleetViewMode.ts
+++ b/packages/web/src/vite/operator-fleet/useFleetViewMode.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 export type FleetViewMode = 'row' | 'grid'
 
@@ -9,16 +9,15 @@ function isViewMode(v: unknown): v is FleetViewMode {
 }
 
 // localStorage-backed persistence for the operator's preferred fleet layout
-// (#561). Defaults to 'row' on first paint and hydrates from storage in an
-// effect so SSR/initial render stays deterministic. Returns a [value, setter]
+// (#561). This is a client-rendered SPA, so the stored value is read in the
+// lazy useState initializer — no SSR paint to stay consistent with, and no
+// row->grid flash for grid-preferring operators. Returns a [value, setter]
 // tuple like useState; the setter writes through to storage.
 export function useFleetViewMode(): readonly [FleetViewMode, (next: FleetViewMode) => void] {
-  const [mode, setMode] = useState<FleetViewMode>('row')
-
-  useEffect(() => {
+  const [mode, setMode] = useState<FleetViewMode>(() => {
     const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (isViewMode(raw)) setMode(raw)
-  }, [])
+    return isViewMode(raw) ? raw : 'row'
+  })
 
   const update = (next: FleetViewMode) => {
     setMode(next)

--- a/packages/web/tests/lib/fleet-grouping.test.ts
+++ b/packages/web/tests/lib/fleet-grouping.test.ts
@@ -1,0 +1,52 @@
+import { type FleetClassGroup, groupVehiclesByClassId } from '@/lib/fleet-grouping'
+import { describe, expect, it } from 'vitest'
+
+interface Row {
+  id: string
+  classId: string | null
+}
+
+function v(id: string, classId: string | null): Row {
+  return { id, classId }
+}
+
+// classNames map order is the display order (server returns classes sortOrder-ordered).
+const names = new Map([
+  ['c_compact', 'Compact'],
+  ['c_suv', 'SUV'],
+])
+
+describe('groupVehiclesByClassId', () => {
+  it('groups vehicles under their class name, preserving class map order', () => {
+    const groups = groupVehiclesByClassId(
+      [v('a', 'c_suv'), v('b', 'c_compact'), v('c', 'c_suv')],
+      names,
+      'Unassigned',
+    )
+    expect(groups.map((g) => g.className)).toEqual(['Compact', 'SUV'])
+    expect(groups[0]).toMatchObject({ classId: 'c_compact', vehicles: [v('b', 'c_compact')] })
+    expect(groups[1]?.vehicles.map((r) => r.id)).toEqual(['a', 'c'])
+  })
+
+  it('drops classes that have no vehicles', () => {
+    const groups = groupVehiclesByClassId([v('a', 'c_suv')], names, 'Unassigned')
+    expect(groups.map((g) => g.classId)).toEqual(['c_suv'])
+  })
+
+  it('puts null-classId vehicles in a trailing Unassigned group', () => {
+    const groups = groupVehiclesByClassId([v('a', 'c_compact'), v('b', null)], names, 'Unassigned')
+    expect(groups.map((g) => g.className)).toEqual(['Compact', 'Unassigned'])
+    const last = groups.at(-1) as FleetClassGroup<Row>
+    expect(last).toMatchObject({ classId: null, vehicles: [v('b', null)] })
+  })
+
+  it('treats a classId with no matching name as Unassigned', () => {
+    const groups = groupVehiclesByClassId([v('a', 'c_ghost')], names, 'Unassigned')
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({ classId: null, className: 'Unassigned' })
+  })
+
+  it('returns an empty array for no vehicles', () => {
+    expect(groupVehiclesByClassId([], names, 'Unassigned')).toEqual([])
+  })
+})

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -73,16 +73,14 @@ function renderView(
   vehicles: OperatorFleetVehicle[],
   classOptions: ReadonlyArray<{ id: string; name: string }> = [],
 ) {
-  const queryClient = new QueryClient({
-    // staleTime Infinity so the seeded class-options cache is used as-is and the
-    // grid's useQuery never refetches the mocked empty list out from under it.
-    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
-  })
-  queryClient.setQueryData(['operator-fleet', 'class-options'], classOptions)
+  // The route prefetches class options and passes them down as a prop, so the
+  // grid groups synchronously with no fetch of its own — the test mirrors that
+  // by handing classOptions straight to the view.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
-        <OperatorFleetView vehicles={vehicles} />
+        <OperatorFleetView vehicles={vehicles} classOptions={classOptions} />
       </IntlProvider>
     </QueryClientProvider>,
   )

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 // The edit sheet lazily loads vehicle-class options; stub the query so it never
@@ -69,8 +69,16 @@ function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVe
   }
 }
 
-function renderView(vehicles: OperatorFleetVehicle[]) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+function renderView(
+  vehicles: OperatorFleetVehicle[],
+  classOptions: ReadonlyArray<{ id: string; name: string }> = [],
+) {
+  const queryClient = new QueryClient({
+    // staleTime Infinity so the seeded class-options cache is used as-is and the
+    // grid's useQuery never refetches the mocked empty list out from under it.
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  })
+  queryClient.setQueryData(['operator-fleet', 'class-options'], classOptions)
   return render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
@@ -81,6 +89,10 @@ function renderView(vehicles: OperatorFleetVehicle[]) {
 }
 
 describe('OperatorFleetView', () => {
+  // The view mode persists to localStorage; clear it so each test starts in the
+  // default row view with no cross-test bleed.
+  beforeEach(() => window.localStorage.clear())
+
   it('shows the empty state when there are no vehicles', () => {
     renderView([])
     expect(screen.getByText(en.empty)).toBeInTheDocument()
@@ -195,5 +207,62 @@ describe('OperatorFleetView', () => {
     await user.click(screen.getByRole('menuitem', { name: editVehicleLabel }))
 
     expect(await screen.findByLabelText(form.name)).toHaveValue('Toyota Aqua')
+  })
+
+  it('defaults to row view, showing the table columns', () => {
+    renderView([vehicle()])
+    expect(screen.getByText(en.columns.vehicle)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.rowView })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('switches to grid view, grouping vehicles under their class name', async () => {
+    const user = userEvent.setup()
+    renderView(
+      [vehicle({ id: 'a', name: 'Toyota Aqua', classId: 'c1' })],
+      [{ id: 'c1', name: 'Compact' }],
+    )
+
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    expect(screen.getByRole('heading', { name: 'Compact' })).toBeInTheDocument()
+    expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+    // The table is gone in grid view.
+    expect(screen.queryByText(en.columns.vehicle)).not.toBeInTheDocument()
+  })
+
+  it('drops a vehicle with no class into the Unassigned group in grid view', async () => {
+    const user = userEvent.setup()
+    renderView(
+      [vehicle({ id: 'a', name: 'Toyota Aqua', classId: null })],
+      [{ id: 'c1', name: 'Compact' }],
+    )
+
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    expect(
+      screen.getByRole('heading', { name: enMessages.business.vehicles.group.unassigned }),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps selection working in grid view', async () => {
+    const user = userEvent.setup()
+    renderView(
+      [vehicle({ id: 'a', name: 'Toyota Aqua', classId: 'c1' })],
+      [{ id: 'c1', name: 'Compact' }],
+    )
+
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select Toyota Aqua' }))
+
+    expect(screen.getByText('1 vehicle selected')).toBeInTheDocument()
+  })
+
+  it('renders the fleet summary counts strip', () => {
+    renderView([
+      vehicle({ id: 'a', status: 'AVAILABLE' }),
+      vehicle({ id: 'b', status: 'MAINTENANCE' }),
+    ])
+    expect(screen.getByText('2 cars')).toBeInTheDocument()
+    expect(screen.getByText('1 maintenance')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #561. Last follow-up under #526 / epic #523 — sequenced after #560 because it also rewrites `OperatorFleetView` row rendering.

## What
Adds a row ↔ grid view toggle to the operator fleet screen. Row mode is the existing table; grid mode shows vehicle cards grouped by class. Selection, bulk actions, per-row actions and the edit sheet all work in both modes. Also lands the `FleetTable`/`FleetGrid` extraction the #560 architect review asked for, plus a fleet-wide summary counts strip.

## Changes
- **`lib/fleet-grouping.ts`** — pure `groupVehiclesByClassId` (FC): buckets by classId, null/archived-class → trailing "Unassigned" group, empty classes dropped.
- **`cells.tsx`** — `StatusPill`/`ExpiryPill`/`priceLabel` extracted so table rows and grid cards render status/expiry/price through one code path (no drift).
- **`FleetTable.tsx`** — the table, extracted (presentational).
- **`FleetVehicleCard.tsx` / `FleetGrid.tsx`** — grid card + collapsible class sections; cards carry the same per-row affordances (checkbox + `FleetRowActions` + `onEdit`).
- **`useFleetViewMode.ts` / `FleetViewToggle.tsx`** — `'row' | 'grid'` persisted to localStorage (lazy init, no flash).
- **`FleetSummaryBar.tsx`** — fleet-wide total / on-rental / available / maintenance / expiring.
- **`OperatorFleetView.tsx`** — thin shell: holds view/selection/filter/sheet state, branches table↔grid. Shrank 197→~115 lines.
- **`fleet.tsx` route** — loader prefetches class options so the grid groups with no "Unassigned" flash and the loading state stays behind the route boundary; passed down as a prop.

## Reviews addressed
code-reviewer + architect ran. Fixed: **H1/MED** class-options fetch lifted out of the (presentational) grid into the route loader; **L1** shared `UNASSIGNED_KEY` sentinel; **L2** lazy-init view mode (no hydration flash); **M2** honest comments on the select-all asymmetry → grid per-group select-all filed as **#596**.

## Test plan
- [x] `fleet-grouping` unit (5 cases incl. null/ghost-class/empty) — TDD red→green
- [x] `OperatorFleetView` extended: default row view, switch-to-grid grouping, Unassigned bucket, selection in grid, summary strip (18 cases)
- [x] Full web suite **974/974** green · tsc 0 · biome clean · i18n parity **813×3**
- [ ] Manual browser smoke of the toggle (operator session)

## Out of scope / follow-up
- Grid per-group + top-level select-all → **#596**