### PR TITLE
chore(web): #525 post-merge review nits

### DIFF
--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -47,47 +47,6 @@ interface RawOperatorBooking {
   renter?: { id: string; name: string | null; email: string | null; language: string } | undefined
 }
 
-export interface OperatorBookingFilters {
-  status?: OperatorBookingStatus
-  limit?: number
-}
-
-function toRow(b: RawOperatorBooking): OperatorBookingRow {
-  return {
-    id: b.id,
-    bookingCode: b.bookingCode,
-    status: b.status,
-    startAt: b.startAt,
-    endAt: b.endAt,
-    totalPrice: b.totalPrice,
-    vehicleName: b.vehicle?.name ?? null,
-    renter: b.renter ? { id: b.renter.id, name: b.renter.name, email: b.renter.email } : null,
-  }
-}
-
-export async function fetchOperatorBookings(
-  filters: OperatorBookingFilters = {},
-): Promise<OperatorBookingRow[]> {
-  const sp = new URLSearchParams({ expand: 'vehicle,renter' })
-  if (filters.status) sp.set('status', filters.status)
-  if (filters.limit) sp.set('limit', String(filters.limit))
-
-  const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
-    credentials: 'include',
-  })
-  const data = await unwrap<RawOperatorBooking[]>(res)
-  return data.map(toRow)
-}
-
-export function operatorBookingsQueryOptions(filters: OperatorBookingFilters = {}) {
-  return queryOptions({
-    // Key on every filter that changes the response (status + limit) so two
-    // callers with different limits never collide on a stale cache entry.
-    queryKey: ['operator-bookings', filters.status, filters.limit],
-    queryFn: () => fetchOperatorBookings(filters),
-  })
-}
-
 // #525: the operator calendar reads bookings over a date range. Unlike the list
 // row, it carries the assigned vehicle id (the resource-column key) and the
 // turnaround-aware end so a booking's block spans its real off-fleet window.
@@ -166,11 +125,20 @@ export interface CalendarVehicle {
 }
 
 export async function fetchCalendarVehicles(): Promise<CalendarVehicle[]> {
-  const res = await fetch(`${getApiBaseUrl()}/vehicles?limit=${VEHICLES_PAGE_LIMIT}`, {
-    credentials: 'include',
-  })
-  const data = await unwrap<Array<{ id: string; name: string }>>(res)
-  return data.map((v) => ({ id: v.id, name: v.name }))
+  // Degrade to an empty list on failure: the vehicle columns + sidebar filter are
+  // a day-view convenience, so a vehicle-list error must NOT take down the whole
+  // bookings calendar (week/month render fine without columns, and the route's
+  // loader Promise.all would otherwise reject and blank the page — the exact
+  // coupling that broke the operator portal when this read /vehicles/fleet-overview).
+  try {
+    const res = await fetch(`${getApiBaseUrl()}/vehicles?limit=${VEHICLES_PAGE_LIMIT}`, {
+      credentials: 'include',
+    })
+    const data = await unwrap<Array<{ id: string; name: string }>>(res)
+    return data.map((v) => ({ id: v.id, name: v.name }))
+  } catch {
+    return []
+  }
 }
 
 export function operatorCalendarVehiclesQueryOptions() {

--- a/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
+++ b/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
@@ -2,10 +2,14 @@ import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 // #525 Slice C: vehicle + status filters for the operator calendar. Ported from
-// the frozen Next hook. Persists to localStorage (filters are a per-user view
+// the frozen Next hook. Persists to localStorage (filters are a device-level view
 // preference, not shareable state — so they live here, not in the URL like
-// view/date). Tracks *hidden* items, not visible ones, so a newly added vehicle
-// defaults to visible (an additive fleet change never retroactively hides a car).
+// view/date). The key is per-browser, NOT per-user: on a shared machine the
+// filters carry across sessions. That is acceptable because they only hide/show
+// rows in the operator's own already-authorized view — no data-access implication;
+// namespacing the key by operator id is a follow-up if shared kiosks materialize.
+// Tracks *hidden* items, not visible ones, so a newly added vehicle defaults to
+// visible (an additive fleet change never retroactively hides a car).
 
 const STORAGE_KEY = 'kuruma.calendar.filters'
 const ALL_STATUSES: readonly OperatorBookingStatus[] = [

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -4,11 +4,11 @@ import {
   bookingEventsQueryOptions,
   fetchBookingEvents,
   fetchCalendarBookings,
+  fetchCalendarVehicles,
   fetchOperatorBookingDetail,
-  fetchOperatorBookings,
   operatorBookingDetailQueryOptions,
-  operatorBookingsQueryOptions,
   operatorCalendarQueryOptions,
+  operatorCalendarVehiclesQueryOptions,
   operatorRowFromDetail,
 } from '@/vite/operator-bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -20,126 +20,8 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-const rawBooking = (over: Record<string, unknown> = {}) => ({
-  id: 'bk-1',
-  operatorId: 'op-1',
-  renterId: 'r-1',
-  assignedVehicleId: 'veh-1',
-  bookingCode: 'ABCD2345',
-  status: 'CONFIRMED',
-  startAt: '2026-07-01T01:00:00.000Z',
-  endAt: '2026-07-03T01:00:00.000Z',
-  totalPrice: 24000,
-  vehicle: { name: 'Toyota Aqua', photos: ['a.jpg'] },
-  renter: { id: 'r-1', name: 'Jane', email: 'jane@example.com', language: 'en' },
-  ...over,
-})
-
 afterEach(() => {
   vi.restoreAllMocks()
-})
-
-describe('fetchOperatorBookings', () => {
-  it('requests the operator-scoped list expanding vehicle and renter, with credentials', async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [], nextCursor: null }))
-    vi.stubGlobal('fetch', fetchMock)
-
-    await fetchOperatorBookings()
-
-    const [url, init] = fetchMock.mock.calls[0]!
-    const parsed = new URL(url as string, 'http://x')
-    expect(parsed.pathname).toBe('/api/bookings')
-    expect(parsed.searchParams.get('expand')).toBe('vehicle,renter')
-    expect((init as RequestInit).credentials).toBe('include')
-  })
-
-  it('maps the envelope to rows (code, status, range, total, vehicle name, renter)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => jsonResponse({ success: true, data: [rawBooking()], nextCursor: null })),
-    )
-
-    const rows = await fetchOperatorBookings()
-
-    expect(rows).toEqual([
-      {
-        id: 'bk-1',
-        bookingCode: 'ABCD2345',
-        status: 'CONFIRMED',
-        startAt: '2026-07-01T01:00:00.000Z',
-        endAt: '2026-07-03T01:00:00.000Z',
-        totalPrice: 24000,
-        vehicleName: 'Toyota Aqua',
-        renter: { id: 'r-1', name: 'Jane', email: 'jane@example.com' },
-      },
-    ])
-  })
-
-  it('passes through an optional status filter', async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [], nextCursor: null }))
-    vi.stubGlobal('fetch', fetchMock)
-
-    await fetchOperatorBookings({ status: 'ACTIVE' })
-
-    const parsed = new URL(fetchMock.mock.calls[0]![0] as string, 'http://x')
-    expect(parsed.searchParams.get('status')).toBe('ACTIVE')
-  })
-
-  it('normalizes a missing vehicle expansion to null', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        jsonResponse({
-          success: true,
-          data: [rawBooking({ vehicle: undefined })],
-          nextCursor: null,
-        }),
-      ),
-    )
-
-    const [row] = await fetchOperatorBookings()
-    expect(row!.vehicleName).toBeNull()
-  })
-
-  it('normalizes a missing renter expansion to null', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        jsonResponse({
-          success: true,
-          data: [rawBooking({ renter: undefined })],
-          nextCursor: null,
-        }),
-      ),
-    )
-
-    const [row] = await fetchOperatorBookings()
-    expect(row!.renter).toBeNull()
-  })
-
-  it('throws ApiError on a failure envelope', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => jsonResponse({ success: false, error: 'Unauthorized' }, 401)),
-    )
-
-    await expect(fetchOperatorBookings()).rejects.toBeInstanceOf(ApiError)
-  })
-})
-
-describe('operatorBookingsQueryOptions', () => {
-  it('keys by the operator-bookings list and the status + limit filters', () => {
-    expect(operatorBookingsQueryOptions().queryKey).toEqual([
-      'operator-bookings',
-      undefined,
-      undefined,
-    ])
-    expect(operatorBookingsQueryOptions({ status: 'ACTIVE', limit: 50 }).queryKey).toEqual([
-      'operator-bookings',
-      'ACTIVE',
-      50,
-    ])
-  })
 })
 
 // #549: the deep-linked trip-detail page reads the single booking WITH expansion
@@ -398,6 +280,70 @@ describe('operatorCalendarQueryOptions', () => {
       'calendar',
       '2026-07-01',
       '2026-07-31',
+    ])
+  })
+})
+
+// #525: the calendar reads the operator's own vehicles ({id,name}) from the
+// tenant-scoped GET /vehicles for its day-view columns + sidebar filter. It must
+// degrade to [] on failure so a vehicle-list error never blanks the bookings.
+
+describe('fetchCalendarVehicles', () => {
+  it('requests the operator vehicles with a bounded limit and credentials', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchCalendarVehicles()
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    const parsed = new URL(url as string, 'http://x')
+    expect(parsed.pathname).toBe('/api/vehicles')
+    expect(parsed.searchParams.get('limit')).toBe('100')
+    expect((init as RequestInit).credentials).toBe('include')
+  })
+
+  it('maps rows to {id, name} only', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [{ id: 'veh-1', name: 'Toyota Aqua', status: 'ACTIVE', seats: 5 }],
+        }),
+      ),
+    )
+
+    const vehicles = await fetchCalendarVehicles()
+    expect(vehicles).toEqual([{ id: 'veh-1', name: 'Toyota Aqua' }])
+  })
+
+  it('degrades to [] on a failure envelope (must not blank the calendar)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'Forbidden' }, 403)),
+    )
+
+    expect(await fetchCalendarVehicles()).toEqual([])
+  })
+
+  it('degrades to [] when the request itself rejects (network error)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('network down')
+      }),
+    )
+
+    expect(await fetchCalendarVehicles()).toEqual([])
+  })
+})
+
+describe('operatorCalendarVehiclesQueryOptions', () => {
+  it('keys by the calendar vehicles list', () => {
+    expect(operatorCalendarVehiclesQueryOptions().queryKey).toEqual([
+      'operator-bookings',
+      'calendar',
+      'vehicles',
     ])
   })
 })


### PR DESCRIPTION
Salvages the SHIP-WITH-NITS findings from the #525 operator-bookings review that were stranded when PR #590 merged at \`5a7ae98\` — *before* the nit commit \`7a27e31\`. The fixes are therefore **not** in trunk.

Cherry-picked clean onto \`marketplace-pivot\` (no conflicts).

## Changes
- **M1** — \`fetchCalendarVehicles\` degrades to \`[]\` on error (+ tests). Prevents a vehicle-list fetch failure from blanking the whole calendar.
- **L1** — removed dead table-query code; added missing vehicle-fetch tests.
- **M2** — fixed misleading "per-user" localStorage comment.

## Test plan
- [x] \`bun run --filter @kuruma/web typecheck\` → 0
- [x] \`bun run --filter @kuruma/web test\` → 1030 passed (171 files)