### PR TITLE
chore(dev): drift-safe, deterministic worktree dev setup (#740)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,9 @@ Critical rules:
 ## Monorepo
 
 - shadcn: `bunx shadcn@latest add <component> -c packages/web`
-- **`.env` lives at repo root; symlinked to `packages/web/.env`.**
+- **`.env` lives at repo root — no `packages/web/.env`.** The API loads root `.env` directly. The Vite web reads only `VITE_*` vars from the shell, each with a safe fallback (`VITE_DEV_API_PROXY`/`VITE_API_BASE_URL` → the `/api` proxy to `localhost:8787`), so it needs no env file. The old `packages/web/.env` symlink was a legacy-Next requirement and is gone.
 - Order: `db:generate` -> `db:migrate` -> `db:seed`.
-- Worktrees: always `bun install` + verify `tsc --noEmit` in a fresh worktree.
+- Worktrees: always `bun install` + `bun run db:migrate` + verify `tsc --noEmit` in a fresh worktree. Each worktree's DB must match *its own* migrations — `bun run dev[:api]` runs a `predev` drift check (`db:drift-warn`) that loudly warns when the DB is behind, so a stale worktree can't silently 500 a page (#740).
 
 ## Database Migrations (drizzle)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {
+    "predev": "bun run db:drift-warn",
     "dev": "bun run --filter @kuruma/web dev",
+    "predev:api": "bun run db:drift-warn",
     "dev:api": "bun run --filter @kuruma/api dev",
     "build": "bun run --filter '*' build",
     "test": "bun run --filter '*' test",
@@ -31,6 +33,7 @@
     "db:seed:tcp": "bun run scripts/seed-tcp.ts",
     "db:backfill-regions": "bun run scripts/backfill-location-regions.ts",
     "db:verify": "bun run scripts/db-verify.ts",
+    "db:drift-warn": "bun run scripts/db-drift-warn.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/db-drift-warn.test.ts
+++ b/scripts/db-drift-warn.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { assessDrift, formatDriftWarning } from './db-drift-warn'
+
+describe('assessDrift', () => {
+  test('behind when the DB has applied fewer migrations than the journal', () => {
+    expect(assessDrift({ journal: 59, applied: 54 })).toEqual({
+      kind: 'behind',
+      pending: 5,
+      journal: 59,
+      applied: 54,
+    })
+  })
+
+  test('in-sync when applied count equals journal count', () => {
+    expect(assessDrift({ journal: 59, applied: 59 })).toEqual({ kind: 'in-sync' })
+  })
+
+  test('ahead when the DB has applied more migrations than this worktree knows', () => {
+    expect(assessDrift({ journal: 54, applied: 59 })).toEqual({
+      kind: 'ahead',
+      journal: 54,
+      applied: 59,
+    })
+  })
+
+  test('a fresh/empty DB (0 applied) is behind by the full journal count', () => {
+    expect(assessDrift({ journal: 59, applied: 0 })).toEqual({
+      kind: 'behind',
+      pending: 59,
+      journal: 59,
+      applied: 0,
+    })
+  })
+})
+
+describe('formatDriftWarning', () => {
+  test('behind → loud warning naming the pending count and the exact fix command', () => {
+    const msg = formatDriftWarning({ kind: 'behind', pending: 5, journal: 59, applied: 54 })
+    expect(msg).toContain('5 migration')
+    expect(msg).toContain('bun run db:migrate')
+  })
+
+  test('in-sync → no warning (null) so dev startup stays quiet', () => {
+    expect(formatDriftWarning({ kind: 'in-sync' })).toBeNull()
+  })
+
+  test('ahead → silent (null): a DB ahead of the worktree is benign, so avoid alarm fatigue', () => {
+    expect(formatDriftWarning({ kind: 'ahead', journal: 54, applied: 59 })).toBeNull()
+  })
+})

--- a/scripts/db-drift-warn.ts
+++ b/scripts/db-drift-warn.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+/**
+ * db:drift-warn — a fast, NON-BLOCKING heads-up that the dev DB is behind this
+ * worktree's migrations. Wired as `predev` / `predev:api` so `bun run dev[:api]`
+ * surfaces the exact failure that silently broke the locations page once: a dev
+ * server pointed at a DB that was several migrations stale.
+ *
+ * Deliberately NOT `db:verify`: that runs `drizzle-kit generate` (slow) and
+ * flags uncommitted schema edits (noise) — wrong for a per-start hook. This does
+ * one cheap count query, only speaks when something is wrong, and ALWAYS exits 0
+ * so it can never block dev (web doesn't even need a DB). For commit/CI gating,
+ * use `db:verify`.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const JOURNAL_PATH = resolve(import.meta.dir, '..', 'drizzle', 'meta', '_journal.json')
+
+export type MigrationCounts = { journal: number; applied: number }
+
+export type DriftStatus =
+  | { kind: 'in-sync' }
+  | { kind: 'behind'; pending: number; journal: number; applied: number }
+  | { kind: 'ahead'; journal: number; applied: number }
+
+export function assessDrift({ journal, applied }: MigrationCounts): DriftStatus {
+  if (applied < journal) return { kind: 'behind', pending: journal - applied, journal, applied }
+  if (applied > journal) return { kind: 'ahead', journal, applied }
+  return { kind: 'in-sync' }
+}
+
+export function formatDriftWarning(status: DriftStatus): string | null {
+  switch (status.kind) {
+    // 'ahead' (DB has MORE migrations than this worktree) is benign — extra
+    // tables/columns don't break reads — and common when several worktrees share
+    // one local DB. Staying silent avoids the alarm fatigue that would erode the
+    // 'behind' warning, which is the only actionable case.
+    case 'in-sync':
+    case 'ahead':
+      return null
+    case 'behind':
+      return `⚠ Database is ${status.pending} migration(s) behind this worktree (journal ${status.journal}, DB ${status.applied}).
+  Pages that read the new tables/columns will fail. Run \`bun run db:migrate\` before using the app.`
+  }
+}
+
+function readJournalCount(): number | null {
+  if (!existsSync(JOURNAL_PATH)) return null
+  try {
+    const journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf8')) as { entries?: unknown[] }
+    return journal.entries?.length ?? null
+  } catch {
+    return null
+  }
+}
+
+async function readAppliedCount(databaseUrl: string): Promise<number | null> {
+  const postgres = (await import('postgres')).default
+  const sql = postgres(databaseUrl, { max: 1 })
+  try {
+    const rows = await sql<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations`
+    return rows[0]?.n ?? 0
+  } finally {
+    await sql.end()
+  }
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) return // web dev needs no DB — nothing to assert
+  const journal = readJournalCount()
+  if (journal === null) return // no journal here — nothing to compare against
+  try {
+    const applied = await readAppliedCount(databaseUrl)
+    if (applied === null) return
+    const warning = formatDriftWarning(assessDrift({ journal, applied }))
+    if (warning) console.warn(`\n${warning}\n`)
+  } catch {
+    // DB unreachable. Dev (especially web) may not need it — stay silent, never block.
+  }
+}
+
+if (import.meta.main) {
+  // Guarantee exit 0 regardless of outcome: this is a hint, never a gate.
+  main().finally(() => process.exit(0))
+}


### PR DESCRIPTION
## Why
Tonight a dev server running from a worktree whose Postgres was **5 migrations behind** that worktree's `drizzle/` journal silently 500'd the locations page (`无法加载取还点`). Nothing warned the developer. This hardens the worktree dev-start path against that whole class of failure and reconciles the stale `.env` doc (#740).

## What
1. **`predev` / `predev:api` drift guard** (`scripts/db-drift-warn.ts`, wired in root `package.json`). On `bun run dev[:api]` it runs one cheap `SELECT count(*) FROM drizzle.__drizzle_migrations` and **loudly warns** when the DB is behind this worktree's `_journal.json`. **Always exits 0** — a hint, never a gate. Silent when in-sync, no `DATABASE_URL`, or DB unreachable (web dev needs no DB). `db:verify` remains the blocking commit/CI gate.
2. **CLAUDE.md (#740)** — the "`.env` symlinked to `packages/web/.env`" note was stale: mp's web is Vite and reads only `VITE_*` shell vars with safe fallbacks (`VITE_DEV_API_PROXY ?? localhost:8787`, `VITE_API_BASE_URL ?? '/api'`), needing no env file. Corrected + added a worktree `db:migrate` / drift-guard note.

## Design
Functional Core / Imperative Shell: pure `assessDrift`/`formatDriftWarning` (discriminated union, unit-tested with no DB) + a thin I/O shell whose `process.exit(0)` is gated behind `import.meta.main` so importing it (the test) can never kill the runner. `ahead` is deliberately **silent** to avoid alarm fatigue across shared-DB worktrees — `behind` is the only actionable case.

## Verification
- 7/7 `bun:test` cases (behind / in-sync / ahead / fresh-DB `applied:0`).
- **Real-Postgres end-to-end**, 3 states: behind(54/59) → fires `5 behind… run db:migrate`; in-sync → silent; ahead → silent; all exit 0.
- biome clean; lint:size adds no warning; husky/lint-staged (biome + tsc web/api + module-boundaries) green on commit.
- **No CI/e2e impact**: Playwright/real-db servers use `--filter @kuruma/web dev` / `bunx vite` directly, never the root `dev` script, so the predev hook never fires in CI. Confirmed by code review.

Closes #740