### PR TITLE
refactor(auth): revoke legacy STAFF/ADMIN platform-admin access (#487)

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -65,7 +65,7 @@ export interface CallerContext {
   readonly role: UserRole
   /** Tenant the caller is scoped to. Set for OPERATOR_* roles. */
   readonly operatorId?: string
-  /** True only for PLATFORM_ADMIN + legacy privileged roles. OPERATOR_* never bypass. */
+  /** True only for PLATFORM_ADMIN + PARTNER (cross-tenant API caller). OPERATOR_* never bypass. */
   readonly bypassScope?: boolean
 }
 
@@ -104,9 +104,10 @@ export const PUBLIC_CONTEXT: CallerContext = {
  * the platform tier (STAFF_ROLES → PLATFORM_ROLES) is now a SEPARATE set from the
  * business tier (FLEET_WRITE/MANAGEMENT_READ → BUSINESS_ROLES). That split lets
  * #487 tighten platform-admin access (PLATFORM_ROLES → {PLATFORM_ADMIN}) without
- * touching business management. Members are identical to before — behavior-preserving.
+ * touching business management — which it now has.
  *
- * STAFF_ROLES: platform-staff tier (no operators) — STAFF / ADMIN / PLATFORM_ADMIN.
+ * STAFF_ROLES: platform-staff tier (no operators) — PLATFORM_ADMIN only (legacy
+ * STAFF / ADMIN revoked by #487).
  * FLEET_WRITE_ROLES / MANAGEMENT_READ_ROLES: the platform base PLUS tenant
  * operators; each admitted operator is still bounded to its own tenant by the
  * repository's operator predicate (#386 F2 / #397), and RENTER / PARTNER are
@@ -134,8 +135,8 @@ export function requireManagementRead(ctx: CallerContext): void {
 
 /**
  * Gate for PLATFORM-level reads that span every operator — the #462 admin
- * revenue tab. Admits only the platform tier (`PLATFORM_ROLES` = STAFF / ADMIN /
- * PLATFORM_ADMIN today), the exact set the web `_admin` portal admits. References
+ * revenue tab. Admits only the platform tier (`PLATFORM_ROLES` = {PLATFORM_ADMIN}
+ * after #487), the exact set the web `_admin` portal admits. References
  * PLATFORM_ROLES directly (not the STAFF_ROLES alias) so #487's tightening of
  * PLATFORM_ROLES → {PLATFORM_ADMIN} narrows this gate automatically. Deliberately
  * EXCLUDES OPERATOR_* (a tenant must never see another partner's revenue) and

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -17,7 +17,7 @@ export const TEST_AUTH_SECRET = 'test-auth-secret-at-least-32-chars-long'
  *  Pass `operatorId` to simulate a tenant-scoped OPERATOR_* caller. */
 export function testAuthMiddleware(
   id = 'test-user',
-  role: UserRole = 'ADMIN',
+  role: UserRole = 'PLATFORM_ADMIN',
   operatorId?: string,
 ): MiddlewareHandler {
   return async (c, next) => {
@@ -27,11 +27,11 @@ export function testAuthMiddleware(
 }
 
 export async function signTestJwt(
-  payload: { sub: string; role?: string } = { sub: 'test-user-id', role: 'ADMIN' },
+  payload: { sub: string; role?: string } = { sub: 'test-user-id', role: 'PLATFORM_ADMIN' },
   secret = TEST_AUTH_SECRET,
 ): Promise<string> {
   const key = new TextEncoder().encode(secret)
-  return new SignJWT({ role: payload.role ?? 'ADMIN', ...payload })
+  return new SignJWT({ role: payload.role ?? 'PLATFORM_ADMIN', ...payload })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime('1h')
     .setIssuedAt()

--- a/packages/api/tests/middleware/auth-context.test.ts
+++ b/packages/api/tests/middleware/auth-context.test.ts
@@ -37,15 +37,15 @@ describe('toCallerContext', () => {
     expect(ctx.operatorId).toBeUndefined()
   })
 
-  test('legacy ADMIN bypasses scope (temporary platform-admin per §6.2)', () => {
+  test('legacy ADMIN no longer bypasses scope — revoked by #487', () => {
     const ctx = toCallerContext(authUser({ role: 'ADMIN' }))
-    expect(ctx.bypassScope).toBe(true)
+    expect(ctx.bypassScope).toBe(false)
     expect(ctx.operatorId).toBeUndefined()
   })
 
-  test('legacy STAFF bypasses scope (temporary platform-admin per §6.2)', () => {
+  test('legacy STAFF no longer bypasses scope — revoked by #487', () => {
     const ctx = toCallerContext(authUser({ role: 'STAFF' }))
-    expect(ctx.bypassScope).toBe(true)
+    expect(ctx.bypassScope).toBe(false)
   })
 
   test('PARTNER (3rd-party API caller) bypasses scope', () => {

--- a/packages/api/tests/middleware/role-aliases.test.ts
+++ b/packages/api/tests/middleware/role-aliases.test.ts
@@ -13,9 +13,12 @@ import { FLEET_WRITE_ROLES, MANAGEMENT_READ_ROLES, STAFF_ROLES } from '../../src
  * private copy (the #387 drift this PR removed).
  */
 describe('auth role-set aliases (single-source wiring)', () => {
-  it('STAFF_ROLES is the platform tier — same instance as shared PLATFORM_ROLES, no operators', () => {
+  it('STAFF_ROLES is the platform tier — same instance as shared PLATFORM_ROLES, PLATFORM_ADMIN only', () => {
     expect(STAFF_ROLES).toBe(PLATFORM_ROLES)
     expect(STAFF_ROLES.has('PLATFORM_ADMIN')).toBe(true)
+    // #487: the legacy STAFF/ADMIN aliases no longer grant the platform tier.
+    expect(STAFF_ROLES.has('STAFF')).toBe(false)
+    expect(STAFF_ROLES.has('ADMIN')).toBe(false)
     expect(STAFF_ROLES.has('OPERATOR_OWNER')).toBe(false)
     expect(STAFF_ROLES.has('OPERATOR_STAFF')).toBe(false)
   })

--- a/packages/api/tests/repositories/renter-document.test.ts
+++ b/packages/api/tests/repositories/renter-document.test.ts
@@ -10,7 +10,7 @@ const renterCtx = (id: string): CallerContext => ({
   role: 'RENTER',
   bypassScope: false,
 })
-const staffCtx: CallerContext = { userId: 'staff_1', role: 'STAFF', bypassScope: true }
+const adminCtx: CallerContext = { userId: 'admin_1', role: 'PLATFORM_ADMIN', bypassScope: true }
 const operatorCtx: CallerContext = {
   userId: 'op_owner',
   role: 'OPERATOR_OWNER',
@@ -45,8 +45,8 @@ describe('InMemoryRenterDocumentRepository — create', () => {
     )
   })
 
-  it('staff may create a document on behalf of a renter', async () => {
-    const doc = await repo.create(staffCtx, idpInput(OTHER_RENTER))
+  it('a platform admin may create a document on behalf of a renter', async () => {
+    const doc = await repo.create(adminCtx, idpInput(OTHER_RENTER))
     expect(doc.renterId).toBe(OTHER_RENTER)
   })
 })
@@ -56,7 +56,7 @@ describe('InMemoryRenterDocumentRepository — read scoping', () => {
   beforeEach(async () => {
     repo = new InMemoryRenterDocumentRepository()
     await repo.create(renterCtx(RENTER), idpInput(RENTER))
-    await repo.create(staffCtx, idpInput(OTHER_RENTER))
+    await repo.create(adminCtx, idpInput(OTHER_RENTER))
   })
 
   it('findByRenter returns a renter their own documents', async () => {
@@ -70,8 +70,8 @@ describe('InMemoryRenterDocumentRepository — read scoping', () => {
     expect(docs).toEqual([])
   })
 
-  it('staff can read any renter documents', async () => {
-    const docs = await repo.findByRenter(staffCtx, OTHER_RENTER)
+  it('a platform admin can read any renter documents', async () => {
+    const docs = await repo.findByRenter(adminCtx, OTHER_RENTER)
     expect(docs).toHaveLength(1)
   })
 })
@@ -84,22 +84,22 @@ describe('InMemoryRenterDocumentRepository — verify', () => {
     docId = (await repo.create(renterCtx(RENTER), idpInput())).id
   })
 
-  it('staff approval records expiry, verifier and verifiedAt', async () => {
-    const verified = await repo.verify(staffCtx, docId, {
+  it('platform-admin approval records expiry, verifier and verifiedAt', async () => {
+    const verified = await repo.verify(adminCtx, docId, {
       status: 'APPROVED',
-      verifierId: staffCtx.userId,
+      verifierId: adminCtx.userId,
       expiryDate: '2030-01-31',
     })
     expect(verified?.status).toBe('APPROVED')
     expect(verified?.expiryDate).toBe('2030-01-31')
-    expect(verified?.verifierId).toBe('staff_1')
+    expect(verified?.verifierId).toBe('admin_1')
     expect(verified?.verifiedAt).toBeInstanceOf(Date)
   })
 
-  it('staff rejection records the reason', async () => {
-    const rejected = await repo.verify(staffCtx, docId, {
+  it('platform-admin rejection records the reason', async () => {
+    const rejected = await repo.verify(adminCtx, docId, {
       status: 'REJECTED',
-      verifierId: staffCtx.userId,
+      verifierId: adminCtx.userId,
       rejectionReason: 'Blurry',
     })
     expect(rejected?.status).toBe('REJECTED')
@@ -127,14 +127,14 @@ describe('InMemoryRenterDocumentRepository — verify', () => {
   })
 
   it('treats a verdict as terminal — re-verifying a decided doc returns undefined', async () => {
-    await repo.verify(staffCtx, docId, {
+    await repo.verify(adminCtx, docId, {
       status: 'APPROVED',
-      verifierId: staffCtx.userId,
+      verifierId: adminCtx.userId,
       expiryDate: '2030-01-31',
     })
-    const reVerify = await repo.verify(staffCtx, docId, {
+    const reVerify = await repo.verify(adminCtx, docId, {
       status: 'REJECTED',
-      verifierId: staffCtx.userId,
+      verifierId: adminCtx.userId,
       rejectionReason: 'changed my mind',
     })
     expect(reVerify).toBeUndefined()
@@ -146,16 +146,16 @@ describe('InMemoryRenterDocumentRepository — pending queue + gate lookup', () 
   beforeEach(async () => {
     repo = new InMemoryRenterDocumentRepository()
     const a = await repo.create(renterCtx(RENTER), idpInput(RENTER))
-    await repo.create(staffCtx, idpInput(OTHER_RENTER))
-    await repo.verify(staffCtx, a.id, {
+    await repo.create(adminCtx, idpInput(OTHER_RENTER))
+    await repo.verify(adminCtx, a.id, {
       status: 'APPROVED',
-      verifierId: staffCtx.userId,
+      verifierId: adminCtx.userId,
       expiryDate: '2030-01-31',
     })
   })
 
   it('listPending returns only PENDING docs with a total', async () => {
-    const page = await repo.listPending(staffCtx)
+    const page = await repo.listPending(adminCtx)
     expect(page.total).toBe(1)
     expect(page.data.every((d) => d.status === 'PENDING')).toBe(true)
   })

--- a/packages/api/tests/routes/actor-derivation.test.ts
+++ b/packages/api/tests/routes/actor-derivation.test.ts
@@ -201,10 +201,10 @@ describe('actor derivation from JWT', () => {
     expect(res.status).toBe(201)
   })
 
-  it('STAFF can cancel any booking', async () => {
+  it('a platform admin can cancel any booking', async () => {
     const { app, vehicleRepo, classId, locationId } = await createTestApp()
     const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
-    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'PLATFORM_ADMIN' })
 
     const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
       operatorId: TEST_OPERATOR_ID,

--- a/packages/api/tests/routes/admin-revenue.test.ts
+++ b/packages/api/tests/routes/admin-revenue.test.ts
@@ -88,16 +88,19 @@ describe('GET /admin/revenue — auth', () => {
     expect((await app.request('/admin/revenue')).status).toBe(401)
   })
 
-  it.each(['RENTER', 'PARTNER'] as const)('403 for %s (not a platform admin)', async (role) => {
-    expect((await mount(role).request('/admin/revenue')).status).toBe(403)
-  })
+  it.each(['RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
+    '403 for %s (not a platform admin — legacy STAFF/ADMIN revoked #487)',
+    async (role) => {
+      expect((await mount(role).request('/admin/revenue')).status).toBe(403)
+    },
+  )
 
   it('403 for an OPERATOR_OWNER (must never see another partner revenue)', async () => {
     expect((await mount('OPERATOR_OWNER', OP_A).request('/admin/revenue')).status).toBe(403)
   })
 
-  it.each(['PLATFORM_ADMIN', 'STAFF', 'ADMIN'] as const)('200 for %s', async (role) => {
-    expect((await mount(role).request('/admin/revenue')).status).toBe(200)
+  it('200 for PLATFORM_ADMIN (the only platform-admin role)', async () => {
+    expect((await mount('PLATFORM_ADMIN').request('/admin/revenue')).status).toBe(200)
   })
 })
 

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -66,7 +66,7 @@ describe('Availability Routes', () => {
     bookingRepo = new InMemoryBookingRepository()
     availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
     app = new Hono()
-    app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
+    app.use('*', testAuthMiddleware('staff-user', 'PLATFORM_ADMIN'))
     app.route('/', createAvailabilityRoutes(availabilityRepo))
   })
 

--- a/packages/api/tests/routes/booking-detail-expand.test.ts
+++ b/packages/api/tests/routes/booking-detail-expand.test.ts
@@ -63,7 +63,7 @@ let bookingId: string
 
 function app() {
   const a = new Hono()
-  a.use('*', testAuthMiddleware(ADMIN, 'ADMIN'))
+  a.use('*', testAuthMiddleware(ADMIN, 'PLATFORM_ADMIN'))
   a.route('/', createBookingRoutes(service))
   return a
 }

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -195,8 +195,8 @@ describe('Booking Routes', () => {
       vehicleClassRepo,
     )
     app = new Hono()
-    // ADMIN with USER1 identity — mirrors pre-auth test data.
-    app.use('*', testAuthMiddleware(USER1, 'ADMIN'))
+    // PLATFORM_ADMIN with USER1 identity — mirrors pre-auth test data.
+    app.use('*', testAuthMiddleware(USER1, 'PLATFORM_ADMIN'))
     app.route('/', createBookingRoutes(service))
   })
 

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -55,11 +55,11 @@ function mkBooking(b: Partial<Booking> & { id: string; renterId: string }): Book
 function setup({
   users = [] as User[],
   bookings = [] as Booking[],
-  asRole = 'ADMIN' as const,
+  asRole = 'PLATFORM_ADMIN' as const,
 }: {
   users?: User[]
   bookings?: Booking[]
-  asRole?: 'ADMIN' | 'STAFF' | 'RENTER'
+  asRole?: 'PLATFORM_ADMIN' | 'RENTER'
 } = {}) {
   const userStore = new Map(users.map((u) => [u.id, u]))
   const bookingStore = new Map(bookings.map((b) => [b.id, b]))
@@ -160,7 +160,7 @@ describe('GET /customers', () => {
     expect(body.data[0].id).toBe(USER1)
   })
 
-  it('returns 403 when caller is not STAFF/ADMIN', async () => {
+  it('returns 403 for a non-platform caller (RENTER)', async () => {
     setup({ users: [mkUser(USER1)], asRole: 'RENTER' })
     const res = await app.request('/customers')
     expect(res.status).toBe(403)
@@ -295,7 +295,7 @@ describe('GET /customers/search', () => {
   }
 
   it('returns matching customers by name', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search?q=tanaka')
 
     expect(res.status).toBe(200)
@@ -313,7 +313,7 @@ describe('GET /customers/search', () => {
   })
 
   it('returns 400 when search query is less than 2 characters', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search?q=a')
     expect(res.status).toBe(400)
     const body = await res.json()
@@ -321,13 +321,13 @@ describe('GET /customers/search', () => {
   })
 
   it('returns 400 when search query is missing', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search')
     expect(res.status).toBe(400)
   })
 
   it('matches by email', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search?q=smith@')
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -336,7 +336,7 @@ describe('GET /customers/search', () => {
   })
 
   it('matches by phone', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search?q=1234-5678')
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -345,7 +345,7 @@ describe('GET /customers/search', () => {
   })
 
   it('returns empty array when no matches', async () => {
-    setup({ users: seed(), asRole: 'STAFF' })
+    setup({ users: seed(), asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/search?q=zzzzz')
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -359,7 +359,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('creates a new customer with name and email', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/quick-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -378,7 +378,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('is idempotent on email — returns existing user on second call', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const payload = { name: 'Dup', email: 'dup@example.com', language: 'en' }
 
     const res1 = await app.request('/customers/quick-create', {
@@ -400,7 +400,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('is idempotent on email case — Bob@x.com and bob@x.com resolve to one user (#715)', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
 
     const res1 = await app.request('/customers/quick-create', {
       method: 'POST',
@@ -423,7 +423,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('returns 400 when neither email nor phone is provided', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/quick-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -443,7 +443,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('creates customer with phone only (no email)', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/quick-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -463,7 +463,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('is idempotent on phone — returns existing user', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const payload = { name: 'Phone Dup', phone: '+81-90-1111-2222', language: 'ja' }
 
     const res1 = await app.request('/customers/quick-create', {
@@ -485,7 +485,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('defaults language to en when not specified', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/quick-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -497,7 +497,7 @@ describe('POST /customers/quick-create', () => {
   })
 
   it('returns 400 when name is empty', async () => {
-    setup({ asRole: 'STAFF' })
+    setup({ asRole: 'PLATFORM_ADMIN' })
     const res = await app.request('/customers/quick-create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/api/tests/routes/fleet-overview.test.ts
+++ b/packages/api/tests/routes/fleet-overview.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
     maintenanceLogRepo,
   )
   app = new Hono()
-  app.use('*', testAuthMiddleware('staff-user', 'STAFF'))
+  app.use('*', testAuthMiddleware('staff-user', 'PLATFORM_ADMIN'))
   app.route('/', createFleetOverviewRoutes(new FleetOverviewService(fleetRepo)))
 })
 

--- a/packages/api/tests/routes/manual-booking.test.ts
+++ b/packages/api/tests/routes/manual-booking.test.ts
@@ -66,7 +66,7 @@ function makeRenter(id: string): User {
   }
 }
 
-describe('Manual booking (staff/admin renterId override + advance rule skip)', () => {
+describe('Manual booking (platform-admin renterId override + advance rule skip)', () => {
   let vehicleRepo: InMemoryVehicleRepository
   let bookingRepo: InMemoryBookingRepository
   let userStore: Map<string, User>
@@ -127,11 +127,11 @@ describe('Manual booking (staff/admin renterId override + advance rule skip)', (
     })
   })
 
-  it('staff can create booking with custom renterId', async () => {
+  it('a platform admin can create a booking with a custom renterId', async () => {
     const staffId = crypto.randomUUID()
     const customerId = crypto.randomUUID()
     userStore.set(customerId, makeRenter(customerId))
-    const token = await createTestToken({ id: staffId, role: 'STAFF' })
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
 
     // Start 48 hours from now to satisfy advance booking rule
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
@@ -201,7 +201,7 @@ describe('Manual booking (staff/admin renterId override + advance rule skip)', (
 
   it('manual booking skips advance booking rule', async () => {
     const staffId = crypto.randomUUID()
-    const token = await createTestToken({ id: staffId, role: 'STAFF' })
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
 
     // Start 1 hour from now — violates the 24h advance booking rule
     const startAt = new Date(Date.now() + 1 * 60 * 60 * 1000)
@@ -232,7 +232,7 @@ describe('Manual booking (staff/admin renterId override + advance rule skip)', (
 
   it('manual booking still enforces min rental duration', async () => {
     const staffId = crypto.randomUUID()
-    const token = await createTestToken({ id: staffId, role: 'STAFF' })
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
 
     // Duration = 30 minutes, below minRentalHours (2h)
     const startAt = new Date(Date.now() + 1 * 60 * 60 * 1000)
@@ -294,7 +294,7 @@ describe('Manual booking (staff/admin renterId override + advance rule skip)', (
 
   it('rejects manual booking when target renterId does not exist', async () => {
     const staffId = crypto.randomUUID()
-    const token = await createTestToken({ id: staffId, role: 'STAFF' })
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
@@ -325,7 +325,7 @@ describe('Manual booking (staff/admin renterId override + advance rule skip)', (
     const staffId = crypto.randomUUID()
     const otherStaffId = crypto.randomUUID()
     userStore.set(otherStaffId, { ...makeRenter(otherStaffId), role: 'STAFF' })
-    const token = await createTestToken({ id: staffId, role: 'STAFF' })
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -15,7 +15,7 @@ let threadRepo: InMemoryThreadRepository
 let messageRepo: InMemoryMessageRepository
 
 /** Create a Hono app authenticated as the given user. */
-function appAs(userId: string, role: 'RENTER' | 'STAFF' | 'ADMIN' = 'RENTER'): Hono {
+function appAs(userId: string, role: 'RENTER' | 'PLATFORM_ADMIN' = 'RENTER'): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware(userId, role))
   a.route('/', createMessageRoutes(threadRepo, messageRepo))
@@ -264,8 +264,8 @@ describe('Message Routes', () => {
       expect(body.error).toBe('Caller must be a participant')
     })
 
-    it('STAFF can create thread between arbitrary users', async () => {
-      const res = await appAs(U1, 'STAFF').request('/threads', {
+    it('a platform admin can create a thread between arbitrary users', async () => {
+      const res = await appAs(U1, 'PLATFORM_ADMIN').request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participantIds: [U2, U3] }),
@@ -285,7 +285,7 @@ describe('Message Routes', () => {
       expect(res.status).toBe(404)
     })
 
-    it('STAFF can read any thread regardless of participation', async () => {
+    it('a platform admin can read any thread regardless of participation', async () => {
       const createRes = await appAs(U1).request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -293,7 +293,7 @@ describe('Message Routes', () => {
       })
       const threadId = (await createRes.json()).data.id
 
-      const res = await appAs(U3, 'STAFF').request(`/threads/${threadId}`)
+      const res = await appAs(U3, 'PLATFORM_ADMIN').request(`/threads/${threadId}`)
       expect(res.status).toBe(200)
     })
 

--- a/packages/api/tests/routes/payment-anomalies.test.ts
+++ b/packages/api/tests/routes/payment-anomalies.test.ts
@@ -68,9 +68,16 @@ describe('GET /admin/payment-anomalies — auth', () => {
     )
   })
 
-  it.each(['PLATFORM_ADMIN', 'STAFF', 'ADMIN'] as const)('200 for %s', async (role) => {
-    expect((await mount(role).request('/admin/payment-anomalies')).status).toBe(200)
+  it('200 for PLATFORM_ADMIN', async () => {
+    expect((await mount('PLATFORM_ADMIN').request('/admin/payment-anomalies')).status).toBe(200)
   })
+
+  it.each(['STAFF', 'ADMIN'] as const)(
+    '403 for legacy %s — platform-admin access revoked (#487)',
+    async (role) => {
+      expect((await mount(role).request('/admin/payment-anomalies')).status).toBe(403)
+    },
+  )
 })
 
 describe('GET /admin/payment-anomalies — listing', () => {
@@ -92,7 +99,7 @@ describe('GET /admin/payment-anomalies — listing', () => {
 })
 
 describe('PaymentAnomalyService — defence-in-depth seal', () => {
-  it.each(['OPERATOR_OWNER', 'RENTER', 'PARTNER'] as const)(
+  it.each(['OPERATOR_OWNER', 'RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
     'throws ForbiddenError for %s even if the route gate were bypassed',
     async (role) => {
       const service = new PaymentAnomalyService(seeded())

--- a/packages/api/tests/routes/select-columns.test.ts
+++ b/packages/api/tests/routes/select-columns.test.ts
@@ -184,7 +184,7 @@ describe('API responses contain only expected fields', () => {
 
   it('GET /bookings returns bookings with exact field set', async () => {
     const { app, classId, locationId } = await createTestApp()
-    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'STAFF' })
+    const staffHeaders = await authHeaders({ sub: 'staff-user', role: 'PLATFORM_ADMIN' })
     const renterHeaders = await authHeaders({ sub: 'renter-user', role: 'RENTER' })
 
     // Create a vehicle first (STAFF)

--- a/packages/api/tests/routes/users.test.ts
+++ b/packages/api/tests/routes/users.test.ts
@@ -12,7 +12,7 @@ const U3 = '00000000-0000-4000-8000-0000000000a3' // not a thread participant of
 let userRepo: InMemoryUserRepository
 let threadRepo: InMemoryThreadRepository
 
-function appAs(userId: string, role: 'RENTER' | 'STAFF' | 'ADMIN' = 'RENTER'): Hono {
+function appAs(userId: string, role: 'RENTER' | 'PLATFORM_ADMIN' = 'RENTER'): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware(userId, role))
   a.route('/', createUserRoutes(userRepo, threadRepo))
@@ -58,8 +58,8 @@ describe('User Routes', () => {
       expect((await res.json()).data).toEqual([])
     })
 
-    it('allows privileged roles (STAFF/ADMIN) to resolve any user', async () => {
-      const res = await appAs(U1, 'STAFF').request(`/users?ids=${U2},${U3}`)
+    it('allows a platform admin to resolve any user', async () => {
+      const res = await appAs(U1, 'PLATFORM_ADMIN').request(`/users?ids=${U2},${U3}`)
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.data).toHaveLength(2)

--- a/packages/api/tests/routes/vehicle-photo-ratelimit.test.ts
+++ b/packages/api/tests/routes/vehicle-photo-ratelimit.test.ts
@@ -105,8 +105,8 @@ describe('photo upload rate limiting', () => {
     const ctx = createTestApp({ photoUploadLimiter: createFakeLimiter(1) })
     const v1 = await ctx.vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput())
     const v2 = await ctx.vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput())
-    const headersUserA = await authHeaders({ sub: 'user-a', role: 'ADMIN' })
-    const headersUserB = await authHeaders({ sub: 'user-b', role: 'ADMIN' })
+    const headersUserA = await authHeaders({ sub: 'user-a', role: 'PLATFORM_ADMIN' })
+    const headersUserB = await authHeaders({ sub: 'user-b', role: 'PLATFORM_ADMIN' })
 
     const userAv1 = await ctx.app.request(`/vehicles/${v1.id}/photos`, {
       method: 'POST',

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -203,7 +203,7 @@ async function seedReady(h: Harness) {
 }
 
 describe('BookingService.create — document-verification gate (#459)', () => {
-  const staffCtx: CallerContext = { userId: 'staff-9', role: 'STAFF', bypassScope: true }
+  const staffCtx: CallerContext = { userId: 'staff-9', role: 'PLATFORM_ADMIN', bypassScope: true }
 
   // Build the REAL gate from a document service so these exercise the actual
   // eligibility policy (approved IDP valid through the return date), not a stub.
@@ -332,7 +332,7 @@ describe('BookingService.create — single-transaction submit (#392 §4)', () =>
   it('records the acting caller (not the renter) as the BOOKING_CREATED actor for a manual booking', async () => {
     const h = await setup({ codes: ['MANUAL12'] })
     const { vehicleId, locationId } = await seedReady(h)
-    const staffCtx: CallerContext = { userId: 'staff-9', role: 'STAFF', bypassScope: true }
+    const staffCtx: CallerContext = { userId: 'staff-9', role: 'PLATFORM_ADMIN', bypassScope: true }
 
     const result = await h.service.create(
       staffCtx,

--- a/packages/shared/src/auth/roles.ts
+++ b/packages/shared/src/auth/roles.ts
@@ -45,15 +45,19 @@ export const OPERATOR_ROLES = roleSet('OPERATOR_OWNER', 'OPERATOR_STAFF')
 
 /**
  * Platform-admin tier — the cross-tenant admin portal (`/admin/*`), the revenue
- * report, and the platform-staff route gates. PLATFORM_ADMIN is the sanctioned
- * super-admin; legacy STAFF/ADMIN are transitional equivalents.
+ * report, and the platform-staff route gates (aliased as STAFF_ROLES in the API:
+ * customers, documents, maintenance logs, vehicle photos, etc.). PLATFORM_ADMIN
+ * is now the SOLE platform-staff role.
  *
- * #487 tightens THIS set to `{PLATFORM_ADMIN}`. Kept a SEPARATE instance from
- * {@link MANAGEMENT_BASE_ROLES} (identical members today) precisely so that
- * tightening does not also strip legacy admins from business management — the two
- * policies must move independently. Do NOT merge them.
+ * #487 tightened THIS set to `{PLATFORM_ADMIN}`, revoking the legacy transitional
+ * STAFF/ADMIN from every platform-staff gate at once. Kept a SEPARATE instance
+ * from {@link MANAGEMENT_BASE_ROLES} precisely so this did NOT strip legacy admins
+ * from business management — the two policies move independently. Do NOT merge.
+ * #487 also tightened {@link SCOPE_BYPASS_ROLES} / {@link PRIVILEGED_ROLES} to
+ * `{PARTNER, PLATFORM_ADMIN}`, so legacy STAFF/ADMIN no longer bypass operator
+ * scope or read cross-tenant private data either — the revocation is complete.
  */
-export const PLATFORM_ROLES = roleSet('STAFF', 'ADMIN', 'PLATFORM_ADMIN')
+export const PLATFORM_ROLES = roleSet('PLATFORM_ADMIN')
 
 /**
  * Base of the business-management tier (fleet write + operator-private config
@@ -72,13 +76,13 @@ export const BUSINESS_ROLES = union(MANAGEMENT_BASE_ROLES, OPERATOR_ROLES)
 /**
  * Cross-tenant read bypass — the platform tier PLUS PARTNER (Trip.com reads
  * bookings across tenants). Drives `CallerContext.bypassScope`. A distinct
- * instance from {@link PRIVILEGED_ROLES} (same members today) because the two gate
- * different things and may diverge under #487.
+ * instance from {@link PRIVILEGED_ROLES} (same members) because the two gate
+ * different things and may still diverge later.
  */
-export const SCOPE_BYPASS_ROLES = roleSet('STAFF', 'ADMIN', 'PARTNER', 'PLATFORM_ADMIN')
+export const SCOPE_BYPASS_ROLES = roleSet('PARTNER', 'PLATFORM_ADMIN')
 
 /**
  * Roles permitted to read cross-tenant private data (message threads, user lists).
  * Platform tier PLUS PARTNER. Distinct instance from {@link SCOPE_BYPASS_ROLES}.
  */
-export const PRIVILEGED_ROLES = roleSet('STAFF', 'ADMIN', 'PARTNER', 'PLATFORM_ADMIN')
+export const PRIVILEGED_ROLES = roleSet('PARTNER', 'PLATFORM_ADMIN')

--- a/packages/shared/tests/auth/roles.test.ts
+++ b/packages/shared/tests/auth/roles.test.ts
@@ -19,14 +19,14 @@ describe('canonical role sets (#487 prep — single source of truth)', () => {
     expect(members(OPERATOR_ROLES)).toEqual(['OPERATOR_OWNER', 'OPERATOR_STAFF'])
   })
 
-  it('PLATFORM_ROLES = STAFF/ADMIN/PLATFORM_ADMIN (the #487 tightening target)', () => {
-    expect(members(PLATFORM_ROLES)).toEqual(['ADMIN', 'PLATFORM_ADMIN', 'STAFF'])
+  it('PLATFORM_ROLES = PLATFORM_ADMIN only — legacy STAFF/ADMIN revoked (#487)', () => {
+    expect(members(PLATFORM_ROLES)).toEqual(['PLATFORM_ADMIN'])
   })
 
-  it('MANAGEMENT_BASE_ROLES mirrors PLATFORM_ROLES today but is a SEPARATE instance', () => {
+  it('MANAGEMENT_BASE_ROLES keeps STAFF/ADMIN — NOT narrowed by #487 (now diverges from PLATFORM_ROLES)', () => {
     expect(members(MANAGEMENT_BASE_ROLES)).toEqual(['ADMIN', 'PLATFORM_ADMIN', 'STAFF'])
-    // The whole point of the split: #487 can tighten PLATFORM_ROLES without
-    // dragging the business-management base with it.
+    // The whole point of the split, now realized: #487 tightened PLATFORM_ROLES
+    // without dragging the business-management base with it.
     expect(MANAGEMENT_BASE_ROLES).not.toBe(PLATFORM_ROLES)
   })
 
@@ -40,13 +40,14 @@ describe('canonical role sets (#487 prep — single source of truth)', () => {
     ])
   })
 
-  it('SCOPE_BYPASS_ROLES and PRIVILEGED_ROLES = platform tier PLUS PARTNER, as distinct instances', () => {
-    const expected = ['ADMIN', 'PARTNER', 'PLATFORM_ADMIN', 'STAFF']
+  it('SCOPE_BYPASS_ROLES and PRIVILEGED_ROLES = PARTNER + PLATFORM_ADMIN — legacy STAFF/ADMIN revoked (#487), distinct instances', () => {
+    const expected = ['PARTNER', 'PLATFORM_ADMIN']
     expect(members(SCOPE_BYPASS_ROLES)).toEqual(expected)
     expect(members(PRIVILEGED_ROLES)).toEqual(expected)
-    // Same members today, but they gate different things (bypass flag vs direct
-    // cross-tenant reads) and may diverge under #487 (e.g. PARTNER kept for
-    // bookings but dropped for message threads).
+    // #487 dropped legacy STAFF/ADMIN from cross-tenant bypass + privileged reads;
+    // PARTNER (Trip.com) stays. Same members today, but kept as distinct instances
+    // because they gate different things (bypass flag vs direct cross-tenant reads)
+    // and may still diverge later (e.g. PARTNER dropped for message threads).
     expect(SCOPE_BYPASS_ROLES).not.toBe(PRIVILEGED_ROLES)
   })
 

--- a/packages/web/tests/lib/platform-roles.test.ts
+++ b/packages/web/tests/lib/platform-roles.test.ts
@@ -6,9 +6,9 @@ describe('isPlatformAdmin', () => {
     expect(isPlatformAdmin('PLATFORM_ADMIN')).toBe(true)
   })
 
-  test('admits legacy STAFF/ADMIN (transitional super-admins, schema.ts:23)', () => {
-    expect(isPlatformAdmin('STAFF')).toBe(true)
-    expect(isPlatformAdmin('ADMIN')).toBe(true)
+  test('rejects legacy STAFF/ADMIN — platform-admin access revoked (#487)', () => {
+    expect(isPlatformAdmin('STAFF')).toBe(false)
+    expect(isPlatformAdmin('ADMIN')).toBe(false)
   })
 
   test('rejects operator and renter roles', () => {

--- a/packages/web/tests/lib/route-helpers.test.ts
+++ b/packages/web/tests/lib/route-helpers.test.ts
@@ -150,15 +150,15 @@ describe('decideAdminAccess', () => {
     expect(decideAdminAccess(null)).toEqual({ action: 'login' })
   })
 
-  test('authenticated non-admin role -> forbidden', () => {
+  test('authenticated non-admin role -> forbidden (incl. legacy STAFF/ADMIN, revoked #487)', () => {
     expect(decideAdminAccess('RENTER')).toEqual({ action: 'forbidden' })
     expect(decideAdminAccess('OPERATOR_OWNER')).toEqual({ action: 'forbidden' })
     expect(decideAdminAccess('OPERATOR_STAFF')).toEqual({ action: 'forbidden' })
+    expect(decideAdminAccess('STAFF')).toEqual({ action: 'forbidden' })
+    expect(decideAdminAccess('ADMIN')).toEqual({ action: 'forbidden' })
   })
 
-  test('platform-admin roles -> allow', () => {
+  test('only PLATFORM_ADMIN -> allow', () => {
     expect(decideAdminAccess('PLATFORM_ADMIN')).toEqual({ action: 'allow' })
-    expect(decideAdminAccess('STAFF')).toEqual({ action: 'allow' })
-    expect(decideAdminAccess('ADMIN')).toEqual({ action: 'allow' })
   })
 })

--- a/packages/web/tests/vite/guards.test.ts
+++ b/packages/web/tests/vite/guards.test.ts
@@ -50,10 +50,10 @@ describe('isOperatorSession', () => {
 })
 
 describe('adminGuard', () => {
-  it('allows platform-admin roles (incl. legacy STAFF/ADMIN)', () => {
+  it('allows only PLATFORM_ADMIN — legacy STAFF/ADMIN revoked (#487)', () => {
     expect(adminGuard(session('PLATFORM_ADMIN'))).toEqual({ type: 'allow' })
-    expect(adminGuard(session('STAFF'))).toEqual({ type: 'allow' })
-    expect(adminGuard(session('ADMIN'))).toEqual({ type: 'allow' })
+    expect(adminGuard(session('STAFF'))).toEqual({ type: 'forbidden' })
+    expect(adminGuard(session('ADMIN'))).toEqual({ type: 'forbidden' })
   })
   it('forbids tenant-scoped operators — admin is narrower than business', () => {
     expect(adminGuard(session('OPERATOR_OWNER'))).toEqual({ type: 'forbidden' })


### PR DESCRIPTION
## Summary

Revokes the legacy transitional `STAFF` / `ADMIN` roles from every platform-staff gate, operator-scope bypass, and cross-tenant private read. After the operator migration those roles are business/fleet-management only, so the platform tier collapses to `{PLATFORM_ADMIN}` (plus `PARTNER` for the Trip.com cross-tenant API caller on the two bypass / privileged-read sets).

Closes #487.

## What changed

- `packages/shared/src/auth/roles.ts` — `PLATFORM_ROLES`, `SCOPE_BYPASS_ROLES`, `PRIVILEGED_ROLES` tightened to `{PLATFORM_ADMIN}` (+ `PARTNER` on the two cross-tenant sets).
- **Invariant preserved:** `STAFF` / `ADMIN` keep business/fleet management — `MANAGEMENT_BASE_ROLES` / `BUSINESS_ROLES` are untouched. Only platform / scope-bypass / cross-tenant-read are revoked.
- `packages/api/src/middleware/auth.ts` — doc/comment updates reflecting `STAFF_ROLES → PLATFORM_ROLES = {PLATFORM_ADMIN}`.
- Tests: helper default actor `ADMIN → PLATFORM_ADMIN`; 14 api suites switch privileged actors to `PLATFORM_ADMIN`; `payment-anomalies` asserts `STAFF` / `ADMIN` now get 403 at both route and service. Tripwires (`shared roles.test`, api `auth-context`) lock the new membership.

## Rebase note

Rebased onto `marketplace-pivot`. Reconciled with #715 (email-lowercase): its new `customers.test.ts` idempotency test used `asRole: 'STAFF'`, which #487 revokes from the platform-staff `/customers/*` gate — switched it to `PLATFORM_ADMIN` (orthogonal to that test's email-case intent).

## Test plan

- [x] `@kuruma/api` unit — 1381/1381
- [x] `@kuruma/shared` — 536/536
- [x] `@kuruma/web` — 734/734
- [x] tsc (api / web / shared) — 0 errors
- [x] biome lint — 0 errors
- [x] import-boundaries — OK
