### PR TITLE
feat(operator): vehicle substitution UI on trip-detail (#610)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -885,7 +885,20 @@
         "loading": "Loading booking…",
         "loadError": "Couldn't load this booking",
         "missing": "Booking not found",
-        "actions": "Actions"
+        "actions": "Actions",
+        "substitute": {
+          "action": "Substitute vehicle",
+          "dialogTitle": "Substitute vehicle",
+          "dialogDescription": "Swap in another available car of the same class at this pickup location. The renter keeps their original booking; the change is recorded.",
+          "vehicleLabel": "Replacement vehicle",
+          "reasonLabel": "Reason (optional)",
+          "reasonPlaceholder": "e.g. original car in for repair",
+          "noCandidates": "No same-class vehicle is available at this pickup location.",
+          "submit": "Confirm substitution",
+          "cancel": "Cancel",
+          "error": "Couldn't substitute the vehicle. It may have just been booked.",
+          "unavailable": "Vehicle substitution is only available for confirmed or active bookings."
+        }
       },
       "timeline": {
         "heading": "Timeline",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -885,7 +885,20 @@
         "loading": "予約を読み込み中…",
         "loadError": "この予約を読み込めませんでした",
         "missing": "予約が見つかりません",
-        "actions": "操作"
+        "actions": "操作",
+        "substitute": {
+          "action": "車両を変更",
+          "dialogTitle": "車両を変更",
+          "dialogDescription": "同じ受取場所で同クラスの空き車両に振り替えます。お客様の予約はそのまま保持され、変更は記録されます。",
+          "vehicleLabel": "代替車両",
+          "reasonLabel": "理由（任意）",
+          "reasonPlaceholder": "例：元の車両が修理中",
+          "noCandidates": "この受取場所で利用可能な同クラスの車両がありません。",
+          "submit": "変更を確定",
+          "cancel": "キャンセル",
+          "error": "車両を変更できませんでした。直前に予約された可能性があります。",
+          "unavailable": "車両の変更は確定済みまたは利用中の予約でのみ可能です。"
+        }
       },
       "timeline": {
         "heading": "タイムライン",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -885,7 +885,20 @@
         "loading": "正在加载预订…",
         "loadError": "无法加载此预订",
         "missing": "未找到预订",
-        "actions": "操作"
+        "actions": "操作",
+        "substitute": {
+          "action": "更换车辆",
+          "dialogTitle": "更换车辆",
+          "dialogDescription": "在同一取车点更换为同级别的另一辆可用车辆。租客的原始预订保持不变，变更将被记录。",
+          "vehicleLabel": "替换车辆",
+          "reasonLabel": "原因（可选）",
+          "reasonPlaceholder": "例如：原车辆正在维修",
+          "noCandidates": "该取车点暂无可用的同级别车辆。",
+          "submit": "确认更换",
+          "cancel": "取消",
+          "error": "无法更换车辆，该车辆可能刚被预订。",
+          "unavailable": "仅确认或进行中的预订可更换车辆。"
+        }
       },
       "timeline": {
         "heading": "时间线",

--- a/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
@@ -1,4 +1,5 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { BookingActionsPanel } from '@/vite/operator-bookings/BookingActionsPanel'
 import { BookingTimeline } from '@/vite/operator-bookings/BookingTimeline'
 import { OperatorBookingDetail } from '@/vite/operator-bookings/OperatorBookingDetail'
 import {
@@ -6,6 +7,8 @@ import {
   operatorBookingDetailQueryOptions,
   operatorRowFromDetail,
 } from '@/vite/operator-bookings/api'
+import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
+import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import {
   type ErrorComponentProps,
@@ -21,16 +24,20 @@ import { useTranslations } from 'use-intl'
 // replacement for the #548 drawer — an operator can bookmark/share a reservation.
 // Behind `_business`; the single read is tenant-sealed server-side (404 -> null ->
 // notFound). All data comes from the API, so a hard refresh works (no list row).
-// Two-column layout: booking detail + an Actions placeholder (cancel / substitute
-// / status — reserved for phase 2) on the left, the vertical event timeline right.
+// Two-column layout: booking detail + the Actions panel (#610 vehicle substitution)
+// on the left, the vertical event timeline right.
 export const Route = createFileRoute('/$locale/_business/manage/bookings/$bookingId')({
   loader: async ({ context, params }) => {
     const detail = await context.queryClient.ensureQueryData(
       operatorBookingDetailQueryOptions(params.bookingId),
     )
     if (!detail) throw notFound()
-    // Warm the timeline cache so the page renders without a second waterfall.
-    await context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId))
+    // Warm the timeline + replacement-candidate caches so the page renders without
+    // a second waterfall. The fleet read backs the substitution dialog's picker.
+    await Promise.all([
+      context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId)),
+      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+    ])
     return { detail }
   },
   pendingComponent: PageSkeleton,
@@ -43,6 +50,8 @@ function TripDetailRoute() {
   const { locale, bookingId } = Route.useParams()
   const { detail } = Route.useLoaderData()
   const { data: events } = useSuspenseQuery(bookingEventsQueryOptions(bookingId))
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  const { data: fleet } = useSuspenseQuery(operatorFleetQueryOptions())
   const row = operatorRowFromDetail(detail)
 
   return (
@@ -61,10 +70,7 @@ function TripDetailRoute() {
             <div className="rounded-xl border border-border py-6">
               <OperatorBookingDetail row={row} booking={detail} locale={locale} />
             </div>
-            {/* Actions reserved for phase 2 (cancel / substitute / status). */}
-            <div className="rounded-xl border border-dashed border-border px-4 py-6">
-              <h2 className="text-sm font-semibold text-muted-foreground">{t('detail.actions')}</h2>
-            </div>
+            <BookingActionsPanel detail={detail} session={session} fleet={fleet} />
           </section>
           <aside className="rounded-xl border border-border px-4 py-6">
             <h2 className="mb-6 text-sm font-semibold">{t('timeline.heading')}</h2>

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -1,0 +1,66 @@
+import { isOperatorSession } from '@/vite/guards'
+import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
+import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { Session } from '@/vite/session'
+import { useTranslations } from 'use-intl'
+
+interface BookingActionsPanelProps {
+  readonly detail: OperatorBookingDetailDto
+  readonly session: Session | null
+  readonly fleet: readonly OperatorFleetVehicle[]
+}
+
+// #610: the operator Actions panel on the trip-detail page. Today it owns one
+// action — vehicle substitution (故障车换同店同级别车) — but it is the home for cancel /
+// status transitions next. Kept router-free (props in, no useSuspenseQuery) so the
+// route owns data + chrome and this stays a pure, directly-testable unit.
+//
+// Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) read the
+// booking cross-operator for oversight but cannot act on it: substitution needs a
+// single target tenant they don't carry. So the panel is operator-only, mirroring
+// fleet/classes (#581/#583/#598). The `_business` shell guard admits the page; this
+// gates the action by role + capability (the API is the real boundary).
+export function BookingActionsPanel({ detail, session, fleet }: BookingActionsPanelProps) {
+  const t = useTranslations('bookings.operator.detail')
+
+  if (!isOperatorSession(session)) return null
+
+  // The server only substitutes a live booking (409 otherwise); the renter's slot
+  // is gone once the trip is completed or cancelled.
+  const isSubstitutable = detail.status === 'CONFIRMED' || detail.status === 'ACTIVE'
+
+  // Mirror the server's substitution rules so a picked car never 400s: same operator
+  // (the scoped fleet read), same class, same pickup location, AVAILABLE, and not the
+  // car already on the booking. `classId != null` makes the (server-impossible) null-
+  // class booking explicit — the server derives a class at create time and rejects a
+  // classless replacement, so we never surface unassigned cars.
+  // NOTE: the server matches by *ACRISS code*, not classId (two classes may share a
+  // code — schema.ts "ACRISS is a category"). Filtering on classId is a strict subset:
+  // it never offers a car the server rejects, but can hide a same-ACRISS replacement
+  // in a different class. The fleet row carries no ACRISS code today; widening to a
+  // code-based match is a follow-up (#610 review). Conservative on purpose.
+  const candidates = fleet.filter(
+    (v) =>
+      v.status === 'AVAILABLE' &&
+      detail.classId != null &&
+      v.classId === detail.classId &&
+      v.pickupLocationId === detail.pickupLocationId &&
+      v.id !== detail.assignedVehicleId,
+  )
+
+  return (
+    <div className="rounded-xl border border-border px-4 py-6">
+      <h2 className="mb-4 text-sm font-semibold text-muted-foreground">{t('actions')}</h2>
+      {isSubstitutable ? (
+        <SubstituteVehicleDialog
+          bookingId={detail.id}
+          candidates={candidates}
+          csrfToken={session?.csrfToken ?? ''}
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">{t('substitute.unavailable')}</p>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
@@ -1,0 +1,135 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  bookingEventsQueryOptions,
+  operatorBookingDetailQueryOptions,
+  substituteBooking,
+} from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { type FormEvent, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface SubstituteVehicleDialogProps {
+  readonly bookingId: string
+  /** Replacement candidates, already filtered to the booking's class + location. */
+  readonly candidates: readonly OperatorFleetVehicle[]
+  readonly csrfToken: string
+}
+
+// #610: operator vehicle substitution (故障车换同店同级别车，系统留痕). A dialog that
+// swaps the booking's assigned car for another AVAILABLE same-class, same-location
+// vehicle via POST /bookings/:id/substitute. The candidate list is pre-filtered by
+// the page to mirror the server's rules exactly, so the operator can never pick an
+// invalid car. On success it invalidates the detail (re-fetch the new vehicle) and
+// events (the appended VEHICLE_SUBSTITUTED audit row) queries — the timeline renders
+// the 系统留痕 automatically. CSRF-gated; the session token rides the write.
+export function SubstituteVehicleDialog({
+  bookingId,
+  candidates,
+  csrfToken,
+}: SubstituteVehicleDialogProps) {
+  const t = useTranslations('bookings.operator.detail.substitute')
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [vehicleId, setVehicleId] = useState('')
+  const [reason, setReason] = useState('')
+
+  const mutation = useMutation({
+    mutationFn: () => substituteBooking(bookingId, vehicleId, reason.trim() || null, csrfToken),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: operatorBookingDetailQueryOptions(bookingId).queryKey,
+      })
+      queryClient.invalidateQueries({ queryKey: bookingEventsQueryOptions(bookingId).queryKey })
+      setOpen(false)
+    },
+  })
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (next) {
+      // Default to the first candidate so a single-option list submits in one click.
+      setVehicleId(candidates[0]?.id ?? '')
+      setReason('')
+      mutation.reset()
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!vehicleId || mutation.isPending) return
+    mutation.mutate()
+  }
+
+  const hasCandidates = candidates.length > 0
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button variant="outline" size="sm" />}>{t('action')}</DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t('dialogTitle')}</DialogTitle>
+            <DialogDescription>{t('dialogDescription')}</DialogDescription>
+          </DialogHeader>
+
+          {hasCandidates ? (
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="substitute-vehicle">{t('vehicleLabel')}</Label>
+                <select
+                  id="substitute-vehicle"
+                  value={vehicleId}
+                  onChange={(e) => setVehicleId(e.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  {candidates.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {v.licensePlate ? `${v.name} — ${v.licensePlate}` : v.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="substitute-reason">{t('reasonLabel')}</Label>
+                <Textarea
+                  id="substitute-reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder={t('reasonPlaceholder')}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="py-4 text-sm text-muted-foreground">{t('noCandidates')}</p>
+          )}
+
+          {mutation.isError && (
+            <output className="block text-sm text-destructive">{t('error')}</output>
+          )}
+
+          <DialogFooter>
+            <DialogClose render={<Button type="button" variant="outline" />}>
+              {t('cancel')}
+            </DialogClose>
+            <Button type="submit" disabled={!hasCandidates || !vehicleId || mutation.isPending}>
+              {t('submit')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -195,6 +195,33 @@ export function operatorRowFromDetail(dto: OperatorBookingDetailDto): OperatorBo
   }
 }
 
+// #610: operator vehicle substitution. POST /bookings/:id/substitute swaps the
+// booking's assigned car for another AVAILABLE vehicle of the SAME operator,
+// pickup location and ACRISS class (the server enforces all three). The renter's
+// `requestedVehicleId` is preserved; only `assignedVehicleId` + a re-snapshotted
+// totalPrice change, and a VEHICLE_SUBSTITUTED audit event (系统留痕) is appended,
+// which the existing timeline renders once the events query is invalidated. As a
+// cookie-authed POST it is CSRF-gated (global csrf()), so the caller echoes the
+// session token. `reason` is optional in the schema, so it is omitted when blank.
+export async function substituteBooking(
+  bookingId: string,
+  newVehicleId: string,
+  reason: string | null,
+  csrfToken: string,
+): Promise<BookingDto> {
+  const body = reason != null ? { newVehicleId, reason } : { newVehicleId }
+  const res = await fetch(
+    `${getApiBaseUrl()}/bookings/${encodeURIComponent(bookingId)}/substitute`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify(body),
+    },
+  )
+  return unwrap<BookingDto>(res)
+}
+
 /** One lifecycle event as the operator timeline reads it (dates are ISO JSON). */
 export interface BookingEventDto {
   id: string

--- a/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
@@ -1,0 +1,149 @@
+import type { BookingDto } from '@/vite/bookings/api'
+import { BookingActionsPanel } from '@/vite/operator-bookings/BookingActionsPanel'
+import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const sub = enMessages.bookings.operator.detail.substitute
+
+function detail(over: Partial<BookingDto> = {}): OperatorBookingDetailDto {
+  return {
+    id: 'bk-1',
+    bookingCode: 'H7K2M9PQ',
+    renterId: 'r-1',
+    classId: 'cls-1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    effectiveEndAt: '2026-07-03T01:00:00.000Z',
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    totalPrice: 18000,
+    notes: null,
+    createdAt: '2026-06-20T00:00:00.000Z',
+    updatedAt: '2026-06-20T00:00:00.000Z',
+    ...over,
+  }
+}
+
+function fleetVehicle(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'veh-2',
+    operatorId: 'op-1',
+    classId: 'cls-1',
+    pickupLocationId: 'loc-1',
+    name: 'Honda Fit',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'OSAKA 9999',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 7000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...over,
+  }
+}
+
+const operatorSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
+  csrfToken: 't',
+}
+
+const bypassSession: Session = {
+  user: { id: 'u', role: 'PLATFORM_ADMIN' },
+  csrfToken: 't',
+}
+
+function renderPanel(
+  session: Session | null,
+  bookingDetail: OperatorBookingDetailDto,
+  fleet: OperatorFleetVehicle[] = [fleetVehicle({ id: 'veh-1' }), fleetVehicle()],
+) {
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <BookingActionsPanel detail={bookingDetail} session={session} fleet={fleet} />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('BookingActionsPanel substitution gating (#610)', () => {
+  it('offers the Substitute action to a tenant-scoped operator on a live booking', () => {
+    renderPanel(operatorSession, detail({ status: 'CONFIRMED' }))
+    expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
+  })
+
+  it('renders nothing for a bypass role with no operatorId (read-only oversight)', () => {
+    const { container } = render(
+      <QueryClientProvider client={new QueryClient()}>
+        <IntlProvider locale="en" messages={enMessages}>
+          <BookingActionsPanel
+            detail={detail({ status: 'CONFIRMED' })}
+            session={bypassSession}
+            fleet={[fleetVehicle()]}
+          />
+        </IntlProvider>
+      </QueryClientProvider>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('disables substitution on a terminal booking, explaining why instead of the action', () => {
+    renderPanel(operatorSession, detail({ status: 'COMPLETED' }))
+    expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
+    expect(screen.getByText(sub.unavailable)).toBeInTheDocument()
+  })
+
+  it('only surfaces same-class, same-location, AVAILABLE candidates (never the assigned car)', async () => {
+    const user = userEvent.setup()
+    renderPanel(operatorSession, detail({ status: 'CONFIRMED' }), [
+      fleetVehicle({ id: 'veh-1', name: 'Assigned Car' }), // the current car — excluded
+      fleetVehicle({ id: 'ok', name: 'Same Class Same Loc' }), // valid
+      fleetVehicle({ id: 'other-class', name: 'Other Class', classId: 'cls-2' }), // wrong class
+      fleetVehicle({ id: 'other-loc', name: 'Other Loc', pickupLocationId: 'loc-9' }), // wrong loc
+      fleetVehicle({ id: 'maint', name: 'In Maintenance', status: 'MAINTENANCE' }), // not available
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+
+    expect(screen.getByRole('option', { name: /Same Class Same Loc/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Assigned Car/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Other Class/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Other Loc/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /In Maintenance/ })).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
@@ -1,0 +1,154 @@
+import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
+import * as api from '@/vite/operator-bookings/api'
+import {
+  bookingEventsQueryOptions,
+  operatorBookingDetailQueryOptions,
+} from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const sub = enMessages.bookings.operator.detail.substitute
+
+function candidate(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'veh-2',
+    operatorId: 'op-1',
+    classId: 'cls-1',
+    pickupLocationId: 'loc-1',
+    name: 'Toyota Aqua',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'OSAKA 5678',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...over,
+  }
+}
+
+function renderDialog(candidates: OperatorFleetVehicle[], queryClient = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <SubstituteVehicleDialog bookingId="bk-1" candidates={candidates} csrfToken="csrf-tok" />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('SubstituteVehicleDialog', () => {
+  it('lists candidate vehicles (name + plate) when the trigger is opened', async () => {
+    const user = userEvent.setup()
+    renderDialog([
+      candidate(),
+      candidate({ id: 'veh-3', name: 'Mazda 2', licensePlate: 'KYOTO 1' }),
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+
+    expect(screen.getByRole('option', { name: /Toyota Aqua/ })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Mazda 2/ })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /OSAKA 5678/ })).toBeInTheDocument()
+  })
+
+  it('submits the picked vehicle id + reason + csrf and invalidates the detail and events queries', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    renderDialog([candidate(), candidate({ id: 'veh-3', name: 'Mazda 2' })], queryClient)
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.selectOptions(screen.getByRole('combobox'), 'veh-3')
+    await user.type(screen.getByLabelText(sub.reasonLabel), 'engine fault')
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('bk-1', 'veh-3', 'engine fault', 'csrf-tok'),
+    )
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: operatorBookingDetailQueryOptions('bk-1').queryKey,
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: bookingEventsQueryOptions('bk-1').queryKey,
+    })
+    // The dialog closes on success (the picker only renders while it is open).
+    await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument())
+  })
+
+  it('passes null reason when the field is left blank', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
+    renderDialog([candidate()])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'veh-2', null, 'csrf-tok'))
+  })
+
+  it('collapses a whitespace-only reason to null', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
+    renderDialog([candidate()])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.type(screen.getByLabelText(sub.reasonLabel), '   ')
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'veh-2', null, 'csrf-tok'))
+  })
+
+  it('shows the empty state and disables submit when there are no candidates', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'substituteBooking')
+    renderDialog([])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+
+    expect(screen.getByText(sub.noCandidates)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: sub.submit })).toBeDisabled()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error message when the substitution fails', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'substituteBooking').mockRejectedValue(new Error('409'))
+    renderDialog([candidate()])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    expect(await screen.findByText(sub.error)).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -10,6 +10,7 @@ import {
   operatorCalendarQueryOptions,
   operatorCalendarVehiclesQueryOptions,
   operatorRowFromDetail,
+  substituteBooking,
 } from '@/vite/operator-bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -345,5 +346,50 @@ describe('operatorCalendarVehiclesQueryOptions', () => {
       'calendar',
       'vehicles',
     ])
+  })
+})
+
+// #610: operator vehicle substitution. POST /bookings/:id/substitute swaps the
+// assigned car for another AVAILABLE same-class, same-location vehicle. Cookie +
+// CSRF-gated (global csrf()), so the caller echoes the session CSRF token.
+describe('substituteBooking', () => {
+  it('POSTs the substitute endpoint with the new vehicle id, reason, csrf header and credentials', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await substituteBooking('bk-1', 'veh-2', 'engine fault', 'csrf-tok')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    const parsed = new URL(url as string, 'http://x')
+    expect(parsed.pathname).toBe('/api/bookings/bk-1/substitute')
+    const request = init as RequestInit
+    expect(request.method).toBe('POST')
+    expect(request.credentials).toBe('include')
+    expect((request.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-tok')
+    expect(JSON.parse(request.body as string)).toEqual({
+      newVehicleId: 'veh-2',
+      reason: 'engine fault',
+    })
+  })
+
+  it('omits the reason field when none is given (schema reason is optional)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await substituteBooking('bk-1', 'veh-2', null, 'csrf-tok')
+
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string)
+    expect(body).toEqual({ newVehicleId: 'veh-2' })
+  })
+
+  it('throws ApiError on a domain failure (e.g. 409 replacement just booked)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'Vehicle already booked' }, 409)),
+    )
+
+    await expect(substituteBooking('bk-1', 'veh-2', null, 'csrf-tok')).rejects.toBeInstanceOf(
+      ApiError,
+    )
   })
 })


### PR DESCRIPTION
Finishes **operator step 8** of the MVP screenshot (管理订单 → 故障车换同店同级别车，系统留痕). Web-only slice: the backend (`POST /bookings/:id/substitute`) was already shipped; this wires the dashed Actions placeholder on `/<locale>/manage/bookings/:id` into a working **Substitute vehicle** action.

## What changed
- **`substituteBooking()`** (`vite/operator-bookings/api.ts`) — CSRF-gated POST mirroring the operator-fees write thread; omits a blank/whitespace reason.
- **`SubstituteVehicleDialog`** — candidate `<select>` (name + plate) + optional reason → `useMutation` → on success invalidates the detail **and** events queries (the appended `VEHICLE_SUBSTITUTED` event = the 系统留痕, rendered by the existing timeline) and closes. Empty-candidate + error states handled.
- **`BookingActionsPanel`** — operator-only gating via `isOperatorSession` (bypass roles read-only, per #581/#583/#598); only enabled for `CONFIRMED`/`ACTIVE` (else an explanatory disabled state). Client candidate filter mirrors the server rules (same class + pickup location, `AVAILABLE`, not the assigned car) so a picked car never 400s.
- Route loader prefetches the fleet for the picker; i18n `en`/`ja`/`zh` under `bookings.operator.detail.substitute`.

## Tests (TDD)
- `api.test.ts` — URL/method/body/CSRF header, blank-reason omission, 409 → `ApiError`.
- `SubstituteVehicleDialog.test.tsx` — candidate listing, submit args + invalidation + dialog close, blank & whitespace reason → null, empty state disables submit, error surfaced.
- `BookingActionsPanel.test.tsx` — operator sees the action; bypass role renders nothing; terminal booking shows the disabled explanation; candidate filter excludes wrong-class/wrong-location/unavailable/assigned cars.

## Verification
- web suite green · `typecheck` 0 · `lint`/biome clean · `lint:i18n-parity` 856×3 · `lint:size`/`lint:modules` pass · pre-commit hooks pass.
- `code-reviewer`: Ship-ready, no CRITICAL/HIGH. Applied the LOW fixes (null-class guard, dialog-close + whitespace-reason test assertions, named `FormEvent` import). One MEDIUM noted as a deliberate, conservative narrowing + follow-up: the client filters by `classId` while the server matches by **ACRISS code** (two classes may share a code) — a strict subset that never 400s but can hide a same-ACRISS replacement; the fleet row carries no ACRISS code today, so a code-based match is a follow-up.

## Notes
- Rebased onto `origin/marketplace-pivot` (resolved a #525 test-file conflict; both describe blocks kept).
- Non-default base (`marketplace-pivot`) — may need a manual close of #610 if GitHub doesn't auto-close.

Closes #610