### PR TITLE
docs: reconcile modules.md with the real MVC+DI API architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,13 +120,16 @@ bun run db:verify   # must show 3 green checks
 
 ---
 
-# Architecture Rules (Feature Modules)
+# Architecture Rules
 
-Feature code lives under `src/modules/<feature>/`. Canonical rules: `docs/architecture/modules.md`.
+Canonical rules: `docs/architecture/modules.md`.
 
-**Grandfather policy:** before non-trivial changes to code in `lib/` or `components/<feature>/`, land a migration PR first.
+- **`packages/api`** is layered MVC + DI: `routes/` → `services/` → `repositories/`, wired in `index.ts`. Import direction never goes backwards. Details in AGENTS.md ("API Layer Architecture").
+- **`packages/web`** organizes UI by feature under `src/modules/<feature>/`; import only from the `@/modules/<feature>` barrel.
 
-Enforcement: `bun run lint:size`, `bun run lint:modules`, `.husky/pre-commit`.
+**Grandfather policy (web):** before non-trivial changes to code in `lib/` or `components/<feature>/`, land a migration PR first.
+
+Enforcement: `bun run --filter @kuruma/api lint:boundaries` (api layers), `bun run lint:modules` (web barrels), `bun run lint:size` (file size), `.husky/pre-commit`.
 
 ---
 

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,7 +1,17 @@
-# Feature Modules & Fan-Out Discipline
+# Architecture Rules & Fan-Out Discipline
 
-This is the canonical rules doc. The design rationale lives in
+This is the canonical rules doc for how code is organized across the monorepo.
+The original design rationale lives in
 `docs/superpowers/specs/2026-04-11-feature-modules-design.md`.
+
+> **History.** The early-2026 plan was to organize *every* package by feature
+> folder (`src/modules/<feature>/{routes,service,repo}.ts`). The API never
+> adopted that shape — it settled on a layered **MVC + Dependency Injection**
+> architecture instead, documented in `AGENTS.md` ("API Layer Architecture")
+> and enforced by `packages/api/scripts/check-import-boundaries.ts`. This doc
+> now describes what the code actually does. The `@/modules/<feature>` barrel
+> convention still exists and is still enforced (see below), but only the web
+> package uses it.
 
 ## The one-line rule
 
@@ -9,87 +19,158 @@ This is the canonical rules doc. The design rationale lives in
 change without editing a dozen files, the architecture is wrong — fix the
 architecture, don't fight it.
 
-## Target layout
+---
 
-Feature code lives under `src/modules/<feature>/` in each package.
+## packages/api — MVC + Dependency Injection (canonical)
 
-### packages/api
+The API is **not** organized by feature folder. It is organized by layer.
+Source of truth: the `## API Layer Architecture (MVC + Dependency Injection)`
+section in `AGENTS.md`.
 
-    modules/<feature>/
-      routes.ts      # thin Hono controller: parse, call service, respond
-      service.ts     # business rules, invariants, orchestration
-      repo.ts        # Drizzle queries only, no logic
-      index.ts       # public surface (usually { router, types })
-      *.test.ts
+    packages/api/src/
+      routes/        # Controller layer: HTTP in/out only (one file per resource)
+        helpers.ts   # ok() / fail() / parseBody() / parseDateRange() / pagination
+      services/      # Service layer: business rules, validation, orchestration
+      repositories/  # Data access: drizzle/ (prod), in-memory/ (tests), types.ts
+        types.ts     # Repository *interfaces* — what services depend on
+      index.ts       # Composition root: constructs concretes, wires DI, mounts routes
+      lib/           # Cross-cutting pure helpers (booking-code, image-signature, …)
+      middleware/    # Hono middleware (auth, csrf, logger, request-id)
 
-Cross-module helpers live in `packages/api/src/lib/`. `app.ts` mounts each
-module's router.
+> `packages/api/src/modules/` exists only as an empty `.gitkeep` placeholder.
+> It is **not** the API's structure — do not create `modules/<feature>/`
+> folders under the API. Add a resource as a layer-spread (a `routes/` file, a
+> `services/` file, repository interfaces + implementations), not a folder.
 
-### packages/web
+### Import direction (the core rule)
 
-    modules/<feature>/
-      api.ts         # fetch calls to the Hono API
+**`routes/` → `services/` → `repositories/`. Never backwards.**
+
+| Layer | May import | Must NOT import |
+|-------|-----------|-----------------|
+| `routes/*.ts` | services, `routes/helpers.ts`, repository *type* imports from `repositories/types` | concrete repositories (`repositories/drizzle`, `repositories/in-memory`) |
+| `services/*.ts` | repository **interfaces** from `repositories/types` | concrete repository classes |
+| `index.ts` (composition root) | concrete repositories + services + routes | — (it is the one place wiring is allowed) |
+
+- **Routes are thin controllers.** They parse the request, call a service, and
+  respond. No business logic.
+- **Routes parse bodies via `parseBody(c, schema)`** from `routes/helpers.ts`,
+  never `c.req.json()` directly — this keeps the `{ success, data | error }`
+  envelope consistent. Build responses with `ok(c, data)` / `fail(c, error, status)`.
+- **Services depend on interfaces, not implementations.** A service receives its
+  repositories by injection so a test can pass an `InMemory*` double and prod
+  can pass a `Drizzle*` one without changing the service.
+- **Only `index.ts` may `new` a concrete repository.** Routes are factory
+  functions (e.g. `createBookingRoutes(bookingService)`) chained onto the app
+  via `.route('/', …)` inside `createApp()` in `index.ts`. There is no `app.ts`.
+
+### Enforcement
+
+`packages/api/scripts/check-import-boundaries.ts`, run as:
+
+```bash
+bun run --filter @kuruma/api lint:boundaries
+```
+
+It is a CI step (`.github/workflows/ci.yml`) and flags:
+1. a `routes/` file importing a concrete repository,
+2. a `services/` file importing a concrete repository,
+3. any non-`index.ts` file importing `repositories/drizzle` or `repositories/in-memory`,
+4. a route calling `c.req.json()` instead of `parseBody()`.
+
+`*.test.ts` files are exempt — they legitimately construct concretes to exercise DI.
+
+---
+
+## packages/web — feature folders + barrel imports
+
+The web shell (`packages/web/src/`) organizes UI by feature.
+
+    src/modules/<feature>/
+      api.ts         # typed hono/client calls to the API (web has NO direct DB access)
       components/    # feature components (VehicleForm, BookingCard, …)
       hooks.ts       # feature-specific hooks
       types.ts       # feature-local types
-      index.ts       # public surface
-      *.test.ts / *.test.tsx
+      index.ts       # the public surface (barrel)
 
-Pages in `src/app/.../page.tsx` stay thin and import from
-`@/modules/<feature>`. Cross-module primitives go in `src/lib/`. Design-system
-primitives stay in `src/components/ui/`.
+- **Import only from the barrel: `@/modules/<feature>`.** Never reach into
+  another feature's internals (`@/modules/foo/components/Bar`).
+- Cross-feature primitives live in `src/lib/`. Design-system primitives stay in
+  `src/components/ui/`.
 
-### packages/shared
+> Note: `packages/web` was migrated off Next.js to **Vite + TanStack Router**
+> (epic #378). The live shell is `src/vite/` + `src/routes/`; a frozen Next.js
+> tree (`src/app/`) is still present but is not the build path — do not extend
+> it. See the banner at the top of `AGENTS.md`.
 
-No changes. Schema and validators already live in per-feature files.
+### Enforcement
 
-## The rules
+`scripts/lint-module-boundaries.ts` (a **root** script), run as:
 
-| # | Rule | Enforced by |
-|---|---|---|
-| R1  | Feature = one folder under `src/modules/<feature>/` | convention + review |
-| R2  | Single public surface: import only from `@/modules/<feature>` (the barrel) | `scripts/lint-module-boundaries.ts` |
-| R3  | No cross-module internal imports | `scripts/lint-module-boundaries.ts` |
-| R4  | `routes.ts` contains no business logic, max 150 lines | `scripts/lint-file-size.ts` |
-| R5  | `service.ts` has one responsibility, no "misc" or "utils" services | review |
-| R6  | `repo.ts` is pure data access, no validation, no side effects | review |
-| R7  | `page.tsx` is thin composition, max 80 lines | `scripts/lint-file-size.ts` |
-| R8  | Source files: soft warn at 400 lines, hard fail at 800 lines | `scripts/lint-file-size.ts` |
-| R9  | Rule of three for DRY: duplicate first, extract on the third use | convention |
-| R10 | Cross-module helpers live in `lib/`, never inside another module | R3 + review |
-| R11 | Tests colocate with the code they test | convention |
-| R12 | `index.ts` exports only what the outside actually uses | review |
+```bash
+bun run lint:modules   # also runs as part of `bun run lint`
+```
 
-## Grandfather policy
+It scans `packages/{api,web,shared}/src` and fails on any cross-module internal
+import — i.e. importing `@/modules/<a>/<internal>` from a file in a different
+module. (Its `@/`-alias matcher only fires for web's barrels; the API has no
+`@/modules` imports, so it is effectively the web barrel guard.)
 
-Legacy files under `lib/` and `components/<feature>/` are exempt from
-R2/R3/R4/R7 until they are migrated. R8 (file size) applies everywhere.
+---
 
-**Migrate before you modify.** Before making any non-trivial change to a
-grandfathered feature, land a standalone migration PR that moves it into
-`modules/<feature>/`. The feature-change PR builds on top. Migrations and
+## packages/shared
+
+No feature-folder structure. Schema and validators already live in per-feature
+files (`db/schema.ts`, `validators/<feature>.ts`). Import from `@kuruma/shared/*`.
+
+---
+
+## File-size rules (everywhere)
+
+`scripts/lint-file-size.ts`, run as `bun run lint:size` (also part of
+`bun run lint` and the pre-commit hook):
+
+- **Soft warn at 400 lines, hard fail at 800 lines** for source files.
+
+---
+
+## Grandfather / migrate-before-you-modify policy
+
+Some web features still live outside `src/modules/<feature>/` (legacy `lib/`
+and `components/<feature>/` from before the module convention, plus the frozen
+Next.js tree). They are exempt from the barrel rules until migrated. The
+**file-size cap applies everywhere**.
+
+**Migrate before you modify.** Before a non-trivial change to a grandfathered
+*web* feature, land a standalone migration PR that moves it into
+`src/modules/<feature>/`. The feature-change PR builds on top. Migrations and
 feature changes never share a PR.
 
 Trivial exceptions: typo fixes, one-line string tweaks, dependency bumps.
 
-## How to add a new feature
+> This policy is about the **web** module convention. The API is already
+> uniformly layered; "migrating" an API resource means keeping it within the
+> `routes/services/repositories` layers and respecting the import direction —
+> not moving it into a `modules/` folder.
 
-1. Create `packages/api/src/modules/<feature>/` with `routes.ts`,
-   `service.ts`, `repo.ts`, `index.ts`, and tests.
-2. Mount the router in `packages/api/src/app.ts`.
-3. Create `packages/web/src/modules/<feature>/` with `api.ts`,
-   `components/`, `hooks.ts`, `types.ts`, `index.ts`, and tests.
-4. Import from `@/modules/<feature>` in pages. Never reach into internals.
-5. Run `bun run lint` before committing.
+---
 
-## How to migrate a grandfathered feature
+## How to add an API resource
 
-1. Create the `modules/<feature>/` folders in api and web.
-2. Move files into their new homes (one commit per logical move).
-3. Update imports across the monorepo (can be done in the same commit as
-   the move, since the move would break the build otherwise).
-4. Move tests alongside the code they test.
-5. Run `bun run lint`, `bun run test`, `bun run --filter @kuruma/api test:integration`,
-   and the relevant builds. All must pass.
-6. Open the migration PR. It should contain only file moves and import
-   updates — no logic changes.
+1. Add `packages/api/src/routes/<resource>.ts` — a factory function
+   (`create<Resource>Routes(service)`) that parses via `parseBody` and responds
+   via `ok` / `fail`.
+2. Add `packages/api/src/services/<resource>.ts` for the business logic,
+   depending only on repository interfaces from `repositories/types.ts`.
+3. Add the repository interface to `repositories/types.ts` and its
+   implementations under `repositories/drizzle/` and `repositories/in-memory/`.
+4. Wire it in `index.ts`: construct the concrete repo + service, then chain
+   `.route('/', create<Resource>Routes(service))` onto the app in `createApp()`.
+5. Run `bun run --filter @kuruma/api lint:boundaries` and `bun run lint`.
+
+## How to add a web feature
+
+1. Create `packages/web/src/modules/<feature>/` with `api.ts`, `components/`,
+   `hooks.ts`, `types.ts`, `index.ts`, and colocated tests.
+2. Import from `@/modules/<feature>` in routes/pages. Never reach into internals.
+3. Run `bun run lint` (includes `lint:modules` and `lint:size`).


### PR DESCRIPTION
## Summary

`docs/architecture/modules.md` mandated an `packages/api/src/modules/<feature>/{routes,service,repo,index}.ts` structure that the API **never adopted**. The real API architecture is layered **MVC + Dependency Injection** — `routes/` -> `services/` -> `repositories/`, wired in `index.ts` — documented in `AGENTS.md` and enforced by `packages/api/scripts/check-import-boundaries.ts` (`bun run --filter @kuruma/api lint:boundaries`).

This is a **full rewrite** of the doc (preferred over a superseded banner, since the doc is referenced for the grandfather/migrate-before-modify policy).

## Changes

- **`docs/architecture/modules.md`** — rewritten so MVC+DI is canonical for `packages/api`:
  - Accurate layout + import-direction table (`routes -> services -> repositories`, never backwards).
  - `routes/helpers.ts` envelope rule (`ok()`/`fail()`/`parseBody()`/`parseDateRange()`), routes are factory functions mounted via `.route()` in `createApp()` (there is no `app.ts`).
  - Enforcement section points at the real `lint:boundaries` checker and lists its four rules.
  - Notes `packages/api/src/modules/` is only an empty `.gitkeep` stub — do not create feature folders under the API.
  - Keeps the `@/modules/<feature>` barrel convention documented for `packages/web` (which genuinely uses it), enforced by the root `lint:modules` script.
- **`CLAUDE.md`** — "Architecture Rules" section split into api (MVC+DI) vs web (modules barrel); added the missing `lint:boundaries` enforcer.

## Inaccuracy resolved

The issue/brief stated `lint:modules` "does not exist." It **does** — as a **root** `package.json` script (`scripts/lint-module-boundaries.ts`), part of `bun run lint` and the pre-commit hook. It only doesn't exist *in the api package* (which uses `lint:boundaries`). CLAUDE.md's `lint:modules` reference was therefore already correct and is retained; the genuine gap was the **missing `lint:boundaries`** reference for the api layer, which this PR adds.

Two other stale facts the old doc had, now fixed: it told contributors to mount routers in `packages/api/src/app.ts` (no such file — routing is in `index.ts`), and `repo.ts`/`service.ts`/`routes.ts` per-feature files (the API uses one file per resource per layer).

## Gate

Every file path and script name in both edited files was grep-verified to exist. Docs-only; zero code/test changes.

Relates to #690