### PR TITLE
refactor(api): extract asTxDb helper so the tx-to-Db cast lives in one place (#733)

### DIFF
--- a/packages/api/src/repositories/drizzle/operator-grant-transaction.ts
+++ b/packages/api/src/repositories/drizzle/operator-grant-transaction.ts
@@ -2,7 +2,7 @@ import type { RunTx } from '@kuruma/shared/db'
 import type { RunOperatorGrant } from '../types'
 import { DrizzleOperatorMembershipRepository } from './operator-membership'
 import { DrizzleProviderInviteRepository } from './provider-invite'
-import type { Db } from './shared'
+import { asTxDb } from './shared'
 import { DrizzleUserRepository } from './user'
 
 /**
@@ -18,11 +18,10 @@ import { DrizzleUserRepository } from './user'
  * uses can't run interactive transactions on CF Workers, so the runner is injected.
  */
 export function createDrizzleOperatorGrant(runInteractiveTx: RunTx): RunOperatorGrant {
-  // Drizzle's tx exposes the same query-builder API as db; the cast is safe because
-  // the repos only use select/insert/update (see createDrizzleTransaction's note).
+  // Tx-bound repos via the single asTxDb cast seam (#733).
   return async (fn) =>
     runInteractiveTx(async (tx) => {
-      const txDb = tx as unknown as Db
+      const txDb = asTxDb(tx)
       return fn({
         memberships: new DrizzleOperatorMembershipRepository(txDb),
         users: new DrizzleUserRepository(txDb),

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -1,5 +1,5 @@
 import type { Column } from 'drizzle-orm'
-import type { getDb } from '@kuruma/shared/db'
+import type { getDb, RunTx } from '@kuruma/shared/db'
 import {
   addOnOptions,
   bookingEvents,
@@ -36,6 +36,23 @@ import type {
 } from '../../stores'
 
 export type Db = ReturnType<typeof getDb>
+
+// The interactive-transaction handle drizzle hands the runTx callback (#493),
+// derived from the same source so it tracks the driver type.
+type TxClient = Parameters<Parameters<RunTx>[0]>[0]
+
+/**
+ * The single sanctioned bridge from an interactive-tx handle to the repo-facing
+ * `Db` type (#733). Drizzle's tx exposes the same query-builder surface
+ * (select/insert/update/delete) as `Db`; the two driver types differ only in
+ * their result HKT (see `runTx`), so this `as unknown as Db` is the ONE place
+ * the unsafe seam lives. Repos use only those methods — if `Db` ever gains one
+ * `tx` lacks (e.g. nested transactions) this fails at runtime; revisit if
+ * Drizzle ships a Transaction utility type.
+ */
+export function asTxDb(tx: TxClient): Db {
+  return tx as unknown as Db
+}
 
 export const vehicleClassColumns = {
   id: vehicleClasses.id,

--- a/packages/api/src/repositories/drizzle/transaction.ts
+++ b/packages/api/src/repositories/drizzle/transaction.ts
@@ -7,15 +7,10 @@ import { DrizzleFeeScheduleRepository } from './fee-schedule'
 import { DrizzleInsuranceOptionRepository } from './insurance-option'
 import { DrizzleLocationRepository } from './location'
 import { DrizzleMaintenanceLogRepository } from './maintenance-log'
-import type { Db } from './shared'
+import { asTxDb } from './shared'
 import { DrizzleVehicleRepository } from './vehicle'
 
 export function createDrizzleTransaction(runInteractiveTx: RunTx): RunInTransaction {
-  // Drizzle's tx exposes the same query-builder API (select/insert/update/delete)
-  // as db. The cast is safe because repos only use those methods. If Db ever gains
-  // a method tx lacks (e.g. nested transactions), this will fail at runtime — revisit
-  // if Drizzle ships a Transaction utility type.
-  //
   // Slice 6 (#392) widens the bundle to all 7 tx-bound repos so the single-
   // transaction booking submit (proposal §4) can validate availability, append
   // the BOOKING_CREATED event, and read vehicle/location/insurance/fee rows at a
@@ -25,7 +20,7 @@ export function createDrizzleTransaction(runInteractiveTx: RunTx): RunInTransact
     // transaction (#493): the neon-http driver getDb() uses can't run
     // interactive transactions on CF Workers.
     runInteractiveTx(async (tx) => {
-      const txDb = tx as unknown as Db
+      const txDb = asTxDb(tx)
       return fn({
         vehicleRepo: new DrizzleVehicleRepository(txDb),
         maintenanceLogRepo: new DrizzleMaintenanceLogRepository(txDb),


### PR DESCRIPTION
Closes #733 (base ≠ default branch → close manually after merge).

## What
The `tx as unknown as Db` double-cast was duplicated in `transaction.ts` and `operator-grant-transaction.ts`. Extracted a single `asTxDb(tx): Db` helper into `drizzle/shared.ts` (where `Db` is defined), carrying the explanatory rationale, and call it from both factories. The unsafe seam now exists in exactly one greppable place.

The `tx` param type derives from `RunTx` (`Parameters<Parameters<RunTx>[0]>[0]`) — the same way the driver derives its own `TxHandle` — so it tracks the driver type rather than hard-coding it. `asTxDb` is a runtime identity (`return tx as unknown as Db`), so behavior is unchanged.

The shared/db driver cast (`as unknown as NeonHttpDb`, a different type) is intentionally left as-is per the issue.

## Test plan
- [x] `tsc --noEmit -p packages/api` — exit 0 (proves the type bridge holds at both call sites)
- [x] `bun run --filter @kuruma/api test` — 1430/1430 pass
- [x] `grep "as unknown as Db" packages/api/src` — only in `shared.ts` (the helper)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)