### PR TITLE
test(api): cover renter status-update + cancellation email localization (#735)

### DIFF
--- a/packages/api/tests/services/email/templates.test.ts
+++ b/packages/api/tests/services/email/templates.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { renderOperatorAlert } from '../../../src/services/email/templates/operator-alert'
+import type { RenterCancellationData } from '../../../src/services/email/templates/renter-cancellation'
+import { renderRenterCancellation } from '../../../src/services/email/templates/renter-cancellation'
 import type { RenterConfirmationData } from '../../../src/services/email/templates/renter-confirmation'
 import { renderRenterConfirmation } from '../../../src/services/email/templates/renter-confirmation'
+import type { RenterStatusUpdateData } from '../../../src/services/email/templates/renter-status-update'
+import { renderRenterStatusUpdate } from '../../../src/services/email/templates/renter-status-update'
 
 // §4c / §7: renderers are a PURE functional core — data in, {subject, html, text}
 // out, zero I/O. Tests assert exact, mutation-resistant strings: the booking code,
@@ -98,5 +102,90 @@ describe('renderOperatorAlert', () => {
 
   it('renders en when requested', () => {
     expect(renderOperatorAlert(baseOp, 'en').subject).toContain('New booking')
+  })
+})
+
+// A raw entity UUID must never leak into a renter-facing body — only the human
+// booking code (e.g. WXYZ7890) should appear. This guards the #664 lifecycle
+// renderers against a future row accidentally interpolating data.id.
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+describe('renderRenterStatusUpdate', () => {
+  const baseStatus: RenterStatusUpdateData = {
+    status: 'ACTIVE',
+    bookingCode: 'WXYZ7890',
+    vehicle: { name: 'Honda Fit', licensePlate: 'なにわ 500 か 56-78' },
+    pickupLocationName: 'Namba Station Lot',
+    dropoffLocationName: 'Kansai Airport Lot',
+    startAt: new Date('2026-07-01T10:00:00Z'),
+    endAt: new Date('2026-07-03T18:00:00Z'),
+  }
+
+  it('localizes the ACTIVE (trip started) subject for en/ja/zh and appends the booking code', () => {
+    expect(renderRenterStatusUpdate(baseStatus, 'en').subject).toContain('Trip started')
+    expect(renderRenterStatusUpdate(baseStatus, 'ja').subject).toContain('レンタル開始のお知らせ')
+    expect(renderRenterStatusUpdate(baseStatus, 'zh').subject).toContain('行程开始通知')
+    expect(renderRenterStatusUpdate(baseStatus, 'en').subject).toContain('WXYZ7890')
+  })
+
+  it('localizes the COMPLETED (trip completed) subject for en/ja/zh', () => {
+    const completed = { ...baseStatus, status: 'COMPLETED' as const }
+    expect(renderRenterStatusUpdate(completed, 'en').subject).toContain('Trip completed')
+    expect(renderRenterStatusUpdate(completed, 'ja').subject).toContain('レンタル完了のお知らせ')
+    expect(renderRenterStatusUpdate(completed, 'zh').subject).toContain('行程完成通知')
+  })
+
+  it('puts the booking code and location names in the body, with no raw UUID', () => {
+    const { html, text } = renderRenterStatusUpdate(baseStatus, 'en')
+    for (const body of [html, text]) {
+      expect(body).toContain('WXYZ7890')
+      expect(body).toContain('Namba Station Lot')
+      expect(body).toContain('Kansai Airport Lot')
+      expect(body).not.toMatch(UUID_RE)
+    }
+  })
+
+  it('falls back to the en subject for an unknown locale', () => {
+    expect(renderRenterStatusUpdate(baseStatus, 'fr').subject).toContain('Trip started')
+  })
+})
+
+describe('renderRenterCancellation', () => {
+  const baseCancel: RenterCancellationData = {
+    bookingCode: 'WXYZ7890',
+    startAt: new Date('2026-07-01T10:00:00Z'),
+    endAt: new Date('2026-07-03T18:00:00Z'),
+    cancellationFeeJpy: null,
+  }
+
+  it('localizes the subject for en/ja/zh and appends the booking code', () => {
+    expect(renderRenterCancellation(baseCancel, 'en').subject).toContain('Booking cancelled')
+    expect(renderRenterCancellation(baseCancel, 'ja').subject).toContain(
+      'ご予約キャンセルのお知らせ',
+    )
+    expect(renderRenterCancellation(baseCancel, 'zh').subject).toContain('预订取消通知')
+    expect(renderRenterCancellation(baseCancel, 'en').subject).toContain('WXYZ7890')
+  })
+
+  it('puts the booking code in the body, with no raw UUID', () => {
+    const { html, text } = renderRenterCancellation(baseCancel, 'en')
+    for (const body of [html, text]) {
+      expect(body).toContain('WXYZ7890')
+      expect(body).not.toMatch(UUID_RE)
+    }
+  })
+
+  it('shows the cancellation-fee line only when a fee was actually charged', () => {
+    const charged = renderRenterCancellation({ ...baseCancel, cancellationFeeJpy: 7000 }, 'en')
+    expect(charged.html).toContain('Cancellation fee')
+    expect(charged.text).toContain('¥7,000')
+
+    const free = renderRenterCancellation(baseCancel, 'en')
+    expect(free.html).not.toContain('Cancellation fee')
+    expect(free.text).not.toContain('Cancellation fee')
+  })
+
+  it('falls back to the en subject for an unknown locale', () => {
+    expect(renderRenterCancellation(baseCancel, 'fr').subject).toContain('Booking cancelled')
   })
 })


### PR DESCRIPTION
## Summary
`templates.test.ts` directly tested only `renderRenterConfirmation` and `renderOperatorAlert`. The two #664 renter lifecycle renderers — **status-update** (trip started/completed) and **cancellation** — had no content-specific assertions (only smoke-covered via "a row sent" in the dispatcher test), so a localization regression (untranslated subject, missing booking code, or a leaked entity UUID) would slip through. Test-only, no production change.

## What
Adds per-template cases (mirroring the confirmation style) for `renderRenterStatusUpdate` and `renderRenterCancellation`:
- **Localized subjects** for en/ja/zh — specific strings, not truthy (e.g. `レンタル開始のお知らせ`, `行程开始通知`, `ご予約キャンセルのお知らせ`), so an untranslated subject fails.
- **Booking code present** in both `html` and `text` bodies.
- **No raw UUID** in either body (regex seal — only the human booking code should appear, never `data.id`).
- **Cancellation fee line only when charged** — the documented behavior (a free cancellation never shows a `¥0` fee line); charged shows `¥7,000`.
- Status-update covers both ACTIVE and COMPLETED branches + unknown-locale → en fallback.

## Verification (local, rebased onto mp@69133bf8)
- `bun run --filter @kuruma/api test tests/services/email/templates.test.ts` → **15 passed** (7 existing + 8 new)
- `bun run --filter @kuruma/api typecheck` → exit 0
- `biome check` → clean

Closes #735