### PR TITLE
fix(api): cap concurrent OAuth flow cookies to bound the header budget (#592)

### DIFF
--- a/packages/api/src/auth/google.ts
+++ b/packages/api/src/auth/google.ts
@@ -69,6 +69,30 @@ export function flowCookieName(state: string): string {
   return `${OAUTH_FLOW_COOKIE_PREFIX}${state}`
 }
 
+/** Cap on concurrent in-flight Google sign-in flows per browser (#592). Each
+ *  abandoned flow leaves a `<prefix><state>` cookie until its 600s TTL self-heals it;
+ *  without a cap, a rapid abandon — or a login-CSRF `/start` flood — accumulates
+ *  empty-payload cookies until they blow the ~4KB per-domain header budget, at which
+ *  point NEW logins start failing. 10 sits far above any real user's tab count, so a
+ *  legitimate multi-tab sign-in is never evicted. */
+export const MAX_CONCURRENT_OAUTH_FLOWS = 10
+
+/** Given the flow-cookie names a browser is currently carrying and the per-flow cap,
+ *  return the names `/start` must erase so that adding ONE new flow keeps the live
+ *  count at or under `cap`. The browser sends only `name=value` (no creation time),
+ *  and `state` is random — so name order carries no age signal. The threat is the
+ *  COUNT (header-budget exhaustion), not which flow dies, so we evict the
+ *  lexicographically-smallest names — an arbitrary but DETERMINISTIC choice — keeping
+ *  `cap-1` to leave room for the incoming flow. */
+export function flowCookiesToEvict(
+  flowCookieNames: readonly string[],
+  cap = MAX_CONCURRENT_OAUTH_FLOWS,
+): string[] {
+  const keep = Math.max(0, cap - 1)
+  const sorted = [...flowCookieNames].sort()
+  return sorted.slice(0, Math.max(0, sorted.length - keep))
+}
+
 /** Which sign-in door the user came through. Identity is shared; only the
  *  post-login authorization decision and destination differ (#521). */
 export const OAUTH_INTENTS = ['renter', 'provider'] as const

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4,11 +4,13 @@ import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import {
   type GoogleAuthRuntime,
   type GoogleOAuthConfig,
+  OAUTH_FLOW_COOKIE_PREFIX,
   OAUTH_STATE_TTL_SECONDS,
   buildGoogleAuthorizeUrl,
   decodeFlowPayload,
   encodeFlowPayload,
   flowCookieName,
+  flowCookiesToEvict,
   localeFromReturnPath,
   parseOAuthIntent,
   randomToken,
@@ -106,6 +108,16 @@ export function createAuthRoutes(
         intent: parseOAuthIntent(c.req.query('intent')),
         invite: safeInviteToken(c.req.query('invite')),
       })
+      // Bound the live flow-cookie count before adding this one (issue #592): an
+      // abandoned flow lingers until its 600s TTL, so a rapid abandon — or a
+      // login-CSRF /start flood — could otherwise pile up empty-payload cookies past
+      // the ~4KB header budget and start failing NEW logins. Erase the oldest excess.
+      const liveFlowCookies = Object.keys(getCookie(c)).filter((name) =>
+        name.startsWith(OAUTH_FLOW_COOKIE_PREFIX),
+      )
+      for (const name of flowCookiesToEvict(liveFlowCookies)) {
+        deleteCookie(c, name, { path: '/' })
+      }
       setCookie(c, flowCookieName(state), payload, OAUTH_FLOW_COOKIE_OPTS)
       return c.redirect(buildGoogleAuthorizeUrl(googleConfig, state), 302)
     })

--- a/packages/api/tests/auth/oauth-flow-cap.test.ts
+++ b/packages/api/tests/auth/oauth-flow-cap.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_CONCURRENT_OAUTH_FLOWS,
+  flowCookieName,
+  flowCookiesToEvict,
+} from '../../src/auth/google'
+
+// #592: each abandoned Google sign-in leaves its per-flow cookie until the 600s TTL
+// self-heals it. A user rapidly abandoning sign-ins (or a login-CSRF /start flood)
+// could accumulate enough empty-payload cookies to blow the ~4KB per-domain header
+// budget, at which point NEW logins start failing. `flowCookiesToEvict` decides which
+// existing flow cookies /start must erase so that adding one more keeps the live
+// count at or under the cap. We can't read a cookie's creation time from the request
+// (the browser sends only name=value), so the contract bounds the COUNT — the actual
+// threat — and picks victims deterministically (sorted) rather than by true age.
+
+/** `n` distinct flow-cookie names, zero-padded so lexicographic === numeric order. */
+function flowNames(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => flowCookieName(`s${String(i).padStart(3, '0')}`))
+}
+
+describe('flowCookiesToEvict', () => {
+  it('evicts nothing when no flow cookies are present', () => {
+    expect(flowCookiesToEvict([], 10)).toEqual([])
+  })
+
+  it('evicts nothing while there is still room for the new flow (at cap-1)', () => {
+    // 9 existing + 1 about-to-be-added = 10 = cap, so nothing must be erased.
+    expect(flowCookiesToEvict(flowNames(9), 10)).toEqual([])
+  })
+
+  it('evicts exactly one when already at the cap', () => {
+    // 10 existing would become 11 after adding one — erase 1 to land back on 10.
+    const evicted = flowCookiesToEvict(flowNames(10), 10)
+    expect(evicted).toHaveLength(1)
+  })
+
+  it('evicts down to cap-1 when over the cap', () => {
+    // 12 existing → keep 9, erase 3, so post-add total is exactly the cap.
+    expect(flowCookiesToEvict(flowNames(12), 10)).toHaveLength(3)
+  })
+
+  it('keeps the largest cap-1 names and evicts the smallest (deterministic by sort)', () => {
+    const names = flowNames(12)
+    const evicted = flowCookiesToEvict(names, 10)
+    // Victims are the 3 lexicographically-smallest; the kept set is the rest.
+    expect(evicted).toEqual(names.slice(0, 3))
+    const kept = names.filter((n) => !evicted.includes(n))
+    expect(kept).toEqual(names.slice(3))
+  })
+
+  it('is order-independent: shuffled input yields the same victim set', () => {
+    const names = flowNames(12)
+    const shuffled = [...names].reverse()
+    expect(flowCookiesToEvict(shuffled, 10)).toEqual(names.slice(0, 3))
+  })
+
+  it('honours a custom (small) cap of 2: two existing → erase the smaller one', () => {
+    const [a, b] = [flowCookieName('a'), flowCookieName('b')]
+    expect(flowCookiesToEvict([b, a], 2)).toEqual([a])
+  })
+
+  it('defaults the cap to MAX_CONCURRENT_OAUTH_FLOWS (10)', () => {
+    expect(MAX_CONCURRENT_OAUTH_FLOWS).toBe(10)
+    // 11 existing with the default cap → erase 2 (keep 9, +1 new = 10).
+    expect(flowCookiesToEvict(flowNames(11))).toHaveLength(2)
+  })
+})

--- a/packages/api/tests/routes/auth-google-start.test.ts
+++ b/packages/api/tests/routes/auth-google-start.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { createApp } from '../../src/index'
-import { readOAuthFlowCookie, setupAuthEnv } from '../helpers/auth'
+import { oauthFlowCookie, readOAuthFlowCookie, setupAuthEnv } from '../helpers/auth'
 
 function setupGoogleEnv() {
   setupAuthEnv()
@@ -139,5 +139,76 @@ describe('POST /auth/google/start', () => {
     })
     expect(res.status).toBe(302)
     expect(readOAuthFlowCookie(res)?.payload.invite).toBeUndefined()
+  })
+
+  // #592: abandoned sign-ins leave their per-flow cookies until the 600s TTL clears
+  // them. /start must cap the live count so a rapid abandon / login-CSRF flood can't
+  // accumulate cookies past the ~4KB header budget and lock out new logins. The cap
+  // is MAX_CONCURRENT_OAUTH_FLOWS (10): each /start evicts just enough of the oldest
+  // (smallest-named) flows that adding the new one stays at or under the cap.
+
+  /** The flow cookies a /start response Set-Cookie'd, split into erases vs fresh. */
+  function flowSetCookies(res: Response): { erases: string[]; fresh: string[] } {
+    const flow = (res.headers.getSetCookie?.() ?? []).filter((c) =>
+      c.startsWith('kuruma_oauth_flow_'),
+    )
+    return {
+      erases: flow.filter((c) => /Max-Age=0/.test(c)),
+      fresh: flow.filter((c) => !/Max-Age=0/.test(c)),
+    }
+  }
+
+  /** A Cookie header carrying `n` in-flight flows, named old00..old{n-1} (sortable). */
+  function carrying(n: number): string {
+    return Array.from({ length: n }, (_, i) =>
+      oauthFlowCookie(`old${String(i).padStart(2, '0')}`),
+    ).join('; ')
+  }
+
+  test('below the cap: sets the new flow cookie and erases none', async () => {
+    setupGoogleEnv()
+    const app = createApp()
+    const res = await app.request('/auth/google/start', {
+      method: 'POST',
+      headers: { Cookie: carrying(5) },
+    })
+    expect(res.status).toBe(302)
+    const { erases, fresh } = flowSetCookies(res)
+    expect(erases).toHaveLength(0)
+    expect(fresh).toHaveLength(1)
+  })
+
+  test('at the cap (10 in flight): erases exactly one stale flow — the oldest by name', async () => {
+    setupGoogleEnv()
+    const app = createApp()
+    const res = await app.request('/auth/google/start', {
+      method: 'POST',
+      headers: { Cookie: carrying(10) },
+    })
+    expect(res.status).toBe(302)
+    const { erases, fresh } = flowSetCookies(res)
+    // One new flow set, one stale flow erased → live count stays at 10, not 11.
+    expect(fresh).toHaveLength(1)
+    expect(erases).toHaveLength(1)
+    expect(erases[0]).toContain('kuruma_oauth_flow_old00=')
+  })
+
+  test('over the cap (12 in flight): erases down to cap-1 so the post-add total is the cap', async () => {
+    setupGoogleEnv()
+    const app = createApp()
+    const res = await app.request('/auth/google/start', {
+      method: 'POST',
+      headers: { Cookie: carrying(12) },
+    })
+    expect(res.status).toBe(302)
+    const { erases, fresh } = flowSetCookies(res)
+    // 12 existing → keep 9, erase 3, +1 new = 10 = cap.
+    expect(fresh).toHaveLength(1)
+    expect(erases).toHaveLength(3)
+    expect(erases.map((c) => c.split('=')[0]).sort()).toEqual([
+      'kuruma_oauth_flow_old00',
+      'kuruma_oauth_flow_old01',
+      'kuruma_oauth_flow_old02',
+    ])
   })
 })


### PR DESCRIPTION
## What & why
`POST /auth/google/start` names each per-flow OAuth cookie by a random `state` (#519). Abandoned sign-ins leave the cookie until a 600s TTL self-heals it. The endpoint is unauthenticated + CSRF-exempt, so a rapid abandon — or a login-CSRF `/start` flood — could accumulate empty-payload `kuruma_oauth_flow_*` cookies past the ~4KB per-domain header budget, at which point **new logins start failing**.

## Change
- New pure `flowCookiesToEvict(names, cap=10)` in `auth/google.ts`: returns the flow-cookie names to erase so adding one more keeps the live count ≤ cap. Request cookies carry no creation time, so it bounds the **count** (the actual threat) deterministically by sort, not true age.
- `/auth/google/start` enumerates live `kuruma_oauth_flow_*` cookies and `deleteCookie`s the excess **before** setting the new one — each `/start` self-limits, so no flood can push the persisted count above the cap.
- `MAX_CONCURRENT_OAUTH_FLOWS = 10` sits far above any honest multi-tab user, so legitimate sign-ins are never evicted.

## Tests (TDD, RED→GREEN)
- Unit (`tests/auth/oauth-flow-cap.test.ts`): cap math at every boundary (0 / cap-1 / cap / over-cap), deterministic + order-independent victim set, custom cap.
- Route (`tests/routes/auth-google-start.test.ts`): integrated `/start` with N in-flight flows → exactly one fresh cookie + the right count of `Max-Age=0` erases, pinning which names are erased.

## Verification
- api suite **1463/1463**, `tsc --noEmit` clean, `lint:boundaries` OK, biome clean. Rebased onto latest trunk (incl. #807 route-boundary refactor); re-verified green.
- Comprehensive code review: **SHIP** — no CRITICAL/HIGH/MEDIUM; FC/IS split correct, erase attributes verified, no #519/CSRF regression.

Closes #592. Refs #519.