### PR TITLE
refactor(api): extract UserDirectoryService from users route (#712 Slice B)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -177,6 +177,7 @@ import { RenterDocumentService } from './services/renter-document'
 import { StorefrontDetailService } from './services/storefront-detail'
 import { StorefrontSearchService } from './services/storefront-search'
 import { createTranslationProvider } from './services/translation-provider-factory'
+import { UserDirectoryService } from './services/user-directory'
 import { VehicleClassService } from './services/vehicle-class'
 import { VehicleClassAvailabilityService } from './services/vehicle-class-availability'
 import { VehicleDetailService } from './services/vehicle-detail'
@@ -632,6 +633,7 @@ export function createApp(overrides?: AppOverrides) {
     notificationDispatcher,
   )
   const customerService = new CustomerService(customerRepo, userRepo)
+  const userDirectoryService = new UserDirectoryService(userRepo, threadRepo)
   const maintenanceService = new MaintenanceService(
     vehicleRepo,
     maintenanceLogRepo,
@@ -729,7 +731,7 @@ export function createApp(overrides?: AppOverrides) {
       createTranslateRoutes(new MessageTranslationService(messageRepo, translationProvider)),
     )
     .route('/', createCustomerRoutes(customerService))
-    .route('/', createUserRoutes(userRepo, threadRepo))
+    .route('/', createUserRoutes(userDirectoryService))
     .route('/', createAdminRoutes(operatorService, providerInviteService))
     .route('/', createLocationRoutes(locationService, resolveWriteOperatorId))
     .route('/', createInsuranceOptionRoutes(insuranceOptionService, resolveWriteOperatorId))

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1,40 +1,13 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
-import type { CallerContext } from '../middleware/auth'
-import { PRIVILEGED_ROLES, isOperatorRole, requireUser, toCallerContext } from '../middleware/auth'
-import type { ThreadRepository, UserRepository } from '../repositories/types'
+import { requireUser, toCallerContext } from '../middleware/auth'
+import type { UserDirectoryService } from '../services/user-directory'
 import { fail, ok } from './helpers'
 
 const MAX_IDS = 50
 const idsSchema = z.array(z.string().uuid()).max(MAX_IDS)
 
-/**
- * Build the set of user ids the caller is allowed to resolve. Privileged roles
- * (STAFF/ADMIN/PARTNER) can resolve anyone; renters can only resolve users they
- * share a thread with. Without this filter the endpoint becomes a name-harvest
- * oracle: any authenticated renter could probe arbitrary UUIDs and dump the
- * user table 50 ids at a time.
- */
-async function allowedUserIds(
-  ctx: CallerContext,
-  threadRepo: ThreadRepository,
-): Promise<Set<string> | 'all'> {
-  if (PRIVILEGED_ROLES.has(ctx.role)) return 'all'
-  // #396: OPERATOR_* are self-only here. The thread lookup below uses a
-  // synthetic RENTER context to resolve a caller's co-participants for renter
-  // messaging; operators have no messaging surface yet (slice 7) and must not
-  // resolve another tenant's users via a shared thread. Fail closed until
-  // operator messaging is deliberately modeled.
-  if (isOperatorRole(ctx.role)) return new Set<string>([ctx.userId])
-  const threads = await threadRepo.findAll({ userId: ctx.userId, role: 'RENTER' })
-  const allowed = new Set<string>([ctx.userId])
-  for (const thread of threads) {
-    for (const p of thread.participants) allowed.add(p.userId)
-  }
-  return allowed
-}
-
-export function createUserRoutes(userRepo: UserRepository, threadRepo: ThreadRepository) {
+export function createUserRoutes(service: UserDirectoryService) {
   return new Hono().get('/users', async (c) => {
     const ctx = toCallerContext(requireUser(c))
 
@@ -53,13 +26,7 @@ export function createUserRoutes(userRepo: UserRepository, threadRepo: ThreadRep
       return fail(c, message, 400)
     }
 
-    const allowed = await allowedUserIds(ctx, threadRepo)
-    const requested = allowed === 'all' ? parsed.data : parsed.data.filter((id) => allowed.has(id))
-
-    const users = await userRepo.findByIds(requested)
-    return ok(
-      c,
-      users.map((u) => ({ id: u.id, name: u.name })),
-    )
+    const users = await service.resolveVisibleUsers(ctx, parsed.data)
+    return ok(c, users)
   })
 }

--- a/packages/api/src/services/user-directory.ts
+++ b/packages/api/src/services/user-directory.ts
@@ -1,0 +1,51 @@
+import type { CallerContext } from '../middleware/auth'
+import { PRIVILEGED_ROLES, isOperatorRole } from '../middleware/auth'
+import type { ThreadRepository, UserRepository } from '../repositories/types'
+
+/** Public projection of a user surfaced by the directory: id + display name only.
+ *  Email, language, and every other column stay server-side. */
+export interface UserSummary {
+  id: string
+  name: string | null
+}
+
+/**
+ * Resolves a batch of user ids to {id, name} pairs, scoped to who the caller is
+ * allowed to see. The scoping is the whole point: without it the /users endpoint
+ * is a name-harvest oracle — any authenticated renter could probe arbitrary
+ * UUIDs and dump the user table. Hono-free so the policy is unit-testable.
+ */
+export class UserDirectoryService {
+  constructor(
+    private readonly userRepo: UserRepository,
+    private readonly threadRepo: ThreadRepository,
+  ) {}
+
+  async resolveVisibleUsers(ctx: CallerContext, requestedIds: string[]): Promise<UserSummary[]> {
+    const allowed = await this.allowedUserIds(ctx)
+    const visibleIds =
+      allowed === 'all' ? requestedIds : requestedIds.filter((id) => allowed.has(id))
+    const users = await this.userRepo.findByIds(visibleIds)
+    return users.map((u) => ({ id: u.id, name: u.name }))
+  }
+
+  /**
+   * The set of user ids the caller may resolve. Privileged roles (STAFF/ADMIN/
+   * PARTNER) resolve anyone; renters resolve only users they share a thread with.
+   */
+  private async allowedUserIds(ctx: CallerContext): Promise<Set<string> | 'all'> {
+    if (PRIVILEGED_ROLES.has(ctx.role)) return 'all'
+    // #396: OPERATOR_* are self-only here. The thread lookup below uses a
+    // synthetic RENTER context to resolve a caller's co-participants for renter
+    // messaging; operators have no messaging surface yet (slice 7) and must not
+    // resolve another tenant's users via a shared thread. Fail closed until
+    // operator messaging is deliberately modeled.
+    if (isOperatorRole(ctx.role)) return new Set<string>([ctx.userId])
+    const threads = await this.threadRepo.findAll({ userId: ctx.userId, role: 'RENTER' })
+    const allowed = new Set<string>([ctx.userId])
+    for (const thread of threads) {
+      for (const p of thread.participants) allowed.add(p.userId)
+    }
+    return allowed
+  }
+}

--- a/packages/api/tests/routes/users.test.ts
+++ b/packages/api/tests/routes/users.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
 import { InMemoryThreadRepository, InMemoryUserRepository } from '../../src/repositories/in-memory'
 import { createUserRoutes } from '../../src/routes/users'
+import { UserDirectoryService } from '../../src/services/user-directory'
 import { setupAuthEnv, testAuthMiddleware } from '../helpers/auth'
 
 const U1 = '00000000-0000-4000-8000-0000000000a1'
@@ -15,7 +16,7 @@ let threadRepo: InMemoryThreadRepository
 function appAs(userId: string, role: 'RENTER' | 'STAFF' | 'ADMIN' = 'RENTER'): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware(userId, role))
-  a.route('/', createUserRoutes(userRepo, threadRepo))
+  a.route('/', createUserRoutes(new UserDirectoryService(userRepo, threadRepo)))
   return a
 }
 

--- a/packages/api/tests/services/user-directory.test.ts
+++ b/packages/api/tests/services/user-directory.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type AuthUser, toCallerContext } from '../../src/middleware/auth'
+import { InMemoryThreadRepository, InMemoryUserRepository } from '../../src/repositories/in-memory'
+import { UserDirectoryService } from '../../src/services/user-directory'
+
+const U1 = '00000000-0000-4000-8000-0000000000a1'
+const U2 = '00000000-0000-4000-8000-0000000000a2'
+const U3 = '00000000-0000-4000-8000-0000000000a3' // shares no thread with U1
+
+let userRepo: InMemoryUserRepository
+let threadRepo: InMemoryThreadRepository
+let service: UserDirectoryService
+
+function ctxFor(userId: string, role: AuthUser['role'], operatorId?: string) {
+  return toCallerContext(operatorId ? { id: userId, role, operatorId } : { id: userId, role })
+}
+
+beforeEach(async () => {
+  const store = new Map([
+    [U1, { id: U1, name: 'Alice', email: 'a@x', language: 'en' }],
+    [U2, { id: U2, name: 'Bob', email: 'b@x', language: 'en' }],
+    [U3, { id: U3, name: 'Carol', email: 'c@x', language: 'en' }],
+  ])
+  userRepo = new InMemoryUserRepository(store)
+  threadRepo = new InMemoryThreadRepository()
+  // U1 and U2 share a thread; U3 is unrelated to U1.
+  await threadRepo.create({ userId: U1, role: 'RENTER' }, null, [U1, U2], null)
+  service = new UserDirectoryService(userRepo, threadRepo)
+})
+
+describe('UserDirectoryService.resolveVisibleUsers', () => {
+  it('omits ids a renter shares no thread with (no name-harvest oracle)', async () => {
+    const result = await service.resolveVisibleUsers(ctxFor(U1, 'RENTER'), [U2, U3])
+
+    expect(result).toEqual([{ id: U2, name: 'Bob' }])
+  })
+
+  it('lets a renter resolve themselves even with no threads', async () => {
+    const result = await service.resolveVisibleUsers(ctxFor(U2, 'RENTER'), [U2, U3])
+
+    expect(result).toEqual([{ id: U2, name: 'Bob' }])
+  })
+
+  it('lets a privileged role resolve any user', async () => {
+    const result = await service.resolveVisibleUsers(ctxFor(U1, 'STAFF'), [U2, U3])
+
+    expect(result).toContainEqual({ id: U2, name: 'Bob' })
+    expect(result).toContainEqual({ id: U3, name: 'Carol' })
+    expect(result).toHaveLength(2)
+  })
+
+  it('restricts an operator to itself, never another tenant via a shared thread (#396)', async () => {
+    // U1 (operator) shares the seeded thread with U2, but operators are self-only.
+    const result = await service.resolveVisibleUsers(ctxFor(U1, 'OPERATOR_OWNER', 'op-1'), [U1, U2])
+
+    expect(result).toEqual([{ id: U1, name: 'Alice' }])
+  })
+})


### PR DESCRIPTION
## What

Slice B of #712 (health-audit P2/L, epic #701): pull the **name-harvest-prevention authz rule** out of the `users` HTTP controller into a Hono-free, DI'd `UserDirectoryService`.

- **New** `services/user-directory.ts` — `UserDirectoryService.resolveVisibleUsers(ctx, requestedIds)` owns the `allowedUserIds` scoping: privileged roles resolve anyone; renters resolve only users they share a RENTER thread with (plus self); `OPERATOR_*` are self-only (#396). Returns `{ id, name }` summaries.
- `routes/users.ts` — now a thin shell: parse + zod-validate the `ids` query (MAX_IDS=50, 400 on bad input), then delegate. Route shrank ~33 lines and **no longer imports repositories**.
- `index.ts` — wires `new UserDirectoryService(userRepo, threadRepo)` at the composition root.
- Tests: new `tests/services/user-directory.test.ts` (4 unit tests, no Hono, real in-memory repos — pins both the allow and deny sides of the policy + the #396 operator self-only edge); route test wiring updated.

## Why

This `/users` endpoint is security-sensitive — without the scoping it is a name-harvest oracle (any authenticated renter could probe arbitrary UUIDs and dump the user table 50 ids at a time). Moving the rule into a service makes the policy unit-testable without an HTTP context and restores the `routes → services → repositories` import direction (AGENTS.md MVC+DI; FC/IS).

## Behavior

Byte-identical: same `{id,name}` projection, same 200/400 statuses + messages, same scoping. Confirmed by the unchanged `users.test.ts` + `operator-user-isolation.test.ts` (#396 guard) plus the new service tests.

## Verification

- New service 4/4, route + isolation 15/15, **full API unit suite 1383/1383**
- `tsc` clean, `lint:boundaries` OK, all pre-commit hooks pass
- code-reviewer agent: clean (no CRITICAL/HIGH/MEDIUM/LOW) — verified byte-for-byte authz equivalence

Part of #712. Built independently off trunk (parallel to Slice C #768); both touch `index.ts` in different regions and are independently mergeable — the second to merge rebases. Slice A (MessageService) to follow.