### PR TITLE
refactor(api): extract AvailabilityService from availability route (#712 Slice C)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -145,6 +145,7 @@ import { createVehiclePhotoRoutes } from './routes/vehicle-photos'
 import { createVehicleRoutes } from './routes/vehicles'
 import { AddOnService } from './services/add-on'
 import { AdminRevenueService } from './services/admin-revenue'
+import { AvailabilityService } from './services/availability'
 import { BookingService } from './services/booking'
 import { BookingPostCommitDispatcher } from './services/booking-post-commit-dispatcher'
 import { CustomerService } from './services/customer'
@@ -627,6 +628,7 @@ export function createApp(overrides?: AppOverrides) {
     bookingRepo,
     notificationDispatcher,
   )
+  const availabilityService = new AvailabilityService(availabilityRepo)
   const customerService = new CustomerService(customerRepo, userRepo)
   const maintenanceService = new MaintenanceService(
     vehicleRepo,
@@ -714,7 +716,7 @@ export function createApp(overrides?: AppOverrides) {
     .route('/', createMaintenanceLogRoutes(maintenanceService))
     .route('/', createBookingRoutes(bookingService))
     .route('/', createPaymentRoutes(paymentService))
-    .route('/', createAvailabilityRoutes(availabilityRepo))
+    .route('/', createAvailabilityRoutes(availabilityService))
     .route('/', createStatsRoutes(statsRepo))
     .route('/', createOverviewRoutes(overviewService))
     .route('/', createAdminRevenueRoutes(adminRevenueService))

--- a/packages/api/src/routes/availability.ts
+++ b/packages/api/src/routes/availability.ts
@@ -1,15 +1,15 @@
 import { Hono } from 'hono'
-import { STAFF_ROLES, getUser } from '../middleware/auth'
-import type { AvailabilityRepository } from '../repositories/types'
+import { getUser } from '../middleware/auth'
+import type { AvailabilityService } from '../services/availability'
 import { fail, ok, parseDateRange } from './helpers'
 
-export function createAvailabilityRoutes(repo: AvailabilityRepository) {
+export function createAvailabilityRoutes(service: AvailabilityService) {
   return new Hono()
     .get('/availability', async (c) => {
       const range = parseDateRange(c, true)
       if (!range.ok) return range.response
 
-      const available = await repo.findAvailableVehicles(range.from, range.to)
+      const available = await service.findAvailableVehicles(range.from, range.to)
       return ok(c, available)
     })
     .get('/availability/:vehicleId', async (c) => {
@@ -17,26 +17,22 @@ export function createAvailabilityRoutes(repo: AvailabilityRepository) {
       const range = parseDateRange(c, true)
       if (!range.ok) return range.response
 
-      const result = await repo.checkVehicleAvailability(vehicleId, range.from, range.to)
-      if (!result) {
-        return fail(c, 'Vehicle not found', 404)
+      // Role is the only authz input; extracting it here keeps getUser (a context
+      // concern) out of the service, which stays a pure policy core (FC/IS).
+      const result = await service.checkVehicleAvailability(
+        vehicleId,
+        range.from,
+        range.to,
+        getUser(c)?.role,
+      )
+
+      switch (result.kind) {
+        case 'not_found':
+          return fail(c, 'Vehicle not found', 404)
+        case 'available':
+          return ok(c, { available: true, vehicle: result.vehicle })
+        case 'unavailable':
+          return ok(c, { available: false, vehicle: result.vehicle, conflicts: result.conflicts })
       }
-
-      if (result.available) {
-        return ok(c, { available: true, vehicle: result.vehicle })
-      }
-
-      const user = getUser(c)
-      const isStaff = user != null && STAFF_ROLES.has(user.role)
-
-      const conflicts = isStaff
-        ? result.conflicts
-        : result.conflicts.map((b) => ({ startAt: b.startAt, effectiveEndAt: b.effectiveEndAt }))
-
-      return ok(c, {
-        available: false,
-        vehicle: result.vehicle,
-        conflicts,
-      })
     })
 }

--- a/packages/api/src/services/availability.ts
+++ b/packages/api/src/services/availability.ts
@@ -1,0 +1,49 @@
+import type { UserRole } from '@kuruma/shared/auth/roles'
+import { STAFF_ROLES } from '../middleware/auth'
+import type {
+  AvailabilityFilters,
+  AvailabilityRepository,
+  Booking,
+  Vehicle,
+} from '../repositories/types'
+
+/** Time-window projection of a conflicting booking shown to non-staff callers.
+ *  Everything that could identify the other renter (id, renterId, notes, status)
+ *  is dropped — a renter learns only *when* a vehicle is taken, never by whom. */
+export type RedactedConflict = Pick<Booking, 'startAt' | 'effectiveEndAt'>
+
+/** Discriminated result so the route maps to an HTTP shape without re-deriving
+ *  the availability/redaction policy (FC/IS: this service is the pure core). */
+export type VehicleAvailabilityResult =
+  | { kind: 'not_found' }
+  | { kind: 'available'; vehicle: Vehicle }
+  | { kind: 'unavailable'; vehicle: Vehicle; conflicts: Booking[] | RedactedConflict[] }
+
+export class AvailabilityService {
+  constructor(private readonly repo: AvailabilityRepository) {}
+
+  async findAvailableVehicles(
+    from: Date,
+    to: Date,
+    filters?: AvailabilityFilters,
+  ): Promise<Vehicle[]> {
+    return this.repo.findAvailableVehicles(from, to, filters)
+  }
+
+  async checkVehicleAvailability(
+    vehicleId: string,
+    from: Date,
+    to: Date,
+    viewerRole: UserRole | undefined,
+  ): Promise<VehicleAvailabilityResult> {
+    const result = await this.repo.checkVehicleAvailability(vehicleId, from, to)
+    if (!result) return { kind: 'not_found' }
+    if (result.available) return { kind: 'available', vehicle: result.vehicle }
+
+    const isStaff = viewerRole != null && STAFF_ROLES.has(viewerRole)
+    const conflicts = isStaff
+      ? result.conflicts
+      : result.conflicts.map((b) => ({ startAt: b.startAt, effectiveEndAt: b.effectiveEndAt }))
+    return { kind: 'unavailable', vehicle: result.vehicle, conflicts }
+  }
+}

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../src/repositories/in-memory'
 import type { Booking, Vehicle } from '../../src/repositories/types'
 import { createAvailabilityRoutes } from '../../src/routes/availability'
+import { AvailabilityService } from '../../src/services/availability'
 import { testAuthMiddleware } from '../helpers/auth'
 import { bookingInput } from '../helpers/booking'
 
@@ -67,7 +68,7 @@ describe('Availability Routes', () => {
     availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
     app = new Hono()
     app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
-    app.route('/', createAvailabilityRoutes(availabilityRepo))
+    app.route('/', createAvailabilityRoutes(new AvailabilityService(availabilityRepo)))
   })
 
   describe('GET /availability', () => {
@@ -288,7 +289,7 @@ describe('Availability Routes', () => {
     it('strips conflict details for RENTER role', async () => {
       const renterApp = new Hono()
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))
-      renterApp.route('/', createAvailabilityRoutes(availabilityRepo))
+      renterApp.route('/', createAvailabilityRoutes(new AvailabilityService(availabilityRepo)))
 
       const vehicle = await createTestVehicle()
       await createTestBooking({

--- a/packages/api/tests/services/availability.test.ts
+++ b/packages/api/tests/services/availability.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import type { Booking, Vehicle } from '../../src/repositories/types'
+import { AvailabilityService } from '../../src/services/availability'
+import { bookingInput } from '../helpers/booking'
+
+let vehicleRepo: InMemoryVehicleRepository
+let bookingRepo: InMemoryBookingRepository
+let availabilityRepo: InMemoryAvailabilityRepository
+let service: AvailabilityService
+
+async function seedVehicle(overrides: Partial<Vehicle> = {}): Promise<Vehicle> {
+  return vehicleRepo.create(SYSTEM_CONTEXT, {
+    name: 'Toyota Corolla',
+    description: null,
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    bufferMinutes: 30,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    ...overrides,
+  })
+}
+
+async function seedBooking(vehicleId: string, overrides: Partial<Booking> = {}): Promise<Booking> {
+  const endAt = overrides.endAt ?? new Date('2026-06-01T14:00:00Z')
+  const effectiveEndAt = overrides.effectiveEndAt ?? new Date(endAt.getTime() + 30 * 60 * 1000)
+  return bookingRepo.create(
+    SYSTEM_CONTEXT,
+    bookingInput({
+      assignedVehicleId: vehicleId,
+      startAt: new Date('2026-06-01T10:00:00Z'),
+      status: 'CONFIRMED',
+      ...overrides,
+      endAt,
+      effectiveEndAt,
+    }),
+  )
+}
+
+// The query window overlaps the seeded 10:00-14:00(+buffer) booking.
+const FROM = new Date('2026-06-01T12:00:00Z')
+const TO = new Date('2026-06-01T16:00:00Z')
+
+beforeEach(() => {
+  vehicleRepo = new InMemoryVehicleRepository()
+  bookingRepo = new InMemoryBookingRepository()
+  availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  service = new AvailabilityService(availabilityRepo)
+})
+
+describe('AvailabilityService.checkVehicleAvailability', () => {
+  it('redacts a conflict to only its time window for a non-staff viewer', async () => {
+    const vehicle = await seedVehicle()
+    await seedBooking(vehicle.id, { renterId: 'other-renter', notes: 'secret internal note' })
+
+    const result = await service.checkVehicleAvailability(vehicle.id, FROM, TO, 'RENTER')
+
+    expect(result.kind).toBe('unavailable')
+    if (result.kind !== 'unavailable') throw new Error('expected unavailable')
+    expect(result.conflicts).toHaveLength(1)
+    expect(Object.keys(result.conflicts[0]!)).toEqual(['startAt', 'effectiveEndAt'])
+  })
+
+  it('returns full conflict rows for a staff viewer', async () => {
+    const vehicle = await seedVehicle()
+    const booking = await seedBooking(vehicle.id, { notes: 'secret internal note' })
+
+    const result = await service.checkVehicleAvailability(vehicle.id, FROM, TO, 'STAFF')
+
+    expect(result.kind).toBe('unavailable')
+    if (result.kind !== 'unavailable') throw new Error('expected unavailable')
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0]).toMatchObject({ id: booking.id, notes: 'secret internal note' })
+  })
+
+  it('returns available with the vehicle when the window is free', async () => {
+    const vehicle = await seedVehicle()
+
+    const result = await service.checkVehicleAvailability(vehicle.id, FROM, TO, 'RENTER')
+
+    expect(result).toEqual({ kind: 'available', vehicle })
+  })
+
+  it('returns not_found for an unknown vehicle id', async () => {
+    const result = await service.checkVehicleAvailability('nonexistent', FROM, TO, 'STAFF')
+
+    expect(result).toEqual({ kind: 'not_found' })
+  })
+})


### PR DESCRIPTION
## What

Slice C of #712 (health-audit P2/L, epic #701): pull the **staff-vs-renter conflict-redaction** business rule out of the `availability` HTTP controller into a Hono-free, DI'd `AvailabilityService`.

- **New** `services/availability.ts` — `AvailabilityService` returning a discriminated-union result (`not_found` / `available` / `unavailable`). Non-staff viewers get conflicts redacted to only `{ startAt, effectiveEndAt }`.
- `routes/availability.ts` — now a thin shell: parse the date range, read the viewer role from context, map the result to `ok()`/`fail()`. **No longer imports the repository.**
- `index.ts` — wires `new AvailabilityService(availabilityRepo)` at the composition root.
- Tests: new `tests/services/availability.test.ts` (4 unit tests, no Hono, real in-memory repos); route test wiring updated to pass the service.

## Why

Routes are controllers (HTTP in/out only); business rules belong in services (AGENTS.md MVC+DI). This restores the `routes → services → repositories` import direction (the route previously imported the repo directly) and makes the redaction policy unit-testable without a Hono context (FC/IS: pure decision core, boring shell).

## Behavior

Byte-identical HTTP contract — same 200/404 statuses, same JSON shapes, same renter redaction. Confirmed by the unchanged route tests + new service tests.

## Verification

- New service 4/4, route 12/12, **full API unit suite 1362/1362**
- `tsc` clean, `lint:boundaries` OK, all pre-commit hooks pass
- code-reviewer agent: clean (no CRITICAL/HIGH/MEDIUM); one optional LOW skipped per YAGNI

Part of #712. Slices B (UserDirectoryService) and A (MessageService) to follow.