### PR TITLE
feat(admin): surface unresolved payment anomalies on the revenue tab (#744)

### DIFF
--- a/packages/api/src/routes/payment-anomalies.ts
+++ b/packages/api/src/routes/payment-anomalies.ts
@@ -1,7 +1,27 @@
+import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
 import { Hono } from 'hono'
 import { requireAuth, requirePlatformRead, requireUser, toCallerContext } from '../middleware/auth'
 import type { PaymentAnomalyService } from '../services/payment-anomaly'
+import type { PaymentAnomaly } from '../stores'
 import { ok } from './helpers'
+
+// Project a persisted anomaly onto the admin wire view (@kuruma/shared): drop the
+// internal resolved flag (this list is unresolved-only) and the checkout-session
+// id (refunds are issued against the paymentIntent), and serialize createdAt as ISO.
+function toView(a: PaymentAnomaly): PaymentAnomalyView {
+  return {
+    id: a.id,
+    kind: a.kind,
+    operatorId: a.operatorId,
+    bookingId: a.bookingId,
+    receivedAmountJpy: a.receivedAmountJpy,
+    expectedAmountJpy: a.expectedAmountJpy,
+    currency: a.currency,
+    stripeEventId: a.stripeEventId,
+    stripePaymentIntentId: a.stripePaymentIntentId,
+    createdAt: a.createdAt.toISOString(),
+  }
+}
 
 /**
  * Platform-admin payment anomalies needing review (#508 P2). Cross-tenant by
@@ -16,7 +36,7 @@ export function createPaymentAnomalyRoutes(service: PaymentAnomalyService) {
   return app.get('/admin/payment-anomalies', async (c) => {
     const ctx = toCallerContext(requireUser(c))
     requirePlatformRead(ctx)
-    const anomalies = await service.listUnresolved(ctx)
+    const anomalies = (await service.listUnresolved(ctx)).map(toView)
     return ok(c, { anomalies })
   })
 }

--- a/packages/api/tests/routes/payment-anomalies.test.ts
+++ b/packages/api/tests/routes/payment-anomalies.test.ts
@@ -73,21 +73,28 @@ describe('GET /admin/payment-anomalies — auth', () => {
   })
 })
 
-describe('GET /admin/payment-anomalies — listing', () => {
-  it('returns only unresolved anomalies with their reconciliation identifiers', async () => {
+describe('GET /admin/payment-anomalies — listing (PaymentAnomalyView contract)', () => {
+  it('returns only unresolved anomalies as views with reconciliation identifiers', async () => {
     const res = await mount('PLATFORM_ADMIN').request('/admin/payment-anomalies')
     const { data } = await res.json()
 
     expect(data.anomalies).toHaveLength(1)
-    expect(data.anomalies[0]).toMatchObject({
+    const [view] = data.anomalies
+    expect(view).toMatchObject({
       kind: 'DOUBLE_PAYMENT',
       operatorId: OP_A,
       stripeEventId: 'evt_unresolved',
       stripePaymentIntentId: 'pi_dup',
       receivedAmountJpy: 100_000,
       expectedAmountJpy: 100_000,
-      resolvedAt: null,
+      currency: 'jpy',
     })
+    // Dates cross the wire as ISO strings (JSON has no Date type).
+    expect(view.createdAt).toBe('2026-06-10T03:00:00.000Z')
+    // Lean admin projection: the internal resolved flag and the checkout-session
+    // id are not part of the unresolved-anomaly view.
+    expect('resolvedAt' in view).toBe(false)
+    expect('stripeCheckoutSessionId' in view).toBe(false)
   })
 })
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./types/stats": "./src/types/stats.ts",
     "./types/overview": "./src/types/overview.ts",
     "./types/admin-revenue": "./src/types/admin-revenue.ts",
+    "./types/payment-anomaly": "./src/types/payment-anomaly.ts",
     "./types/api-response": "./src/types/api-response.ts",
     "./types/fleet": "./src/types/fleet.ts",
     "./types/vehicle": "./src/types/vehicle.ts",

--- a/packages/shared/src/types/payment-anomaly.ts
+++ b/packages/shared/src/types/payment-anomaly.ts
@@ -1,0 +1,46 @@
+/**
+ * Platform-admin view of a payment anomaly needing review (#508 P2, surfaced #744).
+ *
+ * A verified Stripe webhook can report a charge that does NOT become a clean
+ * `payment_events` row: a second distinct Session paying an already-paid booking
+ * (`DOUBLE_PAYMENT` — refund the duplicate) or a Session whose amount/currency
+ * does not match the booking snapshot (`AMOUNT_MISMATCH` — investigate). These are
+ * persisted in `payment_anomalies` (kept OUT of `payment_events` so revenue math is
+ * never polluted) and surfaced read-only on the admin revenue tab (#462).
+ *
+ * This is the WIRE contract the API returns and the web consumes — web cannot
+ * import the Drizzle schema, so the shape (and the kind union) live here. Dates are
+ * ISO 8601 strings (JSON has no Date); amounts are whole JPY and may be null when
+ * Stripe sent a malformed event.
+ */
+
+/** The `payment_anomaly_kind` DB enum, mirrored for the web boundary. Order must
+ *  match the schema enum — pinned by `tests/types/payment-anomaly.test.ts`. */
+export const PAYMENT_ANOMALY_KINDS = ['DOUBLE_PAYMENT', 'AMOUNT_MISMATCH'] as const
+
+export type PaymentAnomalyKind = (typeof PAYMENT_ANOMALY_KINDS)[number]
+
+/** One unresolved anomaly. Identifiers are carried so an admin can reconcile or
+ *  refund: `stripeEventId` is the reconciliation handle, `stripePaymentIntentId`
+ *  is what an actual refund is issued against (null on a malformed event). */
+export interface PaymentAnomalyView {
+  id: string
+  kind: PaymentAnomalyKind
+  /** Partner attribution, re-derived from the booking on the webhook. */
+  operatorId: string
+  bookingId: string
+  /** Stripe `amount_total` (whole JPY); null when Stripe omitted it. */
+  receivedAmountJpy: number | null
+  /** The booking total snapshot at webhook time (whole JPY). */
+  expectedAmountJpy: number | null
+  currency: string | null
+  stripeEventId: string
+  stripePaymentIntentId: string | null
+  /** ISO 8601 (UTC). When the anomaly was recorded. */
+  createdAt: string
+}
+
+/** Response body of `GET /admin/payment-anomalies` (unresolved only, newest first). */
+export interface PaymentAnomaliesResponse {
+  anomalies: PaymentAnomalyView[]
+}

--- a/packages/shared/tests/types/payment-anomaly.test.ts
+++ b/packages/shared/tests/types/payment-anomaly.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { paymentAnomalyKindEnum } from '../../src/db/schema'
+import { PAYMENT_ANOMALY_KINDS, type PaymentAnomalyView } from '../../src/types/payment-anomaly'
+
+describe('PaymentAnomalyView contract', () => {
+  // Drift fence: the web-facing kind union must stay identical to the DB enum
+  // (payment_anomaly_kind). Web cannot import the schema, so this is the only
+  // place the two are pinned together — mirrors the roleEnum guard in schema.test.ts.
+  it('PAYMENT_ANOMALY_KINDS mirrors the payment_anomaly_kind DB enum (order matters)', () => {
+    expect([...PAYMENT_ANOMALY_KINDS]).toEqual([...paymentAnomalyKindEnum.enumValues])
+  })
+
+  it('a DOUBLE_PAYMENT view carries the refund/reconcile identifiers', () => {
+    const view: PaymentAnomalyView = {
+      id: 'pa_1',
+      kind: 'DOUBLE_PAYMENT',
+      bookingId: 'bk_1',
+      operatorId: 'op_1',
+      receivedAmountJpy: 12000,
+      expectedAmountJpy: 12000,
+      currency: 'jpy',
+      stripeEventId: 'evt_1',
+      stripePaymentIntentId: 'pi_1',
+      createdAt: '2026-06-13T03:00:00.000Z',
+    }
+    expect(view.kind).toBe('DOUBLE_PAYMENT')
+    expect(view.stripePaymentIntentId).toBe('pi_1')
+  })
+
+  it('an AMOUNT_MISMATCH view allows null amounts/intent (malformed Stripe event)', () => {
+    const view: PaymentAnomalyView = {
+      id: 'pa_2',
+      kind: 'AMOUNT_MISMATCH',
+      bookingId: 'bk_2',
+      operatorId: 'op_2',
+      receivedAmountJpy: null,
+      expectedAmountJpy: 12000,
+      currency: null,
+      stripeEventId: 'evt_2',
+      stripePaymentIntentId: null,
+      createdAt: '2026-06-13T03:00:00.000Z',
+    }
+    expect(view.receivedAmountJpy).toBeNull()
+    expect(view.stripePaymentIntentId).toBeNull()
+  })
+})

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1048,6 +1048,21 @@
       "monthFilterLabel": "Filter by payout month",
       "loadError": "Couldn't load partner revenue.",
       "retry": "Retry"
+    },
+    "anomalies": {
+      "title": "Payment anomalies",
+      "subtitle": "Charges flagged during reconciliation — refund a duplicate or investigate a mismatch.",
+      "empty": "No unresolved payment anomalies.",
+      "colKind": "Type",
+      "colBooking": "Booking",
+      "colReceived": "Received",
+      "colExpected": "Expected",
+      "colStripeEvent": "Stripe event",
+      "colWhen": "When",
+      "kind": {
+        "DOUBLE_PAYMENT": "Double payment",
+        "AMOUNT_MISMATCH": "Amount mismatch"
+      }
     }
   },
   "documents": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1048,6 +1048,21 @@
       "monthFilterLabel": "支払月で絞り込み",
       "loadError": "パートナー収益を読み込めませんでした。",
       "retry": "再試行"
+    },
+    "anomalies": {
+      "title": "決済の異常",
+      "subtitle": "照合中にフラグが付いた請求 — 二重請求は返金、金額不一致は確認してください。",
+      "empty": "未対応の決済異常はありません。",
+      "colKind": "種別",
+      "colBooking": "予約",
+      "colReceived": "受領額",
+      "colExpected": "予定額",
+      "colStripeEvent": "Stripeイベント",
+      "colWhen": "日時",
+      "kind": {
+        "DOUBLE_PAYMENT": "二重決済",
+        "AMOUNT_MISMATCH": "金額不一致"
+      }
     }
   },
   "documents": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1048,6 +1048,21 @@
       "monthFilterLabel": "按结算月份筛选",
       "loadError": "无法加载合作伙伴收益。",
       "retry": "重试"
+    },
+    "anomalies": {
+      "title": "支付异常",
+      "subtitle": "对账时标记的扣款 — 重复扣款应退款，金额不符需核查。",
+      "empty": "没有待处理的支付异常。",
+      "colKind": "类型",
+      "colBooking": "订单",
+      "colReceived": "实收",
+      "colExpected": "应收",
+      "colStripeEvent": "Stripe 事件",
+      "colWhen": "时间",
+      "kind": {
+        "DOUBLE_PAYMENT": "重复支付",
+        "AMOUNT_MISMATCH": "金额不符"
+      }
     }
   },
   "documents": {

--- a/packages/web/src/routes/$locale/_admin/admin/revenue.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/revenue.tsx
@@ -1,5 +1,7 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { AnomaliesPanel } from '@/vite/admin/AnomaliesPanel'
 import { RevenueView } from '@/vite/admin/RevenueView'
+import { paymentAnomaliesQueryOptions } from '@/vite/admin/anomalies/api'
 import { adminRevenueQueryOptions } from '@/vite/admin/revenue/api'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
@@ -23,21 +25,33 @@ export const Route = createFileRoute('/$locale/_admin/admin/revenue')({
   validateSearch,
   loaderDeps: ({ search }) => ({ month: search.month }),
   loader: ({ context, deps }) =>
-    context.queryClient.ensureQueryData(adminRevenueQueryOptions(deps.month)),
+    Promise.all([
+      context.queryClient.ensureQueryData(adminRevenueQueryOptions(deps.month)),
+      context.queryClient.ensureQueryData(paymentAnomaliesQueryOptions()),
+    ]),
   pendingComponent: PageSkeleton,
   errorComponent: RevenueError,
   component: RevenueRoute,
 })
 
 function RevenueRoute() {
+  const { locale } = Route.useParams()
   const { month } = Route.useSearch()
   const navigate = Route.useNavigate()
   const { data } = useSuspenseQuery(adminRevenueQueryOptions(month))
+  const { data: anomalyData } = useSuspenseQuery(paymentAnomaliesQueryOptions())
   return (
-    <RevenueView
-      report={data}
-      onSelectMonth={(next) => navigate({ search: () => (next ? { month: next } : {}) })}
-    />
+    <>
+      {/* Anomalies sit above the revenue tables: a duplicate charge to refund or a
+          mismatch to investigate needs the admin's eye before the payout figures. */}
+      <div className="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+        <AnomaliesPanel anomalies={anomalyData.anomalies} locale={locale} />
+      </div>
+      <RevenueView
+        report={data}
+        onSelectMonth={(next) => navigate({ search: () => (next ? { month: next } : {}) })}
+      />
+    </>
   )
 }
 

--- a/packages/web/src/routes/$locale/_admin/admin/revenue.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/revenue.tsx
@@ -3,7 +3,7 @@ import { AnomaliesPanel } from '@/vite/admin/AnomaliesPanel'
 import { RevenueView } from '@/vite/admin/RevenueView'
 import { paymentAnomaliesQueryOptions } from '@/vite/admin/anomalies/api'
 import { adminRevenueQueryOptions } from '@/vite/admin/revenue/api'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
 
@@ -24,11 +24,13 @@ function validateSearch(search: Record<string, unknown>): { month?: string } {
 export const Route = createFileRoute('/$locale/_admin/admin/revenue')({
   validateSearch,
   loaderDeps: ({ search }) => ({ month: search.month }),
-  loader: ({ context, deps }) =>
-    Promise.all([
-      context.queryClient.ensureQueryData(adminRevenueQueryOptions(deps.month)),
-      context.queryClient.ensureQueryData(paymentAnomaliesQueryOptions()),
-    ]),
+  // Revenue is the page's primary data and blocks render. Anomalies are secondary
+  // oversight (#744), prefetched fire-and-forget so a failing or absent endpoint
+  // can never fault the loader and blank the payout report.
+  loader: ({ context, deps }) => {
+    void context.queryClient.prefetchQuery(paymentAnomaliesQueryOptions())
+    return context.queryClient.ensureQueryData(adminRevenueQueryOptions(deps.month))
+  },
   pendingComponent: PageSkeleton,
   errorComponent: RevenueError,
   component: RevenueRoute,
@@ -39,14 +41,18 @@ function RevenueRoute() {
   const { month } = Route.useSearch()
   const navigate = Route.useNavigate()
   const { data } = useSuspenseQuery(adminRevenueQueryOptions(month))
-  const { data: anomalyData } = useSuspenseQuery(paymentAnomaliesQueryOptions())
+  // Non-blocking: while the anomalies read is pending or if it fails, the panel is
+  // simply omitted and the revenue report still renders (the panel is supplementary).
+  const { data: anomalyData } = useQuery(paymentAnomaliesQueryOptions())
   return (
     <>
       {/* Anomalies sit above the revenue tables: a duplicate charge to refund or a
           mismatch to investigate needs the admin's eye before the payout figures. */}
-      <div className="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
-        <AnomaliesPanel anomalies={anomalyData.anomalies} locale={locale} />
-      </div>
+      {anomalyData ? (
+        <div className="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+          <AnomaliesPanel anomalies={anomalyData.anomalies} locale={locale} />
+        </div>
+      ) : null}
       <RevenueView
         report={data}
         onSelectMonth={(next) => navigate({ search: () => (next ? { month: next } : {}) })}

--- a/packages/web/src/vite/admin/AnomaliesPanel.tsx
+++ b/packages/web/src/vite/admin/AnomaliesPanel.tsx
@@ -1,0 +1,117 @@
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
+import { useTranslations } from 'use-intl'
+
+interface AnomaliesPanelProps {
+  readonly anomalies: PaymentAnomalyView[]
+  readonly locale: string
+}
+
+const DASH = '—'
+
+// Whole JPY, but Stripe may omit amount_total on a malformed event — degrade a
+// null to a dash so a money cell never reads "￥NaN".
+function money(amount: number | null): string {
+  return amount === null ? DASH : formatJpy(amount)
+}
+
+/**
+ * Platform-admin panel of unresolved payment anomalies (#744) on the revenue tab
+ * (#462). Pure function of props (FC/IS — the route owns the query + boundary).
+ * DOUBLE_PAYMENT = a duplicate charge to refund; AMOUNT_MISMATCH = a charge whose
+ * amount/currency differs from the booking snapshot to investigate. `stripeEventId`
+ * is the reconciliation handle the admin carries to Stripe.
+ */
+export function AnomaliesPanel({ anomalies, locale }: AnomaliesPanelProps) {
+  const t = useTranslations('admin.anomalies')
+  const head = 'px-3 py-2 text-left font-medium text-muted-foreground'
+  const headNum = 'px-3 py-2 text-right font-medium text-muted-foreground'
+
+  return (
+    <section className="rounded-xl border border-border p-6">
+      <div className="flex items-center gap-3">
+        <h2 className="text-lg font-semibold">{t('title')}</h2>
+        {anomalies.length > 0 && (
+          <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 font-medium text-destructive text-sm tabular-nums">
+            {anomalies.length}
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-muted-foreground text-sm">{t('subtitle')}</p>
+
+      {anomalies.length === 0 ? (
+        <p className="mt-4 text-muted-foreground text-sm">{t('empty')}</p>
+      ) : (
+        <div className="mt-4 overflow-x-auto rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="border-border border-b bg-muted/50">
+              <tr>
+                <th scope="col" className={head}>
+                  {t('colKind')}
+                </th>
+                <th scope="col" className={head}>
+                  {t('colBooking')}
+                </th>
+                <th scope="col" className={headNum}>
+                  {t('colReceived')}
+                </th>
+                <th scope="col" className={headNum}>
+                  {t('colExpected')}
+                </th>
+                <th scope="col" className={head}>
+                  {t('colStripeEvent')}
+                </th>
+                <th scope="col" className={head}>
+                  {t('colWhen')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {anomalies.map((a) => (
+                <tr key={a.id} className="border-border border-b last:border-0">
+                  <td className="px-3 py-2">
+                    <KindBadge kind={a.kind} label={t(`kind.${a.kind}`)} />
+                  </td>
+                  <th scope="row" className="px-3 py-2 text-left font-mono font-normal text-xs">
+                    {a.bookingId}
+                  </th>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {money(a.receivedAmountJpy)}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {money(a.expectedAmountJpy)}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">{a.stripeEventId}</td>
+                  <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                    <time dateTime={a.createdAt}>{formatDateTime(a.createdAt, locale)}</time>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function KindBadge({
+  kind,
+  label,
+}: {
+  readonly kind: PaymentAnomalyView['kind']
+  readonly label: string
+}) {
+  // DOUBLE_PAYMENT is money already taken twice (refund) — louder than a mismatch.
+  const tone =
+    kind === 'DOUBLE_PAYMENT'
+      ? 'bg-destructive/10 text-destructive'
+      : 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-medium text-xs ${tone}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/packages/web/src/vite/admin/anomalies/api.ts
+++ b/packages/web/src/vite/admin/anomalies/api.ts
@@ -1,0 +1,24 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import type { PaymentAnomaliesResponse } from '@kuruma/shared/types/payment-anomaly'
+import { queryOptions } from '@tanstack/react-query'
+
+// Platform-admin unresolved payment anomalies (#744), surfaced on the revenue tab
+// (#462). Cookie-based (credentials: 'include') so the API gates on the session
+// role server-side (requirePlatformRead = STAFF/ADMIN/PLATFORM_ADMIN); no params.
+// Mirrors admin/revenue/api.ts.
+export const PAYMENT_ANOMALIES_QUERY_KEY = ['admin-payment-anomalies'] as const
+
+export async function fetchPaymentAnomalies(): Promise<PaymentAnomaliesResponse> {
+  const res = await fetch(`${getApiBaseUrl()}/admin/payment-anomalies`, {
+    credentials: 'include',
+  })
+  return unwrap<PaymentAnomaliesResponse>(res)
+}
+
+export function paymentAnomaliesQueryOptions() {
+  return queryOptions({
+    queryKey: PAYMENT_ANOMALIES_QUERY_KEY,
+    queryFn: fetchPaymentAnomalies,
+  })
+}

--- a/packages/web/tests/vite/admin/AnomaliesPanel.test.tsx
+++ b/packages/web/tests/vite/admin/AnomaliesPanel.test.tsx
@@ -1,0 +1,73 @@
+import { AnomaliesPanel } from '@/vite/admin/AnomaliesPanel'
+import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('use-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+afterEach(() => cleanup())
+
+const double: PaymentAnomalyView = {
+  id: 'pa_1',
+  kind: 'DOUBLE_PAYMENT',
+  operatorId: 'op_1',
+  bookingId: 'bk_double',
+  receivedAmountJpy: 100_000,
+  expectedAmountJpy: 100_000,
+  currency: 'jpy',
+  stripeEventId: 'evt_double',
+  stripePaymentIntentId: 'pi_1',
+  createdAt: '2026-06-10T03:00:00.000Z',
+}
+
+function rowOf(bookingId: string): HTMLElement {
+  const cell = screen.getByText(bookingId)
+  const row = cell.closest('tr')
+  if (!row) throw new Error(`no row for ${bookingId}`)
+  return row
+}
+
+describe('AnomaliesPanel', () => {
+  it('shows the all-clear empty state when there are no anomalies', () => {
+    render(<AnomaliesPanel anomalies={[]} locale="en" />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders a DOUBLE_PAYMENT row with kind, booking, amount and the stripe event id', () => {
+    render(<AnomaliesPanel anomalies={[double]} locale="en" />)
+    const row = rowOf('bk_double')
+    expect(within(row).getByText('kind.DOUBLE_PAYMENT')).toBeInTheDocument()
+    expect(within(row).getByText('evt_double')).toBeInTheDocument()
+    // received and expected both render the amount (a duplicate of the same charge)
+    expect(within(row).getAllByText('￥100,000')).toHaveLength(2)
+  })
+
+  it('labels an AMOUNT_MISMATCH and degrades a missing received amount to a dash', () => {
+    const mismatch: PaymentAnomalyView = {
+      ...double,
+      id: 'pa_2',
+      kind: 'AMOUNT_MISMATCH',
+      bookingId: 'bk_mismatch',
+      stripeEventId: 'evt_mismatch',
+      receivedAmountJpy: null,
+      stripePaymentIntentId: null,
+    }
+    render(<AnomaliesPanel anomalies={[mismatch]} locale="en" />)
+    const row = rowOf('bk_mismatch')
+    expect(within(row).getByText('kind.AMOUNT_MISMATCH')).toBeInTheDocument()
+    // A null Stripe amount must render a dash, never "¥NaN".
+    expect(within(row).getByText('—')).toBeInTheDocument()
+    expect(within(row).queryByText(/NaN/)).not.toBeInTheDocument()
+  })
+
+  it('renders one row per anomaly plus the header row', () => {
+    render(
+      <AnomaliesPanel
+        anomalies={[double, { ...double, id: 'pa_3', bookingId: 'bk_3', stripeEventId: 'evt_3' }]}
+        locale="en"
+      />,
+    )
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+  })
+})

--- a/packages/web/tests/vite/admin/anomalies/api.test.ts
+++ b/packages/web/tests/vite/admin/anomalies/api.test.ts
@@ -1,0 +1,63 @@
+import { ApiError } from '@/lib/api-error'
+import {
+  PAYMENT_ANOMALIES_QUERY_KEY,
+  fetchPaymentAnomalies,
+  paymentAnomaliesQueryOptions,
+} from '@/vite/admin/anomalies/api'
+import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => vi.restoreAllMocks())
+
+const anomaly: PaymentAnomalyView = {
+  id: 'pa_1',
+  kind: 'DOUBLE_PAYMENT',
+  operatorId: 'op_1',
+  bookingId: 'bk_1',
+  receivedAmountJpy: 100_000,
+  expectedAmountJpy: 100_000,
+  currency: 'jpy',
+  stripeEventId: 'evt_1',
+  stripePaymentIntentId: 'pi_1',
+  createdAt: '2026-06-10T03:00:00.000Z',
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('fetchPaymentAnomalies', () => {
+  it('GETs /admin/payment-anomalies with cookie credentials and unwraps the anomalies', async () => {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: { anomalies: [anomaly] } }))
+
+    const result = await fetchPaymentAnomalies()
+
+    expect(result.anomalies).toHaveLength(1)
+    expect(result.anomalies[0]?.stripeEventId).toBe('evt_1')
+    const [url, init] = spy.mock.calls[0] ?? []
+    expect(String(url)).toMatch(/\/admin\/payment-anomalies$/)
+    expect(init?.credentials).toBe('include')
+  })
+
+  it('throws an ApiError carrying the status when the API rejects (e.g. 403)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Forbidden' }, 403),
+    )
+    const err = await fetchPaymentAnomalies().catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(403)
+    expect((err as ApiError).message).toBe('Forbidden')
+  })
+})
+
+describe('paymentAnomaliesQueryOptions', () => {
+  it('carries the stable query key', () => {
+    expect(paymentAnomaliesQueryOptions().queryKey).toEqual(PAYMENT_ANOMALIES_QUERY_KEY)
+    expect(PAYMENT_ANOMALIES_QUERY_KEY).toEqual(['admin-payment-anomalies'])
+  })
+})


### PR DESCRIPTION
## Summary
Surfaces unresolved `payment_anomalies` (persisted by #676) on the platform-admin revenue tab (#462). The backend read path already existed; this PR adds the typed wire contract and the admin-only UI.

- **shared**: `PaymentAnomalyView` DTO + `PAYMENT_ANOMALY_KINDS`, drift-fenced to the `payment_anomaly_kind` DB enum (web can't import the schema directly).
- **api**: `routes/payment-anomalies.ts` projects the row -> `PaymentAnomalyView` (ISO dates; drops always-null `resolvedAt` + `checkoutSessionId`).
- **web**: `AnomaliesPanel` (kind badge, null-safe yen amounts, Stripe event id) wired above `RevenueView` in the revenue route loader; en/ja/zh i18n.

Design = typed wire contract (api maps domain -> shared DTO) so the contract is tsc-enforced. This is admin-only oversight of webhook anomalies; unrelated to the renter pay-at-pickup flow (#511).

No migration in this PR -> no drift/collision risk.

## Test plan
- [x] tsc 0 across shared / api / web
- [x] shared drift-fence 3/3, api route 11/11, web panel+api 7/7
- [x] i18n parity 906=906=906 (11 anomaly keys present in all locales)
- [x] biome clean, api import boundaries OK, no new file-size violations
- [ ] CI green

Closes #744
Refs #676 #462