### PR TITLE
chore(web): lint-restrict web runtime DB imports to the Auth.js carve-out (#722)

### DIFF
--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -1,3 +1,6 @@
+// #722 carve-out: auth.ts is the sanctioned Auth.js DB toucher (Drizzle adapter +
+// session lookup). lint-module-boundaries exempts it from the "web has no direct
+// DB access" rule; all other web code must route through the Hono API.
 import { getDb } from '@/lib/db'
 import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import { accounts, users } from '@kuruma/shared/db/schema'

--- a/packages/web/src/lib/db.ts
+++ b/packages/web/src/lib/db.ts
@@ -1,3 +1,6 @@
+// #722 carve-out: the web package's sanctioned Drizzle client factory for Auth.js.
+// lint-module-boundaries exempts lib/db.ts from the "web has no direct DB access"
+// rule — do not import getDb() elsewhere in web; route through the Hono API.
 import { getDb as getDbBase } from '@kuruma/shared/db'
 
 // Resolves DATABASE_URL from CF Workers context or process.env.

--- a/scripts/__fixtures__/boundaries/packages/api/src/uses-drizzle.ts
+++ b/scripts/__fixtures__/boundaries/packages/api/src/uses-drizzle.ts
@@ -1,0 +1,4 @@
+// #722 OK fixture: only packages/web is forbidden from runtime DB access; api is fine.
+import { eq } from 'drizzle-orm'
+
+export const equals = eq

--- a/scripts/__fixtures__/boundaries/packages/web/src/auth.ts
+++ b/scripts/__fixtures__/boundaries/packages/web/src/auth.ts
@@ -1,0 +1,7 @@
+// #722 carve-out fixture: mirrors the real packages/web/src/auth.ts — the sanctioned
+// Auth.js DB toucher, exempt from the web no-runtime-DB rule.
+import { getDb } from '@/lib/db'
+import { users } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+
+export const lookup = (id: string) => getDb().select().from(users).where(eq(users.id, id))

--- a/scripts/__fixtures__/boundaries/packages/web/src/lib/db.ts
+++ b/scripts/__fixtures__/boundaries/packages/web/src/lib/db.ts
@@ -1,0 +1,4 @@
+// #722 carve-out fixture: mirrors packages/web/src/lib/db.ts — the Drizzle client factory.
+import { getDb as getDbBase } from '@kuruma/shared/db'
+
+export const getDb = getDbBase

--- a/scripts/__fixtures__/boundaries/packages/web/src/loaders/bad-runtime-db.ts
+++ b/scripts/__fixtures__/boundaries/packages/web/src/loaders/bad-runtime-db.ts
@@ -1,0 +1,8 @@
+// #722 VIOLATION fixture: a web file reaching the DB at runtime bypasses the Hono API.
+import { getDb } from '@/lib/db'
+import { users } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+
+export function leak(id: string) {
+  return getDb().select().from(users).where(eq(users.id, id))
+}

--- a/scripts/__fixtures__/boundaries/packages/web/src/loaders/good-type-only.ts
+++ b/scripts/__fixtures__/boundaries/packages/web/src/loaders/good-type-only.ts
@@ -1,0 +1,4 @@
+// #722 OK fixture: type-only DB imports are erased at build — no runtime DB path.
+import type { BookingCancelledPayload, BookingStatus } from '@kuruma/shared/db/schema'
+
+export type Row = { status: BookingStatus; payload: BookingCancelledPayload }

--- a/scripts/lint-module-boundaries.test.ts
+++ b/scripts/lint-module-boundaries.test.ts
@@ -28,3 +28,28 @@ describe('lint-module-boundaries', () => {
     expect(report).toHaveLength(0)
   })
 })
+
+describe('lint-module-boundaries: web no direct DB access (#722)', () => {
+  const WEB = `${FIX}/packages/web/src`
+
+  test('flags runtime DB imports in a web file (@/lib/db, drizzle-orm, @kuruma/shared/db)', () => {
+    const report = checkImports([`${WEB}/loaders/bad-runtime-db.ts`])
+    expect(report).toHaveLength(3)
+    expect(report.every((v) => v.reason === 'web-runtime-db')).toBe(true)
+    expect(new Set(report.map((v) => v.importPath))).toEqual(
+      new Set(['@/lib/db', '@kuruma/shared/db/schema', 'drizzle-orm']),
+    )
+  })
+
+  test('allows type-only DB imports in a web file (erased at build)', () => {
+    expect(checkImports([`${WEB}/loaders/good-type-only.ts`])).toHaveLength(0)
+  })
+
+  test('exempts the Auth.js carve-out (auth.ts, lib/db.ts)', () => {
+    expect(checkImports([`${WEB}/auth.ts`, `${WEB}/lib/db.ts`])).toHaveLength(0)
+  })
+
+  test('does not restrict non-web packages (api may import drizzle at runtime)', () => {
+    expect(checkImports([`${FIX}/packages/api/src/uses-drizzle.ts`])).toHaveLength(0)
+  })
+})

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -5,11 +5,17 @@ import { Glob } from 'bun'
 export type Violation = {
   file: string
   importPath: string
-  reason: 'cross-module-internal'
+  reason: 'cross-module-internal' | 'web-runtime-db'
 }
 
-// Matches: import ... from '<spec>'  and  import '<spec>'  and  export ... from '<spec>'
-const IMPORT_RE = /(?:import|export)[^'"`]*?from\s*['"]([^'"]+)['"]/g
+type ImportRef = { spec: string; typeOnly: boolean }
+
+// Matches `import ... from '<spec>'` and `export ... from '<spec>'`, capturing a
+// leading `type` modifier (group 1) so `import type {...}` / `export type {...}`
+// are told apart from runtime imports. The negated class spans newlines, so
+// multi-line imports are handled. Inline `import { type X }` is treated as
+// runtime (conservative); biome's useImportType keeps that form rare.
+const IMPORT_RE = /(?:import|export)\s+(type\s+)?[^'"`]*?from\s*['"]([^'"]+)['"]/g
 const BARE_IMPORT_RE = /import\s+['"]([^'"]+)['"]/g
 
 // Alias import reaching into module internals: @/modules/<name>/<sub>
@@ -19,17 +25,43 @@ const BARE_IMPORT_RE = /import\s+['"]([^'"]+)['"]/g
 // real problem, upgrade to an AST-based check or add a relative-path resolver.
 const INTERNAL_ALIAS_RE = /^@\/modules\/([^/]+)\/(.+)$/
 
-function collectImports(source: string): string[] {
-  const specs: string[] = []
-  for (const match of source.matchAll(IMPORT_RE)) specs.push(match[1]!)
-  for (const match of source.matchAll(BARE_IMPORT_RE)) specs.push(match[1]!)
-  return specs
+// #722: packages/web has NO direct DB access — all data flows through the Hono
+// API (CLAUDE.md architecture boundary). A runtime import of the web DB client
+// or Drizzle anywhere under packages/web/src is forbidden, EXCEPT the two
+// sanctioned Auth.js files below, which need the Drizzle adapter at runtime.
+// `import type` is always allowed (erased at build, so it creates no DB path).
+const WEB_SRC_MARKER = 'packages/web/src/'
+const WEB_DB_CARVE_OUT = new Set(['auth.ts', 'lib/db.ts'])
+const FORBIDDEN_WEB_DB_PREFIXES = ['@/lib/db', '@kuruma/shared/db', 'drizzle-orm']
+
+function collectImports(source: string): ImportRef[] {
+  const refs: ImportRef[] = []
+  for (const match of source.matchAll(IMPORT_RE)) {
+    refs.push({ spec: match[2]!, typeOnly: Boolean(match[1]) })
+  }
+  for (const match of source.matchAll(BARE_IMPORT_RE)) {
+    refs.push({ spec: match[1]!, typeOnly: false })
+  }
+  return refs
 }
 
 function moduleOfFile(file: string): string | null {
   const p = file.replaceAll('\\', '/')
   const match = p.match(/\/modules\/([^/]+)\//)
   return match ? match[1]! : null
+}
+
+// The path under packages/web/src (e.g. 'auth.ts', 'vite/bookings/api.ts'), or
+// null if the file is outside the web package. Substring-based so it resolves
+// real files and test fixtures alike.
+function webRelPath(file: string): string | null {
+  const p = file.replaceAll('\\', '/')
+  const i = p.indexOf(WEB_SRC_MARKER)
+  return i === -1 ? null : p.slice(i + WEB_SRC_MARKER.length)
+}
+
+function isForbiddenWebDbSpec(spec: string): boolean {
+  return FORBIDDEN_WEB_DB_PREFIXES.some((p) => spec === p || spec.startsWith(`${p}/`))
 }
 
 export function checkImports(files: string[]): Violation[] {
@@ -43,14 +75,18 @@ export function checkImports(files: string[]): Violation[] {
       continue
     }
     const importingModule = moduleOfFile(file)
-    for (const spec of collectImports(source)) {
-      const m = spec.match(INTERNAL_ALIAS_RE)
-      if (!m) continue
-      const targetModule = m[1]!
-      // Allow files inside the same module to reference their own internals
-      // (though relative imports are preferred). This check is cross-module only.
-      if (importingModule === targetModule) continue
-      violations.push({ file, importPath: spec, reason: 'cross-module-internal' })
+    const webRel = webRelPath(file)
+    const webDbExempt = webRel !== null && WEB_DB_CARVE_OUT.has(webRel)
+    for (const { spec, typeOnly } of collectImports(source)) {
+      // Rule 1: no cross-module reach into another module's internals.
+      const internal = spec.match(INTERNAL_ALIAS_RE)
+      if (internal && importingModule !== internal[1]!) {
+        violations.push({ file, importPath: spec, reason: 'cross-module-internal' })
+      }
+      // Rule 2 (#722): no runtime DB import from the web package (Auth.js aside).
+      if (webRel !== null && !webDbExempt && !typeOnly && isForbiddenWebDbSpec(spec)) {
+        violations.push({ file, importPath: spec, reason: 'web-runtime-db' })
+      }
     }
   }
   return violations
@@ -83,18 +119,21 @@ function discover(): string[] {
   return out
 }
 
+function describeViolation(v: Violation): string {
+  if (v.reason === 'web-runtime-db') {
+    return `runtime DB import "${v.importPath}" — packages/web has no direct DB access; route through the Hono API. Use 'import type' for types; only auth.ts/lib/db.ts may touch the DB at runtime (Auth.js).`
+  }
+  return `imports "${v.importPath}" — cross-module internal import; use the '@/modules/<name>' barrel instead.`
+}
+
 function main(): number {
   const files = discover()
   const violations = checkImports(files)
   for (const v of violations) {
-    process.stderr.write(
-      `[lint-module-boundaries] ERROR ${v.file}: imports "${v.importPath}" (cross-module internal import)\n`,
-    )
+    process.stderr.write(`[lint-module-boundaries] ERROR ${v.file}: ${describeViolation(v)}\n`)
   }
   if (violations.length > 0) {
-    process.stderr.write(
-      `[lint-module-boundaries] ${violations.length} violation(s). Import from '@/modules/<name>' (the barrel) instead.\n`,
-    )
+    process.stderr.write(`[lint-module-boundaries] ${violations.length} violation(s).\n`)
     return 1
   }
   return 0


### PR DESCRIPTION
## Summary
`packages/web` has no direct DB access (CLAUDE.md), but the boundary was convention-only — nothing stopped a future loader from importing `getDb()` / runtime `@kuruma/shared/db` / `drizzle-orm` and bypassing the Hono API.

- New rule in `scripts/lint-module-boundaries.ts`: a **non-type** import of `@/lib/db`, `@kuruma/shared/db` (incl. subpaths), or `drizzle-orm` anywhere under `packages/web/src` is a violation, **except** the sanctioned Auth.js files (`auth.ts`, `lib/db.ts`).
- `import type` stays allowed (erased at build, no DB path) — existing type-only DB imports (e.g. `BookingTimeline`, `vite/*/api`) keep passing.
- `collectImports` now captures the `type` modifier (multi-line aware) to distinguish type-only from runtime imports.
- Carve-out documented adjacent to the rule + back-referenced in `auth.ts` / `lib/db.ts`.

## Test plan
- [x] TDD: 4 new boundary tests (flags runtime import, allows type-only, exempts carve-out, ignores non-web) + 5 fixtures — `scripts/lint-module-boundaries.test.ts` 8/8
- [x] `lint:modules` 0 violations on the real tree
- [x] web typecheck 0
- [x] full `bun run lint` 0
- [ ] CI green (pending)

Closes #722
Part of #701