### PR TITLE
perf(web): memoize geocodedByLocation in SearchMapList (#737)

### DIFF
--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import type { SearchResultItem } from '@kuruma/shared/types/search-result'
 import { MapPin } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
 import type { MapAdapter } from './MapAdapter'
 import { SearchResultRow } from './SearchResultRow'
@@ -23,7 +23,9 @@ interface SearchMapListProps {
 export function SearchMapList({ items, adapter: Adapter }: SearchMapListProps) {
   const t = useTranslations('search')
   const [selectedId, setSelectedId] = useState<string | null>(null)
-  const mapItems = geocodedByLocation(items)
+  // Dedupe is keyed on the loader-stable `items`; memoizing keeps the plotted
+  // array reference stable across selection-only re-renders (#737).
+  const mapItems = useMemo(() => geocodedByLocation(items), [items])
 
   return (
     <div className="grid gap-4 lg:grid-cols-2">

--- a/packages/web/tests/vite/search/SearchMapList.test.tsx
+++ b/packages/web/tests/vite/search/SearchMapList.test.tsx
@@ -1,6 +1,6 @@
 import type { MapAdapter } from '@/vite/search/MapAdapter'
 import { SearchMapList } from '@/vite/search/SearchMapList'
-import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import type { SearchResultItem, SpecificSearchResult } from '@kuruma/shared/types/search-result'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it } from 'vitest'
@@ -136,5 +136,42 @@ describe('SearchMapList', () => {
   it('offers no "show on map" control for a list-only (null-coord) row', () => {
     renderMapList([carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS)])
     expect(screen.queryByRole('button', { name: /show on map/i })).toBeNull()
+  })
+
+  it('does not rebuild the plotted array on a selection-only re-render (#737)', () => {
+    const seen: SearchResultItem[][] = []
+    const CapturingAdapter: MapAdapter = ({ items, selectedId, onSelect }) => {
+      // Record the array reference handed to the adapter on every render.
+      seen.push(items)
+      return (
+        <div data-selected={selectedId ?? ''}>
+          {items.map((item) => (
+            <button
+              key={item.location.locationId}
+              type="button"
+              data-testid={`marker-${item.location.locationId}`}
+              onClick={() => onSelect(item.location.locationId)}
+            >
+              marker
+            </button>
+          ))}
+        </div>
+      )
+    }
+    render(
+      <IntlProvider locale="en" messages={en}>
+        <SearchMapList
+          items={[carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)]}
+          adapter={CapturingAdapter}
+        />
+      </IntlProvider>,
+    )
+
+    const rendersBefore = seen.length
+    // Selection-only state change: selectedId flips, the items prop is untouched.
+    fireEvent.click(screen.getByTestId('marker-loc_namba'))
+
+    expect(seen.length).toBeGreaterThan(rendersBefore) // a re-render did happen
+    expect(new Set(seen).size).toBe(1) // ...but geocodedByLocation was not re-run
   })
 })


### PR DESCRIPTION
## Summary
`SearchMapList` recomputed `geocodedByLocation(items)` on every render — including the frequent selection-only re-renders from marker/row clicks — rebuilding the O(n) deduped array and handing a fresh reference to the injected map adapter each time. Wrap it in `useMemo` keyed on the loader-stable `items`.

## Verification
- New reference-stability test: the adapter receives a **single** array reference across a selection-only re-render (was 2 before the memo — confirmed RED→GREEN).
- Existing 6 SearchMapList behavior tests unchanged; 7/7 green.
- web tsc EXIT=0, biome clean.

## AC (#737)
- [x] `mapItems` computed via `useMemo` keyed on `items`
- [x] `geocodedByLocation` does not re-run on a selection-only state change (proven by the test)
- [x] Map and list behavior unchanged

Closes #737
Part of #701