### PR TITLE
refactor(api): drop non-null assertions in parseDateRange (#732)

### DIFF
--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -214,16 +214,18 @@ export function parseDateRange(
     return { ok: true, from: undefined, to: undefined }
   }
 
-  // Only one provided
-  if ((fromParam && !toParam) || (!fromParam && toParam)) {
+  // Both-absent returned above, so at least one is present here; require both.
+  // This local guard narrows fromParam/toParam to string via control flow, so
+  // the date parsing below needs no non-null assertions (#732).
+  if (!fromParam || !toParam) {
     return {
       ok: false,
       response: fail(c, 'Both "from" and "to" are required for date range filtering', 400),
     }
   }
 
-  const from = new Date(fromParam!)
-  const to = new Date(toParam!)
+  const from = new Date(fromParam)
+  const to = new Date(toParam)
 
   if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
     return {


### PR DESCRIPTION
## Summary
`parseDateRange` parsed dates with `new Date(fromParam!)` / `new Date(toParam!)`. The `!` were safe only *transitively*, via two positional compound guards TS's control-flow analysis can't collapse into "both are string" — a refactor hazard, and the project rule allows `!` only after an explicit local null check (here the check was positional).

Replace the convoluted `(fromParam && !toParam) || (!fromParam && toParam)` check with a local `if (!fromParam || !toParam) return 400` immediately before the date parsing. It narrows both params to `string` via control flow, so the assertions are dropped — and reads cleaner.

## Verification
- **tsc EXIT=0** — the proof of narrowing: without it, `new Date(string | undefined)` is itself a type error, so a green typecheck confirms the local guard narrows correctly.
- **44/44 helpers tests green** — behavior unchanged across all six cases (both-missing required/optional, exactly-one 400 ×2, invalid-date, to<=from, valid).
- biome clean; zero non-null assertions remain on the date params.

## AC (#732)
- [x] No non-null assertions on the date params
- [x] Both params narrowed to `string` by a local guard before use
- [x] Existing behavior preserved by tests

Closes #732
Part of #701