### PR TITLE
feat(search): renter vehicle-class filter chips on the search bar (#658)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -988,6 +988,7 @@
     "fromLabel": "Pickup date & time",
     "toLabel": "Return date & time",
     "submit": "Search",
+    "classFilterLabel": "Vehicle class",
     "needDates": "Choose a pickup and return time to see available stores.",
     "empty": "No stores have cars available for these dates.",
     "fromDaily": "From ¥{price} / day",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -988,6 +988,7 @@
     "fromLabel": "受け取り日時",
     "toLabel": "返却日時",
     "submit": "検索",
+    "classFilterLabel": "車種クラス",
     "needDates": "受け取りと返却の日時を選ぶと、空車のある店舗が表示されます。",
     "empty": "選択した日時に空車のある店舗はありません。",
     "fromDaily": "¥{price}〜／日",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -988,6 +988,7 @@
     "fromLabel": "取车日期与时间",
     "toLabel": "还车日期与时间",
     "submit": "搜索",
+    "classFilterLabel": "车型类别",
     "needDates": "选择取车和还车时间即可查看有空车的门店。",
     "empty": "所选时间内没有门店有可用车辆。",
     "fromDaily": "¥{price}起／天",

--- a/packages/web/src/vite/storefronts/StorefrontSearchForm.tsx
+++ b/packages/web/src/vite/storefronts/StorefrontSearchForm.tsx
@@ -1,11 +1,20 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { carryForwardFilters } from '@/vite/storefronts/params'
+import { carryForwardFilters, normalizeClassFilter } from '@/vite/storefronts/params'
 import { persistSearchRange } from '@/vite/storefronts/storage'
+import { ACRISS_CODES } from '@kuruma/shared'
 import { useNavigate } from '@tanstack/react-router'
 import type { FormEvent } from 'react'
 import { useLocale, useTranslations } from 'use-intl'
+
+// The renter-selectable class filter chips: the 8-code MVP ACRISS subset (#388).
+// Values are the exact ACRISS codes the search API matches on, so a checked chip
+// becomes a `class` URL param the API + `carryForwardFilters` already understand.
+// Limitation: a URL-carried code OUTSIDE this subset (operator-custom, #388) has
+// no chip, so it is dropped on resubmit; direct navigation still honors it. Add a
+// chip source from the live class catalog when operator-custom codes ship.
+const CLASS_CODES = Object.keys(ACRISS_CODES) as (keyof typeof ACRISS_CODES)[]
 
 interface StorefrontSearchFormProps {
   /** Wall-clock `datetime-local` strings (JST) to prefill from the URL. */
@@ -30,8 +39,11 @@ export function StorefrontSearchForm({
   pickupLocationId,
 }: StorefrontSearchFormProps) {
   const t = useTranslations('search')
+  const tAcriss = useTranslations('acriss')
   const locale = useLocale()
   const navigate = useNavigate()
+
+  const selectedClasses = normalizeClassFilter(classFilter)
 
   // Read the range from the FORM (DOM), not React state. Uncontrolled inputs
   // survive a pre-hydration fill on slow CI runners; a controlled form would
@@ -41,29 +53,53 @@ export function StorefrontSearchForm({
     const data = new FormData(e.currentTarget)
     const from = String(data.get('from') ?? '')
     const to = String(data.get('to') ?? '')
+    // Repeatable `class` checkboxes → an ACRISS code array the API filters on.
+    const classes = data.getAll('class').map(String)
     // Remember the range so the landing hero restores a refinement made here.
     persistSearchRange(from, to)
     navigate({
       to: '/$locale/search',
       params: { locale },
-      // Re-emit the active filters so refining dates doesn't reset them (#499).
-      search: { from, to, ...carryForwardFilters({ class: classFilter, pickupLocationId }) },
+      // The chips SET the class filter; pickup-location still carries forward so
+      // refining the search doesn't reset it (#499).
+      search: { from, to, ...carryForwardFilters({ class: classes, pickupLocationId }) },
     })
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4 sm:flex-row sm:items-end">
-      <div className="flex-1 space-y-2">
-        <Label htmlFor="from">{t('fromLabel')}</Label>
-        <Input id="from" name="from" type="datetime-local" defaultValue={defaultFrom} required />
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="from">{t('fromLabel')}</Label>
+          <Input id="from" name="from" type="datetime-local" defaultValue={defaultFrom} required />
+        </div>
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="to">{t('toLabel')}</Label>
+          <Input id="to" name="to" type="datetime-local" defaultValue={defaultTo} required />
+        </div>
+        <Button type="submit" className="sm:w-auto">
+          {t('submit')}
+        </Button>
       </div>
-      <div className="flex-1 space-y-2">
-        <Label htmlFor="to">{t('toLabel')}</Label>
-        <Input id="to" name="to" type="datetime-local" defaultValue={defaultTo} required />
-      </div>
-      <Button type="submit" className="sm:w-auto">
-        {t('submit')}
-      </Button>
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">{t('classFilterLabel')}</legend>
+        <div className="flex flex-wrap gap-2">
+          {CLASS_CODES.map((code) => (
+            <label key={code} className="cursor-pointer">
+              <input
+                type="checkbox"
+                name="class"
+                value={code}
+                defaultChecked={selectedClasses.includes(code)}
+                className="peer sr-only"
+              />
+              <span className="inline-flex items-center rounded-full border border-input bg-background px-3 py-1 text-sm transition-colors hover:bg-accent peer-checked:border-primary peer-checked:bg-primary peer-checked:text-primary-foreground peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-ring">
+                {tAcriss(code)}
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
     </form>
   )
 }

--- a/packages/web/tests/vite/storefronts/StorefrontSearchForm.test.tsx
+++ b/packages/web/tests/vite/storefronts/StorefrontSearchForm.test.tsx
@@ -3,7 +3,8 @@
 // Here submit drives TanStack `navigate` instead of next-intl `router.push`.
 import { StorefrontSearchForm } from '@/vite/storefronts/StorefrontSearchForm'
 import { readPersistedRange } from '@/vite/storefronts/storage'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { ACRISS_CODES } from '@kuruma/shared'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
@@ -11,7 +12,9 @@ import en from '../../../messages/en.json'
 const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }))
 vi.mock('@tanstack/react-router', () => ({ useNavigate: () => mockNavigate }))
 
-function renderForm(props: { defaultFrom?: string; defaultTo?: string } = {}) {
+function renderForm(
+  props: { defaultFrom?: string; defaultTo?: string; classFilter?: string | string[] } = {},
+) {
   return render(
     <IntlProvider locale="en" messages={en}>
       <StorefrontSearchForm {...props} />
@@ -67,5 +70,52 @@ describe('StorefrontSearchForm', () => {
     fireEvent.submit(container.querySelector('form') as HTMLFormElement)
 
     expect(readPersistedRange()).toEqual({ from: '2026-09-10T12:00', to: '2026-09-13T12:00' })
+  })
+
+  it('renders a selectable class chip for each ACRISS code, labeled from the acriss namespace', () => {
+    renderForm()
+
+    expect(screen.getAllByRole('checkbox')).toHaveLength(Object.keys(ACRISS_CODES).length)
+    expect(screen.getByRole('checkbox', { name: 'Compact' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'SUV' })).toBeInTheDocument()
+  })
+
+  it('pre-checks the chips named by the classFilter prop (round-trip from the URL)', () => {
+    renderForm({ classFilter: ['CCAR'] })
+
+    expect(screen.getByRole('checkbox', { name: 'Compact' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'SUV' })).not.toBeChecked()
+  })
+
+  it('pushes the checked class codes as the repeatable class param on submit', () => {
+    const { container } = renderForm({
+      defaultFrom: '2026-07-01T10:00',
+      defaultTo: '2026-07-03T10:00',
+    })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Compact' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'SUV' }))
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/$locale/search',
+      params: { locale: 'en' },
+      search: { from: '2026-07-01T10:00', to: '2026-07-03T10:00', class: ['CCAR', 'SUVR'] },
+    })
+  })
+
+  it('omits the class param when no chip is checked (clean URL)', () => {
+    const { container } = renderForm({
+      defaultFrom: '2026-07-01T10:00',
+      defaultTo: '2026-07-03T10:00',
+    })
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/$locale/search',
+      params: { locale: 'en' },
+      search: { from: '2026-07-01T10:00', to: '2026-07-03T10:00' },
+    })
   })
 })


### PR DESCRIPTION
## What

Closes #658 (P1). The storefront search API already trims results by repeatable ACRISS `class` params and `carryForwardFilters`/`normalizeClassFilter` already thread them — but `StorefrontSearchForm` was **date-only**, a backend capability with no front door. This adds the missing UI control.

## Fix
- **Multi-select class chips** on the search bar: the 8-code MVP ACRISS subset (`ACRISS_CODES` from `@kuruma/shared`), labeled via the existing `acriss` i18n namespace.
- Native checkboxes named `class` (sr-only + chip-styled `<label>`, keyboard-operable, visible focus ring) → submit reads `FormData.getAll('class')` into the repeatable param. Matches the form's deliberate DOM-over-state hydration pattern (#392).
- Chips **pre-check from the `classFilter` prop**, which `search.tsx` feeds from the URL → the filter round-trips search → detail → back.

## Acceptance criteria
- [x] Search bar exposes a class selector that pushes `class` and filters results.
- [x] Round-trips via the existing `carryForwardFilters` / `normalizeClassFilter`.
- [x] Trilingual (new `search.classFilterLabel` en/ja/zh); i18n parity passes.

## Test plan
- [x] 4 new `StorefrontSearchForm` tests: renders a chip per ACRISS code, pre-checks from prop (round-trip), submit pushes `class: ['CCAR','SUVR']`, omits `class` when none checked. 9/9 in file.
- [x] Full web suite **1110/1110**; web `tsc` 0; biome clean; i18n parity **886 keys × 3**.
- [x] code-reviewer: **SHIP** (no CRIT/HIGH/MEDIUM; 2 LOW pre-acknowledged).

## Notes
- A URL-carried code **outside** the 8-code subset (operator-custom, #388) has no chip and is dropped on resubmit (direct nav still honors it) — documented inline; follow-up when operator-custom codes ship.
- Not exercised in a live browser (unit + round-trip wiring verified instead).

Closes #658