### PR TITLE
feat(operator): vehicle substitution UI — finish order-management step 8 (#610)

### DIFF
--- a/docs/2026-06-13-issue-610-substitution-ui-continue-handoff.md
+++ b/docs/2026-06-13-issue-610-substitution-ui-continue-handoff.md
@@ -1,0 +1,38 @@
+# Handoff — #610 operator vehicle substitution UI · IMPLEMENTED, pre-PR
+
+> Continues `docs/2026-06-13-operator-substitution-ui-handoff.md`. **Code is done + all
+> local gates green.** What's left is review → push → PR → merge.
+
+## State
+- Worktree `~/Dev/kuruma-610-substitution-ui` · branch `feat/610-substitution-ui` off
+  `marketplace-pivot@946a5e7` · commit **`5ad0462`** · **NOT pushed, no PR**.
+- #610 has the `in-progress` label. Web-only; no API/schema/migration.
+- Gates: web **1050 pass** (+18 new), `typecheck` 0, biome clean, i18n parity **858×3**.
+
+## What was built (TDD, RED→GREEN each slice)
+1. `vite/operator-bookings/api.ts` → `substituteBooking(bookingId, newVehicleId, reason, csrf)`
+   POSTs `/bookings/:id/substitute`, CSRF header, drops empty reason. (api.test.ts +4)
+2. `lib/substitution.ts` → pure `selectSubstitutionCandidates(fleet, booking)` mirroring the
+   server rules (same class + pickup location, AVAILABLE, excl. assigned car). (substitution.test.ts +6)
+3. `vite/operator-bookings/SubstituteVehicleAction.tsx` → candidate radio picker + reason
+   dialog. Gated: `isOperatorSession` → write; bypass role → read-only note; terminal status
+   → unavailable note. Invalidates detail + events on success. (SubstituteVehicleAction.test.tsx +8)
+4. Wired into `$locale/_business/manage/bookings/$bookingId.tsx`: loader prefetches fleet +
+   session; Actions placeholder replaced. `substitute.*` i18n in en/ja/zh.
+
+## Remaining (the finish line)
+1. `/code-review` + `architect` (user-launched billed review is theirs; the agent reviews are yours).
+2. `git push -u origin feat/610-substitution-ui` → `gh pr create --base marketplace-pivot`
+   body `Closes #610`.
+3. `git fetch` + `gh pr update-branch` if BEHIND (swarm drains mp fast). **No rebase / no force-push.**
+4. CI 4/4 (test-and-build, db-drift, e2e, e2e-real-db) → `gh pr merge --squash`.
+5. Manual close #610 + drop `in-progress` (base ≠ default → no auto-close) → teardown worktree+branch.
+
+## Notes / gotchas
+- The route component itself is NOT unit-tested (router-coupled `useLoaderData`/`useParams`,
+  same as #549). All gating (operator sees / admin doesn't / terminal disables) is covered by
+  the prop-driven `SubstituteVehicleAction.test.tsx`. Mention in PR.
+- **Manual browser smoke NOT done** — verify the dialog opens + a real substitute round-trips.
+- Sibling worktree `~/Dev/kuruma-525-operator-bookings` also edits `operator-bookings/api.ts`
+  (append-only; my addition is at the file end) — fetch + update-branch before merge; don't touch it.
+- CSRF is global (`app.use('*', csrf())`); the write echoes `session.csrfToken`.

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -896,6 +896,21 @@
         "cancelled": "Booking cancelled",
         "cancellationFee": "Cancellation fee {fee}",
         "empty": "No events yet"
+      },
+      "substitute": {
+        "action": "Substitute vehicle",
+        "dialogTitle": "Substitute vehicle",
+        "dialogDescription": "Swap in another available car of the same class at this pick-up location. The renter's original choice is preserved; only the assigned car changes.",
+        "pickLabel": "Choose a replacement",
+        "vehicleOption": "{name} · {plate}",
+        "reasonLabel": "Reason (optional)",
+        "reasonPlaceholder": "e.g. mechanical fault",
+        "noCandidates": "No same-class car is available at this pick-up location.",
+        "submit": "Substitute",
+        "cancel": "Cancel",
+        "error": "Couldn't substitute the vehicle — it may have just been booked. Try another.",
+        "unavailable": "Substitution is only available for confirmed or active bookings.",
+        "readOnly": "View only — sign in as the operator to manage this booking."
       }
     }
   },

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -896,6 +896,21 @@
         "cancelled": "予約がキャンセルされました",
         "cancellationFee": "キャンセル料 {fee}",
         "empty": "イベントはまだありません"
+      },
+      "substitute": {
+        "action": "車両を変更",
+        "dialogTitle": "車両を変更",
+        "dialogDescription": "同じ受取場所にある同クラスの空き車両に入れ替えます。利用者が選んだ車両の記録は保持され、割り当て車両のみ変更されます。",
+        "pickLabel": "代替車両を選択",
+        "vehicleOption": "{name}・{plate}",
+        "reasonLabel": "理由（任意）",
+        "reasonPlaceholder": "例：機械的な不具合",
+        "noCandidates": "この受取場所に利用可能な同クラスの車両がありません。",
+        "submit": "変更する",
+        "cancel": "キャンセル",
+        "error": "車両を変更できませんでした。直前に予約された可能性があります。別の車両をお試しください。",
+        "unavailable": "車両の変更は確定済みまたは利用中の予約でのみ可能です。",
+        "readOnly": "閲覧のみ — この予約を管理するには事業者としてサインインしてください。"
       }
     }
   },

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -896,6 +896,21 @@
         "cancelled": "预订已取消",
         "cancellationFee": "取消费 {fee}",
         "empty": "暂无事件"
+      },
+      "substitute": {
+        "action": "更换车辆",
+        "dialogTitle": "更换车辆",
+        "dialogDescription": "在同一取车点更换为同级别的其他可用车辆。系统保留租客最初的选择，仅更改已分配的车辆。",
+        "pickLabel": "选择替换车辆",
+        "vehicleOption": "{name} · {plate}",
+        "reasonLabel": "原因（可选）",
+        "reasonPlaceholder": "例如：机械故障",
+        "noCandidates": "该取车点没有可用的同级别车辆。",
+        "submit": "更换",
+        "cancel": "取消",
+        "error": "无法更换车辆，可能刚刚被预订。请尝试其他车辆。",
+        "unavailable": "仅确认或进行中的预订可更换车辆。",
+        "readOnly": "仅查看 — 请以运营商身份登录以管理此预订。"
       }
     }
   },

--- a/packages/web/src/lib/substitution.ts
+++ b/packages/web/src/lib/substitution.ts
@@ -1,0 +1,35 @@
+// Pure candidate filter for operator vehicle substitution (#610, FC/IS core).
+// Mirrors the server's substitution rules (services/booking.ts `substitute`):
+// the replacement must be the same ACRISS class + pickup location, AVAILABLE,
+// and not the car already on the booking. Filtering on the client keeps the
+// operator from ever picking a car the POST would reject (400 wrong-class /
+// 400 wrong-location / 400 not-available / 409 just-booked). Generic over the
+// vehicle shape so the caller gets its full rows back (name/plate for the UI).
+
+/** The booking fields that constrain a valid replacement. */
+export interface SubstitutionBooking {
+  readonly classId: string | null
+  readonly pickupLocationId: string
+  readonly assignedVehicleId: string
+}
+
+/** The minimal vehicle fields the rules read. */
+export interface SubstitutionCandidate {
+  readonly id: string
+  readonly classId: string | null
+  readonly pickupLocationId: string | null
+  readonly status: string
+}
+
+export function selectSubstitutionCandidates<V extends SubstitutionCandidate>(
+  fleet: readonly V[],
+  booking: SubstitutionBooking,
+): V[] {
+  return fleet.filter(
+    (v) =>
+      v.status === 'AVAILABLE' &&
+      v.classId === booking.classId &&
+      v.pickupLocationId === booking.pickupLocationId &&
+      v.id !== booking.assignedVehicleId,
+  )
+}

--- a/packages/web/src/lib/substitution.ts
+++ b/packages/web/src/lib/substitution.ts
@@ -1,10 +1,13 @@
 // Pure candidate filter for operator vehicle substitution (#610, FC/IS core).
-// Mirrors the server's substitution rules (services/booking.ts `substitute`):
-// the replacement must be the same ACRISS class + pickup location, AVAILABLE,
-// and not the car already on the booking. Filtering on the client keeps the
-// operator from ever picking a car the POST would reject (400 wrong-class /
-// 400 wrong-location / 400 not-available / 409 just-booked). Generic over the
-// vehicle shape so the caller gets its full rows back (name/plate for the UI).
+// Approximates the server's substitution rules (services/booking.ts `substitute`):
+// same pickup location, AVAILABLE, and not the car already on the booking. The
+// server matches the replacement by ACRISS *code*; the fleet projection carries
+// no ACRISS code, so we proxy it with exact `classId` equality. That is
+// stricter-or-equal: same classId always shares the same ACRISS code, so we
+// never offer a car the POST would reject (400 wrong-class / 400 wrong-location /
+// 400 not-available / 409 just-booked); at worst we hide a valid replacement in
+// a different class row that happens to share an ACRISS code (rare). Generic over
+// the vehicle shape so the caller gets its full rows back (name/plate for the UI).
 
 /** The booking fields that constrain a valid replacement. */
 export interface SubstitutionBooking {
@@ -19,6 +22,12 @@ export interface SubstitutionCandidate {
   readonly classId: string | null
   readonly pickupLocationId: string | null
   readonly status: string
+}
+
+/** A candidate enriched with the fields the picker UI renders (name + plate). */
+export interface SubstitutionVehicle extends SubstitutionCandidate {
+  readonly name: string
+  readonly licensePlate: string | null
 }
 
 export function selectSubstitutionCandidates<V extends SubstitutionCandidate>(

--- a/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
@@ -1,11 +1,14 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { BookingTimeline } from '@/vite/operator-bookings/BookingTimeline'
 import { OperatorBookingDetail } from '@/vite/operator-bookings/OperatorBookingDetail'
+import { SubstituteVehicleAction } from '@/vite/operator-bookings/SubstituteVehicleAction'
 import {
   bookingEventsQueryOptions,
   operatorBookingDetailQueryOptions,
   operatorRowFromDetail,
 } from '@/vite/operator-bookings/api'
+import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
+import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import {
   type ErrorComponentProps,
@@ -29,8 +32,14 @@ export const Route = createFileRoute('/$locale/_business/manage/bookings/$bookin
       operatorBookingDetailQueryOptions(params.bookingId),
     )
     if (!detail) throw notFound()
-    // Warm the timeline cache so the page renders without a second waterfall.
-    await context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId))
+    // Warm the timeline cache plus the fleet (substitution candidates) and the
+    // session (write gating) so the page — and its Actions panel (#610) — render
+    // without a second waterfall.
+    await Promise.all([
+      context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId)),
+      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+      context.queryClient.ensureQueryData(sessionQueryOptions()),
+    ])
     return { detail }
   },
   pendingComponent: PageSkeleton,
@@ -43,6 +52,8 @@ function TripDetailRoute() {
   const { locale, bookingId } = Route.useParams()
   const { detail } = Route.useLoaderData()
   const { data: events } = useSuspenseQuery(bookingEventsQueryOptions(bookingId))
+  const { data: fleet } = useSuspenseQuery(operatorFleetQueryOptions())
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
   const row = operatorRowFromDetail(detail)
 
   return (
@@ -61,9 +72,10 @@ function TripDetailRoute() {
             <div className="rounded-xl border border-border py-6">
               <OperatorBookingDetail row={row} booking={detail} locale={locale} />
             </div>
-            {/* Actions reserved for phase 2 (cancel / substitute / status). */}
-            <div className="rounded-xl border border-dashed border-border px-4 py-6">
+            {/* Actions panel: vehicle substitution (#610); cancel / status follow. */}
+            <div className="space-y-4 rounded-xl border border-border px-4 py-6">
               <h2 className="text-sm font-semibold text-muted-foreground">{t('detail.actions')}</h2>
+              <SubstituteVehicleAction booking={detail} fleet={fleet} session={session} />
             </div>
           </section>
           <aside className="rounded-xl border border-border px-4 py-6">

--- a/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
@@ -6,8 +6,8 @@ import {
   bookingEventsQueryOptions,
   operatorBookingDetailQueryOptions,
   operatorRowFromDetail,
+  substitutionCandidatesQueryOptions,
 } from '@/vite/operator-bookings/api'
-import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
 import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import {
@@ -32,12 +32,13 @@ export const Route = createFileRoute('/$locale/_business/manage/bookings/$bookin
       operatorBookingDetailQueryOptions(params.bookingId),
     )
     if (!detail) throw notFound()
-    // Warm the timeline cache plus the fleet (substitution candidates) and the
+    // Warm the timeline cache plus the substitution candidate list and the
     // session (write gating) so the page — and its Actions panel (#610) — render
-    // without a second waterfall.
+    // without a second waterfall. The candidate read degrades to [] on failure,
+    // so a vehicle-list error can never reject this Promise.all and blank the page.
     await Promise.all([
       context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId)),
-      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+      context.queryClient.ensureQueryData(substitutionCandidatesQueryOptions()),
       context.queryClient.ensureQueryData(sessionQueryOptions()),
     ])
     return { detail }
@@ -52,7 +53,7 @@ function TripDetailRoute() {
   const { locale, bookingId } = Route.useParams()
   const { detail } = Route.useLoaderData()
   const { data: events } = useSuspenseQuery(bookingEventsQueryOptions(bookingId))
-  const { data: fleet } = useSuspenseQuery(operatorFleetQueryOptions())
+  const { data: vehicles } = useSuspenseQuery(substitutionCandidatesQueryOptions())
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
   const row = operatorRowFromDetail(detail)
 
@@ -75,7 +76,7 @@ function TripDetailRoute() {
             {/* Actions panel: vehicle substitution (#610); cancel / status follow. */}
             <div className="space-y-4 rounded-xl border border-border px-4 py-6">
               <h2 className="text-sm font-semibold text-muted-foreground">{t('detail.actions')}</h2>
-              <SubstituteVehicleAction booking={detail} fleet={fleet} session={session} />
+              <SubstituteVehicleAction booking={detail} vehicles={vehicles} session={session} />
             </div>
           </section>
           <aside className="rounded-xl border border-border px-4 py-6">

--- a/packages/web/src/vite/operator-bookings/SubstituteVehicleAction.tsx
+++ b/packages/web/src/vite/operator-bookings/SubstituteVehicleAction.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { selectSubstitutionCandidates } from '@/lib/substitution'
+import { type SubstitutionVehicle, selectSubstitutionCandidates } from '@/lib/substitution'
 import { isOperatorSession } from '@/vite/guards'
 import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
 import {
@@ -18,7 +18,6 @@ import {
   operatorBookingDetailQueryOptions,
   substituteBooking,
 } from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
 import type { Session } from '@/vite/session'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
@@ -26,7 +25,7 @@ import { useTranslations } from 'use-intl'
 
 interface SubstituteVehicleActionProps {
   readonly booking: OperatorBookingDetailDto
-  readonly fleet: readonly OperatorFleetVehicle[]
+  readonly vehicles: readonly SubstitutionVehicle[]
   readonly session: Session | null
 }
 
@@ -39,7 +38,11 @@ interface SubstituteVehicleActionProps {
 // would reject. Gated like every operator write surface (#581/#583/#598): only
 // a tenant-scoped operator session writes; a bypass role (no operatorId) gets a
 // read-only note, and a terminal booking explains the action is unavailable.
-export function SubstituteVehicleAction({ booking, fleet, session }: SubstituteVehicleActionProps) {
+export function SubstituteVehicleAction({
+  booking,
+  vehicles,
+  session,
+}: SubstituteVehicleActionProps) {
   const t = useTranslations('bookings.operator')
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
@@ -49,7 +52,7 @@ export function SubstituteVehicleAction({ booking, fleet, session }: SubstituteV
   const canWrite = isOperatorSession(session)
   const isActionable = booking.status === 'CONFIRMED' || booking.status === 'ACTIVE'
   const csrfToken = session?.csrfToken ?? ''
-  const candidates = selectSubstitutionCandidates(fleet, booking)
+  const candidates = selectSubstitutionCandidates(vehicles, booking)
 
   const mutation = useMutation({
     mutationFn: (input: { newVehicleId: string; reason: string }) =>

--- a/packages/web/src/vite/operator-bookings/SubstituteVehicleAction.tsx
+++ b/packages/web/src/vite/operator-bookings/SubstituteVehicleAction.tsx
@@ -1,0 +1,164 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { selectSubstitutionCandidates } from '@/lib/substitution'
+import { isOperatorSession } from '@/vite/guards'
+import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
+import {
+  bookingEventsQueryOptions,
+  operatorBookingDetailQueryOptions,
+  substituteBooking,
+} from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { Session } from '@/vite/session'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface SubstituteVehicleActionProps {
+  readonly booking: OperatorBookingDetailDto
+  readonly fleet: readonly OperatorFleetVehicle[]
+  readonly session: Session | null
+}
+
+// Operator action: swap a broken/unavailable car for another of the same class
+// at the same store (#610, screenshot step 8 — 故障车换同店同级别车，系统留痕). The
+// server re-validates and writes the VEHICLE_SUBSTITUTED audit event, so on
+// success we only invalidate the detail + events queries and the timeline
+// reflects the swap. The candidate filter is the pure FC/IS core
+// (selectSubstitutionCandidates) — the operator can never pick a car the POST
+// would reject. Gated like every operator write surface (#581/#583/#598): only
+// a tenant-scoped operator session writes; a bypass role (no operatorId) gets a
+// read-only note, and a terminal booking explains the action is unavailable.
+export function SubstituteVehicleAction({ booking, fleet, session }: SubstituteVehicleActionProps) {
+  const t = useTranslations('bookings.operator')
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState('')
+  const [reason, setReason] = useState('')
+
+  const canWrite = isOperatorSession(session)
+  const isActionable = booking.status === 'CONFIRMED' || booking.status === 'ACTIVE'
+  const csrfToken = session?.csrfToken ?? ''
+  const candidates = selectSubstitutionCandidates(fleet, booking)
+
+  const mutation = useMutation({
+    mutationFn: (input: { newVehicleId: string; reason: string }) =>
+      substituteBooking(booking.id, input.newVehicleId, input.reason, csrfToken),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: operatorBookingDetailQueryOptions(booking.id).queryKey,
+      })
+      queryClient.invalidateQueries({ queryKey: bookingEventsQueryOptions(booking.id).queryKey })
+      setOpen(false)
+      setSelectedId('')
+      setReason('')
+    },
+  })
+
+  if (!canWrite) {
+    return <p className="text-sm text-muted-foreground">{t('substitute.readOnly')}</p>
+  }
+  if (!isActionable) {
+    return <p className="text-sm text-muted-foreground">{t('substitute.unavailable')}</p>
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!selectedId) return
+    mutation.mutate({ newVehicleId: selectedId, reason })
+  }
+
+  return (
+    <>
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        {t('substitute.action')}
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+          if (!next) {
+            setSelectedId('')
+            setReason('')
+            mutation.reset()
+          }
+        }}
+      >
+        <DialogContent>
+          <form onSubmit={handleSubmit}>
+            <DialogHeader>
+              <DialogTitle>{t('substitute.dialogTitle')}</DialogTitle>
+              <DialogDescription>{t('substitute.dialogDescription')}</DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-4">
+              {candidates.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t('substitute.noCandidates')}</p>
+              ) : (
+                <fieldset className="space-y-2">
+                  <legend className="mb-1 font-medium text-sm">{t('substitute.pickLabel')}</legend>
+                  {candidates.map((v) => (
+                    <label
+                      key={v.id}
+                      className="flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm hover:bg-muted/40"
+                    >
+                      <input
+                        type="radio"
+                        name="substitute-candidate"
+                        value={v.id}
+                        checked={selectedId === v.id}
+                        onChange={() => setSelectedId(v.id)}
+                      />
+                      <span>
+                        {t('substitute.vehicleOption', {
+                          name: v.name,
+                          plate: v.licensePlate ?? t('none'),
+                        })}
+                      </span>
+                    </label>
+                  ))}
+                </fieldset>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="substitute-reason">{t('substitute.reasonLabel')}</Label>
+                <Textarea
+                  id="substitute-reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder={t('substitute.reasonPlaceholder')}
+                />
+              </div>
+
+              {mutation.isError && (
+                <output className="text-destructive text-sm">{t('substitute.error')}</output>
+              )}
+            </div>
+
+            <DialogFooter>
+              <DialogClose
+                render={<Button type="button" variant="outline" disabled={mutation.isPending} />}
+              >
+                {t('substitute.cancel')}
+              </DialogClose>
+              <Button type="submit" disabled={!selectedId || mutation.isPending}>
+                {t('substitute.submit')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -1,4 +1,5 @@
 import { unwrap } from '@/lib/api-error'
+import type { SubstitutionVehicle } from '@/lib/substitution'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { BookingDto } from '@/vite/bookings/api'
 import type { BookingEventPayload, BookingEventType } from '@kuruma/shared/db/schema'
@@ -246,4 +247,47 @@ export async function substituteBooking(
     },
   )
   return unwrap<BookingDto>(res)
+}
+
+// #610: the substitution picker needs the operator's own vehicles with the four
+// fields the candidate rule reads (classId, pickupLocationId, status) plus name +
+// plate for display. Read them from the lean tenant-scoped `GET /vehicles` (the
+// same operator-accessible list the calendar uses), NOT the heavy STAFF-only
+// `/vehicles/fleet-overview` — and degrade to [] on failure so a vehicle-list
+// error never blanks the trip-detail page (timeline included). The pure
+// `selectSubstitutionCandidates` filter is the single rule authority, so this
+// fetches the whole page and lets the filter narrow it.
+type RawSubstitutionVehicle = {
+  id: string
+  name: string
+  licensePlate: string | null
+  classId: string | null
+  pickupLocationId: string | null
+  status: string
+}
+
+export async function fetchSubstitutionCandidates(): Promise<SubstitutionVehicle[]> {
+  try {
+    const res = await fetch(`${getApiBaseUrl()}/vehicles?limit=${VEHICLES_PAGE_LIMIT}`, {
+      credentials: 'include',
+    })
+    const data = await unwrap<RawSubstitutionVehicle[]>(res)
+    return data.map((v) => ({
+      id: v.id,
+      name: v.name,
+      licensePlate: v.licensePlate,
+      classId: v.classId,
+      pickupLocationId: v.pickupLocationId,
+      status: v.status,
+    }))
+  } catch {
+    return []
+  }
+}
+
+export function substitutionCandidatesQueryOptions() {
+  return queryOptions({
+    queryKey: ['operator-bookings', 'substitution-candidates'],
+    queryFn: fetchSubstitutionCandidates,
+  })
 }

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -251,3 +251,31 @@ export function bookingEventsQueryOptions(id: string) {
     queryFn: () => fetchBookingEvents(id),
   })
 }
+
+// #610: operator-only vehicle substitution (故障车换同级别车). Swaps the assigned
+// car for another AVAILABLE vehicle of the same class + pickup location; the
+// server re-validates those rules, re-snapshots totalPrice and appends the
+// VEHICLE_SUBSTITUTED audit event (which the timeline already renders). Cookie-
+// authed + CSRF-gated, so the caller echoes the session token. An empty reason is
+// dropped so the body carries only what the operator supplied.
+export async function substituteBooking(
+  bookingId: string,
+  newVehicleId: string,
+  reason: string,
+  csrfToken: string,
+): Promise<BookingDto> {
+  const trimmedReason = reason.trim()
+  const res = await fetch(
+    `${getApiBaseUrl()}/bookings/${encodeURIComponent(bookingId)}/substitute`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify({
+        newVehicleId,
+        ...(trimmedReason ? { reason: trimmedReason } : {}),
+      }),
+    },
+  )
+  return unwrap<BookingDto>(res)
+}

--- a/packages/web/tests/lib/substitution.test.ts
+++ b/packages/web/tests/lib/substitution.test.ts
@@ -1,0 +1,78 @@
+import {
+  type SubstitutionBooking,
+  type SubstitutionCandidate,
+  selectSubstitutionCandidates,
+} from '@/lib/substitution'
+import { describe, expect, it } from 'vitest'
+
+// The candidate filter MUST mirror the server's substitution rules exactly
+// (same operator + class + pickup location, AVAILABLE, not the current car) so
+// an operator can never pick a car the POST would 400/409 on (#610).
+function candidate(over: Partial<SubstitutionCandidate> = {}): SubstitutionCandidate {
+  return {
+    id: 'veh-2',
+    classId: 'class-compact',
+    pickupLocationId: 'loc-namba',
+    status: 'AVAILABLE',
+    ...over,
+  }
+}
+
+const booking: SubstitutionBooking = {
+  classId: 'class-compact',
+  pickupLocationId: 'loc-namba',
+  assignedVehicleId: 'veh-1',
+}
+
+describe('selectSubstitutionCandidates', () => {
+  it('keeps an AVAILABLE car of the same class at the same pickup location', () => {
+    const result = selectSubstitutionCandidates([candidate({ id: 'veh-2' })], booking)
+    expect(result.map((v) => v.id)).toEqual(['veh-2'])
+  })
+
+  it('excludes a car of a different class', () => {
+    const result = selectSubstitutionCandidates(
+      [candidate({ id: 'veh-2', classId: 'class-van' })],
+      booking,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('excludes a car at a different pickup location', () => {
+    const result = selectSubstitutionCandidates(
+      [candidate({ id: 'veh-2', pickupLocationId: 'loc-umeda' })],
+      booking,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('excludes a car that is not AVAILABLE (maintenance / retired)', () => {
+    const result = selectSubstitutionCandidates(
+      [
+        candidate({ id: 'veh-2', status: 'MAINTENANCE' }),
+        candidate({ id: 'veh-3', status: 'RETIRED' }),
+      ],
+      booking,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('excludes the booking’s currently assigned vehicle', () => {
+    const result = selectSubstitutionCandidates([candidate({ id: 'veh-1' })], booking)
+    expect(result).toEqual([])
+  })
+
+  it('returns every matching car and only those', () => {
+    const result = selectSubstitutionCandidates(
+      [
+        candidate({ id: 'veh-1' }), // assigned — excluded
+        candidate({ id: 'veh-2' }), // match
+        candidate({ id: 'veh-3', classId: 'class-van' }), // wrong class
+        candidate({ id: 'veh-4', status: 'MAINTENANCE' }), // unavailable
+        candidate({ id: 'veh-5' }), // match
+      ],
+      booking,
+    )
+    expect(result.map((v) => v.id)).toEqual(['veh-2', 'veh-5'])
+  })
+})

--- a/packages/web/tests/lib/substitution.test.ts
+++ b/packages/web/tests/lib/substitution.test.ts
@@ -5,9 +5,11 @@ import {
 } from '@/lib/substitution'
 import { describe, expect, it } from 'vitest'
 
-// The candidate filter MUST mirror the server's substitution rules exactly
-// (same operator + class + pickup location, AVAILABLE, not the current car) so
-// an operator can never pick a car the POST would 400/409 on (#610).
+// The candidate filter is stricter-or-equal to the server's substitution rules
+// (same class + pickup location, AVAILABLE, not the current car): exact classId
+// is a subset of the server's ACRISS-code match, so an operator can never pick a
+// car the POST would 400/409 on (#610). See lib/substitution.ts for why classId
+// proxies the ACRISS code here.
 function candidate(over: Partial<SubstitutionCandidate> = {}): SubstitutionCandidate {
   return {
     id: 'veh-2',

--- a/packages/web/tests/vite/operator-bookings/SubstituteVehicleAction.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/SubstituteVehicleAction.test.tsx
@@ -1,0 +1,219 @@
+import { SubstituteVehicleAction } from '@/vite/operator-bookings/SubstituteVehicleAction'
+import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
+import { substituteBooking } from '@/vite/operator-bookings/api'
+import {
+  bookingEventsQueryOptions,
+  operatorBookingDetailQueryOptions,
+} from '@/vite/operator-bookings/api'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+vi.mock('@/vite/operator-bookings/api', async (orig) => {
+  const actual = await orig<typeof import('@/vite/operator-bookings/api')>()
+  return { ...actual, substituteBooking: vi.fn() }
+})
+const substituteBookingMock = vi.mocked(substituteBooking)
+
+const sub = enMessages.bookings.operator.substitute
+
+function fleetVehicle(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'veh-2',
+    operatorId: 'op_1',
+    classId: 'c1',
+    pickupLocationId: 'l1',
+    name: 'Honda Fit',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'OSAKA 5678',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...over,
+  }
+}
+
+function bookingDetail(over: Partial<OperatorBookingDetailDto> = {}): OperatorBookingDetailDto {
+  return {
+    id: 'bk-1',
+    bookingCode: 'ABCD2345',
+    renterId: 'r-1',
+    classId: 'c1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'l1',
+    dropoffLocationId: 'l1',
+    startAt: '2026-07-01T01:00:00.000Z',
+    endAt: '2026-07-03T01:00:00.000Z',
+    effectiveEndAt: '2026-07-03T02:00:00.000Z',
+    status: 'CONFIRMED',
+    source: 'WEB',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    totalPrice: 24000,
+    notes: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+const operatorSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
+  csrfToken: 'csrf-token',
+}
+const bypassSession: Session = { user: { id: 'u', role: 'PLATFORM_ADMIN' }, csrfToken: 't' }
+
+function renderAction(
+  session: Session | null,
+  booking: OperatorBookingDetailDto,
+  fleet: OperatorFleetVehicle[],
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <SubstituteVehicleAction booking={booking} fleet={fleet} session={session} />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+  return queryClient
+}
+
+describe('SubstituteVehicleAction', () => {
+  beforeEach(() => {
+    substituteBookingMock.mockReset()
+    substituteBookingMock.mockResolvedValue(bookingDetail({ assignedVehicleId: 'veh-2' }))
+  })
+
+  it('shows the Substitute action for a tenant-scoped operator on a confirmed booking', () => {
+    renderAction(operatorSession, bookingDetail(), [fleetVehicle()])
+    expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
+  })
+
+  it('hides the action and shows a read-only note for a bypass role with no operatorId', () => {
+    renderAction(bypassSession, bookingDetail(), [fleetVehicle()])
+    expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
+    expect(screen.getByText(sub.readOnly)).toBeInTheDocument()
+  })
+
+  it('hides the action and explains it is unavailable for a completed booking', () => {
+    renderAction(operatorSession, bookingDetail({ status: 'COMPLETED' }), [fleetVehicle()])
+    expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
+    expect(screen.getByText(sub.unavailable)).toBeInTheDocument()
+  })
+
+  it('lists only same-class, same-location, available cars (excluding the current one)', async () => {
+    const user = userEvent.setup()
+    renderAction(operatorSession, bookingDetail(), [
+      fleetVehicle({ id: 'veh-1', name: 'Current Car' }), // assigned -> excluded
+      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }), // match
+      fleetVehicle({ id: 'veh-3', name: 'Big Van', classId: 'c2' }), // wrong class
+      fleetVehicle({ id: 'veh-4', name: 'Broken Car', status: 'MAINTENANCE' }), // unavailable
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+
+    expect(screen.getByRole('radio', { name: /Honda Fit/ })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Current Car/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Big Van/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: /Broken Car/ })).not.toBeInTheDocument()
+  })
+
+  it('substitutes the picked car, sending its id + reason + the session CSRF token', async () => {
+    const user = userEvent.setup()
+    renderAction(operatorSession, bookingDetail(), [
+      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('radio', { name: /Honda Fit/ }))
+    await user.type(screen.getByLabelText(sub.reasonLabel), 'mechanical fault')
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    await waitFor(() =>
+      expect(substituteBookingMock).toHaveBeenCalledWith(
+        'bk-1',
+        'veh-2',
+        'mechanical fault',
+        'csrf-token',
+      ),
+    )
+  })
+
+  it('shows the empty-candidate state and disables submit when no replacement exists', async () => {
+    const user = userEvent.setup()
+    renderAction(operatorSession, bookingDetail(), [
+      fleetVehicle({ id: 'veh-1', name: 'Current Car' }),
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+
+    expect(screen.getByText(sub.noCandidates)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: sub.submit })).toBeDisabled()
+  })
+
+  it('surfaces an error when the substitution fails (e.g. the car was just booked)', async () => {
+    const user = userEvent.setup()
+    substituteBookingMock.mockRejectedValue(new Error('Vehicle is no longer available'))
+    renderAction(operatorSession, bookingDetail(), [
+      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+    ])
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('radio', { name: /Honda Fit/ }))
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    expect(await screen.findByText(sub.error)).toBeInTheDocument()
+  })
+
+  it('invalidates the booking detail and events queries on success', async () => {
+    const user = userEvent.setup()
+    const queryClient = renderAction(operatorSession, bookingDetail(), [
+      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+    ])
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('radio', { name: /Honda Fit/ }))
+    await user.click(screen.getByRole('button', { name: sub.submit }))
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: operatorBookingDetailQueryOptions('bk-1').queryKey,
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: bookingEventsQueryOptions('bk-1').queryKey,
+      })
+    })
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/SubstituteVehicleAction.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/SubstituteVehicleAction.test.tsx
@@ -1,3 +1,4 @@
+import type { SubstitutionVehicle } from '@/lib/substitution'
 import { SubstituteVehicleAction } from '@/vite/operator-bookings/SubstituteVehicleAction'
 import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
 import { substituteBooking } from '@/vite/operator-bookings/api'
@@ -5,7 +6,6 @@ import {
   bookingEventsQueryOptions,
   operatorBookingDetailQueryOptions,
 } from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
 import type { Session } from '@/vite/session'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
@@ -22,40 +22,14 @@ const substituteBookingMock = vi.mocked(substituteBooking)
 
 const sub = enMessages.bookings.operator.substitute
 
-function fleetVehicle(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+function candidateVehicle(over: Partial<SubstitutionVehicle> = {}): SubstitutionVehicle {
   return {
     id: 'veh-2',
-    operatorId: 'op_1',
     classId: 'c1',
     pickupLocationId: 'l1',
     name: 'Honda Fit',
-    description: null,
-    photos: [],
-    seats: 5,
-    luggageCapacity: 2,
-    luggageSize: 'MEDIUM',
-    transmission: 'AUTO',
-    fuelType: null,
     licensePlate: 'OSAKA 5678',
     status: 'AVAILABLE',
-    minRentalHours: null,
-    maxRentalHours: null,
-    advanceBookingHours: null,
-    make: null,
-    model: null,
-    year: null,
-    color: null,
-    dailyRateJpy: 8000,
-    hourlyRateJpy: null,
-    shakenExpiryDate: null,
-    insuranceExpiryDate: null,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    utilization: 0,
-    bookingCountLast30Days: 0,
-    currentBooking: null,
-    nextBooking: null,
-    activeMaintenanceReason: null,
     ...over,
   }
 }
@@ -96,13 +70,13 @@ const bypassSession: Session = { user: { id: 'u', role: 'PLATFORM_ADMIN' }, csrf
 function renderAction(
   session: Session | null,
   booking: OperatorBookingDetailDto,
-  fleet: OperatorFleetVehicle[],
+  vehicles: SubstitutionVehicle[],
 ) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
-        <SubstituteVehicleAction booking={booking} fleet={fleet} session={session} />
+        <SubstituteVehicleAction booking={booking} vehicles={vehicles} session={session} />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -116,18 +90,18 @@ describe('SubstituteVehicleAction', () => {
   })
 
   it('shows the Substitute action for a tenant-scoped operator on a confirmed booking', () => {
-    renderAction(operatorSession, bookingDetail(), [fleetVehicle()])
+    renderAction(operatorSession, bookingDetail(), [candidateVehicle()])
     expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
   })
 
   it('hides the action and shows a read-only note for a bypass role with no operatorId', () => {
-    renderAction(bypassSession, bookingDetail(), [fleetVehicle()])
+    renderAction(bypassSession, bookingDetail(), [candidateVehicle()])
     expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
     expect(screen.getByText(sub.readOnly)).toBeInTheDocument()
   })
 
   it('hides the action and explains it is unavailable for a completed booking', () => {
-    renderAction(operatorSession, bookingDetail({ status: 'COMPLETED' }), [fleetVehicle()])
+    renderAction(operatorSession, bookingDetail({ status: 'COMPLETED' }), [candidateVehicle()])
     expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
     expect(screen.getByText(sub.unavailable)).toBeInTheDocument()
   })
@@ -135,10 +109,10 @@ describe('SubstituteVehicleAction', () => {
   it('lists only same-class, same-location, available cars (excluding the current one)', async () => {
     const user = userEvent.setup()
     renderAction(operatorSession, bookingDetail(), [
-      fleetVehicle({ id: 'veh-1', name: 'Current Car' }), // assigned -> excluded
-      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }), // match
-      fleetVehicle({ id: 'veh-3', name: 'Big Van', classId: 'c2' }), // wrong class
-      fleetVehicle({ id: 'veh-4', name: 'Broken Car', status: 'MAINTENANCE' }), // unavailable
+      candidateVehicle({ id: 'veh-1', name: 'Current Car' }), // assigned -> excluded
+      candidateVehicle({ id: 'veh-2', name: 'Honda Fit' }), // match
+      candidateVehicle({ id: 'veh-3', name: 'Big Van', classId: 'c2' }), // wrong class
+      candidateVehicle({ id: 'veh-4', name: 'Broken Car', status: 'MAINTENANCE' }), // unavailable
     ])
 
     await user.click(screen.getByRole('button', { name: sub.action }))
@@ -152,7 +126,7 @@ describe('SubstituteVehicleAction', () => {
   it('substitutes the picked car, sending its id + reason + the session CSRF token', async () => {
     const user = userEvent.setup()
     renderAction(operatorSession, bookingDetail(), [
-      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+      candidateVehicle({ id: 'veh-2', name: 'Honda Fit' }),
     ])
 
     await user.click(screen.getByRole('button', { name: sub.action }))
@@ -173,7 +147,7 @@ describe('SubstituteVehicleAction', () => {
   it('shows the empty-candidate state and disables submit when no replacement exists', async () => {
     const user = userEvent.setup()
     renderAction(operatorSession, bookingDetail(), [
-      fleetVehicle({ id: 'veh-1', name: 'Current Car' }),
+      candidateVehicle({ id: 'veh-1', name: 'Current Car' }),
     ])
 
     await user.click(screen.getByRole('button', { name: sub.action }))
@@ -186,7 +160,7 @@ describe('SubstituteVehicleAction', () => {
     const user = userEvent.setup()
     substituteBookingMock.mockRejectedValue(new Error('Vehicle is no longer available'))
     renderAction(operatorSession, bookingDetail(), [
-      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+      candidateVehicle({ id: 'veh-2', name: 'Honda Fit' }),
     ])
 
     await user.click(screen.getByRole('button', { name: sub.action }))
@@ -199,7 +173,7 @@ describe('SubstituteVehicleAction', () => {
   it('invalidates the booking detail and events queries on success', async () => {
     const user = userEvent.setup()
     const queryClient = renderAction(operatorSession, bookingDetail(), [
-      fleetVehicle({ id: 'veh-2', name: 'Honda Fit' }),
+      candidateVehicle({ id: 'veh-2', name: 'Honda Fit' }),
     ])
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -10,6 +10,7 @@ import {
   operatorBookingsQueryOptions,
   operatorCalendarQueryOptions,
   operatorRowFromDetail,
+  substituteBooking,
 } from '@/vite/operator-bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -399,5 +400,62 @@ describe('operatorCalendarQueryOptions', () => {
       '2026-07-01',
       '2026-07-31',
     ])
+  })
+})
+
+// Slice 6 (#610): operator vehicle substitution — POST /bookings/:id/substitute,
+// cookie-authed + CSRF-gated, returns the re-assigned booking.
+describe('substituteBooking', () => {
+  it('POSTs to the substitute endpoint with the CSRF header, JSON body and credentials', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await substituteBooking('bk-1', 'veh-9', 'mechanical fault', 'csrf-token')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    const request = init as RequestInit
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/bookings/bk-1/substitute')
+    expect(request.method).toBe('POST')
+    expect(request.credentials).toBe('include')
+    expect(new Headers(request.headers).get('X-CSRF-Token')).toBe('csrf-token')
+    expect(JSON.parse(request.body as string)).toEqual({
+      newVehicleId: 'veh-9',
+      reason: 'mechanical fault',
+    })
+  })
+
+  it('omits an empty reason from the body (sends only newVehicleId)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await substituteBooking('bk-1', 'veh-9', '', 'csrf-token')
+
+    expect(JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)).toEqual({
+      newVehicleId: 'veh-9',
+    })
+  })
+
+  it('returns the re-assigned booking from the envelope', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: detailRaw({ assignedVehicleId: 'veh-9' }) }),
+      ),
+    )
+
+    const booking = await substituteBooking('bk-1', 'veh-9', '', 't')
+
+    expect(booking).toMatchObject({ id: 'bk-1', assignedVehicleId: 'veh-9' })
+  })
+
+  it('throws ApiError when the replacement was just booked (409)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: false, error: 'Vehicle is no longer available' }, 409),
+      ),
+    )
+
+    await expect(substituteBooking('bk-1', 'veh-9', '', 't')).rejects.toBeInstanceOf(ApiError)
   })
 })

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -6,11 +6,13 @@ import {
   fetchCalendarBookings,
   fetchCalendarVehicles,
   fetchOperatorBookingDetail,
+  fetchSubstitutionCandidates,
   operatorBookingDetailQueryOptions,
   operatorCalendarQueryOptions,
   operatorCalendarVehiclesQueryOptions,
   operatorRowFromDetail,
   substituteBooking,
+  substitutionCandidatesQueryOptions,
 } from '@/vite/operator-bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -402,6 +404,89 @@ describe('operatorCalendarVehiclesQueryOptions', () => {
       'operator-bookings',
       'calendar',
       'vehicles',
+    ])
+  })
+})
+
+// #610: the substitution picker reads the operator's own vehicles from the lean
+// tenant-scoped GET /vehicles (NOT the heavy STAFF-only fleet-overview), carrying
+// the rule fields (classId, pickupLocationId, status) plus name + plate. It must
+// degrade to [] on failure so a vehicle-list error never blanks the trip page.
+
+const vehicleRaw = (over: Record<string, unknown> = {}) => ({
+  id: 'veh-2',
+  name: 'Honda Fit',
+  licensePlate: 'OSAKA 5678',
+  classId: 'c1',
+  pickupLocationId: 'l1',
+  status: 'AVAILABLE',
+  ...over,
+})
+
+describe('fetchSubstitutionCandidates', () => {
+  it('requests the operator vehicles with a bounded limit and credentials', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchSubstitutionCandidates()
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    const parsed = new URL(url as string, 'http://x')
+    expect(parsed.pathname).toBe('/api/vehicles')
+    expect(parsed.searchParams.get('limit')).toBe('100')
+    expect((init as RequestInit).credentials).toBe('include')
+  })
+
+  it('maps rows to the candidate shape (rule fields + name + plate)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [vehicleRaw({ seats: 5, dailyRateJpy: 8000 })],
+        }),
+      ),
+    )
+
+    const vehicles = await fetchSubstitutionCandidates()
+    expect(vehicles).toEqual([
+      {
+        id: 'veh-2',
+        name: 'Honda Fit',
+        licensePlate: 'OSAKA 5678',
+        classId: 'c1',
+        pickupLocationId: 'l1',
+        status: 'AVAILABLE',
+      },
+    ])
+  })
+
+  it('degrades to [] on a failure envelope (must not blank the trip page)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'Forbidden' }, 403)),
+    )
+
+    expect(await fetchSubstitutionCandidates()).toEqual([])
+  })
+
+  it('degrades to [] when the request itself rejects (network error)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('network down')
+      }),
+    )
+
+    expect(await fetchSubstitutionCandidates()).toEqual([])
+  })
+})
+
+describe('substitutionCandidatesQueryOptions', () => {
+  it('keys by the substitution candidate list', () => {
+    expect(substitutionCandidatesQueryOptions().queryKey).toEqual([
+      'operator-bookings',
+      'substitution-candidates',
     ])
   })
 })


### PR DESCRIPTION
Closes #610.

Finishes operator order-management **step 8** — swap a broken/unavailable car for another of the same class at the same store, with the swap recorded on the booking timeline (故障车换同店同级别车，系统留痕). Web-only: the backend `POST /bookings/:id/substitute` endpoint, audit event, and price re-snapshot were already shipped; this wires the UI.

## What's in it
- **`lib/substitution.ts`** — pure `selectSubstitutionCandidates(vehicles, booking)` (FC/IS core): same class + pickup location, `AVAILABLE`, excludes the current car. It is *stricter-or-equal* to the server (server matches by ACRISS code; the fleet projection carries no ACRISS code, so `classId` is the proxy) — it can never offer a car the POST would reject.
- **`SubstituteVehicleAction.tsx`** — candidate-radio + reason dialog. Gated like every operator write surface: only a tenant-scoped operator session writes; a bypass role (no `operatorId`) gets a read-only note; a terminal booking explains the action is unavailable. On success invalidates the detail + events queries so the timeline reflects the swap.
- **`operator-bookings/api.ts`** — `substituteBooking()` CSRF-gated write client + `fetchSubstitutionCandidates()` (lean, degrading `GET /vehicles` read).
- Wired into the trip-detail Actions panel (`bookings/$bookingId.tsx`).
- `substitute.*` i18n in en/ja/zh.

## Review addressed (code-reviewer + architect)
- Swapped the heavy STAFF-only `fleet-overview` loader dependency for a lean `GET /vehicles` candidate read that **degrades to `[]`** — a vehicle-list error can no longer reject the loader and blank the trip page (timeline included). Matches the calendar's `fetchCalendarVehicles` pattern.
- Narrowed the component prop from the 40-field `OperatorFleetVehicle` to the 5-field `SubstitutionVehicle` it reads (ISP).
- Corrected the comments to state the stricter-or-equal classId/ACRISS relationship honestly.

## Test plan
- [x] `bun run --filter @kuruma/web test` — 1068 pass (substitution lib 6, api 30, dialog 8)
- [x] `bun run --filter @kuruma/web typecheck` — 0 errors
- [x] `bun run lint` — exit 0 (biome + size + module-boundaries)
- [x] i18n parity (en/ja/zh) green
- [ ] Manual browser smoke (not done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)