### PR TITLE
test(api): de-flake booking-code 10k-uniqueness assertion

### DIFF
--- a/packages/api/tests/lib/booking-code.test.ts
+++ b/packages/api/tests/lib/booking-code.test.ts
@@ -21,11 +21,20 @@ describe('generateBookingCode', () => {
     expect(BOOKING_CODE_PATTERN.test('HACKED01')).toBe(false) // contains 0, 1
   })
 
-  it('generates 10k codes that all match the pattern and are unique', () => {
+  it('generates 10k well-formed codes with negligible collisions', () => {
     const codes = Array.from({ length: 10_000 }, () => generateBookingCode())
     for (const code of codes) {
       expect(code).toMatch(/^[2-9A-HJ-NP-Z]{8}$/)
     }
-    expect(new Set(codes).size).toBe(codes.length)
+    // Codes are crypto-random over a 32^8 (~2^40) space, so demanding ZERO
+    // collisions in 10k draws is a birthday-paradox flake (~1/22k runs, #672).
+    // Real uniqueness is the `bookingCode UNIQUE` constraint + regenerate-on-23505
+    // retry in booking.ts, not a generator guarantee. Tolerating <=1 collision keeps
+    // the false-failure probability ~1e-9. The real entropy guard is the per-code
+    // {8}-length/alphabet assertion above (any shrunk length or alphabet fails it
+    // deterministically); this count only catches a same-shape RNG whose effective
+    // range has collapsed.
+    const collisions = codes.length - new Set(codes).size
+    expect(collisions, 'unexpected booking-code collisions in 10k draws').toBeLessThanOrEqual(1)
   })
 })


### PR DESCRIPTION
Follow-up to #672 (closed by #743).

#743 de-flaked the auth-middleware / auth-session / rate-limit timeout flake (reuse one app per file). It did **not** touch `booking-code.test.ts`, which still asserts zero collisions across 10k crypto-random booking codes.

`generateBookingCode()` draws from a 32^8 (~2^40) space, so demanding zero collisions in 10k draws is a birthday-paradox flake (~1/22k runs) that has fired in CI (the #684 run). Real uniqueness is the `bookingCode UNIQUE` constraint + regenerate-on-23505 retry in `booking.ts`, not a generator guarantee.

**Fix:** tolerate `<=1` collision (false-failure ~1e-9); keep the deterministic per-code length/alphabet assertion as the real entropy guard.

## Test plan
- [x] `bun run --filter @kuruma/api test booking-code` -> 4/4 pass
- [ ] CI green (4/4)