### PR TITLE
refactor(shared): make BookingEventPayload a discriminated union (#716)

### DIFF
--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -16,6 +16,7 @@ import {
   vehicleClasses,
   vehicles,
 } from '@kuruma/shared/db/schema'
+import type { BookingEventPayload } from '@kuruma/shared/db/schema'
 import type { VehicleDetailBooking } from '@kuruma/shared/types/vehicle-detail'
 import type {
   AddOn,
@@ -474,7 +475,10 @@ export function toBookingEvent(r: BookingEventRow): BookingEvent {
     id: r.id,
     bookingId: r.bookingId,
     type: r.type,
-    payload: r.payload,
+    // #716: the `type` column is authoritative; backfill it into the discriminated
+    // payload so rows whose stored jsonb predates the embedded discriminant still
+    // narrow on payload.type.
+    payload: { ...r.payload, type: r.type } as BookingEventPayload,
     actorId: r.actorId,
     createdAt: r.createdAt,
   }

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -316,6 +316,7 @@ export class BookingCreationService {
       // VEHICLE_SUBSTITUTED, which also uses ctx.userId.
       actorId: ctx.userId,
       payload: {
+        type: 'BOOKING_CREATED',
         requestedVehicleId: input.requestedVehicleId,
         assignedVehicleId,
         classId,

--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -127,6 +127,7 @@ export class BookingLifecycleService {
           type: 'VEHICLE_SUBSTITUTED',
           actorId: ctx.userId,
           payload: {
+            type: 'VEHICLE_SUBSTITUTED',
             fromVehicleId: booking.assignedVehicleId,
             toVehicleId: replacement.id,
             reason,
@@ -232,7 +233,11 @@ export class BookingLifecycleService {
         bookingId: booking.id,
         type: 'STATUS_CHANGED',
         actorId: ctx.userId,
-        payload: { from: booking.status, to: newStatus as Booking['status'] },
+        payload: {
+          type: 'STATUS_CHANGED',
+          from: booking.status,
+          to: newStatus as Booking['status'],
+        },
       })
       return next
     })
@@ -283,7 +288,11 @@ export class BookingLifecycleService {
         bookingId: booking.id,
         type: 'BOOKING_CANCELLED',
         actorId: ctx.userId,
-        payload: { cancellationFee: cancellation.feeAmount, cancelledAt: now.toISOString() },
+        payload: {
+          type: 'BOOKING_CANCELLED',
+          cancellationFee: cancellation.feeAmount,
+          cancelledAt: now.toISOString(),
+        },
       })
       return next
     })

--- a/packages/api/tests/repositories/booking-event.test.ts
+++ b/packages/api/tests/repositories/booking-event.test.ts
@@ -4,6 +4,7 @@ import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryBookingEventRepository } from '../../src/repositories/in-memory/booking-event'
 
 const createdPayload: BookingCreatedPayload = {
+  type: 'BOOKING_CREATED',
   requestedVehicleId: 'veh-1',
   assignedVehicleId: 'veh-1',
   classId: 'class-1',
@@ -15,7 +16,11 @@ const createdPayload: BookingCreatedPayload = {
   feeSnapshot: [],
   addOnSnapshot: [],
 }
-const statusPayload: StatusChangedPayload = { from: 'CONFIRMED', to: 'ACTIVE' }
+const statusPayload: StatusChangedPayload = {
+  type: 'STATUS_CHANGED',
+  from: 'CONFIRMED',
+  to: 'ACTIVE',
+}
 
 describe('InMemoryBookingEventRepository', () => {
   it('append assigns an id + createdAt and preserves the event content', async () => {

--- a/packages/api/tests/repositories/to-booking-event.test.ts
+++ b/packages/api/tests/repositories/to-booking-event.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { toBookingEvent } from '../../src/repositories/drizzle/shared'
+
+// #716: BookingEventPayload is a discriminated union keyed on `type`. Rows seeded
+// or persisted before that change stored the jsonb payload WITHOUT an embedded
+// `type`, so the read mapper must normalize it from the authoritative `type`
+// column — otherwise the operator timeline can't narrow legacy events.
+describe('toBookingEvent', () => {
+  it('injects the discriminant from the type column into a legacy payload that lacks it', () => {
+    const legacyRow = {
+      id: 'e1',
+      bookingId: 'b1',
+      type: 'STATUS_CHANGED' as const,
+      // Legacy/seed shape: no embedded `type`.
+      payload: { from: 'CONFIRMED', to: 'ACTIVE' },
+      actorId: null,
+      createdAt: new Date('2026-07-01T01:00:00.000Z'),
+    }
+
+    const event = toBookingEvent(legacyRow as Parameters<typeof toBookingEvent>[0])
+
+    expect(event.payload.type).toBe('STATUS_CHANGED')
+    // The discriminant must narrow the payload without a cast.
+    if (event.payload.type !== 'STATUS_CHANGED') throw new Error('payload did not narrow')
+    expect(event.payload.from).toBe('CONFIRMED')
+    expect(event.payload.to).toBe('ACTIVE')
+  })
+
+  it('keeps a payload that already carries the discriminant', () => {
+    const row = {
+      id: 'e2',
+      bookingId: 'b1',
+      type: 'BOOKING_CANCELLED' as const,
+      payload: {
+        type: 'BOOKING_CANCELLED',
+        cancellationFee: 5000,
+        cancelledAt: '2026-07-02T01:00:00Z',
+      },
+      actorId: null,
+      createdAt: new Date('2026-07-02T01:00:00.000Z'),
+    }
+
+    const event = toBookingEvent(row as Parameters<typeof toBookingEvent>[0])
+
+    expect(event.payload.type).toBe('BOOKING_CANCELLED')
+    if (event.payload.type !== 'BOOKING_CANCELLED') throw new Error('payload did not narrow')
+    expect(event.payload.cancellationFee).toBe(5000)
+  })
+
+  it('lets the type column win when a stored payload.type disagrees (column is authoritative)', () => {
+    const driftedRow = {
+      id: 'e3',
+      bookingId: 'b1',
+      type: 'BOOKING_CANCELLED' as const,
+      // Drifted jsonb: the embedded type disagrees with the column. The column is
+      // the source of truth (§3.1), so the mapper overwrites rather than preserves
+      // — this pins the spread precedence `{ ...payload, type: column }` relies on.
+      payload: {
+        type: 'STATUS_CHANGED',
+        cancellationFee: 5000,
+        cancelledAt: '2026-07-02T01:00:00Z',
+      },
+      actorId: null,
+      createdAt: new Date('2026-07-02T01:00:00.000Z'),
+    }
+
+    const event = toBookingEvent(driftedRow as Parameters<typeof toBookingEvent>[0])
+
+    expect(event.payload.type).toBe('BOOKING_CANCELLED')
+  })
+})

--- a/packages/shared/src/db/booking-types.ts
+++ b/packages/shared/src/db/booking-types.ts
@@ -29,6 +29,7 @@ export type AddOnSnapshot = {
 }
 
 export type BookingCreatedPayload = {
+  type: 'BOOKING_CREATED'
   requestedVehicleId: string
   assignedVehicleId: string
   classId: string
@@ -43,15 +44,26 @@ export type BookingCreatedPayload = {
   addOnSnapshot: AddOnSnapshot[]
 }
 export type VehicleSubstitutedPayload = {
+  type: 'VEHICLE_SUBSTITUTED'
   fromVehicleId: string
   toVehicleId: string
   reason: string | null
 }
 export type BookingCancelledPayload = {
+  type: 'BOOKING_CANCELLED'
   cancellationFee: number | null
   cancelledAt: string
 }
-export type StatusChangedPayload = { from: BookingStatus; to: BookingStatus }
+export type StatusChangedPayload = {
+  type: 'STATUS_CHANGED'
+  from: BookingStatus
+  to: BookingStatus
+}
+// #716: discriminated union keyed on `type`. The literals mirror BOOKING_EVENT_TYPES
+// (booking_events.type is the storage-side discriminant), so consumers narrow on
+// payload.type with zero casts and gain assertNever exhaustiveness. The read mapper
+// (toBookingEvent) backfills the discriminant for legacy rows whose stored jsonb
+// payload predates it.
 export type BookingEventPayload =
   | BookingCreatedPayload
   | VehicleSubstitutedPayload

--- a/packages/shared/src/db/seed-bookings.ts
+++ b/packages/shared/src/db/seed-bookings.ts
@@ -244,6 +244,7 @@ export async function seedBookings(db: ReturnType<typeof getDb>) {
     })
 
     const createdPayload: BookingCreatedPayload = {
+      type: 'BOOKING_CREATED',
       requestedVehicleId: requested.id,
       assignedVehicleId: assigned.id,
       classId: seedId(b.classId),
@@ -263,6 +264,7 @@ export async function seedBookings(db: ReturnType<typeof getDb>) {
     })
     if (b.substitute) {
       const substitutedPayload: VehicleSubstitutedPayload = {
+        type: 'VEHICLE_SUBSTITUTED',
         fromVehicleId: requested.id,
         toVehicleId: assigned.id,
         reason: 'Original vehicle in maintenance — upgraded same class.',

--- a/packages/web/src/vite/operator-bookings/BookingTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingTimeline.tsx
@@ -1,10 +1,5 @@
 import { formatDateTime, formatJpy } from '@/lib/format'
 import type { BookingEventDto } from '@/vite/operator-bookings/api'
-import type {
-  BookingCancelledPayload,
-  StatusChangedPayload,
-  VehicleSubstitutedPayload,
-} from '@kuruma/shared/db/schema'
 import { useTranslations } from 'use-intl'
 
 interface BookingTimelineProps {
@@ -15,7 +10,8 @@ interface BookingTimelineProps {
 // Vertical audit-trail stepper (#549). Pure presentation (FC/IS): the route owns
 // the events fetch; this renders them oldest -> newest top-to-bottom (the API
 // returns createdAt asc, id asc), with a connecting line down the spine. The
-// payload union is not discriminated, so each branch narrows it off event.type.
+// payload is a discriminated union (#716), so branches narrow on event.payload.type
+// with no casts and an assertNever exhaustiveness guard.
 export function BookingTimeline({ events, locale }: BookingTimelineProps) {
   const t = useTranslations('bookings.operator.timeline')
   const ts = useTranslations('bookings.operator.status')
@@ -52,36 +48,40 @@ export function BookingTimeline({ events, locale }: BookingTimelineProps) {
 type Translate = ReturnType<typeof useTranslations>
 
 function eventLabel(event: BookingEventDto, t: Translate, ts: Translate): string {
-  switch (event.type) {
-    case 'STATUS_CHANGED': {
-      const p = event.payload as StatusChangedPayload
-      return t('statusChanged', { from: ts(p.from), to: ts(p.to) })
-    }
+  const { payload } = event
+  switch (payload.type) {
+    case 'STATUS_CHANGED':
+      return t('statusChanged', { from: ts(payload.from), to: ts(payload.to) })
     case 'VEHICLE_SUBSTITUTED':
       return t('vehicleSubstituted')
     case 'BOOKING_CANCELLED':
       return t('cancelled')
-    default:
+    case 'BOOKING_CREATED':
       return t('created')
+    default:
+      return assertNever(payload)
   }
 }
 
 function EventDetail({ event, t }: { event: BookingEventDto; t: Translate }) {
-  if (event.type === 'VEHICLE_SUBSTITUTED') {
-    const { reason } = event.payload as VehicleSubstitutedPayload
-    if (reason) {
-      return <p className="text-sm text-muted-foreground">{t('reason', { reason })}</p>
-    }
+  const { payload } = event
+  if (payload.type === 'VEHICLE_SUBSTITUTED' && payload.reason) {
+    return (
+      <p className="text-sm text-muted-foreground">{t('reason', { reason: payload.reason })}</p>
+    )
   }
-  if (event.type === 'BOOKING_CANCELLED') {
-    const { cancellationFee } = event.payload as BookingCancelledPayload
-    if (cancellationFee != null) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          {t('cancellationFee', { fee: formatJpy(cancellationFee) })}
-        </p>
-      )
-    }
+  if (payload.type === 'BOOKING_CANCELLED' && payload.cancellationFee != null) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t('cancellationFee', { fee: formatJpy(payload.cancellationFee) })}
+      </p>
+    )
   }
   return null
+}
+
+// Compile-time exhaustiveness: a new BookingEventPayload member makes eventLabel a
+// type error until it is handled here (#716).
+function assertNever(value: never): never {
+  throw new Error(`Unhandled booking event payload: ${JSON.stringify(value)}`)
 }

--- a/packages/web/tests/vite/operator-bookings/BookingTimeline.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingTimeline.test.tsx
@@ -13,6 +13,9 @@ function event(
     actorId: null,
     createdAt: '2026-07-01T01:00:00.000Z',
     ...over,
+    // #716: payload.type mirrors the authoritative event type, exactly as the API's
+    // toBookingEvent backfills it for legacy rows — so a fixture sets only `type`.
+    payload: { ...over.payload, type: over.type } as BookingEventDto['payload'],
   }
 }
 


### PR DESCRIPTION
## What

Make `BookingEventPayload` a discriminated union keyed on a `type` literal, so the operator booking timeline narrows on `payload.type` with **zero force-casts** and an `assertNever` exhaustiveness guard (previously three `as` casts).

Closes #716.

## Changes
- **shared/db/booking-types.ts** — per-member `type` literal → discriminated union, mirroring `booking_events.type` (the storage-side discriminant).
- **api/repositories/drizzle/shared.ts** — `toBookingEvent` backfills `payload.type` from the authoritative `type` column for legacy/seeded jsonb rows that predate the embedded discriminant. The column always wins (`{ ...payload, type: column }`), so the redundant discriminant cannot drift at runtime.
- **api/services/booking-creation.ts + booking-lifecycle.ts** — stamp the discriminant on all four append sites (created / substituted / status / cancelled).
- **web/BookingTimeline.tsx** — `switch (payload.type)`, 3 casts removed + `assertNever`. A 5th event type is now a compile error in `eventLabel` until handled (OCP).
- Test fixtures + the web timeline test helper carry the discriminant; new `to-booking-event.test.ts` pins the backfill, including the column-wins-on-disagreement invariant.

## Deferred (#760)
Correlating the outer `BookingEvent.type` with `payload.type` at the type level needs the in-memory `BookingEvent` union in `stores.ts`; that lands with #760. This PR is the payload-level half.

## Verification
- `tsc` green: shared / api / web
- `bun run lint` clean (file-size cap OK — #713 already split `booking.ts`)
- Tests: api booking-domain 43/43, web `BookingTimeline` 7/7, shared 511/511
- Reviewed (code-reviewer): SHIP — no CRITICAL/HIGH/MEDIUM

> Base = `marketplace-pivot` (not the default branch), so merging won't auto-close #716 — will close manually.
