### PR TITLE
fix(api): explicit bare /availability auth mount (#739)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -299,6 +299,9 @@ export function createApp(overrides?: AppOverrides) {
   app.use('/vehicles/*', requireAuth())
   app.use('/bookings/*', requireAuth())
   app.use('/availability/*', requireAuth())
+  // Bare path explicit (don't rely on the wildcard matching it) — same
+  // bare+wildcard pattern as /customers and /documents below (#739).
+  app.use('/availability', requireAuth())
   app.use('/threads/*', requireAuth())
   app.use('/messages/*', requireAuth())
   app.use('/customers/*', requireAuth())

--- a/packages/api/tests/routes/auth-middleware.test.ts
+++ b/packages/api/tests/routes/auth-middleware.test.ts
@@ -150,4 +150,26 @@ describe('auth middleware', () => {
     expect(res.status).toBe(401)
     process.env.PARTNER_API_KEY = undefined
   })
+
+  // #739: the bare /availability path must be gated explicitly, not by relying on
+  // the /availability/* wildcard incidentally matching it.
+  test('GET /availability (bare path) returns 401 without auth (#739)', async () => {
+    const app = createTestApp()
+    const res = await app.request('/availability')
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('Unauthorized')
+  })
+
+  test('GET /availability (bare path) passes the auth gate with a valid JWT (#739)', async () => {
+    const app = createTestApp()
+    const token = await signJwt({ sub: 'user_123', role: 'RENTER' })
+    const res = await app.request(
+      '/availability?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z',
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    // Past the auth gate (not 401) — the route returns 200 for a valid window.
+    expect(res.status).toBe(200)
+  })
 })


### PR DESCRIPTION
Part of the #701 audit epic.

## Problem
`index.ts` mounts `app.use('/availability/*', requireAuth())` but the bare `GET /availability` had no explicit gate — it 401s only because Hono's `*` wildcard incidentally matches the bare path. `/customers` and `/documents` were given both the bare and `/*` mounts explicitly; `/availability` was not. No real authz gap (401 confirmed), purely a consistency/robustness nit.

## Change
Add an explicit `app.use('/availability', requireAuth())` next to the wildcard mount, mirroring the established bare+wildcard pattern. Guard tests in `auth-middleware.test.ts` (real composed `createApp()`) assert unauthenticated bare `/availability` → 401 and authenticated → 200.

## Test plan
- [x] `@kuruma/api` — 1439/1439 (incl. 2 new guard tests)
- [x] tsc · biome lint · import-boundaries — clean

Closes #739