### PR TITLE
test(web): strengthen error-helper assertions to specific type+message (#734)

### DIFF
--- a/packages/web/tests/vite/operator-fleet/api.test.ts
+++ b/packages/web/tests/vite/operator-fleet/api.test.ts
@@ -104,13 +104,17 @@ describe('fetchVehicleDetail', () => {
     expect(await fetchVehicleDetail('missing')).toBeNull()
   })
 
-  it('throws ApiError on a failure envelope (e.g. a renter 403)', async () => {
+  it('throws ApiError carrying the status and message on a failure envelope (renter 403)', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => jsonResponse({ success: false, error: 'Forbidden' }, 403)),
     )
 
     await expect(fetchVehicleDetail('veh-1')).rejects.toBeInstanceOf(ApiError)
+    await expect(fetchVehicleDetail('veh-1')).rejects.toMatchObject({
+      status: 403,
+      message: 'Forbidden',
+    })
   })
 })
 

--- a/packages/web/tests/vite/session.test.ts
+++ b/packages/web/tests/vite/session.test.ts
@@ -113,7 +113,7 @@ describe('fetchSession', () => {
       'fetch',
       vi.fn(async () => jsonResponse({ success: false }, 500)),
     )
-    await expect(fetchSession()).rejects.toThrow()
+    await expect(fetchSession()).rejects.toThrow('Failed to load session: 500')
   })
 })
 


### PR DESCRIPTION
## Summary
Replaces weak `.rejects.toThrow()` assertions with specific type+message contracts (testing cheat-sheet: a bare throw passes even if the wrong error type/message is thrown).

- **session.test.ts**: bare `.toThrow()` on a 500 → `.toThrow('Failed to load session: 500')` (mirrors the sibling `signOut '403'` test). `fetchSession` throws a plain `Error`, not `ApiError`.
- **operator-fleet/api.test.ts**: the original `modules/vehicles/vehicle-api.test.ts` was deleted by #704; its live replacement asserted only `toBeInstanceOf(ApiError)`. Added `status: 403, message: 'Forbidden'` so it fails if the error type **or** message regresses.

## Verification
- 16/16 tests green (session 9, fleet 7); web tsc EXIT=0; biome clean.

## AC (#734)
- [x] vehicle client asserts the specific ApiError type + message contract
- [x] session test asserts the specific '500'/load-session message
- [x] both fail if the thrown error type or message changes
- [x] green in the web suite

Closes #734
Part of #701