### PR TITLE
docs(api): document deferred search pagination bound (#727)

### DIFF
--- a/packages/api/src/services/flat-search.ts
+++ b/packages/api/src/services/flat-search.ts
@@ -98,6 +98,14 @@ export class FlatSearchService {
 
     const requested = classes && classes.length > 0 ? new Set(classes) : null
 
+    // Pagination bound (#727, deferred): the page is built in memory — sort the
+    // whole availability scan, then findIndex(cursor)+slice. Each page is O(total):
+    // full sort + linear cursor walk, re-done per request. Fine at MVP scale
+    // (40-50 cars; default browse-all already scans the whole fleet, sort is
+    // microseconds). Not pushed into SQL because the sort key spans joined
+    // operator/location columns the vehicles-only availability query can't ORDER
+    // BY without a join restructure. Revisit if inventory reaches the hundreds or
+    // search p95 regresses: ORDER BY + keyset + LIMIT n+1 on a joined query.
     const items = available
       .map((v) => toSpecific(v, locationById, classById, requested))
       .filter((i): i is SpecificSearchResult => i !== null)

--- a/packages/api/src/services/storefront-search.ts
+++ b/packages/api/src/services/storefront-search.ts
@@ -121,6 +121,14 @@ export class StorefrontSearchService {
     const vehiclesByLocation = groupByLocation(available)
     const requested = classes && classes.length > 0 ? new Set(classes) : null
 
+    // Pagination bound (#727, deferred): the page is built in memory — group the
+    // whole scan into cards, sort, then findIndex(cursor)+slice. Each page is
+    // O(total): full sort + linear cursor walk, re-done per request. Fine at MVP
+    // scale (40-50 cars; default browse-all scans the whole fleet, sort is
+    // microseconds). Not pushed into SQL because the page unit is an aggregated
+    // store CARD (a GROUP BY over availability), not a vehicle row — there is no
+    // per-vehicle keyset LIMIT for it. Revisit if inventory reaches the hundreds
+    // or search p95 regresses: a windowed GROUP BY + keyset on the card sort key.
     const cards = storefronts
       .map((sf) => buildCard(sf, vehiclesByLocation.get(sf.id) ?? [], classById, requested))
       .filter((c): c is StorefrontCard => c !== null)


### PR DESCRIPTION
## What

#727 proposed pushing a keyset cursor + LIMIT into the availability SQL so storefront/flat search materialize one page instead of scanning and sorting the whole fleet in memory per request. **Deferring as premature at MVP scale and documenting the bound instead** — the issue body explicitly offers this ("Document the MVP bound if deferring is preferred").

Adds a precise bound + revisit-trigger comment at both pagination sites; no behavior change.

## Why defer

- **It's microseconds at our scale.** The default browse-all path is O(total) per page (full sort + linear cursor `findIndex`), but `total` is the 40-50 car fleet. Region/operator/pickup-narrowed paths already bound the scan to in-region storefronts.
- **It's a restructure, not a `LIMIT`.** `flat-search` sorts on `(operatorName, location.name, vehicleId)` — joined operator/location columns the vehicles-only NOT-EXISTS availability query can't `ORDER BY` without a join rewrite. `storefront-search` paginates over **aggregated store cards** (a `GROUP BY` over availability), which has no per-vehicle keyset at all.
- Building tuple-cursor keyset over joins + a windowed GROUP BY for a 50-row hot path adds real cyclomatic complexity for a scale we won't hit soon (YAGNI/KISS).

## Revisit trigger (in the comments)

Inventory reaching the hundreds, or search p95 regressing → push `ORDER BY` + keyset + `LIMIT n+1` into a joined availability query (flat), and a windowed `GROUP BY` + keyset on the card sort key (storefront).

## Test plan

- [x] `tsc --noEmit` clean (api)
- [x] `flat-search` / `storefronts` / `search` route tests green (31/31)
- [x] biome + file-size + module-boundaries (pre-commit)
- Comments-only; no behavior change at the API boundary.

Part of #701. Closes #727 (base ≠ default branch, so closing manually on merge).