### PR TITLE
test(api): TRIGGER_KINDS parity with LifecycleTrigger + notificationKindEnum (#720)

### DIFF
--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -26,7 +26,10 @@ type Kind = NotificationLog['kind']
  */
 export type LifecycleTrigger = 'CREATED' | 'SUBSTITUTED' | 'CANCELLED' | 'ACTIVATED' | 'COMPLETED'
 
-const TRIGGER_KINDS: Record<LifecycleTrigger, Kind[]> = {
+// Exported for the parity test (#720): a renamed enum can leave this hand-map
+// stale, surfacing only as a missing renter notification in prod. Adding a new
+// trigger fails to compile via the Record type; the test guards the rename vector.
+export const TRIGGER_KINDS: Record<LifecycleTrigger, Kind[]> = {
   CREATED: ['RENTER_BOOKING_CONFIRM', 'OPERATOR_BOOKING_ALERT'],
   SUBSTITUTED: ['RENTER_SUBSTITUTION'],
   CANCELLED: ['RENTER_CANCELLATION'],

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -1,3 +1,4 @@
+import { notificationKindEnum } from '@kuruma/shared/db/schema'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { InMemoryNotificationLogRepository } from '../../src/repositories/in-memory/notification-log'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
@@ -5,7 +6,11 @@ import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
 import { MAX_NOTIFICATION_ATTEMPTS, SEND_LEASE_MS } from '../../src/repositories/types'
 import type { LocationRepository, VehicleRepository } from '../../src/repositories/types'
 import type { EmailSender } from '../../src/services/email/email-sender'
-import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
+import {
+  type LifecycleTrigger,
+  NotificationDispatcher,
+  TRIGGER_KINDS,
+} from '../../src/services/notification-dispatcher'
 import type { Booking, User } from '../../src/stores'
 
 const OP = 'op-1'
@@ -308,5 +313,52 @@ describe('NotificationDispatcher', () => {
       expect(blob).not.toContain('veh-1') // assignedVehicleId never rendered
       expect(blob).not.toContain(OP) // operatorId never rendered
     })
+  })
+})
+
+// #720: TRIGGER_KINDS is a hand-map from lifecycle event -> notification kinds.
+// Adding a NEW trigger fails to compile via the Record<LifecycleTrigger, Kind[]>
+// type, so that vector is already guarded. The vectors NOT caught by the compiler
+// are (a) the hand-mirror going stale and (b) a kind literal that drifts from the
+// DB enum after a rename — both surface only in prod as a missing renter email.
+// These parity tests close that gap against the single source of truth
+// (notificationKindEnum.enumValues from @kuruma/shared/db/schema).
+describe('TRIGGER_KINDS parity (#720)', () => {
+  // Runtime oracle for the LifecycleTrigger union. The `satisfies` keeps every
+  // member a real trigger; the round-trip type below makes OMITTING a trigger a
+  // COMPILE error — so the oracle itself can never silently drift out of sync,
+  // which is what would otherwise make the key-set assertion vacuous.
+  const ALL_TRIGGERS = [
+    'CREATED',
+    'SUBSTITUTED',
+    'CANCELLED',
+    'ACTIVATED',
+    'COMPLETED',
+  ] as const satisfies readonly LifecycleTrigger[]
+  // If a trigger is added to the union but not to ALL_TRIGGERS above, `Missing`
+  // becomes a non-`never` union and this line fails `tsc` — forcing the oracle
+  // (and thus the test) to stay exhaustive.
+  type Missing = Exclude<LifecycleTrigger, (typeof ALL_TRIGGERS)[number]>
+  const _exhaustive: Missing extends never ? true : never = true
+  void _exhaustive
+
+  const enumKinds: readonly string[] = notificationKindEnum.enumValues
+
+  it('key set equals the full LifecycleTrigger union exhaustively', () => {
+    expect([...Object.keys(TRIGGER_KINDS)].sort()).toEqual([...ALL_TRIGGERS].sort())
+  })
+
+  it('every flattened kind is a member of notificationKindEnum.enumValues', () => {
+    const usedKinds = [...new Set(Object.values(TRIGGER_KINDS).flat())]
+    const strays = usedKinds.filter((kind) => !enumKinds.includes(kind))
+    // Assert the offending values, not a bare boolean, so a failure names the
+    // stale kind(s) directly.
+    expect(strays).toEqual([])
+  })
+
+  it('maps each trigger to at least one kind (a trigger mapping to [] sends nothing)', () => {
+    for (const trigger of ALL_TRIGGERS) {
+      expect(TRIGGER_KINDS[trigger].length).toBeGreaterThan(0)
+    }
   })
 })


### PR DESCRIPTION
## Summary

The notification dispatcher hand-maps every `LifecycleTrigger` to its notification kinds in `TRIGGER_KINDS`. The compiler already guards the **add-a-trigger** vector (`Record<LifecycleTrigger, Kind[]>` fails to compile if a key is missing for a new union member), but two drift vectors slip past it:

1. **Stale entry after an enum rename** — the hand-mirror (`notificationKindEnum` -> `NotificationLog['kind']` -> `TRIGGER_KINDS`) can leave a value pointing at a kind that no longer exists.
2. **A value not in the DB enum** — surfaces only in production as a missing renter notification.

This adds a parity test closing that gap, comparing against the single source of truth post-#688/#710 (`notificationKindEnum.enumValues` from `@kuruma/shared/db/schema`). Test-only; the one production-file change is making `TRIGGER_KINDS` `export` (visibility only — no behavior change), so the test reads the real runtime map rather than a copy.

Note: the issue's "depends on #710" referred to deriving `NotificationLog['kind']` from the pgEnum; #710 is not on trunk yet, but the membership oracle here already reads the DB-backed `notificationKindEnum.enumValues` directly, so the test is correct against current code and stays correct after #710 lands.

Closes #720

## Test plan

New `describe('TRIGGER_KINDS parity (#720)')` in `packages/api/tests/services/notification-dispatcher.test.ts`:
- **key set equals the full LifecycleTrigger union exhaustively** — the runtime oracle (`ALL_TRIGGERS`) is pinned exhaustive by a compile-time `Exclude<LifecycleTrigger, ...>` guard, so the oracle itself cannot silently drift (which would make the assertion vacuous).
- **every flattened kind is a member of `notificationKindEnum.enumValues`** — asserts the offending stray value(s) on failure, not a bare boolean.
- **each trigger maps to >=1 kind** — a trigger mapping to `[]` would silently send nothing.

Gates (all green):
- `bun run --filter @kuruma/api test tests/services/notification-dispatcher.test.ts` -> 16/16 passed
- `bunx tsc --noEmit -p packages/api/tsconfig.json` -> exit 0
- `bunx biome check <changed>` -> clean
- `bun run lint:size` -> only pre-existing warnings (changed files under cap)
- `bun run --filter @kuruma/api lint:boundaries` -> OK

Mutation check (temporarily broke `TRIGGER_KINDS`, reverted):
- Removed the `COMPLETED` key -> "key set ... exhaustively" FAILED as expected.
- Injected a stray kind `RENTER_CANCELLATION_TYPO` -> "every flattened kind is a member ..." FAILED as expected.