### PR TITLE
feat(api): operator→region loop guard on location save (#651 Slice 2)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -384,7 +384,7 @@ export function createApp(overrides?: AppOverrides) {
   // inference is retired, so it no longer needs an operator lookup.
   const resolveWriteOperatorId: ResolveWriteOperatorId = (ctx, inputOperatorId) =>
     resolveOperatorIdForWrite(ctx, inputOperatorId)
-  const locationService = new LocationService(locationRepo, bookingRepo, geocoder)
+  const locationService = new LocationService(locationRepo, bookingRepo, geocoder, regionRepo)
   const insuranceOptionService = new InsuranceOptionService(insuranceOptionRepo)
   const addOnService = new AddOnService(addOnRepo)
   const feeScheduleService = new FeeScheduleService(feeScheduleRepo)

--- a/packages/api/src/repositories/drizzle/region.ts
+++ b/packages/api/src/repositories/drizzle/region.ts
@@ -1,4 +1,5 @@
 import { regions } from '@kuruma/shared/db/schema'
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { asc } from 'drizzle-orm'
 import type { Region } from '../../stores'
 import { collectDescendantIds } from '../region-tree'
@@ -11,6 +12,18 @@ const regionColumns = {
   nameEn: regions.nameEn,
   nameJa: regions.nameJa,
   nameZh: regions.nameZh,
+  sortOrder: regions.sortOrder,
+}
+
+// The geo/taxonomy projection (#651 Slice 2) — exactly what `nearestAssignableRegion`
+// needs to match a pickup point to its nearest assignable area + validate a supplied
+// regionId. Mirrors the one-off backfill's projection (backfill-regions.ts).
+const regionCandidateColumns = {
+  id: regions.id,
+  latitude: regions.latitude,
+  longitude: regions.longitude,
+  assignable: regions.assignable,
+  status: regions.status,
   sortOrder: regions.sortOrder,
 }
 
@@ -28,6 +41,10 @@ export class DrizzleRegionRepository implements RegionRepository {
       .select(regionColumns)
       .from(regions)
       .orderBy(asc(regions.sortOrder), asc(regions.nameEn))
+  }
+
+  async findCandidates(): Promise<RegionCandidate[]> {
+    return this.db.select(regionCandidateColumns).from(regions)
   }
 
   async findDescendantIds(rootId: string): Promise<string[]> {

--- a/packages/api/src/repositories/in-memory/region.ts
+++ b/packages/api/src/repositories/in-memory/region.ts
@@ -1,3 +1,4 @@
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import type { Region } from '../../stores'
 import { collectDescendantIds } from '../region-tree'
 import type { RegionRepository } from '../types'
@@ -8,10 +9,20 @@ import type { RegionRepository } from '../types'
  * contract the Drizzle impl honours. Platform-global (no CallerContext).
  */
 export class InMemoryRegionRepository implements RegionRepository {
-  constructor(private readonly regions: readonly Region[] = []) {}
+  // `candidates` (the geo/taxonomy projection #651 Slice 2) is a SEPARATE optional
+  // seed from the cascade `regions`, so existing fixtures that only need the tree
+  // stay a one-arg construct; the loop-guard tests seed candidates directly.
+  constructor(
+    private readonly regions: readonly Region[] = [],
+    private readonly candidates: readonly RegionCandidate[] = [],
+  ) {}
 
   async findAll(): Promise<Region[]> {
     return [...this.regions]
+  }
+
+  async findCandidates(): Promise<RegionCandidate[]> {
+    return [...this.candidates]
   }
 
   async findDescendantIds(rootId: string): Promise<string[]> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -25,6 +25,7 @@ export type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 export type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 
 import type { CoordinateSource } from '@kuruma/shared/db/schema'
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
@@ -531,6 +532,16 @@ export interface RegionRepository {
   findAll(): Promise<Region[]>
   /** `rootId` plus every descendant id (inclusive). Empty when `rootId` is unknown. */
   findDescendantIds(rootId: string): Promise<string[]>
+  /**
+   * Every region projected to the geo/taxonomy columns needed to match a pickup
+   * point to its nearest assignable area (#651 Slice 2): the operator location-save
+   * loop guard derives a region from coords via `nearestAssignableRegion`, and
+   * validates that an operator-supplied regionId is assignable + ACTIVE. Returns
+   * ALL regions (matching + validation filter as needed), mirroring the one-off
+   * backfill's projection. Kept separate from the lean `findAll` cascade projection
+   * so the cached public taxonomy read stays minimal.
+   */
+  findCandidates(): Promise<RegionCandidate[]>
 }
 
 /**

--- a/packages/api/src/services/location.ts
+++ b/packages/api/src/services/location.ts
@@ -1,4 +1,5 @@
 import type { CoordinateSource } from '@kuruma/shared/db/schema'
+import { nearestAssignableRegion } from '@kuruma/shared/lib/region-distance'
 import type { CallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
@@ -6,6 +7,7 @@ import type {
   Location,
   LocationFilters,
   LocationRepository,
+  RegionRepository,
 } from '../repositories/types'
 import type { GeocodeOutcome, Geocoder } from './geocoding/types'
 
@@ -36,6 +38,13 @@ export type LocationUpdateData = Partial<
 
 const DUPLICATE_NAME_MESSAGE = 'A location with this name already exists'
 const NOT_FOUND_MESSAGE = 'Location not found'
+// #651 Slice 2: an ACTIVE location with no derivable region is refused rather than
+// saved invisible to renter region search — the operator must pick a region.
+const NO_REGION_MESSAGE =
+  'This location needs a region; none could be matched to its address — please select one'
+// Matches the route's existing FK->422 message so a service-level rejection and the
+// DB-level FK seal read identically to the client.
+const INVALID_REGION_MESSAGE = 'Invalid region'
 
 const isDuplicateName = (err: unknown): boolean => pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION
 
@@ -72,6 +81,7 @@ export class LocationService {
     private readonly repo: LocationRepository,
     private readonly bookingRepo: BookingRepository,
     private readonly geocoder: Geocoder,
+    private readonly regionRepo: RegionRepository,
   ) {}
 
   async findAll(ctx: CallerContext, filters?: LocationFilters): Promise<Location[]> {
@@ -93,11 +103,19 @@ export class LocationService {
 
     const coords = await this.resolveCreateCoords(data)
 
+    const region = await this.resolveRegionId({
+      status: data.status,
+      providedRegionId: data.regionId,
+      existingRegionId: null,
+      coords,
+    })
+    if (!region.ok) return region
+
     // The pre-check is a UX nicety; the unique constraint is the real seal.
     // A concurrent insert can win the race after the check passes, so map the
     // resulting unique-violation to the same friendly 409 instead of a 500.
     try {
-      const location = await this.repo.create({ ...data, ...coords })
+      const location = await this.repo.create({ ...data, ...coords, regionId: region.regionId })
       return { ok: true, location }
     } catch (err) {
       if (isDuplicateName(err)) return { ok: false, error: DUPLICATE_NAME_MESSAGE, status: 409 }
@@ -120,9 +138,25 @@ export class LocationService {
     }
 
     const resolution = await this.resolveUpdateCoords(existing, data)
+    // The coords the region is derived against: the freshly-resolved triple when the
+    // edit set them, otherwise the ones already on the row (a 'preserve').
+    const effectiveCoords =
+      resolution.kind === 'set'
+        ? resolution.coords
+        : { latitude: existing.latitude, longitude: existing.longitude }
+    const region = await this.resolveRegionId({
+      status: data.status ?? existing.status,
+      providedRegionId: data.regionId,
+      existingRegionId: existing.regionId,
+      coords: effectiveCoords,
+    })
+    if (!region.ok) return region
 
     try {
-      const updated = await this.repo.update(id, this.toPatch(data, resolution))
+      const updated = await this.repo.update(id, {
+        ...this.toPatch(data, resolution),
+        regionId: region.regionId,
+      })
       if (!updated) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
       return { ok: true, location: updated }
     } catch (err) {
@@ -174,6 +208,56 @@ export class LocationService {
     } catch {
       return { status: 'notFound' }
     }
+  }
+
+  // #651 Slice 2 — resolve the regionId a save persists, applying the operator->region
+  // loop guard. An ACTIVE location with no region is assigned its nearest assignable
+  // area (derived from the effective coords); when none is in range the save is refused
+  // (422) so the storefront can't vanish from renter region search. ARCHIVED locations
+  // are exempt, and a region already chosen (non-null) is kept as-is.
+  private async resolveRegionId(args: {
+    status: 'ACTIVE' | 'ARCHIVED'
+    // The operator's intent: a real id = set, explicit null = clear, undefined = leave
+    // unchanged (only meaningful on update; create always passes a value or null).
+    providedRegionId: string | null | undefined
+    existingRegionId: string | null
+    coords: { latitude: number | null; longitude: number | null }
+  }): Promise<
+    { ok: true; regionId: string | null } | { ok: false; error: string; status: number }
+  > {
+    const { status, providedRegionId, existingRegionId, coords } = args
+
+    // An explicitly provided region must reference an assignable, ACTIVE area — never an
+    // unknown id (which would otherwise surface as a raw FK 500) nor a navigation-only
+    // (prefecture/city) or retired (INACTIVE) node.
+    if (providedRegionId != null) {
+      const region = (await this.regionRepo.findCandidates()).find((r) => r.id === providedRegionId)
+      if (!region || !region.assignable || region.status !== 'ACTIVE') {
+        return { ok: false, error: INVALID_REGION_MESSAGE, status: 422 }
+      }
+      return { ok: true, regionId: providedRegionId }
+    }
+
+    // No region explicitly provided: `undefined` keeps the existing one (an unrelated
+    // edit), explicit `null` clears it. The existing region is trusted as-is (it was
+    // validated when set) so an unrelated edit never 422s on a region that has since
+    // gone INACTIVE; only a NEW region is re-validated above.
+    const effectiveRegionId = providedRegionId === undefined ? existingRegionId : null
+
+    // ARCHIVED is exempt; an ACTIVE location that still has a region keeps it.
+    if (status !== 'ACTIVE' || effectiveRegionId !== null) {
+      return { ok: true, regionId: effectiveRegionId }
+    }
+
+    // ACTIVE + no region: derive the nearest assignable area from the effective coords,
+    // or refuse so the storefront can't vanish from renter region search.
+    const point =
+      coords.latitude != null && coords.longitude != null
+        ? { latitude: coords.latitude, longitude: coords.longitude }
+        : null
+    const match = nearestAssignableRegion(await this.regionRepo.findCandidates(), point)
+    if (match === null) return { ok: false, error: NO_REGION_MESSAGE, status: 422 }
+    return { ok: true, regionId: match.id }
   }
 
   // Create always *sets* a triple (there is nothing to preserve), so this returns

--- a/packages/api/tests/integration/backfill-regions.test.ts
+++ b/packages/api/tests/integration/backfill-regions.test.ts
@@ -1,0 +1,120 @@
+import { backfillLocationRegions } from '@kuruma/shared/db/backfill-regions'
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { locations, regions } from '@kuruma/shared/db/schema'
+import { eq, inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { db } from './setup'
+
+// #651 Slice 1 — the one-off location->region backfill, end-to-end against Postgres
+// (PR #758 review LOW #4). `backfillLocationRegions` reads EVERY region + location in
+// the database (it is the global one-off, not a scoped query), so this suite cannot
+// assert on global counts — concurrent integration files seed their own Kansai rows.
+// Instead it seeds ONE assignable area far from the demo geography (Sapporo) plus a
+// far point with nothing in radius (Okinawa), and asserts PER ROW by id. That is both
+// mutation-resistant (the exact target region is checked, not "something changed") and
+// isolation-safe (no other file touches Hokkaido/Okinawa).
+describe('location->region backfill (#651 Slice 1)', () => {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const areaId = crypto.randomUUID()
+  const nearId = crypto.randomUUID()
+  const farId = crypto.randomUUID()
+  const archivedId = crypto.randomUUID()
+  const noCoordsId = crypto.randomUUID()
+  const preAssignedId = crypto.randomUUID()
+
+  // An assignable area + a pickup point ~1 km away; both ~1000 km from the Kansai
+  // demo areas, so the area is the unambiguous nearest regardless of seeded data.
+  const SAPPORO_AREA = { latitude: 43.0621, longitude: 141.3544 }
+  const NEAR_POINT = { latitude: 43.07, longitude: 141.36 }
+  // ~2200 km from Sapporo — beyond REGION_SANITY_RADIUS_KM (100), so unassignable.
+  const OKINAWA_FAR = { latitude: 26.2124, longitude: 127.6809 }
+
+  // Report from the first backfill run, captured once for the assertion cases.
+  let report: Awaited<ReturnType<typeof backfillLocationRegions>>
+
+  // `backfillLocationRegions` is typed against the production neon-http handle; the
+  // integration suite injects the structurally-identical postgres-js `testDb` (the
+  // same cast every Drizzle repo construction here uses).
+  type BackfillDb = Parameters<typeof backfillLocationRegions>[0]
+  const runBackfill = () => backfillLocationRegions(db as unknown as BackfillDb)
+
+  const loc = (id: string, name: string, extra: Record<string, unknown>) => ({
+    id,
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    name: `BF ${name} ${uniq}`,
+    address: '1-1 Backfill, Test',
+    status: 'ACTIVE' as const,
+    regionId: null,
+    ...extra,
+  })
+
+  const regionOf = async (id: string): Promise<string | null | undefined> => {
+    const [row] = await db
+      .select({ regionId: locations.regionId })
+      .from(locations)
+      .where(eq(locations.id, id))
+    return row?.regionId
+  }
+
+  beforeAll(async () => {
+    await db.insert(regions).values({
+      id: areaId,
+      parentId: null,
+      nameEn: `Backfill Area ${uniq}`,
+      nameJa: 'テスト地区',
+      nameZh: '测试地区',
+      type: 'AREA',
+      assignable: true,
+      status: 'ACTIVE',
+      ...SAPPORO_AREA,
+    })
+    await db
+      .insert(locations)
+      .values([
+        loc(nearId, 'near', { ...NEAR_POINT }),
+        loc(farId, 'far', { ...OKINAWA_FAR }),
+        loc(archivedId, 'archived', { ...NEAR_POINT, status: 'ARCHIVED' }),
+        loc(noCoordsId, 'nocoords', { latitude: null, longitude: null }),
+        loc(preAssignedId, 'preassigned', { ...NEAR_POINT, regionId: areaId }),
+      ])
+    report = await runBackfill()
+  })
+
+  afterAll(async () => {
+    // locations FK regions, so delete the locations before the area they point at.
+    await db
+      .delete(locations)
+      .where(inArray(locations.id, [nearId, farId, archivedId, noCoordsId, preAssignedId]))
+    await db.delete(regions).where(eq(regions.id, areaId))
+  })
+
+  it('assigns a region-less ACTIVE location to its nearest assignable area', async () => {
+    expect(await regionOf(nearId)).toBe(areaId)
+  })
+
+  it('reports a far-away location as unassigned and leaves its region null', async () => {
+    expect(report.unassigned).toContain(farId)
+    expect(await regionOf(farId)).toBeNull()
+  })
+
+  it('skips ARCHIVED locations even when a nearby area exists', async () => {
+    expect(await regionOf(archivedId)).toBeNull()
+  })
+
+  it('skips locations with no coordinates', async () => {
+    expect(await regionOf(noCoordsId)).toBeNull()
+  })
+
+  it('leaves an already-assigned location untouched', async () => {
+    expect(await regionOf(preAssignedId)).toBe(areaId)
+  })
+
+  it('is idempotent — a second run re-reports the far row and changes no assignment', async () => {
+    const second = await runBackfill()
+    expect(second.unassigned).toContain(farId)
+    // The row assigned on the first run is region-bearing now, so the second run
+    // never reconsiders it: its region is unchanged.
+    expect(await regionOf(nearId)).toBe(areaId)
+    expect(await regionOf(farId)).toBeNull()
+  })
+})

--- a/packages/api/tests/integration/locations-region.test.ts
+++ b/packages/api/tests/integration/locations-region.test.ts
@@ -6,22 +6,30 @@ import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
   DrizzleLocationRepository,
+  DrizzleRegionRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
 import { db } from './setup'
 
-// #394: locations.regionId is a client-supplied FK to the platform-global regions
-// tree. Adding it means POST /locations now carries TWO client FKs (operatorId +
-// regionId), so the 23503->422 mapping must disambiguate on the constraint name
-// ("Invalid region" vs "Invalid operator"). Only the real DB exercises the FK, so
-// this drives the full HTTP app against Postgres. Also proves the column is
-// settable end-to-end (create + PATCH) and defaults to null when omitted.
-describe('locations.regionId write-path (#394)', () => {
+// #651 Slice 2 — the operator->region loop guard, end-to-end against Postgres. An
+// ACTIVE location must resolve a region so it surfaces in renter region search: the
+// service validates a provided one (assignable + ACTIVE, else 422 — never a raw FK
+// 500), derives the nearest assignable area from the location's coords, or refuses
+// (422). The two client FKs (operatorId + regionId) must still disambiguate. The
+// Drizzle findCandidates projection + the FK are only exercised by the real DB, so
+// this drives the full HTTP app against Postgres with an explicit null geocoder
+// (deterministic: addresses never resolve, so derivation hinges only on sent coords).
+describe('locations region loop guard write-path (#651 Slice 2)', () => {
   const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const opId = `op_loc_region_${uniq}`
   const staffUserId = crypto.randomUUID()
-  const validRegionId = crypto.randomUUID()
+  const nambaId = crypto.randomUUID()
+  const umedaId = crypto.randomUUID()
+  const prefectureId = crypto.randomUUID()
+  // Mirror the demo geography so derivation reads against credible coords.
+  const NAMBA = { latitude: 34.6627, longitude: 135.5012 }
+  const UMEDA = { latitude: 34.7025, longitude: 135.4959 }
   let app: ReturnType<typeof createApp>
   let headers: Record<string, string>
 
@@ -29,6 +37,8 @@ describe('locations.regionId write-path (#394)', () => {
     operatorId: opId,
     name: `Region Loc ${uniq} ${Math.random().toString(36).slice(2, 6)}`,
     address: '1-1 Namba, Chuo-ku, Osaka',
+    // Default to the seeded assignable area; derivation/rejection tests override it.
+    regionId: nambaId,
     ...extra,
   })
 
@@ -41,18 +51,46 @@ describe('locations.regionId write-path (#394)', () => {
       role: 'STAFF',
       language: 'en',
     })
-    await db.insert(regions).values({
-      id: validRegionId,
-      parentId: null,
-      nameEn: 'Osaka',
-      nameJa: '大阪府',
-      nameZh: '大阪府',
-    })
+    await db.insert(regions).values([
+      // Two assignable AREA nodes (provided / derive / PATCH-between cases)...
+      {
+        id: nambaId,
+        parentId: null,
+        nameEn: 'Namba',
+        nameJa: '難波',
+        nameZh: '难波',
+        type: 'AREA',
+        assignable: true,
+        ...NAMBA,
+      },
+      {
+        id: umedaId,
+        parentId: null,
+        nameEn: 'Umeda',
+        nameJa: '梅田',
+        nameZh: '梅田',
+        type: 'AREA',
+        assignable: true,
+        ...UMEDA,
+      },
+      // ...and one navigation-only PREFECTURE (assignable defaults false, no coords).
+      {
+        id: prefectureId,
+        parentId: null,
+        nameEn: 'Osaka',
+        nameJa: '大阪府',
+        nameZh: '大阪府',
+        type: 'PREFECTURE',
+      },
+    ])
     app = createApp({
       vehicleRepo: new DrizzleVehicleRepository(db),
       bookingRepo: new DrizzleBookingRepository(db),
       availabilityRepo: new DrizzleAvailabilityRepository(db),
       locationRepo: new DrizzleLocationRepository(db),
+      regionRepo: new DrizzleRegionRepository(db),
+      // Deterministic: addresses never geocode, so derivation depends only on coords sent.
+      geocoder: { geocode: async () => ({ status: 'notFound' }) },
     })
     headers = await authHeaders({ sub: staffUserId, role: 'STAFF' })
   })
@@ -60,7 +98,7 @@ describe('locations.regionId write-path (#394)', () => {
   afterAll(async () => {
     // locations FK regions, so delete locations before regions.
     await db.delete(locations).where(inArray(locations.operatorId, [opId]))
-    await db.delete(regions).where(inArray(regions.id, [validRegionId]))
+    await db.delete(regions).where(inArray(regions.id, [nambaId, umedaId, prefectureId]))
     await db.delete(operators).where(inArray(operators.id, [opId]))
     await db.delete(users).where(inArray(users.id, [staffUserId]))
   })
@@ -78,42 +116,55 @@ describe('locations.regionId write-path (#394)', () => {
       body: JSON.stringify(b),
     })
 
-  it('creates a location without a region — regionId defaults to null', async () => {
+  it('creates a location with a provided assignable region', async () => {
     const res = await post(body())
     expect(res.status).toBe(201)
-    expect((await res.json()).data.regionId).toBeNull()
+    expect((await res.json()).data.regionId).toBe(nambaId)
   })
 
-  it('creates a location with a valid regionId', async () => {
-    const res = await post(body({ regionId: validRegionId }))
+  it('derives the nearest assignable area when an ACTIVE create omits the region', async () => {
+    // No region, but coords sit on Namba -> the guard derives it through the real DB.
+    const res = await post(body({ regionId: undefined, ...NAMBA }))
     expect(res.status).toBe(201)
-    expect((await res.json()).data.regionId).toBe(validRegionId)
+    expect((await res.json()).data.regionId).toBe(nambaId)
   })
 
-  it('maps an unknown regionId to 422 "Invalid region"', async () => {
+  it('refuses an ACTIVE create with no region and no derivable coords (422)', async () => {
+    const res = await post(body({ regionId: undefined }))
+    expect(res.status).toBe(422)
+  })
+
+  it('maps an unknown regionId to 422 "Invalid region" (service guard, not a raw FK)', async () => {
     const res = await post(body({ regionId: crypto.randomUUID() }))
     expect(res.status).toBe(422)
     expect((await res.json()).error).toBe('Invalid region')
   })
 
-  it('still maps an unknown operatorId to 422 "Invalid operator" (disambiguation guard)', async () => {
+  it('maps a non-assignable (navigation-only) regionId to 422 "Invalid region"', async () => {
+    const res = await post(body({ regionId: prefectureId }))
+    expect(res.status).toBe(422)
+    expect((await res.json()).error).toBe('Invalid region')
+  })
+
+  it('still maps an unknown operatorId to 422 "Invalid operator" (FK disambiguation holds)', async () => {
     const res = await post(body({ operatorId: `op_missing_${uniq}` }))
     expect(res.status).toBe(422)
     expect((await res.json()).error).toBe('Invalid operator')
   })
 
-  it('PATCH sets a regionId on an existing location', async () => {
+  it('PATCH moves a location to another assignable region', async () => {
     const created = await (await post(body())).json()
-    const res = await patch(created.data.id, { regionId: validRegionId })
+    const res = await patch(created.data.id, { regionId: umedaId })
     expect(res.status).toBe(200)
-    expect((await res.json()).data.regionId).toBe(validRegionId)
+    expect((await res.json()).data.regionId).toBe(umedaId)
   })
 
-  it('PATCH clears a regionId when sent null', async () => {
-    const created = await (await post(body({ regionId: validRegionId }))).json()
+  it('PATCH clearing the region of an ACTIVE location re-derives it (never null)', async () => {
+    // Coords on Namba, so clearing the region re-derives Namba rather than nulling it.
+    const created = await (await post(body({ ...NAMBA }))).json()
     const res = await patch(created.data.id, { regionId: null })
     expect(res.status).toBe(200)
-    expect((await res.json()).data.regionId).toBeNull()
+    expect((await res.json()).data.regionId).toBe(nambaId)
   })
 
   it('PATCH maps an unknown regionId to 422 "Invalid region"', async () => {
@@ -124,8 +175,8 @@ describe('locations.regionId write-path (#394)', () => {
   })
 
   it('persists the assigned region to the row (DB projection)', async () => {
-    const created = await (await post(body({ regionId: validRegionId }))).json()
+    const created = await (await post(body({ regionId: umedaId }))).json()
     const [row] = await db.select().from(locations).where(eq(locations.id, created.data.id))
-    expect(row?.regionId).toBe(validRegionId)
+    expect(row?.regionId).toBe(umedaId)
   })
 })

--- a/packages/api/tests/integration/locations-route-fk.test.ts
+++ b/packages/api/tests/integration/locations-route-fk.test.ts
@@ -1,11 +1,12 @@
-import { locations, operators, users } from '@kuruma/shared/db/schema'
-import { inArray } from 'drizzle-orm'
+import { locations, operators, regions, users } from '@kuruma/shared/db/schema'
+import { eq, inArray } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
 import {
   DrizzleAvailabilityRepository,
   DrizzleBookingRepository,
   DrizzleLocationRepository,
+  DrizzleRegionRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
 import { authHeaders, setupAuthEnv } from '../helpers/auth'
@@ -21,14 +22,17 @@ describe('POST /locations maps a non-existent operatorId to 422 (#411)', () => {
   const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const opId = `op_loc_fk_${uniq}`
   const staffUserId = crypto.randomUUID()
+  const regionId = crypto.randomUUID()
   let app: ReturnType<typeof createApp>
   let headers: Record<string, string>
 
-  // Bypass caller (STAFF) names the operator explicitly via the body.
+  // Bypass caller (STAFF) names the operator explicitly via the body. A valid region
+  // satisfies the #651 loop guard so the create reaches the operator FK under test.
   const locationBody = (operatorId: string, name: string) => ({
     operatorId,
     name,
     address: '1-1 Namba, Chuo-ku, Osaka',
+    regionId,
   })
 
   beforeAll(async () => {
@@ -40,17 +44,30 @@ describe('POST /locations maps a non-existent operatorId to 422 (#411)', () => {
       role: 'STAFF',
       language: 'en',
     })
+    await db.insert(regions).values({
+      id: regionId,
+      parentId: null,
+      nameEn: 'Namba',
+      nameJa: '難波',
+      nameZh: '难波',
+      type: 'AREA',
+      latitude: 34.6627,
+      longitude: 135.5012,
+      assignable: true,
+    })
     app = createApp({
       vehicleRepo: new DrizzleVehicleRepository(db),
       bookingRepo: new DrizzleBookingRepository(db),
       availabilityRepo: new DrizzleAvailabilityRepository(db),
       locationRepo: new DrizzleLocationRepository(db),
+      regionRepo: new DrizzleRegionRepository(db),
     })
     headers = await authHeaders({ sub: staffUserId, role: 'STAFF' })
   })
 
   afterAll(async () => {
     await db.delete(locations).where(inArray(locations.operatorId, [opId]))
+    await db.delete(regions).where(eq(regions.id, regionId))
     await db.delete(operators).where(inArray(operators.id, [opId]))
     await db.delete(users).where(inArray(users.id, [staffUserId]))
   })

--- a/packages/api/tests/integration/locations.test.ts
+++ b/packages/api/tests/integration/locations.test.ts
@@ -1,9 +1,9 @@
-import { locations, operators } from '@kuruma/shared/db/schema'
-import { inArray } from 'drizzle-orm'
+import { locations, operators, regions } from '@kuruma/shared/db/schema'
+import { eq, inArray } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { pgErrorCode } from '../../src/pg-errors'
-import { DrizzleLocationRepository } from '../../src/repositories/drizzle'
+import { DrizzleLocationRepository, DrizzleRegionRepository } from '../../src/repositories/drizzle'
 import { DrizzleBookingRepository } from '../../src/repositories/drizzle/booking'
 import { LocationService } from '../../src/services/location'
 import type { Location } from '../../src/stores'
@@ -176,12 +176,18 @@ describe('archiving a location frees its name for re-creation (#410)', () => {
 describe('cross-operator location WRITE denial (service seal, #387)', () => {
   const repo = new DrizzleLocationRepository(db)
   // Geocoding is irrelevant to this tenant-seal probe; stub it (returns notFound).
-  const service = new LocationService(repo, new DrizzleBookingRepository(db), {
-    geocode: async () => ({ status: 'notFound' }),
-  })
+  // The region repo reads real regions — locationA carries one so an own-tenant edit
+  // keeps it and the #651 loop guard never has to re-derive for this probe.
+  const service = new LocationService(
+    repo,
+    new DrizzleBookingRepository(db),
+    { geocode: async () => ({ status: 'notFound' }) },
+    new DrizzleRegionRepository(db),
+  )
   const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const opAId = `op_locw_a_${uniq}`
   const opBId = `op_locw_b_${uniq}`
+  const regionId = crypto.randomUUID()
   let locationA: Location
 
   beforeAll(async () => {
@@ -189,12 +195,24 @@ describe('cross-operator location WRITE denial (service seal, #387)', () => {
       { id: opAId, slug: `locw-a-${uniq}`, name: 'LocW Operator A' },
       { id: opBId, slug: `locw-b-${uniq}`, name: 'LocW Operator B' },
     ])
-    locationA = await repo.create(locationInput(opAId, 'Umeda'))
+    await db.insert(regions).values({
+      id: regionId,
+      parentId: null,
+      nameEn: 'Umeda',
+      nameJa: '梅田',
+      nameZh: '梅田',
+      type: 'AREA',
+      latitude: 34.7025,
+      longitude: 135.4959,
+      assignable: true,
+    })
+    locationA = await repo.create({ ...locationInput(opAId, 'Umeda'), regionId })
   })
 
   afterAll(async () => {
     await db.delete(locations).where(inArray(locations.operatorId, [opAId, opBId]))
     await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+    await db.delete(regions).where(eq(regions.id, regionId))
   })
 
   it('operator B cannot update operator A location (404, row untouched)', async () => {

--- a/packages/api/tests/routes/location-geocoder-di.test.ts
+++ b/packages/api/tests/routes/location-geocoder-di.test.ts
@@ -1,12 +1,28 @@
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { SignJWT } from 'jose'
 import { describe, expect, test, vi } from 'vitest'
 import { createApp } from '../../src/index'
 import {
   InMemoryAvailabilityRepository,
   InMemoryBookingRepository,
+  InMemoryRegionRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import type { GeocodeOutcome } from '../../src/services/geocoding/types'
+
+// #651 Slice 2: createApp's default region repo is empty, so an ACTIVE create can't
+// derive a region. Seed one assignable area AT the fake geocoder's coords so the
+// address-only create still resolves a region (test 1); the PENDING test has no coords
+// to derive from, so it supplies the regionId explicitly (test 2).
+const AREA: RegionCandidate = {
+  id: '00000000-0000-4000-8000-000000000002',
+  latitude: 34.6937,
+  longitude: 135.5023,
+  assignable: true,
+  status: 'ACTIVE',
+  sortOrder: 1,
+}
+const regionRepo = () => new InMemoryRegionRepository([], [AREA])
 import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
 
 // Provider-independence proof (#531): the composition root (index.ts) is the
@@ -36,7 +52,13 @@ describe('Geocoder DI — provider swap touches only index.ts (#531)', () => {
     const geocode = vi.fn(
       async (): Promise<GeocodeOutcome> => ({ status: 'ok', lat: 34.6937, lng: 135.5023 }),
     )
-    const app = createApp({ vehicleRepo, bookingRepo, availabilityRepo, geocoder: { geocode } })
+    const app = createApp({
+      vehicleRepo,
+      bookingRepo,
+      availabilityRepo,
+      geocoder: { geocode },
+      regionRepo: regionRepo(),
+    })
 
     const res = await app.request('/locations', {
       method: 'POST',
@@ -70,12 +92,13 @@ describe('Geocoder DI — provider swap touches only index.ts (#531)', () => {
       availabilityRepo,
       geocoder: { geocode },
       geocodeLimiter,
+      regionRepo: regionRepo(),
     })
 
     const res = await app.request('/locations', {
       method: 'POST',
       headers: await ownerHeaders('op_a'),
-      body: JSON.stringify({ name: 'Namba HQ', address: '1-2-3 Namba, Osaka' }),
+      body: JSON.stringify({ name: 'Namba HQ', address: '1-2-3 Namba, Osaka', regionId: AREA.id }),
     })
 
     expect(res.status).toBe(201)

--- a/packages/api/tests/routes/locations.test.ts
+++ b/packages/api/tests/routes/locations.test.ts
@@ -1,8 +1,12 @@
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
 import type { UserRole } from '../../src/middleware/auth'
-import { InMemoryLocationRepository } from '../../src/repositories/in-memory'
+import {
+  InMemoryLocationRepository,
+  InMemoryRegionRepository,
+} from '../../src/repositories/in-memory'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { createLocationRoutes } from '../../src/routes/locations'
 import type { Geocoder } from '../../src/services/geocoding/types'
@@ -18,6 +22,20 @@ const OP_B = 'operator-bbbbbbbb'
 // the service test, and the provider-swap contract in the createApp DI test.
 const nullGeocoder: Geocoder = { geocode: async () => ({ status: 'notFound' }) }
 
+// #651 Slice 2: an ACTIVE create must resolve a region. These routing/auth tests pin
+// every location at one seeded assignable area via a provided regionId in body(), so
+// the loop guard is satisfied and the create succeeds — region behavior itself is
+// covered in the service test. The id is a real UUID (regionIdSchema enforces it).
+const SEEDED_AREA: RegionCandidate = {
+  id: '00000000-0000-4000-8000-000000000001',
+  latitude: 34.6627,
+  longitude: 135.5012,
+  assignable: true,
+  status: 'ACTIVE',
+  sortOrder: 1,
+}
+const regionRepo = () => new InMemoryRegionRepository([], [SEEDED_AREA])
+
 function mountFor(
   repo: InMemoryLocationRepository,
   role: UserRole,
@@ -30,7 +48,7 @@ function mountFor(
   app.route(
     '/',
     createLocationRoutes(
-      new LocationService(repo, bookingRepo, nullGeocoder),
+      new LocationService(repo, bookingRepo, nullGeocoder, regionRepo()),
       testResolveWriteOperatorId(),
     ),
   )
@@ -38,7 +56,13 @@ function mountFor(
 }
 
 function body(extra: Record<string, unknown> = {}) {
-  return JSON.stringify({ name: 'Osaka Namba', address: '1-2-3 Namba', ...extra })
+  // A valid assignable region satisfies the #651 loop guard so an ACTIVE create succeeds.
+  return JSON.stringify({
+    name: 'Osaka Namba',
+    address: '1-2-3 Namba',
+    regionId: SEEDED_AREA.id,
+    ...extra,
+  })
 }
 
 const POST = (app: Hono, b = body()) =>
@@ -58,6 +82,7 @@ describe('Location routes — auth', () => {
           new InMemoryLocationRepository(),
           new InMemoryBookingRepository(),
           nullGeocoder,
+          regionRepo(),
         ),
         testResolveWriteOperatorId(),
       ),

--- a/packages/api/tests/services/location.test.ts
+++ b/packages/api/tests/services/location.test.ts
@@ -1,7 +1,11 @@
+import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CallerContext } from '../../src/middleware/auth'
 import { PG_ERROR } from '../../src/pg-errors'
-import { InMemoryLocationRepository } from '../../src/repositories/in-memory'
+import {
+  InMemoryLocationRepository,
+  InMemoryRegionRepository,
+} from '../../src/repositories/in-memory'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import type { Geocoder } from '../../src/services/geocoding/types'
 import { LocationService } from '../../src/services/location'
@@ -27,6 +31,20 @@ const uniqueViolation = () =>
 const opA = 'op_a'
 const opB = 'op_b'
 
+// One assignable, ACTIVE area (Namba coords) the loop guard can both derive to and
+// validate a provided regionId against. createInput pins every location to it, so the
+// pre-existing scope/name/geocode tests satisfy "an ACTIVE location needs a region"
+// via the provided-id path — coord-derivation and the 422 no-region paths get their
+// own dedicated guard tests below.
+const SEEDED_AREA: RegionCandidate = {
+  id: 'reg_namba',
+  latitude: 34.6627,
+  longitude: 135.5012,
+  assignable: true,
+  status: 'ACTIVE',
+  sortOrder: 1,
+}
+
 const ctxFor = (operatorId: string): CallerContext => ({
   userId: 'owner',
   role: 'OPERATOR_OWNER',
@@ -43,6 +61,7 @@ function createInput(operatorId: string, name: string) {
     timezone: 'Asia/Tokyo',
     defaultTurnaroundMinutes: 2880,
     status: 'ACTIVE' as const,
+    regionId: SEEDED_AREA.id,
   }
 }
 
@@ -87,7 +106,12 @@ describe('LocationService', () => {
 
   // Build a service wired to a specific Geocoder; the matrix tests vary it.
   const build = (geocoder: Geocoder = missGeocoder) =>
-    new LocationService(repo, new InMemoryBookingRepository(bookingStore), geocoder)
+    new LocationService(
+      repo,
+      new InMemoryBookingRepository(bookingStore),
+      geocoder,
+      new InMemoryRegionRepository([], [SEEDED_AREA]),
+    )
 
   beforeEach(() => {
     repo = new InMemoryLocationRepository()
@@ -543,6 +567,185 @@ describe('LocationService', () => {
         const result = await build(missGeocoder).update(ctxFor(opA), loc.id, { regeocode: true })
         expect(result.ok).toBe(true)
         if (result.ok) expect('regeocode' in result.location).toBe(false)
+      })
+    })
+  })
+
+  // #651 Slice 2 — operator->region loop guard. An ACTIVE location must end with a
+  // region so it surfaces in renter region search; the service derives one from the
+  // effective coords, or 422s asking the operator to pick a region. ARCHIVED is exempt.
+  describe('region loop guard (#651 Slice 2)', () => {
+    // A region repo seeded with a specific candidate set, for the validation/derivation
+    // cases the default single-area seed can't express.
+    const buildWithRegions = (candidates: RegionCandidate[], geocoder: Geocoder = missGeocoder) =>
+      new LocationService(
+        repo,
+        new InMemoryBookingRepository(bookingStore),
+        geocoder,
+        new InMemoryRegionRepository([], candidates),
+      )
+
+    const prefecture: RegionCandidate = {
+      id: 'reg_osaka',
+      latitude: null,
+      longitude: null,
+      assignable: false,
+      status: 'ACTIVE',
+      sortOrder: 0,
+    }
+
+    describe('create', () => {
+      it('rejects an ACTIVE location whose coords resolve near no assignable region (422)', async () => {
+        const result = await service.create(ctxFor(opA), {
+          ...createInput(opA, 'Lost'),
+          regionId: null,
+          latitude: 35.6812, // Tokyo — ~400 km from the only seeded area (Namba)
+          longitude: 139.7671,
+        })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+
+      it('rejects a create whose provided regionId is unknown (422, not a raw FK error)', async () => {
+        const result = await service.create(ctxFor(opA), {
+          ...createInput(opA, 'UnknownRegion'),
+          regionId: '11111111-1111-1111-1111-111111111111',
+        })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+
+      it('rejects a create whose provided regionId is a non-assignable navigation node (422)', async () => {
+        const result = await buildWithRegions([SEEDED_AREA, prefecture]).create(ctxFor(opA), {
+          ...createInput(opA, 'PrefRegion'),
+          regionId: 'reg_osaka',
+        })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+
+      it('derives and stamps the nearest assignable region when an ACTIVE create omits one', async () => {
+        const result = await service.create(ctxFor(opA), {
+          ...createInput(opA, 'NearNamba'),
+          regionId: null,
+          latitude: 34.6627, // sitting on Namba, the only seeded assignable area
+          longitude: 135.5012,
+        })
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.location.regionId).toBe('reg_namba')
+      })
+
+      it('keeps a provided assignable region as-is and does not override it by deriving', async () => {
+        const result = await service.create(ctxFor(opA), {
+          ...createInput(opA, 'Provided'),
+          regionId: SEEDED_AREA.id,
+          latitude: 35.6812, // far from Namba — proves the provided id wins over derivation
+          longitude: 139.7671,
+        })
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.location.regionId).toBe('reg_namba')
+      })
+
+      it('rejects an ACTIVE create with no region and an unresolvable address (422)', async () => {
+        // missGeocoder -> null coords -> nothing to derive from -> refused.
+        const result = await build(missGeocoder).create(ctxFor(opA), {
+          ...createInput(opA, 'NoCoords'),
+          regionId: null,
+        })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+    })
+
+    describe('update', () => {
+      // Seed a row directly (bypassing the service guard) so each update test starts
+      // from a known region/coords state.
+      const seedLoc = (over: Partial<Parameters<typeof repo.create>[0]>) =>
+        repo.create({ ...createInput(opA, `Seed ${Math.random()}`), ...over })
+
+      it('refuses to clear the region of an ACTIVE location when none can be re-derived (422)', async () => {
+        // Far coords + an existing region; clearing the region re-derives from the
+        // PRESERVED coords, finds no area in range, and refuses.
+        const loc = await seedLoc({
+          latitude: 35.6812,
+          longitude: 139.7671,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { regionId: null })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+
+      it('re-derives a region (never leaves null) when an ACTIVE location clears its region over good coords', async () => {
+        const loc = await seedLoc({
+          latitude: 34.6627,
+          longitude: 135.5012,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { regionId: null })
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.location.regionId).toBe('reg_namba')
+      })
+
+      it('lets an ARCHIVED location clear its region (exempt from the guard)', async () => {
+        const loc = await seedLoc({
+          status: 'ARCHIVED',
+          latitude: 35.6812, // far coords would 422 an ACTIVE location; ARCHIVED is exempt
+          longitude: 139.7671,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { regionId: null })
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.location.regionId).toBeNull()
+      })
+
+      it('rejects an update whose provided regionId is not an assignable, ACTIVE region (422)', async () => {
+        const loc = await seedLoc({})
+        const result = await service.update(ctxFor(opA), loc.id, {
+          regionId: '11111111-1111-1111-1111-111111111111',
+        })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
+      })
+
+      it('stamps a provided assignable region, overriding what derivation would pick', async () => {
+        // Region-less + far coords: derivation would 422, but an explicit valid region wins.
+        const loc = await seedLoc({
+          regionId: null,
+          latitude: 35.6812,
+          longitude: 139.7671,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { regionId: SEEDED_AREA.id })
+        expect(result.ok).toBe(true)
+        if (result.ok) expect(result.location.regionId).toBe('reg_namba')
+      })
+
+      it('backfills a region on an unrelated edit to a region-less ACTIVE location with good coords', async () => {
+        const loc = await seedLoc({
+          regionId: null,
+          latitude: 34.6627,
+          longitude: 135.5012,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { defaultTurnaroundMinutes: 3600 })
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.location.regionId).toBe('reg_namba')
+          expect(result.location.defaultTurnaroundMinutes).toBe(3600)
+        }
+      })
+
+      it('refuses an unrelated edit to a region-less ACTIVE location whose coords match no area (422)', async () => {
+        const loc = await seedLoc({
+          regionId: null,
+          latitude: 35.6812,
+          longitude: 139.7671,
+          coordinateSource: 'MANUAL',
+        })
+        const result = await service.update(ctxFor(opA), loc.id, { defaultTurnaroundMinutes: 3600 })
+        expect(result.ok).toBe(false)
+        if (!result.ok) expect(result.status).toBe(422)
       })
     })
   })

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./db": "./src/db/index.ts",
     "./db/schema": "./src/db/schema.ts",
     "./db/constants": "./src/db/constants.ts",
+    "./db/backfill-regions": "./src/db/backfill-regions.ts",
     "./validators/auth": "./src/validators/auth.ts",
     "./validators/message": "./src/validators/message.ts",
     "./types/stats": "./src/types/stats.ts",

--- a/packages/shared/src/lib/region-distance.ts
+++ b/packages/shared/src/lib/region-distance.ts
@@ -49,22 +49,29 @@ export function haversineKm(a: GeoPoint, b: GeoPoint): number {
   return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
 }
 
+// `Number.isFinite` over a bare `!== null` so a NaN/Infinity coordinate is
+// rejected too, not just null — a non-finite latitude would make every haversine
+// distance NaN and can never be selected, but the predicate should still tell the
+// truth: a `GeoPoint` carries real, finite degrees.
 function hasCoords(r: RegionCandidate): r is RegionCandidate & GeoPoint {
-  return r.latitude !== null && r.longitude !== null
+  return Number.isFinite(r.latitude) && Number.isFinite(r.longitude)
 }
 
 /**
  * The nearest assignable, ACTIVE, coordinate-bearing region to `point`, or null
  * when there is no point, no eligible region, or the closest one sits beyond
  * REGION_SANITY_RADIUS_KM. Ties break by sortOrder then id for determinism.
+ *
+ * The return is narrowed to `(T & GeoPoint)` (never just `T`): a match always has
+ * finite coords, so callers can read `.latitude/.longitude` without a non-null `!`.
  */
 export function nearestAssignableRegion<T extends RegionCandidate>(
   regions: readonly T[],
   point: GeoPoint | null,
-): T | null {
+): (T & GeoPoint) | null {
   if (point === null) return null
 
-  let best: T | null = null
+  let best: (T & GeoPoint) | null = null
   let bestKm = Number.POSITIVE_INFINITY
   for (const region of regions) {
     if (!region.assignable || region.status !== 'ACTIVE' || !hasCoords(region)) continue

--- a/packages/shared/tests/lib/region-distance.test.ts
+++ b/packages/shared/tests/lib/region-distance.test.ts
@@ -167,4 +167,23 @@ describe('planRegionBackfill', () => {
     expect(plan.assignments).toEqual([])
     expect(plan.unassigned).toEqual([])
   })
+
+  it('handles a mixed batch in one pass: assigns the eligible, buckets the far, skips the rest', () => {
+    // >1 location exercises loop accumulation + ordering that a single-location
+    // case can't: an early-skip (already-assigned) must not drop a later
+    // assignment, and assignments preserve input order alongside the unassigned bucket.
+    const plan = planRegionBackfill(areas, [
+      { id: 'loc_umeda', ...UMEDA, regionId: null, status: 'ACTIVE' }, // -> reg_umeda
+      { id: 'loc_done', ...NAMBA, regionId: 'reg_namba', status: 'ACTIVE' }, // already assigned -> skip
+      { id: 'loc_kix', ...KIX, regionId: null, status: 'ACTIVE' }, // -> reg_kix
+      { id: 'loc_tokyo', ...TOKYO, regionId: null, status: 'ACTIVE' }, // far -> unassigned
+      { id: 'loc_arch', ...UMEDA, regionId: null, status: 'ARCHIVED' }, // archived -> skip
+      { id: 'loc_nogeo', latitude: null, longitude: null, regionId: null, status: 'ACTIVE' }, // no coords -> skip
+    ])
+    expect(plan.assignments).toEqual([
+      { locationId: 'loc_umeda', regionId: 'reg_umeda' },
+      { locationId: 'loc_kix', regionId: 'reg_kix' },
+    ])
+    expect(plan.unassigned).toEqual(['loc_tokyo'])
+  })
 })


### PR DESCRIPTION
Part of #651 (Slice 2 of 3) — **do not close #651** (Slice 3 renter picker follows).

Slice 2 of the renter location search build: the **operator→region loop guard** on location save, plus the integration coverage outstanding from Slice 1's review.

## What this does
An ACTIVE location must resolve to a region so it surfaces in renter region search. `LocationService` gains a `regionRepo` dependency and a private `resolveRegionId()` applied on **create and update**:
- A provided `regionId` (any status) must be **assignable + ACTIVE**, else `422 "Invalid region"` — never a raw FK 500. Rejects unknown ids, navigation-only prefecture/city nodes, and retired (INACTIVE) nodes.
- ACTIVE + no region → derive the **nearest assignable area** from the effective coords (`nearestAssignableRegion`); none within the sanity radius → `422` (operator must pick one). ARCHIVED is exempt.
- On update, `undefined` regionId keeps the existing one **without re-validating** (an unrelated edit never 422s on a since-INACTIVE region); explicit `null` clears → re-derives.

The guard is service-level (not the route), so it covers the operator, platform-admin, and seed write paths uniformly. Also folds in the `region-distance` review LOWs from #758 (narrowed return type, `Number.isFinite` coord guard, the missing >1-location backfill-plan test).

## Backfill coverage (Slice 1 review LOW #4)
Adds `tests/integration/backfill-regions.test.ts` exercising `backfillLocationRegions` end-to-end against Postgres — assigns the nearest area, reports far rows unassigned, skips ARCHIVED + coord-less rows, idempotent on re-run. Asserts per-row on distinctive far-from-demo coords (the backfill is global/unscoped). Adds the `@kuruma/shared/db/backfill-regions` package export so the api test can import it.

## Not in this PR (deliberate follow-up)
The operator location **form cascade** (manual prefecture→city→area override + "suggested region" hint) is Slice 2's web half, landing as a follow-up. Until then the guard **auto-derives** the region from the geocoded/pinned address, so the happy path needs no UI change; the 422 only blocks an ACTIVE location whose address can't be matched to any assignable area within the sanity radius.

## Test plan
- [x] api unit — 1443/1443
- [x] api integration (real Postgres) — 244/244 (incl. 10 loop-guard cases + 6 backfill cases)
- [x] typecheck (api + shared) — 0
- [x] lint:boundaries — OK
- [x] db:verify — all drift checks pass (this slice adds no migration)
