### PR TITLE
docs(api): document booking-write authz model (Model C) (#647)

### DIFF
--- a/docs/architecture/booking-authz.md
+++ b/docs/architecture/booking-authz.md
@@ -1,0 +1,60 @@
+# Booking-Write Authorization Model
+
+Canonical rules for who may invoke each booking endpoint, and why the gates are
+**not uniform**. The booking routes carry a deliberate asymmetry — the read-feed
+and status routes admit platform staff, but `/substitute` is operator-only. This
+doc records the intent (#647) so a later reader does not "harmonize" the gates
+into one set and silently change behavior.
+
+The route gate is **not** the tenant boundary. Every booking query is row-scoped
+by `CallerContext` in the repository (#386 F2 / #397): an operator only ever sees
+or mutates its own tenant's bookings, a renter only its own. The gates below are
+correct-actor semantics plus defense-in-depth on top of that scoping — never the
+thing that stops a cross-tenant read.
+
+## Role sets
+
+Defined in `packages/api/src/middleware/auth.ts`:
+
+| Set | Members |
+|-----|---------|
+| `isOperatorRole` (`OPERATOR_ROLES`) | `OPERATOR_OWNER`, `OPERATOR_STAFF` |
+| `STAFF_ROLES` | `STAFF`, `ADMIN`, `PLATFORM_ADMIN` |
+| `MANAGEMENT_READ_ROLES` | `STAFF_ROLES` ∪ operators — everything except `RENTER` and `PARTNER` |
+
+`RENTER` is the customer. `PARTNER` is a 3rd-party API caller (Trip.com).
+
+## The map
+
+| Route | Enforced at | Gate | Rationale |
+|-------|-------------|------|-----------|
+| `POST /bookings` | route | any authed user (books for self) | Instant-book. Only `STAFF_ROLES` may set `renterId` / `source=MANUAL` (on-behalf). Operators are excluded from on-behalf: `UserRepository` is not tenant-scoped, so letting an operator resolve an arbitrary `renterId` reopens the #396 cross-tenant user-enumeration vector. A `RENTER` must accept the liability disclaimer (#613). |
+| `PATCH /:id/status` | route | `MANAGEMENT_READ_ROLES` | Lifecycle advance (`CONFIRMED → ACTIVE → COMPLETED`) is a physical pickup/return event — operational, so platform support (STAFF/ADMIN) is admitted alongside operators. Row-scoping alone would let a renter self-advance via the raw API and skew dashboards / settlement (#643). |
+| `POST /:id/cancel` | service | renter (own) + management | Tiered cancellation (72h / 48h / 24h / same-day) is a renter-facing feature, so there is no route gate; the service authorizes renter-own plus management. |
+| `POST /:id/substitute` | route | `isOperatorRole` | Choosing which car serves a booking is a **fleet-ownership** decision, named to the operator in the marketplace proposal (§321 / §345). There is no admin substitute UI and the audit `actorId` assumes an operator, so platform staff are deliberately excluded. |
+| `GET /:id/substitution-candidates` | route | `isOperatorRole` | Feeds the substitute write only — inherits its gate (see below). |
+| `GET /:id/events` | route | `MANAGEMENT_READ_ROLES` | The lifecycle log exposes `actorId`, internal vehicle ids and substitution reasons. No renter UI consumes a timeline, so renters are rejected (403) rather than served a sanitized projection (§549). |
+
+## Two principles
+
+**A feeder-read inherits its write's gate.** `GET /:id/substitution-candidates`
+exists solely to populate the operator's substitute dialog. It is gated
+`isOperatorRole`, identically to the `POST /:id/substitute` it feeds — never
+looser. When you add a read that exists only to drive one write, gate it like
+the write.
+
+**The status/substitute asymmetry is intentional.** `/status` admits
+`MANAGEMENT_READ_ROLES` while the more-destructive `/substitute` is
+`isOperatorRole`-only. This is not an oversight. The two gates encode different
+concerns: status advance is *operational* (support coordinates pickup / return,
+so platform staff are in); substitution is *fleet ownership* (only the operator
+that owns the car decides, so platform staff are out). Operators are in both
+sets — the only difference is whether platform staff are admitted, and that
+tracks operational-support vs. ownership, not "how destructive." Do not collapse
+the two onto one set.
+
+## PARTNER (Trip.com)
+
+`PARTNER` can `POST /bookings` (it is a booking source) but is excluded from
+`/status`, `/substitute`, `/substitution-candidates`, and `/events`: a 3rd-party
+caller books, it does not manage the order or read internal lifecycle data.

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -101,6 +101,7 @@ export function createBookingRoutes(service: BookingService) {
       // internal vehicle ids and the substitution reason; no renter UI consumes
       // a timeline today, so renters are rejected here (403) rather than served a
       // sanitized projection. Cross-tenant reads still 404 at the service.
+      // authz model: docs/architecture/booking-authz.md
       if (!MANAGEMENT_READ_ROLES.has(ctx.role)) {
         return fail(c, 'Only operators can view booking events', 403)
       }
@@ -117,6 +118,7 @@ export function createBookingRoutes(service: BookingService) {
 
       // §A: operator-only, mirroring the substitute route. Renters never browse
       // the fleet (403); a foreign/missing booking 404s at the service (no leak).
+      // authz model: docs/architecture/booking-authz.md (feeder-read inherits its write's gate)
       if (!isOperatorRole(ctx.role)) {
         return fail(c, 'Only operators can view substitution candidates', 403)
       }
@@ -187,6 +189,7 @@ export function createBookingRoutes(service: BookingService) {
       // skewing operator dashboards and any settlement keyed off status. Gate on
       // management roles (operators + staff/admin); renter self-cancel stays open
       // on /cancel by design (tiered cancellation is a renter-facing feature).
+      // authz model: docs/architecture/booking-authz.md
       if (!MANAGEMENT_READ_ROLES.has(ctx.role)) {
         return fail(c, 'Only operators can update booking status', 403)
       }
@@ -216,6 +219,7 @@ export function createBookingRoutes(service: BookingService) {
 
       // §5.5: substitution is operator-only. Renters never reassign their own
       // vehicle (403). Cross-operator bookings 404 at the service (no leak).
+      // authz model: docs/architecture/booking-authz.md (deliberately stricter than /status)
       if (!isOperatorRole(ctx.role)) {
         return fail(c, 'Only operators can substitute a vehicle', 403)
       }

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1017,10 +1017,11 @@ describe('Booking Routes', () => {
         ).id
 
         const res = await createBooking(
+          // Use validBookingInput's single-`now` anchored 24h window. Overriding
+          // with two separate futureDate() calls reintroduces the few-ms gap that
+          // Math.ceil() in pricing rounds up to 2 days (see the helper comment).
           validBookingInput({
             requestedVehicleId: vehicleId,
-            startAt: futureDate(48),
-            endAt: futureDate(72),
             totalPrice: 1, // attacker-controlled — must be stripped + ignored
           }),
         )

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1347,6 +1347,134 @@ describe('Booking Routes', () => {
     })
   })
 
+  // #647: the booking-write authorization model as an executable table. Each row
+  // is one (role, route) -> outcome cell of the policy documented in
+  // docs/architecture/booking-authz.md: status advance is management-wide
+  // (operators + platform staff/admin); substitution and its candidate feed are
+  // operator-only (choosing which car serves a booking is a fleet-ownership
+  // decision). The matrix is the single source for the asymmetry — a future
+  // change that "aligns" the gates turns exactly the offending row red.
+  describe('booking-write authorization model (#647)', () => {
+    function operatorApp() {
+      const a = new Hono()
+      a.use('*', testAuthMiddleware(OP_USER, 'OPERATOR_OWNER', OPERATOR))
+      a.route('/', createBookingRoutes(service))
+      return a
+    }
+    function renterApp() {
+      const a = new Hono()
+      a.use('*', testAuthMiddleware(USER1, 'RENTER'))
+      a.route('/', createBookingRoutes(service))
+      return a
+    }
+    async function freshBookingId(): Promise<string> {
+      const res = await createBooking(validBookingInput())
+      const body = await res.json()
+      return body.data.id as string
+    }
+
+    // `gate` is the authorization outcome only: 'deny' MUST 403 at the route gate
+    // before any business logic; 'allow' MUST pass the gate (any non-403 — the
+    // 200/400/404 business result is covered by the dedicated route tests above).
+    // Coupling an authz assertion to vehicle-availability would make the policy
+    // test brittle, so we assert the gate decision, nothing more.
+    const MODEL: ReadonlyArray<{
+      label: string
+      app: () => Hono
+      method: string
+      path: (id: string) => string
+      body?: Record<string, unknown>
+      gate: 'allow' | 'deny'
+    }> = [
+      // PATCH /status — management-wide (operators + platform staff/admin)
+      {
+        label: 'ADMIN (management) is allowed status advance',
+        app: () => app,
+        method: 'PATCH',
+        path: (id) => `/bookings/${id}/status`,
+        body: { status: 'ACTIVE' },
+        gate: 'allow',
+      },
+      {
+        label: 'OPERATOR is allowed status advance',
+        app: operatorApp,
+        method: 'PATCH',
+        path: (id) => `/bookings/${id}/status`,
+        body: { status: 'ACTIVE' },
+        gate: 'allow',
+      },
+      {
+        label: 'RENTER is denied status advance on own booking',
+        app: renterApp,
+        method: 'PATCH',
+        path: (id) => `/bookings/${id}/status`,
+        body: { status: 'ACTIVE' },
+        gate: 'deny',
+      },
+      // POST /substitute — operator-only (fleet-ownership decision)
+      {
+        label: 'ADMIN (management) is denied substitute',
+        app: () => app,
+        method: 'POST',
+        path: (id) => `/bookings/${id}/substitute`,
+        body: { newVehicleId: seededVehicle2Id },
+        gate: 'deny',
+      },
+      {
+        label: 'OPERATOR is allowed substitute',
+        app: operatorApp,
+        method: 'POST',
+        path: (id) => `/bookings/${id}/substitute`,
+        body: { newVehicleId: seededVehicle2Id },
+        gate: 'allow',
+      },
+      {
+        label: 'RENTER is denied substitute',
+        app: renterApp,
+        method: 'POST',
+        path: (id) => `/bookings/${id}/substitute`,
+        body: { newVehicleId: seededVehicle2Id },
+        gate: 'deny',
+      },
+      // GET /substitution-candidates — operator-only (inherits substitute's gate)
+      {
+        label: 'ADMIN (management) is denied candidate list',
+        app: () => app,
+        method: 'GET',
+        path: (id) => `/bookings/${id}/substitution-candidates`,
+        gate: 'deny',
+      },
+      {
+        label: 'OPERATOR is allowed candidate list',
+        app: operatorApp,
+        method: 'GET',
+        path: (id) => `/bookings/${id}/substitution-candidates`,
+        gate: 'allow',
+      },
+      {
+        label: 'RENTER is denied candidate list',
+        app: renterApp,
+        method: 'GET',
+        path: (id) => `/bookings/${id}/substitution-candidates`,
+        gate: 'deny',
+      },
+    ]
+
+    it.each(MODEL)('$label ($gate)', async ({ app: makeApp, method, path, body, gate }) => {
+      const id = await freshBookingId()
+      const res = await makeApp().request(path(id), {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      })
+      if (gate === 'deny') {
+        expect(res.status).toBe(403)
+      } else {
+        expect(res.status).not.toBe(403)
+      }
+    })
+  })
+
   describe('GET /bookings/:id/substitution-candidates', () => {
     // An OPERATOR_OWNER app scoped to the booking's operator tenant.
     function operatorApp() {


### PR DESCRIPTION
## What

Makes the booking-route gate **asymmetry intentional and enforced** — no behavior change. `PATCH /:id/status` admits `MANAGEMENT_READ_ROLES` while the more-destructive `POST /:id/substitute` (and its candidate feed) are operator-only. The split arose per-route; this records it as **Model C** so it isn't "harmonized" into one set later.

## Changes

- **`docs/architecture/booking-authz.md`** (new) — the 6-route authz map, role sets, the *"feeder-read inherits its write's gate"* principle, the deliberate status/substitute asymmetry, and the PARTNER note. New file, not an extension of `modules.md` (per architect review).
- **Executable matrix test** (`718073f`) — `test.each` role×route gate-decision matrix locking Model C (deny→403, allow→not-403, decoupled from business validity).
- **Gate-comment anchors** — each of the 4 gated routes in `bookings.ts` now points to the doc (minimal churn).
- **Flake fix** (`51dccbe`, pre-existing / unrelated to #647) — the server-side pricing test overrode `validBookingInput`'s anchored dates with two separate `futureDate()` calls; the few-ms gap made `Math.ceil(ms / MS_PER_DAY)` round a 24h window up to 2 days (20000 vs 10000). Surfaced while running the suite; fixed by using the helper's single-`now` window (the pattern its own comment prescribes).

## Why there's no security gap

The route gate is **not** the tenant boundary — the repository row-scopes every booking query by `CallerContext` (#386 F2 / #397). The gates are correct-actor semantics + defense-in-depth, so admitting platform staff to `/status` but not `/substitute` changes *who can act*, never *who can cross tenants*.

## Test plan

- [x] `bun run --filter @kuruma/api test` — **1273/1273**
- [x] `tsc --noEmit` — 0 errors
- [x] `lint:modules` + api `lint:boundaries` — clean
- [x] biome — clean
- Architect reviewed the plan (APPROVE-WITH-CHANGES; all 6 changes folded in).

Closes #647
