### PR TITLE
fix(api): use ?? not || for renter language fallback in dispatcher (#731)

### DIFF
--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -154,7 +154,7 @@ export class NotificationDispatcher {
     if (kind.startsWith('RENTER_')) {
       const [renter] = await this.userRepo.findByIds([booking.renterId])
       if (!renter?.email) return undefined
-      return { recipient: renter.email, locale: renter.language || 'en' }
+      return { recipient: renter.email, locale: renter.language ?? 'en' }
     }
     // OPERATOR_BOOKING_ALERT — first owner, else the platform ops fallback.
     const owners = await this.userRepo.findOperatorContacts(booking.operatorId)


### PR DESCRIPTION
## Summary
`notification-dispatcher.ts` `resolveRecipient` used `renter.language || 'en'` — the lone `||` default-coalescer in the file (line 161 already uses `??`). The `language` column is `notNull().default('en')`, and downstream `emailStrings` treats `''` and `'en'` identically, so **behavior is unchanged**; but `||` coerces `''`, which the project's "`??` not `||` for defaults" rule explicitly forbids. One-line rule-compliance fix.

## Verification (local, rebased onto mp)
- `bun run --filter @kuruma/api typecheck` → exit 0
- dispatcher tests (`notification-dispatcher` + `booking-post-commit-dispatcher`) → **21 passed**

Closes #731