### PR TITLE
refactor(web): Zod-validate reservation/search/bookings response bodies (#711)

### DIFF
--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -1,8 +1,9 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { AddOnSnapshot, FeeSnapshotItem, InsuranceSnapshot } from '@kuruma/shared/db/schema'
-import type { BookingStatus } from '@kuruma/shared/enums'
+import { BOOKING_STATUSES, type BookingStatus, FEE_TYPES, FEE_UNITS } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // JSON-serialized booking (#392/#460) as the renter read model sees it — dates
 // are ISO strings (no Date instances). The Vite shell owns this DTO rather than
@@ -32,8 +33,57 @@ export interface BookingDto {
   notes: string | null
   createdAt: string
   updatedAt: string
-  operator?: { name: string; preAuthHandoffUrl: string | null }
+  operator?: { name: string; preAuthHandoffUrl: string | null } | undefined
 }
+
+// #711: response schemas pin the runtime parse to the DTOs above via `satisfies
+// z.ZodType<...>` — the interfaces stay the single source for the shape, while a
+// drifted/dropped field now fails as a ParseError at the seam instead of
+// surfacing as `undefined` on the confirmation page or in My Bookings.
+const insuranceSnapshotSchema = z.object({
+  insuranceOptionId: z.string(),
+  name: z.string(),
+  dailyPriceJpy: z.number(),
+  deductibleJpy: z.number().nullable(),
+}) satisfies z.ZodType<InsuranceSnapshot>
+
+const feeSnapshotItemSchema = z.object({
+  feeType: z.enum(FEE_TYPES),
+  unit: z.enum(FEE_UNITS),
+  amountJpy: z.number(),
+  vehicleClassId: z.string().nullable(),
+}) satisfies z.ZodType<FeeSnapshotItem>
+
+const addOnSnapshotSchema = z.object({
+  addOnId: z.string(),
+  name: z.string(),
+  priceJpy: z.number(),
+}) satisfies z.ZodType<AddOnSnapshot>
+
+const bookingDtoSchema = z.object({
+  id: z.string(),
+  bookingCode: z.string(),
+  renterId: z.string(),
+  classId: z.string().nullable(),
+  requestedVehicleId: z.string(),
+  assignedVehicleId: z.string(),
+  pickupLocationId: z.string(),
+  dropoffLocationId: z.string(),
+  startAt: z.string(),
+  endAt: z.string(),
+  effectiveEndAt: z.string(),
+  status: z.enum(BOOKING_STATUSES),
+  source: z.string(),
+  insuranceOptionId: z.string().nullable(),
+  insuranceSnapshot: insuranceSnapshotSchema.nullable(),
+  feeSnapshot: z.array(feeSnapshotItemSchema),
+  addOnSnapshot: z.array(addOnSnapshotSchema),
+  totalPrice: z.number().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  operator: z.object({ name: z.string(), preAuthHandoffUrl: z.string().nullable() }).optional(),
+}) satisfies z.ZodType<BookingDto>
 
 // What the renter selected in the wizard; the server derives operatorId, classId,
 // assignedVehicleId, totalPrice + snapshots (none are client fields, proposal §6.2).
@@ -80,7 +130,7 @@ export async function createBooking(
       disclaimerAccepted: input.disclaimerAccepted,
     }),
   })
-  return unwrap<BookingDto>(res)
+  return unwrap(res, bookingDtoSchema)
 }
 
 // Renter-scoped read for the confirmation page. The API's GET /bookings/:id is
@@ -92,7 +142,7 @@ export async function fetchBookingById(id: string): Promise<BookingDto | null> {
     credentials: 'include',
   })
   if (res.status === 404) return null
-  return unwrap<BookingDto>(res)
+  return unwrap(res, bookingDtoSchema)
 }
 
 export function bookingByIdQueryOptions(id: string) {
@@ -130,6 +180,16 @@ interface RawMyBooking {
   vehicle?: { name: string; photos: string[] } | undefined
 }
 
+const rawMyBookingSchema = z.object({
+  id: z.string(),
+  bookingCode: z.string(),
+  status: z.enum(BOOKING_STATUSES),
+  startAt: z.string(),
+  endAt: z.string(),
+  totalPrice: z.number().nullable(),
+  vehicle: z.object({ name: z.string(), photos: z.array(z.string()) }).optional(),
+}) satisfies z.ZodType<RawMyBooking>
+
 function toMyRow(b: RawMyBooking): MyBookingRow {
   return {
     id: b.id,
@@ -152,7 +212,7 @@ export async function fetchMyBookings(renterId: string): Promise<MyBookingRow[]>
   const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
     credentials: 'include',
   })
-  const data = await unwrap<RawMyBooking[]>(res)
+  const data = await unwrap(res, rawMyBookingSchema.array())
   return data.map(toMyRow)
 }
 

--- a/packages/web/src/vite/reservation/api.ts
+++ b/packages/web/src/vite/reservation/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { z } from 'zod'
 
 // JSON shapes returned by the public storefront endpoints the reservation wizard
 // consumes (#460/#392). The Vite shell owns these DTOs so it stays free of the
@@ -7,22 +8,28 @@ import { getApiBaseUrl } from '@/vite/api-base'
 // are no Date instances. These mirror the renter-safe projections in
 // services/storefront-detail.ts (StorefrontAddOn / StorefrontInsuranceOption).
 
-export interface ReservationAddOn {
-  id: string
-  name: string
-  description: string | null
+// #711: the schema is the single source — the DTO type is inferred from it, so
+// web's compile-time shape and the runtime parse at the seam derive from one
+// definition and cannot drift. A renamed/dropped field fails as a ParseError in
+// the fetch helpers below instead of surfacing as `undefined` deep in the wizard.
+export const reservationAddOnSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
   /** Flat price charged once per booking (not per-day). */
-  priceJpy: number
-}
+  priceJpy: z.number(),
+})
+export type ReservationAddOn = z.infer<typeof reservationAddOnSchema>
 
-export interface ReservationInsuranceOption {
-  id: string
-  name: string
-  description: string | null
+export const reservationInsuranceOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
   /** Per-day coverage price (billed × rental days). */
-  dailyPriceJpy: number
-  deductibleJpy: number | null
-}
+  dailyPriceJpy: z.number(),
+  deductibleJpy: z.number().nullable(),
+})
+export type ReservationInsuranceOption = z.infer<typeof reservationInsuranceOptionSchema>
 
 // Public endpoints — no auth. ACTIVE-only, single-operator reads (the API seals
 // cross-tenant leaks). A 404 (unknown/archived storefront) surfaces as an
@@ -32,7 +39,7 @@ export async function fetchAddOns(locationId: string): Promise<ReservationAddOn[
     `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/add-ons`,
     { credentials: 'include' },
   )
-  return unwrap<ReservationAddOn[]>(res)
+  return unwrap(res, reservationAddOnSchema.array())
 }
 
 export async function fetchInsuranceOptions(
@@ -42,5 +49,5 @@ export async function fetchInsuranceOptions(
     `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/insurance-options`,
     { credentials: 'include' },
   )
-  return unwrap<ReservationInsuranceOption[]>(res)
+  return unwrap(res, reservationInsuranceOptionSchema.array())
 }

--- a/packages/web/src/vite/search/api.ts
+++ b/packages/web/src/vite/search/api.ts
@@ -1,11 +1,62 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { SearchResultsData } from '@kuruma/shared/types/search-result'
+import { z } from 'zod'
+
+// #711: a runtime mirror of the shared search-result contract. `satisfies
+// z.ZodType<SearchResultsData>` pins it to that single-source type, so the schema
+// can't fall out of sync without a compile error — while at runtime a drifted or
+// dropped renter-safe field now fails as a ParseError at the seam instead of
+// surfacing as `undefined` deep in the map/list.
+const resultLocationSchema = z.object({
+  locationId: z.string(),
+  operatorId: z.string(),
+  operatorName: z.string(),
+  name: z.string(),
+  address: z.string(),
+  latitude: z.number().nullable(),
+  longitude: z.number().nullable(),
+})
+
+const searchResultBase = {
+  location: resultLocationSchema,
+  dailyRateJpy: z.number().nullable(),
+  hourlyRateJpy: z.number().nullable(),
+  classLabel: z.string(),
+  acrissCode: z.string().nullable(),
+  seats: z.number(),
+  photos: z.array(z.string()),
+}
+
+const searchResultsDataSchema = z.object({
+  items: z.array(
+    z.discriminatedUnion('kind', [
+      z.object({
+        kind: z.literal('SPECIFIC'),
+        ...searchResultBase,
+        vehicleId: z.string(),
+        name: z.string(),
+        make: z.string().nullable(),
+        model: z.string().nullable(),
+        year: z.number().nullable(),
+        transmission: z.enum(['AUTO', 'MANUAL']),
+      }),
+      z.object({
+        kind: z.literal('CLASS_COMBO'),
+        ...searchResultBase,
+        classId: z.string(),
+        availableCount: z.number(),
+      }),
+    ]),
+  ),
+  nextCursor: z.string().nullable(),
+}) satisfies z.ZodType<SearchResultsData>
 
 // The cross-operator flat search result contract (#458) is the shared
 // `@kuruma/shared/types/search-result` union — the same DTO the API service
-// returns, so there is no separate web mirror to drift. The API serializes to
-// JSON, so the payload carries no Date instances (range goes out as ISO).
+// returns. `searchResultsDataSchema` above is the runtime mirror. The API
+// serializes to JSON, so the payload carries no Date instances (range goes out
+// as ISO).
 export interface FlatSearchParams {
   from: Date
   to: Date
@@ -34,5 +85,5 @@ export async function fetchSearchResults(params: FlatSearchParams): Promise<Sear
   const res = await fetch(`${getApiBaseUrl()}/search/vehicles?${sp.toString()}`, {
     credentials: 'include',
   })
-  return unwrap<SearchResultsData>(res)
+  return unwrap(res, searchResultsDataSchema)
 }

--- a/packages/web/tests/vite/bookings/api.test.ts
+++ b/packages/web/tests/vite/bookings/api.test.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/lib/api-error'
+import { ApiError, ParseError } from '@/lib/api-error'
 import {
   createBooking,
   fetchBookingById,
@@ -230,5 +230,39 @@ describe('fetchMyBookings', () => {
 describe('myBookingsQueryOptions', () => {
   it('keys by the renter so two principals never collide on cache', () => {
     expect(myBookingsQueryOptions('me-42').queryKey).toEqual(['bookings', 'mine', 'me-42'])
+  })
+})
+
+// #711: validate the response body at the seam. Drift (a renamed/dropped field)
+// must fail here as a ParseError, not surface as `undefined` on the confirmation
+// page or in the My Bookings list.
+describe('bookings response validation (#711)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetchBookingById rejects with a ParseError when the booking body drifts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: { id: 'b-1', bookingCode: 'ABCD1234', status: 'CONFIRMED' },
+        }),
+      ),
+    )
+    await expect(fetchBookingById('b-1')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('fetchMyBookings rejects with a ParseError when a row omits bookingCode', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [rawMyBooking({ bookingCode: undefined })],
+          nextCursor: null,
+        }),
+      ),
+    )
+    await expect(fetchMyBookings('me-42')).rejects.toBeInstanceOf(ParseError)
   })
 })

--- a/packages/web/tests/vite/reservation/api.test.ts
+++ b/packages/web/tests/vite/reservation/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { fetchAddOns, fetchInsuranceOptions } from '@/vite/reservation/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -81,5 +82,37 @@ describe('fetchInsuranceOptions', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/storefronts/loc-1/insurance-options', {
       credentials: 'include',
     })
+  })
+})
+
+// #711: validate the response body at the network seam. A renamed/dropped field
+// must fail here as a ParseError, not surface as `undefined` deep in the wizard.
+describe('reservation response validation (#711)', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('rejects with a ParseError when an add-on row drifts (priceJpy renamed)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [{ id: 'a1', name: 'Baby seat', description: null, priceAmount: 2000 }],
+        }),
+      ),
+    )
+    await expect(fetchAddOns('loc-1')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('rejects with a ParseError when an insurance row omits dailyPriceJpy (drift)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [{ id: 'i1', name: 'Basic', description: null, deductibleJpy: 50000 }],
+        }),
+      ),
+    )
+    await expect(fetchInsuranceOptions('loc-1')).rejects.toBeInstanceOf(ParseError)
   })
 })

--- a/packages/web/tests/vite/search/api.test.ts
+++ b/packages/web/tests/vite/search/api.test.ts
@@ -66,6 +66,42 @@ describe('fetchSearchResults', () => {
     expect(url.searchParams.get('limit')).toBe('20')
   })
 
+  it('parses a CLASS_COMBO row with null coordinates + rates (the schema laxness margin)', async () => {
+    // Every `.nullable()`/CLASS_COMBO branch is a safety margin: the API legitimately
+    // sends null coords (not-yet-geocoded), null rates, and CLASS_COMBO items. They
+    // must parse, not throw — this guards against a later "tidy-up" tightening.
+    const classCombo = {
+      kind: 'CLASS_COMBO',
+      location: {
+        locationId: 'loc2',
+        operatorId: 'op2',
+        operatorName: 'Kyoto Cars',
+        name: 'Kyoto Station',
+        address: '2-2 Kyoto',
+        latitude: null,
+        longitude: null,
+      },
+      dailyRateJpy: null,
+      hourlyRateJpy: 1200,
+      classLabel: 'SUV',
+      acrissCode: null,
+      seats: 7,
+      photos: [],
+      classId: 'cls-1',
+      availableCount: 3,
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: { items: [classCombo], nextCursor: null } }),
+      ),
+    )
+    await expect(fetchSearchResults(range)).resolves.toEqual({
+      items: [classCombo],
+      nextCursor: null,
+    })
+  })
+
   it('rejects with a ParseError when a result row drifts (missing seats/location)', async () => {
     // The API dropped renter-safe fields; the legacy cast surfaced them as
     // `undefined` deep in the map/list. With a schema the drift fails at the seam.

--- a/packages/web/tests/vite/search/api.test.ts
+++ b/packages/web/tests/vite/search/api.test.ts
@@ -1,0 +1,86 @@
+import { ParseError } from '@/lib/api-error'
+import { fetchSearchResults } from '@/vite/search/api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// A complete SPECIFIC search row (#458) — the renter-safe per-car projection.
+const specificItem = {
+  kind: 'SPECIFIC',
+  location: {
+    locationId: 'loc1',
+    operatorId: 'op1',
+    operatorName: 'Osaka Cars',
+    name: 'Namba Pickup',
+    address: '1-1 Namba',
+    latitude: 34.6,
+    longitude: 135.5,
+  },
+  dailyRateJpy: 8000,
+  hourlyRateJpy: null,
+  classLabel: 'Compact',
+  acrissCode: 'CDMR',
+  seats: 5,
+  photos: ['a.jpg'],
+  vehicleId: 'v1',
+  name: 'Toyota Aqua',
+  make: 'Toyota',
+  model: 'Aqua',
+  year: 2022,
+  transmission: 'AUTO',
+}
+
+const range = {
+  from: new Date('2026-07-01T01:00:00.000Z'),
+  to: new Date('2026-07-03T01:00:00.000Z'),
+}
+
+describe('fetchSearchResults', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('serializes the range + repeatable class filters and unwraps the flat list', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: { items: [specificItem], nextCursor: 'cur-2' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchSearchResults({
+      ...range,
+      pickupLocationId: 'loc1',
+      classes: ['CDMR', 'ICAR'],
+      limit: 20,
+    })
+
+    expect(result).toEqual({ items: [specificItem], nextCursor: 'cur-2' })
+    const url = new URL((fetchMock.mock.calls[0] as [string])[0], 'http://x')
+    expect(url.pathname).toBe('/api/search/vehicles')
+    expect(url.searchParams.get('from')).toBe('2026-07-01T01:00:00.000Z')
+    expect(url.searchParams.get('to')).toBe('2026-07-03T01:00:00.000Z')
+    expect(url.searchParams.get('pickupLocationId')).toBe('loc1')
+    expect(url.searchParams.getAll('class')).toEqual(['CDMR', 'ICAR'])
+    expect(url.searchParams.get('limit')).toBe('20')
+  })
+
+  it('rejects with a ParseError when a result row drifts (missing seats/location)', async () => {
+    // The API dropped renter-safe fields; the legacy cast surfaced them as
+    // `undefined` deep in the map/list. With a schema the drift fails at the seam.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: {
+            items: [{ kind: 'SPECIFIC', vehicleId: 'v1', name: 'Toyota Aqua' }],
+            nextCursor: null,
+          },
+        }),
+      ),
+    )
+    await expect(fetchSearchResults(range)).rejects.toBeInstanceOf(ParseError)
+  })
+})


### PR DESCRIPTION
Slice 2 of the #711 `unwrap` migration (Slice 1 = #786). Threads response schemas through the three renter-facing data clients so API/web drift fails as a `ParseError` at the network seam instead of surfacing as `undefined` deep in render.

## What
- **reservation** — add-on + insurance schemas; DTO types now inferred from them.
- **search** — `discriminatedUnion('kind', …)` mirror of `SearchResultsData`, pinned to the shared type via `satisfies z.ZodType<…>` (the shared type stays the single source; the schema can't drift without a compile error).
- **bookings** — `BookingDto` + `RawMyBooking` + the three booking snapshots, pinned to the shared DTO/enum/snapshot types via `satisfies`.

Advances AC#2 (booking + vehicle clients validate; `class`/operator-classes already did in Slice 1).

## Out of scope (Slice 3)
The large operator clients (`operator-fleet` ~327 LOC, `operator-bookings` ~323 LOC) and the `customer` boundary — they need the #785 `vite/<feature>/schema.ts` convention to stay under the 800-line `lint:size` cap.

## Test plan
- [x] TDD: a drifted/renamed/dropped field per client → `ParseError` at the seam (6 new tests).
- [x] `bun run --filter @kuruma/web typecheck` — clean (all `satisfies` pins compile).
- [x] `bun run --filter @kuruma/web test` — 761 passed (no regressions).
- [x] biome check clean.

Part of #711