### PR TITLE
fix(web): map tile provider + attribution — stop defaulting to public OSM (#660)

### DIFF
--- a/packages/web/src/vite/search/PigeonMapAdapter.tsx
+++ b/packages/web/src/vite/search/PigeonMapAdapter.tsx
@@ -9,6 +9,28 @@ import { type Pin, computeViewport } from './viewport'
 const MARKER_COLOR = '#6b7280'
 const SELECTED_COLOR = '#2563eb'
 
+// Explicit basemap provider (#660). Without one, pigeon-maps falls back to the
+// public OpenStreetMap tile server, which the OSMF tile-usage policy bars from
+// production/commercial reliance (no SLA, requires attribution). GSI (Geospatial
+// Information Authority of Japan) std raster tiles are free for commercial web
+// use with the credit "出典: 国土地理院". https://maps.gsi.go.jp/development/ichiran.html
+export function gsiTileProvider(x: number, y: number, z: number): string {
+  return `https://cyberjapandata.gsi.go.jp/xyz/std/${z}/${x}/${y}.png`
+}
+
+const GSI_ATTRIBUTION = (
+  <span>
+    出典:{' '}
+    <a
+      href="https://maps.gsi.go.jp/development/ichiran.html"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      国土地理院
+    </a>
+  </span>
+)
+
 /** Concrete `MapAdapter` (#458). Maps each geocoded result to a pigeon-maps
  *  `<Marker>`; a marker click reports its location id back to the view. The
  *  viewport is fit to ALL pins so a Kansai-wide result set isn't pinned to one
@@ -28,6 +50,9 @@ export function PigeonMapAdapter({ items, selectedId, onSelect }: MapAdapterProp
   return (
     <PigeonMap
       key={pins.map((p) => p.id).join(',')}
+      provider={gsiTileProvider}
+      attribution={GSI_ATTRIBUTION}
+      attributionPrefix={false}
       defaultCenter={viewport.center}
       defaultZoom={viewport.zoom}
     >

--- a/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
+++ b/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
@@ -1,13 +1,28 @@
-import { PigeonMapAdapter } from '@/vite/search/PigeonMapAdapter'
+import { PigeonMapAdapter, gsiTileProvider } from '@/vite/search/PigeonMapAdapter'
 import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-// Mock pigeon-maps → no real tiles in happy-dom. Assert only the adapter's
-// mapping of props → <Marker> components (the design's seam, not tile rendering).
+// Mock pigeon-maps → no real tiles in happy-dom. Assert the adapter's mapping of
+// props → <Marker> components (the design's seam) plus the tile `provider` +
+// `attribution` it configures (#660). The fake Map calls `provider` with a sample
+// z/x/y so the test can read back the URL the real library would request.
 vi.mock('pigeon-maps', () => ({
-  Map: ({ children }: { children: ReactNode }) => <div data-testid="pigeon-map">{children}</div>,
+  Map: ({
+    children,
+    provider,
+    attribution,
+  }: {
+    children: ReactNode
+    provider?: (x: number, y: number, z: number) => string
+    attribution?: ReactNode
+  }) => (
+    <div data-testid="pigeon-map" data-tile-url={provider ? provider(3, 5, 12) : ''}>
+      {attribution}
+      {children}
+    </div>
+  ),
   Marker: ({
     anchor,
     onClick,
@@ -120,5 +135,38 @@ describe('PigeonMapAdapter', () => {
 
     const markers = screen.getAllByTestId('marker')
     expect(markers[0]?.getAttribute('data-color')).not.toBe(markers[1]?.getAttribute('data-color'))
+  })
+
+  it('configures an explicit GSI tile provider, not the default public OSM server (#660)', () => {
+    render(
+      <PigeonMapAdapter
+        items={[carAt('loc_namba', { latitude: 34.6627, longitude: 135.5023 })]}
+        selectedId={null}
+        onSelect={() => {}}
+      />,
+    )
+
+    const tileUrl = screen.getByTestId('pigeon-map').getAttribute('data-tile-url') ?? ''
+    expect(tileUrl).toContain('cyberjapandata.gsi.go.jp')
+    expect(tileUrl).not.toContain('tile.openstreetmap.org')
+  })
+
+  it('renders a visible basemap attribution crediting the tile source (#660)', () => {
+    render(
+      <PigeonMapAdapter
+        items={[carAt('loc_namba', { latitude: 34.6627, longitude: 135.5023 })]}
+        selectedId={null}
+        onSelect={() => {}}
+      />,
+    )
+
+    const credit = screen.getByRole('link', { name: '国土地理院' })
+    expect(credit.getAttribute('href')).toContain('gsi.go.jp')
+  })
+})
+
+describe('gsiTileProvider', () => {
+  it('builds the GSI std raster tile URL in {z}/{x}/{y} order', () => {
+    expect(gsiTileProvider(3, 5, 12)).toBe('https://cyberjapandata.gsi.go.jp/xyz/std/12/3/5.png')
   })
 })


### PR DESCRIPTION
## What

Fixes #660 (P1). `PigeonMapAdapter` passed **no tile `provider`** to pigeon-maps, so the renter search map fell back to the **public OpenStreetMap tile server** (`tile.openstreetmap.org`) and rendered **no attribution**. The [OSMF tile-usage policy](https://operations.osmfoundation.org/policies/tiles/) bars that server from production/commercial reliance (no SLA, attribution required, can be blocked) — a real pre-production defect.

## Fix
- Add `gsiTileProvider(x, y, z)` → **GSI** (Geospatial Information Authority of Japan) std raster tiles (`cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png`) — free for commercial web use, no API key.
- Render a visible `出典: 国土地理院` attribution (linked) and drop the pigeon-maps prefix (`attributionPrefix={false}`).
- pigeon-maps stays imported in **this one file only**, preserving the #458 `MapAdapter` port/adapter boundary.

## Acceptance criteria
- [x] Map renders from an explicitly configured provider, not the default public OSM server.
- [x] Visible attribution shown (出典: 国土地理院, linked to GSI terms).
- [x] One-file change — `MapAdapter` abstraction preserved.

## Test plan
- [x] `PigeonMapAdapter.test.tsx`: new tests assert the exact GSI URL (`.../std/12/3/5.png` — pins {z}/{x}/{y} order), the provider is GSI not OSM, and the attribution link is present by role + href. 7/7 pass.
- [x] Full web suite: **1106/1106**; web `tsc` clean; biome clean.
- [x] code-reviewer: **SHIP** (no CRITICAL/HIGH/MEDIUM).
- [ ] CI green.

## Notes
- GSI tiles are kanji-labeled. For the international-tourist audience an English-labeled basemap (keyed provider e.g. MapTiler/Stadia) may be preferable later — that needs an API key/secret, so it's out of scope here. Possible follow-up.
- Not exercised in a live browser (the search map is behind a list/map toggle); unit-verified the provider URL + attribution instead.

Closes #660