### PR TITLE
feat(shared): region coordinates, taxonomy + nearest-area backfill (#651 Slice 1)

### DIFF
--- a/drizzle/0058_add_region_coords_and_taxonomy.sql
+++ b/drizzle/0058_add_region_coords_and_taxonomy.sql
@@ -1,0 +1,9 @@
+CREATE TYPE "public"."region_status" AS ENUM('ACTIVE', 'INACTIVE');--> statement-breakpoint
+CREATE TYPE "public"."region_type" AS ENUM('PREFECTURE', 'CITY', 'AREA');--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "type" "region_type";--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "latitude" double precision;--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "longitude" double precision;--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "assignable" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "status" "region_status" DEFAULT 'ACTIVE' NOT NULL;--> statement-breakpoint
+ALTER TABLE "regions" ADD COLUMN "slug" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "regions_slug_unique" ON "regions" USING btree ("slug");

--- a/drizzle/meta/0058_snapshot.json
+++ b/drizzle/meta/0058_snapshot.json
@@ -1,0 +1,3689 @@
+{
+  "id": "a12c1d7d-3d0b-4370-8025-78ed48d75ce7",
+  "prevId": "13e8994d-cceb-4c37-ac8d-9304faf8919e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_events": {
+      "name": "booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booking_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_booking_events_bookingId": {
+          "name": "idx_booking_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_events_actorId": {
+          "name": "idx_booking_events_actorId",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_events_bookingId_bookings_id_fk": {
+          "name": "booking_events_bookingId_bookings_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "booking_events_actorId_users_id_fk": {
+          "name": "booking_events_actorId_users_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestedVehicleId": {
+          "name": "requestedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedVehicleId": {
+          "name": "assignedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropoffLocationId": {
+          "name": "dropoffLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "fulfillmentMode": {
+          "name": "fulfillmentMode",
+          "type": "booking_fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPECIFIC'"
+        },
+        "bookingCode": {
+          "name": "bookingCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insuranceOptionId": {
+          "name": "insuranceOptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceSnapshot": {
+          "name": "insuranceSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeSnapshot": {
+          "name": "feeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "addOnSnapshot": {
+          "name": "addOnSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerAcknowledgedAt": {
+          "name": "disclaimerAcknowledgedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerTermsVersion": {
+          "name": "disclaimerTermsVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_operatorId": {
+          "name": "idx_bookings_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_requestedVehicleId": {
+          "name": "idx_bookings_requestedVehicleId",
+          "columns": [
+            {
+              "expression": "requestedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_assignedVehicleId": {
+          "name": "idx_bookings_assignedVehicleId",
+          "columns": [
+            {
+              "expression": "assignedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_pickupLocationId": {
+          "name": "idx_bookings_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_dropoffLocationId": {
+          "name": "idx_bookings_dropoffLocationId",
+          "columns": [
+            {
+              "expression": "dropoffLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_insuranceOptionId": {
+          "name": "idx_bookings_insuranceOptionId",
+          "columns": [
+            {
+              "expression": "insuranceOptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_operatorId_operators_id_fk": {
+          "name": "bookings_operatorId_operators_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_pickupLocationId_locations_id_fk": {
+          "name": "bookings_pickupLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_dropoffLocationId_locations_id_fk": {
+          "name": "bookings_dropoffLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "dropoffLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_class_fk": {
+          "name": "bookings_operator_class_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_requested_vehicle_fk": {
+          "name": "bookings_operator_requested_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "requestedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_assigned_vehicle_fk": {
+          "name": "bookings_operator_assigned_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "assignedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_insurance_fk": {
+          "name": "bookings_operator_insurance_fk",
+          "tableFrom": "bookings",
+          "tableTo": "insurance_options",
+          "columnsFrom": [
+            "operatorId",
+            "insuranceOptionId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookings_bookingCode_unique": {
+          "name": "bookings_bookingCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bookings_specific_requires_assigned": {
+          "name": "bookings_specific_requires_assigned",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"assignedVehicleId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleClassId": {
+          "name": "vehicleClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "fee_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fee_schedule_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_schedules_operator_class": {
+          "name": "idx_fee_schedules_operator_class",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_schedules_vehicle_class": {
+          "name": "idx_fee_schedules_vehicle_class",
+          "columns": [
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_class_unique": {
+          "name": "fee_schedules_active_class_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_operatorwide_unique": {
+          "name": "fee_schedules_active_operatorwide_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_schedules_operatorId_operators_id_fk": {
+          "name": "fee_schedules_operatorId_operators_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fee_schedules_operator_class_fk": {
+          "name": "fee_schedules_operator_class_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleClassId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fee_schedules_amount_non_negative": {
+          "name": "fee_schedules_amount_non_negative",
+          "value": "\"fee_schedules\".\"amountJpy\" >= 0"
+        },
+        "fee_schedules_feetype_unit_coherent": {
+          "name": "fee_schedules_feetype_unit_coherent",
+          "value": "(\"fee_schedules\".\"feeType\" = 'OVERTIME_HOURLY' AND \"fee_schedules\".\"unit\" = 'PER_HOUR') OR (\"fee_schedules\".\"feeType\" = 'CLEANING_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT') OR (\"fee_schedules\".\"feeType\" = 'NO_FUEL_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_options": {
+      "name": "insurance_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyPriceJpy": {
+          "name": "dailyPriceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deductibleJpy": {
+          "name": "deductibleJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_insurance_options_operatorId": {
+          "name": "idx_insurance_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_options_active_name_unique": {
+          "name": "insurance_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_options_operatorId_operators_id_fk": {
+          "name": "insurance_options_operatorId_operators_id_fk",
+          "tableFrom": "insurance_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_options_operatorId_id_unique": {
+          "name": "insurance_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "insurance_options_daily_price_non_negative": {
+          "name": "insurance_options_daily_price_non_negative",
+          "value": "\"insurance_options\".\"dailyPriceJpy\" >= 0"
+        },
+        "insurance_options_deductible_non_negative": {
+          "name": "insurance_options_deductible_non_negative",
+          "value": "\"insurance_options\".\"deductibleJpy\" IS NULL OR \"insurance_options\".\"deductibleJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coordinate_source": {
+          "name": "coordinate_source",
+          "type": "coordinate_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatingHours": {
+          "name": "operatingHours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Tokyo'"
+        },
+        "defaultTurnaroundMinutes": {
+          "name": "defaultTurnaroundMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2880
+        },
+        "regionId": {
+          "name": "regionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_operatorId": {
+          "name": "idx_locations_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_regionId": {
+          "name": "idx_locations_regionId",
+          "columns": [
+            {
+              "expression": "regionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_operatorId_active_name_unique": {
+          "name": "locations_operatorId_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"status\" <> 'ARCHIVED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_operatorId_operators_id_fk": {
+          "name": "locations_operatorId_operators_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "locations_regionId_regions_id_fk": {
+          "name": "locations_regionId_regions_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_operatorId_id_unique": {
+          "name": "locations_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "locations_turnaround_min_60": {
+          "name": "locations_turnaround_min_60",
+          "value": "\"locations\".\"defaultTurnaroundMinutes\" >= 60"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "providerMessageId": {
+          "name": "providerMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_bookingId": {
+          "name": "idx_notification_log_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_log_operatorId": {
+          "name": "idx_notification_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_bookingId_bookings_id_fk": {
+          "name": "notification_log_bookingId_bookings_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_log_operatorId_operators_id_fk": {
+          "name": "notification_log_operatorId_operators_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_log_idempotency_unique": {
+          "name": "notification_log_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotencyKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_anomalies": {
+      "name": "payment_anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAmountJpy": {
+          "name": "receivedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedAmountJpy": {
+          "name": "expectedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_anomalies_operatorId": {
+          "name": "idx_payment_anomalies_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_anomalies_bookingId": {
+          "name": "idx_payment_anomalies_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_anomalies_stripeEventId_unique": {
+          "name": "payment_anomalies_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_anomalies_operatorId_operators_id_fk": {
+          "name": "payment_anomalies_operatorId_operators_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_anomalies_bookingId_bookings_id_fk": {
+          "name": "payment_anomalies_bookingId_bookings_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_events": {
+      "name": "payment_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grossJpy": {
+          "name": "grossJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFeeJpy": {
+          "name": "platformFeeJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "netToPartnerJpy": {
+          "name": "netToPartnerJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'jpy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_events_operatorId": {
+          "name": "idx_payment_events_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_events_bookingId": {
+          "name": "idx_payment_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeEventId_unique": {
+          "name": "payment_events_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeCheckoutSessionId_unique": {
+          "name": "payment_events_stripeCheckoutSessionId_unique",
+          "columns": [
+            {
+              "expression": "stripeCheckoutSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_one_success_per_booking": {
+          "name": "payment_events_one_success_per_booking",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'SUCCEEDED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_events_operatorId_operators_id_fk": {
+          "name": "payment_events_operatorId_operators_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_events_bookingId_bookings_id_fk": {
+          "name": "payment_events_bookingId_bookings_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nameEn": {
+          "name": "nameEn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameJa": {
+          "name": "nameJa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameZh": {
+          "name": "nameZh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignable": {
+          "name": "assignable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "region_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_regions_parentId": {
+          "name": "idx_regions_parentId",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_unique": {
+          "name": "regions_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parentId_regions_id_fk": {
+          "name": "regions_parentId_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.renter_documents": {
+      "name": "renter_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiryDate": {
+          "name": "expiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_renter_documents_renterId": {
+          "name": "idx_renter_documents_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_verifierId": {
+          "name": "idx_renter_documents_verifierId",
+          "columns": [
+            {
+              "expression": "verifierId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_status": {
+          "name": "idx_renter_documents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "renter_documents_renterId_users_id_fk": {
+          "name": "renter_documents_renterId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "renter_documents_verifierId_users_id_fk": {
+          "name": "renter_documents_verifierId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acrissCode": {
+          "name": "acrissCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_acriss_code_format": {
+          "name": "vehicle_classes_acriss_code_format",
+          "value": "\"vehicle_classes\".\"acrissCode\" IS NULL OR \"vehicle_classes\".\"acrissCode\" ~ '^[A-Z9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_pickupLocationId": {
+          "name": "idx_vehicles_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_pickupLocationId_fk": {
+          "name": "vehicles_operatorId_pickupLocationId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "operatorId",
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        },
+        "vehicles_operatorId_id_unique": {
+          "name": "vehicles_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.add_on_options": {
+      "name": "add_on_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceJpy": {
+          "name": "priceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "add_on_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_add_on_options_operatorId": {
+          "name": "idx_add_on_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "add_on_options_active_name_unique": {
+          "name": "add_on_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "add_on_options_operatorId_operators_id_fk": {
+          "name": "add_on_options_operatorId_operators_id_fk",
+          "tableFrom": "add_on_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "add_on_options_operatorId_id_unique": {
+          "name": "add_on_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "add_on_options_price_non_negative": {
+          "name": "add_on_options_price_non_negative",
+          "value": "\"add_on_options\".\"priceJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operator_memberships": {
+      "name": "operator_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_memberships_active_user_unique": {
+          "name": "operator_memberships_active_user_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operator_memberships_operatorId": {
+          "name": "idx_operator_memberships_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_memberships_userId_users_id_fk": {
+          "name": "operator_memberships_userId_users_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_memberships_operatorId_operators_id_fk": {
+          "name": "operator_memberships_operatorId_operators_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_invites": {
+      "name": "provider_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedByUserId": {
+          "name": "acceptedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_invites_tokenHash_unique": {
+          "name": "provider_invites_tokenHash_unique",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_email": {
+          "name": "idx_provider_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_operatorId": {
+          "name": "idx_provider_invites_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_invitedByUserId": {
+          "name": "idx_provider_invites_invitedByUserId",
+          "columns": [
+            {
+              "expression": "invitedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_acceptedByUserId": {
+          "name": "idx_provider_invites_acceptedByUserId",
+          "columns": [
+            {
+              "expression": "acceptedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_invites_operatorId_operators_id_fk": {
+          "name": "provider_invites_operatorId_operators_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provider_invites_invitedByUserId_users_id_fk": {
+          "name": "provider_invites_invitedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_invites_acceptedByUserId_users_id_fk": {
+          "name": "provider_invites_acceptedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acceptedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_event_type": {
+      "name": "booking_event_type",
+      "schema": "public",
+      "values": [
+        "BOOKING_CREATED",
+        "VEHICLE_SUBSTITUTED",
+        "BOOKING_CANCELLED",
+        "STATUS_CHANGED"
+      ]
+    },
+    "public.booking_fulfillment_mode": {
+      "name": "booking_fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "SPECIFIC",
+        "CLASS_COMBO"
+      ]
+    },
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.coordinate_source": {
+      "name": "coordinate_source",
+      "schema": "public",
+      "values": [
+        "GEOCODED",
+        "MANUAL",
+        "PENDING"
+      ]
+    },
+    "public.document_status": {
+      "name": "document_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "IDP",
+        "PASSPORT"
+      ]
+    },
+    "public.fee_schedule_status": {
+      "name": "fee_schedule_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "OVERTIME_HOURLY",
+        "CLEANING_FLAT",
+        "NO_FUEL_FLAT"
+      ]
+    },
+    "public.fee_unit": {
+      "name": "fee_unit",
+      "schema": "public",
+      "values": [
+        "PER_HOUR",
+        "PER_DAY",
+        "PER_KM",
+        "FLAT"
+      ]
+    },
+    "public.insurance_status": {
+      "name": "insurance_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.luggage_size": {
+      "name": "luggage_size",
+      "schema": "public",
+      "values": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE"
+      ]
+    },
+    "public.notification_kind": {
+      "name": "notification_kind",
+      "schema": "public",
+      "values": [
+        "OPERATOR_BOOKING_ALERT",
+        "RENTER_BOOKING_CONFIRM",
+        "RENTER_SUBSTITUTION",
+        "RENTER_CANCELLATION",
+        "RENTER_TRIP_STARTED",
+        "RENTER_TRIP_COMPLETED"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "DEAD"
+      ]
+    },
+    "public.payment_anomaly_kind": {
+      "name": "payment_anomaly_kind",
+      "schema": "public",
+      "values": [
+        "DOUBLE_PAYMENT",
+        "AMOUNT_MISMATCH"
+      ]
+    },
+    "public.payment_event_status": {
+      "name": "payment_event_status",
+      "schema": "public",
+      "values": [
+        "SUCCEEDED"
+      ]
+    },
+    "public.region_status": {
+      "name": "region_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "PREFECTURE",
+        "CITY",
+        "AREA"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.add_on_status": {
+      "name": "add_on_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.operator_membership_status": {
+      "name": "operator_membership_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED"
+      ]
+    },
+    "public.operator_role": {
+      "name": "operator_role",
+      "schema": "public",
+      "values": [
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF"
+      ]
+    },
+    "public.provider_invite_status": {
+      "name": "provider_invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1781381003516,
       "tag": "0057_fee_schedules_feetype_unit_coherence",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1781381920311,
+      "tag": "0058_add_region_coords_and_taxonomy",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:seed": "bun run scripts/seed.ts",
     "db:seed-bookings": "bun run scripts/seed-bookings.ts",
     "db:seed:tcp": "bun run scripts/seed-tcp.ts",
+    "db:backfill-regions": "bun run scripts/backfill-location-regions.ts",
     "db:verify": "bun run scripts/db-verify.ts",
     "prepare": "husky"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,6 +32,7 @@
     "./lib/expiry": "./src/lib/expiry.ts",
     "./lib/rental-rules": "./src/lib/rental-rules.ts",
     "./lib/return-path": "./src/lib/return-path.ts",
+    "./lib/region-distance": "./src/lib/region-distance.ts",
     "./validators/booking": "./src/validators/booking.ts",
     "./validators/vehicle": "./src/validators/vehicle.ts",
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",

--- a/packages/shared/src/db/backfill-regions.ts
+++ b/packages/shared/src/db/backfill-regions.ts
@@ -1,0 +1,53 @@
+import { eq } from 'drizzle-orm'
+import { planRegionBackfill } from '../lib/region-distance'
+import type { getDb } from './index'
+import { locations, regions } from './schema'
+
+type Db = ReturnType<typeof getDb>
+
+export interface RegionBackfillReport {
+  /** Number of locations updated to point at their nearest assignable area. */
+  assigned: number
+  /** ACTIVE, coord-bearing locations with no area within radius — left null. */
+  unassigned: readonly string[]
+}
+
+/**
+ * One-off, idempotent backfill (#651 Slice 1): assign every ACTIVE location that
+ * has coordinates but no region to its nearest assignable area. Injectable (DIP)
+ * like `seed` so it runs against either the production neon-http `getDb()` or a
+ * TCP postgres-js handle. The matching decision is the pure `planRegionBackfill`;
+ * this function is the thin DB shell (read rows -> plan -> apply -> report).
+ *
+ * Idempotent: only region-less rows are considered, so a second run is a no-op.
+ * Far-away locations (no area within REGION_SANITY_RADIUS_KM) are reported, never
+ * mis-assigned.
+ */
+export async function backfillLocationRegions(db: Db): Promise<RegionBackfillReport> {
+  const regionRows = await db
+    .select({
+      id: regions.id,
+      latitude: regions.latitude,
+      longitude: regions.longitude,
+      assignable: regions.assignable,
+      status: regions.status,
+      sortOrder: regions.sortOrder,
+    })
+    .from(regions)
+
+  const locationRows = await db
+    .select({
+      id: locations.id,
+      latitude: locations.latitude,
+      longitude: locations.longitude,
+      regionId: locations.regionId,
+      status: locations.status,
+    })
+    .from(locations)
+
+  const plan = planRegionBackfill(regionRows, locationRows)
+  for (const { locationId, regionId } of plan.assignments) {
+    await db.update(locations).set({ regionId }).where(eq(locations.id, locationId))
+  }
+  return { assigned: plan.assignments.length, unassigned: plan.unassigned }
+}

--- a/packages/shared/src/db/regions.ts
+++ b/packages/shared/src/db/regions.ts
@@ -1,4 +1,22 @@
-import { type AnyPgColumn, index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import {
+  type AnyPgColumn,
+  boolean,
+  doublePrecision,
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core'
+
+// Taxonomy level of a region node (#651 Slice 1). Drives the renter cascade
+// (prefecture -> city -> area dropdowns) and marks which level is assignable.
+export const regionTypeEnum = pgEnum('region_type', ['PREFECTURE', 'CITY', 'AREA'])
+// Lifecycle of a region node. INACTIVE nodes are hidden from search + never
+// matched by `nearestAssignableRegion` (assignment requires ACTIVE).
+export const regionStatusEnum = pgEnum('region_status', ['ACTIVE', 'INACTIVE'])
 
 // #394 hierarchical region taxonomy (prefecture -> city -> area). PLATFORM-GLOBAL
 // reference data — NO operatorId: every operator searches the same tree. Adjacency
@@ -26,9 +44,29 @@ export const regions = pgTable(
     nameZh: text('nameZh').notNull(),
     // Stable dropdown ordering within a level; ties break on nameEn at query time.
     sortOrder: integer('sortOrder').notNull().default(0),
+    // Taxonomy level. Nullable on add (seed populates every row) — mirrors the
+    // nullable-on-add pattern used for locations.regionId / coordinateSource.
+    type: regionTypeEnum('type'),
+    // Region centre in WGS84 decimal degrees, nullable. Set on assignable (area)
+    // nodes so `nearestAssignableRegion` can match a pickup point; prefecture /
+    // city nodes stay null (the map view falls back to fit-all-pins, #458).
+    latitude: doublePrecision('latitude'),
+    longitude: doublePrecision('longitude'),
+    // Whether a renter location may be assigned to this node. Only the deepest
+    // (area) level is assignable; cities/prefectures are navigation-only.
+    assignable: boolean('assignable').notNull().default(false),
+    status: regionStatusEnum('status').notNull().default('ACTIVE'),
+    // URL-stable handle for renter quick-chips (?region=namba) and deep links —
+    // never expose the UUID. Unique; nullable on add (seed populates).
+    slug: text('slug'),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updatedAt', { withTimezone: true }).notNull().defaultNow(),
   },
-  // Covers the self-FK (lint-fk-indexes) + the recursive-descendant walk by parent.
-  (t) => [index('idx_regions_parentId').on(t.parentId)],
+  (t) => [
+    // Covers the self-FK (lint-fk-indexes) + the recursive-descendant walk by parent.
+    index('idx_regions_parentId').on(t.parentId),
+    // Renter chip/deep-link lookups resolve a region by slug; also enforces global
+    // slug uniqueness (Postgres treats NULL slugs as distinct, so pre-seed rows are fine).
+    uniqueIndex('regions_slug_unique').on(t.slug),
+  ],
 )

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -857,7 +857,7 @@ export const notificationLog = pgTable(
 )
 
 export { documentStatusEnum, documentTypeEnum, renterDocuments } from './renter-documents'
-export { regions } from './regions'
+export { regions, regionTypeEnum, regionStatusEnum } from './regions'
 
 // Enum string-union types are derived ONCE in ../enums from the same value arrays
 // the pgEnums above consume (#688). Re-exported here so existing

--- a/packages/shared/src/db/seed-data/regions.ts
+++ b/packages/shared/src/db/seed-data/regions.ts
@@ -10,10 +10,25 @@ import type { regions } from '../schema'
  *
  * Each `DEMO_LOCATIONS` row points its `regionId` at the deepest (area) node here.
  * `nameZh` uses simplified Chinese where it diverges from the Japanese kanji.
+ *
+ * #651 Slice 1 — every node carries a taxonomy `type`, a URL-stable `slug`, and
+ * (on AREA nodes only) the area's WGS84 centre = its anchor location's coords, so
+ * `nearestAssignableRegion` can match a pickup point. Only AREA nodes are
+ * `assignable`; prefectures/cities are navigation-only and keep null coords.
  */
 export type DemoRegion = Pick<
   typeof regions.$inferInsert,
-  'id' | 'parentId' | 'nameEn' | 'nameJa' | 'nameZh' | 'sortOrder'
+  | 'id'
+  | 'parentId'
+  | 'nameEn'
+  | 'nameJa'
+  | 'nameZh'
+  | 'sortOrder'
+  | 'type'
+  | 'latitude'
+  | 'longitude'
+  | 'assignable'
+  | 'slug'
 > & {
   readonly id: string
   /** null = a root (prefecture); otherwise the parent region's id. */
@@ -22,6 +37,14 @@ export type DemoRegion = Pick<
   readonly nameJa: string
   readonly nameZh: string
   readonly sortOrder: number
+  readonly type: 'PREFECTURE' | 'CITY' | 'AREA'
+  /** Set on AREA nodes (= anchor location centre); null on prefectures/cities. */
+  readonly latitude: number | null
+  readonly longitude: number | null
+  /** Only AREA nodes accept location assignment. */
+  readonly assignable: boolean
+  /** Unique, kebab-case URL handle for renter chips/deep links (?region=namba). */
+  readonly slug: string
 }
 
 export const DEMO_REGIONS: readonly DemoRegion[] = [
@@ -33,6 +56,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '大阪府',
     nameZh: '大阪府',
     sortOrder: 1,
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'osaka',
   },
   {
     id: 'reg_osaka_city',
@@ -41,6 +69,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '大阪市',
     nameZh: '大阪市',
     sortOrder: 1,
+    type: 'CITY',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'osaka-city',
   },
   {
     id: 'reg_namba',
@@ -49,6 +82,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '難波',
     nameZh: '难波',
     sortOrder: 1,
+    type: 'AREA',
+    latitude: 34.6627,
+    longitude: 135.5012,
+    assignable: true,
+    slug: 'namba',
   },
   {
     id: 'reg_umeda',
@@ -57,6 +95,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '梅田',
     nameZh: '梅田',
     sortOrder: 2,
+    type: 'AREA',
+    latitude: 34.7025,
+    longitude: 135.4959,
+    assignable: true,
+    slug: 'umeda',
   },
   {
     id: 'reg_tennoji',
@@ -65,6 +108,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '天王寺',
     nameZh: '天王寺',
     sortOrder: 3,
+    type: 'AREA',
+    latitude: 34.6463,
+    longitude: 135.5135,
+    assignable: true,
+    slug: 'tennoji',
   },
   {
     id: 'reg_osaka_castle',
@@ -73,6 +121,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '大阪城',
     nameZh: '大阪城',
     sortOrder: 4,
+    type: 'AREA',
+    latitude: 34.6873,
+    longitude: 135.5259,
+    assignable: true,
+    slug: 'osaka-castle',
   },
   {
     id: 'reg_shin_osaka',
@@ -81,6 +134,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '新大阪',
     nameZh: '新大阪',
     sortOrder: 5,
+    type: 'AREA',
+    latitude: 34.7338,
+    longitude: 135.5003,
+    assignable: true,
+    slug: 'shin-osaka',
   },
   {
     id: 'reg_izumisano',
@@ -89,6 +147,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '泉佐野市',
     nameZh: '泉佐野市',
     sortOrder: 2,
+    type: 'CITY',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'izumisano',
   },
   {
     id: 'reg_kix',
@@ -97,6 +160,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '関西空港',
     nameZh: '关西机场',
     sortOrder: 1,
+    type: 'AREA',
+    latitude: 34.4347,
+    longitude: 135.2441,
+    assignable: true,
+    slug: 'kix',
   },
   // ── Kyoto 京都府 ──────────────────────────────────────────────────────────
   {
@@ -106,6 +174,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '京都府',
     nameZh: '京都府',
     sortOrder: 2,
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'kyoto',
   },
   {
     id: 'reg_kyoto_city',
@@ -114,6 +187,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '京都市',
     nameZh: '京都市',
     sortOrder: 1,
+    type: 'CITY',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'kyoto-city',
   },
   {
     id: 'reg_kyoto_station',
@@ -122,6 +200,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '京都駅',
     nameZh: '京都站',
     sortOrder: 1,
+    type: 'AREA',
+    latitude: 34.9858,
+    longitude: 135.7588,
+    assignable: true,
+    slug: 'kyoto-station',
   },
   // ── Hyogo 兵庫県 ──────────────────────────────────────────────────────────
   {
@@ -131,6 +214,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '兵庫県',
     nameZh: '兵库县',
     sortOrder: 3,
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'hyogo',
   },
   {
     id: 'reg_kobe_city',
@@ -139,6 +227,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '神戸市',
     nameZh: '神户市',
     sortOrder: 1,
+    type: 'CITY',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'kobe-city',
   },
   {
     id: 'reg_sannomiya',
@@ -147,6 +240,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '三宮',
     nameZh: '三宫',
     sortOrder: 1,
+    type: 'AREA',
+    latitude: 34.6946,
+    longitude: 135.1956,
+    assignable: true,
+    slug: 'sannomiya',
   },
   // ── Nara 奈良県 ───────────────────────────────────────────────────────────
   {
@@ -156,6 +254,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '奈良県',
     nameZh: '奈良县',
     sortOrder: 4,
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'nara',
   },
   {
     id: 'reg_nara_city',
@@ -164,6 +267,11 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '奈良市',
     nameZh: '奈良市',
     sortOrder: 1,
+    type: 'CITY',
+    latitude: null,
+    longitude: null,
+    assignable: false,
+    slug: 'nara-city',
   },
   {
     id: 'reg_nara_area',
@@ -172,5 +280,10 @@ export const DEMO_REGIONS: readonly DemoRegion[] = [
     nameJa: '奈良',
     nameZh: '奈良',
     sortOrder: 1,
+    type: 'AREA',
+    latitude: 34.6803,
+    longitude: 135.8174,
+    assignable: true,
+    slug: 'nara-area',
   },
 ] as const

--- a/packages/shared/src/db/seed.ts
+++ b/packages/shared/src/db/seed.ts
@@ -173,6 +173,11 @@ export async function seed(db: ReturnType<typeof getDb>) {
       nameJa: region.nameJa,
       nameZh: region.nameZh,
       sortOrder: region.sortOrder,
+      type: region.type,
+      latitude: region.latitude,
+      longitude: region.longitude,
+      assignable: region.assignable,
+      slug: region.slug,
     }
     await db
       .insert(regions)
@@ -185,6 +190,11 @@ export async function seed(db: ReturnType<typeof getDb>) {
           nameJa: region.nameJa,
           nameZh: region.nameZh,
           sortOrder: region.sortOrder,
+          type: region.type,
+          latitude: region.latitude,
+          longitude: region.longitude,
+          assignable: region.assignable,
+          slug: region.slug,
           updatedAt: now,
         },
       })

--- a/packages/shared/src/lib/region-distance.ts
+++ b/packages/shared/src/lib/region-distance.ts
@@ -1,0 +1,126 @@
+/**
+ * Region geo-matching (#651 Slice 1). Pure functions shared by the one-off
+ * location→region backfill (this slice), the operator location-save suggestion
+ * (Slice 2), and the renter "near me" labels (Slice 3). No DB, no I/O — the
+ * decision is pure; the thin shell that reads/writes the DB lives in
+ * `scripts/backfill-location-regions.ts` (Functional Core / Imperative Shell).
+ *
+ * Distances use the Haversine great-circle formula on WGS84 decimal degrees.
+ * Kansai is small (the demo prefectures span ~80 km), so spherical-earth error
+ * (<0.5%) is irrelevant to "which area is nearest".
+ */
+
+/** A WGS84 point in decimal degrees. */
+export interface GeoPoint {
+  latitude: number
+  longitude: number
+}
+
+/** Minimal structural shape of a region needed to match a point to it. */
+export interface RegionCandidate {
+  id: string
+  latitude: number | null
+  longitude: number | null
+  assignable: boolean
+  status: 'ACTIVE' | 'INACTIVE'
+  /** Stable tiebreak when two assignable regions are equidistant. */
+  sortOrder: number
+}
+
+/**
+ * Cap on how far a point may sit from its nearest assignable area before we
+ * decline to assign one (returning null instead of mis-assigning). Kansai's
+ * assignable areas are dense city districts, so a legitimate pickup point is
+ * always within a few km of its area centre; 100 km comfortably covers suburban
+ * Kansai while rejecting other regions (Tokyo is ~400 km away).
+ */
+export const REGION_SANITY_RADIUS_KM = 100
+
+const EARTH_RADIUS_KM = 6371
+const DEG_TO_RAD = Math.PI / 180
+
+/** Great-circle distance between two points, in kilometres. */
+export function haversineKm(a: GeoPoint, b: GeoPoint): number {
+  const dLat = (b.latitude - a.latitude) * DEG_TO_RAD
+  const dLng = (b.longitude - a.longitude) * DEG_TO_RAD
+  const lat1 = a.latitude * DEG_TO_RAD
+  const lat2 = b.latitude * DEG_TO_RAD
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
+}
+
+function hasCoords(r: RegionCandidate): r is RegionCandidate & GeoPoint {
+  return r.latitude !== null && r.longitude !== null
+}
+
+/**
+ * The nearest assignable, ACTIVE, coordinate-bearing region to `point`, or null
+ * when there is no point, no eligible region, or the closest one sits beyond
+ * REGION_SANITY_RADIUS_KM. Ties break by sortOrder then id for determinism.
+ */
+export function nearestAssignableRegion<T extends RegionCandidate>(
+  regions: readonly T[],
+  point: GeoPoint | null,
+): T | null {
+  if (point === null) return null
+
+  let best: T | null = null
+  let bestKm = Number.POSITIVE_INFINITY
+  for (const region of regions) {
+    if (!region.assignable || region.status !== 'ACTIVE' || !hasCoords(region)) continue
+    const km = haversineKm(point, region)
+    if (km > REGION_SANITY_RADIUS_KM) continue
+    if (km < bestKm || (km === bestKm && isPreferredTiebreak(region, best))) {
+      best = region
+      bestKm = km
+    }
+  }
+  return best
+}
+
+function isPreferredTiebreak(candidate: RegionCandidate, current: RegionCandidate | null): boolean {
+  if (current === null) return true
+  if (candidate.sortOrder !== current.sortOrder) return candidate.sortOrder < current.sortOrder
+  return candidate.id < current.id
+}
+
+/** A location considered by the backfill. */
+export interface BackfillLocation {
+  id: string
+  latitude: number | null
+  longitude: number | null
+  regionId: string | null
+  status: 'ACTIVE' | 'ARCHIVED'
+}
+
+export interface RegionBackfillPlan {
+  /** Locations that should be updated to point at the named region. */
+  assignments: readonly { locationId: string; regionId: string }[]
+  /** ACTIVE, coord-bearing, region-less locations with no area within radius. */
+  unassigned: readonly string[]
+}
+
+/**
+ * Idempotent plan for assigning every ACTIVE location that has coordinates but
+ * no region to its nearest assignable area. Already-assigned, archived, and
+ * coordinate-less locations are left alone; far-away locations are reported in
+ * `unassigned` rather than mis-assigned.
+ */
+export function planRegionBackfill(
+  regions: readonly RegionCandidate[],
+  locations: readonly BackfillLocation[],
+): RegionBackfillPlan {
+  const assignments: { locationId: string; regionId: string }[] = []
+  const unassigned: string[] = []
+  for (const loc of locations) {
+    if (loc.regionId !== null || loc.status !== 'ACTIVE') continue
+    if (loc.latitude === null || loc.longitude === null) continue
+    const match = nearestAssignableRegion(regions, {
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+    })
+    if (match === null) unassigned.push(loc.id)
+    else assignments.push({ locationId: loc.id, regionId: match.id })
+  }
+  return { assignments, unassigned }
+}

--- a/packages/shared/tests/db/seed-data.test.ts
+++ b/packages/shared/tests/db/seed-data.test.ts
@@ -182,10 +182,21 @@ describe('seed-data demo regions (#394)', () => {
     for (const r of DEMO_REGIONS) expect(r.assignable).toBe(r.type === 'AREA')
   })
 
-  it('gives every assignable (area) region real coordinates', () => {
+  it('gives every assignable (area) region valid WGS84 coordinates', () => {
     for (const r of DEMO_REGIONS.filter((r) => r.assignable)) {
-      expect(typeof r.latitude).toBe('number')
-      expect(typeof r.longitude).toBe('number')
+      const lat = r.latitude as number
+      const lng = r.longitude as number
+      // Finite numbers (rejects null / NaN / Infinity)...
+      expect(Number.isFinite(lat)).toBe(true)
+      expect(Number.isFinite(lng)).toBe(true)
+      // ...inside the WGS84 envelope...
+      expect(lat).toBeGreaterThanOrEqual(-90)
+      expect(lat).toBeLessThanOrEqual(90)
+      expect(lng).toBeGreaterThanOrEqual(-180)
+      expect(lng).toBeLessThanOrEqual(180)
+      // ...and not the (0,0) Atlantic-Ocean default (Kansai is firmly NE quadrant).
+      expect(lat).toBeGreaterThan(0)
+      expect(lng).toBeGreaterThan(0)
     }
   })
 

--- a/packages/shared/tests/db/seed-data.test.ts
+++ b/packages/shared/tests/db/seed-data.test.ts
@@ -167,6 +167,46 @@ describe('seed-data demo regions (#394)', () => {
       expect(parentIds.has(loc.regionId)).toBe(false)
     }
   })
+
+  // #651 Slice 1 — region coordinates + taxonomy + slugs.
+  const isLeaf = (id: string) => !parentIds.has(id)
+
+  it('types every region by tree position (root=PREFECTURE, leaf=AREA, else CITY)', () => {
+    for (const r of DEMO_REGIONS) {
+      const expected = r.parentId === null ? 'PREFECTURE' : isLeaf(r.id) ? 'AREA' : 'CITY'
+      expect(r.type).toBe(expected)
+    }
+  })
+
+  it('marks a region assignable iff it is an AREA (leaf) node', () => {
+    for (const r of DEMO_REGIONS) expect(r.assignable).toBe(r.type === 'AREA')
+  })
+
+  it('gives every assignable (area) region real coordinates', () => {
+    for (const r of DEMO_REGIONS.filter((r) => r.assignable)) {
+      expect(typeof r.latitude).toBe('number')
+      expect(typeof r.longitude).toBe('number')
+    }
+  })
+
+  it("centres each area region on its anchor location's coordinates", () => {
+    for (const loc of DEMO_LOCATIONS) {
+      const region = regionsById.get(loc.regionId)
+      expect(region?.latitude).toBe(loc.latitude)
+      expect(region?.longitude).toBe(loc.longitude)
+    }
+  })
+
+  it('gives every region a unique, kebab-case slug', () => {
+    const slugs = DEMO_REGIONS.map((r) => r.slug)
+    expect(new Set(slugs).size).toBe(DEMO_REGIONS.length)
+    for (const slug of slugs) expect(slug).toMatch(KEBAB)
+  })
+
+  it('exposes the renter quick-chip slugs (namba / umeda / kix)', () => {
+    const slugs = new Set(DEMO_REGIONS.map((r) => r.slug))
+    for (const chip of ['namba', 'umeda', 'kix']) expect(slugs.has(chip)).toBe(true)
+  })
 })
 
 // Slice 8 §3.3 — ACRISS class taxonomy; no operator has a single-class fleet.

--- a/packages/shared/tests/lib/region-distance.test.ts
+++ b/packages/shared/tests/lib/region-distance.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REGION_SANITY_RADIUS_KM,
+  haversineKm,
+  nearestAssignableRegion,
+  planRegionBackfill,
+} from '../../src/lib/region-distance'
+
+// Real Kansai coords (WGS84) mirrored from the demo locations so the tests read
+// against credible geography rather than synthetic numbers.
+const NAMBA = { latitude: 34.6627, longitude: 135.5012 }
+const UMEDA = { latitude: 34.7025, longitude: 135.4959 }
+const KIX = { latitude: 34.4347, longitude: 135.2441 }
+const TOKYO = { latitude: 35.6812, longitude: 139.7671 } // ~400 km from Kansai
+
+const area = (over: Partial<Parameters<typeof nearestAssignableRegion>[0][number]> = {}) => ({
+  id: 'reg_namba',
+  latitude: NAMBA.latitude as number | null,
+  longitude: NAMBA.longitude as number | null,
+  assignable: true,
+  status: 'ACTIVE' as 'ACTIVE' | 'INACTIVE',
+  sortOrder: 0,
+  ...over,
+})
+
+describe('haversineKm', () => {
+  it('returns 0 for identical points', () => {
+    expect(haversineKm(NAMBA, NAMBA)).toBe(0)
+  })
+
+  it('matches the known Namba↔Umeda great-circle distance (~4.4 km)', () => {
+    expect(haversineKm(NAMBA, UMEDA)).toBeCloseTo(4.4, 0)
+  })
+
+  it('is symmetric', () => {
+    expect(haversineKm(NAMBA, KIX)).toBeCloseTo(haversineKm(KIX, NAMBA), 6)
+  })
+})
+
+describe('nearestAssignableRegion', () => {
+  it('returns null when the point is null', () => {
+    expect(nearestAssignableRegion([area()], null)).toBeNull()
+  })
+
+  it('returns null when there are no regions', () => {
+    expect(nearestAssignableRegion([], NAMBA)).toBeNull()
+  })
+
+  it('picks the geographically nearest eligible region', () => {
+    const regions = [
+      area({ id: 'reg_kix', ...KIX }),
+      area({ id: 'reg_umeda', ...UMEDA }),
+      area({ id: 'reg_namba', ...NAMBA }),
+    ]
+    // A point sitting on Umeda must resolve to Umeda, not Namba/KIX.
+    expect(nearestAssignableRegion(regions, UMEDA)?.id).toBe('reg_umeda')
+  })
+
+  it('ignores non-assignable regions even when closest', () => {
+    const regions = [
+      area({ id: 'reg_namba', ...NAMBA, assignable: false }),
+      area({ id: 'reg_umeda', ...UMEDA, assignable: true }),
+    ]
+    expect(nearestAssignableRegion(regions, NAMBA)?.id).toBe('reg_umeda')
+  })
+
+  it('ignores INACTIVE regions even when closest', () => {
+    const regions = [
+      area({ id: 'reg_namba', ...NAMBA, status: 'INACTIVE' }),
+      area({ id: 'reg_umeda', ...UMEDA, status: 'ACTIVE' }),
+    ]
+    expect(nearestAssignableRegion(regions, NAMBA)?.id).toBe('reg_umeda')
+  })
+
+  it('ignores regions without coordinates', () => {
+    const regions = [
+      area({ id: 'reg_namba', latitude: null, longitude: null }),
+      area({ id: 'reg_umeda', ...UMEDA }),
+    ]
+    expect(nearestAssignableRegion(regions, NAMBA)?.id).toBe('reg_umeda')
+  })
+
+  it('returns null when the nearest region is beyond the sanity radius', () => {
+    expect(nearestAssignableRegion([area({ id: 'reg_namba', ...NAMBA })], TOKYO)).toBeNull()
+  })
+
+  it('breaks ties by sortOrder, then id, when distances are equal', () => {
+    const regions = [
+      area({ id: 'reg_b', ...NAMBA, sortOrder: 2 }),
+      area({ id: 'reg_a', ...NAMBA, sortOrder: 1 }),
+      area({ id: 'reg_c', ...NAMBA, sortOrder: 1 }),
+    ]
+    // Equal distance (same coords): lowest sortOrder wins; sortOrder tie → lowest id.
+    expect(nearestAssignableRegion(regions, NAMBA)?.id).toBe('reg_a')
+  })
+
+  it('keeps the sanity radius within a sane Kansai-scale bound', () => {
+    expect(REGION_SANITY_RADIUS_KM).toBeGreaterThan(0)
+    expect(REGION_SANITY_RADIUS_KM).toBeLessThanOrEqual(150)
+  })
+})
+
+describe('planRegionBackfill', () => {
+  const areas = [
+    area({ id: 'reg_namba', ...NAMBA }),
+    area({ id: 'reg_umeda', ...UMEDA }),
+    area({ id: 'reg_kix', ...KIX }),
+  ]
+
+  it('assigns a coord-bearing ACTIVE location with no region to its nearest area', () => {
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_1', ...UMEDA, regionId: null, status: 'ACTIVE' },
+    ])
+    expect(plan.assignments).toEqual([{ locationId: 'loc_1', regionId: 'reg_umeda' }])
+    expect(plan.unassigned).toEqual([])
+  })
+
+  it('reports far-away locations as unassigned instead of mis-assigning them', () => {
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_tokyo', ...TOKYO, regionId: null, status: 'ACTIVE' },
+    ])
+    expect(plan.assignments).toEqual([])
+    expect(plan.unassigned).toEqual(['loc_tokyo'])
+  })
+
+  it('is idempotent: leaves already-assigned locations untouched', () => {
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_1', ...UMEDA, regionId: 'reg_umeda', status: 'ACTIVE' },
+    ])
+    expect(plan.assignments).toEqual([])
+    expect(plan.unassigned).toEqual([])
+  })
+
+  it('skips locations with no coordinates', () => {
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_nogeo', latitude: null, longitude: null, regionId: null, status: 'ACTIVE' },
+    ])
+    expect(plan.assignments).toEqual([])
+    expect(plan.unassigned).toEqual([])
+  })
+
+  it('skips ARCHIVED locations', () => {
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_archived', ...UMEDA, regionId: null, status: 'ARCHIVED' },
+    ])
+    expect(plan.assignments).toEqual([])
+    expect(plan.unassigned).toEqual([])
+  })
+})

--- a/packages/shared/tests/lib/region-distance.test.ts
+++ b/packages/shared/tests/lib/region-distance.test.ts
@@ -84,6 +84,27 @@ describe('nearestAssignableRegion', () => {
     expect(nearestAssignableRegion([area({ id: 'reg_namba', ...NAMBA })], TOKYO)).toBeNull()
   })
 
+  it('skips an out-of-radius region but still selects a nearer one later in the list', () => {
+    // Far region listed FIRST: a `continue`->`break` mutation in the radius guard
+    // would exit before reaching the in-radius region and wrongly return null.
+    const regions = [
+      area({ id: 'reg_tokyo', ...TOKYO }), // ~400 km from NAMBA — beyond radius
+      area({ id: 'reg_umeda', ...UMEDA }), // ~4 km from NAMBA — within radius
+    ]
+    expect(nearestAssignableRegion(regions, NAMBA)?.id).toBe('reg_umeda')
+  })
+
+  it('accepts a region just inside the radius and rejects one just outside it', () => {
+    // On the equator east of (0,0), distance ≈ 6371 km · Δlng(rad). 0.898° ≈ 99.85 km
+    // (inside 100 km); 0.902° ≈ 100.30 km (outside). Straddles REGION_SANITY_RADIUS_KM,
+    // pinning the radius constant + the cutoff direction without a flaky exact-boundary point.
+    const origin = { latitude: 0, longitude: 0 }
+    const justInside = area({ id: 'reg_inside', latitude: 0, longitude: 0.898 })
+    const justOutside = area({ id: 'reg_outside', latitude: 0, longitude: 0.902 })
+    expect(nearestAssignableRegion([justInside], origin)?.id).toBe('reg_inside')
+    expect(nearestAssignableRegion([justOutside], origin)).toBeNull()
+  })
+
   it('breaks ties by sortOrder, then id, when distances are equal', () => {
     const regions = [
       area({ id: 'reg_b', ...NAMBA, sortOrder: 2 }),

--- a/scripts/backfill-location-regions.ts
+++ b/scripts/backfill-location-regions.ts
@@ -1,0 +1,21 @@
+import { getDb } from '../packages/shared/src/db'
+import { backfillLocationRegions } from '../packages/shared/src/db/backfill-regions'
+
+// CLI entry for `bun run db:backfill-regions` — assigns every region-less ACTIVE
+// location to its nearest assignable area against the Neon DATABASE_URL. The
+// matching logic is the pure, injectable backfillLocationRegions in @kuruma/shared.
+backfillLocationRegions(getDb())
+  .then((report) => {
+    console.log(`Region backfill complete: ${report.assigned} location(s) assigned.`)
+    if (report.unassigned.length > 0) {
+      console.warn(
+        `${report.unassigned.length} location(s) left unassigned (no assignable area within radius):`,
+      )
+      for (const id of report.unassigned) console.warn(`  - ${id}`)
+    }
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.error('Region backfill failed:', err)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Slice 1 — region coordinates, taxonomy + nearest-area backfill

First build slice of NicoNico-style renter location search (plan: **#394 §8**, `docs/plans/2026-06-12-renter-location-search-niconico.md`). Slice 0 (#671) landed the `regions` table, `GET /regions`, and the subtree filter. This slice adds the geo + taxonomy data model and the **pure matching engine** that Slice 2 (operator location-save suggestion) and Slice 3 (renter "near me") build on. **api/web untouched** — those are separate follow-up PRs.

### What's included
- **Schema (`regions.ts`)**: `type` (PREFECTURE/CITY/AREA), `latitude`/`longitude` (WGS84), `assignable`, `status` (ACTIVE/INACTIVE), `slug` (unique). All nullable/defaulted — additive over Slice 0's seeded rows.
- **Migration `0058_add_region_coords_and_taxonomy`**: 2 enums + 6 columns + slug unique index. Additive. (Renumbered 0056→0058 to clear collisions with `0056_add_payment_anomalies` and `0057_fee_schedules_feetype_unit_coherence`, both of which merged to mp while this was in flight.)
- **Pure matching (`lib/region-distance.ts`)** — Functional Core: `haversineKm`; `nearestAssignableRegion` (assignable + ACTIVE + coords, 100 km sanity cap, `sortOrder`→`id` tiebreak, null-point → null); `planRegionBackfill` (idempotent — skips already-assigned/archived/coord-less, reports far-away locations as `unassigned` rather than mis-assigning).
- **Injectable backfill shell (`db/backfill-regions.ts`)** + one-off runner (`scripts/backfill-location-regions.ts`) — Imperative Shell: read rows → plan → apply → report. Injectable like `seed` (DIP), idempotent.
- **Seed**: 18 region centers, 9 assignable AREA nodes, unique slugs.

### Test plan
- `db:verify` **5/5** on a fresh pg migrated `0001→0058` — schema↔snapshot, journal↔disk, `when` monotonic, journal↔DB = 59 applied, and #702's critical-objects assertion (exclusion / check / trigger / idempotency all present).
- **514** `@kuruma/shared` unit tests green (incl. `region-distance.test.ts`, `seed-data.test.ts`).
- `tsc --noEmit` (shared) + `biome check` clean on all slice files; `lint:modules` + `lint:fk-indexes` (regions self-FK indexed) green.

Part of #651 (Slice 1 of 3 — Slices 2 & 3 ship as separate PRs; do not auto-close the epic).
