### PR TITLE
refactor(web): extract shared businessNavItems source of truth (#603)

### DIFF
--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -2,6 +2,7 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { cn } from '@/lib/utils'
+import type { BusinessNavTo } from '@/vite/nav/business-nav-items'
 import { type Session, signOut } from '@/vite/session'
 import { useQueryClient } from '@tanstack/react-query'
 import { Link, useRouter } from '@tanstack/react-router'
@@ -10,20 +11,11 @@ import { useState } from 'react'
 import { useLocale, useTranslations } from 'use-intl'
 
 // `to` is a literal union of real routes so the typed TanStack <Link> compiles;
-// a plain `string` here would fail typecheck. Renter nav (#543) adds Browse
-// (-> public search) and Documents alongside My Bookings.
-export type NavTo =
-  | '/$locale/dashboard'
-  | '/$locale/bookings'
-  | '/$locale/manage/bookings'
-  | '/$locale/manage/fleet'
-  | '/$locale/manage/classes'
-  | '/$locale/manage/locations'
-  | '/$locale/manage/insurance'
-  | '/$locale/manage/fees'
-  | '/$locale/manage/add-ons'
-  | '/$locale/search'
-  | '/$locale/documents'
+// a plain `string` here would fail typecheck. The business-view routes come from
+// the shared `businessNavItems` array (#603) so the union can't drift from the
+// list Navbar renders; the renter routes (#543: Browse + Documents alongside My
+// Bookings) are listed inline since they aren't part of the operator portal.
+export type NavTo = BusinessNavTo | '/$locale/bookings' | '/$locale/search' | '/$locale/documents'
 
 export interface NavItem {
   readonly to: NavTo

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils'
 import { LocaleSwitcher } from '@/vite/nav/LocaleSwitcher'
 import { MobileMenu, type NavItem } from '@/vite/nav/MobileMenu'
 import { NavbarClient } from '@/vite/nav/NavbarClient'
+import { businessNavItems } from '@/vite/nav/business-nav-items'
 import { useSession } from '@/vite/session'
 import { getViewMode, isBusiness } from '@/vite/view-mode'
 import { Link } from '@tanstack/react-router'
@@ -33,16 +34,7 @@ export function Navbar() {
 
   const navItems: readonly NavItem[] =
     viewMode === 'business'
-      ? [
-          { to: '/$locale/dashboard', label: t('dashboard') },
-          { to: '/$locale/manage/bookings', label: t('bookings') },
-          { to: '/$locale/manage/fleet', label: t('fleet') },
-          { to: '/$locale/manage/classes', label: t('classes') },
-          { to: '/$locale/manage/locations', label: t('locations') },
-          { to: '/$locale/manage/insurance', label: t('insurance') },
-          { to: '/$locale/manage/fees', label: t('fees') },
-          { to: '/$locale/manage/add-ons', label: t('addOns') },
-        ]
+      ? businessNavItems.map((item) => ({ to: item.to, label: t(item.labelKey) }))
       : session?.user
         ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]
         : []

--- a/packages/web/src/vite/nav/business-nav-items.ts
+++ b/packages/web/src/vite/nav/business-nav-items.ts
@@ -1,0 +1,23 @@
+// Single source of truth for the business-view (operator) nav (#603). Both
+// Navbar (which builds the desktop list and passes it to MobileMenu) and
+// MobileMenu's `NavTo` union derive from THIS array, so adding a `/manage/*`
+// route is a one-line edit here instead of the three-way "nav-link conflict
+// tax" — Navbar array + MobileMenu union + the nav-count test — that every
+// operator-portal slice (#528/#529/#530/#585…) used to pay.
+//
+// `labelKey` is a key under the `nav` i18n namespace; the caller resolves it
+// with useTranslations('nav'). `to` values are real TanStack route literals so
+// the typed <Link> compiles (a plain string would fail typecheck).
+export const businessNavItems = [
+  { to: '/$locale/dashboard', labelKey: 'dashboard' },
+  { to: '/$locale/manage/bookings', labelKey: 'bookings' },
+  { to: '/$locale/manage/fleet', labelKey: 'fleet' },
+  { to: '/$locale/manage/classes', labelKey: 'classes' },
+  { to: '/$locale/manage/locations', labelKey: 'locations' },
+  { to: '/$locale/manage/insurance', labelKey: 'insurance' },
+  { to: '/$locale/manage/fees', labelKey: 'fees' },
+  { to: '/$locale/manage/add-ons', labelKey: 'addOns' },
+] as const
+
+// Derived so the union can never drift from the array above.
+export type BusinessNavTo = (typeof businessNavItems)[number]['to']

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -1,5 +1,6 @@
 import type { NavItem } from '@/vite/nav/MobileMenu'
 import { Navbar } from '@/vite/nav/Navbar'
+import { businessNavItems } from '@/vite/nav/business-nav-items'
 import type { Session } from '@/vite/session'
 import { useSession } from '@/vite/session'
 import { render, screen } from '@testing-library/react'
@@ -125,7 +126,12 @@ describe('Navbar', () => {
     const client = screen.getByTestId('navbar-client')
     expect(client).toHaveAttribute('data-view-mode', 'business')
     expect(client).toHaveAttribute('data-can-switch', 'true')
-    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '8')
+    // Derived from the shared source of truth, not a magic number — adding a
+    // /manage/* route to businessNavItems keeps this assertion correct (#603).
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute(
+      'data-nav-count',
+      String(businessNavItems.length),
+    )
   })
 
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {

--- a/packages/web/tests/vite/nav/business-nav-items.test.ts
+++ b/packages/web/tests/vite/nav/business-nav-items.test.ts
@@ -1,0 +1,29 @@
+import { businessNavItems } from '@/vite/nav/business-nav-items'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+// businessNavItems is now the single source of truth for the operator nav: both
+// Navbar's rendered list and MobileMenu's `NavTo` union derive from it (#603).
+// These guard the two ways the array can silently break a consumer — a dropped
+// /manage route, or a labelKey that has no matching `nav` i18n entry (renders a
+// raw key in the navbar).
+describe('businessNavItems', () => {
+  it('lists every operator-portal route in display order', () => {
+    expect(businessNavItems.map((item) => item.to)).toEqual([
+      '/$locale/dashboard',
+      '/$locale/manage/bookings',
+      '/$locale/manage/fleet',
+      '/$locale/manage/classes',
+      '/$locale/manage/locations',
+      '/$locale/manage/insurance',
+      '/$locale/manage/fees',
+      '/$locale/manage/add-ons',
+    ])
+  })
+
+  it('pairs every route with an existing `nav` i18n key', () => {
+    for (const item of businessNavItems) {
+      expect(en.nav[item.labelKey as keyof typeof en.nav]).toBeTruthy()
+    }
+  })
+})


### PR DESCRIPTION
Closes #603. Follow-up from the #585 architect review.

## Problem

The operator (business-view) nav was duplicated three ways, so every new `/manage/*` route (#528/#529/#530/#585…) three-way-conflicted on the same files — the "nav-link conflict tax":

1. `vite/nav/Navbar.tsx` — the inline `navItems` array (8 links).
2. `vite/nav/MobileMenu.tsx` — the `NavTo` literal union (must list every route for the typed `<Link>` to compile).
3. `tests/vite/nav/Navbar.test.tsx` — a hard-coded `data-nav-count` of `8`.

## Change

Extract one source of truth — `vite/nav/business-nav-items.ts`:

```ts
export const businessNavItems = [
  { to: '/$locale/dashboard', labelKey: 'dashboard' },
  ... // 8 items
] as const
export type BusinessNavTo = (typeof businessNavItems)[number]['to']
```

- **Navbar** maps over it to build the business nav.
- **MobileMenu**'s `NavTo` derives from `BusinessNavTo` (+ the 3 renter routes inline), so the union **cannot drift** from the rendered list.
- **Navbar.test** asserts `data-nav-count === String(businessNavItems.length)` — no magic number.

Adding a `/manage/*` route is now a **one-line edit** in the array.

## Tests

- New `business-nav-items.test.ts`: locks the route list/order and asserts every `labelKey` resolves to an existing `nav` i18n key (catches a dropped route or typo'd key).
- Existing nav tests unchanged in intent (still assert each `data-to`), now count-derived.

## Gates

Behavior-preserving. Web suite **1027 pass**, `tsc` clean (web + node + api), biome clean, lint:size/boundaries pass, pre-commit hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)