### PR TITLE
chore(api): lint-flag concrete-repo construction outside the composition root (#721)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,12 @@ index.ts       → Composition root (constructs concretes, wires DI)
 | Routes import services and `routes/helpers.ts` only. Never repositories. | Routes handle HTTP concerns; business logic belongs in services. |
 | Services import repository *interfaces* (`types.ts`) only. Never concrete classes. | Enables swapping InMemory ↔ Drizzle without touching business logic. |
 | Only `index.ts` imports concrete classes (`DrizzleBookingRepository`, `InMemoryBookingRepository`, etc.) | Single place to change wiring; the rest of the code is implementation-agnostic. |
-| No `new ConcreteRepository()` outside `index.ts`. | Prevents hidden coupling that breaks testability. |
+| No `new ConcreteRepository()` outside the composition root (`index.ts` / `composition/`) — except the two transaction factories (`repositories/drizzle/*-transaction.ts`). | Prevents hidden coupling that breaks testability. The tx factories are the lone carve-out: they must rebind every repo to the per-call neon-serverless tx connection, which `index.ts` can't do per call. |
 
 Shared helpers live in `routes/helpers.ts`: `ok()`, `fail()`, `parseBody()`, `parseDateRange()`.
 Use them instead of manual `c.json({ success: true/false, ... })` construction.
 
-Enforced by `bun run --filter @kuruma/api lint:boundaries` (CI step).
+Enforced by `bun run --filter @kuruma/api lint:boundaries` (CI step) — which also flags any `new Drizzle*`/`new InMemory*` construction outside the composition root and the sanctioned `*-transaction.ts` factories.
 
 ## Commands
 

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -60,9 +60,14 @@ section in `AGENTS.md`.
 - **Services depend on interfaces, not implementations.** A service receives its
   repositories by injection so a test can pass an `InMemory*` double and prod
   can pass a `Drizzle*` one without changing the service.
-- **Only `index.ts` may `new` a concrete repository.** Routes are factory
+- **Only the composition root may `new` a concrete repository.** Routes are factory
   functions (e.g. `createBookingRoutes(bookingService)`) chained onto the app
   via `.route('/', …)` inside `createApp()` in `index.ts`. There is no `app.ts`.
+- **The one carve-out: transaction factories.** `repositories/drizzle/transaction.ts`
+  and `operator-grant-transaction.ts` construct concrete repos directly, because each
+  must rebind to the per-call neon-serverless transaction connection (#493) — something
+  `index.ts` cannot do per call. They are the *only* files outside the composition root
+  allowed to `new` a concrete; the boundary linter flags construction anywhere else.
 
 ### Enforcement
 
@@ -75,8 +80,10 @@ bun run --filter @kuruma/api lint:boundaries
 It is a CI step (`.github/workflows/ci.yml`) and flags:
 1. a `routes/` file importing a concrete repository,
 2. a `services/` file importing a concrete repository,
-3. any non-`index.ts` file importing `repositories/drizzle` or `repositories/in-memory`,
-4. a route calling `c.req.json()` instead of `parseBody()`.
+3. any non-composition-root file importing `repositories/drizzle` or `repositories/in-memory`,
+4. a route calling `c.req.json()` instead of `parseBody()`,
+5. a `new Drizzle*`/`new InMemory*` construction outside the composition root and the
+   sanctioned `repositories/drizzle/*-transaction.ts` factories.
 
 `*.test.ts` files are exempt — they legitimately construct concretes to exercise DI.
 

--- a/packages/api/scripts/check-import-boundaries.ts
+++ b/packages/api/scripts/check-import-boundaries.ts
@@ -32,9 +32,8 @@ function collectTsFiles(dir: string): string[] {
   return files
 }
 
-function checkFile(filePath: string): Violation[] {
+export function checkContent(rel: string, content: string): Violation[] {
   const violations: Violation[] = []
-  const rel = relative(API_SRC, filePath)
 
   // Test files are not part of the production dependency graph. They
   // legitimately construct concrete repositories to exercise the DI wiring
@@ -42,7 +41,7 @@ function checkFile(filePath: string): Violation[] {
   // rules govern production code only, so co-located *.test.ts are exempt.
   if (rel.endsWith('.test.ts') || rel.endsWith('.spec.ts')) return violations
 
-  const lines = readFileSync(filePath, 'utf-8').split('\n')
+  const lines = content.split('\n')
 
   const isRoute = rel.startsWith('routes/')
   const isService = rel.startsWith('services/')
@@ -51,6 +50,13 @@ function checkFile(filePath: string): Violation[] {
   // nothing else may. Keep these the only entries allowed to wire concretes.
   const isCompositionRoot = rel === 'index.ts' || rel.startsWith('composition/')
   const isHelpers = rel === 'routes/helpers.ts'
+  // The two transaction factories are the one sanctioned place outside the
+  // composition root to construct concrete repos. They must rebind every repo to
+  // the per-call neon-serverless tx connection (#493), which index.ts cannot do
+  // per call. Everything else under repositories/drizzle stays construction-free (#721).
+  const isTxFactory =
+    rel === 'repositories/drizzle/transaction.ts' ||
+    rel === 'repositories/drizzle/operator-grant-transaction.ts'
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
@@ -66,6 +72,23 @@ function checkFile(filePath: string): Violation[] {
         line: i + 1,
         text: trimmed,
         rule: 'Routes must use parseBody(c, schema) from helpers.ts instead of calling c.req.json() directly.',
+      })
+    }
+
+    // Rule 5: Concrete repositories may only be `new`ed in the composition root
+    // (index.ts / composition/) or the two sanctioned transaction factories. The
+    // import-path rules below never see construction, so a sibling file under
+    // repositories/drizzle could `new DrizzleXRepository()` and slip the net (#721).
+    if (
+      !isCompositionRoot &&
+      !isTxFactory &&
+      /\bnew\s+(?:Drizzle|InMemory)\w*\s*\(/.test(trimmed)
+    ) {
+      violations.push({
+        file: rel,
+        line: i + 1,
+        text: trimmed,
+        rule: 'Concrete repositories may only be constructed in the composition root (index.ts / composition/) or the sanctioned transaction factories (repositories/drizzle/*-transaction.ts).',
       })
     }
 
@@ -123,17 +146,25 @@ function checkFile(filePath: string): Violation[] {
   return violations
 }
 
-const files = collectTsFiles(API_SRC)
-const allViolations = files.flatMap(checkFile)
+function checkFile(filePath: string): Violation[] {
+  return checkContent(relative(API_SRC, filePath), readFileSync(filePath, 'utf-8'))
+}
 
-if (allViolations.length > 0) {
-  console.error('\nImport boundary violations found:\n')
-  for (const v of allViolations) {
-    console.error(`  ${v.file}:${v.line}`)
-    console.error(`    ${v.text}`)
-    console.error(`    Rule: ${v.rule}\n`)
+// Only scan the tree when run as a script. Importing this module (e.g. from a
+// unit test that exercises checkContent) must not trigger the scan or exit.
+if (import.meta.main) {
+  const files = collectTsFiles(API_SRC)
+  const allViolations = files.flatMap(checkFile)
+
+  if (allViolations.length > 0) {
+    console.error('\nImport boundary violations found:\n')
+    for (const v of allViolations) {
+      console.error(`  ${v.file}:${v.line}`)
+      console.error(`    ${v.text}`)
+      console.error(`    Rule: ${v.rule}\n`)
+    }
+    process.exit(1)
+  } else {
+    console.log('Import boundaries OK')
   }
-  process.exit(1)
-} else {
-  console.log('Import boundaries OK')
 }

--- a/packages/api/tests/scripts/check-import-boundaries.test.ts
+++ b/packages/api/tests/scripts/check-import-boundaries.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkContent } from '../../scripts/check-import-boundaries'
+
+const CONSTRUCT_RULE = /Concrete repositories.*only be constructed/
+
+describe('check-import-boundaries — construction rule (#721)', () => {
+  it('flags constructing a concrete repository in a service file', () => {
+    const content = [
+      'export function wire() {',
+      '  return new DrizzleBookingRepository(db)',
+      '}',
+    ].join('\n')
+
+    const violations = checkContent('services/booking-service.ts', content)
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      file: 'services/booking-service.ts',
+      line: 2,
+      rule: expect.stringMatching(CONSTRUCT_RULE),
+    })
+  })
+
+  it('flags constructing a concrete in a NON-transaction file under repositories/drizzle', () => {
+    const content = 'const repo = new DrizzleVehicleRepository(db)'
+
+    const violations = checkContent('repositories/drizzle/booking.ts', content)
+
+    expect(violations.map((v) => v.rule)).toContainEqual(expect.stringMatching(CONSTRUCT_RULE))
+  })
+
+  it('allows the sanctioned transaction factories to construct tx-bound concretes', () => {
+    const txBody = [
+      'vehicleRepo: new DrizzleVehicleRepository(txDb),',
+      'bookingRepo: new DrizzleBookingRepository(txDb),',
+    ].join('\n')
+
+    expect(checkContent('repositories/drizzle/transaction.ts', txBody)).toEqual([])
+    expect(
+      checkContent(
+        'repositories/drizzle/operator-grant-transaction.ts',
+        'users: new DrizzleUserRepository(txDb),',
+      ),
+    ).toEqual([])
+  })
+
+  it('allows the composition root to construct concretes', () => {
+    expect(checkContent('index.ts', 'const r = new DrizzleBookingRepository(db)')).toEqual([])
+    expect(
+      checkContent('composition/repositories.ts', 'const r = new InMemoryBookingRepository()'),
+    ).toEqual([])
+  })
+
+  it('exempts test files from the construction rule', () => {
+    expect(
+      checkContent('services/foo.test.ts', 'const r = new DrizzleBookingRepository(db)'),
+    ).toEqual([])
+  })
+
+  it('does not flag benign non-repository constructors (rule is prefix-anchored)', () => {
+    const content = [
+      'const now = new Date()',
+      'const seen = new Map()',
+      'const res = new Response()',
+    ].join('\n')
+
+    expect(checkContent('services/booking-service.ts', content)).toEqual([])
+  })
+
+  it('still flags a route importing a concrete repository (existing Rule 1 unbroken)', () => {
+    const content = "import { DrizzleBookingRepository } from '../repositories/drizzle/booking'"
+
+    const violations = checkContent('routes/bookings.ts', content)
+
+    expect(violations.map((v) => v.rule)).toContainEqual(
+      expect.stringMatching(/must not import concrete repositories/),
+    )
+  })
+})


### PR DESCRIPTION
Closes #721.

## Problem
`AGENTS.md` says "No `new ConcreteRepository()` outside `index.ts`", but the import-boundary linter only inspected **import lines** — it never saw construction. The two transaction factories under `repositories/drizzle/` (`transaction.ts`, `operator-grant-transaction.ts`) `new` 11 concrete repos by necessity (each must rebind to the per-call neon-serverless tx connection, #493). They import siblings via `./booking` etc., which Rule 3 deliberately doesn't match — so they were **silently unguarded**, and any sibling file could `new DrizzleXRepository()` and slip the net. The carve-out was real and correct but undocumented and unenforced.

## Change
- **Refactor (FC/IS):** extract a pure `checkContent(rel, content)` core from `checkFile`; guard the tree-scan/`process.exit` behind `import.meta.main` so the module is import-safe for unit tests.
- **Rule 5 (construction):** flag `new (Drizzle|InMemory)\w*(` outside the composition root (`index.ts` / `composition/`) and the two sanctioned `repositories/drizzle/*-transaction.ts` factories. Exact-path allow-list — a hypothetical new `*-transaction.ts` is **not** auto-sanctioned.
- **Docs:** carve-out + rationale in `AGENTS.md` and `docs/architecture/modules.md` (enforcement list now has 5 items).
- **Tests:** 7 vitest cases (`tests/scripts/check-import-boundaries.test.ts`) — flags service + non-tx-drizzle construction; allows the two tx factories + composition root; exempts `*.test.ts`; proves the rule is prefix-anchored (benign `new Date()`/`new Map()` not flagged); confirms existing Rule 1 unbroken.

## Acceptance criteria (all met)
- [x] `modules.md` + `AGENTS.md` state the `*-transaction.ts` carve-out + rationale
- [x] linter explicitly allows the two tx files and documents why (inline comment ties to #493/#721)
- [x] `lint:boundaries` still passes on the live tree
- [x] adding a `new DrizzleXRepository()` to a non-transaction file is flagged

## Verification
- `bun run --filter @kuruma/api test tests/scripts/check-import-boundaries.test.ts` → **7/7**
- `bun run --filter @kuruma/api typecheck` → exit 0
- `bun run --filter @kuruma/api lint:boundaries` → "Import boundaries OK" (before & after rebase onto trunk)
- `bun run lint` (biome + size + modules) → exit 0
- Probe: an injected `new DrizzleBookingRepository()` under `repositories/drizzle/` made the script exit 1, pointing at the **construction** line (not the import)
- code-reviewer agent: ship-ready, no CRITICAL/HIGH

Base is `marketplace-pivot` (not the default branch), so this won't auto-close #721 on merge — will close manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)