### PR TITLE
refactor(web): extract NativeSelect primitive for repeated select-class fields (#604)

### DIFF
--- a/packages/web/src/components/ui/native-select.tsx
+++ b/packages/web/src/components/ui/native-select.tsx
@@ -1,0 +1,23 @@
+import type * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+// Styled native <select> primitive (#604). Owns the shared border/height class
+// string that was copy-pasted across the operator forms. This is a plain native
+// select — distinct from the base-ui composite Select in ./select.tsx — so an
+// RHF register() spreads straight onto it and each call site keeps its own
+// options + setValueAs. Extra `className` merges on top via cn.
+function NativeSelect({ className, ...props }: React.ComponentProps<'select'>) {
+  return (
+    <select
+      data-slot="native-select"
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { NativeSelect }

--- a/packages/web/src/vite/operator-classes/ClassForm.tsx
+++ b/packages/web/src/vite/operator-classes/ClassForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { NativeSelect } from '@/components/ui/native-select'
 import { Textarea } from '@/components/ui/textarea'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ACRISS_CODES } from '@kuruma/shared/acriss'
@@ -143,17 +144,13 @@ export function ClassForm(props: ClassFormProps) {
         {/* No setValueAs/blank option here: the class size is REQUIRED (defaults
             to MEDIUM), unlike the per-vehicle override select in VehicleForm
             which carries a blank "inherit" option. Don't harmonize the two. */}
-        <select
-          id="class-luggageSize"
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
-          {...register('luggageSize')}
-        >
+        <NativeSelect id="class-luggageSize" {...register('luggageSize')}>
           {LUGGAGE_SIZES.map((size) => (
             <option key={size} value={size}>
               {tLuggage(size)}
             </option>
           ))}
-        </select>
+        </NativeSelect>
         {errors.luggageSize && (
           <p className="mt-1 text-sm text-destructive">{errors.luggageSize.message}</p>
         )}
@@ -162,14 +159,10 @@ export function ClassForm(props: ClassFormProps) {
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Label htmlFor="class-transmission">{t('form.transmission')}</Label>
-          <select
-            id="class-transmission"
-            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
-            {...register('transmission')}
-          >
+          <NativeSelect id="class-transmission" {...register('transmission')}>
             <option value="AUTO">{t('form.transmissionAuto')}</option>
             <option value="MANUAL">{t('form.transmissionManual')}</option>
-          </select>
+          </NativeSelect>
         </div>
         <div>
           <Label htmlFor="class-fuelType">{t('form.fuelType')}</Label>
@@ -183,9 +176,8 @@ export function ClassForm(props: ClassFormProps) {
 
       <div>
         <Label htmlFor="class-acrissCode">{t('form.acrissCode')}</Label>
-        <select
+        <NativeSelect
           id="class-acrissCode"
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
           {...register('acrissCode', { setValueAs: nullableString })}
         >
           <option value="">{t('form.acrissCodeNone')}</option>
@@ -194,7 +186,7 @@ export function ClassForm(props: ClassFormProps) {
               {tAcriss(code)}
             </option>
           ))}
-        </select>
+        </NativeSelect>
         {errors.acrissCode && (
           <p className="mt-1 text-sm text-destructive">{errors.acrissCode.message}</p>
         )}

--- a/packages/web/src/vite/operator-fleet/VehicleForm.tsx
+++ b/packages/web/src/vite/operator-fleet/VehicleForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { NativeSelect } from '@/components/ui/native-select'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -47,9 +48,6 @@ interface VehicleFormProps {
   /** Called when the user cancels without saving. */
   readonly onCancel: () => void
 }
-
-const SELECT_CLASS =
-  'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs'
 
 // Blank numeric inputs must submit `null` (not NaN/undefined) so the nullish
 // validators accept a cleared field. Mirrors the frozen form's pricing pattern.
@@ -158,18 +156,14 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
       {classOptions.length > 0 && (
         <div>
           <Label htmlFor="classId">{t('class')}</Label>
-          <select
-            id="classId"
-            className={SELECT_CLASS}
-            {...register('classId', { setValueAs: emptyToNull })}
-          >
+          <NativeSelect id="classId" {...register('classId', { setValueAs: emptyToNull })}>
             <option value="">{t('classNone')}</option>
             {classOptions.map((klass) => (
               <option key={klass.id} value={klass.id}>
                 {klass.name}
               </option>
             ))}
-          </select>
+          </NativeSelect>
         </div>
       )}
 
@@ -209,10 +203,10 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
         </div>
         <div>
           <Label htmlFor="transmission">{t('transmission')}</Label>
-          <select id="transmission" className={SELECT_CLASS} {...register('transmission')}>
+          <NativeSelect id="transmission" {...register('transmission')}>
             <option value="AUTO">{t('transmissionAuto')}</option>
             <option value="MANUAL">{t('transmissionManual')}</option>
-          </select>
+          </NativeSelect>
         </div>
       </div>
 
@@ -248,18 +242,14 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
         </div>
         <div>
           <Label htmlFor="luggageSize">{t('luggageSize')}</Label>
-          <select
-            id="luggageSize"
-            className={SELECT_CLASS}
-            {...register('luggageSize', { setValueAs: emptyToNull })}
-          >
+          <NativeSelect id="luggageSize" {...register('luggageSize', { setValueAs: emptyToNull })}>
             <option value="">{t('luggageSizeInherit')}</option>
             {LUGGAGE_SIZES.map((size) => (
               <option key={size} value={size}>
                 {tLuggage(size)}
               </option>
             ))}
-          </select>
+          </NativeSelect>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Extracts a shared `NativeSelect` UI primitive to absorb the repeated styled-`<select>` markup (and the duplicated `SELECT_CLASS` Tailwind string) across the operator forms.

- **New** `packages/web/src/components/ui/native-select.tsx` — `NativeSelect`, a styled native `<select>`. Deliberately distinct from the base-ui composite at `ui/select.tsx`.
- **Migrated** 6 call sites: `VehicleForm` ×3 (dropping its local `SELECT_CLASS` const) + `ClassForm` ×3.
- Behavior-preserving extraction — no logic or markup changes beyond the shared primitive.

Luggage selects are intentionally left independent per the issue's warning.

## Scope note

This PR originally rode alongside a local #603 commit, but **#603 was already merged via #609** (the `businessNavItems` source-of-truth refactor). That duplicate commit was dropped; this branch carries **only #604**, cherry-picked fresh onto current `marketplace-pivot`.

#605 is deliberately **not** done — its own AC defers it until class fields exceed ~6 (currently 4); acting now would be speculative.

## Test plan

- [x] `bun run --filter @kuruma/web typecheck` — 0 errors
- [x] `bun run --filter @kuruma/web test` — 1027 passed (171 files)
- [x] biome clean on all 3 changed files

Closes #604