### PR TITLE
refactor(api): extract MessageService from messages route (#712 Slice A)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -62,6 +62,7 @@ import type { Geocoder } from './services/geocoding/types'
 import { InsuranceOptionService } from './services/insurance-option'
 import { LocationService } from './services/location'
 import { MaintenanceService } from './services/maintenance'
+import { MessageService } from './services/message'
 import { MessageTranslationService } from './services/message-translation'
 import { NotificationService } from './services/notification'
 import { NotificationDispatcher } from './services/notification-dispatcher'
@@ -365,6 +366,7 @@ export function createApp(overrides?: AppOverrides) {
   )
   const availabilityService = new AvailabilityService(availabilityRepo)
   const customerService = new CustomerService(customerRepo, userRepo)
+  const messageService = new MessageService(threadRepo, messageRepo)
   const maintenanceService = new MaintenanceService(
     vehicleRepo,
     maintenanceLogRepo,
@@ -456,7 +458,7 @@ export function createApp(overrides?: AppOverrides) {
     .route('/', createOverviewRoutes(overviewService))
     .route('/', createAdminRevenueRoutes(adminRevenueService))
     .route('/', createPaymentAnomalyRoutes(paymentAnomalyService))
-    .route('/', createMessageRoutes(threadRepo, messageRepo))
+    .route('/', createMessageRoutes(messageService))
     .route(
       '/',
       createTranslateRoutes(new MessageTranslationService(messageRepo, translationProvider)),

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,37 +1,10 @@
 import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
-import { PRIVILEGED_ROLES, requireUser, toCallerContext } from '../middleware/auth'
-import { PG_ERROR, pgErrorCode } from '../pg-errors'
-import type { MessageRepository, ThreadRepository } from '../repositories/types'
+import { requireUser, toCallerContext } from '../middleware/auth'
+import type { MessageService } from '../services/message'
 import { fail, ok, parseBody, parsePagination } from './helpers'
 
-/**
- * Idempotent create: check for existing record by key, attempt insert,
- * catch UNIQUE_VIOLATION race and re-fetch. Returns { record, status }.
- */
-async function idempotentCreate<T>(
-  key: string | null,
-  find: (k: string) => Promise<T | undefined>,
-  insert: () => Promise<T>,
-): Promise<{ record: T; status: 200 | 201 }> {
-  if (key) {
-    const existing = await find(key)
-    if (existing) return { record: existing, status: 200 }
-  }
-
-  try {
-    const record = await insert()
-    return { record, status: 201 }
-  } catch (err) {
-    if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION && key) {
-      const existing = await find(key)
-      if (existing) return { record: existing, status: 200 }
-    }
-    throw err
-  }
-}
-
-export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: MessageRepository) {
+export function createMessageRoutes(service: MessageService) {
   return new Hono()
     .get('/threads', async (c) => {
       const ctx = toCallerContext(requireUser(c))
@@ -40,15 +13,13 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
       if (!pg.ok) return pg.response
       const { limit, offset } = pg
 
-      const all = await threadRepo.findAll(ctx)
-      const page = all.slice(offset, offset + limit)
-      return ok(c, page, 200, { total: all.length, limit, offset })
+      const { threads, total } = await service.listThreads(ctx, limit, offset)
+      return ok(c, threads, 200, { total, limit, offset })
     })
     .get('/threads/:id', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      // CallerContext scoping in repo handles participant check for renters
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
+      const thread = await service.getThread(ctx, c.req.param('id'))
       if (!thread) return fail(c, 'Thread not found', 404)
 
       return ok(c, thread)
@@ -59,49 +30,34 @@ export function createMessageRoutes(threadRepo: ThreadRepository, messageRepo: M
       const parsed = await parseBody(c, createThreadSchema)
       if (!parsed.ok) return parsed.response
 
-      if (!PRIVILEGED_ROLES.has(ctx.role) && !parsed.data.participantIds.includes(ctx.userId)) {
-        return fail(c, 'Caller must be a participant', 400)
-      }
-
-      const idempotencyKey = parsed.data.idempotencyKey ?? null
-      const { record: thread, status } = await idempotentCreate(
-        idempotencyKey,
-        (k) => threadRepo.findByIdempotencyKey(ctx, k),
-        () =>
-          threadRepo.create(
-            ctx,
-            parsed.data.bookingId ?? null,
-            parsed.data.participantIds,
-            idempotencyKey,
-          ),
-      )
-      return ok(c, thread, status)
+      const result = await service.createThread(ctx, parsed.data)
+      if (result.kind === 'forbidden') return fail(c, 'Caller must be a participant', 400)
+      return ok(c, result.thread, result.status)
     })
     .post('/threads/:id/messages', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      // CallerContext scoping in repo handles participant check
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
+      // Existence/scope (404) is checked BEFORE body validation (400) to preserve
+      // the original ordering; createMessage then reuses this confirmed thread id.
+      const thread = await service.getThread(ctx, c.req.param('id'))
       if (!thread) return fail(c, 'Thread not found', 404)
 
       const parsed = await parseBody(c, sendMessageSchema)
       if (!parsed.ok) return parsed.response
 
-      const msgIdempotencyKey = parsed.data.idempotencyKey ?? null
-      const { record: message, status } = await idempotentCreate(
-        msgIdempotencyKey,
-        (k) => messageRepo.findByIdempotencyKey(ctx, k),
-        () => messageRepo.create(ctx, thread.id, parsed.data.content, msgIdempotencyKey),
+      const { message, status } = await service.createMessage(
+        ctx,
+        thread.id,
+        parsed.data.content,
+        parsed.data.idempotencyKey ?? null,
       )
       return ok(c, message, status)
     })
     .post('/threads/:id/read', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
-      const thread = await threadRepo.findById(ctx, c.req.param('id'))
-      if (!thread) return fail(c, 'Thread not found', 404)
-
-      await threadRepo.markAsRead(ctx, thread.id)
+      const result = await service.markRead(ctx, c.req.param('id'))
+      if (result.kind === 'thread_not_found') return fail(c, 'Thread not found', 404)
       return ok(c, null)
     })
 }

--- a/packages/api/src/services/message.ts
+++ b/packages/api/src/services/message.ts
@@ -1,0 +1,110 @@
+import type { CreateThreadInput } from '@kuruma/shared/validators/message'
+import type { CallerContext } from '../middleware/auth'
+import { PRIVILEGED_ROLES } from '../middleware/auth'
+import { PG_ERROR, pgErrorCode } from '../pg-errors'
+import type { MessageRepository, ThreadRepository } from '../repositories/types'
+import type { Message, Thread } from '../stores'
+
+type ThreadListItem = Awaited<ReturnType<ThreadRepository['findAll']>>[number]
+type ThreadDetail = NonNullable<Awaited<ReturnType<ThreadRepository['findById']>>>
+
+/** A thread create either fails the participant gate or produces a record with
+ *  its HTTP-meaningful status (201 fresh insert / 200 idempotent replay). */
+export type CreateThreadResult =
+  | { kind: 'forbidden' }
+  | { kind: 'created'; thread: Thread; status: 200 | 201 }
+
+export type MarkReadResult = { kind: 'thread_not_found' } | { kind: 'ok' }
+
+/**
+ * Messaging business logic, Hono-free: thread/message creation with idempotent
+ * replay handling and the participant-authz gate. The route stays a thin shell
+ * that parses input, maps these results to HTTP, and owns the 404-before-400
+ * ordering by calling {@link MessageService.getThread} before parsing the body.
+ */
+export class MessageService {
+  constructor(
+    private readonly threadRepo: ThreadRepository,
+    private readonly messageRepo: MessageRepository,
+  ) {}
+
+  async listThreads(
+    ctx: CallerContext,
+    limit: number,
+    offset: number,
+  ): Promise<{ threads: ThreadListItem[]; total: number }> {
+    const all = await this.threadRepo.findAll(ctx)
+    return { threads: all.slice(offset, offset + limit), total: all.length }
+  }
+
+  async getThread(ctx: CallerContext, id: string): Promise<ThreadDetail | undefined> {
+    return this.threadRepo.findById(ctx, id)
+  }
+
+  async createThread(ctx: CallerContext, input: CreateThreadInput): Promise<CreateThreadResult> {
+    if (!PRIVILEGED_ROLES.has(ctx.role) && !input.participantIds.includes(ctx.userId)) {
+      return { kind: 'forbidden' }
+    }
+    const idempotencyKey = input.idempotencyKey ?? null
+    const { record, status } = await idempotentCreate(
+      idempotencyKey,
+      (k) => this.threadRepo.findByIdempotencyKey(ctx, k),
+      () =>
+        this.threadRepo.create(ctx, input.bookingId ?? null, input.participantIds, idempotencyKey),
+    )
+    return { kind: 'created', thread: record, status }
+  }
+
+  /**
+   * Create a message in a thread the caller has already been confirmed to reach
+   * (the route guards existence + scope via {@link getThread} first, preserving
+   * the original 404-before-400 order).
+   */
+  async createMessage(
+    ctx: CallerContext,
+    threadId: string,
+    content: string,
+    idempotencyKey: string | null,
+  ): Promise<{ message: Message; status: 200 | 201 }> {
+    const { record, status } = await idempotentCreate(
+      idempotencyKey,
+      (k) => this.messageRepo.findByIdempotencyKey(ctx, k),
+      () => this.messageRepo.create(ctx, threadId, content, idempotencyKey),
+    )
+    return { message: record, status }
+  }
+
+  async markRead(ctx: CallerContext, threadId: string): Promise<MarkReadResult> {
+    const thread = await this.threadRepo.findById(ctx, threadId)
+    if (!thread) return { kind: 'thread_not_found' }
+    await this.threadRepo.markAsRead(ctx, thread.id)
+    return { kind: 'ok' }
+  }
+}
+
+/**
+ * Idempotent create: check for an existing record by key, attempt insert, catch
+ * the UNIQUE_VIOLATION race and re-fetch. Returns { record, status } where 201
+ * is a fresh insert and 200 an idempotent replay.
+ */
+async function idempotentCreate<T>(
+  key: string | null,
+  find: (k: string) => Promise<T | undefined>,
+  insert: () => Promise<T>,
+): Promise<{ record: T; status: 200 | 201 }> {
+  if (key) {
+    const existing = await find(key)
+    if (existing) return { record: existing, status: 200 }
+  }
+
+  try {
+    const record = await insert()
+    return { record, status: 201 }
+  } catch (err) {
+    if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION && key) {
+      const existing = await find(key)
+      if (existing) return { record: existing, status: 200 }
+    }
+    throw err
+  }
+}

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -5,6 +5,7 @@ import {
   InMemoryThreadRepository,
 } from '../../src/repositories/in-memory'
 import { createMessageRoutes } from '../../src/routes/messages'
+import { MessageService } from '../../src/services/message'
 import { testAuthMiddleware } from '../helpers/auth'
 
 const U1 = '00000000-0000-4000-8000-0000000000a1'
@@ -18,7 +19,7 @@ let messageRepo: InMemoryMessageRepository
 function appAs(userId: string, role: 'RENTER' | 'STAFF' | 'ADMIN' = 'RENTER'): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware(userId, role))
-  a.route('/', createMessageRoutes(threadRepo, messageRepo))
+  a.route('/', createMessageRoutes(new MessageService(threadRepo, messageRepo)))
   return a
 }
 

--- a/packages/api/tests/services/message.test.ts
+++ b/packages/api/tests/services/message.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type AuthUser, toCallerContext } from '../../src/middleware/auth'
+import {
+  InMemoryMessageRepository,
+  InMemoryThreadRepository,
+} from '../../src/repositories/in-memory'
+import { MessageService } from '../../src/services/message'
+
+const U1 = '00000000-0000-4000-8000-0000000000a1'
+const U2 = '00000000-0000-4000-8000-0000000000a2'
+const U3 = '00000000-0000-4000-8000-0000000000a3'
+
+let threadRepo: InMemoryThreadRepository
+let messageRepo: InMemoryMessageRepository
+let service: MessageService
+
+function ctxFor(userId: string, role: AuthUser['role'] = 'RENTER') {
+  return toCallerContext({ id: userId, role })
+}
+
+beforeEach(() => {
+  threadRepo = new InMemoryThreadRepository()
+  messageRepo = new InMemoryMessageRepository(threadRepo)
+  service = new MessageService(threadRepo, messageRepo)
+})
+
+describe('MessageService.createThread', () => {
+  it('forbids a non-privileged caller from creating a thread they are not in', async () => {
+    const result = await service.createThread(ctxFor(U1, 'RENTER'), { participantIds: [U2, U3] })
+
+    expect(result).toEqual({ kind: 'forbidden' })
+  })
+
+  it('lets a privileged caller create a thread between other users (status 201)', async () => {
+    const result = await service.createThread(ctxFor(U1, 'STAFF'), { participantIds: [U2, U3] })
+
+    expect(result.kind).toBe('created')
+    if (result.kind !== 'created') throw new Error('expected created')
+    expect(result.status).toBe(201)
+  })
+
+  it('replays an idempotency key: second create returns status 200 and the same thread', async () => {
+    const ctx = ctxFor(U1, 'RENTER')
+    const input = { participantIds: [U1, U2], idempotencyKey: 'key-thread-1' }
+
+    const first = await service.createThread(ctx, input)
+    const second = await service.createThread(ctx, input)
+
+    if (first.kind !== 'created' || second.kind !== 'created') throw new Error('expected created')
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(200)
+    expect(second.thread.id).toBe(first.thread.id)
+  })
+})
+
+describe('MessageService.createMessage', () => {
+  it('replays an idempotency key: second send returns status 200 and the same message', async () => {
+    const ctx = ctxFor(U1, 'RENTER')
+    const created = await service.createThread(ctx, { participantIds: [U1, U2] })
+    if (created.kind !== 'created') throw new Error('expected created')
+    const threadId = created.thread.id
+
+    const first = await service.createMessage(ctx, threadId, 'hi', 'key-msg-1')
+    const second = await service.createMessage(ctx, threadId, 'hi', 'key-msg-1')
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(200)
+    expect(second.message.id).toBe(first.message.id)
+  })
+})
+
+describe('MessageService.markRead', () => {
+  it('reports thread_not_found for a thread the caller cannot reach', async () => {
+    const result = await service.markRead(ctxFor(U3, 'RENTER'), 'no-such-thread')
+
+    expect(result).toEqual({ kind: 'thread_not_found' })
+  })
+})


### PR DESCRIPTION
## What

Slice A (final) of #712 (health-audit P2/L, epic #701): pull the messaging business rules out of the `messages` HTTP controller into a Hono-free, DI'd `MessageService`.

- **New** `services/message.ts` — `MessageService` owns:
  - `idempotentCreate` (check-by-key → insert → catch PG `UNIQUE_VIOLATION` race → re-fetch; returns `{record, status:200|201}`),
  - the thread-create **participant-authz gate** (non-privileged caller must be in `participantIds`),
  - thread/message creation, listing, and mark-read, returning discriminated results.
- `routes/messages.ts` — now a thin shell: parse/validate bodies + pagination, map results to `ok()`/`fail()`. Shrank ~58 lines and **no longer imports repositories, pg-errors, or PRIVILEGED_ROLES**.
- `index.ts` — wires `new MessageService(threadRepo, messageRepo)`.
- Tests: new `tests/services/message.test.ts` (5 unit tests — forbidden gate, privileged bypass, thread + message idempotency replay, markRead not-found); route test wiring updated.

## Behavior preserved

Byte-identical across all 5 endpoints (`GET /threads` paginated, `GET /threads/:id`, `POST /threads`, `POST /threads/:id/messages`, `POST /threads/:id/read`): same 200/201/400/404 statuses + messages, same idempotency-replay semantics, same #328 caller-scoped key lookups. **Crucially, the send-message path still checks thread existence (404) BEFORE body validation (400)** — the route calls `getThread` before `parseBody`, preserving the original ordering. Confirmed by the unchanged comprehensive `messages.test.ts` (idempotency, access control, cross-tenant) + new service tests.

## Why

Routes are controllers; business rules (idempotency, authz) belong in services (AGENTS.md MVC+DI; FC/IS). Restores the `routes → services → repositories` import direction and makes the rules unit-testable without an HTTP context.

## Verification

- New service 5/5, messages route 26/26, **full API unit suite 1404/1404**
- `tsc` clean, `lint:boundaries` OK, all pre-commit hooks pass
- code-reviewer agent: clean (no CRITICAL/HIGH/MEDIUM) — verified 404-before-400 ordering + byte-for-byte idempotency/authz equivalence

Closes #712 (manual close — base is `marketplace-pivot`, not the default branch). Completes the 3-slice extraction (C #768 merged, B #773 open). Built off trunk; both B and A touch `index.ts` in different regions and are independently mergeable — the second to merge rebases.