### PR TITLE
refactor(api): parseId boundary helper for route :id params (#691)

### DIFF
--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -16,7 +16,7 @@ import type { AddOnFilters } from '../repositories/types'
 import type { AddOnService } from '../services/add-on'
 import type { AddOn } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
 
 export function createAddOnRoutes(
   service: AddOnService,
@@ -63,7 +63,10 @@ export function createAddOnRoutes(
       const user = requireUser(c)
       if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const option = await service.findById(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const option = await service.findById(toCallerContext(user), idResult.id)
       if (!option) return fail(c, 'Add-on not found', 404)
       return ok(c, option)
     })
@@ -105,12 +108,15 @@ export function createAddOnRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateAddOnSchema)
       if (!parsed.ok) return parsed.response
 
       const result = await service.update(
         toCallerContext(user),
-        c.req.param('id'),
+        idResult.id,
         stripUndefined(parsed.data) as Partial<AddOn>,
       )
       if (!result.ok) return fail(c, result.error, result.status)
@@ -120,7 +126,10 @@ export function createAddOnRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const result = await service.archive(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const result = await service.archive(toCallerContext(user), idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, result.option)
     })

--- a/packages/api/src/routes/availability.ts
+++ b/packages/api/src/routes/availability.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { STAFF_ROLES, getUser } from '../middleware/auth'
 import type { AvailabilityRepository } from '../repositories/types'
-import { fail, ok, parseDateRange } from './helpers'
+import { fail, ok, parseDateRange, parseId } from './helpers'
 
 export function createAvailabilityRoutes(repo: AvailabilityRepository) {
   return new Hono()
@@ -13,11 +13,12 @@ export function createAvailabilityRoutes(repo: AvailabilityRepository) {
       return ok(c, available)
     })
     .get('/availability/:vehicleId', async (c) => {
-      const vehicleId = c.req.param('vehicleId')
+      const idResult = parseId(c, 'vehicleId')
+      if (!idResult.ok) return idResult.response
       const range = parseDateRange(c, true)
       if (!range.ok) return range.response
 
-      const result = await repo.checkVehicleAvailability(vehicleId, range.from, range.to)
+      const result = await repo.checkVehicleAvailability(idResult.id, range.from, range.to)
       if (!result) {
         return fail(c, 'Vehicle not found', 404)
       }

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -13,7 +13,7 @@ import {
 } from '../middleware/auth'
 import type { BookingFilters } from '../repositories/types'
 import type { BookingService } from '../services/booking'
-import { fail, ok, parseBody, parseDateRange, parseLimit } from './helpers'
+import { fail, ok, parseBody, parseDateRange, parseId, parseLimit } from './helpers'
 
 export function createBookingRoutes(service: BookingService) {
   return new Hono()
@@ -72,7 +72,9 @@ export function createBookingRoutes(service: BookingService) {
     })
     .get('/bookings/:id', async (c) => {
       const ctx = toCallerContext(requireUser(c))
-      const id = c.req.param('id')
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+      const { id } = idResult
 
       // Mirror the list endpoint's `expand` parsing. A deep-linked trip-detail
       // page (#549) has no list-row data, so it requests `vehicle,renter` to
@@ -106,7 +108,10 @@ export function createBookingRoutes(service: BookingService) {
         return fail(c, 'Only operators can view booking events', 403)
       }
 
-      const events = await service.findEvents(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const events = await service.findEvents(ctx, idResult.id)
       if (!events) {
         return fail(c, 'Booking not found', 404)
       }
@@ -123,7 +128,10 @@ export function createBookingRoutes(service: BookingService) {
         return fail(c, 'Only operators can view substitution candidates', 403)
       }
 
-      const candidates = await service.findSubstitutionCandidates(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const candidates = await service.findSubstitutionCandidates(ctx, idResult.id)
       if (!candidates) {
         return fail(c, 'Booking not found', 404)
       }
@@ -194,10 +202,13 @@ export function createBookingRoutes(service: BookingService) {
         return fail(c, 'Only operators can update booking status', 403)
       }
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateBookingStatusSchema)
       if (!parsed.ok) return parsed.response
 
-      const result = await service.updateStatus(ctx, c.req.param('id'), parsed.data.status)
+      const result = await service.updateStatus(ctx, idResult.id, parsed.data.status)
       if (!result.ok) {
         return fail(c, result.error, result.status)
       }
@@ -207,7 +218,10 @@ export function createBookingRoutes(service: BookingService) {
     .post('/bookings/:id/cancel', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      const result = await service.cancel(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const result = await service.cancel(ctx, idResult.id)
       if (!result.ok) {
         return fail(c, result.error, result.status)
       }
@@ -224,12 +238,15 @@ export function createBookingRoutes(service: BookingService) {
         return fail(c, 'Only operators can substitute a vehicle', 403)
       }
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, substituteVehicleSchema)
       if (!parsed.ok) return parsed.response
 
       const result = await service.substitute(
         ctx,
-        c.req.param('id'),
+        idResult.id,
         parsed.data.newVehicleId,
         parsed.data.reason ?? null,
       )

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -2,7 +2,7 @@ import { quickCreateCustomerSchema } from '@kuruma/shared/validators/customer'
 import { Hono } from 'hono'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { CustomerService } from '../services/customer'
-import { fail, ok, parseBody, parseLimit } from './helpers'
+import { fail, ok, parseBody, parseId, parseLimit } from './helpers'
 
 const ALLOWED_SORTS = new Set(['lastBookingAt', 'bookingCount', 'name'])
 
@@ -51,7 +51,9 @@ export function createCustomerRoutes(service: CustomerService) {
       return ok(c, customer, created ? 201 : 200)
     })
     .get('/customers/:id', async (c) => {
-      const customer = await service.findById(c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+      const customer = await service.findById(idResult.id)
       if (!customer) return fail(c, 'Customer not found', 404)
       return ok(c, customer)
     })

--- a/packages/api/src/routes/documents.ts
+++ b/packages/api/src/routes/documents.ts
@@ -11,6 +11,7 @@ import {
   fail,
   ok,
   parseBody,
+  parseId,
   parsePagination,
   rejectOversizedBody,
 } from './helpers'
@@ -68,10 +69,13 @@ export function createDocumentRoutes(service: RenterDocumentService) {
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, verifyDocumentSchema)
       if (!parsed.ok) return parsed.response
 
-      const result = await service.verify(ctx, c.req.param('id'), {
+      const result = await service.verify(ctx, idResult.id, {
         status: parsed.data.status,
         verifierId: ctx.userId,
         expiryDate: parsed.data.expiryDate ?? null,

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -16,7 +16,7 @@ import type { FeeScheduleFilters } from '../repositories/types'
 import type { FeeScheduleService } from '../services/fee-schedule'
 import type { FeeSchedule } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
 
 export function createFeeScheduleRoutes(
   service: FeeScheduleService,
@@ -70,7 +70,10 @@ export function createFeeScheduleRoutes(
       const user = requireUser(c)
       if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const feeSchedule = await service.findById(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const feeSchedule = await service.findById(toCallerContext(user), idResult.id)
       if (!feeSchedule) return fail(c, 'Fee schedule not found', 404)
       return ok(c, feeSchedule)
     })
@@ -113,12 +116,15 @@ export function createFeeScheduleRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateFeeScheduleSchema)
       if (!parsed.ok) return parsed.response
 
       const result = await service.update(
         toCallerContext(user),
-        c.req.param('id'),
+        idResult.id,
         stripUndefined(parsed.data) as Partial<FeeSchedule>,
       )
       if (!result.ok)
@@ -129,7 +135,10 @@ export function createFeeScheduleRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const result = await service.archive(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const result = await service.archive(toCallerContext(user), idResult.id)
       if (!result.ok)
         return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
       return ok(c, result.feeSchedule)

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-import type { z } from 'zod'
+import { z } from 'zod'
 
 // --- Response helpers ---
 
@@ -134,6 +134,38 @@ export function rejectOversizedBody(c: Context, maxBytes: number): Response | un
  */
 export function cachePublic(c: Context, maxAgeSeconds: number): void {
   c.header('Cache-Control', `public, s-maxage=${maxAgeSeconds}`)
+}
+
+// --- Path param helpers ---
+
+type ParseIdSuccess = { ok: true; id: string }
+type ParseIdFailure = { ok: false; response: Response }
+
+// Every entity `id` is a `crypto.randomUUID()` (schema.ts) stored in a `text`
+// column, so a malformed value doesn't fail a DB cast — it silently matches no
+// row and the handler can't tell "bad input" from "not found". Validate the
+// shape at the boundary so a non-uuid path param returns a clean 400 instead of
+// leaking into a service/query. `z.string().uuid()` mirrors users.ts:9.
+const idSchema = z.string().uuid()
+
+/**
+ * Validate a UUID path param at the HTTP boundary. Reads `c.req.param(name)` and
+ * returns the id on success, or a 400 `fail()` envelope to short-circuit:
+ *
+ *   const idResult = parseId(c)
+ *   if (!idResult.ok) return idResult.response
+ *   ... service.findById(ctx, idResult.id)
+ *
+ * `name` defaults to `'id'`; pass the actual param (`'vehicleId'`, `'bookingId'`)
+ * for routes that name it differently. The error names the param so a caller can
+ * tell which segment was malformed. Only for UUID ids — never for `slug`/`token`.
+ */
+export function parseId(c: Context, name = 'id'): ParseIdSuccess | ParseIdFailure {
+  const result = idSchema.safeParse(c.req.param(name))
+  if (!result.success) {
+    return { ok: false, response: fail(c, `${name} must be a valid uuid`, 400) }
+  }
+  return { ok: true, id: result.data }
 }
 
 // --- Body parsing helpers ---

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -16,7 +16,7 @@ import type { InsuranceOptionFilters } from '../repositories/types'
 import type { InsuranceOptionService } from '../services/insurance-option'
 import type { InsuranceOption } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
 
 export function createInsuranceOptionRoutes(
   service: InsuranceOptionService,
@@ -63,7 +63,10 @@ export function createInsuranceOptionRoutes(
       const user = requireUser(c)
       if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const option = await service.findById(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const option = await service.findById(toCallerContext(user), idResult.id)
       if (!option) return fail(c, 'Insurance option not found', 404)
       return ok(c, option)
     })
@@ -106,12 +109,15 @@ export function createInsuranceOptionRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateInsuranceOptionSchema)
       if (!parsed.ok) return parsed.response
 
       const result = await service.update(
         toCallerContext(user),
-        c.req.param('id'),
+        idResult.id,
         stripUndefined(parsed.data) as Partial<InsuranceOption>,
       )
       if (!result.ok) return fail(c, result.error, result.status)
@@ -121,7 +127,10 @@ export function createInsuranceOptionRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const result = await service.archive(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const result = await service.archive(toCallerContext(user), idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, result.option)
     })

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -10,7 +10,7 @@ import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '..
 import type { LocationFilters } from '../repositories/types'
 import type { LocationService, LocationUpdateData } from '../services/location'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
 
 export function createLocationRoutes(
   service: LocationService,
@@ -54,7 +54,10 @@ export function createLocationRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const location = await service.findById(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const location = await service.findById(toCallerContext(user), idResult.id)
       if (!location) return fail(c, 'Location not found', 404)
       return ok(c, location)
     })
@@ -115,6 +118,9 @@ export function createLocationRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateLocationSchema)
       if (!parsed.ok) return parsed.response
 
@@ -123,7 +129,7 @@ export function createLocationRoutes(
       try {
         const result = await service.update(
           toCallerContext(user),
-          c.req.param('id'),
+          idResult.id,
           stripUndefined(parsed.data) as LocationUpdateData,
         )
         if (!result.ok) return fail(c, result.error, result.status)
@@ -141,7 +147,10 @@ export function createLocationRoutes(
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-      const result = await service.archive(toCallerContext(user), c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const result = await service.archive(toCallerContext(user), idResult.id)
       if (!result.ok) {
         // Surface the active-bookings discriminator so the portal can prompt the
         // owner to reassign/cancel first instead of showing a generic 409 (#412).

--- a/packages/api/src/routes/maintenance-logs.ts
+++ b/packages/api/src/routes/maintenance-logs.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { MANAGEMENT_READ_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { MaintenanceService } from '../services/maintenance'
-import { fail, ok } from './helpers'
+import { fail, ok, parseId } from './helpers'
 
 export function createMaintenanceLogRoutes(maintenanceService: MaintenanceService) {
   return new Hono().get('/vehicles/:vehicleId/maintenance-logs', async (c) => {
@@ -12,10 +12,10 @@ export function createMaintenanceLogRoutes(maintenanceService: MaintenanceServic
     const user = requireUser(c)
     if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    const logs = await maintenanceService.findLogsByVehicleId(
-      toCallerContext(user),
-      c.req.param('vehicleId'),
-    )
+    const idResult = parseId(c, 'vehicleId')
+    if (!idResult.ok) return idResult.response
+
+    const logs = await maintenanceService.findLogsByVehicleId(toCallerContext(user), idResult.id)
     return ok(c, logs)
   })
 }

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { PRIVILEGED_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { MessageRepository, ThreadRepository } from '../repositories/types'
-import { fail, ok, parseBody, parsePagination } from './helpers'
+import { fail, ok, parseBody, parseId, parsePagination } from './helpers'
 
 /**
  * Idempotent create: check for existing record by key, attempt insert,
@@ -47,8 +47,11 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
     .get('/threads/:id', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       // CallerContext scoping in repo handles participant check for renters
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
+      const thread = await threadRepo.findById(ctx, idResult.id)
       if (!thread) return fail(c, 'Thread not found', 404)
 
       return ok(c, thread)
@@ -80,8 +83,11 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
     .post('/threads/:id/messages', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       // CallerContext scoping in repo handles participant check
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
+      const thread = await threadRepo.findById(ctx, idResult.id)
       if (!thread) return fail(c, 'Thread not found', 404)
 
       const parsed = await parseBody(c, sendMessageSchema)
@@ -98,7 +104,10 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
     .post('/threads/:id/read', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const thread = await threadRepo.findById(ctx, idResult.id)
       if (!thread) return fail(c, 'Thread not found', 404)
 
       await threadRepo.markAsRead(ctx, thread.id)

--- a/packages/api/src/routes/notifications.ts
+++ b/packages/api/src/routes/notifications.ts
@@ -8,7 +8,7 @@ import {
 import type { NotificationLogFilters } from '../repositories/types'
 import type { NotificationService } from '../services/notification'
 import { operatorReadScope } from '../tenancy'
-import { fail, ok } from './helpers'
+import { fail, ok, parseId } from './helpers'
 
 /**
  * Operator-portal surface for the outbound-notification ledger (#393): a scoped
@@ -50,9 +50,12 @@ export function createNotificationRoutes(service: NotificationService) {
       const user = requireUser(c)
       if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       // A cross-operator id resolves to 404 (not 403) in the service — no
       // tenant-existence leak. The atomic claim makes a double-click send once.
-      const result = await service.resend(toCallerContext(user), c.req.param('id'))
+      const result = await service.resend(toCallerContext(user), idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       // `outcome` lets the portal distinguish a real re-send from a no-op
       // ("already in progress" / "already sent") instead of a blanket green (#485).

--- a/packages/api/src/routes/operators.ts
+++ b/packages/api/src/routes/operators.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import type { OperatorService } from '../services/operator'
-import { fail, ok } from './helpers'
+import { fail, ok, parseId } from './helpers'
 
 /**
  * Read-only operator resolution for the business portal (#387). The web layout
@@ -45,7 +45,10 @@ export function createOperatorRoutes(service: OperatorService) {
         const user = requireUser(c)
         if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-        const operator = await service.getById(toCallerContext(user), c.req.param('id'))
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+
+        const operator = await service.getById(toCallerContext(user), idResult.id)
         if (!operator) return fail(c, 'Operator not found', 404)
         return ok(c, operator)
       })

--- a/packages/api/src/routes/payments.ts
+++ b/packages/api/src/routes/payments.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { PaymentService } from '../services/payment/payment'
-import { fail, ok } from './helpers'
+import { fail, ok, parseId } from './helpers'
 
 const STRIPE_SIGNATURE_HEADER = 'stripe-signature'
 
@@ -21,13 +21,17 @@ export function createPaymentRoutes(service: PaymentService) {
   return app
     .post('/bookings/:bookingId/checkout-session', async (c) => {
       const ctx = toCallerContext(requireUser(c))
-      const result = await service.createCheckoutSession(ctx, c.req.param('bookingId'))
+      const idResult = parseId(c, 'bookingId')
+      if (!idResult.ok) return idResult.response
+      const result = await service.createCheckoutSession(ctx, idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, { url: result.url })
     })
     .get('/bookings/:bookingId/payment', async (c) => {
       const ctx = toCallerContext(requireUser(c))
-      const status = await service.getBookingPaymentStatus(ctx, c.req.param('bookingId'))
+      const idResult = parseId(c, 'bookingId')
+      if (!idResult.ok) return idResult.response
+      const status = await service.getBookingPaymentStatus(ctx, idResult.id)
       if (!status) return fail(c, 'Booking not found', 404)
       return ok(c, status)
     })

--- a/packages/api/src/routes/storefronts.ts
+++ b/packages/api/src/routes/storefronts.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { PUBLIC_CONTEXT } from '../middleware/auth'
 import type { StorefrontDetailService } from '../services/storefront-detail'
 import type { StorefrontSearchService } from '../services/storefront-search'
-import { cachePublic, fail, ok, parseDateRange, parseLimit } from './helpers'
+import { cachePublic, fail, ok, parseDateRange, parseId, parseLimit } from './helpers'
 import { rateLimitByIp } from './rate-limit'
 
 const DEFAULT_LIMIT = 25
@@ -60,6 +60,8 @@ export function createStorefrontRoutes(
       return ok(c, result.data)
     })
     .get('/storefronts/:locationId/vehicles', async (c) => {
+      const idResult = parseId(c, 'locationId')
+      if (!idResult.ok) return idResult.response
       const range = parseDateRange(c, true)
       if (!range.ok) return range.response
       const limit = parseLimit(c, { defaultLimit: DEFAULT_LIMIT, maxLimit: MAX_LIMIT })
@@ -69,7 +71,7 @@ export function createStorefrontRoutes(
       const cursor = c.req.query('cursor')
 
       const result = await detailService.getDetail(PUBLIC_CONTEXT, {
-        locationId: c.req.param('locationId'),
+        locationId: idResult.id,
         from: range.from,
         to: range.to,
         limit: limit.limit,
@@ -83,22 +85,25 @@ export function createStorefrontRoutes(
       return ok(c, result.data)
     })
     .get('/storefronts/:locationId/insurance-options', async (c) => {
+      const idResult = parseId(c, 'locationId')
+      if (!idResult.ok) return idResult.response
+
       // The ACTIVE coverage a renter can add when booking at this storefront
       // (#392). Public + active-only + single-operator — see the service for the
       // [P0] seal rationale. 404 mirrors the vehicles route (unknown/archived).
-      const result = await detailService.getInsuranceOptions(
-        PUBLIC_CONTEXT,
-        c.req.param('locationId'),
-      )
+      const result = await detailService.getInsuranceOptions(PUBLIC_CONTEXT, idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)
     })
     .get('/storefronts/:locationId/add-ons', async (c) => {
+      const idResult = parseId(c, 'locationId')
+      if (!idResult.ok) return idResult.response
+
       // The ACTIVE paid add-ons a renter can pick when booking at this storefront
       // (#460). Public + active-only + single-operator — see the service for the
       // [P0] seal rationale. 404 mirrors the vehicles route (unknown/archived).
-      const result = await detailService.getAddOns(PUBLIC_CONTEXT, c.req.param('locationId'))
+      const result = await detailService.getAddOns(PUBLIC_CONTEXT, idResult.id)
       if (!result.ok) return fail(c, result.error, result.status)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)

--- a/packages/api/src/routes/translate.ts
+++ b/packages/api/src/routes/translate.ts
@@ -2,16 +2,19 @@ import { translateMessageSchema } from '@kuruma/shared/validators/translation'
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageTranslationService } from '../services/message-translation'
-import { fail, ok, parseBody } from './helpers'
+import { fail, ok, parseBody, parseId } from './helpers'
 
 export function createTranslateRoutes(service: MessageTranslationService) {
   return new Hono().post('/messages/:id/translate', async (c) => {
     const ctx = toCallerContext(requireUser(c))
 
+    const idResult = parseId(c)
+    if (!idResult.ok) return idResult.response
+
     const parsed = await parseBody(c, translateMessageSchema)
     if (!parsed.ok) return parsed.response
 
-    const result = await service.translate(ctx, c.req.param('id'), parsed.data.targetLanguage)
+    const result = await service.translate(ctx, idResult.id, parsed.data.targetLanguage)
     if (!result.ok) return fail(c, result.error, result.status)
 
     return ok(c, {

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -16,7 +16,7 @@ import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
-import { cachePublic, fail, ok, parseBody, parseDateRange, stripUndefined } from './helpers'
+import { cachePublic, fail, ok, parseBody, parseDateRange, parseId, stripUndefined } from './helpers'
 import { rateLimitByIp } from './rate-limit'
 
 export function createVehicleClassRoutes(
@@ -107,7 +107,9 @@ export function createVehicleClassRoutes(
         // Operator-scoped: an OPERATOR_* caller can only read its own class;
         // bypass roles (STAFF/ADMIN/PLATFORM_ADMIN) read across operators (#395).
         const ctx = toCallerContext(requireUser(c))
-        const vc = await service.findById(ctx, c.req.param('id'))
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+        const vc = await service.findById(ctx, idResult.id)
         if (!vc) return fail(c, 'Vehicle class not found', 404)
         return ok(c, vc)
       })
@@ -156,12 +158,15 @@ export function createVehicleClassRoutes(
         const user = requireUser(c)
         if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+
         const parsed = await parseBody(c, updateVehicleClassSchema)
         if (!parsed.ok) return parsed.response
 
         const result = await service.update(
           toCallerContext(user),
-          c.req.param('id'),
+          idResult.id,
           stripUndefined(parsed.data) as Partial<import('../stores').VehicleClass>,
         )
         if (!result.ok) return fail(c, result.error, result.status)
@@ -171,7 +176,10 @@ export function createVehicleClassRoutes(
         const user = requireUser(c)
         if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-        const result = await service.archive(toCallerContext(user), c.req.param('id'))
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+
+        const result = await service.archive(toCallerContext(user), idResult.id)
         if (!result.ok) {
           const extras: Record<string, unknown> = {}
           if (result.code) extras.code = result.code

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -16,7 +16,15 @@ import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
-import { cachePublic, fail, ok, parseBody, parseDateRange, parseId, stripUndefined } from './helpers'
+import {
+  cachePublic,
+  fail,
+  ok,
+  parseBody,
+  parseDateRange,
+  parseId,
+  stripUndefined,
+} from './helpers'
 import { rateLimitByIp } from './rate-limit'
 
 export function createVehicleClassRoutes(

--- a/packages/api/src/routes/vehicle-detail.ts
+++ b/packages/api/src/routes/vehicle-detail.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { MANAGEMENT_READ_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { VehicleDetailService } from '../services/vehicle-detail'
-import { fail, ok } from './helpers'
+import { fail, ok, parseId } from './helpers'
 
 export function createVehicleDetailRoutes(service: VehicleDetailService) {
   return new Hono().get('/vehicles/:id/detail', async (c) => {
@@ -12,7 +12,10 @@ export function createVehicleDetailRoutes(service: VehicleDetailService) {
     const user = requireUser(c)
     if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
-    const detail = await service.findVehicleDetail(toCallerContext(user), c.req.param('id'))
+    const idResult = parseId(c)
+    if (!idResult.ok) return idResult.response
+
+    const detail = await service.findVehicleDetail(toCallerContext(user), idResult.id)
     if (!detail) {
       return fail(c, 'Vehicle not found', 404)
     }

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -6,7 +6,7 @@ import {
   MAX_PHOTOS_PER_VEHICLE,
   type VehiclePhotoService,
 } from '../services/vehicle-photo'
-import { MULTIPART_OVERHEAD_BYTES, fail, ok, rejectOversizedBody } from './helpers'
+import { MULTIPART_OVERHEAD_BYTES, fail, ok, parseId, rejectOversizedBody } from './helpers'
 
 // Up to MAX_PHOTOS_PER_VEHICLE files per request; cap the whole multipart body
 // at that many max-sized files plus framing slack.
@@ -37,6 +37,9 @@ export function createVehiclePhotoRoutes(
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const oversized = rejectOversizedBody(c, MAX_PHOTOS_REQUEST_BYTES)
       if (oversized) return oversized
 
@@ -46,7 +49,7 @@ export function createVehiclePhotoRoutes(
         (f): f is File => f instanceof File,
       )
 
-      const result = await service.uploadPhotos(ctx, c.req.param('id'), files)
+      const result = await service.uploadPhotos(ctx, idResult.id, files)
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, { uploaded: result.uploaded, total: result.total }, 201)
     })
@@ -55,10 +58,13 @@ export function createVehiclePhotoRoutes(
       if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const url = c.req.query('url')
       if (!url) return fail(c, 'url query parameter required', 400)
 
-      const result = await service.deletePhoto(ctx, c.req.param('id'), url)
+      const result = await service.deletePhoto(ctx, idResult.id, url)
       if (!result.ok) return fail(c, result.error, result.status)
       return ok(c, { deleted: url, remaining: result.remaining })
     })

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -16,7 +16,7 @@ import {
 import type { Vehicle, VehicleFilters, VehicleRepository } from '../repositories/types'
 import type { MaintenanceService } from '../services/maintenance'
 import type { ResolveWriteOperatorId } from '../tenancy'
-import { fail, ok, parseBody, parsePagination, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, parsePagination, stripUndefined } from './helpers'
 
 // vehicles carries three FKs — composite (operatorId, classId) -> vehicle_classes
 // (#400), composite (operatorId, pickupLocationId) -> locations (#435), and the
@@ -52,7 +52,9 @@ export function createVehicleRoutes(
     })
     .get('/vehicles/:id', async (c) => {
       const ctx = toCallerContext(requireUser(c))
-      const vehicle = await repo.findById(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+      const vehicle = await repo.findById(ctx, idResult.id)
       if (!vehicle) {
         return fail(c, 'Vehicle not found', 404)
       }
@@ -144,7 +146,10 @@ export function createVehicleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
-      const existing = await repo.findById(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const existing = await repo.findById(ctx, idResult.id)
       if (!existing) {
         return fail(c, 'Vehicle not found', 404)
       }
@@ -218,12 +223,15 @@ export function createVehicleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
       const parsed = await parseBody(c, updateVehicleStatusWithReasonSchema)
       if (!parsed.ok) return parsed.response
 
       const result = await maintenanceService.toggleStatus(
         ctx,
-        c.req.param('id'),
+        idResult.id,
         parsed.data.status,
         parsed.data.reason,
       )
@@ -235,7 +243,10 @@ export function createVehicleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
-      const existing = await repo.findById(ctx, c.req.param('id'))
+      const idResult = parseId(c)
+      if (!idResult.ok) return idResult.response
+
+      const existing = await repo.findById(ctx, idResult.id)
       if (!existing) {
         return fail(c, 'Vehicle not found', 404)
       }

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -273,9 +273,9 @@ describe('Availability Routes', () => {
       expect(body.data.conflicts[0].id).toBe(booking.id)
     })
 
-    it('returns 404 for nonexistent vehicle', async () => {
+    it('returns 404 for a valid-but-nonexistent vehicle id', async () => {
       const res = await app.request(
-        '/availability/nonexistent?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z',
+        '/availability/00000000-0000-4000-8000-0000000000ff?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z',
       )
 
       expect(res.status).toBe(404)
@@ -283,6 +283,15 @@ describe('Availability Routes', () => {
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBe('Vehicle not found')
+    })
+
+    it('returns 400 for a malformed (non-uuid) vehicle id', async () => {
+      const res = await app.request(
+        '/availability/nonexistent?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z',
+      )
+
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe('vehicleId must be a valid uuid')
     })
 
     it('strips conflict details for RENTER role', async () => {

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1049,14 +1049,24 @@ describe('Booking Routes', () => {
       expect(body.data.assignedVehicleId).toBe(seededVehicleId)
     })
 
-    it('returns 404 for nonexistent booking', async () => {
-      const res = await app.request('/bookings/nonexistent-id')
+    it('returns 404 for a valid-but-nonexistent booking id', async () => {
+      const res = await app.request('/bookings/00000000-0000-4000-8000-00000000bbbb')
 
       expect(res.status).toBe(404)
 
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBe('Booking not found')
+    })
+
+    it('returns 400 for a malformed (non-uuid) booking id', async () => {
+      const res = await app.request('/bookings/nonexistent-id')
+
+      expect(res.status).toBe(400)
+
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('id must be a valid uuid')
     })
   })
 
@@ -1116,7 +1126,7 @@ describe('Booking Routes', () => {
     })
 
     it('returns 404 for nonexistent booking', async () => {
-      const res = await app.request('/bookings/nonexistent-id/status', {
+      const res = await app.request('/bookings/00000000-0000-4000-8000-00000000bbbb/status', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'ACTIVE' }),
@@ -1197,7 +1207,9 @@ describe('Booking Routes', () => {
     })
 
     it('returns 404 for nonexistent booking', async () => {
-      const res = await app.request('/bookings/nonexistent-id/cancel', { method: 'POST' })
+      const res = await app.request('/bookings/00000000-0000-4000-8000-00000000bbbb/cancel', {
+        method: 'POST',
+      })
 
       expect(res.status).toBe(404)
 

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -234,10 +234,17 @@ describe('GET /customers/:id', () => {
     app = new Hono()
   })
 
-  it('returns 404 for unknown customer', async () => {
+  it('returns 404 for a valid-but-unknown customer id', async () => {
+    setup({ users: [mkUser(USER1)] })
+    const res = await app.request('/customers/00000000-0000-4000-8000-0000000000ff')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for a malformed (non-uuid) customer id', async () => {
     setup({ users: [mkUser(USER1)] })
     const res = await app.request('/customers/does-not-exist')
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('id must be a valid uuid')
   })
 
   it('returns 404 when user exists but has no bookings', async () => {

--- a/packages/api/tests/routes/documents.test.ts
+++ b/packages/api/tests/routes/documents.test.ts
@@ -171,7 +171,7 @@ describe('POST /documents/:id/verify', () => {
 
   it('returns 404 verifying a document that does not exist', async () => {
     const app = createTestApp().app
-    const res = await app.request('/documents/nope/verify', {
+    const res = await app.request('/documents/00000000-0000-4000-8000-0000000000ff/verify', {
       method: 'POST',
       headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
       body: JSON.stringify({ status: 'APPROVED', expiryDate: '2027-01-01' }),

--- a/packages/api/tests/routes/helpers.test.ts
+++ b/packages/api/tests/routes/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   ok,
   parseBody,
   parseDateRange,
+  parseId,
   parseLimit,
   parsePagination,
   rejectOversizedBody,
@@ -68,6 +69,18 @@ function createTestApp() {
   })
 
   app.post('/guarded', (c) => rejectOversizedBody(c, GUARD_MAX_BYTES) ?? ok(c, { passed: true }))
+
+  app.get('/parse-id/:id', (c) => {
+    const result = parseId(c)
+    if (!result.ok) return result.response
+    return ok(c, { id: result.id })
+  })
+
+  app.get('/parse-id-custom/:vehicleId', (c) => {
+    const result = parseId(c, 'vehicleId')
+    if (!result.ok) return result.response
+    return ok(c, { id: result.id })
+  })
 
   return app
 }
@@ -417,5 +430,39 @@ describe('parsePagination()', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('limit must be between 1 and 50')
+  })
+})
+
+describe('parseId()', () => {
+  const app = createTestApp()
+  const VALID_UUID = '00000000-0000-4000-8000-0000000000a1'
+
+  it('returns 400 with the standard fail envelope on a malformed (non-uuid) id', async () => {
+    const res = await app.request('/parse-id/not-a-uuid')
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ success: false, error: 'id must be a valid uuid' })
+  })
+
+  it('passes a valid uuid through unchanged', async () => {
+    const res = await app.request(`/parse-id/${VALID_UUID}`)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, data: { id: VALID_UUID } })
+  })
+
+  it('names the offending param in the error (custom param name)', async () => {
+    const res = await app.request('/parse-id-custom/123')
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ success: false, error: 'vehicleId must be a valid uuid' })
+  })
+
+  it('rejects a uuid with surrounding whitespace rather than trimming it', async () => {
+    const res = await app.request(`/parse-id/${encodeURIComponent(` ${VALID_UUID} `)}`)
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
   })
 })

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -553,14 +553,24 @@ describe('Message Routes', () => {
       expect(body.data.messages[1].senderId).toBe(U2)
     })
 
-    it('returns 404 for nonexistent thread', async () => {
-      const res = await app.request('/threads/nonexistent-id')
+    it('returns 404 for a valid-but-nonexistent thread id', async () => {
+      const res = await app.request('/threads/00000000-0000-4000-8000-0000000000ff')
 
       expect(res.status).toBe(404)
 
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBe('Thread not found')
+    })
+
+    it('returns 400 for a malformed (non-uuid) thread id', async () => {
+      const res = await app.request('/threads/nonexistent-id')
+
+      expect(res.status).toBe(400)
+
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('id must be a valid uuid')
     })
   })
 

--- a/packages/api/tests/routes/operators.test.ts
+++ b/packages/api/tests/routes/operators.test.ts
@@ -86,8 +86,18 @@ describe('GET /operators/:id', () => {
     expect((await mountFor('RENTER').request(`/operators/${opA.id}`)).status).toBe(403)
   })
 
-  it('returns 404 for an unknown id (admin)', async () => {
-    expect((await mountFor('PLATFORM_ADMIN').request('/operators/nope')).status).toBe(404)
+  it('returns 404 for a valid-but-unknown id (admin)', async () => {
+    expect(
+      (
+        await mountFor('PLATFORM_ADMIN').request(
+          '/operators/00000000-0000-4000-8000-0000000000ff',
+        )
+      ).status,
+    ).toBe(404)
+  })
+
+  it('returns 400 for a malformed (non-uuid) id (admin)', async () => {
+    expect((await mountFor('PLATFORM_ADMIN').request('/operators/nope')).status).toBe(400)
   })
 })
 

--- a/packages/api/tests/routes/operators.test.ts
+++ b/packages/api/tests/routes/operators.test.ts
@@ -88,11 +88,8 @@ describe('GET /operators/:id', () => {
 
   it('returns 404 for a valid-but-unknown id (admin)', async () => {
     expect(
-      (
-        await mountFor('PLATFORM_ADMIN').request(
-          '/operators/00000000-0000-4000-8000-0000000000ff',
-        )
-      ).status,
+      (await mountFor('PLATFORM_ADMIN').request('/operators/00000000-0000-4000-8000-0000000000ff'))
+        .status,
     ).toBe(404)
   })
 

--- a/packages/api/tests/routes/payments.test.ts
+++ b/packages/api/tests/routes/payments.test.ts
@@ -16,10 +16,14 @@ import type {
 import type { Booking } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 
+// Bookings carry DB-generated UUIDs; the route now validates `:bookingId` as a
+// uuid at the boundary (#691), so the fixture id must be a real uuid too.
+const BOOKING_ID = '00000000-0000-4000-8000-0000000000b1'
+
 function makeBooking(): Booking {
   const now = new Date('2026-06-09T00:00:00Z')
   return {
-    id: 'bk-1',
+    id: BOOKING_ID,
     operatorId: 'op-1',
     renterId: 'renter-1',
     classId: 'cls-1',
@@ -59,7 +63,7 @@ class StubGateway implements PaymentGateway {
 }
 
 function setup(role: UserRole = 'RENTER', userId = 'renter-1') {
-  const bookings = new Map([['bk-1', makeBooking()]])
+  const bookings = new Map([[BOOKING_ID, makeBooking()]])
   const bookingRepo = new InMemoryBookingRepository(bookings)
   const paymentRepo = new InMemoryPaymentEventRepository()
   const gateway = new StubGateway()
@@ -79,7 +83,7 @@ function setup(role: UserRole = 'RENTER', userId = 'renter-1') {
 
 function publicApp() {
   // Webhook must work with NO auth middleware mounted (Stripe is unauthenticated).
-  const bookingRepo = new InMemoryBookingRepository(new Map([['bk-1', makeBooking()]]))
+  const bookingRepo = new InMemoryBookingRepository(new Map([[BOOKING_ID, makeBooking()]]))
   const paymentRepo = new InMemoryPaymentEventRepository()
   const gateway = new StubGateway()
   const service = new PaymentService(
@@ -103,13 +107,13 @@ const completed = (): VerifiedPaymentEvent => ({
   amountTotal: 100_000,
   currency: 'jpy',
   paymentStatus: 'paid',
-  metadata: { bookingId: 'bk-1' },
+  metadata: { bookingId: BOOKING_ID },
 })
 
 describe('POST /bookings/:id/checkout-session', () => {
   it('401 when unauthenticated (relies on the app-level /bookings/* guard)', async () => {
     // Mirror index.ts: checkout sits under /bookings/*, guarded by requireAuth().
-    const bookingRepo = new InMemoryBookingRepository(new Map([['bk-1', makeBooking()]]))
+    const bookingRepo = new InMemoryBookingRepository(new Map([[BOOKING_ID, makeBooking()]]))
     const service = new PaymentService(
       new InMemoryPaymentEventRepository(),
       bookingRepo,
@@ -121,13 +125,13 @@ describe('POST /bookings/:id/checkout-session', () => {
     setupGlobalHandlers(app)
     app.use('/bookings/*', requireAuth())
     app.route('/', createPaymentRoutes(service))
-    const res = await app.request('/bookings/bk-1/checkout-session', { method: 'POST' })
+    const res = await app.request(`/bookings/${BOOKING_ID}/checkout-session`, { method: 'POST' })
     expect(res.status).toBe(401)
   })
 
   it('returns the Stripe Checkout URL for the booking owner', async () => {
     const { app } = setup()
-    const res = await app.request('/bookings/bk-1/checkout-session', { method: 'POST' })
+    const res = await app.request(`/bookings/${BOOKING_ID}/checkout-session`, { method: 'POST' })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       success: true,
@@ -137,7 +141,7 @@ describe('POST /bookings/:id/checkout-session', () => {
 
   it('maps a non-owner to 404', async () => {
     const { app } = setup('RENTER', 'someone-else')
-    const res = await app.request('/bookings/bk-1/checkout-session', { method: 'POST' })
+    const res = await app.request(`/bookings/${BOOKING_ID}/checkout-session`, { method: 'POST' })
     expect(res.status).toBe(404)
   })
 })
@@ -158,7 +162,7 @@ describe('POST /webhooks/stripe (public)', () => {
     })
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ received: false })
-    expect(await paymentRepo.findSucceededByBookingId('bk-1')).toBeNull()
+    expect(await paymentRepo.findSucceededByBookingId(BOOKING_ID)).toBeNull()
   })
 
   it('200 + records a payment on a verified completed event', async () => {
@@ -171,14 +175,16 @@ describe('POST /webhooks/stripe (public)', () => {
     })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ received: true })
-    expect(await paymentRepo.findSucceededByBookingId('bk-1')).toMatchObject({ grossJpy: 100_000 })
+    expect(await paymentRepo.findSucceededByBookingId(BOOKING_ID)).toMatchObject({
+      grossJpy: 100_000,
+    })
   })
 })
 
 describe('GET /bookings/:id/payment', () => {
   it('UNPAID before, PAID after the webhook', async () => {
     const { app, gateway } = setup()
-    const before = await app.request('/bookings/bk-1/payment')
+    const before = await app.request(`/bookings/${BOOKING_ID}/payment`)
     expect(await before.json()).toEqual({ success: true, data: { status: 'UNPAID' } })
 
     gateway.event = completed()
@@ -187,7 +193,7 @@ describe('GET /bookings/:id/payment', () => {
       headers: { 'stripe-signature': 't=1,v1=good' },
       body: 'raw',
     })
-    const after = await app.request('/bookings/bk-1/payment')
+    const after = await app.request(`/bookings/${BOOKING_ID}/payment`)
     expect(await after.json()).toEqual({ success: true, data: { status: 'PAID' } })
   })
 })

--- a/packages/api/tests/routes/storefronts.test.ts
+++ b/packages/api/tests/routes/storefronts.test.ts
@@ -236,7 +236,9 @@ describe('storefront routes (#391)', () => {
 
     it('returns 404 for an unknown locationId (does not cache the miss)', async () => {
       const ctx = setup()
-      const res = await ctx.app.request(`/storefronts/loc_nope/vehicles?from=${FROM}&to=${TO}`)
+      const res = await ctx.app.request(
+        `/storefronts/00000000-0000-4000-8000-0000000000ff/vehicles?from=${FROM}&to=${TO}`,
+      )
       expect(res.status).toBe(404)
       expect(res.headers.get('Cache-Control')).toBeNull()
     })
@@ -305,7 +307,9 @@ describe('storefront routes (#391)', () => {
 
     it('returns 404 for an unknown locationId (does not cache the miss)', async () => {
       const ctx = setup()
-      const res = await ctx.app.request('/storefronts/loc_nope/insurance-options')
+      const res = await ctx.app.request(
+        '/storefronts/00000000-0000-4000-8000-0000000000ff/insurance-options',
+      )
       expect(res.status).toBe(404)
       expect(res.headers.get('Cache-Control')).toBeNull()
     })

--- a/packages/api/tests/routes/translate.test.ts
+++ b/packages/api/tests/routes/translate.test.ts
@@ -64,13 +64,26 @@ describe('POST /messages/:id/translate', () => {
     expect(body.data.cached).toBe(true)
   })
 
-  it('returns 404 for an unknown message', async () => {
+  it('returns 404 for a valid-but-unknown message id', async () => {
+    const res = await appWith(messageRepo).request(
+      '/messages/00000000-0000-4000-8000-0000000000ff/translate',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetLanguage: 'en' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for a malformed (non-uuid) message id', async () => {
     const res = await appWith(messageRepo).request('/messages/nonexistent/translate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ targetLanguage: 'en' }),
     })
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('id must be a valid uuid')
   })
 
   it('rejects an invalid targetLanguage with 400', async () => {

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -323,9 +323,15 @@ describe('Vehicle Class CRUD Routes', () => {
       expect(data.slug).toBe('compact')
     })
 
-    it('returns 404 for nonexistent', async () => {
-      const res = await app.request('/vehicle-classes/nonexistent-id')
+    it('returns 404 for a valid-but-nonexistent id', async () => {
+      const res = await app.request('/vehicle-classes/00000000-0000-4000-8000-0000000000ff')
       expect(res.status).toBe(404)
+    })
+
+    it('returns 400 for a malformed (non-uuid) id', async () => {
+      const res = await app.request('/vehicle-classes/nonexistent-id')
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe('id must be a valid uuid')
     })
   })
 
@@ -360,7 +366,7 @@ describe('Vehicle Class CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent', async () => {
-      const res = await app.request('/vehicle-classes/missing-id', {
+      const res = await app.request('/vehicle-classes/00000000-0000-4000-8000-0000000000ff', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: 'X' }),
@@ -521,7 +527,9 @@ describe('Vehicle Class CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent', async () => {
-      const res = await app.request('/vehicle-classes/missing', { method: 'DELETE' })
+      const res = await app.request('/vehicle-classes/00000000-0000-4000-8000-0000000000ff', {
+        method: 'DELETE',
+      })
       expect(res.status).toBe(404)
     })
   })

--- a/packages/api/tests/routes/vehicle-detail.test.ts
+++ b/packages/api/tests/routes/vehicle-detail.test.ts
@@ -99,13 +99,20 @@ describe('GET /vehicles/:id/detail', () => {
     return a
   }
 
-  it('returns 404 for nonexistent vehicle', async () => {
-    const res = await app.request('/vehicles/nonexistent/detail')
+  it('returns 404 for a valid-but-nonexistent vehicle id', async () => {
+    const res = await app.request('/vehicles/00000000-0000-4000-8000-0000000000ff/detail')
 
     expect(res.status).toBe(404)
     const body = await res.json()
     expect(body.success).toBe(false)
     expect(body.error).toBe('Vehicle not found')
+  })
+
+  it('returns 400 for a malformed (non-uuid) vehicle id', async () => {
+    const res = await app.request('/vehicles/nonexistent/detail')
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('id must be a valid uuid')
   })
 
   it('returns vehicle with empty enrichment when no bookings exist', async () => {

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -206,7 +206,20 @@ describe('POST /vehicles/:id/photos', () => {
     expect(body.error).toContain('10')
   })
 
-  it('returns 404 for nonexistent vehicle', async () => {
+  it('returns 404 for a valid-but-nonexistent vehicle id', async () => {
+    const headers = await authHeaders()
+    const form = makeFormData('car.jpg', 'image/jpeg', 1024)
+
+    const res = await app.request('/vehicles/00000000-0000-4000-8000-0000000000ff/photos', {
+      method: 'POST',
+      headers,
+      body: form,
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for a malformed (non-uuid) vehicle id', async () => {
     const headers = await authHeaders()
     const form = makeFormData('car.jpg', 'image/jpeg', 1024)
 
@@ -216,7 +229,8 @@ describe('POST /vehicles/:id/photos', () => {
       body: form,
     })
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('id must be a valid uuid')
   })
 
   it('returns 403 for RENTER role', async () => {
@@ -353,11 +367,11 @@ describe('DELETE /vehicles/:id/photos?url=', () => {
     expect(res.status).toBe(404)
   })
 
-  it('returns 404 for nonexistent vehicle', async () => {
+  it('returns 404 for a valid-but-nonexistent vehicle id', async () => {
     const headers = await authHeaders()
 
     const res = await app.request(
-      `/vehicles/nonexistent/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      `/vehicles/00000000-0000-4000-8000-0000000000ff/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
       { method: 'DELETE', headers },
     )
 

--- a/packages/api/tests/routes/vehicles.test.ts
+++ b/packages/api/tests/routes/vehicles.test.ts
@@ -273,13 +273,23 @@ describe('Vehicle CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent vehicle', async () => {
-      const res = await app.request('/vehicles/nonexistent-id')
+      const res = await app.request('/vehicles/00000000-0000-4000-8000-00000000cccc')
 
       expect(res.status).toBe(404)
 
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error).toBe('Vehicle not found')
+    })
+
+    it('returns 400 for a malformed (non-uuid) vehicle id', async () => {
+      const res = await app.request('/vehicles/nonexistent-id')
+
+      expect(res.status).toBe(400)
+
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('id must be a valid uuid')
     })
   })
 
@@ -362,7 +372,7 @@ describe('Vehicle CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent vehicle', async () => {
-      const res = await app.request('/vehicles/nonexistent-id', {
+      const res = await app.request('/vehicles/00000000-0000-4000-8000-00000000cccc', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: 'Updated' }),
@@ -636,7 +646,11 @@ describe('Vehicle CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent vehicle', async () => {
-      const res = await patchStatus('nonexistent-id', 'MAINTENANCE', 'Does not matter')
+      const res = await patchStatus(
+        '00000000-0000-4000-8000-00000000cccc',
+        'MAINTENANCE',
+        'Does not matter',
+      )
 
       expect(res.status).toBe(404)
       const body = await res.json()
@@ -710,7 +724,7 @@ describe('Vehicle CRUD Routes', () => {
     })
 
     it('returns 404 for nonexistent vehicle', async () => {
-      const res = await app.request('/vehicles/nonexistent-id', {
+      const res = await app.request('/vehicles/00000000-0000-4000-8000-00000000cccc', {
         method: 'DELETE',
       })
 


### PR DESCRIPTION
Relates to #691.

Adds a `parseId` helper to routes/helpers.ts and applies it across ~20 routes, replacing ad-hoc id parsing; 13 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)