### PR TITLE
fix(api): add explicit bare /availability mount to the auth allow-list (#739)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -299,6 +299,7 @@ export function createApp(overrides?: AppOverrides) {
   app.use('/vehicles/*', requireAuth())
   app.use('/bookings/*', requireAuth())
   app.use('/availability/*', requireAuth())
+  app.use('/availability', requireAuth())
   app.use('/threads/*', requireAuth())
   app.use('/messages/*', requireAuth())
   app.use('/customers/*', requireAuth())

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryAvailabilityRepository,
@@ -9,8 +10,10 @@ import {
 import type { Booking, Vehicle } from '../../src/repositories/types'
 import { createAvailabilityRoutes } from '../../src/routes/availability'
 import { AvailabilityService } from '../../src/services/availability'
-import { testAuthMiddleware } from '../helpers/auth'
+import { authHeaders, setupAuthEnv, testAuthMiddleware } from '../helpers/auth'
 import { bookingInput } from '../helpers/booking'
+
+const AVAIL_QUERY = '/availability?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z'
 
 let app: Hono
 let vehicleRepo: InMemoryVehicleRepository
@@ -330,5 +333,27 @@ describe('Availability Routes', () => {
       expect(conflict).not.toHaveProperty('notes')
       expect(conflict).not.toHaveProperty('status')
     })
+  })
+})
+
+// The bare GET /availability path is gated by index.ts composition wiring, not the
+// route layer above. Pin it through the real createApp() so the requireAuth mount
+// can't silently regress (e.g. if the /availability/* wildcard it currently leans
+// on were ever removed). See #739.
+describe('GET /availability auth mount (#739)', () => {
+  beforeEach(() => {
+    setupAuthEnv()
+  })
+
+  it('401s an unauthenticated request to the bare /availability path', async () => {
+    const res = await createApp().request(AVAIL_QUERY)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('does not 401 an authenticated request to the bare /availability path', async () => {
+    const res = await createApp().request(AVAIL_QUERY, { headers: await authHeaders() })
+
+    expect(res.status).not.toBe(401)
   })
 })


### PR DESCRIPTION
Closes #739.

## Problem
The composition root gated `/availability/*` with `requireAuth()` but **not** the bare `/availability` path. It only 401s today because Hono's `*` wildcard also matches the bare path. `/customers` and `/documents` already declare **both** the bare and `/*` mounts explicitly — `/availability` was the lone inconsistency, leaning on wildcard matching for its gate.

No real authz gap (bare path already 401s; availability is also reachable publicly via `/storefronts` + `/search`, and non-staff get conflict details stripped). Pure consistency / defense-in-depth.

## Change
- `index.ts`: add `app.use('/availability', requireAuth())` beside the existing `/availability/*` mount, matching the `/customers` + `/documents` bare+wildcard pattern.
- `availability.test.ts`: a `createApp()`-level regression guard pinning bare `GET /availability` → 401 unauth, and not-401 when authed. These run through the **real composition root** (the existing route-layer tests bypass it via `testAuthMiddleware`).

## Note on TDD
This is a defense-in-depth change with **no behavior change** — I verified empirically that the bare path already 401s (the new tests passed against pre-change code). The test is therefore a regression guard: it locks the 401 invariant so a future removal of the `/availability/*` wildcard the bare path currently leans on can't silently open it.

## Acceptance criteria (all met)
- [x] `index.ts` has both `/availability` and `/availability/*` requireAuth mounts
- [x] Unauthenticated `GET /availability` returns 401
- [x] Authenticated `GET /availability` still works (not 401)
- [x] No other route behavior changes

## Verification
- `bun run --filter @kuruma/api test tests/routes/availability.test.ts` → **15/15** (incl. 2 new)
- `typecheck` exit 0 · `lint:boundaries` OK · pre-commit hook (biome + size + modules + tsc all packages) green · rebased clean on trunk

Base is `marketplace-pivot` (not default) → won't auto-close #739; will close manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)