### PR TITLE
feat(operator): in-app new-order red-dot badge (#611)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -72,7 +72,8 @@
     "search": "Search",
     "browse": "Browse",
     "myBookings": "My Bookings",
-    "documents": "Documents"
+    "documents": "Documents",
+    "newBookings": "{count, plural, one {# new booking} other {# new bookings}}"
   },
   "acriss": {
     "MCAR": "Mini",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -72,7 +72,8 @@
     "search": "検索",
     "browse": "車を探す",
     "myBookings": "予約一覧",
-    "documents": "書類"
+    "documents": "書類",
+    "newBookings": "新規予約 {count}件"
   },
   "acriss": {
     "MCAR": "ミニ",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -72,7 +72,8 @@
     "search": "搜索",
     "browse": "浏览车辆",
     "myBookings": "我的预订",
-    "documents": "证件"
+    "documents": "证件",
+    "newBookings": "{count} 个新订单"
   },
   "acriss": {
     "MCAR": "微型车",

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -14,10 +14,11 @@ import {
   parseCalendarView,
   toCalendarEvents,
 } from '@/vite/operator-bookings/calendar-events'
+import { markBookingsSeen } from '@/vite/operator-bookings/new-bookings'
 import { useCalendarFilters } from '@/vite/operator-bookings/useCalendarFilters'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslations } from 'use-intl'
 
 interface BookingsCalendarSearch {
@@ -63,6 +64,14 @@ function OperatorBookingsRoute() {
   const { locale } = Route.useParams()
   const { view: viewParam, date } = Route.useSearch()
   const navigate = Route.useNavigate()
+
+  const queryClient = useQueryClient()
+
+  // #611: opening the orders list is "seeing" the new orders — clear the nav
+  // red-dot badge (advance lastSeenAt to now) on every mount of this route.
+  useEffect(() => {
+    markBookingsSeen(queryClient)
+  }, [queryClient])
 
   const view = viewParam ?? DEFAULT_VIEW
   const anchorDate = useMemo(() => parseCalendarDate(date), [date])

--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -2,6 +2,7 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { cn } from '@/lib/utils'
+import { NavBadge } from '@/vite/nav/NavBadge'
 import type { BusinessNavTo } from '@/vite/nav/business-nav-items'
 import { type Session, signOut } from '@/vite/session'
 import { useQueryClient } from '@tanstack/react-query'
@@ -20,6 +21,8 @@ export type NavTo = BusinessNavTo | '/$locale/bookings' | '/$locale/search' | '/
 export interface NavItem {
   readonly to: NavTo
   readonly label: string
+  // #611: optional red-dot count (the operator "new orders" alert on Bookings).
+  readonly badge?: number
 }
 
 interface MobileMenuProps {
@@ -64,9 +67,12 @@ export function MobileMenu({ session, navItems }: MobileMenuProps) {
               to={item.to}
               params={{ locale }}
               onClick={() => setOpen(false)}
-              className="px-3 py-2 rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors"
+              className="flex items-center px-3 py-2 rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors"
             >
               {item.label}
+              {item.badge ? (
+                <NavBadge count={item.badge} label={t('nav.newBookings', { count: item.badge })} />
+              ) : null}
             </Link>
           ))}
         </nav>

--- a/packages/web/src/vite/nav/NavBadge.tsx
+++ b/packages/web/src/vite/nav/NavBadge.tsx
@@ -1,0 +1,28 @@
+// #611: red-dot count badge for a nav item (the operator's "new orders" alert).
+// Presentational only — the caller resolves the count + a translated aria-label
+// so this stays shared between the desktop Navbar and the MobileMenu list.
+interface NavBadgeProps {
+  readonly count: number
+  /** Full, translated description for screen readers, e.g. "3 new bookings". */
+  readonly label: string
+}
+
+// Above this, the dot reads "9+" — a precise count past a handful is noise.
+const MAX_DISPLAY = 9
+
+export function NavBadge({ count, label }: NavBadgeProps) {
+  if (count <= 0) return null
+
+  const display = count > MAX_DISPLAY ? `${MAX_DISPLAY}+` : String(count)
+
+  return (
+    // <output> carries an implicit ARIA role of "status" (a polite live region),
+    // so screen readers announce the count change without a manual role attr.
+    <output
+      aria-label={label}
+      className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[0.625rem] font-semibold leading-none text-destructive-foreground"
+    >
+      {display}
+    </output>
+  )
+}

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -2,8 +2,10 @@ import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { LocaleSwitcher } from '@/vite/nav/LocaleSwitcher'
 import { MobileMenu, type NavItem } from '@/vite/nav/MobileMenu'
+import { NavBadge } from '@/vite/nav/NavBadge'
 import { NavbarClient } from '@/vite/nav/NavbarClient'
 import { businessNavItems } from '@/vite/nav/business-nav-items'
+import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import { useSession } from '@/vite/session'
 import { getViewMode, isBusiness } from '@/vite/view-mode'
 import { Link } from '@tanstack/react-router'
@@ -25,6 +27,11 @@ export function Navbar() {
   const viewMode = getViewMode(role)
   const isRenter = role === 'RENTER'
 
+  // #611: in-app "new order" alert. Only an operator (business view) scans for
+  // new bookings; the count rides the Bookings nav item as a red dot.
+  const isBusinessView = viewMode === 'business'
+  const { count: newBookingsCount } = useNewBookingsBadge({ enabled: isBusinessView })
+
   const renterNavItems: readonly NavItem[] = isRenter
     ? [
         { to: '/$locale/bookings', label: t('myBookings') },
@@ -32,12 +39,18 @@ export function Navbar() {
       ]
     : []
 
-  const navItems: readonly NavItem[] =
-    viewMode === 'business'
-      ? businessNavItems.map((item) => ({ to: item.to, label: t(item.labelKey) }))
-      : session?.user
-        ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]
-        : []
+  const navItems: readonly NavItem[] = isBusinessView
+    ? businessNavItems.map((item) => ({
+        to: item.to,
+        label: t(item.labelKey),
+        // exactOptionalPropertyTypes: only attach `badge` when there is one.
+        ...(item.to === '/$locale/manage/bookings' && newBookingsCount > 0
+          ? { badge: newBookingsCount }
+          : {}),
+      }))
+    : session?.user
+      ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]
+      : []
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -68,6 +81,9 @@ export function Navbar() {
                 className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
               >
                 {item.label}
+                {item.badge ? (
+                  <NavBadge count={item.badge} label={t('newBookings', { count: item.badge })} />
+                ) : null}
               </Link>
             ))}
           </nav>

--- a/packages/web/src/vite/operator-bookings/new-bookings.ts
+++ b/packages/web/src/vite/operator-bookings/new-bookings.ts
@@ -11,6 +11,7 @@ import { type QueryClient, queryOptions } from '@tanstack/react-query'
 
 export const LAST_SEEN_STORAGE_KEY = 'kuruma_bookings_last_seen_at'
 export const LAST_SEEN_QUERY_KEY = ['operator-bookings', 'last-seen-at'] as const
+export const NEW_ORDER_SCAN_QUERY_KEY = ['operator-bookings', 'new-order-scan'] as const
 
 // The badge only needs to count, so it pulls the newest page (the list is
 // ordered createdAt DESC, so recent orders are always on page 1) and reads just
@@ -45,7 +46,7 @@ export async function fetchNewOrderBookings(): Promise<NewOrderBooking[]> {
 
 export function newOrderBookingsQueryOptions(enabled: boolean) {
   return queryOptions({
-    queryKey: ['operator-bookings', 'new-order-scan'],
+    queryKey: NEW_ORDER_SCAN_QUERY_KEY,
     queryFn: fetchNewOrderBookings,
     enabled,
     refetchOnWindowFocus: true,
@@ -77,12 +78,19 @@ export function lastSeenQueryOptions() {
 }
 
 /**
- * Mark the orders list as seen: advance `lastSeenAt` to now in both storage and
- * the query cache. Writing to the cache makes the nav badge re-derive its count
- * to 0 immediately (every existing booking is now <= lastSeenAt).
+ * Mark the orders list as seen: advance `lastSeenAt` in both storage and the
+ * query cache so the nav badge re-derives its count to 0 immediately.
+ *
+ * It anchors to the newest order actually scanned (a server-minted `createdAt`)
+ * rather than the client clock: `createdAt` is compared against `lastSeenAt`, so
+ * mixing a client `Date.now()` with server timestamps would mis-clear (clock
+ * behind) or bury new orders (clock ahead) under any skew. The scan is ordered
+ * createdAt DESC, so the head is the newest seen order; fall back to now only
+ * when nothing has been scanned (no orders, or the scan hasn't loaded).
  */
 export function markBookingsSeen(queryClient: QueryClient): void {
-  const now = new Date().toISOString()
-  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, now)
-  queryClient.setQueryData(LAST_SEEN_QUERY_KEY, now)
+  const scanned = queryClient.getQueryData<NewOrderBooking[]>(NEW_ORDER_SCAN_QUERY_KEY)
+  const seenAt = scanned?.[0]?.createdAt ?? new Date().toISOString()
+  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, seenAt)
+  queryClient.setQueryData(LAST_SEEN_QUERY_KEY, seenAt)
 }

--- a/packages/web/src/vite/operator-bookings/new-bookings.ts
+++ b/packages/web/src/vite/operator-bookings/new-bookings.ts
@@ -1,0 +1,88 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import { type QueryClient, queryOptions } from '@tanstack/react-query'
+
+// #611: operator in-app "new order" red-dot badge. There is no server-side
+// unread/seen state (`/notifications` is an email-delivery log, not an inbox),
+// so "new" is defined client-side as: CONFIRMED bookings whose `createdAt` is
+// after the operator last opened the orders list. `lastSeenAt` lives in
+// localStorage (per-device, no migration) and is mirrored into the React Query
+// cache so the Navbar badge and the orders-route clear-on-visit stay in sync.
+
+export const LAST_SEEN_STORAGE_KEY = 'kuruma_bookings_last_seen_at'
+export const LAST_SEEN_QUERY_KEY = ['operator-bookings', 'last-seen-at'] as const
+
+// The badge only needs to count, so it pulls the newest page (the list is
+// ordered createdAt DESC, so recent orders are always on page 1) and reads just
+// the timestamp. 50 comfortably exceeds any realistic since-last-visit burst for
+// a 40-50 car operator; a higher true count is fine to display as "9+".
+const NEW_ORDER_SCAN_LIMIT = 50
+// The operator portal is low-traffic — a slow poll plus refetch-on-focus is
+// plenty; a tight loop would hammer the API for a cosmetic dot.
+const NEW_ORDER_REFETCH_MS = 60_000
+
+/** Minimal row the badge needs: just the creation timestamp (ISO JSON). */
+export interface NewOrderBooking {
+  createdAt: string
+}
+
+/** Pure: how many bookings were created strictly after the last-seen instant. */
+export function countNewBookings(bookings: readonly NewOrderBooking[], lastSeenAt: string): number {
+  const threshold = new Date(lastSeenAt).getTime()
+  return bookings.filter((b) => new Date(b.createdAt).getTime() > threshold).length
+}
+
+export async function fetchNewOrderBookings(): Promise<NewOrderBooking[]> {
+  // Operator-scoped server-side via the session cookie (CallerContext) — no
+  // operatorId is passed, so a cross-tenant read is impossible by construction.
+  const sp = new URLSearchParams({ status: 'CONFIRMED', limit: String(NEW_ORDER_SCAN_LIMIT) })
+  const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
+    credentials: 'include',
+  })
+  const data = await unwrap<NewOrderBooking[]>(res)
+  return data.map((b) => ({ createdAt: b.createdAt }))
+}
+
+export function newOrderBookingsQueryOptions(enabled: boolean) {
+  return queryOptions({
+    queryKey: ['operator-bookings', 'new-order-scan'],
+    queryFn: fetchNewOrderBookings,
+    enabled,
+    refetchOnWindowFocus: true,
+    refetchInterval: NEW_ORDER_REFETCH_MS,
+    staleTime: 30_000,
+  })
+}
+
+/**
+ * Read `lastSeenAt` from localStorage. On a fresh device there is no record of
+ * when the operator last looked, so initialize to *now* (and persist) rather
+ * than the epoch — otherwise the badge would light up with the entire existing
+ * backlog, which is not "new".
+ */
+export function getStoredLastSeenAt(): string {
+  const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)
+  if (stored) return stored
+  const now = new Date().toISOString()
+  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, now)
+  return now
+}
+
+export function lastSeenQueryOptions() {
+  return queryOptions({
+    queryKey: LAST_SEEN_QUERY_KEY,
+    queryFn: () => getStoredLastSeenAt(),
+    staleTime: Number.POSITIVE_INFINITY,
+  })
+}
+
+/**
+ * Mark the orders list as seen: advance `lastSeenAt` to now in both storage and
+ * the query cache. Writing to the cache makes the nav badge re-derive its count
+ * to 0 immediately (every existing booking is now <= lastSeenAt).
+ */
+export function markBookingsSeen(queryClient: QueryClient): void {
+  const now = new Date().toISOString()
+  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, now)
+  queryClient.setQueryData(LAST_SEEN_QUERY_KEY, now)
+}

--- a/packages/web/src/vite/operator-bookings/useNewBookingsBadge.ts
+++ b/packages/web/src/vite/operator-bookings/useNewBookingsBadge.ts
@@ -1,0 +1,24 @@
+import {
+  countNewBookings,
+  lastSeenQueryOptions,
+  newOrderBookingsQueryOptions,
+} from '@/vite/operator-bookings/new-bookings'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+
+// #611: the count behind the operator's "new order" nav badge. Derived from two
+// cache entries so it stays reactive: the CONFIRMED-orders scan (refetched on
+// focus / slow poll) and `lastSeenAt` (advanced when the operator opens the
+// orders list — see markBookingsSeen). `enabled` is false in renter view-mode so
+// a renter never fires the operator-scoped scan.
+export function useNewBookingsBadge({ enabled }: { enabled: boolean }): { count: number } {
+  const { data: lastSeenAt } = useQuery(lastSeenQueryOptions())
+  const { data: bookings } = useQuery(newOrderBookingsQueryOptions(enabled))
+
+  const count = useMemo(
+    () => (enabled && lastSeenAt ? countNewBookings(bookings ?? [], lastSeenAt) : 0),
+    [enabled, bookings, lastSeenAt],
+  )
+
+  return { count }
+}

--- a/packages/web/tests/vite/nav/MobileMenu.test.tsx
+++ b/packages/web/tests/vite/nav/MobileMenu.test.tsx
@@ -68,6 +68,16 @@ describe('MobileMenu', () => {
     )
   })
 
+  it('renders the new-order red-dot badge on a nav item that carries a count (#611)', () => {
+    renderMenu({
+      session,
+      navItems: [{ to: '/$locale/manage/bookings', label: 'Bookings', badge: 3 }],
+    })
+    const badge = screen.getByRole('status')
+    expect(badge).toHaveTextContent('3')
+    expect(badge).toHaveAttribute('aria-label', '3 new bookings')
+  })
+
   it('signs out with the CSRF token then invalidates the session and router', async () => {
     renderMenu({ session, navItems: bookings })
     fireEvent.click(screen.getByText('Log out'))

--- a/packages/web/tests/vite/nav/NavBadge.test.tsx
+++ b/packages/web/tests/vite/nav/NavBadge.test.tsx
@@ -1,0 +1,29 @@
+import { NavBadge } from '@/vite/nav/NavBadge'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+describe('NavBadge', () => {
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<NavBadge count={0} label="0 new bookings" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a negative count', () => {
+    const { container } = render(<NavBadge count={-1} label="x" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the exact count with a status role and aria-label', () => {
+    render(<NavBadge count={3} label="3 new bookings" />)
+    const badge = screen.getByRole('status')
+    expect(badge).toHaveTextContent('3')
+    expect(badge).toHaveAttribute('aria-label', '3 new bookings')
+  })
+
+  it('caps the visible count at 9+ while keeping the full aria-label', () => {
+    render(<NavBadge count={12} label="12 new bookings" />)
+    const badge = screen.getByRole('status')
+    expect(badge).toHaveTextContent('9+')
+    expect(badge).toHaveAttribute('aria-label', '12 new bookings')
+  })
+})

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -1,9 +1,10 @@
 import type { NavItem } from '@/vite/nav/MobileMenu'
 import { Navbar } from '@/vite/nav/Navbar'
 import { businessNavItems } from '@/vite/nav/business-nav-items'
+import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import type { Session } from '@/vite/session'
 import { useSession } from '@/vite/session'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -48,8 +49,14 @@ vi.mock('@/vite/nav/MobileMenu', () => ({
 vi.mock('@/vite/nav/LocaleSwitcher', () => ({
   LocaleSwitcher: () => <div data-testid="locale-switcher" />,
 }))
+// #611: the new-order badge count is a data hook; Navbar's job is to render the
+// dot on the Bookings item in business view only. Stub the count source.
+vi.mock('@/vite/operator-bookings/useNewBookingsBadge', () => ({
+  useNewBookingsBadge: vi.fn(() => ({ count: 0 })),
+}))
 
 const mockUseSession = vi.mocked(useSession)
+const mockUseBadge = vi.mocked(useNewBookingsBadge)
 const business: Session = {
   user: { id: 'u1', role: 'OPERATOR_OWNER', name: 'Aiko', email: 'aiko@example.com' },
   csrfToken: 'csrf-1',
@@ -70,6 +77,7 @@ function renderNavbar(data: Session | undefined) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockUseBadge.mockReturnValue({ count: 0 })
   document.cookie = 'kuruma-view=; max-age=0; path=/'
 })
 
@@ -84,6 +92,7 @@ describe('Navbar', () => {
   })
 
   it('shows the dashboard, operator bookings + fleet + classes + insurance links and business markers for a business user', () => {
+    mockUseBadge.mockReturnValue({ count: 3 })
     const { container } = renderNavbar(business)
     expect(screen.getByText('Dashboard').closest('a')).toHaveAttribute(
       'data-to',
@@ -132,9 +141,18 @@ describe('Navbar', () => {
       'data-nav-count',
       String(businessNavItems.length),
     )
+    // #611: a red-dot count rides the Bookings item (and only that item).
+    const bookingsLink = screen.getByText('Bookings').closest('a') as HTMLElement
+    const badge = within(bookingsLink).getByRole('status')
+    expect(badge).toHaveTextContent('3')
+    expect(badge).toHaveAttribute('aria-label', '3 new bookings')
+    // It is not duplicated onto another nav item.
+    expect(screen.getAllByRole('status')).toHaveLength(1)
   })
 
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {
+    // Even with a non-zero count, the operator badge is gated to business view.
+    mockUseBadge.mockReturnValue({ count: 5 })
     const { container } = renderNavbar(renter)
     expect(screen.getByText('Browse').closest('a')).toHaveAttribute('data-to', '/$locale/search')
     expect(screen.getByText('My Bookings').closest('a')).toHaveAttribute(
@@ -146,6 +164,7 @@ describe('Navbar', () => {
       '/$locale/documents',
     )
     expect(container.querySelector('nav')?.hasAttribute('data-business-nav')).toBe(false)
+    expect(screen.queryByRole('status')).toBeNull()
     const client = screen.getByTestId('navbar-client')
     expect(client).toHaveAttribute('data-view-mode', 'renter')
     expect(client).toHaveAttribute('data-can-switch', 'false')

--- a/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
+++ b/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
@@ -1,5 +1,6 @@
 import {
   LAST_SEEN_STORAGE_KEY,
+  NEW_ORDER_SCAN_QUERY_KEY,
   countNewBookings,
   getStoredLastSeenAt,
   markBookingsSeen,
@@ -49,17 +50,33 @@ describe('getStoredLastSeenAt', () => {
 })
 
 describe('markBookingsSeen', () => {
-  it('advances lastSeenAt to now in both storage and the query cache', () => {
+  it('anchors lastSeenAt to the newest scanned order (server time, skew-immune)', () => {
+    window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, '2020-01-01T00:00:00.000Z')
+    const qc = new QueryClient()
+    // The scan is ordered createdAt DESC, so the head is the newest seen order.
+    qc.setQueryData(NEW_ORDER_SCAN_QUERY_KEY, [
+      { createdAt: '2026-06-13T05:00:00.000Z' },
+      { createdAt: '2026-06-13T04:00:00.000Z' },
+    ])
+
+    markBookingsSeen(qc)
+
+    const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)
+    // Exactly the newest scanned createdAt — NOT the client clock.
+    expect(stored).toBe('2026-06-13T05:00:00.000Z')
+    // Same value mirrored into the cache so subscribers (the nav badge) re-derive.
+    expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
+  })
+
+  it('falls back to now when no orders have been scanned yet', () => {
     window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, '2020-01-01T00:00:00.000Z')
     const qc = new QueryClient()
     markBookingsSeen(qc)
 
-    const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)
-    expect(stored).not.toBe('2020-01-01T00:00:00.000Z')
-    expect(new Date(stored as string).getTime()).toBeGreaterThan(
+    const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY) as string
+    expect(new Date(stored).getTime()).toBeGreaterThan(
       new Date('2020-01-01T00:00:00.000Z').getTime(),
     )
-    // Same value mirrored into the cache so subscribers (the nav badge) re-derive.
     expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
   })
 })

--- a/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
+++ b/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
@@ -1,0 +1,65 @@
+import {
+  LAST_SEEN_STORAGE_KEY,
+  countNewBookings,
+  getStoredLastSeenAt,
+  markBookingsSeen,
+} from '@/vite/operator-bookings/new-bookings'
+import { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('countNewBookings', () => {
+  const lastSeen = '2026-06-13T00:00:00.000Z'
+
+  it('counts only bookings created strictly after lastSeenAt', () => {
+    const bookings = [
+      { createdAt: '2026-06-13T02:00:00.000Z' }, // new
+      { createdAt: '2026-06-13T01:00:00.000Z' }, // new
+      { createdAt: '2026-06-12T23:00:00.000Z' }, // old
+      { createdAt: lastSeen }, // exactly equal -> not new
+    ]
+    expect(countNewBookings(bookings, lastSeen)).toBe(2)
+  })
+
+  it('is 0 when nothing is newer than lastSeenAt', () => {
+    expect(countNewBookings([{ createdAt: '2026-06-12T00:00:00.000Z' }], lastSeen)).toBe(0)
+  })
+
+  it('is 0 for an empty list', () => {
+    expect(countNewBookings([], lastSeen)).toBe(0)
+  })
+})
+
+describe('getStoredLastSeenAt', () => {
+  it('returns the stored ISO timestamp when present', () => {
+    window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, '2026-01-01T00:00:00.000Z')
+    expect(getStoredLastSeenAt()).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('initializes to now and persists it on first read (no backlog flood)', () => {
+    expect(window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)).toBeNull()
+    const first = getStoredLastSeenAt()
+    expect(window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)).toBe(first)
+    // Stable across reads
+    expect(getStoredLastSeenAt()).toBe(first)
+  })
+})
+
+describe('markBookingsSeen', () => {
+  it('advances lastSeenAt to now in both storage and the query cache', () => {
+    window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, '2020-01-01T00:00:00.000Z')
+    const qc = new QueryClient()
+    markBookingsSeen(qc)
+
+    const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)
+    expect(stored).not.toBe('2020-01-01T00:00:00.000Z')
+    expect(new Date(stored as string).getTime()).toBeGreaterThan(
+      new Date('2020-01-01T00:00:00.000Z').getTime(),
+    )
+    // Same value mirrored into the cache so subscribers (the nav badge) re-derive.
+    expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/useNewBookingsBadge.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/useNewBookingsBadge.test.tsx
@@ -1,0 +1,77 @@
+import { LAST_SEEN_STORAGE_KEY, markBookingsSeen } from '@/vite/operator-bookings/new-bookings'
+import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const LAST_SEEN = '2026-06-13T00:00:00.000Z'
+
+function mockBookings(rows: { createdAt: string }[]) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, data: rows }),
+  } as unknown as Response)
+}
+
+function makeWrapper(qc: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, LAST_SEEN)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useNewBookingsBadge', () => {
+  it('counts CONFIRMED bookings created after lastSeenAt when enabled', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockBookings([
+        { createdAt: '2026-06-13T03:00:00.000Z' },
+        { createdAt: '2026-06-13T02:00:00.000Z' },
+        { createdAt: '2026-06-12T22:00:00.000Z' },
+      ]),
+    )
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useNewBookingsBadge({ enabled: true }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await waitFor(() => expect(result.current.count).toBe(2))
+  })
+
+  it('clears to 0 after markBookingsSeen advances lastSeenAt', async () => {
+    // Past-dated fixtures so markBookingsSeen's real "now" is reliably AFTER the
+    // booking (the badge clears) regardless of the test machine's clock.
+    window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, '2019-01-01T00:00:00.000Z')
+    vi.stubGlobal('fetch', mockBookings([{ createdAt: '2020-01-01T00:00:00.000Z' }]))
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useNewBookingsBadge({ enabled: true }), {
+      wrapper: makeWrapper(qc),
+    })
+    await waitFor(() => expect(result.current.count).toBe(1))
+
+    act(() => markBookingsSeen(qc))
+
+    await waitFor(() => expect(result.current.count).toBe(0))
+  })
+
+  it('does not fetch and reports 0 when disabled (renter view)', async () => {
+    const fetchSpy = mockBookings([{ createdAt: '2026-06-13T03:00:00.000Z' }])
+    vi.stubGlobal('fetch', fetchSpy)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useNewBookingsBadge({ enabled: false }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await waitFor(() => expect(result.current.count).toBe(0))
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Finishes **operator step 7** of the MVP screenshot (接订单 → 后台收到新订单**红点提醒** + 邮件通知). The email alert already fires (`OPERATOR_BOOKING_ALERT`); this adds the missing **in-app red-dot badge** on the operator's **Bookings** nav item.

Closes #611

## Design (Option 2 — confirmed in the handoff/issue)
There is **no server-side unread/seen state** (`/notifications` is an email log), so "new" is defined client-side:
- **New = CONFIRMED bookings with `createdAt > lastSeenAt`.** `lastSeenAt` lives in **localStorage** (per-device, no migration) and is mirrored into the React Query cache so the Navbar badge and the orders-route clear-on-visit stay in sync.
- **Reuses the existing operator-scoped `GET /bookings`** (ordered `createdAt` DESC, base projection already carries `createdAt`) — **zero API/schema/migration change**.
- Badge rides the shared `businessNavItems` (#603), so it's added in **one** place (Navbar + MobileMenu both derive from it — no nav-conflict tax).
- **Gated to business view-mode**: a renter never fires the scan or sees the badge (hook `enabled` + server-side `bookingReadScope`).
- **Clear-on-visit**: mounting `/manage/bookings` advances `lastSeenAt` → dot clears.

## What's here
- `operator-bookings/new-bookings.ts` — pure `countNewBookings`, lastSeen store, CONFIRMED-scan query (`refetchOnWindowFocus` + 60s poll, no tight loop)
- `useNewBookingsBadge()` — reactive count, gated by `enabled`
- `nav/NavBadge.tsx` — shared red-dot (`<output>` polite live region, `9+` cap, a11y label)
- wired into `Navbar` + `MobileMenu`; clear-on-visit effect; `nav.newBookings` i18n ×3

## Review fix folded in
- **clock skew (MEDIUM)**: `markBookingsSeen` now anchors `lastSeenAt` to the newest **scanned** order (a server `createdAt`), not a client `Date.now()` — comparing client-vs-server timestamps mis-cleared/buried orders under skew.

## Deferred follow-ups (noted by review, low value for a single-operator portal)
- Cross-tab `storage`-event sync of `lastSeenAt` (a reload fixes it today).
- Optional: cap the aria count at "50+" to mirror the `NEW_ORDER_SCAN_LIMIT`.

## Test plan
- [x] `bun run --filter @kuruma/web test` — **1046 pass** (Navbar/MobileMenu/NavBadge/new-bookings/useNewBookingsBadge incl. `data-nav-count` unchanged)
- [x] `typecheck` 0 · biome clean · `lint:i18n-parity` 846 keys ×3
- [x] pre-commit gate (module boundaries + tsc ×3) green
- [ ] manual browser smoke (operator: dot lights on new order, clears on opening Bookings; hidden in renter view)

P2 — lower priority than #610 (substitution UI).