### PR TITLE
test(e2e): capture /admin/revenue in the demo-walkthrough gate (#645)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
       - name: Seed the marketplace fixture over TCP
         # db:seed:tcp uses postgres-js (TCP); the production neon-http getDb()
         # cannot reach a plain postgres:16 container.
+        env:
+          # Grant the walkthrough admin persona PLATFORM_ADMIN so it can reach the
+          # env-gated /admin/revenue tab (#462). Mirror of ADMIN_SEED_EMAIL in
+          # e2e/real-db/constants.ts — yaml can't import TS; keep them in sync.
+          PLATFORM_ADMIN_EMAILS: platform-admin@kuruma.test
         run: bun run db:seed:tcp
 
       - name: Run authenticated real-DB E2E

--- a/e2e/real-db/auth.setup.ts
+++ b/e2e/real-db/auth.setup.ts
@@ -1,8 +1,9 @@
 import type { BrowserContext } from '@playwright/test'
 import { test as setup } from '@playwright/test'
-import { OPERATOR_STORAGE_STATE, RENTER_STORAGE_STATE } from './constants'
+import { ADMIN_STORAGE_STATE, OPERATOR_STORAGE_STATE, RENTER_STORAGE_STATE } from './constants'
 import {
   SESSION_COOKIE_NAME,
+  mintAdminSessionToken,
   mintOperatorSessionToken,
   mintRenterSessionToken,
 } from './mint-session'
@@ -34,4 +35,8 @@ setup('mint operator session cookie', async ({ context }) => {
 
 setup('mint renter session cookie', async ({ context }) => {
   await saveSession(context, await mintRenterSessionToken(), RENTER_STORAGE_STATE)
+})
+
+setup('mint platform-admin session cookie', async ({ context }) => {
+  await saveSession(context, await mintAdminSessionToken(), ADMIN_STORAGE_STATE)
 })

--- a/e2e/real-db/constants.ts
+++ b/e2e/real-db/constants.ts
@@ -8,3 +8,14 @@ export const OPERATOR_STORAGE_STATE = STORAGE_STATE
 // Renter (RENTER) session — the marketplace happy-path spec attaches this to a
 // second browser context so steps 1-5 run as the booking renter (#390).
 export const RENTER_STORAGE_STATE = 'e2e/.auth/renter.json'
+
+// Platform-admin (PLATFORM_ADMIN) session — the demo walkthrough attaches this
+// to a third context so it can capture the env-gated /admin/revenue tab (#462).
+export const ADMIN_STORAGE_STATE = 'e2e/.auth/admin.json'
+
+// The seed grants this email PLATFORM_ADMIN when it appears in PLATFORM_ADMIN_EMAILS
+// (seed.ts §3). SINGLE SOURCE OF TRUTH: the local runner + mint-session read it
+// here so the seeded admin and the minted token never drift. The CI workflow
+// duplicates the literal in ci.yml's seed step (yaml can't import TS) — keep them
+// in sync.
+export const ADMIN_SEED_EMAIL = 'platform-admin@kuruma.test'

--- a/e2e/real-db/demo-walkthrough.auth.spec.ts
+++ b/e2e/real-db/demo-walkthrough.auth.spec.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from 'node:fs'
 import { writeFileSync } from 'node:fs'
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
-import { RENTER_STORAGE_STATE } from './constants'
+import { ADMIN_STORAGE_STATE, RENTER_STORAGE_STATE } from './constants'
 
 // Dev-only console noise that is never a demo defect — exclude so the gate stays
 // mutation-resistant (fails on real regressions, not React/Vite chatter).
@@ -211,6 +211,19 @@ test.describe('#509 demo walkthrough — capture every page', () => {
     await capture(renter, '10-renter-home', '/en')
     await capture(renter, '11-renter-search', '/en/search')
     await capture(renter, '12-renter-mybookings', '/en/bookings')
+    await ctx.close()
+  })
+
+  // #462 — platform-admin partner-revenue tab. Lives behind the _admin guard
+  // (PLATFORM_ADMIN only), so it gets its own env-gated admin context rather than
+  // the default operator/renter sessions. #627 seeds payment_events so the tab
+  // shows real data; an empty payment_events still renders clean, so the gate is
+  // robust either way — the assertion is "renders without guard redirect / 403".
+  test('platform-admin surface — revenue tab', async ({ browser, baseURL }) => {
+    test.setTimeout(120_000)
+    const ctx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE, baseURL })
+    const admin = await ctx.newPage()
+    await capture(admin, '13-admin-revenue', '/en/admin/revenue')
     await ctx.close()
   })
 })

--- a/e2e/real-db/mint-session.ts
+++ b/e2e/real-db/mint-session.ts
@@ -1,3 +1,4 @@
+import { ADMIN_SEED_EMAIL } from './constants'
 import { testSql } from './pg'
 
 // The Vite/CF-Pages stack (#378) authenticates the browser with the API's own
@@ -38,6 +39,16 @@ const RENTER = {
   role: 'RENTER',
 } as const
 
+// Platform-admin persona (#462 revenue tab). Email mirrors PLATFORM_ADMIN_EMAILS
+// fed to the seed (ADMIN_SEED_EMAIL), which upserts it as role PLATFORM_ADMIN
+// with operatorId = null — so its token omits the tenant claim, matching a real
+// admin who belongs to no operator (proposal §6.2).
+const ADMIN = {
+  email: ADMIN_SEED_EMAIL,
+  name: 'Platform Admin',
+  role: 'PLATFORM_ADMIN',
+} as const
+
 /** Look up a seeded user's id + tenant (operatorId) by its stable seed email. */
 async function findUser(email: string): Promise<{ id: string; operatorId: string | null }> {
   const sql = testSql()
@@ -58,7 +69,7 @@ async function findUser(email: string): Promise<{ id: string; operatorId: string
 interface SessionIdentity {
   email: string
   name: string
-  role: 'RENTER' | 'OPERATOR_OWNER'
+  role: 'RENTER' | 'OPERATOR_OWNER' | 'PLATFORM_ADMIN'
 }
 
 /**
@@ -103,4 +114,9 @@ export function mintOperatorSessionToken(): Promise<string> {
 /** Session cookie value for the seeded RENTER persona (Sarah Smith). */
 export function mintRenterSessionToken(): Promise<string> {
   return mintSession(RENTER)
+}
+
+/** Session cookie value for the seeded PLATFORM_ADMIN persona (#462 revenue tab). */
+export function mintAdminSessionToken(): Promise<string> {
+  return mintSession(ADMIN)
 }

--- a/scripts/e2e-real-db-local.ts
+++ b/scripts/e2e-real-db-local.ts
@@ -1,4 +1,5 @@
 import { $ } from 'bun'
+import { ADMIN_SEED_EMAIL } from '../e2e/real-db/constants'
 
 /**
  * One-shot local real-DB e2e (#542): boots a disposable `postgres:16`, applies
@@ -26,6 +27,9 @@ const env = {
   // Any 32+ char string: the harness mints the session cookie and the API
   // verifies it with the SAME value. Not a secret — the DB is local + disposable.
   AUTH_SECRET: process.env.AUTH_SECRET ?? 'local-real-db-e2e-static-secret-0123456789',
+  // Grant the demo-walkthrough admin persona PLATFORM_ADMIN so it can reach the
+  // env-gated /admin/revenue tab (#462). seed.ts §3 upserts this email as admin.
+  PLATFORM_ADMIN_EMAILS: ADMIN_SEED_EMAIL,
 }
 
 console.log(`[e2e] (re)creating disposable postgres:16 (${CONTAINER}) on :${PORT}`)


### PR DESCRIPTION
## What

Slice 2 of #637 — adds the platform-admin **partner-revenue tab** (#462) to the real-DB demo-walkthrough gate (`e2e/real-db/demo-walkthrough.auth.spec.ts`). Slice 1 (#641) covered vehicle-detail (#527) + trip-detail (#610).

Unlike the operator/renter pages, `/admin/revenue` sits behind the `_admin` guard (PLATFORM_ADMIN only), so it needs an **env-gated admin session**:

- `constants.ts` — `ADMIN_STORAGE_STATE` + `ADMIN_SEED_EMAIL` (single source of truth for the admin email)
- `mint-session.ts` — `ADMIN` persona + `mintAdminSessionToken()` (role `PLATFORM_ADMIN`, `operatorId: null` so the token omits the tenant claim); widened the `SessionIdentity` role union
- `auth.setup.ts` — new setup step mints the admin cookie to `ADMIN_STORAGE_STATE`
- `demo-walkthrough.auth.spec.ts` — new test captures `/en/admin/revenue` in a 3rd browser context
- `scripts/e2e-real-db-local.ts` + `.github/workflows/ci.yml` — feed `PLATFORM_ADMIN_EMAILS` to the seed step so the persona is granted `PLATFORM_ADMIN`

The capture's load-bearing assertion is `redirected: false` — a wrong-role visitor would bounce off the `_admin` guard, so this proves the admin session reaches the gated route (plus the existing no-4xx/5xx / no-console-error / ready-selector checks). It deliberately does **not** assert specific revenue figures — #627 seeds `payment_events` for real data, but the tab renders clean on empty data too, so the gate is robust either way.

## Test plan

- [x] `bun run test:e2e:real-db:local` — **7/7 green**; `13-admin-revenue -> /en/admin/revenue` passes with no redirect / no HTTP errors / no console errors (36.9s)
- [x] Pre-commit hooks: biome, lint:size, lint:modules, tsc (web + api) all pass
- [x] code-reviewer: SHIP (no CRITICAL/HIGH/MEDIUM)
- [ ] CI `e2e-real-db` job green on the seeded-admin path

Closes #645