### PR TITLE
chore(web): make modules/ canonical web home + ratchet vite/ deprecation (#719)

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -91,9 +91,10 @@ It is a CI step (`.github/workflows/ci.yml`) and flags:
 
 ## packages/web — feature folders + barrel imports
 
-The web shell (`packages/web/src/`) organizes UI by feature.
+The web shell (`packages/web/src/`) organizes UI by feature. There is **one
+canonical home** for a web feature:
 
-    src/modules/<feature>/
+    src/modules/<feature>/        # CANONICAL — the home for every web feature
       api.ts         # typed hono/client calls to the API (web has NO direct DB access)
       components/    # feature components (VehicleForm, BookingCard, …)
       hooks.ts       # feature-specific hooks
@@ -105,10 +106,36 @@ The web shell (`packages/web/src/`) organizes UI by feature.
 - Cross-feature primitives live in `src/lib/`. Design-system primitives stay in
   `src/components/ui/`.
 
-> Note: `packages/web` was migrated off Next.js to **Vite + TanStack Router**
-> (epic #378). The live shell is `src/vite/` + `src/routes/`; a frozen Next.js
-> tree (`src/app/`) is still present but is not the build path — do not extend
-> it. See the banner at the top of `AGENTS.md`.
+> **`src/modules/` does not exist on disk yet.** Every live feature is still in
+> `src/vite/` (below). The layout above is the *target*; the first feature
+> drained out of `src/vite/` creates `src/modules/`. Until then, an
+> `ls src/modules` returning nothing is expected — not staleness.
+
+### Migration status: draining `src/vite/` into `src/modules/`
+
+`packages/web` was migrated off Next.js to **Vite + TanStack Router** (epic
+#378). The dead Next.js source trees (`src/app/`, the old `modules/`, dead
+`components/<feature>/`, `nav/`, `actions/`, `hooks/`) were deleted in #704.
+What remains alongside `src/routes/` (TanStack Router) and `src/components/ui/`
+(design-system primitives) is **`src/vite/`** — a time-boxed **migration
+staging tree** that holds live feature code until each feature is moved to its
+canonical `src/modules/<feature>/` home.
+
+**`src/vite/` and `src/components/<feature>/` are deprecated roots — do not add
+new features there.** "Deprecated" means *no new features*, **not** frozen:
+in-place fixes, refactors, and tweaks to existing `src/vite/` code are expected
+and fine until that feature is drained. Drain them per-feature:
+
+1. **One feature at a time.** Move `src/vite/<feature>/` (plus any
+   `src/components/<feature>/` leftovers) into `src/modules/<feature>/` with the
+   barrel layout above. Track each move as its own item.
+2. **Same-PR deletion ratchet.** The PR that creates `src/modules/<feature>/`
+   **deletes** the old `vite/` / `components/<feature>/` copies in the *same*
+   PR — never leave two homes for one feature.
+3. **No regrowth.** `lint:modules` carries a non-failing deprecation ratchet
+   (`DEPRECATED_WEB_TREE_BASELINE`) that warns when the deprecated-tree file
+   count grows past its baseline. After a drain, refresh it in place with
+   `bun run scripts/lint-module-boundaries.ts --update-baseline`.
 
 ### Enforcement
 
@@ -118,10 +145,18 @@ The web shell (`packages/web/src/`) organizes UI by feature.
 bun run lint:modules   # also runs as part of `bun run lint`
 ```
 
-It scans `packages/{api,web,shared}/src` and fails on any cross-module internal
-import — i.e. importing `@/modules/<a>/<internal>` from a file in a different
-module. (Its `@/`-alias matcher only fires for web's barrels; the API has no
-`@/modules` imports, so it is effectively the web barrel guard.)
+It scans `packages/{api,web,shared}/src` and enforces three rules:
+1. **No cross-module internal imports** — importing `@/modules/<a>/<internal>`
+   from a file in a different module fails. (Its `@/`-alias matcher only fires
+   for web's barrels; the API has no `@/modules` imports, so it is effectively
+   the web barrel guard.)
+2. **No web runtime DB access (#722)** — a non-`type` import of `@/lib/db`,
+   `@kuruma/shared/db`, or `drizzle-orm` anywhere under `packages/web/src`
+   fails, except the Auth.js carve-out (`auth.ts`, `lib/db.ts`). `import type`
+   is always allowed (erased at build).
+3. **Deprecated-tree ratchet (#719)** — a non-failing warning when the file
+   count under `src/vite/` or `src/components/<feature>/` grows past
+   `DEPRECATED_WEB_TREE_BASELINE` (see migration status above).
 
 ---
 
@@ -143,17 +178,20 @@ files (`db/schema.ts`, `validators/<feature>.ts`). Import from `@kuruma/shared/*
 
 ## Grandfather / migrate-before-you-modify policy
 
-Some web features still live outside `src/modules/<feature>/` (legacy `lib/`
-and `components/<feature>/` from before the module convention, plus the frozen
-Next.js tree). They are exempt from the barrel rules until migrated. The
-**file-size cap applies everywhere**.
+Most web features currently live in the `src/vite/` staging tree (see migration
+status above); a few legacy bits remain in `src/lib/`. These are exempt from the
+barrel rules until migrated. The **file-size cap applies everywhere**.
 
-**Migrate before you modify.** Before a non-trivial change to a grandfathered
-*web* feature, land a standalone migration PR that moves it into
-`src/modules/<feature>/`. The feature-change PR builds on top. Migrations and
-feature changes never share a PR.
+**Migrate before you modify.** Before a non-trivial change to a feature still in
+`src/vite/` (or a legacy `components/<feature>/` / `lib/` spot), land a
+standalone migration PR that moves it into `src/modules/<feature>/`. The
+feature-change PR builds on top. Migrations and feature changes never share a PR.
 
 Trivial exceptions: typo fixes, one-line string tweaks, dependency bumps.
+
+While `src/modules/` is still empty, "migrate" means creating a feature's first
+canonical home — so this rule activates per-feature as drains begin, not as a
+blanket tax on the whole `src/vite/` tree today.
 
 > This policy is about the **web** module convention. The API is already
 > uniformly layered; "migrating" an API resource means keeping it within the
@@ -177,7 +215,9 @@ Trivial exceptions: typo fixes, one-line string tweaks, dependency bumps.
 
 ## How to add a web feature
 
-1. Create `packages/web/src/modules/<feature>/` with `api.ts`, `components/`,
-   `hooks.ts`, `types.ts`, `index.ts`, and colocated tests.
+1. Create `packages/web/src/modules/<feature>/` (the canonical home — **not**
+   `src/vite/`; you create `src/modules/` itself if you are the first feature
+   drained out) with `api.ts`, `components/`, `hooks.ts`, `types.ts`,
+   `index.ts`, and colocated tests.
 2. Import from `@/modules/<feature>` in routes/pages. Never reach into internals.
 3. Run `bun run lint` (includes `lint:modules` and `lint:size`).

--- a/scripts/lint-module-boundaries.test.ts
+++ b/scripts/lint-module-boundaries.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { checkImports } from './lint-module-boundaries'
+import {
+  checkImports,
+  countDeprecatedWebFiles,
+  deprecatedTreeStatus,
+  formatDeprecationNotice,
+  isDeprecatedWebFile,
+} from './lint-module-boundaries'
 
 const FIX = 'scripts/__fixtures__/boundaries'
 
@@ -51,5 +57,44 @@ describe('lint-module-boundaries: web no direct DB access (#722)', () => {
 
   test('does not restrict non-web packages (api may import drizzle at runtime)', () => {
     expect(checkImports([`${FIX}/packages/api/src/uses-drizzle.ts`])).toHaveLength(0)
+  })
+})
+
+describe('lint-module-boundaries: deprecated web tree ratchet (#719)', () => {
+  test('vite/ and components/<feature>/ are deprecated; components/ui/ and other roots are not', () => {
+    expect(isDeprecatedWebFile('vite/search/api.ts')).toBe(true)
+    expect(isDeprecatedWebFile('components/vehicles/Card.tsx')).toBe(true)
+    expect(isDeprecatedWebFile('components/ui/button.tsx')).toBe(false)
+    expect(isDeprecatedWebFile('lib/api-base.ts')).toBe(false)
+    expect(isDeprecatedWebFile('auth.ts')).toBe(false)
+    expect(isDeprecatedWebFile('vite/vite-env.d.ts')).toBe(false) // ambient stub
+    expect(isDeprecatedWebFile(null)).toBe(false)
+  })
+
+  test('counts only files under deprecated web roots', () => {
+    const files = [
+      'packages/web/src/vite/search/api.ts',
+      'packages/web/src/vite/bookings/list.tsx',
+      'packages/web/src/components/vehicles/Card.tsx',
+      'packages/web/src/components/ui/button.tsx', // sanctioned — not counted
+      'packages/web/src/lib/db.ts', // not deprecated
+      'packages/api/src/index.ts', // not web
+    ]
+    expect(countDeprecatedWebFiles(files)).toBe(3)
+  })
+
+  test('status flags growth, shrinkage, or steady against the baseline', () => {
+    expect(deprecatedTreeStatus(146, 145).level).toBe('grew')
+    expect(deprecatedTreeStatus(144, 145).level).toBe('shrank')
+    expect(deprecatedTreeStatus(145, 145).level).toBe('ok')
+  })
+
+  test('notice is silent when steady and names the new baseline when it changes', () => {
+    expect(formatDeprecationNotice({ count: 145, baseline: 145, level: 'ok' })).toBeNull()
+    const grew = formatDeprecationNotice({ count: 146, baseline: 145, level: 'grew' })
+    expect(grew).toContain('src/modules/<feature>/')
+    expect(grew).toContain('DEPRECATED_WEB_TREE_BASELINE=146')
+    const shrank = formatDeprecationNotice({ count: 144, baseline: 145, level: 'shrank' })
+    expect(shrank).toContain('DEPRECATED_WEB_TREE_BASELINE=144')
   })
 })

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { Glob } from 'bun'
 
 export type Violation = {
@@ -62,6 +62,60 @@ function webRelPath(file: string): string | null {
 
 function isForbiddenWebDbSpec(spec: string): boolean {
   return FORBIDDEN_WEB_DB_PREFIXES.some((p) => spec === p || spec.startsWith(`${p}/`))
+}
+
+// #719: src/modules/<feature>/ is the canonical web feature home (see
+// docs/architecture/modules.md). src/vite/ is a time-boxed migration staging
+// tree to be drained per-feature; src/components/<feature>/ is grandfathered
+// (only src/components/ui/ design-system primitives are sanctioned). This is a
+// NON-FAILING ratchet: it warns only when the count of migratable files under
+// the deprecated roots grows past the baseline, so the swarm still working in
+// src/vite/ today is not blocked. The count mirrors the failing-rule scan
+// (tests and fixtures excluded) and skips ambient .d.ts stubs.
+//
+// Known gap (accepted): being count-based, a same-PR delete+add nets zero and
+// slips past this. That is fine — this is a soft tripwire, not a gate; the
+// binding rule is the doc's "no new features in src/vite/". Upgrade to a path
+// manifest only if net-zero regressions actually happen in practice.
+//
+// After a drain, refresh in place with:
+//   bun run scripts/lint-module-boundaries.ts --update-baseline
+const DEPRECATED_WEB_TREE_BASELINE = 144
+
+export type DeprecatedTreeStatus = {
+  count: number
+  baseline: number
+  level: 'ok' | 'grew' | 'shrank'
+}
+
+// A web file under a deprecated root: anything in vite/, or a feature subdir of
+// components/ other than the sanctioned ui/ primitives. `webRel` is the path
+// under packages/web/src, or null for non-web files.
+export function isDeprecatedWebFile(webRel: string | null): boolean {
+  if (webRel === null) return false
+  // Ambient type stubs (e.g. vite-env.d.ts) are not migratable feature code.
+  if (webRel.endsWith('.d.ts')) return false
+  if (webRel.startsWith('vite/')) return true
+  const feature = webRel.match(/^components\/([^/]+)\//)
+  return feature !== null && feature[1] !== 'ui'
+}
+
+export function countDeprecatedWebFiles(files: string[]): number {
+  return files.filter((f) => isDeprecatedWebFile(webRelPath(f))).length
+}
+
+export function deprecatedTreeStatus(count: number, baseline: number): DeprecatedTreeStatus {
+  const level = count > baseline ? 'grew' : count < baseline ? 'shrank' : 'ok'
+  return { count, baseline, level }
+}
+
+export function formatDeprecationNotice(status: DeprecatedTreeStatus): string | null {
+  if (status.level === 'ok') return null
+  const refresh = `run \`bun run scripts/lint-module-boundaries.ts --update-baseline\` to set DEPRECATED_WEB_TREE_BASELINE=${status.count}`
+  if (status.level === 'grew') {
+    return `${status.count} source file(s) under deprecated web trees (src/vite/, src/components/<feature>/), up from baseline ${status.baseline}. New web features belong in src/modules/<feature>/ — see docs/architecture/modules.md. If intentional, ${refresh}.`
+  }
+  return `deprecated web tree shrank to ${status.count} (baseline ${status.baseline}) — lock in the migration: ${refresh}.`
 }
 
 export function checkImports(files: string[]): Violation[] {
@@ -132,6 +186,12 @@ function main(): number {
   for (const v of violations) {
     process.stderr.write(`[lint-module-boundaries] ERROR ${v.file}: ${describeViolation(v)}\n`)
   }
+  // Warning only — the deprecation ratchet must NEVER affect the exit code;
+  // only real violations below fail the build. Keep this above the return.
+  const notice = formatDeprecationNotice(
+    deprecatedTreeStatus(countDeprecatedWebFiles(files), DEPRECATED_WEB_TREE_BASELINE),
+  )
+  if (notice) process.stderr.write(`[lint-module-boundaries] WARNING ${notice}\n`)
   if (violations.length > 0) {
     process.stderr.write(`[lint-module-boundaries] ${violations.length} violation(s).\n`)
     return 1
@@ -140,5 +200,15 @@ function main(): number {
 }
 
 if (import.meta.main) {
+  if (process.argv.includes('--update-baseline')) {
+    const count = countDeprecatedWebFiles(discover())
+    const updated = readFileSync(import.meta.path, 'utf8').replace(
+      /(const DEPRECATED_WEB_TREE_BASELINE = )\d+/,
+      `$1${count}`,
+    )
+    writeFileSync(import.meta.path, updated)
+    process.stdout.write(`[lint-module-boundaries] DEPRECATED_WEB_TREE_BASELINE set to ${count}.\n`)
+    process.exit(0)
+  }
   process.exit(main())
 }


### PR DESCRIPTION
## Summary
`src/modules/<feature>/` is the canonical home for web features, but after the dead-Next deletion (#704) the only live web tree is `src/vite/` — a migration staging area with no governance. Nothing stopped new features from piling into `src/vite/` (or `src/components/<feature>/`) indefinitely. **Doc/lint-only — no code is moved.**

**Doc (`docs/architecture/modules.md`):**
- Declare `src/modules/<feature>/` canonical; note it does **not** exist on disk yet (the first drain creates it).
- Document the per-feature `vite/` drain order + same-PR deletion ratchet.
- Clarify "deprecated" = no NEW features, **not** frozen (in-place fixes welcome).
- Record all three `lint-module-boundaries` rules; drop stale frozen-Next.js (`src/app/`) references.

**Linter (`scripts/lint-module-boundaries.ts`):**
- Add a NON-FAILING deprecation ratchet: warns only when the count of migratable files under `src/vite/` or `src/components/<feature>/` grows past `DEPRECATED_WEB_TREE_BASELINE` (144). Existing files never fail; `lint:modules` still passes.
- `components/ui/` (design-system primitives) and ambient `.d.ts` stubs are exempt.
- `--update-baseline` rewrites the baseline in place after a drain.

## Acceptance criteria
- [x] modules.md: modules/ canonical + drain order + same-PR deletion ratchet
- [x] linter warns on new files under `src/vite/` / `src/components/<feature>/`
- [x] existing vite/ and components/ files do not newly fail
- [x] `bun run lint:modules` still passes on the current tree

## Test plan
- [x] TDD: +4 ratchet tests (classification incl. `.d.ts`, count, status, notice) — 12/12 boundary tests
- [x] `bun run lint` exit 0 (ratchet silent at baseline); tsc clean
- [x] Proved end-to-end: a new `vite/` file → WARNING + exit 0 (non-failing)
- [x] code-reviewer + architect reviewed; both HIGHs (no-op `--update-baseline`, empty-canonical doc) + MED/LOW folded in
- [ ] CI green (pending)

Closes #719
Part of #701