### PR TITLE
feat(seed): demo payment_events so admin revenue tab shows data (#627)

### DIFF
--- a/packages/shared/src/db/seed-bookings.ts
+++ b/packages/shared/src/db/seed-bookings.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { computePlatformCommission } from '../lib/commission'
 import type { getDb } from './index'
 import {
   type BookingCreatedPayload,
@@ -8,6 +9,7 @@ import {
   bookingEvents,
   bookings,
   notificationLog,
+  paymentEvents,
   users,
   vehicles,
 } from './schema'
@@ -17,6 +19,7 @@ import {
   DEMO_INSURANCE_OPTIONS,
   DEMO_OPERATORS,
   DEMO_RENTERS,
+  type DemoBooking,
 } from './seed-data'
 import { seedId } from './seed-id'
 
@@ -43,6 +46,66 @@ function dayAt(dayOffset: number, hour: number): Date {
   d.setDate(d.getDate() + dayOffset)
   d.setHours(hour, 0, 0, 0)
   return d
+}
+
+// Demo payment_events for the #462 admin revenue tab (#627). Each non-cancelled
+// booking gets one SUCCEEDED payment so the tab shows real figures on a freshly
+// seeded DB (otherwise it sits empty until a live Stripe webhook fires). Each
+// partner's payments are stepped ~a month apart so the per-partner monthly
+// breakdown is non-trivial. A CANCELLED booking earns no revenue — it stays
+// unpaid, which also demonstrates the tab's SUCCEEDED-only filter.
+const PAYMENT_LEAD_DAYS = 10 // most recent payment ~10 days ago
+const PAYMENT_MONTH_STEP_DAYS = 35 // each older payment another ~month back
+
+export interface DemoPaymentRow {
+  /** Raw operator slug — the shell maps it through `seedId` to the FK. */
+  readonly operatorId: string
+  /** Raw booking slug — likewise mapped through `seedId`. */
+  readonly bookingId: string
+  readonly stripeEventId: string
+  readonly stripeCheckoutSessionId: string
+  readonly stripePaymentIntentId: string
+  readonly grossJpy: number
+  readonly platformFeeJpy: number
+  readonly netToPartnerJpy: number
+  readonly status: 'SUCCEEDED'
+  readonly createdAt: Date
+}
+
+// `now` is injected so the JST-month spread is testable without a wall clock
+// (FC/IS: pure decision, the seed shell supplies `new Date()`).
+function paymentDate(now: Date, partnerSeq: number): Date {
+  const d = new Date(now)
+  d.setDate(d.getDate() - (PAYMENT_LEAD_DAYS + partnerSeq * PAYMENT_MONTH_STEP_DAYS))
+  d.setHours(12, 0, 0, 0)
+  return d
+}
+
+export function demoPaymentRows(
+  bookingDescriptors: readonly DemoBooking[],
+  now: Date,
+): DemoPaymentRow[] {
+  const seqByOperator = new Map<string, number>()
+  return bookingDescriptors.flatMap((b) => {
+    if (b.status === 'CANCELLED') return []
+    const seq = seqByOperator.get(b.operatorId) ?? 0
+    seqByOperator.set(b.operatorId, seq + 1)
+    const { platformFeeJpy, netToPartnerJpy } = computePlatformCommission(b.totalPriceJpy)
+    return [
+      {
+        operatorId: b.operatorId,
+        bookingId: b.id,
+        stripeEventId: `seed-evt-${b.bookingCode}`,
+        stripeCheckoutSessionId: `seed-cs-${b.bookingCode}`,
+        stripePaymentIntentId: `seed-pi-${b.bookingCode}`,
+        grossJpy: b.totalPriceJpy,
+        platformFeeJpy,
+        netToPartnerJpy,
+        status: 'SUCCEEDED' as const,
+        createdAt: paymentDate(now, seq),
+      },
+    ]
+  })
 }
 
 const insuranceById = new Map(DEMO_INSURANCE_OPTIONS.map((o) => [o.id, o]))
@@ -94,6 +157,7 @@ export async function seedBookings(db: ReturnType<typeof getDb>) {
     if (ownedIds.length > 0) {
       await db.delete(notificationLog).where(inArray(notificationLog.bookingId, ownedIds))
       await db.delete(bookingEvents).where(inArray(bookingEvents.bookingId, ownedIds))
+      await db.delete(paymentEvents).where(inArray(paymentEvents.bookingId, ownedIds))
       await db.delete(bookings).where(inArray(bookings.id, ownedIds))
     }
     await db.delete(users).where(inArray(users.id, renterIds))
@@ -228,12 +292,28 @@ export async function seedBookings(db: ReturnType<typeof getDb>) {
     })
   }
 
+  // Payments reference bookings (FK), so insert after them.
+  const paymentValues = demoPaymentRows(DEMO_BOOKINGS, new Date()).map((p) => ({
+    operatorId: seedId(p.operatorId),
+    bookingId: seedId(p.bookingId),
+    stripeEventId: p.stripeEventId,
+    stripeCheckoutSessionId: p.stripeCheckoutSessionId,
+    stripePaymentIntentId: p.stripePaymentIntentId,
+    grossJpy: p.grossJpy,
+    platformFeeJpy: p.platformFeeJpy,
+    netToPartnerJpy: p.netToPartnerJpy,
+    status: p.status,
+    createdAt: p.createdAt,
+  }))
+
   await db.insert(bookings).values(bookingValues)
   await db.insert(bookingEvents).values(eventValues)
   await db.insert(notificationLog).values(notificationValues)
+  await db.insert(paymentEvents).values(paymentValues)
 
   console.log(
     `\nSeeded ${DEMO_RENTERS.length} renters, ${bookingValues.length} bookings, ` +
-      `${eventValues.length} events, ${notificationValues.length} notifications.`,
+      `${eventValues.length} events, ${notificationValues.length} notifications, ` +
+      `${paymentValues.length} payments.`,
   )
 }

--- a/packages/shared/src/db/seed-payments.test.ts
+++ b/packages/shared/src/db/seed-payments.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { jstYearMonth } from '../lib/admin-revenue'
+import { computePlatformCommission } from '../lib/commission'
+import { demoPaymentRows } from './seed-bookings'
+import { DEMO_BOOKINGS } from './seed-data'
+
+// Fixed clock so the JST-month spread is deterministic regardless of when the
+// suite runs (the seed shell passes `new Date()`; this passes a frozen instant).
+const NOW = new Date('2026-06-15T03:00:00.000Z')
+
+describe('demoPaymentRows', () => {
+  it('emits one SUCCEEDED payment per non-cancelled booking', () => {
+    const rows = demoPaymentRows(DEMO_BOOKINGS, NOW)
+    const nonCancelled = DEMO_BOOKINGS.filter((b) => b.status !== 'CANCELLED')
+    expect(rows).toHaveLength(nonCancelled.length)
+    expect(rows.every((r) => r.status === 'SUCCEEDED')).toBe(true)
+  })
+
+  it('skips cancelled bookings — a refunded/voided booking earns no revenue', () => {
+    const rows = demoPaymentRows(DEMO_BOOKINGS, NOW)
+    const cancelledCodes = DEMO_BOOKINGS.filter((b) => b.status === 'CANCELLED').map(
+      (b) => b.bookingCode,
+    )
+    expect(cancelledCodes.length).toBeGreaterThan(0)
+    for (const code of cancelledCodes) {
+      expect(rows.some((r) => r.stripeEventId.includes(code))).toBe(false)
+    }
+  })
+
+  it('locks gross = total price and splits the 4% fee via commission.ts', () => {
+    const rows = demoPaymentRows(DEMO_BOOKINGS, NOW)
+    const booking = DEMO_BOOKINGS.find((b) => b.bookingCode === 'H7K2M9PQ') // CONFIRMED ¥18,000
+    expect(booking).toBeDefined()
+    const row = rows.find((r) => r.bookingId === booking?.id)
+    expect(row).toBeDefined()
+    expect(row?.grossJpy).toBe(18000)
+    const { platformFeeJpy, netToPartnerJpy } = computePlatformCommission(18000)
+    expect(row?.platformFeeJpy).toBe(platformFeeJpy) // 720
+    expect(row?.netToPartnerJpy).toBe(netToPartnerJpy) // 17280
+    // The webhook invariant: fee + net always sums back to gross (no yen lost).
+    expect((row?.platformFeeJpy ?? 0) + (row?.netToPartnerJpy ?? 0)).toBe(row?.grossJpy)
+  })
+
+  it('spreads each partner across multiple JST months for a non-trivial breakdown', () => {
+    const rows = demoPaymentRows(DEMO_BOOKINGS, NOW)
+    const monthsByOperator = new Map<string, Set<string>>()
+    for (const r of rows) {
+      const months = monthsByOperator.get(r.operatorId) ?? new Set<string>()
+      months.add(jstYearMonth(r.createdAt))
+      monthsByOperator.set(r.operatorId, months)
+    }
+    const expectedOperators = new Set(
+      DEMO_BOOKINGS.filter((b) => b.status !== 'CANCELLED').map((b) => b.operatorId),
+    )
+    expect(monthsByOperator.size).toBe(expectedOperators.size)
+    for (const months of monthsByOperator.values()) {
+      expect(months.size).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('assigns unique stripe event + session ids (redelivery + one-success-per-booking seals)', () => {
+    const rows = demoPaymentRows(DEMO_BOOKINGS, NOW)
+    expect(new Set(rows.map((r) => r.stripeEventId)).size).toBe(rows.length)
+    expect(new Set(rows.map((r) => r.stripeCheckoutSessionId)).size).toBe(rows.length)
+  })
+})


### PR DESCRIPTION
Closes #627. Follow-up to #462 (PR #625, admin revenue tab).

## Problem
The platform-admin revenue tab (`GET /admin/revenue`, #462) reads `payment_events`, which only get rows when a live Stripe webhook fires. On a freshly seeded DB the tab sits empty — there's nothing to demo or eyeball.

## Change
`seedBookings` now writes one `SUCCEEDED` `payment_events` row per **non-cancelled** demo booking:
- **gross** = booking `totalPrice`; the 4% platform fee / net-to-partner split comes from the shared `computePlatformCommission` (DRY — same source the webhook uses, never recomputed).
- Each partner's payments are stepped ~35 days apart (`paymentDate(now, seq)`) so the per-partner **monthly** breakdown is non-trivial — each of the 3 partners spans ~3 JST months.
- The one **CANCELLED** booking (`H9M3PQRS`) stays unpaid, which also exercises the tab's `SUCCEEDED`-only filter.

Pure `demoPaymentRows(bookings, now)` (FC/IS — `now` injected, unit-testable without a DB) + FK-safe cleanup (delete `payment_events` before `bookings`). **No schema change / no migration** — `payment_events` already exists.

## Tests
- 5 new unit tests (`seed-payments.test.ts`) over the pure core. Shared suite **450 green**.
- Real-pg smoke (disposable `postgres:16`): migrate → seed → **re-seed** (proves FK-safe cleanup ordering) → drive the production read path (`DrizzlePaymentEventRepository.listSucceeded` → `aggregateRevenueByPartner`). Result: **3 partners, 9 payments (3 each), gross ¥124,500, fee+net==gross, 3 JST months each**. CI's `e2e-real-db` re-validates the seed end-to-end.

## Follow-up
#628 — `?month=` filter on the revenue endpoint.