### PR TITLE
feat(web): browser Sentry monitoring (#765, web slice of #361)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@kuruma/shared": "workspace:*",
+        "@sentry/react": "^10",
         "@tanstack/react-query": "^5.96.2",
         "@tanstack/react-router": "^1.170.15",
         "@types/react-big-calendar": "^1.16.3",
@@ -731,9 +732,21 @@
 
     "@schummar/icu-type-parser": ["@schummar/icu-type-parser@1.21.5", "", {}, "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="],
 
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" } }, "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" } }, "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.57.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.57.0", "", { "dependencies": { "@sentry-internal/replay": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A=="],
+
+    "@sentry/browser": ["@sentry/browser@10.57.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.57.0", "@sentry-internal/feedback": "10.57.0", "@sentry-internal/replay": "10.57.0", "@sentry-internal/replay-canvas": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA=="],
+
     "@sentry/cloudflare": ["@sentry/cloudflare@10.57.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.57.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-LDKk177la/uG92ILNozcwQR7+4/pizPu01Y7M7l9J7o1uwAi9WjElafh/HU2Jqw+vST1BKknw/tQB1pnsnkDlA=="],
 
     "@sentry/core": ["@sentry/core@10.57.0", "", {}, "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="],
+
+    "@sentry/react": ["@sentry/react@10.57.0", "", { "dependencies": { "@sentry/browser": "10.57.0", "@sentry/core": "10.57.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,6 +23,7 @@
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@kuruma/shared": "workspace:*",
+    "@sentry/react": "^10",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.170.15",
     "@types/react-big-calendar": "^1.16.3",

--- a/packages/web/src/lib/observability/sentry-options.test.ts
+++ b/packages/web/src/lib/observability/sentry-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBrowserSentryOptions } from './sentry-options'
+
+describe('resolveBrowserSentryOptions', () => {
+  it('is disabled with no dsn when env is undefined (local dev / tests)', () => {
+    const opts = resolveBrowserSentryOptions(undefined)
+    expect(opts.enabled).toBe(false)
+    expect(opts.dsn).toBeUndefined()
+    expect(opts.environment).toBe('production')
+    expect(opts.release).toBeUndefined()
+  })
+
+  it('enables and carries the dsn when VITE_SENTRY_DSN is set', () => {
+    const opts = resolveBrowserSentryOptions({
+      VITE_SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+    })
+    expect(opts.enabled).toBe(true)
+    expect(opts.dsn).toBe('https://abc@o1.ingest.sentry.io/42')
+  })
+
+  it('treats a blank/whitespace dsn as unset (gated off)', () => {
+    const opts = resolveBrowserSentryOptions({ VITE_SENTRY_DSN: '   ' })
+    expect(opts.enabled).toBe(false)
+    expect(opts.dsn).toBeUndefined()
+  })
+
+  it('derives the release from VITE_SENTRY_RELEASE (CI injects the deploy version)', () => {
+    const opts = resolveBrowserSentryOptions({
+      VITE_SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+      VITE_SENTRY_RELEASE: 'deadbeef-version-id',
+    })
+    expect(opts.release).toBe('deadbeef-version-id')
+  })
+
+  it('honours an explicit VITE_SENTRY_ENVIRONMENT override', () => {
+    const opts = resolveBrowserSentryOptions({
+      VITE_SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+      VITE_SENTRY_ENVIRONMENT: 'staging',
+    })
+    expect(opts.environment).toBe('staging')
+  })
+
+  it('keeps PII off and tracing disabled (out of scope for this slice)', () => {
+    const opts = resolveBrowserSentryOptions({
+      VITE_SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+    })
+    expect(opts.sendDefaultPii).toBe(false)
+    expect(opts.tracesSampleRate).toBe(0)
+  })
+})

--- a/packages/web/src/lib/observability/sentry-options.ts
+++ b/packages/web/src/lib/observability/sentry-options.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolves browser Sentry init options from the Vite env (#765, web slice of
+ * #361). Pure so gating + release-tag derivation are testable without a live
+ * Sentry client. Mirrors the API's `observability/sentry-options.ts`.
+ *
+ * Gating: with no `VITE_SENTRY_DSN` the SDK is `enabled: false`, so local dev,
+ * CI, and any build without the public DSN send nothing — the instrumentation
+ * is a no-op until the DSN is provisioned (HITL).
+ */
+
+export interface BrowserSentryEnv {
+  VITE_SENTRY_DSN?: string
+  VITE_SENTRY_ENVIRONMENT?: string
+  /** CI injects the deploy version id so errors group per release (#361 AC). */
+  VITE_SENTRY_RELEASE?: string
+}
+
+export interface ResolvedSentryOptions {
+  dsn: string | undefined
+  enabled: boolean
+  environment: string
+  release: string | undefined
+  tracesSampleRate: number
+  sendDefaultPii: false
+}
+
+export function resolveBrowserSentryOptions(
+  env: BrowserSentryEnv | undefined,
+): ResolvedSentryOptions {
+  const dsn = env?.VITE_SENTRY_DSN?.trim() || undefined
+  const release = env?.VITE_SENTRY_RELEASE?.trim() || undefined
+  return {
+    dsn,
+    enabled: Boolean(dsn),
+    environment: env?.VITE_SENTRY_ENVIRONMENT?.trim() || 'production',
+    release,
+    // Out of scope (#361): full APM / trace waterfalls.
+    tracesSampleRate: 0,
+    // Out of scope (#361): PII scrubbing pipeline. Keep Sentry from attaching
+    // request bodies / headers by default; revisit at scale.
+    sendDefaultPii: false,
+  }
+}

--- a/packages/web/src/lib/observability/sentry-options.ts
+++ b/packages/web/src/lib/observability/sentry-options.ts
@@ -27,6 +27,8 @@ export interface ResolvedSentryOptions {
 export function resolveBrowserSentryOptions(
   env: BrowserSentryEnv | undefined,
 ): ResolvedSentryOptions {
+  // `|| undefined`, not `??`: a blank/whitespace-only value trims to '' and must
+  // gate off — `??` would keep the empty string and wrongly enable Sentry.
   const dsn = env?.VITE_SENTRY_DSN?.trim() || undefined
   const release = env?.VITE_SENTRY_RELEASE?.trim() || undefined
   return {

--- a/packages/web/src/lib/observability/sentry.test.tsx
+++ b/packages/web/src/lib/observability/sentry.test.tsx
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { initBrowserSentry } from './sentry'
+import { captureRouteError, initBrowserSentry } from './sentry'
 
 vi.mock('@sentry/react', () => ({
   init: vi.fn(),
+  captureException: vi.fn(),
   ErrorBoundary: ({ children }: { children: unknown }) => children,
 }))
 
@@ -16,6 +17,7 @@ describe('initBrowserSentry', () => {
     const result = initBrowserSentry(undefined)
     expect(Sentry.init).not.toHaveBeenCalled()
     expect(result.enabled).toBe(false)
+    expect(result.dsn).toBeUndefined()
   })
 
   it('calls Sentry.init with the resolved gated options when a DSN is set', () => {
@@ -34,5 +36,17 @@ describe('initBrowserSentry', () => {
         sendDefaultPii: false,
       }),
     )
+  })
+})
+
+describe('captureRouteError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports the route error to Sentry (the TanStack defaultOnCatch seam)', () => {
+    const error = new Error('route loader blew up')
+    captureRouteError(error)
+    expect(Sentry.captureException).toHaveBeenCalledWith(error)
   })
 })

--- a/packages/web/src/lib/observability/sentry.test.tsx
+++ b/packages/web/src/lib/observability/sentry.test.tsx
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { initBrowserSentry } from './sentry'
+
+vi.mock('@sentry/react', () => ({
+  init: vi.fn(),
+  ErrorBoundary: ({ children }: { children: unknown }) => children,
+}))
+
+describe('initBrowserSentry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does NOT call Sentry.init when no DSN (no-op until provisioned)', () => {
+    const result = initBrowserSentry(undefined)
+    expect(Sentry.init).not.toHaveBeenCalled()
+    expect(result.enabled).toBe(false)
+  })
+
+  it('calls Sentry.init with the resolved gated options when a DSN is set', () => {
+    initBrowserSentry({
+      VITE_SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+      VITE_SENTRY_RELEASE: 'v9',
+      VITE_SENTRY_ENVIRONMENT: 'staging',
+    })
+    expect(Sentry.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: 'https://abc@o1.ingest.sentry.io/42',
+        enabled: true,
+        environment: 'staging',
+        release: 'v9',
+        tracesSampleRate: 0,
+        sendDefaultPii: false,
+      }),
+    )
+  })
+})

--- a/packages/web/src/lib/observability/sentry.tsx
+++ b/packages/web/src/lib/observability/sentry.tsx
@@ -29,6 +29,17 @@ export function initBrowserSentry(env: BrowserSentryEnv | undefined): ResolvedSe
 }
 
 /**
+ * Reports a route-level error to Sentry. TanStack Router catches loader/render
+ * throws in its own error boundaries (route `errorComponent`s), so they never
+ * propagate to the React `SentryErrorBoundary` at the router root. Wiring this
+ * as the router's `defaultOnCatch` is the seam that captures them (#765). The
+ * SDK no-ops when Sentry is disabled (no DSN).
+ */
+export function captureRouteError(error: Error) {
+  Sentry.captureException(error)
+}
+
+/**
  * Minimal crash fallback rendered when the React tree throws above the router.
  * Inline-styled (no Tailwind/i18n dependency) so it still renders if CSS or the
  * locale provider is what failed. `Sentry.ErrorBoundary` reports the error to

--- a/packages/web/src/lib/observability/sentry.tsx
+++ b/packages/web/src/lib/observability/sentry.tsx
@@ -1,0 +1,74 @@
+import * as Sentry from '@sentry/react'
+import type { ReactNode } from 'react'
+import {
+  type BrowserSentryEnv,
+  type ResolvedSentryOptions,
+  resolveBrowserSentryOptions,
+} from './sentry-options'
+
+/**
+ * Browser Sentry init (#765, web slice of #361). Thin shell over the pure
+ * `resolveBrowserSentryOptions` so the gating logic stays unit-testable.
+ *
+ * When no `VITE_SENTRY_DSN` is set we skip `Sentry.init` entirely — a true
+ * no-op for local dev / CI / DSN-less builds. Returns the resolved options so
+ * callers (and tests) can observe the gate without a live client.
+ */
+export function initBrowserSentry(env: BrowserSentryEnv | undefined): ResolvedSentryOptions {
+  const options = resolveBrowserSentryOptions(env)
+  if (!options.enabled) return options
+  Sentry.init({
+    dsn: options.dsn,
+    enabled: true,
+    environment: options.environment,
+    release: options.release,
+    tracesSampleRate: options.tracesSampleRate,
+    sendDefaultPii: options.sendDefaultPii,
+  })
+  return options
+}
+
+/**
+ * Minimal crash fallback rendered when the React tree throws above the router.
+ * Inline-styled (no Tailwind/i18n dependency) so it still renders if CSS or the
+ * locale provider is what failed. `Sentry.ErrorBoundary` reports the error to
+ * Sentry when initialised and no-ops otherwise.
+ */
+function RootErrorFallback() {
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.75rem',
+        padding: '2rem',
+        fontFamily: 'system-ui, sans-serif',
+        textAlign: 'center',
+      }}
+    >
+      <h1 style={{ fontSize: '1.25rem', fontWeight: 600 }}>Something went wrong</h1>
+      <p style={{ color: '#555' }}>The app hit an unexpected error. Please reload the page.</p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        style={{
+          padding: '0.5rem 1rem',
+          borderRadius: '0.5rem',
+          border: '1px solid #ccc',
+          cursor: 'pointer',
+        }}
+      >
+        Reload
+      </button>
+    </div>
+  )
+}
+
+/** Router-root error boundary (#765 AC). Captures render crashes to Sentry. */
+export function SentryErrorBoundary({ children }: { children: ReactNode }) {
+  return <Sentry.ErrorBoundary fallback={<RootErrorFallback />}>{children}</Sentry.ErrorBoundary>
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,5 +1,9 @@
 import '@/styles/globals.css'
-import { SentryErrorBoundary, initBrowserSentry } from '@/lib/observability/sentry'
+import {
+  SentryErrorBoundary,
+  captureRouteError,
+  initBrowserSentry,
+} from '@/lib/observability/sentry'
 import { queryClient } from '@/vite/query-client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { StrictMode } from 'react'
@@ -8,7 +12,11 @@ import { routeTree } from './routeTree.gen'
 
 initBrowserSentry(import.meta.env)
 
-const router = createRouter({ routeTree, context: { queryClient } })
+const router = createRouter({
+  routeTree,
+  context: { queryClient },
+  defaultOnCatch: captureRouteError,
+})
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,9 +1,12 @@
 import '@/styles/globals.css'
+import { SentryErrorBoundary, initBrowserSentry } from '@/lib/observability/sentry'
 import { queryClient } from '@/vite/query-client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
+
+initBrowserSentry(import.meta.env)
 
 const router = createRouter({ routeTree, context: { queryClient } })
 
@@ -17,7 +20,9 @@ const rootElement = document.getElementById('root')
 if (rootElement && !rootElement.innerHTML) {
   createRoot(rootElement).render(
     <StrictMode>
-      <RouterProvider router={router} />
+      <SentryErrorBoundary>
+        <RouterProvider router={router} />
+      </SentryErrorBoundary>
     </StrictMode>,
   )
 }

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -5,6 +5,11 @@
 // app keeps process.env.* typing.
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string
+  // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
+  // injected by CI at build time; environment defaults to 'production'.
+  readonly VITE_SENTRY_DSN?: string
+  readonly VITE_SENTRY_ENVIRONMENT?: string
+  readonly VITE_SENTRY_RELEASE?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
Web slice of #361 (#764 shipped the API slice). Adds browser-side Sentry to the live Vite SPA, **gated on a public DSN** so it is a complete no-op until provisioned (HITL). Mirrors `packages/api/src/observability`.

## What it does
- **`lib/observability/sentry-options.ts`** — pure, DSN-gated `resolveBrowserSentryOptions(env)` reading `VITE_SENTRY_DSN/ENVIRONMENT/RELEASE`. Identical `ResolvedSentryOptions` shape to the API; tracing + PII off (out of scope, same as #361).
- **`sentry.tsx`** — thin `initBrowserSentry` (skips `Sentry.init` entirely without a DSN) + `SentryErrorBoundary` (router-root crash fallback, inline-styled so it renders even if CSS/locale is what failed) + `captureRouteError` reporter.
- **`main.tsx`** — init before render; wrap `<RouterProvider>` in the boundary; wire `captureRouteError` as the router's `defaultOnCatch`.
- **`vite-env.d.ts`** — declares the 3 `VITE_SENTRY_*` keys.

## Error-capture coverage
- Unhandled exceptions + promise rejections → Sentry global handlers (installed by `init`).
- Crashes above the router → `SentryErrorBoundary`.
- **Route loader/component throws → `defaultOnCatch` → `captureRouteError`** — TanStack Router catches these in its own `errorComponent`s, so a top-level React boundary alone would miss them. This closes that gap (code-review MEDIUM).

## Test plan
- **9 unit tests (TDD):** 6 for the pure options (disabled w/o DSN, blank-DSN gated off, release/env override, PII+tracing off), 3 for the shell (`init` NOT called w/o DSN; called with gated opts; `captureRouteError` → `captureException`).
- Full web suite **749 passed**; `tsc` ×3 clean; biome clean; lint:size/modules clean; `vite build` OK.

## Bundle size
`@sentry/react@10` adds ~30 kB gzip; the vendor chunk is 908 kB (279 kB gzip). Acceptable for error monitoring; no hard bundle gate (the dead bundle-check was dropped in #700, #667). Lazy-init is a possible follow-up.

## Activation (HITL — zero runtime effect until done)
Create a Sentry project → set `VITE_SENTRY_DSN` (+ `VITE_SENTRY_RELEASE` from the CI deploy id) → deploy.

Closes #765. Refs #361, #764. (base != default branch → close the issue manually on merge.)