### PR TITLE
fix(api): operator-only gate on PATCH /bookings/:id/status (#643)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -181,6 +181,16 @@ export function createBookingRoutes(service: BookingService) {
     .patch('/bookings/:id/status', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
+      // #643: status transitions (CONFIRMED -> ACTIVE -> COMPLETED) are physical
+      // pickup/return events driven by the operator, not the renter. Row-scoping
+      // alone would let a renter self-advance their own booking via the raw API,
+      // skewing operator dashboards and any settlement keyed off status. Gate on
+      // management roles (operators + staff/admin); renter self-cancel stays open
+      // on /cancel by design (tiered cancellation is a renter-facing feature).
+      if (!MANAGEMENT_READ_ROLES.has(ctx.role)) {
+        return fail(c, 'Only operators can update booking status', 403)
+      }
+
       const parsed = await parseBody(c, updateBookingStatusSchema)
       if (!parsed.ok) return parsed.response
 

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1127,6 +1127,33 @@ describe('Booking Routes', () => {
       expect(body.success).toBe(false)
       expect(body.error).toBe('Booking not found')
     })
+
+    it('forbids a RENTER from advancing status on their own booking (403, #643)', async () => {
+      // Booking is owned by USER1 (the renter), so row-scoping admits the call —
+      // a 403 can therefore only come from the function-level role gate, not from
+      // ownership. Pickup/return (CONFIRMED -> ACTIVE -> COMPLETED) are physical
+      // operator events; a renter must not self-advance via the raw API.
+      const created = await (await createBooking()).json()
+
+      const renterApp = new Hono()
+      renterApp.use('*', testAuthMiddleware(USER1, 'RENTER'))
+      renterApp.route('/', createBookingRoutes(service))
+
+      const res = await renterApp.request(`/bookings/${created.data.id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'ACTIVE' }),
+      })
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+
+      // The transition must not have been applied — proves the gate blocks the
+      // action, not just the response code.
+      const after = await (await app.request(`/bookings/${created.data.id}`)).json()
+      expect(after.data.status).toBe('CONFIRMED')
+    })
   })
 
   describe('POST /bookings/:id/cancel', () => {


### PR DESCRIPTION
## Problem
`PATCH /bookings/:id/status` applied only row-scoping (`bookingReadScope`), no role gate. A **RENTER scoped to their own booking could self-advance** `CONFIRMED → ACTIVE → COMPLETED` via the raw API. Pickup/return are physical operator events; this is broken function-level access control (OWASP API5) — a renter could skew operator dashboards and any settlement keyed off status.

Pre-existing on `marketplace-pivot`, surfaced during #616 review — **not a #642 regression**.

## Fix
Gate `/status` on `MANAGEMENT_READ_ROLES` (operators + staff/admin), mirroring `/substitute` and `/substitution-candidates`. The gate runs before body-parse / service call.

- `POST /bookings/:id/cancel` is **intentionally left open** — renter self-cancel is the tiered-cancellation product feature (72h free / 48h 30% / …). Row-scoping + fee tier still apply.
- The only web caller of this endpoint is the operator bookings UI (`operator-bookings/api.ts`), whose users hold management roles — legit flow unaffected.

## Test (RED → GREEN)
New test: a renter advancing **their own** booking (so row-scoping admits the call — a 403 can only come from the role gate) now 403s, and the booking stays `CONFIRMED` (proves the action was blocked, not just the response code).

## Verification
- `vitest run` (CI unit lane): **1264 pass, 0 fail** — bookings suite 75/75
- tsc clean · import boundaries OK · biome clean
- (Integration tests need a live DB; run in CI's separate `test:integration` job.)

## Follow-up
Code review flagged a non-blocking MEDIUM: `/substitute` uses the narrower `isOperatorRole` while `/status` uses `MANAGEMENT_READ_ROLES`. Filing a follow-up to consciously reconcile the booking-write role model rather than letting it diverge per-route.

Closes #643