### PR TITLE
refactor(web): replace bookingStatus literal copies with shared derived type (#697)

### DIFF
--- a/packages/web/src/lib/event-colors.ts
+++ b/packages/web/src/lib/event-colors.ts
@@ -1,7 +1,4 @@
-// Booking status union, mirrored from @kuruma/shared's bookingStatusEnum. Kept
-// as a local literal (like vite/operator-bookings/api.ts) so this web helper
-// stays free of a runtime dependency on the Drizzle schema module.
-type BookingStatus = 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+import type { BookingStatus } from '@kuruma/shared/enums'
 
 export const STATUS_CLASS: Record<BookingStatus, string> = {
   CONFIRMED: 'rbc-event--confirmed',

--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -1,6 +1,7 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { AddOnSnapshot, FeeSnapshotItem, InsuranceSnapshot } from '@kuruma/shared/db/schema'
+import type { BookingStatus } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
 
 // JSON-serialized booking (#392/#460) as the renter read model sees it — dates
@@ -21,7 +22,7 @@ export interface BookingDto {
   startAt: string
   endAt: string
   effectiveEndAt: string
-  status: 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+  status: BookingStatus
   source: string
   insuranceOptionId: string | null
   insuranceSnapshot: InsuranceSnapshot | null
@@ -105,7 +106,7 @@ export function bookingByIdQueryOptions(id: string) {
 // reads a leaner row shape from `GET /bookings?expand=vehicle`: the assigned car's
 // display name flattened in, dates as ISO strings. Mirrors operator-bookings/api
 // `OperatorBookingRow`/`toRow`, but renter-scoped and without the renter block.
-export type MyBookingStatus = 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+export type MyBookingStatus = BookingStatus
 
 export interface MyBookingRow {
   id: string

--- a/packages/web/src/vite/operator-bookings/CalendarSidebar.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarSidebar.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
 import type { CalendarFiltersApi } from '@/vite/operator-bookings/useCalendarFilters'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
 import { useTranslations } from 'use-intl'
 
 interface SidebarVehicle {
@@ -13,7 +14,7 @@ interface CalendarSidebarProps {
   readonly filters: CalendarFiltersApi
 }
 
-const STATUSES: readonly OperatorBookingStatus[] = ['CONFIRMED', 'ACTIVE', 'COMPLETED', 'CANCELLED']
+const STATUSES = BOOKING_STATUSES
 
 // Dot color tracks STATUS_CLASS / calendar-theme.css so the sidebar swatch stays
 // in sync with the calendar event color.

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -2,6 +2,7 @@ import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { BookingDto } from '@/vite/bookings/api'
 import type { BookingEventPayload, BookingEventType } from '@kuruma/shared/db/schema'
+import type { BookingStatus } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
 
 // #512: operator booking view. The Vite shell owns these DTOs (it never imports
@@ -13,7 +14,7 @@ import { queryOptions } from '@tanstack/react-query'
 // (CallerContext in the repo layer), so this client passes NO operatorId — a
 // cross-tenant read is impossible from here by construction.
 
-export type OperatorBookingStatus = 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+export type OperatorBookingStatus = BookingStatus
 
 /** A booking row as the operator view needs it. Dates are ISO strings (JSON). */
 export interface OperatorBookingRow {

--- a/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
+++ b/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
@@ -1,4 +1,5 @@
 import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 // #525 Slice C: vehicle + status filters for the operator calendar. Ported from
@@ -12,12 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 // visible (an additive fleet change never retroactively hides a car).
 
 const STORAGE_KEY = 'kuruma.calendar.filters'
-const ALL_STATUSES: readonly OperatorBookingStatus[] = [
-  'CONFIRMED',
-  'ACTIVE',
-  'COMPLETED',
-  'CANCELLED',
-]
+const ALL_STATUSES = BOOKING_STATUSES
 
 interface StoredState {
   uncheckedVehicles: string[]

--- a/packages/web/src/vite/operator-fleet/api.ts
+++ b/packages/web/src/vite/operator-fleet/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import type { BookingStatus } from '@kuruma/shared/enums'
 import type { LuggageSize } from '@kuruma/shared/lib/luggage'
 import type {
   BulkVehicleStatus,
@@ -194,7 +195,7 @@ export interface VehicleDetailBookingDto {
   endAt: string
   renterName: string | null
   source: 'DIRECT' | 'TRIP_COM' | 'MANUAL' | 'OTHER'
-  status: 'CONFIRMED' | 'ACTIVE'
+  status: Extract<BookingStatus, 'CONFIRMED' | 'ACTIVE'>
 }
 
 /** One day's booked-hours bucket for the 30-day utilization strip. */


### PR DESCRIPTION
## What

Replaces hand-typed `bookingStatus` literal copies in the **live Vite web tree** with the shared single source of truth from `@kuruma/shared/enums` (#688) — the web slice of the enum-SSoT sweep (audit Theme 2).

## Changes (6 files, +12/-15)

- **Type unions → `BookingStatus`:** `BookingDto.status`, `MyBookingStatus`, `OperatorBookingStatus` (kept as an exported alias `= BookingStatus` so its 3 importers are untouched), and `lib/event-colors.ts`'s local type.
- **Value arrays → `BOOKING_STATUSES`:** `CalendarSidebar`'s `STATUSES`, `useCalendarFilters`'s `ALL_STATUSES`.
- **2-value subset → `Extract<BookingStatus, 'CONFIRMED' | 'ACTIVE'>`:** vehicle-detail's `VehicleDetailBookingDto.status` (stays narrowed, but now SSoT-linked).
- Removed the now-obsolete comments that justified the local copies as a way to avoid a Drizzle-schema runtime dep — `@kuruma/shared/enums` is a zero-DB subpath, so that rationale no longer holds.

## Scope notes

- **Behavior-preserving** — the values were already identical to the SSoT.
- Extends slightly beyond the audit's enumerated type-list to also cover `event-colors.ts` (an audit miss) and the two value arrays — all within the stated `{vite,lib}` live scope.
- The audit's `lib/calendar.ts` + `lib/bookings.ts` refs are **stale** (those files no longer exist on trunk); the frozen-Next `components/bookings` copies are correctly left for #699.

## Test plan

- [x] `bun run --filter @kuruma/web typecheck` → 0 (the real guard: the `Record<BookingStatus, …>` maps + 3 `OperatorBookingStatus` importers are re-checked against the SSoT)
- [x] `bun run --filter @kuruma/web test` → 125 files, 734 passed
- [x] `bun run lint` → 0 (advisory file-size warnings only, none in changed files)
- [x] `code-reviewer` agent → no findings at any severity
- [x] Rebased clean onto `marketplace-pivot` (the 6 newer commits are API-only — no overlap)

Closes #697
Part of #701
