### PR TITLE
refactor(api): derive stores.ts enum unions from @kuruma/shared/enums

### DIFF
--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -8,6 +8,24 @@ import type {
   FeeSnapshotItem,
   InsuranceSnapshot,
 } from '@kuruma/shared/db/schema'
+import type {
+  AddOnStatus,
+  BookingSource,
+  BookingStatus,
+  DocumentStatus,
+  DocumentType,
+  FeeScheduleStatus,
+  FeeType,
+  FeeUnit,
+  InsuranceStatus,
+  LocationStatus,
+  OperatorMembershipStatus,
+  OperatorRole,
+  PaymentEventStatus,
+  ProviderInviteStatus,
+  Transmission,
+  VehicleClassStatus,
+} from '@kuruma/shared/enums'
 import type { LuggageSize } from '@kuruma/shared/lib/luggage'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
 
@@ -30,12 +48,12 @@ export interface VehicleClass {
   seats: number
   luggageCapacity: number
   luggageSize: LuggageSize
-  transmission: 'AUTO' | 'MANUAL'
+  transmission: Transmission
   fuelType: string | null
   /** ACRISS taxonomy code (#388). Null when the class has no mapped code. */
   acrissCode: string | null
   sortOrder: number
-  status: 'ACTIVE' | 'ARCHIVED'
+  status: VehicleClassStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -59,8 +77,8 @@ export interface Booking {
   startAt: Date
   endAt: Date
   effectiveEndAt: Date
-  status: 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
-  source: 'DIRECT' | 'TRIP_COM' | 'MANUAL' | 'OTHER'
+  status: BookingStatus
+  source: BookingSource
   // #463: how the booking is fulfilled. Server-derived SPECIFIC pre-demo;
   // CLASS_COMBO is #464. Always written explicitly by app code (Option B).
   fulfillmentMode: BookingFulfillmentMode
@@ -114,7 +132,7 @@ export interface PaymentEvent {
   platformFeeJpy: number
   netToPartnerJpy: number
   currency: string
-  status: 'SUCCEEDED'
+  status: PaymentEventStatus
   createdAt: Date
 }
 
@@ -254,7 +272,7 @@ export interface Location {
   /** #394 deepest (area) region node, or null (not-yet-assigned, NOT NULL
    *  deferred — D1). Drives the recursive-descendant storefront filter. */
   regionId: string | null
-  status: 'ACTIVE' | 'ARCHIVED'
+  status: LocationStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -281,7 +299,7 @@ export interface InsuranceOption {
   dailyPriceJpy: number
   /** null = no deductible (full cover). */
   deductibleJpy: number | null
-  status: 'ACTIVE' | 'ARCHIVED'
+  status: InsuranceStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -293,7 +311,7 @@ export interface AddOn {
   name: string
   description: string | null
   priceJpy: number
-  status: 'ACTIVE' | 'ARCHIVED'
+  status: AddOnStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -304,10 +322,10 @@ export interface FeeSchedule {
   operatorId: string
   /** null = operator-wide fee; non-null = scoped to one vehicle class. */
   vehicleClassId: string | null
-  feeType: 'OVERTIME_HOURLY' | 'CLEANING_FLAT' | 'NO_FUEL_FLAT'
-  unit: 'PER_HOUR' | 'PER_DAY' | 'PER_KM' | 'FLAT'
+  feeType: FeeType
+  unit: FeeUnit
   amountJpy: number
-  status: 'ACTIVE' | 'ARCHIVED'
+  status: FeeScheduleStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -317,9 +335,9 @@ export interface FeeSchedule {
 export interface RenterDocument {
   id: string
   renterId: string
-  type: 'IDP' | 'PASSPORT'
+  type: DocumentType
   storageKey: string
-  status: 'PENDING' | 'APPROVED' | 'REJECTED'
+  status: DocumentStatus
   expiryDate: string | null
   verifiedAt: Date | null
   verifierId: string | null
@@ -335,8 +353,8 @@ export interface OperatorMembership {
   id: string
   userId: string
   operatorId: string
-  role: 'OPERATOR_OWNER' | 'OPERATOR_STAFF'
-  status: 'ACTIVE' | 'REVOKED'
+  role: OperatorRole
+  status: OperatorMembershipStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -348,9 +366,9 @@ export interface ProviderInvite {
   id: string
   email: string
   operatorId: string
-  role: 'OPERATOR_OWNER' | 'OPERATOR_STAFF'
+  role: OperatorRole
   tokenHash: string
-  status: 'PENDING' | 'ACCEPTED'
+  status: ProviderInviteStatus
   expiresAt: Date
   invitedByUserId: string | null
   acceptedByUserId: string | null


### PR DESCRIPTION
## What

Replace 16 hand-written enum literal unions in `packages/api/src/stores.ts` with the named derived types from the zero-import `@kuruma/shared/enums` subpath (landed via #688/#755). The file header already stated this rationale for the 4 fields it derived; this finishes applying it to the rest.

**Behavior-preserving:** same runtime values, compile-time linkage only. A value added to a pgEnum can no longer drift from these contract types without a `tsc` error.

## Converted (16)

| Interface.field | was | now |
|---|---|---|
| VehicleClass.transmission | `'AUTO' \| 'MANUAL'` | `Transmission` |
| VehicleClass.status | `'ACTIVE' \| 'ARCHIVED'` | `VehicleClassStatus` |
| Booking.status | `'CONFIRMED' \| ...` | `BookingStatus` |
| Booking.source | `'DIRECT' \| ...` | `BookingSource` |
| PaymentEvent.status | `'SUCCEEDED'` | `PaymentEventStatus` |
| Location.status | `'ACTIVE' \| 'ARCHIVED'` | `LocationStatus` |
| InsuranceOption.status | `'ACTIVE' \| 'ARCHIVED'` | `InsuranceStatus` |
| AddOn.status | `'ACTIVE' \| 'ARCHIVED'` | `AddOnStatus` |
| FeeSchedule.feeType | `'OVERTIME_HOURLY' \| ...` | `FeeType` |
| FeeSchedule.unit | `'PER_HOUR' \| ...` | `FeeUnit` |
| FeeSchedule.status | `'ACTIVE' \| 'ARCHIVED'` | `FeeScheduleStatus` |
| RenterDocument.type | `'IDP' \| 'PASSPORT'` | `DocumentType` |
| RenterDocument.status | `'PENDING' \| ...` | `DocumentStatus` |
| OperatorMembership.role | `'OPERATOR_OWNER' \| ...` | `OperatorRole` |
| OperatorMembership.status | `'ACTIVE' \| 'REVOKED'` | `OperatorMembershipStatus` |
| ProviderInvite.role | `'OPERATOR_OWNER' \| ...` | `OperatorRole` |
| ProviderInvite.status | `'PENDING' \| 'ACCEPTED'` | `ProviderInviteStatus` |

## Left as-is (intentional)

- **`NotificationLog.kind`** — notification enums were deliberately excluded from the shared enum SSoT (see the `NOTE` in `enums.ts`, #710 closed unmerged). No derived type exists; inventing one is out of scope.
- **`PaymentAnomalyKind`** — no shared counterpart exists.

The existing `NotificationStatus` derivation (from `notificationStatusEnum.enumValues`) is untouched.

## Scope

`packages/api/src/stores.ts` only. No web, no shared, no `index.ts`, no route files.

## Gates

- `bun run --filter @kuruma/api test` — 1357/1357 passed (118 files)
- `bun run --filter @kuruma/api lint:boundaries` — OK
- `bunx tsc --noEmit` — clean (proves value equivalence)
- `bun run lint` — 0 errors (pre-existing file-size warnings only; none in stores.ts)

Relates to #696