### PR TITLE
feat(operator): grid view select-all (per-class + top-level) (#596)

### DIFF
--- a/docs/2026-06-12-issue-596-grid-selectall-handoff.md
+++ b/docs/2026-06-12-issue-596-grid-selectall-handoff.md
@@ -1,0 +1,35 @@
+# Handoff — #596 grid per-group + top-level select-all (Vite)
+
+**State: RED done, GREEN not written.** Worktree `~/Dev/kuruma-596-grid-selectall`, branch `feat/596-grid-selectall` (pushed, tip `a17e0db` = failing tests). Off `marketplace-pivot`@c97e297 (includes #561 grid + #598 read-only). #596 in-progress, no PR. Web-only, no API/schema/migration.
+
+## What #596 adds
+The fleet **row** view (FleetTable) has a header select-all; the **grid** view (FleetGrid, #561) only has per-card selection. Add: (1) **per-group (per-class) select-all** checkbox in each FleetGrid group header, (2) a **top-level** grid select-all (whole visible fleet). Both `canWrite`-gated (read-only bypass roles, #598).
+
+## Tests already written (RED) — `tests/vite/operator-fleet/OperatorFleetView.test.tsx`
+5 new cases at end of file: per-group selects one class only (`Select all Compact` → "2 vehicles selected"), toggles back off, indeterminate on partial, top-level `bulk.selectAll` → "3 vehicles selected", and read-only absence. Run: `bun run --filter @kuruma/web test OperatorFleetView` (currently 4 fail / 20 pass; the read-only one already passes).
+
+## GREEN steps (exact)
+1. **i18n** add `business.vehicles.bulk.selectGroup` after the `selectRow` line in en/ja/zh:
+   - en `"Select all {group}"` · ja `"{group}をすべて選択"` · zh `"全选{group}"`. Parity becomes 814×3.
+2. **`OperatorFleetView.tsx`** add:
+   ```ts
+   const toggleGroup = (ids: readonly string[]) =>
+     setSelectedIds((prev) =>
+       ids.every((id) => prev.includes(id))
+         ? prev.filter((id) => !ids.includes(id))
+         : [...new Set([...prev, ...ids])])
+   ```
+   Pass to `<FleetGrid>`: `onToggleGroup={toggleGroup}` + `allSelected` + `someSelected` + `onToggleAll={toggleAll}` (all already computed in the container for FleetTable).
+3. **`FleetGrid.tsx`** add those 4 props + `const tBulk = useTranslations('business.vehicles.bulk')`.
+   - **Top-level**: a `canWrite`-gated row above `groups.map`: `<input type="checkbox" aria-label={tBulk('selectAll')} checked={allSelected} ref={el=>{if(el)el.indeterminate=someSelected}} onChange={onToggleAll}/>`.
+   - **Per-group**: restructure the header — the collapse `<button>` and a NEW sibling `<input>` go inside one flex `<div>` (NEVER nest the checkbox in the button → invalid HTML/button-in-button). Per group: `const ids = group.vehicles.map(v=>v.id); const all = ids.every(id=>selectedIds.includes(id)); const some = ids.some(id=>selectedIds.includes(id)) && !all`. Checkbox `canWrite`-gated, `aria-label={tBulk('selectGroup',{group:group.className})}`, `checked={all}`, `ref` sets `.indeterminate=some`, `onChange={()=>onToggleGroup(ids)}`.
+4. **Comments**: drop the "header select-all is row-view only" note in `FleetTable.tsx` and `FleetVehicleCard.tsx` — parity now exists.
+
+## Gotchas
+- The read-only grid test asserts `queryAllByRole('checkbox')` length 0 → EVERY new checkbox must be `canWrite`-gated.
+- `getByRole('checkbox',{name:'Select all'})` is exact-match → won't collide with `'Select all Compact'`.
+- localStorage view-mode persists across tests → `beforeEach(localStorage.clear())` already present.
+- biome auto-formats; re-read after commit (pre-commit runs biome+size+modules+tsc).
+
+## Finish the drill
+Full web suite green + tsc 0 + biome + i18n parity 814×3 → `/code-review` + `architect` agent → PR (Closes #596, base `marketplace-pivot`) → `gh pr update-branch` if BEHIND (NO rebase/force-push) → CI 4/4 → squash merge → manual close #596 + drop in-progress label (base≠default) → `git worktree remove` + `git branch -d`.

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -503,6 +503,7 @@
       "bulk": {
         "selectAll": "Select all",
         "selectRow": "Select {name}",
+        "selectGroup": "Select all {group}",
         "deselectAll": "Deselect all",
         "selectedCount": "{count, plural, one {# vehicle selected} other {# vehicles selected}}",
         "setAvailable": "Set Available",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -503,6 +503,7 @@
       "bulk": {
         "selectAll": "すべて選択",
         "selectRow": "{name}を選択",
+        "selectGroup": "{group}をすべて選択",
         "deselectAll": "選択解除",
         "selectedCount": "{count}台選択中",
         "setAvailable": "利用可能にする",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -503,6 +503,7 @@
       "bulk": {
         "selectAll": "全选",
         "selectRow": "选择{name}",
+        "selectGroup": "全选{group}",
         "deselectAll": "取消全选",
         "selectedCount": "已选择{count}辆车",
         "setAvailable": "设为可用",

--- a/packages/web/src/vite/operator-fleet/FleetGrid.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetGrid.tsx
@@ -9,6 +9,13 @@ interface FleetGridProps {
   readonly vehicles: readonly OperatorFleetVehicle[]
   readonly classOptions: readonly VehicleClassOption[]
   readonly selectedIds: readonly string[]
+  // Top-level select-all over every visible vehicle, mirroring the row view's
+  // header control (#596). allSelected/someSelected are computed by the parent.
+  readonly allSelected: boolean
+  readonly someSelected: boolean
+  readonly onToggleAll: () => void
+  // Per-group select-all: toggles a whole class on/off together (#596).
+  readonly onToggleGroup: (ids: readonly string[]) => void
   readonly onToggleSelect: (id: string) => void
   readonly onEdit: (vehicle: OperatorFleetVehicle) => void
   // False for bypass roles: cards drop their checkbox + actions (#598).
@@ -26,12 +33,17 @@ export function FleetGrid({
   vehicles,
   classOptions,
   selectedIds,
+  allSelected,
+  someSelected,
+  onToggleAll,
+  onToggleGroup,
   onToggleSelect,
   onEdit,
   canWrite,
   todayIso,
 }: FleetGridProps) {
   const t = useTranslations('business.vehicles.group')
+  const tBulk = useTranslations('business.vehicles.bulk')
 
   const groups = useMemo(() => {
     const classNames = new Map(classOptions.map((c) => [c.id, c.name]))
@@ -51,27 +63,62 @@ export function FleetGrid({
 
   return (
     <div className="min-w-0 flex-1 space-y-6">
+      {canWrite && (
+        <label className="-mx-1 flex items-center gap-2 px-1 font-medium text-muted-foreground text-sm">
+          <input
+            type="checkbox"
+            ref={(el) => {
+              if (el) el.indeterminate = someSelected
+            }}
+            aria-label={tBulk('selectAll')}
+            checked={allSelected}
+            onChange={onToggleAll}
+            className="shrink-0"
+          />
+          {tBulk('selectAll')}
+        </label>
+      )}
       {groups.map((group) => {
         const key = group.classId ?? UNASSIGNED_KEY
         const isCollapsed = collapsed.has(key)
+        // `vehicles` is already filtered to visible rows by the container, so
+        // these ids are always visible and reading raw `selectedIds` (not the
+        // parent's effectiveSelectedIds) can't pick up a stale hidden selection.
+        const ids = group.vehicles.map((v) => v.id)
+        const groupAll = ids.length > 0 && ids.every((id) => selectedIds.includes(id))
+        const groupSome = !groupAll && ids.some((id) => selectedIds.includes(id))
         return (
           <section key={key} aria-label={group.className}>
-            <button
-              type="button"
-              onClick={() => toggle(key)}
-              aria-expanded={!isCollapsed}
-              className="-mx-1 mb-4 flex w-full items-center gap-2 rounded-sm border-border border-b px-1 pb-2 text-left transition-colors hover:bg-muted/30"
-            >
-              {isCollapsed ? (
-                <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-              ) : (
-                <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+            <div className="-mx-1 mb-4 flex items-center gap-2 rounded-sm border-border border-b px-1 pb-2">
+              {canWrite && (
+                <input
+                  type="checkbox"
+                  ref={(el) => {
+                    if (el) el.indeterminate = groupSome
+                  }}
+                  aria-label={tBulk('selectGroup', { group: group.className })}
+                  checked={groupAll}
+                  onChange={() => onToggleGroup(ids)}
+                  className="shrink-0"
+                />
               )}
-              <h2 className="flex-1 font-semibold text-lg tracking-tight">{group.className}</h2>
-              <span className="text-muted-foreground text-sm tabular-nums">
-                {t('vehicleCount', { count: group.vehicles.length })}
-              </span>
-            </button>
+              <button
+                type="button"
+                onClick={() => toggle(key)}
+                aria-expanded={!isCollapsed}
+                className="flex flex-1 items-center gap-2 rounded-sm text-left transition-colors hover:bg-muted/30"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                )}
+                <h2 className="flex-1 font-semibold text-lg tracking-tight">{group.className}</h2>
+                <span className="text-muted-foreground text-sm tabular-nums">
+                  {t('vehicleCount', { count: group.vehicles.length })}
+                </span>
+              </button>
+            </div>
             {!isCollapsed && (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
                 {group.vehicles.map((vehicle) => (

--- a/packages/web/src/vite/operator-fleet/FleetTable.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetTable.tsx
@@ -21,9 +21,8 @@ interface FleetTableProps {
 // Row mode for the operator fleet (#561): the original table, extracted from
 // OperatorFleetView so the container can swap it for FleetGrid. Purely
 // presentational — selection state and the edit handler are injected by the
-// parent. Per-row affordances (checkbox + FleetRowActions + onEdit) match the
-// grid cards; the header select-all / indeterminate control is row-view only
-// (grid per-group select-all is a #561 follow-up).
+// parent. Per-row affordances (checkbox + FleetRowActions + onEdit) and the
+// header select-all / indeterminate control mirror the grid view (#596).
 export function FleetTable({
   vehicles,
   selectedIds,

--- a/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
@@ -18,8 +18,8 @@ interface FleetVehicleCardProps {
 // Grid-mode card for one fleet vehicle (#561). Carries the same per-row
 // affordances as a table row — a selection checkbox, the per-row actions menu
 // and Edit — so per-vehicle selection and bulk actions behave identically in
-// both views. (Header select-all is row-view only; see FleetTable.) Presentation
-// (status / expiry / price) comes from the shared cells.
+// both views. (Group + top-level select-all live in FleetGrid, #596.)
+// Presentation (status / expiry / price) comes from the shared cells.
 export function FleetVehicleCard({
   vehicle,
   selected,

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -47,6 +47,14 @@ export function OperatorFleetView({ vehicles, classOptions, canWrite }: Operator
   const toggleAll = () => setSelectedIds(allSelected ? [] : visibleIds)
   const toggleOne = (id: string) =>
     setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  // Grid per-group select-all (#596): select the whole class together, or clear
+  // it when every member is already selected.
+  const toggleGroup = (ids: readonly string[]) =>
+    setSelectedIds((prev) =>
+      ids.every((id) => prev.includes(id))
+        ? prev.filter((id) => !ids.includes(id))
+        : [...prev, ...ids.filter((id) => !prev.includes(id))],
+    )
   const openEdit = (vehicle: OperatorFleetVehicle) => setSheet({ vehicle })
 
   return (
@@ -78,6 +86,10 @@ export function OperatorFleetView({ vehicles, classOptions, canWrite }: Operator
                 vehicles={visibleVehicles}
                 classOptions={classOptions}
                 selectedIds={selectedIds}
+                allSelected={allSelected}
+                someSelected={someSelected}
+                onToggleAll={toggleAll}
+                onToggleGroup={toggleGroup}
                 onToggleSelect={toggleOne}
                 onEdit={openEdit}
                 canWrite={canWrite}

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -280,4 +280,78 @@ describe('OperatorFleetView', () => {
     expect(screen.getByText('2 cars')).toBeInTheDocument()
     expect(screen.getByText('1 maintenance')).toBeInTheDocument()
   })
+
+  const threeAcrossTwoClasses = () =>
+    renderView(
+      [
+        vehicle({ id: 'a', name: 'Aqua', classId: 'c1' }),
+        vehicle({ id: 'b', name: 'Yaris', classId: 'c1' }),
+        vehicle({ id: 'c', name: 'Hiace', classId: 'c2' }),
+      ],
+      [
+        { id: 'c1', name: 'Compact' },
+        { id: 'c2', name: 'Van' },
+      ],
+    )
+
+  it('grid per-group select-all selects every vehicle in that class only (#596)', async () => {
+    const user = userEvent.setup()
+    threeAcrossTwoClasses()
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all Compact' }))
+
+    // Compact holds Aqua + Yaris; Van's Hiace stays unselected.
+    expect(screen.getByText('2 vehicles selected')).toBeInTheDocument()
+  })
+
+  it('grid per-group select-all toggles the class back off when all are selected (#596)', async () => {
+    const user = userEvent.setup()
+    threeAcrossTwoClasses()
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    const groupCheckbox = screen.getByRole('checkbox', { name: 'Select all Compact' })
+    await user.click(groupCheckbox)
+    expect(screen.getByText('2 vehicles selected')).toBeInTheDocument()
+    await user.click(groupCheckbox)
+
+    expect(screen.queryByText(/vehicles? selected/)).not.toBeInTheDocument()
+  })
+
+  it('grid per-group checkbox is indeterminate when only some of the class is selected (#596)', async () => {
+    const user = userEvent.setup()
+    threeAcrossTwoClasses()
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select Aqua' }))
+
+    const groupCheckbox = screen.getByRole('checkbox', {
+      name: 'Select all Compact',
+    }) as HTMLInputElement
+    expect(groupCheckbox.indeterminate).toBe(true)
+    expect(groupCheckbox.checked).toBe(false)
+  })
+
+  it('grid top-level select-all selects every visible vehicle (#596)', async () => {
+    const user = userEvent.setup()
+    threeAcrossTwoClasses()
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    await user.click(screen.getByRole('checkbox', { name: bulk.selectAll }))
+
+    expect(screen.getByText('3 vehicles selected')).toBeInTheDocument()
+  })
+
+  it('grid select-all controls are absent in read-only mode (#596/#598)', async () => {
+    const user = userEvent.setup()
+    renderView(
+      [vehicle({ id: 'a', name: 'Aqua', classId: 'c1' })],
+      [{ id: 'c1', name: 'Compact' }],
+      false,
+    )
+    await user.click(screen.getByRole('button', { name: en.gridView }))
+
+    expect(screen.queryByRole('checkbox', { name: bulk.selectAll })).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: 'Select all Compact' })).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## What

Adds select-all to the operator fleet **grid view** (Vite), bringing it to parity with the row view:

1. **Top-level select-all** — a checkbox above the class groups that selects every visible vehicle (mirrors `FleetTable`'s header control, reusing the same parent-computed `allSelected`/`someSelected`/`toggleAll`).
2. **Per-class select-all** — a checkbox in each `FleetGrid` group header that toggles that whole class on/off, with an indeterminate state when only some of the class is selected.

Both are gated on `canWrite`, so bypass roles (read-only oversight, #598) see **zero** checkboxes.

## How

- `OperatorFleetView` gains `toggleGroup(ids)` — selects the class together, or clears it when every member is already selected. Immutable; preserves selections outside the group.
- `FleetGrid` takes `allSelected`/`someSelected`/`onToggleAll`/`onToggleGroup`. The group header was refactored so the checkbox is a **sibling** of the collapse `<button>` (never nested — button-in-button is invalid HTML).
- `business.vehicles.bulk.selectGroup` added across en/ja/zh (parity 845×3).
- Dropped the now-stale "select-all is row-view only" comments in `FleetTable`/`FleetVehicleCard`.

Web-only. No API/schema/migration.

## Tests

5 new cases in `OperatorFleetView.test.tsx` (per-group select / toggle-off / indeterminate / top-level / read-only absence). Full web suite **1025 passed**, tsc 0, biome clean, i18n parity 845×3.

## Review

`code-reviewer` + `architect` both: **Ship**, no CRITICAL/HIGH/MEDIUM. One LOW applied (documented the visible-only invariant). Optional `selectionState` pure-helper extraction deferred per YAGNI (only 2-3 call sites).

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)