### PR TITLE
perf(api): push admin-revenue month filter + available-months into SQL (#717)

### DIFF
--- a/packages/api/src/repositories/drizzle/payment-event.ts
+++ b/packages/api/src/repositories/drizzle/payment-event.ts
@@ -1,8 +1,13 @@
 import { paymentEvents } from '@kuruma/shared/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { type SQL, and, eq, sql } from 'drizzle-orm'
 import type { PaymentEvent } from '../../stores'
 import type { NewPaymentEvent, PaymentEventRepository } from '../types'
 import { type Db, paymentEventColumns, toPaymentEvent } from './shared'
+
+// The JST (`Asia/Tokyo`) payout month of a row, as `YYYY-MM`. Japan observes no
+// DST, so `AT TIME ZONE` is a constant +9 shift — byte-identical to the pure
+// `jstYearMonth` (UTC+9 then slice) the report aggregation uses (#462/#717).
+const jstMonthExpr = sql<string>`to_char(${paymentEvents.createdAt} AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM')`
 
 export class DrizzlePaymentEventRepository implements PaymentEventRepository {
   constructor(private readonly db: Db) {}
@@ -29,12 +34,25 @@ export class DrizzlePaymentEventRepository implements PaymentEventRepository {
   }
 
   // Platform-admin revenue report (#462). Cross-operator by design; the
-  // AdminRevenueService gates the caller before this runs.
-  async listSucceeded(): Promise<PaymentEvent[]> {
+  // AdminRevenueService gates the caller before this runs. `month` (`YYYY-MM`,
+  // JST) bounds the scan to one payout month so the Worker never materializes the
+  // whole monotonically growing table (#717). The bind is parameterized.
+  async listSucceeded(month?: string): Promise<PaymentEvent[]> {
+    const status = eq(paymentEvents.status, 'SUCCEEDED')
+    const where: SQL | undefined =
+      month === undefined ? status : and(status, sql`${jstMonthExpr} = ${month}`)
+    const rows = await this.db.select(paymentEventColumns).from(paymentEvents).where(where)
+    return rows.map(toPaymentEvent)
+  }
+
+  // Distinct JST payout months with >=1 SUCCEEDED payment, newest first — a cheap
+  // DISTINCT instead of pulling every row to derive the picker options (#717).
+  async listSucceededMonths(): Promise<string[]> {
     const rows = await this.db
-      .select(paymentEventColumns)
+      .selectDistinct({ month: jstMonthExpr })
       .from(paymentEvents)
       .where(eq(paymentEvents.status, 'SUCCEEDED'))
-    return rows.map(toPaymentEvent)
+      .orderBy(sql`${jstMonthExpr} desc`)
+    return rows.map((r) => r.month)
   }
 }

--- a/packages/api/src/repositories/in-memory/payment-event.ts
+++ b/packages/api/src/repositories/in-memory/payment-event.ts
@@ -1,3 +1,4 @@
+import { availableRevenueMonths, jstYearMonth } from '@kuruma/shared/lib/admin-revenue'
 import {
   PAYMENT_EVENT_ONE_SUCCESS_CONSTRAINT,
   PAYMENT_EVENT_SESSION_CONSTRAINT,
@@ -59,7 +60,16 @@ export class InMemoryPaymentEventRepository implements PaymentEventRepository {
     )
   }
 
-  async listSucceeded(): Promise<PaymentEvent[]> {
-    return [...this.store.values()].filter((r) => r.status === 'SUCCEEDED')
+  // Mirrors the Drizzle date-bounded scan: `month` (JST `YYYY-MM`) narrows to one
+  // payout month using the SAME jstYearMonth boundary the SQL uses (#717).
+  async listSucceeded(month?: string): Promise<PaymentEvent[]> {
+    return [...this.store.values()].filter(
+      (r) =>
+        r.status === 'SUCCEEDED' && (month === undefined || jstYearMonth(r.createdAt) === month),
+    )
+  }
+
+  async listSucceededMonths(): Promise<string[]> {
+    return availableRevenueMonths([...this.store.values()].filter((r) => r.status === 'SUCCEEDED'))
   }
 }

--- a/packages/api/src/repositories/types-payment.ts
+++ b/packages/api/src/repositories/types-payment.ts
@@ -14,9 +14,16 @@ export interface PaymentEventRepository {
   // The recorded SUCCEEDED payment for a booking, or null. Powers both the
   // already-paid guard at checkout and the derived "is this booking paid?" read.
   findSucceededByBookingId(bookingId: string): Promise<PaymentEvent | null>
-  // Every SUCCEEDED payment across all operators, for the platform-admin revenue
+  // SUCCEEDED payments across all operators, for the platform-admin revenue
   // report (#462). Unscoped by design — authz lives in AdminRevenueService.
-  listSucceeded(): Promise<PaymentEvent[]>
+  // `month` (`YYYY-MM`, JST) bounds the scan to one payout month so the Worker
+  // never materializes the whole monotonically growing table (#717); omit it for
+  // the full set.
+  listSucceeded(month?: string): Promise<PaymentEvent[]>
+  // The distinct JST (`Asia/Tokyo`) payout months that have >=1 SUCCEEDED
+  // payment, newest first. Powers the month picker without materializing every
+  // row (#717).
+  listSucceededMonths(): Promise<string[]>
 }
 
 /** A payment anomaly to persist. id/createdAt/resolvedAt are store-assigned (#508 P2). */

--- a/packages/api/src/services/admin-revenue.test.ts
+++ b/packages/api/src/services/admin-revenue.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { type CallerContext, ForbiddenError } from '../middleware/auth'
+import { InMemoryOperatorRepository } from '../repositories/in-memory/operator'
+import { InMemoryPaymentEventRepository } from '../repositories/in-memory/payment-event'
+import type { PaymentEventRepository } from '../repositories/types'
+import type { Operator, PaymentEvent } from '../stores'
+import { AdminRevenueService } from './admin-revenue'
+
+const OP_A = 'operator-aaaaaaaa'
+const OP_B = 'operator-bbbbbbbb'
+const ADMIN: CallerContext = { userId: 'admin-user', role: 'PLATFORM_ADMIN' }
+
+function operator(id: string, name: string, slug: string): Operator {
+  return { id, name, slug, preAuthHandoffUrl: null, createdAt: new Date(), updatedAt: new Date() }
+}
+
+function payment(
+  over: Partial<PaymentEvent> & Pick<PaymentEvent, 'operatorId' | 'createdAt'>,
+): PaymentEvent {
+  return {
+    id: crypto.randomUUID(),
+    bookingId: crypto.randomUUID(),
+    stripeEventId: crypto.randomUUID(),
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: null,
+    grossJpy: 10_000,
+    platformFeeJpy: 400,
+    netToPartnerJpy: 9_600,
+    currency: 'jpy',
+    status: 'SUCCEEDED',
+    ...over,
+  }
+}
+
+const EVENTS: PaymentEvent[] = [
+  payment({
+    operatorId: OP_A,
+    grossJpy: 10_000,
+    platformFeeJpy: 400,
+    netToPartnerJpy: 9_600,
+    createdAt: new Date('2026-03-10T03:00:00Z'),
+  }),
+  payment({
+    operatorId: OP_A,
+    grossJpy: 20_000,
+    platformFeeJpy: 800,
+    netToPartnerJpy: 19_200,
+    createdAt: new Date('2026-04-10T03:00:00Z'),
+  }),
+  payment({
+    operatorId: OP_B,
+    grossJpy: 50_000,
+    platformFeeJpy: 2_000,
+    netToPartnerJpy: 48_000,
+    createdAt: new Date('2026-04-10T03:00:00Z'),
+  }),
+]
+
+function seededRepos() {
+  const operators = new Map<string, Operator>([
+    [OP_A, operator(OP_A, 'Best Car Rental', 'best-car')],
+    [OP_B, operator(OP_B, 'Aoki Rentals', 'aoki')],
+  ])
+  const payments = new Map<string, PaymentEvent>(EVENTS.map((e) => [e.id, e]))
+  return {
+    operatorRepo: new InMemoryOperatorRepository(operators),
+    paymentRepo: new InMemoryPaymentEventRepository(payments),
+  }
+}
+
+/**
+ * Records exactly what the service asked the data layer for, so we can prove the
+ * month filter + available-months derivation are pushed DOWN (bounded query +
+ * distinct-months query) rather than materializing the whole table in JS (#717).
+ */
+class SpyPaymentEventRepository implements PaymentEventRepository {
+  readonly listSucceededCalls: Array<string | undefined> = []
+  monthsCallCount = 0
+  constructor(private readonly inner: PaymentEventRepository) {}
+  insert: PaymentEventRepository['insert'] = (e) => this.inner.insert(e)
+  findSucceededByBookingId: PaymentEventRepository['findSucceededByBookingId'] = (id) =>
+    this.inner.findSucceededByBookingId(id)
+  async listSucceeded(month?: string): Promise<PaymentEvent[]> {
+    this.listSucceededCalls.push(month)
+    return this.inner.listSucceeded(month)
+  }
+  async listSucceededMonths(): Promise<string[]> {
+    this.monthsCallCount += 1
+    return this.inner.listSucceededMonths()
+  }
+}
+
+describe('AdminRevenueService.getReport (#717 — push month filter into the data layer)', () => {
+  it('asks the repo for ONLY the requested month, not the whole table', async () => {
+    const { operatorRepo, paymentRepo } = seededRepos()
+    const spy = new SpyPaymentEventRepository(paymentRepo)
+    await new AdminRevenueService(spy, operatorRepo).getReport(ADMIN, '2026-04')
+    // The month must be pushed to the query — not fetched unbounded then filtered in JS.
+    expect(spy.listSucceededCalls).toEqual(['2026-04'])
+  })
+
+  it('derives availableMonths from a dedicated distinct-months query', async () => {
+    const { operatorRepo, paymentRepo } = seededRepos()
+    const spy = new SpyPaymentEventRepository(paymentRepo)
+    const report = await new AdminRevenueService(spy, operatorRepo).getReport(ADMIN, '2026-03')
+    expect(spy.monthsCallCount).toBe(1)
+    // Full set regardless of the selected month — the distinct query, not a JS re-scan.
+    expect(report.availableMonths).toEqual(['2026-04', '2026-03'])
+  })
+
+  it('preserves the per-partner totals when scoped to a month', async () => {
+    const { operatorRepo, paymentRepo } = seededRepos()
+    const report = await new AdminRevenueService(paymentRepo, operatorRepo).getReport(
+      ADMIN,
+      '2026-04',
+    )
+    expect(report.selectedMonth).toBe('2026-04')
+    expect(report.totals).toEqual({
+      grossJpy: 70_000,
+      platformFeeJpy: 2_800,
+      netToPartnerJpy: 67_200,
+      paymentCount: 2,
+    })
+    for (const p of report.partners) {
+      expect(p.months.map((m) => m.month)).toEqual(['2026-04'])
+    }
+  })
+
+  it('returns the full matrix and a null selectedMonth when no month is given', async () => {
+    const { operatorRepo, paymentRepo } = seededRepos()
+    const spy = new SpyPaymentEventRepository(paymentRepo)
+    const report = await new AdminRevenueService(spy, operatorRepo).getReport(ADMIN)
+    // No month => the repo is asked for everything (undefined bound), exactly once.
+    expect(spy.listSucceededCalls).toEqual([undefined])
+    expect(report.selectedMonth).toBeNull()
+    expect(report.availableMonths).toEqual(['2026-04', '2026-03'])
+    expect(report.totals.grossJpy).toBe(80_000)
+  })
+
+  it('gates non-platform callers before any data access (defence in depth)', async () => {
+    const { operatorRepo, paymentRepo } = seededRepos()
+    const spy = new SpyPaymentEventRepository(paymentRepo)
+    await expect(
+      new AdminRevenueService(spy, operatorRepo).getReport({
+        userId: 'op-owner',
+        role: 'OPERATOR_OWNER',
+      }),
+    ).rejects.toThrow(ForbiddenError)
+    expect(spy.listSucceededCalls).toEqual([])
+    expect(spy.monthsCallCount).toBe(0)
+  })
+})

--- a/packages/api/src/services/admin-revenue.ts
+++ b/packages/api/src/services/admin-revenue.ts
@@ -1,8 +1,4 @@
-import {
-  aggregateRevenueByPartner,
-  availableRevenueMonths,
-  filterEventsByMonth,
-} from '@kuruma/shared/lib/admin-revenue'
+import { aggregateRevenueByPartner } from '@kuruma/shared/lib/admin-revenue'
 import type { AdminRevenueResponse } from '@kuruma/shared/types/admin-revenue'
 import { type CallerContext, requirePlatformRead } from '../middleware/auth'
 import type { OperatorRepository, PaymentEventRepository } from '../repositories/types'
@@ -13,7 +9,11 @@ import type { OperatorRepository, PaymentEventRepository } from '../repositories
  * successful payments and operators, and hands them to the pure
  * {@link aggregateRevenueByPartner} core. `requirePlatformRead` lives here (not
  * only at the route) so the gate travels with the business logic — the payment
- * repo's `listSucceeded` is unscoped, so this service is the authz chokepoint.
+ * repo's reads are unscoped, so this service is the authz chokepoint.
+ *
+ * The month filter and `availableMonths` are pushed into the data layer (#717): a
+ * month request scans only that JST payout month and the picker options come from
+ * a DISTINCT query, so the Worker never materializes the whole growing table.
  */
 export class AdminRevenueService {
   constructor(
@@ -28,14 +28,14 @@ export class AdminRevenueService {
    */
   async getReport(ctx: CallerContext, month?: string): Promise<AdminRevenueResponse> {
     requirePlatformRead(ctx)
-    const [events, operators] = await Promise.all([
-      this.paymentEvents.listSucceeded(),
+    const [events, availableMonths, operators] = await Promise.all([
+      this.paymentEvents.listSucceeded(month),
+      this.paymentEvents.listSucceededMonths(),
       this.operators.list(),
     ])
-    const scoped = month ? filterEventsByMonth(events, month) : events
     return {
-      ...aggregateRevenueByPartner(scoped, operators),
-      availableMonths: availableRevenueMonths(events),
+      ...aggregateRevenueByPartner(events, operators),
+      availableMonths,
       selectedMonth: month ?? null,
     }
   }

--- a/packages/api/tests/integration/payment-events.test.ts
+++ b/packages/api/tests/integration/payment-events.test.ts
@@ -180,6 +180,51 @@ describe('DrizzlePaymentEventRepository (real Postgres)', () => {
       .catch((e) => e)
     expect(pgConstraintName(err)).toBe(PAYMENT_EVENT_ONE_SUCCESS_CONSTRAINT)
   })
+
+  // #717: the month filter + available-months are pushed into SQL. The one thing
+  // in-memory cannot prove is that the SQL JST boundary (`AT TIME ZONE
+  // 'Asia/Tokyo'`) matches the pure jstYearMonth: a payment at 15:30 UTC on Jul
+  // 31 is already 00:30 JST on Aug 1, so it must report as 2026-08, not 2026-07.
+  describe('JST-bounded reads (#717)', () => {
+    // createdAt is store-assigned, so the public insert can't set it; write the
+    // boundary instants directly. afterEach cleans these (keyed by bookingA/B).
+    async function seedAtJstBoundary(): Promise<void> {
+      await db.insert(paymentEvents).values([
+        {
+          ...event(bookingA, { stripeEventId: 'evt_aug', stripeCheckoutSessionId: 'cs_aug' }),
+          // 2026-07-31T15:30:00Z === 2026-08-01T00:30:00 JST -> month 2026-08.
+          createdAt: new Date('2026-07-31T15:30:00Z'),
+        },
+        {
+          ...event(bookingB, { stripeEventId: 'evt_jul', stripeCheckoutSessionId: 'cs_jul' }),
+          createdAt: new Date('2026-07-10T03:00:00Z'), // 2026-07 in both UTC and JST.
+        },
+      ])
+    }
+
+    it('listSucceeded(month) returns only that JST payout month (boundary-correct)', async () => {
+      await seedAtJstBoundary()
+      const aug = (await paymentRepo.listSucceeded('2026-08')).filter(
+        (e) => e.bookingId === bookingA || e.bookingId === bookingB,
+      )
+      expect(aug.map((e) => e.stripeEventId)).toEqual(['evt_aug'])
+
+      const jul = (await paymentRepo.listSucceeded('2026-07')).filter(
+        (e) => e.bookingId === bookingA || e.bookingId === bookingB,
+      )
+      expect(jul.map((e) => e.stripeEventId)).toEqual(['evt_jul'])
+    })
+
+    it('listSucceededMonths returns distinct JST months newest-first', async () => {
+      await seedAtJstBoundary()
+      const months = await paymentRepo.listSucceededMonths()
+      // Cross-operator table -> assert OUR two months are present in newest-first order.
+      const mine = months.filter((m) => m === '2026-08' || m === '2026-07')
+      expect(mine).toEqual(['2026-08', '2026-07'])
+      // DISTINCT: a month appears at most once even with multiple rows.
+      expect(new Set(months).size).toBe(months.length)
+    })
+  })
 })
 
 function anomaly(bookingId: string, overrides: Partial<NewPaymentAnomaly> = {}): NewPaymentAnomaly {


### PR DESCRIPTION
## Problem
`payment-event.ts` `listSucceeded()` selected **every** `status='SUCCEEDED'` row (no bound), and `admin-revenue.ts` then filtered the month (`filterEventsByMonth`) **and** re-scanned the full set for `availableRevenueMonths` in JS — on every report load. The `payment_events` table grows one row per completed booking, so the admin revenue tab did a growing full-table read into the Worker each load. Platform-admin-only + an index keep it off the critical path today, but the result-set size and Worker memory were unbounded.

## What changed
Pushed both into the data layer; the pure `aggregateRevenueByPartner` core is reused unchanged, so **report output is identical**.

- `listSucceeded(month?)` date-bounds the scan to one JST payout month via `to_char(createdAt AT TIME ZONE 'Asia/Tokyo','YYYY-MM') = $month` (parameterized bind). Japan has no DST, so `AT TIME ZONE` is a constant +9 shift — byte-identical to the pure `jstYearMonth` (UTC+9 then slice). Omit `month` for the full set.
- New `listSucceededMonths()` derives the picker options with a cheap `SELECT DISTINCT … ORDER BY … DESC` instead of materializing every row.
- `AdminRevenueService.getReport` now calls the bounded query + the distinct-months query (in parallel with `operators.list()`); the JS `filterEventsByMonth`/`availableRevenueMonths` re-scan is gone.
- In-memory repo mirrors the **same** JST boundary via the shared `jstYearMonth`/`availableRevenueMonths` helpers, so DI parity holds.

Scope is exactly the two files named in the issue (drizzle `payment-event.ts` + `admin-revenue.ts` service) plus the repo interface, the in-memory mirror, and tests. No unrelated changes.

Closes #717

## Test plan
- **Bounded-query behavior** (`packages/api/src/services/admin-revenue.test.ts`, new): a spy repo asserts a `?month=` request asks the repo for **only** that month (`listSucceeded('2026-04')`, not unbounded + JS filter), and `availableMonths` comes from a single `listSucceededMonths()` call — not a JS re-scan. Also asserts the gate runs before any data access.
- **Output preserved**: same per-partner totals/months as the previous in-JS aggregation for the existing fixtures; existing `tests/routes/admin-revenue.test.ts` (20 tests) unchanged and green.
- **Real-pg JST boundary** (`tests/integration/payment-events.test.ts`, new block): proves the SQL `AT TIME ZONE 'Asia/Tokyo'` boundary matches `jstYearMonth` — a payment at `2026-07-31T15:30:00Z` (= `2026-08-01 00:30 JST`) reports as `2026-08`, and `listSucceededMonths()` returns distinct months newest-first. (Needs the api integration pg lane.)

## Gates (local)
- `bunx biome check <changed>` — pass
- `bun run lint:size` — pass (only pre-existing warnings; no new file over cap)
- `bun run lint:modules` — pass
- `bun run --filter @kuruma/api lint:boundaries` — Import boundaries OK
- `bunx tsc --noEmit -p packages/api/tsconfig.json` — pass
- `bun run --filter @kuruma/api test` — 1362 passed
- `bun run --filter @kuruma/api test:integration tests/integration/payment-events.test.ts` — 8 passed (real pg)
- `bun run --filter @kuruma/shared test tests/lib/admin-revenue.test.ts` — 13 passed