### PR TITLE
docs(env): rewrite .env.example to the real Auth.js v5 stack (#703)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,46 @@
-  # Supabase Auth
-  NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-  NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Copy to `.env` at the repo root (it is gitignored; only this example is
+# committed). `.env` is symlinked into packages/web/.env. Use placeholder
+# values like the ones here — never commit real secrets.
 
-  # Database (Supabase Postgres — direct connection for Drizzle)
-  DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/po
-  stgres
+# Database — Neon Postgres (serverless) for Drizzle. Used by the API
+# (packages/api), the web auth helper (packages/web/src/lib/db.ts), and every
+# `db:*` script. Use the pooled connection string from the Neon dashboard.
+DATABASE_URL=postgresql://USER:PASSWORD@ep-xxxx-pooler.REGION.aws.neon.tech/DBNAME?sslmode=require
 
-  # Marketplace platform-admin bootstrap (#386). Comma-separated email allowlist;
-  # `bun run db:seed` promotes any matching existing user to PLATFORM_ADMIN and
-  # clears their tenant. A typo here can promote an unintended account — set your
-  # real admin address(es), not a placeholder.
-  PLATFORM_ADMIN_EMAILS=you@yourdomain.example
+# Auth.js v5 + Google OAuth. These four are required at deploy time —
+# .github/workflows/deploy.yml presence-checks them on the API Worker, and
+# packages/api resolveGoogleOAuthConfig() ships /auth/google/* as a silent 503
+# if AUTH_GOOGLE_ID / AUTH_GOOGLE_SECRET / AUTH_URL are missing.
+#
+# AUTH_SECRET signs the session JWT (generate with `openssl rand -base64 32`).
+AUTH_SECRET=replace-with-openssl-rand-base64-32
+# Google OAuth client credentials (Google Cloud Console → Credentials).
+AUTH_GOOGLE_ID=your-google-oauth-client-id.apps.googleusercontent.com
+AUTH_GOOGLE_SECRET=your-google-oauth-client-secret
+# Public origin of the deployed app; the OAuth redirect_uri is derived as
+# `${AUTH_URL}/auth/google/callback`. Locally this is your web dev origin.
+AUTH_URL=http://localhost:3001
 
-  # Forward geocoding for operator locations (#531). DISABLED unless BOTH a
-  # User-Agent AND an endpoint are set (otherwise locations save with null coords —
-  # safe, just no map pin). Outbound lookups are throttled app-wide by the
-  # GEOCODE_LIMITER binding (#574, ~1 req/10s) so a burst can't breach OSMF's 1 req/s.
-  #
-  # Demo / low volume — public OSM (free, no account; throttle keeps it policy-safe):
-  # NOMINATIM_USER_AGENT="kuruma-rental/1.0 (ops@yourdomain.example)"
-  # NOMINATIM_API_URL=https://nominatim.openstreetmap.org
-  #
-  # Production — LocationIQ (Nominatim-compatible drop-in, free 5k/day, storage OK):
-  # keep the UA, point the URL below, add a key. A real provider's own server-side
-  # limit is the actual guarantee; the app throttle is best-effort defense-in-depth.
-  # NOMINATIM_API_URL=https://us1.locationiq.com/v1
-  # NOMINATIM_API_KEY=your-locationiq-token
-  #
-  # NOTE: local dev has no GEOCODE_LIMITER binding (unthrottled). Point at LocationIQ
-  # or a self-host before any bulk seed/import so you don't trip an OSM IP ban.
+# Marketplace platform-admin bootstrap (#386). Comma-separated email allowlist;
+# `bun run db:seed` promotes any matching existing user to PLATFORM_ADMIN and
+# clears their tenant. A typo here can promote an unintended account — set your
+# real admin address(es), not a placeholder.
+PLATFORM_ADMIN_EMAILS=you@yourdomain.example
+
+# Forward geocoding for operator locations (#531). DISABLED unless BOTH a
+# User-Agent AND an endpoint are set (otherwise locations save with null coords —
+# safe, just no map pin). Outbound lookups are throttled app-wide by the
+# GEOCODE_LIMITER binding (#574, ~1 req/10s) so a burst can't breach OSMF's 1 req/s.
+#
+# Demo / low volume — public OSM (free, no account; throttle keeps it policy-safe):
+# NOMINATIM_USER_AGENT="kuruma-rental/1.0 (ops@yourdomain.example)"
+# NOMINATIM_API_URL=https://nominatim.openstreetmap.org
+#
+# Production — LocationIQ (Nominatim-compatible drop-in, free 5k/day, storage OK):
+# keep the UA, point the URL below, add a key. A real provider's own server-side
+# limit is the actual guarantee; the app throttle is best-effort defense-in-depth.
+# NOMINATIM_API_URL=https://us1.locationiq.com/v1
+# NOMINATIM_API_KEY=your-locationiq-token
+#
+# NOTE: local dev has no GEOCODE_LIMITER binding (unthrottled). Point at LocationIQ
+# or a self-host before any bulk seed/import so you don't trip an OSM IP ban.


### PR DESCRIPTION
## Summary
`.env.example` was the only committed env doc but still described the pre-pivot Supabase auth stack (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, a Supabase pooler `DATABASE_URL`) and was missing every secret the app actually needs. A new dev/deployer would configure a non-existent auth path and OAuth would silently 503.

This rewrites it to mirror the real required keys (Neon `DATABASE_URL` + Auth.js v5 / Google OAuth), deletes all Supabase references, keeps the already-correct `PLATFORM_ADMIN_EMAILS` and `NOMINATIM_*` blocks, and fixes the original file's stray 2-space indentation and line-wrapped `DATABASE_URL`. Placeholder values only.

Docs-only change to `.env.example` — no code, no real `.env`, no behavior change.

Closes #703

## Verification (var -> consumer)
The required key set matches `.github/workflows/deploy.yml:74` exactly (`DATABASE_URL AUTH_SECRET AUTH_GOOGLE_ID AUTH_GOOGLE_SECRET AUTH_URL`):

| Var | Consumed by |
|-----|-------------|
| `DATABASE_URL` | `packages/api/src/index.ts:281`, `packages/web/src/lib/db.ts:14`, `deploy.yml:46` (Neon Postgres for Drizzle) |
| `AUTH_SECRET` | `packages/web/src/lib/api-token.ts:11` (signs the API JWT), `deploy.yml:74` |
| `AUTH_GOOGLE_ID` | `packages/api/src/index.ts:752` (`resolveGoogleOAuthConfig`) |
| `AUTH_GOOGLE_SECRET` | `packages/api/src/index.ts:753` |
| `AUTH_URL` | `packages/api/src/index.ts:754` (derives `${AUTH_URL}/auth/google/callback`) |
| `PLATFORM_ADMIN_EMAILS` | `bun run db:seed` admin bootstrap (#386) |
| `NOMINATIM_USER_AGENT` / `_API_URL` / `_API_KEY` | `packages/api/src/index.ts:448-453` (forward geocoding, #531) |

Acceptance criteria:
- [x] Contains `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_URL` and a Neon-style `DATABASE_URL`
- [x] Zero occurrences of `SUPABASE`
- [x] Key set matches `deploy.yml` presence-check loop
- [x] `PLATFORM_ADMIN_EMAILS` and `NOMINATIM_*` blocks present

🤖 Generated with [Claude Code](https://claude.com/claude-code)