### PR TITLE
feat(operator): order management actions (substitute/cancel/status) (#616)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -112,6 +112,23 @@ export function createBookingRoutes(service: BookingService) {
 
       return ok(c, events)
     })
+    .get('/bookings/:id/substitution-candidates', async (c) => {
+      const ctx = toCallerContext(requireUser(c))
+
+      // #616: feeds the operator-only substitute action, so it mirrors the
+      // substitute route's gate — renters never swap a vehicle (403). The service
+      // read is caller-scoped, so a cross-operator booking 404s (no leak).
+      if (!isOperatorRole(ctx.role)) {
+        return fail(c, 'Only operators can substitute a vehicle', 403)
+      }
+
+      const result = await service.substitutionCandidates(ctx, c.req.param('id'))
+      if (!result.ok) {
+        return fail(c, result.error, result.status)
+      }
+
+      return ok(c, result.candidates)
+    })
     .post('/bookings', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 

--- a/packages/api/src/services/booking-results.ts
+++ b/packages/api/src/services/booking-results.ts
@@ -1,0 +1,76 @@
+import type { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
+import type { CallerContext } from '../middleware/auth'
+import type { Booking } from '../stores'
+
+// BookingService input + discriminated result unions, split out of booking.ts to
+// keep that file under the 800-line lint:size cap (#616). Service-layer types;
+// BookingService and its tests consume them.
+
+// Slice 6 (#392): the renter books a CONCRETE vehicle chosen in the storefront
+// (slice 5). operatorId / classId / assignedVehicleId / totalPrice are all
+// server-derived from that vehicle — never client fields (proposal §6.2, §4.1).
+export interface CreateBookingInput {
+  requestedVehicleId: string
+  pickupLocationId: string
+  dropoffLocationId: string
+  insuranceOptionId?: string | null
+  // Selected paid add-on ids (#460). Required at the service boundary (the
+  // validator defaults it to []); the route forwards parsed.data.addOnIds.
+  addOnIds: string[]
+  renterId: string
+  startAt: Date
+  endAt: Date
+  source: Booking['source']
+  externalId?: string | null
+  notes?: string | null
+  idempotencyKey?: string | null
+  // #613: renter ticked the liability-disclaimer (免责声明) checkbox at checkout.
+  // Required for renter self-serve bookings (enforced by caller role in `create`);
+  // staff/manual bookings are exempt. The server stamps the timestamp + version.
+  disclaimerAccepted?: boolean
+}
+
+export type CreateBookingResult =
+  | { ok: true; booking: Booking; status?: 200 }
+  | {
+      ok: false
+      status: 400 | 403 | 409
+      error: string | Record<string, string[]>
+      code?: string
+      details?: { required: number; actual: number }
+    }
+
+/**
+ * Optional pre-transaction authorization gate (#459). When injected, `create`
+ * runs it after idempotency replay and before the booking transaction; a denial
+ * short-circuits with 403. BookingService stays decoupled from the document
+ * domain — it only knows "there may be a gate" (DIP).
+ */
+export type BookingVerificationGate = (
+  ctx: CallerContext,
+  input: CreateBookingInput,
+) => Promise<
+  { ok: true } | { ok: false; status: 403; error: string; code: 'DOCUMENT_VERIFICATION_REQUIRED' }
+>
+
+export type SubstituteResult =
+  | { ok: true; booking: Booking }
+  | { ok: false; status: 400 | 404 | 409; error: string }
+
+/** A vehicle eligible to replace a booking's assigned car (same store + ACRISS). */
+export type SubstitutionCandidate = { id: string; name: string }
+export type SubstitutionCandidatesResult =
+  | { ok: true; candidates: SubstitutionCandidate[] }
+  | { ok: false; status: 404; error: string }
+
+export type StatusTransitionResult =
+  | { ok: true; booking: Booking }
+  | { ok: false; status: 400 | 404 | 409; error: string }
+
+export type CancelResult =
+  | {
+      ok: true
+      booking: Booking
+      cancellation: ReturnType<typeof calculateCancellationFee>
+    }
+  | { ok: false; status: 404 | 409; error: string }

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -19,6 +19,19 @@ import type {
 } from '../repositories/types'
 import type { Booking, BookingEvent } from '../stores'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
+import type {
+  BookingVerificationGate,
+  CancelResult,
+  CreateBookingInput,
+  CreateBookingResult,
+  StatusTransitionResult,
+  SubstituteResult,
+  SubstitutionCandidatesResult,
+} from './booking-results'
+
+// Re-exported so existing importers of these service-layer types keep their
+// `from '.../services/booking'` path after the #616 split into booking-results.ts.
+export type { CreateBookingInput, BookingVerificationGate } from './booking-results'
 
 /** Renter-safe operator projection attached to a single booking read (§4h). */
 export type BookingWithOperator = Booking & {
@@ -38,68 +51,8 @@ const MAX_BOOKING_CODE_ATTEMPTS = 3
 // (the renter-facing copy lives in web i18n; this is the server-authoritative tag).
 export const DISCLAIMER_TERMS_VERSION = '2026-06-13'
 
-// Slice 6 (#392): the renter books a CONCRETE vehicle chosen in the storefront
-// (slice 5). operatorId / classId / assignedVehicleId / totalPrice are all
-// server-derived from that vehicle — never client fields (proposal §6.2, §4.1).
-export interface CreateBookingInput {
-  requestedVehicleId: string
-  pickupLocationId: string
-  dropoffLocationId: string
-  insuranceOptionId?: string | null
-  // Selected paid add-on ids (#460). Required at the service boundary (the
-  // validator defaults it to []); the route forwards parsed.data.addOnIds.
-  addOnIds: string[]
-  renterId: string
-  startAt: Date
-  endAt: Date
-  source: Booking['source']
-  externalId?: string | null
-  notes?: string | null
-  idempotencyKey?: string | null
-  // #613: renter ticked the liability-disclaimer (免责声明) checkbox at checkout.
-  // Required for renter self-serve bookings (enforced by caller role in `create`);
-  // staff/manual bookings are exempt. The server stamps the timestamp + version.
-  disclaimerAccepted?: boolean
-}
-
-export type CreateBookingResult =
-  | { ok: true; booking: Booking; status?: 200 }
-  | {
-      ok: false
-      status: 400 | 403 | 409
-      error: string | Record<string, string[]>
-      code?: string
-      details?: { required: number; actual: number }
-    }
-
-/**
- * Optional pre-transaction authorization gate (#459). When injected, `create`
- * runs it after idempotency replay and before the booking transaction; a denial
- * short-circuits with 403. BookingService stays decoupled from the document
- * domain — it only knows "there may be a gate" (DIP).
- */
-export type BookingVerificationGate = (
-  ctx: CallerContext,
-  input: CreateBookingInput,
-) => Promise<
-  { ok: true } | { ok: false; status: 403; error: string; code: 'DOCUMENT_VERIFICATION_REQUIRED' }
->
-
-export type SubstituteResult =
-  | { ok: true; booking: Booking }
-  | { ok: false; status: 400 | 404 | 409; error: string }
-
-export type StatusTransitionResult =
-  | { ok: true; booking: Booking }
-  | { ok: false; status: 400 | 404 | 409; error: string }
-
-export type CancelResult =
-  | {
-      ok: true
-      booking: Booking
-      cancellation: ReturnType<typeof calculateCancellationFee>
-    }
-  | { ok: false; status: 404 | 409; error: string }
+// One page covers an operator's fleet (~40-50 cars; the vehicles read caps at 100).
+const SUBSTITUTION_CANDIDATE_LIMIT = 100
 
 /**
  * Opt-in messaging hook. When supplied, every confirmed booking also creates
@@ -692,6 +645,57 @@ export class BookingService {
       this.vehicleClassRepo.findById(SYSTEM_CONTEXT, newClassId),
     ])
     return !!bookingClass?.acrissCode && bookingClass.acrissCode === newClass?.acrissCode
+  }
+
+  /**
+   * #616: the eligible replacement vehicles for the operator's substitute action —
+   * SAME store + SAME ACRISS class + AVAILABLE, minus the currently-assigned car.
+   * The eligibility rule mirrors substitute() so the picker never offers a vehicle
+   * the write would reject; it lives here (not the client) because the rule keys
+   * off the class ACRISS code, which the vehicle list response does not carry. The
+   * booking read is caller-scoped, so a cross-tenant id resolves to 404.
+   */
+  async substitutionCandidates(
+    ctx: CallerContext,
+    bookingId: string,
+  ): Promise<SubstitutionCandidatesResult> {
+    if (!this.vehicleRepo || !this.vehicleClassRepo) {
+      throw new Error('BookingService missing vehicle repos; check DI wiring')
+    }
+    const booking = await this.bookingRepo.findById(ctx, bookingId)
+    if (!booking) {
+      return { ok: false, status: 404, error: 'Booking not found' }
+    }
+
+    // An unmapped (null-ACRISS) booking class has no substitute target, matching
+    // sameAcrissClass()'s non-null requirement.
+    const bookingClass = await this.vehicleClassRepo.findById(SYSTEM_CONTEXT, booking.classId)
+    const acrissCode = bookingClass?.acrissCode
+    if (!acrissCode) {
+      return { ok: true, candidates: [] }
+    }
+
+    // The operator's own classes sharing that ACRISS code — multiple classIds may
+    // map to one code (schema allows a non-unique acrissCode), so collect the set.
+    const classes = await this.vehicleClassRepo.findAll(ctx)
+    const sameAcrissClassIds = new Set(
+      classes.filter((cls) => cls.acrissCode === acrissCode).map((cls) => cls.id),
+    )
+
+    const { data } = await this.vehicleRepo.findAll(ctx, {
+      status: 'AVAILABLE',
+      limit: SUBSTITUTION_CANDIDATE_LIMIT,
+    })
+    const candidates = data
+      .filter(
+        (v) =>
+          v.id !== booking.assignedVehicleId &&
+          (v.pickupLocationId ?? null) === booking.pickupLocationId &&
+          !!v.classId &&
+          sameAcrissClassIds.has(v.classId),
+      )
+      .map((v) => ({ id: v.id, name: v.name }))
+    return { ok: true, candidates }
   }
 
   async updateStatus(

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1319,4 +1319,46 @@ describe('Booking Routes', () => {
       expect(body.success).toBe(false)
     })
   })
+
+  describe('GET /bookings/:id/substitution-candidates', () => {
+    function operatorApp() {
+      const opApp = new Hono()
+      opApp.use('*', testAuthMiddleware(OP_USER, 'OPERATOR_OWNER', OPERATOR))
+      opApp.route('/', createBookingRoutes(service))
+      return opApp
+    }
+
+    it('forbids a renter (403)', async () => {
+      const renterApp = new Hono()
+      renterApp.use('*', testAuthMiddleware(USER1, 'RENTER'))
+      renterApp.route('/', createBookingRoutes(service))
+
+      const res = await renterApp.request(
+        `/bookings/${crypto.randomUUID()}/substitution-candidates`,
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 404 for a nonexistent booking', async () => {
+      const res = await operatorApp().request(
+        `/bookings/${crypto.randomUUID()}/substitution-candidates`,
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it('lists eligible same-store same-class vehicles, excluding the assigned car', async () => {
+      const createRes = await createBooking(validBookingInput())
+      const created = await createRes.json()
+
+      const res = await operatorApp().request(
+        `/bookings/${created.data.id}/substitution-candidates`,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      const ids = (body.data as Array<{ id: string }>).map((candidate) => candidate.id)
+      expect(ids).toContain(seededVehicle2Id)
+      expect(ids).not.toContain(seededVehicleId)
+    })
+  })
 })

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1044,6 +1044,61 @@ describe('BookingService.substitute — operator vehicle swap (#392 §5.5)', () 
   })
 })
 
+describe('BookingService.substitutionCandidates — eligible swap targets (#616)', () => {
+  const addVehicle = (h: SubHarness, o: Partial<Vehicle> = {}) =>
+    h.repos.vehicleRepo.create(
+      SYSTEM_CONTEXT,
+      vehicleData({
+        classId: h.classA.id,
+        pickupLocationId: h.locationId,
+        dailyRateJpy: 15000,
+        ...o,
+      }),
+    )
+
+  it('lists same-location same-ACRISS AVAILABLE vehicles, excluding the assigned vehicle', async () => {
+    const h = await setupSub()
+    const r1 = await addVehicle(h)
+    const result = await h.service.substitutionCandidates(opCtxA, h.bookingId)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const ids = result.candidates.map((c) => c.id)
+    expect(ids).toContain(r1.id)
+    expect(ids).not.toContain(h.v1Id) // the currently-assigned car is never its own substitute
+    expect(result.candidates.find((c) => c.id === r1.id)?.name).toEqual(expect.any(String))
+  })
+
+  it('excludes different-location, different-class, and non-AVAILABLE vehicles', async () => {
+    const h = await setupSub()
+    const eligible = await addVehicle(h)
+    const loc2 = await h.repos.locationRepo.create({
+      operatorId: OP_A,
+      name: 'Kyoto',
+      address: '2',
+      operatingHours: null,
+      timezone: 'Asia/Tokyo',
+      defaultTurnaroundMinutes: 2880,
+      status: 'ACTIVE',
+    } as Parameters<typeof h.repos.locationRepo.create>[0])
+    await addVehicle(h, { pickupLocationId: loc2.id }) // wrong location
+    await addVehicle(h, { classId: h.classB.id }) // wrong ACRISS class
+    await addVehicle(h, { status: 'MAINTENANCE' }) // not available
+    const result = await h.service.substitutionCandidates(opCtxA, h.bookingId)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.candidates.map((c) => c.id)).toEqual([eligible.id])
+  })
+
+  it('returns 404 when the booking belongs to another operator (no cross-tenant read)', async () => {
+    const h = await setupSub()
+    await addVehicle(h)
+    const result = await h.service.substitutionCandidates(opCtxB, h.bookingId)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(404)
+  })
+})
+
 describe('BookingService lifecycle events (#392 §3.1)', () => {
   it('appends STATUS_CHANGED in the same tx when a booking transitions', async () => {
     const h = await setup({ codes: ['LIFE0001'] })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -890,19 +890,29 @@
         "loading": "Loading booking…",
         "loadError": "Couldn't load this booking",
         "missing": "Booking not found",
-        "actions": "Actions",
-        "substitute": {
-          "action": "Substitute vehicle",
-          "dialogTitle": "Substitute vehicle",
-          "dialogDescription": "Swap in another available car of the same class at this pickup location. The renter keeps their original booking; the change is recorded.",
-          "vehicleLabel": "Replacement vehicle",
-          "reasonLabel": "Reason (optional)",
-          "reasonPlaceholder": "e.g. original car in for repair",
-          "noCandidates": "No same-class vehicle is available at this pickup location.",
-          "submit": "Confirm substitution",
-          "cancel": "Cancel",
-          "error": "Couldn't substitute the vehicle. It may have just been booked.",
-          "unavailable": "Vehicle substitution is only available for confirmed or active bookings."
+        "actions": {
+          "heading": "Actions",
+          "markActive": "Mark as picked up",
+          "markCompleted": "Mark as returned",
+          "substitute": "Substitute vehicle",
+          "cancel": "Cancel booking",
+          "terminal": "No actions available for this booking.",
+          "confirm": "Confirm",
+          "back": "Back",
+          "close": "Close",
+          "working": "Working…",
+          "markActiveConfirm": "Mark this booking as active? This records that the customer has picked up the vehicle.",
+          "markCompletedConfirm": "Mark this booking as completed? This records that the vehicle has been returned.",
+          "cancelConfirm": "Cancel this booking? A cancellation fee may apply per the policy.",
+          "cancelled": "Booking cancelled.",
+          "cancelTier": "Fee tier: {tier} — {fee}",
+          "substituteTitle": "Substitute vehicle",
+          "substituteDescription": "Choose an available car of the same class at the same pick-up location.",
+          "substituteEmpty": "No eligible same-class vehicle is available at this location.",
+          "substituteVehicleLabel": "Replacement vehicle",
+          "substituteReason": "Reason (optional)",
+          "substituteSubmit": "Confirm substitution",
+          "substituteLoading": "Loading available vehicles…"
         }
       },
       "timeline": {
@@ -1012,8 +1022,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "Overview", "revenue": "Partner Revenue" },
-    "home": { "title": "Platform Admin", "subtitle": "Platform operations" },
+    "nav": {
+      "overview": "Overview",
+      "revenue": "Partner Revenue"
+    },
+    "home": {
+      "title": "Platform Admin",
+      "subtitle": "Platform operations"
+    },
     "revenue": {
       "title": "Partner Revenue",
       "subtitle": "Monthly payout per partner",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -890,19 +890,29 @@
         "loading": "予約を読み込み中…",
         "loadError": "この予約を読み込めませんでした",
         "missing": "予約が見つかりません",
-        "actions": "操作",
-        "substitute": {
-          "action": "車両を変更",
-          "dialogTitle": "車両を変更",
-          "dialogDescription": "同じ受取場所で同クラスの空き車両に振り替えます。お客様の予約はそのまま保持され、変更は記録されます。",
-          "vehicleLabel": "代替車両",
-          "reasonLabel": "理由（任意）",
-          "reasonPlaceholder": "例：元の車両が修理中",
-          "noCandidates": "この受取場所で利用可能な同クラスの車両がありません。",
-          "submit": "変更を確定",
-          "cancel": "キャンセル",
-          "error": "車両を変更できませんでした。直前に予約された可能性があります。",
-          "unavailable": "車両の変更は確定済みまたは利用中の予約でのみ可能です。"
+        "actions": {
+          "heading": "操作",
+          "markActive": "受け渡し済みにする",
+          "markCompleted": "返却済みにする",
+          "substitute": "車両を変更",
+          "cancel": "予約をキャンセル",
+          "terminal": "この予約に利用できる操作はありません。",
+          "confirm": "確定",
+          "back": "戻る",
+          "close": "閉じる",
+          "working": "処理中…",
+          "markActiveConfirm": "この予約を進行中にしますか？お客様が車両を受け取ったことを記録します。",
+          "markCompletedConfirm": "この予約を完了にしますか？車両が返却されたことを記録します。",
+          "cancelConfirm": "この予約をキャンセルしますか？キャンセルポリシーにより料金が発生する場合があります。",
+          "cancelled": "予約をキャンセルしました。",
+          "cancelTier": "料金区分：{tier} — {fee}",
+          "substituteTitle": "車両を変更",
+          "substituteDescription": "同じ受取場所・同じクラスの利用可能な車両を選択してください。",
+          "substituteEmpty": "この受取場所には条件に合う同クラスの車両がありません。",
+          "substituteVehicleLabel": "代替車両",
+          "substituteReason": "理由（任意）",
+          "substituteSubmit": "変更を確定",
+          "substituteLoading": "利用可能な車両を読み込んでいます…"
         }
       },
       "timeline": {
@@ -1012,8 +1022,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "概要", "revenue": "パートナー収益" },
-    "home": { "title": "プラットフォーム管理", "subtitle": "プラットフォーム運営" },
+    "nav": {
+      "overview": "概要",
+      "revenue": "パートナー収益"
+    },
+    "home": {
+      "title": "プラットフォーム管理",
+      "subtitle": "プラットフォーム運営"
+    },
     "revenue": {
       "title": "パートナー収益",
       "subtitle": "パートナーごとの月次支払い",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -890,19 +890,29 @@
         "loading": "正在加载预订…",
         "loadError": "无法加载此预订",
         "missing": "未找到预订",
-        "actions": "操作",
-        "substitute": {
-          "action": "更换车辆",
-          "dialogTitle": "更换车辆",
-          "dialogDescription": "在同一取车点更换为同级别的另一辆可用车辆。租客的原始预订保持不变，变更将被记录。",
-          "vehicleLabel": "替换车辆",
-          "reasonLabel": "原因（可选）",
-          "reasonPlaceholder": "例如：原车辆正在维修",
-          "noCandidates": "该取车点暂无可用的同级别车辆。",
-          "submit": "确认更换",
-          "cancel": "取消",
-          "error": "无法更换车辆，该车辆可能刚被预订。",
-          "unavailable": "仅确认或进行中的预订可更换车辆。"
+        "actions": {
+          "heading": "操作",
+          "markActive": "标记为已取车",
+          "markCompleted": "标记为已还车",
+          "substitute": "更换车辆",
+          "cancel": "取消订单",
+          "terminal": "该订单暂无可用操作。",
+          "confirm": "确认",
+          "back": "返回",
+          "close": "关闭",
+          "working": "处理中…",
+          "markActiveConfirm": "将此订单标记为进行中？这表示客户已取车。",
+          "markCompletedConfirm": "将此订单标记为已完成？这表示车辆已归还。",
+          "cancelConfirm": "取消此订单？根据取消政策可能会收取费用。",
+          "cancelled": "订单已取消。",
+          "cancelTier": "费用档位：{tier} — {fee}",
+          "substituteTitle": "更换车辆",
+          "substituteDescription": "选择同一取车点、同一车型的可用车辆。",
+          "substituteEmpty": "该取车点暂无符合条件的同车型车辆。",
+          "substituteVehicleLabel": "替换车辆",
+          "substituteReason": "原因（可选）",
+          "substituteSubmit": "确认更换",
+          "substituteLoading": "正在加载可用车辆…"
         }
       },
       "timeline": {
@@ -1012,8 +1022,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "概览", "revenue": "合作伙伴收益" },
-    "home": { "title": "平台管理", "subtitle": "平台运营" },
+    "nav": {
+      "overview": "概览",
+      "revenue": "合作伙伴收益"
+    },
+    "home": {
+      "title": "平台管理",
+      "subtitle": "平台运营"
+    },
     "revenue": {
       "title": "合作伙伴收益",
       "subtitle": "按合作伙伴的月度结算",

--- a/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
@@ -7,8 +7,6 @@ import {
   operatorBookingDetailQueryOptions,
   operatorRowFromDetail,
 } from '@/vite/operator-bookings/api'
-import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
-import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import {
   type ErrorComponentProps,
@@ -24,20 +22,17 @@ import { useTranslations } from 'use-intl'
 // replacement for the #548 drawer — an operator can bookmark/share a reservation.
 // Behind `_business`; the single read is tenant-sealed server-side (404 -> null ->
 // notFound). All data comes from the API, so a hard refresh works (no list row).
-// Two-column layout: booking detail + the Actions panel (#610 vehicle substitution)
-// on the left, the vertical event timeline right.
+// Two-column layout: booking detail + the order-management Actions panel (#616:
+// status transitions, vehicle substitution, cancel) left, the event timeline right.
 export const Route = createFileRoute('/$locale/_business/manage/bookings/$bookingId')({
   loader: async ({ context, params }) => {
     const detail = await context.queryClient.ensureQueryData(
       operatorBookingDetailQueryOptions(params.bookingId),
     )
     if (!detail) throw notFound()
-    // Warm the timeline + replacement-candidate caches so the page renders without
-    // a second waterfall. The fleet read backs the substitution dialog's picker.
-    await Promise.all([
-      context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId)),
-      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
-    ])
+    // Warm the timeline cache so the page renders without a second waterfall. The
+    // substitution candidates are fetched lazily by the dialog when it opens.
+    await context.queryClient.ensureQueryData(bookingEventsQueryOptions(params.bookingId))
     return { detail }
   },
   pendingComponent: PageSkeleton,
@@ -50,8 +45,6 @@ function TripDetailRoute() {
   const { locale, bookingId } = Route.useParams()
   const { detail } = Route.useLoaderData()
   const { data: events } = useSuspenseQuery(bookingEventsQueryOptions(bookingId))
-  const { data: session } = useSuspenseQuery(sessionQueryOptions())
-  const { data: fleet } = useSuspenseQuery(operatorFleetQueryOptions())
   const row = operatorRowFromDetail(detail)
 
   return (
@@ -70,7 +63,7 @@ function TripDetailRoute() {
             <div className="rounded-xl border border-border py-6">
               <OperatorBookingDetail row={row} booking={detail} locale={locale} />
             </div>
-            <BookingActionsPanel detail={detail} session={session} fleet={fleet} />
+            <BookingActionsPanel bookingId={bookingId} status={detail.status} />
           </section>
           <aside className="rounded-xl border border-border px-4 py-6">
             <h2 className="mb-6 text-sm font-semibold">{t('timeline.heading')}</h2>

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -1,65 +1,179 @@
-import { isOperatorSession } from '@/vite/guards'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { formatJpy } from '@/lib/format'
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
-import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
-import type { Session } from '@/vite/session'
+import {
+  type OperatorBookingStatus,
+  cancelBooking,
+  updateBookingStatus,
+} from '@/vite/operator-bookings/api'
+import { actionsFor } from '@/vite/operator-bookings/booking-actions'
+import { useSession } from '@/vite/session'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from '@tanstack/react-router'
+import { useRef, useState } from 'react'
 import { useTranslations } from 'use-intl'
 
+// #616 step 8 (管理订单): the operator's order-management panel on the trip-detail
+// page. Buttons come from the pure `actionsFor` gate (state machine + the
+// substitute/cancel exceptions), so they can't drift from the backend rules.
+// Every state-changing action confirms first; cancel additionally surfaces the
+// fee tier the server returns. No optimistic UI — the server CAS 409s a lost
+// race, so we disable-while-pending and invalidate on success instead.
+const OPERATOR_BOOKINGS_KEY = ['operator-bookings'] as const
+
+type ConfirmKind = 'markActive' | 'markCompleted' | 'cancel'
+
 interface BookingActionsPanelProps {
-  readonly detail: OperatorBookingDetailDto
-  readonly session: Session | null
-  readonly fleet: readonly OperatorFleetVehicle[]
+  readonly bookingId: string
+  readonly status: OperatorBookingStatus
 }
 
-// #610: the operator Actions panel on the trip-detail page. Today it owns one
-// action — vehicle substitution (故障车换同店同级别车) — but it is the home for cancel /
-// status transitions next. Kept router-free (props in, no useSuspenseQuery) so the
-// route owns data + chrome and this stays a pure, directly-testable unit.
-//
-// Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) read the
-// booking cross-operator for oversight but cannot act on it: substitution needs a
-// single target tenant they don't carry. So the panel is operator-only, mirroring
-// fleet/classes (#581/#583/#598). The `_business` shell guard admits the page; this
-// gates the action by role + capability (the API is the real boundary).
-export function BookingActionsPanel({ detail, session, fleet }: BookingActionsPanelProps) {
-  const t = useTranslations('bookings.operator.detail')
+export function BookingActionsPanel({ bookingId, status }: BookingActionsPanelProps) {
+  const t = useTranslations('bookings.operator.detail.actions')
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  const csrfToken = useSession().data?.csrfToken ?? ''
+  const actions = actionsFor(status)
 
-  if (!isOperatorSession(session)) return null
+  const [confirm, setConfirm] = useState<ConfirmKind | null>(null)
+  const [substituteOpen, setSubstituteOpen] = useState(false)
 
-  // The server only substitutes a live booking (409 otherwise); the renter's slot
-  // is gone once the trip is completed or cancelled.
-  const isSubstitutable = detail.status === 'CONFIRMED' || detail.status === 'ACTIVE'
+  // Prefix-invalidate (list + calendar + badge + events) then re-run the loader
+  // so the detail + timeline reflect the new state without a manual refresh.
+  async function refresh() {
+    await queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
+    await router.invalidate()
+  }
 
-  // Mirror the server's substitution rules so a picked car never 400s: same operator
-  // (the scoped fleet read), same class, same pickup location, AVAILABLE, and not the
-  // car already on the booking. `classId != null` makes the (server-impossible) null-
-  // class booking explicit — the server derives a class at create time and rejects a
-  // classless replacement, so we never surface unassigned cars.
-  // NOTE: the server matches by *ACRISS code*, not classId (two classes may share a
-  // code — schema.ts "ACRISS is a category"). Filtering on classId is a strict subset:
-  // it never offers a car the server rejects, but can hide a same-ACRISS replacement
-  // in a different class. The fleet row carries no ACRISS code today; widening to a
-  // code-based match is a follow-up (#610 review). Conservative on purpose.
-  const candidates = fleet.filter(
-    (v) =>
-      v.status === 'AVAILABLE' &&
-      detail.classId != null &&
-      v.classId === detail.classId &&
-      v.pickupLocationId === detail.pickupLocationId &&
-      v.id !== detail.assignedVehicleId,
-  )
+  const statusMutation = useMutation({
+    mutationFn: (next: 'ACTIVE' | 'COMPLETED') => updateBookingStatus(bookingId, next, csrfToken),
+    onSuccess: async () => {
+      await refresh()
+      setConfirm(null)
+    },
+  })
+  const cancelMutation = useMutation({
+    mutationFn: () => cancelBooking(bookingId, csrfToken),
+    onSuccess: refresh, // keep the dialog open to show the returned fee tier
+  })
+
+  const isPending = statusMutation.isPending || cancelMutation.isPending
+  const error = statusMutation.error ?? cancelMutation.error
+  const cancelled = cancelMutation.data
+
+  // Synchronous double-submit guard (mirrors AddOnArchiveDialog): isPending only
+  // flips between renders, so two clicks in one frame both read false.
+  const inFlightRef = useRef(false)
+  if (!isPending && inFlightRef.current) inFlightRef.current = false
+
+  function closeConfirm() {
+    setConfirm(null)
+    statusMutation.reset()
+    cancelMutation.reset()
+  }
+
+  function runConfirm() {
+    if (inFlightRef.current || isPending || confirm == null) return
+    inFlightRef.current = true
+    if (confirm === 'cancel') cancelMutation.mutate()
+    else statusMutation.mutate(confirm === 'markActive' ? 'ACTIVE' : 'COMPLETED')
+  }
+
+  const anyAction =
+    actions.markActive || actions.markCompleted || actions.substitute || actions.cancel
 
   return (
-    <div className="rounded-xl border border-border px-4 py-6">
-      <h2 className="mb-4 text-sm font-semibold text-muted-foreground">{t('actions')}</h2>
-      {isSubstitutable ? (
-        <SubstituteVehicleDialog
-          bookingId={detail.id}
-          candidates={candidates}
-          csrfToken={session?.csrfToken ?? ''}
-        />
+    <div>
+      <h2 className="mb-4 text-sm font-semibold">{t('heading')}</h2>
+
+      {anyAction ? (
+        <div className="flex flex-wrap gap-2">
+          {actions.markActive && (
+            <Button onClick={() => setConfirm('markActive')}>{t('markActive')}</Button>
+          )}
+          {actions.markCompleted && (
+            <Button onClick={() => setConfirm('markCompleted')}>{t('markCompleted')}</Button>
+          )}
+          {actions.substitute && (
+            <Button variant="outline" onClick={() => setSubstituteOpen(true)}>
+              {t('substitute')}
+            </Button>
+          )}
+          {actions.cancel && (
+            <Button variant="destructive" onClick={() => setConfirm('cancel')}>
+              {t('cancel')}
+            </Button>
+          )}
+        </div>
       ) : (
-        <p className="text-sm text-muted-foreground">{t('substitute.unavailable')}</p>
+        <p className="text-sm text-muted-foreground">{t('terminal')}</p>
+      )}
+
+      <Dialog
+        open={confirm != null}
+        onOpenChange={(open) => {
+          if (!open) closeConfirm()
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{confirm ? t(confirm) : ''}</DialogTitle>
+            <DialogDescription>{confirm ? t(`${confirm}Confirm`) : ''}</DialogDescription>
+          </DialogHeader>
+
+          {cancelled ? (
+            <div className="space-y-1 text-sm">
+              <p className="font-medium">{t('cancelled')}</p>
+              <p className="text-muted-foreground">
+                {t('cancelTier', {
+                  tier: cancelled.cancellation.tier,
+                  fee: formatJpy(cancelled.cancellation.feeAmount),
+                })}
+              </p>
+            </div>
+          ) : null}
+
+          {error && !cancelled && (
+            <p className="px-1 text-sm text-destructive">
+              {error instanceof Error ? error.message : String(error)}
+            </p>
+          )}
+
+          <DialogFooter>
+            {cancelled ? (
+              <Button onClick={closeConfirm}>{t('close')}</Button>
+            ) : (
+              <>
+                <Button variant="outline" onClick={closeConfirm}>
+                  {t('back')}
+                </Button>
+                <Button
+                  variant={confirm === 'cancel' ? 'destructive' : 'default'}
+                  disabled={isPending}
+                  onClick={runConfirm}
+                >
+                  {isPending ? t('working') : t('confirm')}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {actions.substitute && (
+        <SubstituteVehicleDialog
+          bookingId={bookingId}
+          open={substituteOpen}
+          onOpenChange={setSubstituteOpen}
+        />
       )}
     </div>
   )

--- a/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
@@ -1,134 +1,137 @@
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import {
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
-  substituteBooking,
-} from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { type FormEvent, useState } from 'react'
+import { substituteVehicle, substitutionCandidatesQueryOptions } from '@/vite/operator-bookings/api'
+import { useSession } from '@/vite/session'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from '@tanstack/react-router'
+import { useRef, useState } from 'react'
 import { useTranslations } from 'use-intl'
+
+// #616: swap the assigned car for another eligible vehicle. Eligibility (same
+// store + same ACRISS class + AVAILABLE, excluding the current car) is decided
+// server-side by GET /substitution-candidates — never re-derived here — so the
+// rule lives in exactly one place (the list endpoint can't even feed it: it
+// carries classId, not the acrissCode the real rule uses).
+const OPERATOR_BOOKINGS_KEY = ['operator-bookings'] as const
 
 interface SubstituteVehicleDialogProps {
   readonly bookingId: string
-  /** Replacement candidates, already filtered to the booking's class + location. */
-  readonly candidates: readonly OperatorFleetVehicle[]
-  readonly csrfToken: string
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
 }
 
-// #610: operator vehicle substitution (故障车换同店同级别车，系统留痕). A dialog that
-// swaps the booking's assigned car for another AVAILABLE same-class, same-location
-// vehicle via POST /bookings/:id/substitute. The candidate list is pre-filtered by
-// the page to mirror the server's rules exactly, so the operator can never pick an
-// invalid car. On success it invalidates the detail (re-fetch the new vehicle) and
-// events (the appended VEHICLE_SUBSTITUTED audit row) queries — the timeline renders
-// the 系统留痕 automatically. CSRF-gated; the session token rides the write.
 export function SubstituteVehicleDialog({
   bookingId,
-  candidates,
-  csrfToken,
+  open,
+  onOpenChange,
 }: SubstituteVehicleDialogProps) {
-  const t = useTranslations('bookings.operator.detail.substitute')
+  const t = useTranslations('bookings.operator.detail.actions')
   const queryClient = useQueryClient()
-  const [open, setOpen] = useState(false)
+  const router = useRouter()
+  const csrfToken = useSession().data?.csrfToken ?? ''
+
+  // Only fetch while the dialog is open — the panel mounts it permanently.
+  const { data: candidates, isLoading } = useQuery({
+    ...substitutionCandidatesQueryOptions(bookingId),
+    enabled: open,
+  })
+
   const [vehicleId, setVehicleId] = useState('')
   const [reason, setReason] = useState('')
 
-  const mutation = useMutation({
-    mutationFn: () => substituteBooking(bookingId, vehicleId, reason.trim() || null, csrfToken),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: operatorBookingDetailQueryOptions(bookingId).queryKey,
-      })
-      queryClient.invalidateQueries({ queryKey: bookingEventsQueryOptions(bookingId).queryKey })
-      setOpen(false)
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: () => substituteVehicle(bookingId, vehicleId, reason.trim() || null, csrfToken),
+    onSuccess: async () => {
+      // Prefix-invalidate (list + calendar + badge) then re-run the loader so
+      // the detail + timeline reflect the new car and the VEHICLE_SUBSTITUTED event.
+      await queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
+      await router.invalidate()
+      onOpenChange(false)
     },
   })
 
-  function handleOpenChange(next: boolean) {
-    setOpen(next)
-    if (next) {
-      // Default to the first candidate so a single-option list submits in one click.
-      setVehicleId(candidates[0]?.id ?? '')
-      setReason('')
-      mutation.reset()
-    }
-  }
+  // Synchronous double-submit guard: isPending only flips between renders, so two
+  // clicks in one frame both read false; a ref flips immediately in onClick.
+  const inFlightRef = useRef(false)
+  if (!isPending && inFlightRef.current) inFlightRef.current = false
 
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    if (!vehicleId || mutation.isPending) return
-    mutation.mutate()
-  }
-
-  const hasCandidates = candidates.length > 0
+  const options = candidates ?? []
+  const hasCandidates = options.length > 0
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger render={<Button variant="outline" size="sm" />}>{t('action')}</DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>{t('dialogTitle')}</DialogTitle>
-            <DialogDescription>{t('dialogDescription')}</DialogDescription>
-          </DialogHeader>
+        <DialogHeader>
+          <DialogTitle>{t('substituteTitle')}</DialogTitle>
+          <DialogDescription>{t('substituteDescription')}</DialogDescription>
+        </DialogHeader>
 
-          {hasCandidates ? (
-            <div className="space-y-4 py-4">
-              <div className="space-y-2">
-                <Label htmlFor="substitute-vehicle">{t('vehicleLabel')}</Label>
-                <select
-                  id="substitute-vehicle"
-                  value={vehicleId}
-                  onChange={(e) => setVehicleId(e.target.value)}
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  {candidates.map((v) => (
-                    <option key={v.id} value={v.id}>
-                      {v.licensePlate ? `${v.name} — ${v.licensePlate}` : v.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="substitute-reason">{t('reasonLabel')}</Label>
-                <Textarea
-                  id="substitute-reason"
-                  value={reason}
-                  onChange={(e) => setReason(e.target.value)}
-                  placeholder={t('reasonPlaceholder')}
-                />
-              </div>
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">{t('substituteLoading')}</p>
+        ) : hasCandidates ? (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="substitute-vehicle">{t('substituteVehicleLabel')}</Label>
+              <select
+                id="substitute-vehicle"
+                value={vehicleId}
+                onChange={(e) => setVehicleId(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="" disabled>
+                  —
+                </option>
+                {options.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
             </div>
-          ) : (
-            <p className="py-4 text-sm text-muted-foreground">{t('noCandidates')}</p>
-          )}
+            <div className="space-y-1.5">
+              <Label htmlFor="substitute-reason">{t('substituteReason')}</Label>
+              <Textarea
+                id="substitute-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={2}
+              />
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('substituteEmpty')}</p>
+        )}
 
-          {mutation.isError && (
-            <output className="block text-sm text-destructive">{t('error')}</output>
-          )}
+        {error && (
+          <p className="px-1 text-sm text-destructive">
+            {error instanceof Error ? error.message : String(error)}
+          </p>
+        )}
 
-          <DialogFooter>
-            <DialogClose render={<Button type="button" variant="outline" />}>
-              {t('cancel')}
-            </DialogClose>
-            <Button type="submit" disabled={!hasCandidates || !vehicleId || mutation.isPending}>
-              {t('submit')}
-            </Button>
-          </DialogFooter>
-        </form>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('back')}
+          </Button>
+          <Button
+            disabled={!vehicleId || isPending || !hasCandidates}
+            onClick={() => {
+              if (inFlightRef.current || isPending || !vehicleId) return
+              inFlightRef.current = true
+              mutate()
+            }}
+          >
+            {isPending ? t('working') : t('substituteSubmit')}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -1,7 +1,8 @@
-import { unwrap } from '@/lib/api-error'
+import { ApiError, unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { BookingDto } from '@/vite/bookings/api'
 import type { BookingEventPayload, BookingEventType } from '@kuruma/shared/db/schema'
+import type { CancellationResult } from '@kuruma/shared/lib/cancellation-policy'
 import { queryOptions } from '@tanstack/react-query'
 
 // #512: operator booking view. The Vite shell owns these DTOs (it never imports
@@ -195,33 +196,6 @@ export function operatorRowFromDetail(dto: OperatorBookingDetailDto): OperatorBo
   }
 }
 
-// #610: operator vehicle substitution. POST /bookings/:id/substitute swaps the
-// booking's assigned car for another AVAILABLE vehicle of the SAME operator,
-// pickup location and ACRISS class (the server enforces all three). The renter's
-// `requestedVehicleId` is preserved; only `assignedVehicleId` + a re-snapshotted
-// totalPrice change, and a VEHICLE_SUBSTITUTED audit event (系统留痕) is appended,
-// which the existing timeline renders once the events query is invalidated. As a
-// cookie-authed POST it is CSRF-gated (global csrf()), so the caller echoes the
-// session token. `reason` is optional in the schema, so it is omitted when blank.
-export async function substituteBooking(
-  bookingId: string,
-  newVehicleId: string,
-  reason: string | null,
-  csrfToken: string,
-): Promise<BookingDto> {
-  const body = reason != null ? { newVehicleId, reason } : { newVehicleId }
-  const res = await fetch(
-    `${getApiBaseUrl()}/bookings/${encodeURIComponent(bookingId)}/substitute`,
-    {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
-      body: JSON.stringify(body),
-    },
-  )
-  return unwrap<BookingDto>(res)
-}
-
 /** One lifecycle event as the operator timeline reads it (dates are ISO JSON). */
 export interface BookingEventDto {
   id: string
@@ -244,5 +218,98 @@ export function bookingEventsQueryOptions(id: string) {
   return queryOptions({
     queryKey: ['operator-bookings', 'events', id],
     queryFn: () => fetchBookingEvents(id),
+  })
+}
+
+// --- #616: operator order actions (substitute / cancel / status) -------------
+// Writes are cookie-authed, so each threads the session CSRF token — the global
+// csrf() middleware rejects a mutation without a matching X-CSRF-Token. Mirrors
+// the operator-add-ons client; the bare operator-fleet writeJson omits the
+// header and must not be copied for writes. The trip-detail page wires these
+// into useMutation and invalidates the ['operator-bookings'] prefix on success.
+
+async function writeBooking<T>(
+  path: string,
+  method: 'POST' | 'PATCH',
+  body: unknown,
+  csrfToken: string,
+): Promise<T> {
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method,
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify(body),
+  })
+  return unwrap<T>(res)
+}
+
+export async function updateBookingStatus(
+  id: string,
+  status: OperatorBookingStatus,
+  csrfToken: string,
+): Promise<BookingDto> {
+  return writeBooking<BookingDto>(
+    `/bookings/${encodeURIComponent(id)}/status`,
+    'PATCH',
+    { status },
+    csrfToken,
+  )
+}
+
+export async function substituteVehicle(
+  id: string,
+  newVehicleId: string,
+  reason: string | null,
+  csrfToken: string,
+): Promise<BookingDto> {
+  return writeBooking<BookingDto>(
+    `/bookings/${encodeURIComponent(id)}/substitute`,
+    'POST',
+    { newVehicleId, ...(reason ? { reason } : {}) },
+    csrfToken,
+  )
+}
+
+export interface CancelBookingResult {
+  booking: BookingDto
+  cancellation: CancellationResult
+}
+
+// Cancel returns the fee tier in the envelope META (alongside `data`), which
+// unwrap() discards — so read the raw envelope to surface { booking, cancellation }.
+export async function cancelBooking(id: string, csrfToken: string): Promise<CancelBookingResult> {
+  const res = await fetch(`${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/cancel`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'X-CSRF-Token': csrfToken },
+  })
+  const body = (await res.json().catch(() => ({
+    success: false as const,
+    error: `Non-JSON response (HTTP ${res.status})`,
+  }))) as
+    | { success: true; data: BookingDto; cancellation: CancellationResult }
+    | { success: false; error: string }
+  if (!body.success) throw new ApiError(body.error, res.status)
+  return { booking: body.data, cancellation: body.cancellation }
+}
+
+/** A vehicle eligible to replace the assigned car (same store + ACRISS class). */
+export interface SubstitutionCandidate {
+  id: string
+  name: string
+}
+
+export async function fetchSubstitutionCandidates(id: string): Promise<SubstitutionCandidate[]> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/substitution-candidates`,
+    { credentials: 'include' },
+  )
+  return unwrap<SubstitutionCandidate[]>(res)
+}
+
+export function substitutionCandidatesQueryOptions(id: string) {
+  return queryOptions({
+    queryKey: ['operator-bookings', 'substitution-candidates', id],
+    queryFn: () => fetchSubstitutionCandidates(id),
   })
 }

--- a/packages/web/src/vite/operator-bookings/booking-actions.ts
+++ b/packages/web/src/vite/operator-bookings/booking-actions.ts
@@ -1,0 +1,46 @@
+import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
+
+/** Which operator actions the trip-detail panel offers for a given status. */
+export interface BookingActions {
+  /** CONFIRMED → ACTIVE (pickup). */
+  markActive: boolean
+  /** ACTIVE → COMPLETED (return). */
+  markCompleted: boolean
+  /** Swap the assigned car (CONFIRMED | ACTIVE — substitute()'s own gate). */
+  substitute: boolean
+  /** Cancel with a fee tier (CONFIRMED-only — POST /cancel 409s on ACTIVE). */
+  cancel: boolean
+}
+
+// Local mirror of the booking state machine's forward transitions. Deliberately
+// NOT imported from @kuruma/shared/db/schema: that module's *value* exports
+// (VALID_BOOKING_TRANSITIONS) live alongside 16 pgTable() definitions with no
+// /*#__PURE__*/ annotations, so a value-import drags drizzle-orm + pg-core into
+// the browser bundle (web ships no DB layer). The parity test in
+// booking-actions.test.ts imports the schema map (node-only) and asserts this
+// stays in sync, so the schema remains the source of truth if a transition changes.
+export const OPERATOR_BOOKING_TRANSITIONS: Record<OperatorBookingStatus, OperatorBookingStatus[]> =
+  {
+    CONFIRMED: ['ACTIVE', 'CANCELLED'],
+    ACTIVE: ['COMPLETED', 'CANCELLED'],
+    COMPLETED: [],
+    CANCELLED: [],
+  }
+
+/**
+ * #616: derive the available actions from `status`. Status transitions mirror the
+ * real state machine (OPERATOR_BOOKING_TRANSITIONS, parity-tested against the
+ * schema) so the buttons can't drift from the backend; substitute and cancel
+ * follow their OWN backend rules rather than the transitions map (substitute is
+ * not a status change; cancel is fee-bearing and CONFIRMED-only), which is why
+ * this is not `transitions.includes(...)` for those two.
+ */
+export function actionsFor(status: OperatorBookingStatus): BookingActions {
+  const transitions = OPERATOR_BOOKING_TRANSITIONS[status] ?? []
+  return {
+    markActive: transitions.includes('ACTIVE'),
+    markCompleted: transitions.includes('COMPLETED'),
+    substitute: status === 'CONFIRMED' || status === 'ACTIVE',
+    cancel: status === 'CONFIRMED',
+  }
+}

--- a/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
@@ -1,149 +1,105 @@
-import type { BookingDto } from '@/vite/bookings/api'
 import { BookingActionsPanel } from '@/vite/operator-bookings/BookingActionsPanel'
-import type { OperatorBookingDetailDto } from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
-import type { Session } from '@/vite/session'
+import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
-const sub = enMessages.bookings.operator.detail.substitute
+const invalidate = vi.fn().mockResolvedValue(undefined)
+vi.mock('@tanstack/react-router', () => ({ useRouter: () => ({ invalidate }) }))
+vi.mock('@/vite/session', () => ({ useSession: () => ({ data: { csrfToken: 'csrf-1' } }) }))
 
-function detail(over: Partial<BookingDto> = {}): OperatorBookingDetailDto {
-  return {
-    id: 'bk-1',
-    bookingCode: 'H7K2M9PQ',
-    renterId: 'r-1',
-    classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
-    dropoffLocationId: 'loc-1',
-    startAt: '2026-07-01T01:00:00.000Z',
-    endAt: '2026-07-03T01:00:00.000Z',
-    effectiveEndAt: '2026-07-03T01:00:00.000Z',
-    status: 'CONFIRMED',
-    source: 'DIRECT',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    totalPrice: 18000,
-    notes: null,
-    createdAt: '2026-06-20T00:00:00.000Z',
-    updatedAt: '2026-06-20T00:00:00.000Z',
-    ...over,
-  }
+const en = enMessages.bookings.operator.detail.actions
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
 }
 
-function fleetVehicle(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
-  return {
-    id: 'veh-2',
-    operatorId: 'op-1',
-    classId: 'cls-1',
-    pickupLocationId: 'loc-1',
-    name: 'Honda Fit',
-    description: null,
-    photos: [],
-    seats: 5,
-    luggageCapacity: 2,
-    luggageSize: 'MEDIUM',
-    transmission: 'AUTO',
-    fuelType: null,
-    licensePlate: 'OSAKA 9999',
-    status: 'AVAILABLE',
-    minRentalHours: null,
-    maxRentalHours: null,
-    advanceBookingHours: null,
-    make: null,
-    model: null,
-    year: null,
-    color: null,
-    dailyRateJpy: 7000,
-    hourlyRateJpy: null,
-    shakenExpiryDate: null,
-    insuranceExpiryDate: null,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    utilization: 0,
-    bookingCountLast30Days: 0,
-    currentBooking: null,
-    nextBooking: null,
-    activeMaintenanceReason: null,
-    ...over,
-  }
-}
-
-const operatorSession: Session = {
-  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
-  csrfToken: 't',
-}
-
-const bypassSession: Session = {
-  user: { id: 'u', role: 'PLATFORM_ADMIN' },
-  csrfToken: 't',
-}
-
-function renderPanel(
-  session: Session | null,
-  bookingDetail: OperatorBookingDetailDto,
-  fleet: OperatorFleetVehicle[] = [fleetVehicle({ id: 'veh-1' }), fleetVehicle()],
-) {
+function renderPanel(status: OperatorBookingStatus) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
   render(
-    <QueryClientProvider client={new QueryClient()}>
+    <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <BookingActionsPanel detail={bookingDetail} session={session} fleet={fleet} />
+        <BookingActionsPanel bookingId="bk-1" status={status} />
       </IntlProvider>
     </QueryClientProvider>,
   )
 }
 
-describe('BookingActionsPanel substitution gating (#610)', () => {
-  it('offers the Substitute action to a tenant-scoped operator on a live booking', () => {
-    renderPanel(operatorSession, detail({ status: 'CONFIRMED' }))
-    expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
+const button = (name: string) => screen.queryByRole('button', { name })
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('BookingActionsPanel', () => {
+  it('CONFIRMED → mark-active + substitute + cancel, but never mark-completed', () => {
+    renderPanel('CONFIRMED')
+    expect(button(en.markActive)).toBeInTheDocument()
+    expect(button(en.substitute)).toBeInTheDocument()
+    expect(button(en.cancel)).toBeInTheDocument()
+    expect(button(en.markCompleted)).toBeNull()
   })
 
-  it('renders nothing for a bypass role with no operatorId (read-only oversight)', () => {
-    const { container } = render(
-      <QueryClientProvider client={new QueryClient()}>
-        <IntlProvider locale="en" messages={enMessages}>
-          <BookingActionsPanel
-            detail={detail({ status: 'CONFIRMED' })}
-            session={bypassSession}
-            fleet={[fleetVehicle()]}
-          />
-        </IntlProvider>
-      </QueryClientProvider>,
+  it('ACTIVE → mark-completed + substitute, but NOT cancel (the fee endpoint is CONFIRMED-only)', () => {
+    renderPanel('ACTIVE')
+    expect(button(en.markCompleted)).toBeInTheDocument()
+    expect(button(en.substitute)).toBeInTheDocument()
+    expect(button(en.cancel)).toBeNull()
+    expect(button(en.markActive)).toBeNull()
+  })
+
+  it.each(['COMPLETED', 'CANCELLED'] as const)('%s → no action buttons (terminal)', (status) => {
+    renderPanel(status)
+    for (const name of [en.markActive, en.markCompleted, en.substitute, en.cancel]) {
+      expect(button(name)).toBeNull()
+    }
+    expect(screen.getByText(en.terminal)).toBeInTheDocument()
+  })
+
+  it('cancelling a CONFIRMED booking confirms, then surfaces the returned fee tier', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: { id: 'bk-1', status: 'CANCELLED' },
+        cancellation: { tier: 'TIER_30', feePercentage: 30, feeAmount: 7200, refundAmount: 16800 },
+      }),
     )
-    expect(container).toBeEmptyDOMElement()
-  })
-
-  it('disables substitution on a terminal booking, explaining why instead of the action', () => {
-    renderPanel(operatorSession, detail({ status: 'COMPLETED' }))
-    expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
-    expect(screen.getByText(sub.unavailable)).toBeInTheDocument()
-  })
-
-  it('only surfaces same-class, same-location, AVAILABLE candidates (never the assigned car)', async () => {
+    vi.stubGlobal('fetch', fetchMock)
     const user = userEvent.setup()
-    renderPanel(operatorSession, detail({ status: 'CONFIRMED' }), [
-      fleetVehicle({ id: 'veh-1', name: 'Assigned Car' }), // the current car — excluded
-      fleetVehicle({ id: 'ok', name: 'Same Class Same Loc' }), // valid
-      fleetVehicle({ id: 'other-class', name: 'Other Class', classId: 'cls-2' }), // wrong class
-      fleetVehicle({ id: 'other-loc', name: 'Other Loc', pickupLocationId: 'loc-9' }), // wrong loc
-      fleetVehicle({ id: 'maint', name: 'In Maintenance', status: 'MAINTENANCE' }), // not available
-    ])
+    renderPanel('CONFIRMED')
 
-    await user.click(screen.getByRole('button', { name: sub.action }))
+    await user.click(screen.getByRole('button', { name: en.cancel }))
+    await user.click(screen.getByRole('button', { name: en.confirm }))
 
-    expect(screen.getByRole('option', { name: /Same Class Same Loc/ })).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /Assigned Car/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /Other Class/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /Other Loc/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /In Maintenance/ })).not.toBeInTheDocument()
+    expect(await screen.findByText(en.cancelled)).toBeInTheDocument()
+    expect(screen.getByText(/TIER_30/)).toBeInTheDocument()
+    expect(fetchMock.mock.calls.some(([u]) => String(u).endsWith('/cancel'))).toBe(true)
+  })
+
+  it('marking active PATCHes the status to ACTIVE after the confirm step', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: { id: 'bk-1', status: 'ACTIVE' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+    renderPanel('CONFIRMED')
+
+    await user.click(screen.getByRole('button', { name: en.markActive }))
+    await user.click(screen.getByRole('button', { name: en.confirm }))
+
+    await vi.waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => String(u).endsWith('/status'))
+      expect(call).toBeTruthy()
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toEqual({ status: 'ACTIVE' })
+    })
   })
 })

--- a/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
@@ -1,154 +1,87 @@
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
-import * as api from '@/vite/operator-bookings/api'
-import {
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
-} from '@/vite/operator-bookings/api'
-import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
-const sub = enMessages.bookings.operator.detail.substitute
+// The dialog reads the session CSRF token and re-runs the route loader on a
+// successful swap; stub both so the test exercises the data flow, not the shell.
+const invalidate = vi.fn().mockResolvedValue(undefined)
+vi.mock('@tanstack/react-router', () => ({ useRouter: () => ({ invalidate }) }))
+vi.mock('@/vite/session', () => ({ useSession: () => ({ data: { csrfToken: 'csrf-1' } }) }))
 
-function candidate(over: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
-  return {
-    id: 'veh-2',
-    operatorId: 'op-1',
-    classId: 'cls-1',
-    pickupLocationId: 'loc-1',
-    name: 'Toyota Aqua',
-    description: null,
-    photos: [],
-    seats: 5,
-    luggageCapacity: 2,
-    luggageSize: 'MEDIUM',
-    transmission: 'AUTO',
-    fuelType: null,
-    licensePlate: 'OSAKA 5678',
-    status: 'AVAILABLE',
-    minRentalHours: null,
-    maxRentalHours: null,
-    advanceBookingHours: null,
-    make: null,
-    model: null,
-    year: null,
-    color: null,
-    dailyRateJpy: 8000,
-    hourlyRateJpy: null,
-    shakenExpiryDate: null,
-    insuranceExpiryDate: null,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    utilization: 0,
-    bookingCountLast30Days: 0,
-    currentBooking: null,
-    nextBooking: null,
-    activeMaintenanceReason: null,
-    ...over,
-  }
+const en = enMessages.bookings.operator.detail.actions
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
 }
 
-function renderDialog(candidates: OperatorFleetVehicle[], queryClient = new QueryClient()) {
-  return render(
-    <QueryClientProvider client={queryClient}>
+function renderDialog() {
+  const onOpenChange = vi.fn()
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <SubstituteVehicleDialog bookingId="bk-1" candidates={candidates} csrfToken="csrf-tok" />
+        <SubstituteVehicleDialog bookingId="bk-1" open onOpenChange={onOpenChange} />
       </IntlProvider>
     </QueryClientProvider>,
   )
+  return { onOpenChange }
 }
 
 afterEach(() => {
+  cleanup()
   vi.restoreAllMocks()
 })
 
 describe('SubstituteVehicleDialog', () => {
-  it('lists candidate vehicles (name + plate) when the trigger is opened', async () => {
+  it('lists the eligible candidates and submits the chosen vehicle id with the CSRF token', async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).includes('substitution-candidates')) {
+        return jsonResponse({
+          success: true,
+          data: [
+            { id: 'veh-2', name: 'Toyota Aqua' },
+            { id: 'veh-3', name: 'Nissan Note' },
+          ],
+        })
+      }
+      return jsonResponse({ success: true, data: { id: 'bk-1', status: 'CONFIRMED' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
     const user = userEvent.setup()
-    renderDialog([
-      candidate(),
-      candidate({ id: 'veh-3', name: 'Mazda 2', licensePlate: 'KYOTO 1' }),
-    ])
+    const { onOpenChange } = renderDialog()
 
-    await user.click(screen.getByRole('button', { name: sub.action }))
-
-    expect(screen.getByRole('option', { name: /Toyota Aqua/ })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /Mazda 2/ })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /OSAKA 5678/ })).toBeInTheDocument()
-  })
-
-  it('submits the picked vehicle id + reason + csrf and invalidates the detail and events queries', async () => {
-    const user = userEvent.setup()
-    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
-    const queryClient = new QueryClient()
-    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
-    renderDialog([candidate(), candidate({ id: 'veh-3', name: 'Mazda 2' })], queryClient)
-
-    await user.click(screen.getByRole('button', { name: sub.action }))
-    await user.selectOptions(screen.getByRole('combobox'), 'veh-3')
-    await user.type(screen.getByLabelText(sub.reasonLabel), 'engine fault')
-    await user.click(screen.getByRole('button', { name: sub.submit }))
+    // Options render only once the candidates query resolves.
+    await screen.findByRole('option', { name: 'Nissan Note' })
+    await user.selectOptions(screen.getByLabelText(en.substituteVehicleLabel), 'veh-3')
+    await user.click(screen.getByRole('button', { name: en.substituteSubmit }))
 
     await waitFor(() =>
-      expect(spy).toHaveBeenCalledWith('bk-1', 'veh-3', 'engine fault', 'csrf-tok'),
+      expect(fetchMock.mock.calls.some(([u]) => String(u).endsWith('/substitute'))).toBe(true),
     )
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: operatorBookingDetailQueryOptions('bk-1').queryKey,
-    })
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: bookingEventsQueryOptions('bk-1').queryKey,
-    })
-    // The dialog closes on success (the picker only renders while it is open).
-    await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument())
+    const subCall = fetchMock.mock.calls.find(([u]) => String(u).endsWith('/substitute'))!
+    const init = subCall[1] as RequestInit
+    expect(JSON.parse(init.body as string)).toEqual({ newVehicleId: 'veh-3' })
+    expect((init.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
-  it('passes null reason when the field is left blank', async () => {
-    const user = userEvent.setup()
-    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
-    renderDialog([candidate()])
+  it('shows an empty state and disables submit when no eligible vehicle is available', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [] })),
+    )
+    renderDialog()
 
-    await user.click(screen.getByRole('button', { name: sub.action }))
-    await user.click(screen.getByRole('button', { name: sub.submit }))
-
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'veh-2', null, 'csrf-tok'))
-  })
-
-  it('collapses a whitespace-only reason to null', async () => {
-    const user = userEvent.setup()
-    const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
-    renderDialog([candidate()])
-
-    await user.click(screen.getByRole('button', { name: sub.action }))
-    await user.type(screen.getByLabelText(sub.reasonLabel), '   ')
-    await user.click(screen.getByRole('button', { name: sub.submit }))
-
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'veh-2', null, 'csrf-tok'))
-  })
-
-  it('shows the empty state and disables submit when there are no candidates', async () => {
-    const user = userEvent.setup()
-    const spy = vi.spyOn(api, 'substituteBooking')
-    renderDialog([])
-
-    await user.click(screen.getByRole('button', { name: sub.action }))
-
-    expect(screen.getByText(sub.noCandidates)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: sub.submit })).toBeDisabled()
-    expect(spy).not.toHaveBeenCalled()
-  })
-
-  it('surfaces an error message when the substitution fails', async () => {
-    const user = userEvent.setup()
-    vi.spyOn(api, 'substituteBooking').mockRejectedValue(new Error('409'))
-    renderDialog([candidate()])
-
-    await user.click(screen.getByRole('button', { name: sub.action }))
-    await user.click(screen.getByRole('button', { name: sub.submit }))
-
-    expect(await screen.findByText(sub.error)).toBeInTheDocument()
+    expect(await screen.findByText(en.substituteEmpty)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: en.substituteSubmit })).toBeDisabled()
   })
 })

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -2,15 +2,19 @@ import { ApiError } from '@/lib/api-error'
 import {
   type OperatorBookingDetailDto,
   bookingEventsQueryOptions,
+  cancelBooking,
   fetchBookingEvents,
   fetchCalendarBookings,
   fetchCalendarVehicles,
   fetchOperatorBookingDetail,
+  fetchSubstitutionCandidates,
   operatorBookingDetailQueryOptions,
   operatorCalendarQueryOptions,
   operatorCalendarVehiclesQueryOptions,
   operatorRowFromDetail,
-  substituteBooking,
+  substituteVehicle,
+  substitutionCandidatesQueryOptions,
+  updateBookingStatus,
 } from '@/vite/operator-bookings/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -349,47 +353,99 @@ describe('operatorCalendarVehiclesQueryOptions', () => {
   })
 })
 
-// #610: operator vehicle substitution. POST /bookings/:id/substitute swaps the
-// assigned car for another AVAILABLE same-class, same-location vehicle. Cookie +
-// CSRF-gated (global csrf()), so the caller echoes the session CSRF token.
-describe('substituteBooking', () => {
-  it('POSTs the substitute endpoint with the new vehicle id, reason, csrf header and credentials', async () => {
+// #616: operator order actions — substitute / cancel / status.
+describe('operator order actions (#616)', () => {
+  const headersOf = (init: unknown) => (init as RequestInit).headers as Record<string, string>
+  const bodyOf = (init: unknown) => JSON.parse((init as RequestInit).body as string)
+
+  it('updateBookingStatus PATCHes /status with the CSRF token, body and credentials', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: detailRaw({ status: 'ACTIVE' }) }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateBookingStatus('bk-1', 'ACTIVE', 'csrf-tok')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/bookings/bk-1/status')
+    expect((init as RequestInit).method).toBe('PATCH')
+    expect((init as RequestInit).credentials).toBe('include')
+    expect(headersOf(init)['X-CSRF-Token']).toBe('csrf-tok')
+    expect(bodyOf(init)).toEqual({ status: 'ACTIVE' })
+  })
+
+  it('substituteVehicle POSTs /substitute with newVehicleId + reason', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await substituteBooking('bk-1', 'veh-2', 'engine fault', 'csrf-tok')
+    await substituteVehicle('bk-1', 'veh-2', 'maintenance', 'csrf-tok')
 
     const [url, init] = fetchMock.mock.calls[0]!
-    const parsed = new URL(url as string, 'http://x')
-    expect(parsed.pathname).toBe('/api/bookings/bk-1/substitute')
-    const request = init as RequestInit
-    expect(request.method).toBe('POST')
-    expect(request.credentials).toBe('include')
-    expect((request.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-tok')
-    expect(JSON.parse(request.body as string)).toEqual({
-      newVehicleId: 'veh-2',
-      reason: 'engine fault',
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/bookings/bk-1/substitute')
+    expect(headersOf(init)['X-CSRF-Token']).toBe('csrf-tok')
+    expect(bodyOf(init)).toEqual({ newVehicleId: 'veh-2', reason: 'maintenance' })
+  })
+
+  it('substituteVehicle omits reason when null', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await substituteVehicle('bk-1', 'veh-2', null, 'csrf-tok')
+
+    expect(bodyOf(fetchMock.mock.calls[0]![1])).toEqual({ newVehicleId: 'veh-2' })
+  })
+
+  it('cancelBooking surfaces the booking and the fee tier from the envelope meta', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: detailRaw({ status: 'CANCELLED' }),
+          cancellation: { tier: 'FREE', feePercentage: 0, feeAmount: 0, refundAmount: 24000 },
+        }),
+      ),
+    )
+
+    const result = await cancelBooking('bk-1', 'csrf-tok')
+
+    expect(result.booking.status).toBe('CANCELLED')
+    expect(result.cancellation).toEqual({
+      tier: 'FREE',
+      feePercentage: 0,
+      feeAmount: 0,
+      refundAmount: 24000,
     })
   })
 
-  it('omits the reason field when none is given (schema reason is optional)', async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: detailRaw() }))
-    vi.stubGlobal('fetch', fetchMock)
-
-    await substituteBooking('bk-1', 'veh-2', null, 'csrf-tok')
-
-    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string)
-    expect(body).toEqual({ newVehicleId: 'veh-2' })
-  })
-
-  it('throws ApiError on a domain failure (e.g. 409 replacement just booked)', async () => {
+  it('cancelBooking throws ApiError on a non-CONFIRMED 409', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => jsonResponse({ success: false, error: 'Vehicle already booked' }, 409)),
+      vi.fn(async () => jsonResponse({ success: false, error: 'Cannot cancel' }, 409)),
     )
 
-    await expect(substituteBooking('bk-1', 'veh-2', null, 'csrf-tok')).rejects.toBeInstanceOf(
-      ApiError,
+    await expect(cancelBooking('bk-1', 'csrf-tok')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('fetchSubstitutionCandidates GETs the candidates endpoint and returns the list', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: [{ id: 'veh-2', name: 'Toyota Aqua' }] }),
     )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await fetchSubstitutionCandidates('bk-1')
+
+    expect(new URL(fetchMock.mock.calls[0]![0] as string, 'http://x').pathname).toBe(
+      '/api/bookings/bk-1/substitution-candidates',
+    )
+    expect(out).toEqual([{ id: 'veh-2', name: 'Toyota Aqua' }])
+  })
+
+  it('keys candidates under the operator-bookings prefix', () => {
+    expect(substitutionCandidatesQueryOptions('bk-1').queryKey).toEqual([
+      'operator-bookings',
+      'substitution-candidates',
+      'bk-1',
+    ])
   })
 })

--- a/packages/web/tests/vite/operator-bookings/booking-actions.test.ts
+++ b/packages/web/tests/vite/operator-bookings/booking-actions.test.ts
@@ -1,0 +1,55 @@
+import { OPERATOR_BOOKING_TRANSITIONS, actionsFor } from '@/vite/operator-bookings/booking-actions'
+import { VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
+import { describe, expect, it } from 'vitest'
+
+// Parity guard: the component module keeps a LOCAL transition map so it never
+// value-imports the drizzle schema (which would bundle drizzle-orm into the
+// browser). This test imports the schema map — node-only, never bundled — so the
+// schema stays the source of truth and any drift fails CI.
+describe('OPERATOR_BOOKING_TRANSITIONS', () => {
+  it('mirrors the schema state machine (VALID_BOOKING_TRANSITIONS) exactly', () => {
+    expect(OPERATOR_BOOKING_TRANSITIONS).toEqual(VALID_BOOKING_TRANSITIONS)
+  })
+})
+
+// #616: the operator Actions panel derives its buttons from this pure gate, NOT
+// from VALID_BOOKING_TRANSITIONS alone — substitute and cancel follow their own
+// backend rules (substitute: CONFIRMED|ACTIVE; cancel: CONFIRMED-only, the
+// fee-bearing endpoint that 409s on ACTIVE).
+describe('actionsFor', () => {
+  it('CONFIRMED → mark-active + substitute + cancel (no mark-completed)', () => {
+    expect(actionsFor('CONFIRMED')).toEqual({
+      markActive: true,
+      markCompleted: false,
+      substitute: true,
+      cancel: true,
+    })
+  })
+
+  it('ACTIVE → mark-completed + substitute, but NOT cancel (the fee endpoint is CONFIRMED-only)', () => {
+    expect(actionsFor('ACTIVE')).toEqual({
+      markActive: false,
+      markCompleted: true,
+      substitute: true,
+      cancel: false,
+    })
+  })
+
+  it('COMPLETED → no actions (terminal)', () => {
+    expect(actionsFor('COMPLETED')).toEqual({
+      markActive: false,
+      markCompleted: false,
+      substitute: false,
+      cancel: false,
+    })
+  })
+
+  it('CANCELLED → no actions (terminal)', () => {
+    expect(actionsFor('CANCELLED')).toEqual({
+      markActive: false,
+      markCompleted: false,
+      substitute: false,
+      cancel: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Last canonical MVP gap: operator order-management actions on the trip-detail page. Operators can now drive a booking's lifecycle (status transitions + fee-bearing cancel) and substitute the assigned vehicle from a server-vetted candidate list.

Closes #616
Closes #621

## What's in it

**API (`5515a8d`)**
- New `GET /bookings/:id/substitution-candidates` — operator-gated, tenant-scoped (404 on cross-tenant). Returns AVAILABLE vehicles in the same store + ACRISS class, excluding the currently assigned one.
- Result types moved to `services/booking-results.ts` to keep `booking.ts` under the 800-line `lint:size` cap.
- Candidate matching keys on the server-resolved ACRISS code, not raw classId (closes #621).

**Web (`153c882`)**
- `BookingActionsPanel` — status transitions + fee-bearing cancel (tiered cancellation fee surfaced).
- `SubstituteVehicleDialog` rewired to the new server endpoint (replaces #610's client-side candidate logic).
- CSRF-aware API clients; dropped the now-dead #610 `substituteBooking` path and duplicate badge.
- **Bundle fix:** `booking-actions.ts` uses a local `OPERATOR_BOOKING_TRANSITIONS` map plus a node-only parity test against the schema, so no `drizzle-orm` is pulled into the browser bundle. Verified: `_bookingId` chunk is 9.8 kB (down from 66 kB) and `grep drizzle-orm dist` is empty.

## Verification (post-rebase onto trunk)

- tsc: 0 errors (shared/api/web)
- API tests: 1254 passed
- Web tests: 1083 passed
- i18n parity: 881 keys × 3 locales
- module + API import boundaries: clean
- prod build: success, no `drizzle-orm` in `packages/web/dist`

## Notes

- Base is `marketplace-pivot` (not the default branch) — issues closed manually on merge.
- Manual browser smoke (operator booking → mark active → substitute → timeline shows VEHICLE_SUBSTITUTED; cancel CONFIRMED shows fee tier) not yet done.
- `booking.ts` sits at 798/800 — any further API growth there re-trips the size cap.