### PR TITLE
docs(api): document STAFF-only customer-service boundary (#738)

### DIFF
--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -9,7 +9,15 @@ const ALLOWED_SORTS = new Set(['lastBookingAt', 'bookingCount', 'name'])
 export function createCustomerRoutes(service: CustomerService) {
   const app = new Hono()
 
-  // All customer routes are staff-only.
+  // STAFF-only by design. requireStaff -> STAFF_ROLES admits platform
+  // STAFF/ADMIN/PLATFORM_ADMIN only and excludes OPERATOR_*. These routes are
+  // intentionally unscoped: findById returns full cross-operator booking history
+  // and /search is a flat user-table lookup. That is safe ONLY while operators
+  // cannot reach them. If operator manual-booking is ever added, thread
+  // CallerContext + operator scoping (bookingReadScope-style) through
+  // service.findById/search BEFORE widening this gate — otherwise every operator's
+  // customer list and booking history leaks (cf. #396, which already defended
+  // /users against this same enumeration vector).
   app.use('/customers', requireStaff)
   app.use('/customers/*', requireStaff)
 

--- a/packages/api/src/services/customer.ts
+++ b/packages/api/src/services/customer.ts
@@ -9,6 +9,16 @@ export interface CustomerListQuery {
   search?: string | undefined
 }
 
+/**
+ * STAFF-only by design — enforced by the requireStaff gate in routes/customers.ts.
+ * findById returns a customer's full cross-operator booking history and search() is
+ * a flat user-table lookup; neither takes a CallerContext, so neither is
+ * operator-scoped. That is intentional and safe ONLY because the route gate admits
+ * platform STAFF/ADMIN/PLATFORM_ADMIN exclusively (never OPERATOR_*). Before any
+ * future operator manual-booking access, thread ctx + operator scoping through
+ * findById/search first, or every operator's customer list and booking history
+ * leaks (the #396 enumeration defense on /users is the precedent to follow).
+ */
 export class CustomerService {
   constructor(
     private readonly customerRepo: CustomerRepository,


### PR DESCRIPTION
## What
Documents the STAFF-only-by-design boundary on the customer-service routes/service. **Comment-only — no runtime or authz behavior change.**

## Why
`CustomerService.findById` returns a customer's full cross-operator booking history and `search()` is a flat user-table lookup; neither takes a `CallerContext`. That is safe today only because `requireStaff` (`STAFF_ROLES`) admits platform STAFF/ADMIN/PLATFORM_ADMIN and excludes `OPERATOR_*`. If operator manual-booking is ever added, these unscoped methods would expose every operator's customer list and booking history — the same enumeration vector #396 already defended `/users` against. This makes the assumption explicit before any gate widening.

## Changes
- `routes/customers.ts` — boundary note above the `requireStaff` middleware: future operator access MUST thread ctx + operator scoping through `findById`/`search` first.
- `services/customer.ts` — class-level doc on `CustomerService` stating the unscoped-by-design contract and the precondition for widening it.

## Acceptance criteria
- [x] `customers.ts` and `customer.ts` carry the STAFF-only-by-design boundary + future-scoping requirement
- [x] No runtime/authz behavior changes (comment-only diff)
- [x] api tests still pass (pre-commit gate green: biome, file-size, module-boundaries, 3× tsc)

Closes #738 · Part of #701 · Ref #396