### PR TITLE
refactor(api): make MS_PER_DAY module-local (#713 review follow-up)

### DIFF
--- a/packages/api/src/services/booking-pricing-helpers.ts
+++ b/packages/api/src/services/booking-pricing-helpers.ts
@@ -3,7 +3,8 @@
 // round insurance days identically.
 
 export const MS_PER_MINUTE = 60 * 1000
-export const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE
+// Module-local: only rentalDays() below needs it; other modules define their own.
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE
 
 // Insurance is priced per rental day (ceil), min 1 — matches the daily-rate
 // rounding the base price uses for whole-day rentals.


### PR DESCRIPTION
Follow-up to #769 (#713). The code review flagged one LOW: `MS_PER_DAY` was exported from `booking-pricing-helpers.ts` but consumed only internally by `rentalDays()` in the same file (other modules define their own local copy). #769 was admin-merged at the pre-fix commit before this cleanup could join it, so landing it separately.

Visibility-only change — the constant's value is unchanged.

## Test plan
- [x] tsc + biome verified locally on the identical change during #769 review
- [ ] CI green