### PR TITLE
fix(operator): scope fleet-overview to caller tenant (#594)

### DIFF
--- a/packages/api/src/repositories/drizzle/fleet-overview.ts
+++ b/packages/api/src/repositories/drizzle/fleet-overview.ts
@@ -1,8 +1,10 @@
 import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
-import { and, ne, sql } from 'drizzle-orm'
+import { and, inArray, ne, sql } from 'drizzle-orm'
 import { eq } from 'drizzle-orm'
+import type { CallerContext } from '../../middleware/auth'
 import type { Vehicle } from '../../stores'
+import { operatorReadScope } from '../../tenancy'
 import type { FleetOverviewRepository } from '../types'
 import { type Db, overlapHours, toVehicle, vehicleColumns } from './shared'
 
@@ -17,14 +19,27 @@ const UTILIZATION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
 export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
   constructor(private readonly db: Db) {}
 
-  async findFleetOverview(now: Date): Promise<FleetVehicleOverview[]> {
+  async findFleetOverview(ctx: CallerContext, now: Date): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_MS)
 
-    // Round-trip 1: all vehicles.
-    const vehicleRows = (await this.db.select(vehicleColumns).from(vehicles)).map(toVehicle)
+    // Tenant scope (#594): operators see only their own vehicles; bypass roles
+    // see all; a scoped caller with no tenant sees nothing. Mirrors
+    // DrizzleVehicleRepository.findAll — the repo is the tenant boundary.
+    const scope = operatorReadScope(ctx)
+    if (scope.kind === 'none') return []
+    const vehicleWhere =
+      scope.kind === 'operator' ? eq(vehicles.operatorId, scope.operatorId) : undefined
 
-    // Round-trip 2: bookings we care about -- non-CANCELLED, and either
-    // overlapping the last-30-day window OR starting in the future.
+    // Round-trip 1: this tenant's vehicles.
+    const vehicleRows = (
+      await this.db.select(vehicleColumns).from(vehicles).where(vehicleWhere)
+    ).map(toVehicle)
+    if (vehicleRows.length === 0) return []
+    const vehicleIds = vehicleRows.map((v) => v.id)
+
+    // Round-trip 2: bookings we care about -- constrained to THIS tenant's
+    // vehicles (so no cross-tenant booking row is ever read), non-CANCELLED, and
+    // either overlapping the last-30-day window OR starting in the future.
     // LEFT JOIN users for the renter name.
     const bookingRows = await this.db
       .select({
@@ -40,6 +55,7 @@ export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
       .leftJoin(users, eq(bookings.renterId, users.id))
       .where(
         and(
+          inArray(bookings.assignedVehicleId, vehicleIds),
           ne(bookings.status, 'CANCELLED'),
           sql`(${bookings.endAt} > ${windowStart.toISOString()} OR ${bookings.startAt} > ${now.toISOString()})`,
         ),

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -1,5 +1,5 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
-import { SYSTEM_CONTEXT } from '../../middleware/auth'
+import { type CallerContext, SYSTEM_CONTEXT } from '../../middleware/auth'
 import type {
   BookingRepository,
   FleetOverviewRepository,
@@ -36,10 +36,15 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
     private readonly maintenanceLogRepo?: MaintenanceLogRepository,
   ) {}
 
-  async findFleetOverview(now: Date): Promise<FleetVehicleOverview[]> {
+  async findFleetOverview(ctx: CallerContext, now: Date): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
-    const { data: vehicles } = await this.vehicleRepo.findAll(SYSTEM_CONTEXT)
+    // Scope vehicles to the caller's tenant (#594). VehicleRepository.findAll
+    // already applies operatorReadScope, so an OPERATOR_* caller sees only their
+    // own cars while bypass roles see all. Bookings are read with SYSTEM_CONTEXT
+    // but each output row only surfaces bookings keyed to a vehicle in this
+    // (already tenant-scoped) set, so no cross-tenant booking can leak.
+    const { data: vehicles } = await this.vehicleRepo.findAll(ctx)
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
 
     return Promise.all(

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -1,5 +1,5 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
-import { type CallerContext, SYSTEM_CONTEXT } from '../../middleware/auth'
+import type { CallerContext } from '../../middleware/auth'
 import type {
   BookingRepository,
   FleetOverviewRepository,
@@ -39,13 +39,13 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
   async findFleetOverview(ctx: CallerContext, now: Date): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
-    // Scope vehicles to the caller's tenant (#594). VehicleRepository.findAll
-    // already applies operatorReadScope, so an OPERATOR_* caller sees only their
-    // own cars while bypass roles see all. Bookings are read with SYSTEM_CONTEXT
-    // but each output row only surfaces bookings keyed to a vehicle in this
-    // (already tenant-scoped) set, so no cross-tenant booking can leak.
+    // Scope BOTH reads to the caller's tenant (#594). VehicleRepository.findAll
+    // and BookingRepository.findAll each apply their own operator scope, so an
+    // OPERATOR_* caller never reads another tenant's rows (isolation at the read,
+    // not the projection) while bypass roles see all. Mirrors the Drizzle repo,
+    // which scopes vehicles by operatorId and bookings to those vehicle ids.
     const { data: vehicles } = await this.vehicleRepo.findAll(ctx)
-    const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
+    const allBookings = await this.bookingRepo.findAll(ctx)
 
     return Promise.all(
       vehicles.map(async (vehicle) => {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -289,7 +289,11 @@ export interface FleetOverviewRepository {
   // `now` is injected so time-based cutoffs (utilization window,
   // current/upcoming filtering) live in callers, not infrastructure.
   // Tests can pass a fixed Date without faking the global clock.
-  findFleetOverview(now: Date): Promise<FleetVehicleOverview[]>
+  //
+  // `ctx` carries the caller's tenant scope (#594): OPERATOR_* see only their
+  // own vehicles; bypass roles (PLATFORM_ADMIN / legacy STAFF/ADMIN) see all.
+  // The route gates out RENTER/PARTNER before this is reached.
+  findFleetOverview(ctx: CallerContext, now: Date): Promise<FleetVehicleOverview[]>
 }
 
 /**

--- a/packages/api/src/routes/fleet-overview.ts
+++ b/packages/api/src/routes/fleet-overview.ts
@@ -1,14 +1,20 @@
 import { Hono } from 'hono'
-import { STAFF_ROLES, requireUser } from '../middleware/auth'
+import { MANAGEMENT_READ_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { FleetOverviewService } from '../services/fleet-overview'
 import { fail, ok } from './helpers'
 
 export function createFleetOverviewRoutes(service: FleetOverviewService) {
   return new Hono().get('/vehicles/fleet-overview', async (c) => {
     const user = requireUser(c)
-    if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+    // Admit STAFF roles AND tenant-scoped operators (#594); RENTER/PARTNER are
+    // rejected here BEFORE the repo's operatorReadScope runs (that helper maps a
+    // RENTER to {kind:'all'}, so without this gate a renter would read the whole
+    // cross-operator fleet). Operators are then bounded to their own tenant by
+    // the repository's operator predicate — the repo, not the route, is the
+    // tenant boundary (#386 F2 / #397).
+    if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    const data = await service.findFleetOverview()
+    const data = await service.findFleetOverview(toCallerContext(user))
     return ok(c, data)
   })
 }

--- a/packages/api/src/services/fleet-overview.ts
+++ b/packages/api/src/services/fleet-overview.ts
@@ -1,14 +1,19 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
+import type { CallerContext } from '../middleware/auth'
 import type { FleetOverviewRepository } from '../repositories/types'
 
 // Thin service wrapping FleetOverviewRepository. Its only job is to own
 // the clock — `now` defaults to `new Date()` here so routes don't have
 // to think about it, and tests can pass a deterministic Date without
-// stubbing the global clock.
+// stubbing the global clock. Tenant scoping rides on `ctx` (#594), enforced
+// by the repository's operator predicate.
 export class FleetOverviewService {
   constructor(private readonly repo: FleetOverviewRepository) {}
 
-  async findFleetOverview(now: Date = new Date()): Promise<FleetVehicleOverview[]> {
-    return this.repo.findFleetOverview(now)
+  async findFleetOverview(
+    ctx: CallerContext,
+    now: Date = new Date(),
+  ): Promise<FleetVehicleOverview[]> {
+    return this.repo.findFleetOverview(ctx, now)
   }
 }

--- a/packages/api/tests/integration/fleet-overview.test.ts
+++ b/packages/api/tests/integration/fleet-overview.test.ts
@@ -1,0 +1,157 @@
+import { bookings, operators, users, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleBookingRepository,
+  DrizzleFleetOverviewRepository,
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { bookingInput } from '../helpers/booking'
+import { DEFAULT_DAILY_RATE_JPY, cleanupLocations, db, seedLocation } from './setup'
+
+// #594: the operator portal Fleet page reads GET /vehicles/fleet-overview, so
+// the aggregated read MUST be tenant-scoped at the repository (the production
+// Drizzle path — the in-memory repo is only the behaviour spec). An OPERATOR_*
+// caller sees ONLY its own vehicles and only bookings on those vehicles; a
+// tenant-less operator fails closed; bypass roles (SYSTEM_CONTEXT) see all.
+// Exercised against real Postgres so a wrong SQL predicate cannot pass silently.
+describe('fleet-overview is operator-scoped (Drizzle, real Postgres)', () => {
+  const fleetRepo = new DrizzleFleetOverviewRepository(db)
+  const vehicleRepo = new DrizzleVehicleRepository(db)
+  const classRepo = new DrizzleVehicleClassRepository(db)
+  const bookingRepo = new DrizzleBookingRepository(db)
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `op_fo_a_${uniq}`
+  const opBId = `op_fo_b_${uniq}`
+  const renterId = crypto.randomUUID()
+  const createdLocationIds: string[] = []
+  // Booking sits 5 days before NOW, squarely inside the 30-day utilization window.
+  const NOW = new Date('2027-09-10T12:00:00Z')
+  let vehicleAId: string
+  let vehicleBId: string
+
+  const ctxFor = (operatorId: string): CallerContext => ({
+    userId: 'owner',
+    role: 'OPERATOR_OWNER',
+    operatorId,
+    bypassScope: false,
+  })
+
+  // Seed one tenant: class -> location -> vehicle -> one CONFIRMED booking on it.
+  async function seedTenant(operatorId: string, prefix: string): Promise<string> {
+    const cls = await classRepo.create({
+      operatorId,
+      name: `FO Class ${prefix}-${uniq}`,
+      slug: `fo-class-${prefix}-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+    const loc = await seedLocation(`fo-${prefix}`, 2880, operatorId)
+    createdLocationIds.push(loc.id)
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId,
+      classId: cls.id,
+      name: `FO Car ${prefix}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      licensePlate: null,
+      status: 'AVAILABLE',
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      make: null,
+      model: null,
+      year: null,
+      color: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      shakenExpiryDate: null,
+      insuranceExpiryDate: null,
+    })
+    await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingInput({
+        operatorId,
+        renterId,
+        classId: cls.id,
+        requestedVehicleId: vehicle.id,
+        assignedVehicleId: vehicle.id,
+        pickupLocationId: loc.id,
+        dropoffLocationId: loc.id,
+        startAt: new Date('2027-09-05T10:00:00Z'),
+        endAt: new Date('2027-09-05T14:00:00Z'),
+        status: 'CONFIRMED',
+        source: 'DIRECT',
+      }),
+    )
+    return vehicle.id
+  }
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opAId, slug: `fo-a-${uniq}`, name: 'FO Operator A' },
+      { id: opBId, slug: `fo-b-${uniq}`, name: 'FO Operator B' },
+    ])
+    await db.insert(users).values({
+      id: renterId,
+      email: `fo-${uniq}@kuruma-test.com`,
+      role: 'RENTER',
+      language: 'en',
+    })
+    vehicleAId = await seedTenant(opAId, 'a')
+    vehicleBId = await seedTenant(opBId, 'b')
+  })
+
+  afterAll(async () => {
+    await db.delete(bookings).where(inArray(bookings.operatorId, [opAId, opBId]))
+    await db.delete(vehicles).where(inArray(vehicles.operatorId, [opAId, opBId]))
+    await db.delete(vehicleClasses).where(inArray(vehicleClasses.operatorId, [opAId, opBId]))
+    await cleanupLocations(createdLocationIds)
+    await db.delete(users).where(inArray(users.id, [renterId]))
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+  })
+
+  it('an operator sees only its own vehicles', async () => {
+    const ids = (await fleetRepo.findFleetOverview(ctxFor(opAId), NOW)).map((r) => r.id)
+    expect(ids).toContain(vehicleAId)
+    expect(ids).not.toContain(vehicleBId)
+  })
+
+  it('every overview row belongs to the caller’s tenant', async () => {
+    const rows = await fleetRepo.findFleetOverview(ctxFor(opBId), NOW)
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((r) => r.operatorId === opBId)).toBe(true)
+  })
+
+  it('counts only bookings on the caller’s own vehicles', async () => {
+    const rows = await fleetRepo.findFleetOverview(ctxFor(opAId), NOW)
+    const own = rows.find((r) => r.id === vehicleAId)
+    expect(own?.bookingCountLast30Days).toBe(1)
+    // Operator B's vehicle (and therefore its booking) never appears for A.
+    expect(rows.some((r) => r.id === vehicleBId)).toBe(false)
+  })
+
+  it('a tenant-less operator sees nothing (fail-closed)', async () => {
+    const noTenant: CallerContext = { userId: 'x', role: 'OPERATOR_OWNER', bypassScope: false }
+    expect(await fleetRepo.findFleetOverview(noTenant, NOW)).toEqual([])
+  })
+
+  it('SYSTEM_CONTEXT (bypass) sees both operators’ vehicles', async () => {
+    const ids = (await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, NOW)).map((r) => r.id)
+    expect(ids).toContain(vehicleAId)
+    expect(ids).toContain(vehicleBId)
+  })
+})

--- a/packages/api/tests/repositories/fleet-overview.test.ts
+++ b/packages/api/tests/repositories/fleet-overview.test.ts
@@ -79,7 +79,7 @@ describe('InMemoryFleetOverviewRepository', () => {
   it('returns 0% utilization and null bookings for a vehicle with no bookings', async () => {
     const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, baseVehicleInput({ name: 'Unbooked' }))
 
-    const overviews = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const overviews = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
     const overview = overviews[0]
 
     expect(overviews).toHaveLength(1)
@@ -108,7 +108,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.utilization).toBe(0)
     expect(overview!.bookingCountLast30Days).toBe(0)
@@ -134,7 +134,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.bookingCountLast30Days).toBe(1)
     expect(overview!.utilization).toBeCloseTo((24 / (30 * 24)) * 100, 5)
@@ -157,7 +157,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.currentBooking).not.toBeNull()
     expect(overview!.currentBooking!.startAt).toEqual(new Date('2026-04-11T09:00:00Z'))
@@ -193,7 +193,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.currentBooking).toBeNull()
     expect(overview!.nextBooking).not.toBeNull()
@@ -227,7 +227,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.currentBooking).toBeNull()
     expect(overview!.nextBooking).toBeNull()
@@ -253,7 +253,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.currentBooking!.renterName).toBe('Alice Smith')
   })
@@ -283,7 +283,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.bookingCountLast30Days).toBe(1)
     expect(overview!.utilization).toBeCloseTo((240 / (30 * 24)) * 100, 5)
@@ -314,7 +314,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       }),
     )
 
-    const [overview] = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const [overview] = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overview!.bookingCountLast30Days).toBe(1)
     expect(overview!.utilization).toBeCloseTo((2 / (30 * 24)) * 100, 5)
@@ -330,7 +330,7 @@ describe('InMemoryFleetOverviewRepository', () => {
       baseVehicleInput({ name: 'Second', dailyRateJpy: null, hourlyRateJpy: 1200 }),
     )
 
-    const overviews = await fleetRepo.findFleetOverview(FIXED_NOW)
+    const overviews = await fleetRepo.findFleetOverview(SYSTEM_CONTEXT, FIXED_NOW)
 
     expect(overviews).toHaveLength(2)
     const first = overviews.find((o) => o.id === v1.id)

--- a/packages/api/tests/routes/fleet-overview.test.ts
+++ b/packages/api/tests/routes/fleet-overview.test.ts
@@ -6,7 +6,7 @@
 
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import { SYSTEM_CONTEXT, type UserRole } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryFleetOverviewRepository,
@@ -15,6 +15,7 @@ import {
 } from '../../src/repositories/in-memory'
 import { createFleetOverviewRoutes } from '../../src/routes/fleet-overview'
 import { FleetOverviewService } from '../../src/services/fleet-overview'
+import type { Vehicle } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 import { bookingInput } from '../helpers/booking'
 
@@ -195,5 +196,96 @@ describe('GET /vehicles/fleet-overview', () => {
     const body = await res.json()
 
     expect(body.data[0].activeMaintenanceReason).toBeNull()
+  })
+})
+
+// Operator tenant-scoping (#594). The Fleet page in the operator portal calls
+// this endpoint, so a tenant-scoped OPERATOR_* caller must (a) be admitted, not
+// 403'd, and (b) see ONLY their own vehicles — never another operator's. Renters
+// and 3rd-party PARTNER callers must still be rejected.
+describe('GET /vehicles/fleet-overview — operator scoping', () => {
+  type VehicleInput = Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>
+  function vehicleInput(overrides: Partial<VehicleInput> = {}): VehicleInput {
+    return {
+      name: 'Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      licensePlate: null,
+      status: 'AVAILABLE',
+      bufferMinutes: 60,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      dailyRateJpy: 8000,
+      hourlyRateJpy: null,
+      shakenExpiryDate: null,
+      insuranceExpiryDate: null,
+      ...overrides,
+    }
+  }
+
+  function appAs(role: UserRole, operatorId?: string): Hono {
+    const a = new Hono()
+    a.use('*', testAuthMiddleware('caller', role, operatorId))
+    a.route(
+      '/',
+      createFleetOverviewRoutes(
+        new FleetOverviewService(
+          new InMemoryFleetOverviewRepository(
+            vehicleRepo,
+            bookingRepo,
+            new Map(),
+            maintenanceLogRepo,
+          ),
+        ),
+      ),
+    )
+    return a
+  }
+
+  it('admits an OPERATOR_OWNER and returns only their own vehicles', async () => {
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'A-Car', operatorId: 'op-a' }))
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'B-Car', operatorId: 'op-b' }))
+
+    const res = await appAs('OPERATOR_OWNER', 'op-a').request('/vehicles/fleet-overview')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: Array<{ name: string }> }
+    expect(body.data.map((v) => v.name)).toEqual(['A-Car'])
+  })
+
+  it('admits an OPERATOR_STAFF and isolates them from another tenant', async () => {
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'A-Car', operatorId: 'op-a' }))
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'B-Car', operatorId: 'op-b' }))
+
+    const res = await appAs('OPERATOR_STAFF', 'op-b').request('/vehicles/fleet-overview')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: Array<{ name: string }> }
+    expect(body.data.map((v) => v.name)).toEqual(['B-Car'])
+  })
+
+  it('lets a PLATFORM_ADMIN see every operator’s vehicles (bypass)', async () => {
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'A-Car', operatorId: 'op-a' }))
+    await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput({ name: 'B-Car', operatorId: 'op-b' }))
+
+    const res = await appAs('PLATFORM_ADMIN').request('/vehicles/fleet-overview')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: Array<{ name: string }> }
+    expect(body.data.map((v) => v.name).sort()).toEqual(['A-Car', 'B-Car'])
+  })
+
+  it('rejects a RENTER with 403 (never leaks the operator catalog)', async () => {
+    const res = await appAs('RENTER').request('/vehicles/fleet-overview')
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects a PARTNER (3rd-party API caller) with 403', async () => {
+    const res = await appAs('PARTNER').request('/vehicles/fleet-overview')
+    expect(res.status).toBe(403)
   })
 })

--- a/packages/api/tests/services/fleet-overview.test.ts
+++ b/packages/api/tests/services/fleet-overview.test.ts
@@ -81,11 +81,17 @@ describe('FleetOverviewService — clock injection', () => {
     )
 
     // "now" = 2026-04-11 — booking is inside the 30-day window
-    const insideWindow = await service.findFleetOverview(new Date('2026-04-11T00:00:00Z'))
+    const insideWindow = await service.findFleetOverview(
+      SYSTEM_CONTEXT,
+      new Date('2026-04-11T00:00:00Z'),
+    )
     expect(insideWindow[0]?.bookingCountLast30Days).toBe(1)
 
     // "now" = 2026-06-01 — booking is outside the 30-day window (ended ~60d ago)
-    const outsideWindow = await service.findFleetOverview(new Date('2026-06-01T00:00:00Z'))
+    const outsideWindow = await service.findFleetOverview(
+      SYSTEM_CONTEXT,
+      new Date('2026-06-01T00:00:00Z'),
+    )
     expect(outsideWindow[0]?.bookingCountLast30Days).toBe(0)
   })
 
@@ -100,10 +106,16 @@ describe('FleetOverviewService — clock injection', () => {
     const end = new Date('2026-05-01T12:00:00Z')
     await seedBooking(bookingRepo, vehicle.id, start, end)
 
-    const duringBooking = await service.findFleetOverview(new Date('2026-05-01T06:00:00Z'))
+    const duringBooking = await service.findFleetOverview(
+      SYSTEM_CONTEXT,
+      new Date('2026-05-01T06:00:00Z'),
+    )
     expect(duringBooking[0]?.currentBooking).not.toBeNull()
 
-    const afterBooking = await service.findFleetOverview(new Date('2026-05-02T00:00:00Z'))
+    const afterBooking = await service.findFleetOverview(
+      SYSTEM_CONTEXT,
+      new Date('2026-05-02T00:00:00Z'),
+    )
     expect(afterBooking[0]?.currentBooking).toBeNull()
   })
 })


### PR DESCRIPTION
## Problem

Logged in as an operator (seeded "Kanata Studio", role `OPERATOR_OWNER`), the operator portal **Fleet** page (`/$locale/manage/fleet`) renders its error boundary — *"Couldn't load your fleet"*.

The page loads via `operatorFleetQueryOptions()` → `fetchOperatorFleet()` → `GET /vehicles/fleet-overview`, but that route was a **legacy single-tenant, STAFF-only** endpoint:

- It gated on `STAFF_ROLES = {STAFF, ADMIN, PLATFORM_ADMIN}` → an `OPERATOR_*` caller got **403**, which the loader surfaced as the error boundary.
- Its query returned **every tenant's vehicles** (no operator predicate) — a latent cross-tenant read had operators been admitted as-is.

The Vite operator-fleet integration (#526/#560) wired the operator portal to this pre-marketplace endpoint, which never received the `CallerContext` tenant-scoping that `GET /vehicles` already has.

## Fix

Thread `CallerContext` through the endpoint, mirroring the established `GET /vehicles` pattern (`routes/vehicles.ts` → `repo.findAll(ctx, …)`):

1. **Route** (`routes/fleet-overview.ts`) — admit `MANAGEMENT_READ_ROLES` (STAFF **+** OPERATOR); reject `RENTER`/`PARTNER` with 403 **before** `operatorReadScope` runs (that helper maps a renter to `{kind:'all'}`, so the gate is the renter/partner seal). Pass `toCallerContext(user)` to the service.
2. **Service / interface** — `findFleetOverview(ctx, now)`.
3. **Repos** — apply `operatorReadScope(ctx)`: operators see only their own vehicles; bypass roles see all; a tenant-less operator fails closed (`[]`). The Drizzle path also constrains bookings to the scoped vehicle ids (`inArray`), so no foreign-tenant booking row is ever read. The in-memory repo scopes both reads by `ctx`.

The repo — not the route — is the tenant boundary (#386 F2 / #397), consistent with the rest of the API.

## Tests

- **RED → GREEN (TDD):** new route tests reproduce the bug (operator was 403) and now assert: an `OPERATOR_OWNER`/`OPERATOR_STAFF` gets 200 and sees only their own vehicles; `PLATFORM_ADMIN` (bypass) sees all; `RENTER`/`PARTNER` → 403.
- **Real-Postgres integration** (`tests/integration/fleet-overview.test.ts`, new): exercises the production Drizzle path — cross-tenant isolation of vehicles **and** bookings, tenant-less fail-closed, and bypass-sees-all. (The unit tests only cover the in-memory spec; this covers the actual SQL predicate.)

Verification (local):
- `bun run --filter @kuruma/api test` → **1203 passed**
- `test:integration` (disposable `postgres:16`) → **208 passed** (incl. 5 new)
- `typecheck` clean · `lint:boundaries` OK · biome clean

## Follow-up (out of scope)

- **RETIRED-vehicle parity:** the Drizzle overview includes `RETIRED` vehicles (no status filter, pre-existing) while the in-memory repo excludes them via `vehicleRepo.findAll`. Pre-dates this PR and is a product decision (should the Fleet page show retired cars?). Worth aligning the two repos in a follow-up.

Closes #594
