### PR TITLE
refactor(web): Zod-validate unwrap responses + operator-classes first adopter (#711)

### DIFF
--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
+import type { z } from 'zod'
 
 /**
  * Error thrown by {@link unwrap} when the API returns a non-success body.
@@ -35,11 +36,35 @@ export class ActionError extends Error {
 }
 
 /**
+ * Error thrown by {@link unwrap} when a *success* response's `data` fails the
+ * caller-supplied Zod schema — i.e. the API/web contract drifted (a renamed or
+ * missing field). Without a schema such drift returns `undefined` deep in
+ * render; validating at the seam turns it into a clean failure here (#711).
+ * Carries the HTTP `status` (the response itself was 2xx) and the Zod `issues`.
+ */
+export class ParseError extends Error {
+  readonly name = 'ParseError'
+  readonly status: number
+  readonly issues: z.core.$ZodIssue[]
+
+  constructor(message: string, status: number, issues: z.core.$ZodIssue[]) {
+    super(message)
+    this.status = status
+    this.issues = issues
+  }
+}
+
+/**
  * Shared response unwrapper for the web-side API clients. On a success body
  * returns `data`; on a failure body throws an {@link ApiError} carrying the
  * status. Replaces the per-module copies that discarded the status.
+ *
+ * Pass a Zod `schema` to validate `data` at the network seam instead of trusting
+ * the phantom `T` cast — drift then throws a {@link ParseError} rather than
+ * surfacing as `undefined` in render (#711). Omitting it preserves the legacy
+ * passthrough for clients not yet migrated.
  */
-export async function unwrap<T>(res: Response): Promise<T> {
+export async function unwrap<T>(res: Response, schema?: z.ZodType<T>): Promise<T> {
   const body = (await res.json().catch(() => ({
     success: false as const,
     error: `Non-JSON response (HTTP ${res.status})`,
@@ -49,7 +74,17 @@ export async function unwrap<T>(res: Response): Promise<T> {
     throw new ApiError(body.error ?? `HTTP ${res.status}`, res.status)
   }
 
-  return body.data
+  if (!schema) return body.data
+
+  const parsed = schema.safeParse(body.data)
+  if (!parsed.success) {
+    throw new ParseError(
+      `API response body failed validation (HTTP ${res.status})`,
+      res.status,
+      parsed.error.issues,
+    )
+  }
+  return parsed.data
 }
 
 export const OPERATOR_REQUIRED = 'OPERATOR_REQUIRED'

--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -45,9 +45,9 @@ export class ActionError extends Error {
 export class ParseError extends Error {
   readonly name = 'ParseError'
   readonly status: number
-  readonly issues: z.core.$ZodIssue[]
+  readonly issues: z.ZodError['issues']
 
-  constructor(message: string, status: number, issues: z.core.$ZodIssue[]) {
+  constructor(message: string, status: number, issues: z.ZodError['issues']) {
     super(message)
     this.status = status
     this.issues = issues
@@ -65,6 +65,10 @@ export class ParseError extends Error {
  * passthrough for clients not yet migrated.
  */
 export async function unwrap<T>(res: Response, schema?: z.ZodType<T>): Promise<T> {
+  // The envelope shape (`{ success, data | error }`) is trusted by construction:
+  // every API route emits it through the shared `ok()`/`fail()` helpers, so we
+  // cast it rather than validate it. The optional Zod `schema` below validates
+  // `data` — the part that actually carries the API/web contract (#711).
   const body = (await res.json().catch(() => ({
     success: false as const,
     error: `Non-JSON response (HTTP ${res.status})`,

--- a/packages/web/src/vite/operator-classes/api.ts
+++ b/packages/web/src/vite/operator-classes/api.ts
@@ -5,6 +5,7 @@ import type {
   UpdateVehicleClassInput,
 } from '@kuruma/shared/validators/vehicle-class'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #528: operator vehicle-classes management. Self-contained Vite client — it
 // never imports the frozen Next module's `modules/classes/api.ts` (process.env
@@ -16,27 +17,35 @@ import { queryOptions } from '@tanstack/react-query'
 // `GET /vehicle-classes` is ACTIVE-only, cross-operator, and edge-cached — it
 // can't power an owner's manage screen.
 
-/** A vehicle class as the operator manage screen needs it (JSON: ISO dates). */
-export interface OperatorClass {
-  id: string
+/**
+ * A vehicle class as the operator manage screen needs it (JSON: ISO dates).
+ * The Zod schema is the single source: `OperatorClass` is inferred from it
+ * (#711), so the runtime parse at the seam and the compile-time type cannot
+ * drift apart, and a renamed/missing API field fails in {@link fetchOperatorClasses}
+ * instead of surfacing as `undefined` deep in the grid.
+ */
+export const operatorClassSchema = z.object({
+  id: z.string(),
   // The owning operator. Optional only because legacy fixtures predate it; the
   // API always returns it. Used to scope edit-form options (#456).
-  operatorId?: string
-  name: string
-  slug: string
-  description: string | null
-  photos: string[]
-  seats: number
-  luggageCapacity: number
-  luggageSize: 'SMALL' | 'MEDIUM' | 'LARGE' | null
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  acrissCode: string | null
-  sortOrder: number
-  status: 'ACTIVE' | 'ARCHIVED'
-  createdAt: string
-  updatedAt: string
-}
+  operatorId: z.string().optional(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  photos: z.array(z.string()),
+  seats: z.number(),
+  luggageCapacity: z.number(),
+  luggageSize: z.enum(['SMALL', 'MEDIUM', 'LARGE']).nullable(),
+  transmission: z.enum(['AUTO', 'MANUAL']),
+  fuelType: z.string().nullable(),
+  acrissCode: z.string().nullable(),
+  sortOrder: z.number(),
+  status: z.enum(['ACTIVE', 'ARCHIVED']),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type OperatorClass = z.infer<typeof operatorClassSchema>
 
 export interface OperatorClassFilters {
   includeArchived?: boolean
@@ -51,7 +60,7 @@ export async function fetchOperatorClasses(
   const res = await fetch(`${getApiBaseUrl()}/vehicle-classes/manage${qs}`, {
     credentials: 'include',
   })
-  return unwrap<OperatorClass[]>(res)
+  return unwrap(res, operatorClassSchema.array())
 }
 
 export function operatorClassesQueryOptions(filters: OperatorClassFilters = {}) {
@@ -63,25 +72,30 @@ export function operatorClassesQueryOptions(filters: OperatorClassFilters = {}) 
   })
 }
 
-async function mutateJson<T>(url: string, method: 'POST' | 'PATCH', body: unknown): Promise<T> {
+async function mutateJson<T>(
+  url: string,
+  method: 'POST' | 'PATCH',
+  body: unknown,
+  schema?: z.ZodType<T>,
+): Promise<T> {
   const res = await fetch(url, {
     method,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  return unwrap<T>(res)
+  return unwrap(res, schema)
 }
 
 export function createOperatorClass(input: CreateVehicleClassInput): Promise<OperatorClass> {
-  return mutateJson<OperatorClass>(`${getApiBaseUrl()}/vehicle-classes`, 'POST', input)
+  return mutateJson(`${getApiBaseUrl()}/vehicle-classes`, 'POST', input, operatorClassSchema)
 }
 
 export function updateOperatorClass(
   id: string,
   input: UpdateVehicleClassInput,
 ): Promise<OperatorClass> {
-  return mutateJson<OperatorClass>(`${getApiBaseUrl()}/vehicle-classes/${id}`, 'PATCH', input)
+  return mutateJson(`${getApiBaseUrl()}/vehicle-classes/${id}`, 'PATCH', input, operatorClassSchema)
 }
 
 // API DELETE performs a soft archive (status -> ARCHIVED). Name reflects the
@@ -92,5 +106,5 @@ export async function archiveOperatorClass(id: string): Promise<OperatorClass> {
     method: 'DELETE',
     credentials: 'include',
   })
-  return unwrap<OperatorClass>(res)
+  return unwrap(res, operatorClassSchema)
 }

--- a/packages/web/src/vite/operator-classes/api.ts
+++ b/packages/web/src/vite/operator-classes/api.ts
@@ -19,16 +19,19 @@ import { z } from 'zod'
 
 /**
  * A vehicle class as the operator manage screen needs it (JSON: ISO dates).
- * The Zod schema is the single source: `OperatorClass` is inferred from it
- * (#711), so the runtime parse at the seam and the compile-time type cannot
- * drift apart, and a renamed/missing API field fails in {@link fetchOperatorClasses}
- * instead of surfacing as `undefined` deep in the grid.
+ * `OperatorClass` is inferred from this schema (#711), so web's compile-time
+ * type and the runtime parse at the seam derive from one source and cannot drift
+ * apart. The schema still hand-mirrors the API's DTO, so it can't *prove* the
+ * contract — but if the API renames or drops a field it fails as a `ParseError`
+ * in {@link fetchOperatorClasses} (a runtime tripwire) instead of surfacing as
+ * `undefined` deep in the grid.
  */
 export const operatorClassSchema = z.object({
   id: z.string(),
-  // The owning operator. Optional only because legacy fixtures predate it; the
-  // API always returns it. Used to scope edit-form options (#456).
-  operatorId: z.string().optional(),
+  // The owning operator (DB notNull; the manage list and every mutation return
+  // it). Required so an absent operatorId fails as drift here rather than
+  // surfacing as `undefined` in the edit-form scoping (#456) — the #711 point.
+  operatorId: z.string(),
   name: z.string(),
   slug: z.string(),
   description: z.string().nullable(),

--- a/packages/web/tests/lib/api-error.test.ts
+++ b/packages/web/tests/lib/api-error.test.ts
@@ -1,5 +1,6 @@
-import { ApiError, operatorRequiredCode, unwrap } from '@/lib/api-error'
+import { ApiError, ParseError, operatorRequiredCode, unwrap } from '@/lib/api-error'
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
@@ -32,6 +33,35 @@ describe('unwrap', () => {
   it('throws an ApiError with the status when the body is not JSON', async () => {
     const res = new Response('<html>502</html>', { status: 502 })
     await expect(unwrap(res)).rejects.toMatchObject({ status: 502 })
+  })
+})
+
+describe('unwrap with a Zod schema', () => {
+  const vehicleSchema = z.object({ id: z.string(), seats: z.number() })
+
+  it('returns the parsed data when body.data matches the schema', async () => {
+    const res = jsonResponse({ success: true, data: { id: 'v1', seats: 5 } }, 200)
+    await expect(unwrap(res, vehicleSchema)).resolves.toEqual({ id: 'v1', seats: 5 })
+  })
+
+  it('throws a ParseError at the seam when body.data drifts (renamed field)', async () => {
+    // API renamed `seats` -> `seatCount`: the legacy cast returns an object whose
+    // `seats` is undefined, surfacing deep in render. With a schema it fails here.
+    const res = jsonResponse({ success: true, data: { id: 'v1', seatCount: 5 } }, 200)
+    const err = (await unwrap(res, vehicleSchema).catch((e) => e)) as ParseError
+    expect(err).toBeInstanceOf(ParseError)
+    expect(err.status).toBe(200)
+    expect(err.issues.some((issue) => issue.path.includes('seats'))).toBe(true)
+  })
+
+  it('does not consult the schema on a failure envelope (still throws ApiError)', async () => {
+    const res = jsonResponse({ success: false, error: 'boom' }, 500)
+    await expect(unwrap(res, vehicleSchema)).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('passes data through unchanged when no schema is supplied (back-compat)', async () => {
+    const res = jsonResponse({ success: true, data: { anything: true } }, 200)
+    await expect(unwrap(res)).resolves.toEqual({ anything: true })
   })
 })
 

--- a/packages/web/tests/lib/api-error.test.ts
+++ b/packages/web/tests/lib/api-error.test.ts
@@ -51,6 +51,7 @@ describe('unwrap with a Zod schema', () => {
     const err = (await unwrap(res, vehicleSchema).catch((e) => e)) as ParseError
     expect(err).toBeInstanceOf(ParseError)
     expect(err.status).toBe(200)
+    expect(err.message).toContain('HTTP 200')
     expect(err.issues.some((issue) => issue.path.includes('seats'))).toBe(true)
   })
 

--- a/packages/web/tests/vite/operator-classes/api.test.ts
+++ b/packages/web/tests/vite/operator-classes/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import {
   archiveOperatorClass,
   createOperatorClass,
@@ -19,9 +20,30 @@ function stubFetch(body: unknown) {
 
 afterEach(() => vi.unstubAllGlobals())
 
+// A complete OperatorClass row — the response schema now rejects partials, so
+// fixtures that exercise a validated path must carry every field.
+const validClass = {
+  id: 'c1',
+  operatorId: 'op1',
+  name: 'Compact',
+  slug: 'compact',
+  description: null,
+  photos: [],
+  seats: 5,
+  luggageCapacity: 2,
+  luggageSize: 'MEDIUM' as const,
+  transmission: 'AUTO' as const,
+  fuelType: null,
+  acrissCode: null,
+  sortOrder: 0,
+  status: 'ACTIVE' as const,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
 describe('operator-classes api', () => {
   it('fetches the operator-scoped manage list with includeArchived + cookie auth', async () => {
-    const rows = [{ id: 'c1', name: 'Compact', status: 'ARCHIVED' }]
+    const rows = [{ ...validClass, status: 'ARCHIVED' as const }]
     const fetchMock = stubFetch({ success: true, data: rows })
 
     const result = await fetchOperatorClasses({ includeArchived: true })
@@ -49,7 +71,7 @@ describe('operator-classes api', () => {
   })
 
   it('create POSTs to the collection with cookie auth and JSON body', async () => {
-    const created = { id: 'c2', name: 'SUV', status: 'ACTIVE' }
+    const created = { ...validClass, id: 'c2', name: 'SUV', slug: 'suv' }
     const fetchMock = stubFetch({ success: true, data: created })
 
     const input = { operatorId: 'op1', name: 'SUV', slug: 'suv', seats: 5, luggageCapacity: 2 }
@@ -65,7 +87,7 @@ describe('operator-classes api', () => {
   })
 
   it('update PATCHes the :id resource', async () => {
-    const fetchMock = stubFetch({ success: true, data: { id: 'c1', name: 'Renamed' } })
+    const fetchMock = stubFetch({ success: true, data: { ...validClass, name: 'Renamed' } })
     await updateOperatorClass('c1', { name: 'Renamed' } as never)
 
     expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/c1', {
@@ -77,13 +99,24 @@ describe('operator-classes api', () => {
   })
 
   it('archive DELETEs the :id resource (soft archive)', async () => {
-    const fetchMock = stubFetch({ success: true, data: { id: 'c1', status: 'ARCHIVED' } })
+    const archived = { ...validClass, status: 'ARCHIVED' as const }
+    const fetchMock = stubFetch({ success: true, data: archived })
     const result = await archiveOperatorClass('c1')
 
     expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/c1', {
       method: 'DELETE',
       credentials: 'include',
     })
-    expect(result).toEqual({ id: 'c1', status: 'ARCHIVED' })
+    expect(result).toEqual(archived)
+  })
+
+  it('rejects with a ParseError when a class row is missing a required field (drift)', async () => {
+    // The API dropped `seats`; the legacy cast surfaced it as `undefined` deep in
+    // the grid. With a response schema the contract drift fails at the seam.
+    stubFetch({
+      success: true,
+      data: [{ id: 'c1', name: 'Compact', slug: 'compact', status: 'ACTIVE' }],
+    })
+    await expect(fetchOperatorClasses()).rejects.toBeInstanceOf(ParseError)
   })
 })


### PR DESCRIPTION
Slice 1 of #711 (validate API response bodies with Zod in `unwrap` instead of casting the network body as `T`).

## What
- **Foundation** — `unwrap<T>(res, schema?)` takes an optional Zod schema. When supplied it `safeParse`s `body.data` and throws a typed `ParseError` (carrying the 2xx `status` + Zod `issues`) on drift, instead of casting to a phantom `T` that surfaces as `undefined` deep in render. No schema = legacy passthrough, so unmigrated clients are untouched.
- **First adopter** — `vite/operator-classes/api.ts`: `operatorClassSchema` is the single source (`OperatorClass = z.infer<typeof operatorClassSchema>`), threaded through fetch/create/update/archive. A drifted class row now fails at the seam, not in the grid.

## Review fixes folded in
- `operatorId` is **required** (DB notNull; manage list + every mutation return it) so its absence is caught as drift, not surfaced as `undefined` in edit-form scoping (#456).
- `ParseError.issues` typed via the public `z.ZodError['issues']`, not the `z.core.$ZodIssue` internal.
- Documented the trusted-by-construction envelope cast in `unwrap`; validation is scoped to `data`.
- Softened the schema docstring: kills web-internal type↔parse drift, but for the API contract it is a runtime **tripwire** (still hand-mirrors the DTO), not proof.
- Pinned the `ParseError` message (`HTTP 200`) in the unwrap drift test.

## Verification
- web typecheck: pass (×2 tsconfigs)
- web suite: **746 passed / 127 files**
- biome: clean
- rebased onto trunk `1175fce`

## Scope / follow-ups
Part of #711 — first of multiple slices. ~15 `vite/*/api.ts` clients still cast responses without a schema (booking/customer/vehicle per AC#2). Filed:
- #784 — ratcheting lint so schemaless `unwrap()` can't masquerade as validated.
- #785 — `vite/<feature>/schema.ts` convention for large-DTO clients (fleet/bookings) before migrating them.

Part of #711