### PR TITLE
test(api): de-flake parallel auth/rate-limit unit tests (#672)

### DIFF
--- a/packages/api/tests/routes/auth-middleware.test.ts
+++ b/packages/api/tests/routes/auth-middleware.test.ts
@@ -1,11 +1,22 @@
 import { SignJWT } from 'jose'
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 import { createApp } from '../../src/index'
 import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
 
-function createTestApp() {
+// One app per file (#672): bare createApp() builds the full graph (~30 repos +
+// every service). Rebuilding it per test multiplied that cost ~10x and, under
+// 2-core CI contention, tipped these tests past the 5s timeout. AUTH_SECRET and
+// PARTNER_API_KEY are read per request, so a single shared instance is safe; the
+// lone build now runs in beforeAll under the more generous hook timeout.
+// Invariant: AUTH_SECRET is asserted once here — never mutate it in a test body,
+// or every test after that one would verify against the wrong secret.
+let app: ReturnType<typeof createApp>
+beforeAll(() => {
   setupAuthEnv()
-  return createApp()
+  app = createApp()
+})
+function createTestApp() {
+  return app
 }
 
 async function signJwt(

--- a/packages/api/tests/routes/auth-session.test.ts
+++ b/packages/api/tests/routes/auth-session.test.ts
@@ -1,13 +1,23 @@
 import { SignJWT } from 'jose'
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 import { createApp } from '../../src/index'
 import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
 
 const SESSION_COOKIE = 'kuruma_session'
 
-function createTestApp() {
+// One app per file (#672): bare createApp() builds the full graph; rebuilding it
+// per test multiplied that cost ~11x and, under 2-core CI contention, tipped
+// these tests past the 5s timeout. AUTH_SECRET is read per request, so a single
+// shared instance is safe; the lone build now runs in beforeAll under the hook timeout.
+// Invariant: AUTH_SECRET is asserted once here — never mutate it in a test body,
+// or every test after that one would verify against the wrong secret.
+let app: ReturnType<typeof createApp>
+beforeAll(() => {
   setupAuthEnv()
-  return createApp()
+  app = createApp()
+})
+function createTestApp() {
+  return app
 }
 
 /** Sign a `kuruma_session` cookie JWT. Mirrors the contract the API mints at

--- a/packages/api/tests/routes/rate-limit.test.ts
+++ b/packages/api/tests/routes/rate-limit.test.ts
@@ -8,6 +8,13 @@ import {
 } from '../../src/repositories/in-memory'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
 
+// #672: each test here needs distinct construction-time wiring (per-test limiter
+// overrides; the global-limiter test reads globalThis.RATE_LIMITER at build time),
+// so one-app-per-file reuse isn't clean. Bare createApp() still builds the full
+// graph, which under 2-core CI contention can tip a request past the default 5s
+// timeout — so widen the budget for this file rather than mask it elsewhere.
+vi.setConfig({ testTimeout: 15_000, hookTimeout: 15_000 })
+
 const fakeLimiter = () => ({ limit: vi.fn(async () => ({ success: true })) })
 
 describe('rate limiting wiring', () => {


### PR DESCRIPTION
Closes #672 (base is `marketplace-pivot`, not the default branch, so this needs a **manual close** after merge).

## Problem
`auth-middleware`, `auth-session`, and `rate-limit` route tests fail intermittently under the full parallel run — pass in isolation, **CI-only** (2-core runner), unreproducible locally (dev box has 10+ cores). A prior investigation **disproved** the obvious "env leak across files" hypothesis (vitest isolates env across forks; `AUTH_SECRET` is re-asserted per test). The leading remaining (unproven) hypothesis: **CPU-contention timeout** — these 3 files call **bare `createApp()`** with no overrides, constructing the entire app graph (~30 repos + every service: CORS/CSRF/rate-limit/geocoder/stripe/email/google-auth). Every *other* route test passes light in-memory overrides → cheap `createApp`. Default vitest `testTimeout` is 5s.

## Fix (pragmatic mitigation — chosen over reproducing the real failure first)
- **auth-middleware + auth-session:** build the app **once per file** in `beforeAll`, reuse across tests (~10 builds → 1). `createTestApp()` is kept as a thin accessor returning the memoized app, so **no test body changed**. Safe because `AUTH_SECRET` (`auth.ts:372`) and `PARTNER_API_KEY` (`auth.ts:455`) are read **per request**, and no test mutates persistent app state (the lone POST 403s in CSRF before any write). The single build also moves under the more generous 10s hook timeout.
- **rate-limit:** reuse isn't clean — each test needs distinct *construction-time* wiring (per-test limiter overrides; the global-limiter test reads `globalThis.RATE_LIMITER` at build time). Widen the per-file `testTimeout`/`hookTimeout` to **15s** instead.

## Honest caveat for the next investigator
This lowers the *cost* of the bare-`createApp` path but doesn't remove it. **`rate-limit.test.ts` still calls bare `createApp()` 5×**, now protected only by the 15s bump — so if the flake recurs, **look there first**, and note the 15s timeout makes each failure slower to surface. If it does recur, the real fix path is the 2-CPU repro (`--cpus=2` container + `--reporter=verbose`) to read the actual symptom.

## Verification
- 3 victim files: **25/25 green**
- Full api unit suite: **111 files, 1284/1284 green** — no regressions
- biome clean · `tsc --noEmit` exit 0
- Reuse-safety argument independently verified by code-reviewer agent (build-time vs request-time env reads traced; rate-limit-exclusion confirmed correct)