### PR TITLE
fix(api): normalize user email to lowercase on the write path (#715)

### DIFF
--- a/packages/api/src/repositories/drizzle/user.ts
+++ b/packages/api/src/repositories/drizzle/user.ts
@@ -62,7 +62,9 @@ export class DrizzleUserRepository implements UserRepository {
     // Insert with ON CONFLICT for email AND phone so concurrent walk-in requests
     // with the same contact info resolve to the same row instead of duplicating.
     // The placeholder email is only used when caller supplied no email.
-    const insertEmail = data.email ?? `phone-${crypto.randomUUID()}${PLACEHOLDER_EMAIL_SUFFIX}`
+    const insertEmail = data.email
+      ? data.email.toLowerCase()
+      : `phone-${crypto.randomUUID()}${PLACEHOLDER_EMAIL_SUFFIX}`
 
     const [inserted] = await this.db
       .insert(users)
@@ -94,7 +96,7 @@ export class DrizzleUserRepository implements UserRepository {
     const [row] = await this.db
       .select(userColumns)
       .from(users)
-      .where(eq(users.email, email))
+      .where(eq(users.email, email.toLowerCase()))
       .limit(1)
     return row ? (maskPlaceholderEmail(row) as User) : undefined
   }

--- a/packages/api/src/repositories/in-memory/user.ts
+++ b/packages/api/src/repositories/in-memory/user.ts
@@ -49,7 +49,7 @@ export class InMemoryUserRepository implements UserRepository {
     const user: User = {
       id: crypto.randomUUID(),
       name: data.name,
-      email: data.email,
+      email: data.email?.toLowerCase() ?? null,
       phone: data.phone,
       language: data.language,
       country: null,
@@ -60,7 +60,8 @@ export class InMemoryUserRepository implements UserRepository {
   }
 
   async findByEmail(email: string): Promise<User | undefined> {
-    return [...this.store.values()].find((u) => u.email === email)
+    const target = email.toLowerCase()
+    return [...this.store.values()].find((u) => u.email?.toLowerCase() === target)
   }
 
   async findByPhone(phone: string): Promise<User | undefined> {

--- a/packages/api/src/services/customer.ts
+++ b/packages/api/src/services/customer.ts
@@ -46,11 +46,14 @@ export class CustomerService {
     phone?: string | undefined
     language: string
   }): Promise<{ user: User; created: boolean }> {
+    // Email is a case-insensitive identity (#715): normalize at the boundary so
+    // Bob@x.com and bob@x.com resolve to one human, not two rows.
+    const email = input.email?.toLowerCase()
     // Fast-path: if a customer already exists for this email/phone, return it
     // without attempting an insert. The repository also handles concurrent
     // inserts idempotently, but this short-circuits the common case.
-    if (input.email) {
-      const existing = await this.userRepo.findByEmail(input.email)
+    if (email) {
+      const existing = await this.userRepo.findByEmail(email)
       if (existing) return { user: existing, created: false }
     }
     if (input.phone) {
@@ -60,7 +63,7 @@ export class CustomerService {
 
     const user = await this.userRepo.quickCreate({
       name: input.name,
-      email: input.email ?? null,
+      email: email ?? null,
       phone: input.phone ?? null,
       language: input.language,
     })

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -399,6 +399,29 @@ describe('POST /customers/quick-create', () => {
     expect(body2.data.id).toBe(body1.data.id)
   })
 
+  it('is idempotent on email case — Bob@x.com and bob@x.com resolve to one user (#715)', async () => {
+    setup({ asRole: 'STAFF' })
+
+    const res1 = await app.request('/customers/quick-create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Mixed Case', email: 'Bob@Example.com', language: 'en' }),
+    })
+    expect(res1.status).toBe(201)
+    const body1 = await res1.json()
+    // stored lowercased so the DB unique index can't be defeated by casing
+    expect(body1.data.email).toBe('bob@example.com')
+
+    const res2 = await app.request('/customers/quick-create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Same Human', email: 'bob@example.com', language: 'en' }),
+    })
+    expect(res2.status).toBe(200) // existing user, not a new row
+    const body2 = await res2.json()
+    expect(body2.data.id).toBe(body1.data.id)
+  })
+
   it('returns 400 when neither email nor phone is provided', async () => {
     setup({ asRole: 'STAFF' })
     const res = await app.request('/customers/quick-create', {
@@ -434,6 +457,9 @@ describe('POST /customers/quick-create', () => {
     const body = await res.json()
     expect(body.data.name).toBe('Phone Only')
     expect(body.data.phone).toBe('+81-90-9999-8888')
+    // phone-only must stay email:null — guards the `data.email?.toLowerCase() ?? null`
+    // branch against a refactor that accidentally lowercases the synthetic placeholder
+    expect(body.data.email).toBeNull()
   })
 
   it('is idempotent on phone — returns existing user', async () => {


### PR DESCRIPTION
## Problem
`users.email` is `text().unique()` with default collation, so the UNIQUE index treated `Bob@x.com` and `bob@x.com` as distinct. The operator walk-in `quickCreate` path inserted email verbatim and `findByEmail` matched exactly, so one human could split into two rows (bookings / role / operatorId), and `findByEmail` could return the wrong account. The team already treats email as case-insensitive for reads (`ilike`, and `operator-grant.ts` lowercases invites) — neither the write path nor the constraint enforced it.

## Fix — boundary normalization (per #715)
- **`services/customer.ts`** — lowercase `input.email` once at the top of `quickCreate`; use it for both the findByEmail fast-path and the insert.
- **`repositories/drizzle/user.ts`** — lowercase the inserted email; lowercase the arg in `findByEmail`.
- **`repositories/in-memory/user.ts`** — same normalization, so the `findByEmail is case-insensitive` contract holds for **both** impls (tests run against InMemory; the architecture requires InMemory↔Drizzle substitutability).

Citext + an `ALTER COLUMN` migration is the durable follow-up (also seals raw-SQL/seed writers) — deliberately out of this slice.

## Acceptance criteria
- [x] quickCreate stores email lowercased (createUser = OAuth adapter, already lowercase)
- [x] findByEmail matches case-insensitively
- [x] customer walk-in findOrCreate resolves `Bob@x.com` and `bob@x.com` to one user (test)
- [x] OAuth sign-in flow unaffected (lives in `web`, never calls these repo methods)

## Test plan
- New RED→GREEN route test: `Bob@Example.com` then `bob@example.com` → 201 then 200, same id, stored as `bob@example.com`.
- Strengthened phone-only test to assert `email: null` (locks the `?? null` placeholder branch).
- Gates: api unit **1359/1359**, tsc 0, biome / boundaries / lint:size / lint:modules clean.

## Follow-up
- Citext + backfill (`UPDATE users SET email = lower(email)`) to heal any legacy mixed-case rows and consolidate normalization into one `normalizeEmail()` in `shared`. No prod data exists yet, so there are no legacy rows to heal today.

Closes #715