### PR TITLE
feat(web): operator location region cascade (#651 Slice 2b)

### DIFF
--- a/packages/api/src/repositories/drizzle/region.ts
+++ b/packages/api/src/repositories/drizzle/region.ts
@@ -1,11 +1,13 @@
 import { regions } from '@kuruma/shared/db/schema'
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { asc } from 'drizzle-orm'
 import type { Region } from '../../stores'
 import { collectDescendantIds } from '../region-tree'
 import type { RegionRepository } from '../types'
 import type { Db } from './shared'
 
+// The full region row (#651 Slice 2b): one projection feeds both the GET /regions
+// cascade AND the location-save geo guard (a RegionNode is a superset of the geo
+// columns `nearestAssignableRegion` reads), so there is no separate candidate read.
 const regionColumns = {
   id: regions.id,
   parentId: regions.parentId,
@@ -13,18 +15,12 @@ const regionColumns = {
   nameJa: regions.nameJa,
   nameZh: regions.nameZh,
   sortOrder: regions.sortOrder,
-}
-
-// The geo/taxonomy projection (#651 Slice 2) — exactly what `nearestAssignableRegion`
-// needs to match a pickup point to its nearest assignable area + validate a supplied
-// regionId. Mirrors the one-off backfill's projection (backfill-regions.ts).
-const regionCandidateColumns = {
-  id: regions.id,
+  type: regions.type,
   latitude: regions.latitude,
   longitude: regions.longitude,
   assignable: regions.assignable,
   status: regions.status,
-  sortOrder: regions.sortOrder,
+  slug: regions.slug,
 }
 
 /**
@@ -41,10 +37,6 @@ export class DrizzleRegionRepository implements RegionRepository {
       .select(regionColumns)
       .from(regions)
       .orderBy(asc(regions.sortOrder), asc(regions.nameEn))
-  }
-
-  async findCandidates(): Promise<RegionCandidate[]> {
-    return this.db.select(regionCandidateColumns).from(regions)
   }
 
   async findDescendantIds(rootId: string): Promise<string[]> {

--- a/packages/api/src/repositories/drizzle/region.ts
+++ b/packages/api/src/repositories/drizzle/region.ts
@@ -28,6 +28,11 @@ const regionColumns = {
  * cascading dropdowns render stably without client-side sorting. Descendant
  * resolution loads the (tiny) tree and walks it in app code via the shared pure
  * helper — see region-tree.ts for why we avoid a raw recursive CTE here.
+ *
+ * `findAll` also backs the per-save location loop guard (services/location.ts), so it
+ * runs a fresh SELECT on each location write. Fine at this scale (a few dozen
+ * platform-global rows the public route already edge-caches for 1h); an in-process
+ * cache is deliberately deferred (YAGNI) — revisit if region count or save volume grows.
  */
 export class DrizzleRegionRepository implements RegionRepository {
   constructor(private readonly db: Db) {}

--- a/packages/api/src/repositories/in-memory/region.test.ts
+++ b/packages/api/src/repositories/in-memory/region.test.ts
@@ -11,6 +11,13 @@ const region = (id: string, parentId: string | null): Region => ({
   nameJa: id,
   nameZh: id,
   sortOrder: 0,
+  // #651 2b: geo/taxonomy fields are unused by these tree-walk fixtures → defaults.
+  type: null,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
 })
 
 const TREE: Region[] = [

--- a/packages/api/src/repositories/in-memory/region.ts
+++ b/packages/api/src/repositories/in-memory/region.ts
@@ -1,4 +1,3 @@
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import type { Region } from '../../stores'
 import { collectDescendantIds } from '../region-tree'
 import type { RegionRepository } from '../types'
@@ -6,23 +5,15 @@ import type { RegionRepository } from '../types'
 /**
  * In-memory double for the #394 region taxonomy. Holds the flat region list and
  * delegates descendant resolution to the shared pure tree walk — the same
- * contract the Drizzle impl honours. Platform-global (no CallerContext).
+ * contract the Drizzle impl honours. Platform-global (no CallerContext). Each row
+ * is a full RegionNode, so the single seed feeds both `findAll` (the cascade) and
+ * the location-save geo guard, which reads the geo columns off these same rows.
  */
 export class InMemoryRegionRepository implements RegionRepository {
-  // `candidates` (the geo/taxonomy projection #651 Slice 2) is a SEPARATE optional
-  // seed from the cascade `regions`, so existing fixtures that only need the tree
-  // stay a one-arg construct; the loop-guard tests seed candidates directly.
-  constructor(
-    private readonly regions: readonly Region[] = [],
-    private readonly candidates: readonly RegionCandidate[] = [],
-  ) {}
+  constructor(private readonly regions: readonly Region[] = []) {}
 
   async findAll(): Promise<Region[]> {
     return [...this.regions]
-  }
-
-  async findCandidates(): Promise<RegionCandidate[]> {
-    return [...this.candidates]
   }
 
   async findDescendantIds(rootId: string): Promise<string[]> {

--- a/packages/api/src/repositories/region-tree.test.ts
+++ b/packages/api/src/repositories/region-tree.test.ts
@@ -9,6 +9,13 @@ const region = (id: string, parentId: string | null): Region => ({
   nameJa: id,
   nameZh: id,
   sortOrder: 0,
+  // #651 2b: geo/taxonomy fields are unused by these tree-walk fixtures → defaults.
+  type: null,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
 })
 
 describe('collectDescendantIds (#394 region tree walk)', () => {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -25,7 +25,6 @@ export type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 export type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 
 import type { CoordinateSource } from '@kuruma/shared/db/schema'
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
@@ -528,20 +527,15 @@ export interface StorefrontFilters {
  * StorefrontFilters.regionIds filter.
  */
 export interface RegionRepository {
-  /** The whole tree as a flat list; the web client builds the cascade from it. */
+  /**
+   * The whole tree as a flat list of full RegionNode rows. The web client builds
+   * the prefecture->city->area cascade from it, AND the location-save geo guard
+   * reads the geo columns (lat/lng/assignable/status) off the same rows — because
+   * `RegionNode extends RegionCandidate`, one read serves both (#651 Slice 2b).
+   */
   findAll(): Promise<Region[]>
   /** `rootId` plus every descendant id (inclusive). Empty when `rootId` is unknown. */
   findDescendantIds(rootId: string): Promise<string[]>
-  /**
-   * Every region projected to the geo/taxonomy columns needed to match a pickup
-   * point to its nearest assignable area (#651 Slice 2): the operator location-save
-   * loop guard derives a region from coords via `nearestAssignableRegion`, and
-   * validates that an operator-supplied regionId is assignable + ACTIVE. Returns
-   * ALL regions (matching + validation filter as needed), mirroring the one-off
-   * backfill's projection. Kept separate from the lean `findAll` cascade projection
-   * so the cached public taxonomy read stays minimal.
-   */
-  findCandidates(): Promise<RegionCandidate[]>
 }
 
 /**

--- a/packages/api/src/routes/regions.ts
+++ b/packages/api/src/routes/regions.ts
@@ -12,6 +12,10 @@ const CACHE_SECONDS = 3600
  * the renter search dropdowns load before login. A flat list (parentId edges);
  * the cascade is built client-side. No pagination: the whole tree is a few dozen
  * rows. HTTP in/out only; the repo owns the read.
+ *
+ * #651 2b: the payload carries the full RegionNode — type/slug/assignable/status +
+ * area centroid lat/lng — to anonymous callers. Intentional: the operator cascade
+ * and the renter map (Slice 3) need them, and region centroids aren't sensitive.
  */
 export function createRegionRoutes(regionRepo: RegionRepository) {
   return new Hono().get('/regions', async (c) => {

--- a/packages/api/src/services/flat-search.test.ts
+++ b/packages/api/src/services/flat-search.test.ts
@@ -23,6 +23,13 @@ const reg = (id: string, parentId: string | null): Region => ({
   nameJa: id,
   nameZh: id,
   sortOrder: 0,
+  // #651 2b: geo/taxonomy fields are unused by these tree-walk fixtures → defaults.
+  type: null,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
 })
 const REGIONS: Region[] = [
   reg('reg_osaka', null),

--- a/packages/api/src/services/location.ts
+++ b/packages/api/src/services/location.ts
@@ -231,7 +231,7 @@ export class LocationService {
     // unknown id (which would otherwise surface as a raw FK 500) nor a navigation-only
     // (prefecture/city) or retired (INACTIVE) node.
     if (providedRegionId != null) {
-      const region = (await this.regionRepo.findCandidates()).find((r) => r.id === providedRegionId)
+      const region = (await this.regionRepo.findAll()).find((r) => r.id === providedRegionId)
       if (!region || !region.assignable || region.status !== 'ACTIVE') {
         return { ok: false, error: INVALID_REGION_MESSAGE, status: 422 }
       }
@@ -255,7 +255,7 @@ export class LocationService {
       coords.latitude != null && coords.longitude != null
         ? { latitude: coords.latitude, longitude: coords.longitude }
         : null
-    const match = nearestAssignableRegion(await this.regionRepo.findCandidates(), point)
+    const match = nearestAssignableRegion(await this.regionRepo.findAll(), point)
     if (match === null) return { ok: false, error: NO_REGION_MESSAGE, status: 422 }
     return { ok: true, regionId: match.id }
   }

--- a/packages/api/src/services/storefront-search.test.ts
+++ b/packages/api/src/services/storefront-search.test.ts
@@ -24,6 +24,13 @@ const reg = (id: string, parentId: string | null): Region => ({
   nameJa: id,
   nameZh: id,
   sortOrder: 0,
+  // #651 2b: geo/taxonomy fields are unused by these tree-walk fixtures → defaults.
+  type: null,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
 })
 const REGIONS: Region[] = [
   reg('reg_osaka', null),

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -277,18 +277,12 @@ export interface Location {
   updatedAt: Date
 }
 
-export interface Region {
-  id: string
-  /** Self-ref adjacency edge; null = a root (a prefecture). #394. */
-  parentId: string | null
-  /** Trilingual names — the API is locale-agnostic; the web client picks one
-   *  by route locale (renter UI is en/ja/zh). */
-  nameEn: string
-  nameJa: string
-  nameZh: string
-  /** Stable ordering within a level for the cascading dropdowns. */
-  sortOrder: number
-}
+// #651 Slice 2b: the api region row IS the full shared taxonomy node. One shape
+// now feeds the GET /regions cascade AND the location-save geo guard, because
+// `RegionNode extends RegionCandidate` — so the lean `findCandidates` projection
+// is gone and `findAll` returns everything (type/lat/lng/assignable/status/slug).
+// Inline-import alias keeps the name + definition site here (no top-of-file churn).
+export type Region = import('@kuruma/shared/types/region').RegionNode
 
 export interface InsuranceOption {
   id: string

--- a/packages/api/tests/integration/locations-region.test.ts
+++ b/packages/api/tests/integration/locations-region.test.ts
@@ -17,7 +17,7 @@ import { db } from './setup'
 // service validates a provided one (assignable + ACTIVE, else 422 — never a raw FK
 // 500), derives the nearest assignable area from the location's coords, or refuses
 // (422). The two client FKs (operatorId + regionId) must still disambiguate. The
-// Drizzle findCandidates projection + the FK are only exercised by the real DB, so
+// Drizzle findAll projection + the FK are only exercised by the real DB, so
 // this drives the full HTTP app against Postgres with an explicit null geocoder
 // (deterministic: addresses never resolve, so derivation hinges only on sent coords).
 describe('locations region loop guard write-path (#651 Slice 2)', () => {

--- a/packages/api/tests/integration/regions.test.ts
+++ b/packages/api/tests/integration/regions.test.ts
@@ -51,7 +51,20 @@ describe('region taxonomy against Postgres (#394)', () => {
         sortOrder: 1,
       },
       { id: OSAKA_CITY, parentId: OSAKA, nameEn: 'Osaka City', nameJa: '大阪市', nameZh: '大阪市' },
-      { id: NAMBA, parentId: OSAKA_CITY, nameEn: 'Namba', nameJa: '難波', nameZh: '难波' },
+      {
+        id: NAMBA,
+        parentId: OSAKA_CITY,
+        nameEn: 'Namba',
+        nameJa: '難波',
+        nameZh: '难波',
+        // #651 2b: an assignable AREA leaf with coords + slug, so the GET /regions
+        // enrichment (type/assignable/lat/lng/status/slug) is asserted end-to-end.
+        type: 'AREA',
+        latitude: 34.6627,
+        longitude: 135.5012,
+        assignable: true,
+        slug: `namba-${uniq}`,
+      },
       { id: UMEDA, parentId: OSAKA_CITY, nameEn: 'Umeda', nameJa: '梅田', nameZh: '梅田' },
       {
         id: KYOTO,
@@ -125,7 +138,7 @@ describe('region taxonomy against Postgres (#394)', () => {
     expect(result).toEqual([])
   })
 
-  it('GET /regions returns the flat tree with trilingual names', async () => {
+  it('GET /regions returns the flat tree with trilingual names + geo/taxonomy enrichment (#651 2b)', async () => {
     const app = createApp({
       vehicleRepo: new DrizzleVehicleRepository(db),
       bookingRepo: new DrizzleBookingRepository(db),
@@ -136,11 +149,19 @@ describe('region taxonomy against Postgres (#394)', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     const namba = body.data.find((r: { id: string }) => r.id === NAMBA)
+    // The cascade + renter picker need type/assignable/slug; the geo guard reads
+    // lat/lng/status off the same rows — all must survive the GET /regions projection.
     expect(namba).toMatchObject({
       parentId: OSAKA_CITY,
       nameEn: 'Namba',
       nameJa: '難波',
       nameZh: '难波',
+      type: 'AREA',
+      assignable: true,
+      status: 'ACTIVE',
+      latitude: 34.6627,
+      longitude: 135.5012,
+      slug: `namba-${uniq}`,
     })
   })
 })

--- a/packages/api/tests/routes/location-geocoder-di.test.ts
+++ b/packages/api/tests/routes/location-geocoder-di.test.ts
@@ -1,4 +1,3 @@
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { SignJWT } from 'jose'
 import { describe, expect, test, vi } from 'vitest'
 import { createApp } from '../../src/index'
@@ -9,20 +8,27 @@ import {
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
 import type { GeocodeOutcome } from '../../src/services/geocoding/types'
+import type { Region } from '../../src/stores'
 
 // #651 Slice 2: createApp's default region repo is empty, so an ACTIVE create can't
 // derive a region. Seed one assignable area AT the fake geocoder's coords so the
 // address-only create still resolves a region (test 1); the PENDING test has no coords
 // to derive from, so it supplies the regionId explicitly (test 2).
-const AREA: RegionCandidate = {
+const AREA: Region = {
   id: '00000000-0000-4000-8000-000000000002',
+  parentId: null,
+  nameEn: 'Umeda',
+  nameJa: 'Umeda',
+  nameZh: 'Umeda',
+  type: 'AREA',
   latitude: 34.6937,
   longitude: 135.5023,
   assignable: true,
   status: 'ACTIVE',
   sortOrder: 1,
+  slug: 'umeda',
 }
-const regionRepo = () => new InMemoryRegionRepository([], [AREA])
+const regionRepo = () => new InMemoryRegionRepository([AREA])
 import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
 
 // Provider-independence proof (#531): the composition root (index.ts) is the

--- a/packages/api/tests/routes/locations.test.ts
+++ b/packages/api/tests/routes/locations.test.ts
@@ -25,7 +25,8 @@ const nullGeocoder: Geocoder = { geocode: async () => ({ status: 'notFound' }) }
 // #651 Slice 2: an ACTIVE create must resolve a region. These routing/auth tests pin
 // every location at one seeded assignable area via a provided regionId in body(), so
 // the loop guard is satisfied and the create succeeds — region behavior itself is
-// covered in the service test. The id is a real UUID (regionIdSchema enforces it).
+// covered in the service test. regionIdSchema accepts any non-empty id (region ids
+// are text PKs); the service guard validates existence + assignability.
 const SEEDED_AREA: Region = {
   id: '00000000-0000-4000-8000-000000000001',
   parentId: null,

--- a/packages/api/tests/routes/locations.test.ts
+++ b/packages/api/tests/routes/locations.test.ts
@@ -1,4 +1,3 @@
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
@@ -11,6 +10,7 @@ import { InMemoryBookingRepository } from '../../src/repositories/in-memory/book
 import { createLocationRoutes } from '../../src/routes/locations'
 import type { Geocoder } from '../../src/services/geocoding/types'
 import { LocationService } from '../../src/services/location'
+import type { Region } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 import { testResolveWriteOperatorId } from '../helpers/operator'
 
@@ -26,15 +26,21 @@ const nullGeocoder: Geocoder = { geocode: async () => ({ status: 'notFound' }) }
 // every location at one seeded assignable area via a provided regionId in body(), so
 // the loop guard is satisfied and the create succeeds — region behavior itself is
 // covered in the service test. The id is a real UUID (regionIdSchema enforces it).
-const SEEDED_AREA: RegionCandidate = {
+const SEEDED_AREA: Region = {
   id: '00000000-0000-4000-8000-000000000001',
+  parentId: null,
+  nameEn: 'Namba',
+  nameJa: 'Namba',
+  nameZh: 'Namba',
+  type: 'AREA',
   latitude: 34.6627,
   longitude: 135.5012,
   assignable: true,
   status: 'ACTIVE',
   sortOrder: 1,
+  slug: 'namba',
 }
-const regionRepo = () => new InMemoryRegionRepository([], [SEEDED_AREA])
+const regionRepo = () => new InMemoryRegionRepository([SEEDED_AREA])
 
 function mountFor(
   repo: InMemoryLocationRepository,

--- a/packages/api/tests/services/location.test.ts
+++ b/packages/api/tests/services/location.test.ts
@@ -1,4 +1,3 @@
-import type { RegionCandidate } from '@kuruma/shared/lib/region-distance'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CallerContext } from '../../src/middleware/auth'
 import { PG_ERROR } from '../../src/pg-errors'
@@ -9,7 +8,7 @@ import {
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import type { Geocoder } from '../../src/services/geocoding/types'
 import { LocationService } from '../../src/services/location'
-import type { Booking } from '../../src/stores'
+import type { Booking, Region } from '../../src/stores'
 
 // Fake Geocoders for the #531 write-decision matrix. The real adapter never
 // throws; `throwingGeocoder` proves the service is resilient even if a future
@@ -36,13 +35,19 @@ const opB = 'op_b'
 // pre-existing scope/name/geocode tests satisfy "an ACTIVE location needs a region"
 // via the provided-id path — coord-derivation and the 422 no-region paths get their
 // own dedicated guard tests below.
-const SEEDED_AREA: RegionCandidate = {
+const SEEDED_AREA: Region = {
   id: 'reg_namba',
+  parentId: null,
+  nameEn: 'Namba',
+  nameJa: 'Namba',
+  nameZh: 'Namba',
+  type: 'AREA',
   latitude: 34.6627,
   longitude: 135.5012,
   assignable: true,
   status: 'ACTIVE',
   sortOrder: 1,
+  slug: 'namba',
 }
 
 const ctxFor = (operatorId: string): CallerContext => ({
@@ -110,7 +115,7 @@ describe('LocationService', () => {
       repo,
       new InMemoryBookingRepository(bookingStore),
       geocoder,
-      new InMemoryRegionRepository([], [SEEDED_AREA]),
+      new InMemoryRegionRepository([SEEDED_AREA]),
     )
 
   beforeEach(() => {
@@ -577,21 +582,27 @@ describe('LocationService', () => {
   describe('region loop guard (#651 Slice 2)', () => {
     // A region repo seeded with a specific candidate set, for the validation/derivation
     // cases the default single-area seed can't express.
-    const buildWithRegions = (candidates: RegionCandidate[], geocoder: Geocoder = missGeocoder) =>
+    const buildWithRegions = (nodes: Region[], geocoder: Geocoder = missGeocoder) =>
       new LocationService(
         repo,
         new InMemoryBookingRepository(bookingStore),
         geocoder,
-        new InMemoryRegionRepository([], candidates),
+        new InMemoryRegionRepository(nodes),
       )
 
-    const prefecture: RegionCandidate = {
+    const prefecture: Region = {
       id: 'reg_osaka',
+      parentId: null,
+      nameEn: 'Osaka',
+      nameJa: 'Osaka',
+      nameZh: 'Osaka',
+      type: 'PREFECTURE',
       latitude: null,
       longitude: null,
       assignable: false,
       status: 'ACTIVE',
       sortOrder: 0,
+      slug: 'osaka',
     }
 
     describe('create', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,7 @@
     "./types/customer": "./src/types/customer.ts",
     "./types/location": "./src/types/location.ts",
     "./types/search-result": "./src/types/search-result.ts",
+    "./types/region": "./src/types/region.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/commission": "./src/lib/commission.ts",
     "./lib/admin-revenue": "./src/lib/admin-revenue.ts",

--- a/packages/shared/src/types/region.ts
+++ b/packages/shared/src/types/region.ts
@@ -1,0 +1,28 @@
+import type { RegionCandidate } from '../lib/region-distance'
+
+/**
+ * Taxonomy level of a region node (#651). Mirrors `regionTypeEnum` in
+ * `db/regions.ts`. Nullable on a node because the column is nullable-on-add
+ * (the seed populates every row).
+ */
+export type RegionType = 'PREFECTURE' | 'CITY' | 'AREA'
+
+/**
+ * A full region taxonomy row as returned by `GET /regions` (#651 Slice 2b).
+ *
+ * Superset of {@link RegionCandidate}: it carries the geo-match fields
+ * (latitude/longitude/assignable/status/sortOrder) the location-save loop guard
+ * needs AND the cascade/tree fields (parentId, trilingual names, type, slug) the
+ * operator prefecture->city->area dropdowns + the renter picker (#651 Slice 3)
+ * need. Because it extends RegionCandidate, `nearestAssignableRegion` accepts a
+ * `RegionNode[]` directly, so one repository read (`findAll`) now feeds both the
+ * cascade and the geo guard — the narrower `findCandidates` projection is gone.
+ */
+export interface RegionNode extends RegionCandidate {
+  parentId: string | null
+  nameEn: string
+  nameJa: string
+  nameZh: string
+  type: RegionType | null
+  slug: string | null
+}

--- a/packages/shared/src/validators/location.ts
+++ b/packages/shared/src/validators/location.ts
@@ -97,7 +97,12 @@ const COORD_PAIR_REFINEMENT = {
 // #394 deepest (area) region node. Nullable FK to the platform-global regions
 // tree; a uuid like every other FK (seed-id.ts). NOT NULL is deferred (D1), so
 // null is a first-class value here, not just an absence.
-const regionIdSchema = z.string().uuid('Region ID must be a valid UUID').nullable()
+// Region ids are TEXT PKs (the seed uses readable ids like 'reg_namba'; only
+// auto-generated rows get a UUID), so accept any non-empty id — NOT .uuid() (#651
+// 2b: the operator cascade submits seeded ids). The location-save guard validates
+// the id exists + is assignable (422 if not), so format strictness here would only
+// reject legitimate seeded regions.
+const regionIdSchema = z.string().trim().min(1, 'Region ID is required').nullable()
 
 // Shared base so create + platform-admin + update derive the same field set
 // (the .refine() below would turn this into a ZodEffects that can't be

--- a/packages/shared/tests/validators/location.test.ts
+++ b/packages/shared/tests/validators/location.test.ts
@@ -194,9 +194,20 @@ describe('createLocationSchema', () => {
     if (result.success) expect(result.data.regionId).toBeNull()
   })
 
-  it('rejects a non-uuid regionId (#394)', () => {
+  // #651 2b: region ids are TEXT PKs — the seed uses readable ids like 'reg_osaka',
+  // not UUIDs. The operator cascade submits these, so the schema accepts any
+  // non-empty id; the service guard validates it exists + is assignable (422 if not).
+  it('accepts a text (non-uuid) region id — the seed uses readable ids (#651 2b)', () => {
     const result = createLocationSchema.safeParse({ ...validInput(), regionId: 'reg_osaka' })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.regionId).toBe('reg_osaka')
+  })
+
+  it('rejects an empty / whitespace regionId (#651 2b)', () => {
+    for (const regionId of ['', '   ']) {
+      const result = createLocationSchema.safeParse({ ...validInput(), regionId })
+      expect(result.success).toBe(false)
+    }
   })
 
   it('does not accept an operatorId in the operator-caller schema', () => {
@@ -286,8 +297,14 @@ describe('updateLocationSchema', () => {
     if (result.success) expect(result.data.regionId).toBeUndefined()
   })
 
-  it('rejects a non-uuid regionId on update (#394)', () => {
-    const result = updateLocationSchema.safeParse({ regionId: 'not-a-uuid' })
+  it('accepts a text (non-uuid) region id on update (#651 2b)', () => {
+    const result = updateLocationSchema.safeParse({ regionId: 'reg_umeda' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.regionId).toBe('reg_umeda')
+  })
+
+  it('rejects an empty regionId on update (#651 2b)', () => {
+    const result = updateLocationSchema.safeParse({ regionId: '   ' })
     expect(result.success).toBe(false)
   })
 })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -641,6 +641,14 @@
         "timezone": "Timezone",
         "turnaround": "Turnaround (minutes)",
         "turnaroundHint": "Buffer before a returned vehicle is bookable again. Default 2880 (48h).",
+        "region": {
+          "label": "Region",
+          "help": "Leave blank to auto-assign the nearest area from the address.",
+          "prefecture": "Prefecture",
+          "city": "City",
+          "area": "Area",
+          "placeholder": "Select..."
+        },
         "save": "Save location",
         "saving": "Saving...",
         "cancel": "Cancel"

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -641,6 +641,14 @@
         "timezone": "タイムゾーン",
         "turnaround": "整備時間（分）",
         "turnaroundHint": "返却後、再び予約可能になるまでの猶予。既定 2880（48時間）。",
+        "region": {
+          "label": "地域",
+          "help": "空欄の場合、住所から最寄りのエリアを自動設定します。",
+          "prefecture": "都道府県",
+          "city": "市区町村",
+          "area": "エリア",
+          "placeholder": "選択..."
+        },
         "save": "拠点を保存",
         "saving": "保存中...",
         "cancel": "キャンセル"

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -641,6 +641,14 @@
         "timezone": "时区",
         "turnaround": "周转时间（分钟）",
         "turnaroundHint": "车辆归还后再次可预订前的缓冲。默认 2880（48 小时）。",
+        "region": {
+          "label": "地区",
+          "help": "留空将根据地址自动分配最近的区域。",
+          "prefecture": "都道府县",
+          "city": "城市",
+          "area": "区域",
+          "placeholder": "选择..."
+        },
         "save": "保存取还点",
         "saving": "保存中...",
         "cancel": "取消"

--- a/packages/web/src/vite/operator-locations/AddLocationDialog.tsx
+++ b/packages/web/src/vite/operator-locations/AddLocationDialog.tsx
@@ -7,7 +7,8 @@ import {
 } from '@/components/ui/dialog'
 import { LocationForm } from '@/vite/operator-locations/LocationForm'
 import { LOCATIONS_QUERY_KEY, createLocation } from '@/vite/operator-locations/api'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { regionsQueryOptions } from '@/vite/operator-locations/regions-api'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'use-intl'
 
 interface AddLocationDialogProps {
@@ -22,6 +23,7 @@ interface AddLocationDialogProps {
 export function AddLocationDialog({ open, onOpenChange }: AddLocationDialogProps) {
   const t = useTranslations('business.locations')
   const queryClient = useQueryClient()
+  const { data: regions } = useQuery(regionsQueryOptions())
   const mutation = useMutation({
     mutationFn: createLocation,
     onSuccess: () => {
@@ -53,6 +55,7 @@ export function AddLocationDialog({ open, onOpenChange }: AddLocationDialogProps
           }}
           onCancel={() => handleOpenChange(false)}
           isSubmitting={mutation.isPending}
+          regions={regions ?? []}
         />
       </DialogContent>
     </Dialog>

--- a/packages/web/src/vite/operator-locations/EditLocationDialog.tsx
+++ b/packages/web/src/vite/operator-locations/EditLocationDialog.tsx
@@ -11,8 +11,9 @@ import {
   type OperatorLocation,
   updateLocation,
 } from '@/vite/operator-locations/api'
+import { regionsQueryOptions } from '@/vite/operator-locations/regions-api'
 import type { UpdateLocationInput } from '@kuruma/shared/validators/location'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'use-intl'
 
 interface EditLocationDialogProps {
@@ -27,6 +28,7 @@ interface EditLocationDialogProps {
 export function EditLocationDialog({ location, onOpenChange }: EditLocationDialogProps) {
   const t = useTranslations('business.locations')
   const queryClient = useQueryClient()
+  const { data: regions } = useQuery(regionsQueryOptions())
   const mutation = useMutation({
     mutationFn: (data: UpdateLocationInput) => updateLocation(location?.id ?? '', data),
     onSuccess: () => {
@@ -59,12 +61,14 @@ export function EditLocationDialog({ location, onOpenChange }: EditLocationDialo
             }}
             onCancel={() => handleOpenChange(false)}
             isSubmitting={mutation.isPending}
+            regions={regions ?? []}
             defaultValues={{
               name: location.name,
               address: location.address,
               operatingHours: location.operatingHours,
               timezone: location.timezone,
               defaultTurnaroundMinutes: location.defaultTurnaroundMinutes,
+              regionId: location.regionId,
             }}
           />
         )}

--- a/packages/web/src/vite/operator-locations/LocationForm.tsx
+++ b/packages/web/src/vite/operator-locations/LocationForm.tsx
@@ -2,7 +2,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { RegionCascade } from '@/vite/operator-locations/RegionCascade'
 import { zodResolver } from '@hookform/resolvers/zod'
+import type { RegionNode } from '@kuruma/shared/types/region'
 import {
   type CreateLocationInput,
   type UpdateLocationInput,
@@ -26,6 +28,10 @@ type LocationFormBaseProps = {
   onCancel?: () => void
   defaultValues?: Partial<CreateLocationInput>
   isSubmitting?: boolean
+  // #651 2b: the full region taxonomy (GET /regions) for the prefecture->city->area
+  // cascade. Injected by the dialog (which fetches it) so the form stays presentational
+  // and unit-testable without a QueryClient. Defaults to [] for a graceful empty state.
+  regions?: readonly RegionNode[]
 }
 type LocationFormProps =
   | (LocationFormBaseProps & {
@@ -41,7 +47,7 @@ const DEFAULT_OPEN = '09:00'
 const DEFAULT_CLOSE = '18:00'
 
 export function LocationForm(props: LocationFormProps) {
-  const { onCancel, defaultValues, isSubmitting } = props
+  const { onCancel, defaultValues, isSubmitting, regions = [] } = props
   const mode = props.mode ?? 'create'
   const t = useTranslations('business.locations')
 
@@ -54,6 +60,7 @@ export function LocationForm(props: LocationFormProps) {
     register,
     handleSubmit,
     setValue,
+    watch,
     formState: { errors },
   } = useForm<LocationFormValues, unknown, LocationFormOutput>({
     resolver: zodResolver(
@@ -65,6 +72,9 @@ export function LocationForm(props: LocationFormProps) {
       operatingHours: null,
       timezone: 'Asia/Tokyo',
       defaultTurnaroundMinutes: 2880,
+      // Tracked field (no input) so the cascade's setValue flows into submit, and an
+      // untouched cascade submits null — the server then auto-derives from the address.
+      regionId: null,
       ...defaultValues,
     },
   })
@@ -80,6 +90,9 @@ export function LocationForm(props: LocationFormProps) {
       enabled ? { openTime: DEFAULT_OPEN, closeTime: DEFAULT_CLOSE } : null,
     )
   }
+
+  // The selected region (a deepest AREA id) or null; the cascade drives it via setValue.
+  const regionId = watch('regionId') ?? null
 
   return (
     <form
@@ -173,6 +186,19 @@ export function LocationForm(props: LocationFormProps) {
           )}
         </div>
       </div>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">{t('form.region.label')}</legend>
+        {/* key on regions.length: the cascade seeds its prefecture/city chain on
+            mount, so remount once when the async list loads (0 -> N) to prefill edits. */}
+        <RegionCascade
+          key={regions.length}
+          regions={regions}
+          value={regionId}
+          onChange={(id) => setValue('regionId', id, { shouldValidate: true })}
+        />
+        <p className="text-xs text-muted-foreground">{t('form.region.help')}</p>
+      </fieldset>
 
       <div className="flex justify-end gap-2 pt-4">
         {onCancel && (

--- a/packages/web/src/vite/operator-locations/LocationForm.tsx
+++ b/packages/web/src/vite/operator-locations/LocationForm.tsx
@@ -189,10 +189,12 @@ export function LocationForm(props: LocationFormProps) {
 
       <fieldset className="space-y-2">
         <legend className="text-sm font-medium">{t('form.region.label')}</legend>
-        {/* key on regions.length: the cascade seeds its prefecture/city chain on
-            mount, so remount once when the async list loads (0 -> N) to prefill edits. */}
+        {/* The cascade seeds its prefecture/city chain from `value` on mount, so it
+            must remount once when the async region list first arrives (empty -> loaded)
+            to prefill an edit. Key on that transition only — NOT on length, which would
+            also remount (and wipe in-progress navigation) on an unrelated refetch. */}
         <RegionCascade
-          key={regions.length}
+          key={regions.length > 0 ? 'loaded' : 'empty'}
           regions={regions}
           value={regionId}
           onChange={(id) => setValue('regionId', id, { shouldValidate: true })}

--- a/packages/web/src/vite/operator-locations/RegionCascade.tsx
+++ b/packages/web/src/vite/operator-locations/RegionCascade.tsx
@@ -1,0 +1,118 @@
+import { Label } from '@/components/ui/label'
+import { NativeSelect } from '@/components/ui/native-select'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { useState } from 'react'
+import { useLocale, useTranslations } from 'use-intl'
+
+interface RegionCascadeProps {
+  /** Flat taxonomy from GET /regions (every prefecture/city/area node). */
+  regions: readonly RegionNode[]
+  /** The selected region id — always a deepest (assignable AREA) node, or null. */
+  value: string | null
+  onChange: (regionId: string | null) => void
+  disabled?: boolean
+}
+
+// The API is locale-agnostic (trilingual names); the client picks one by route locale.
+function nameOf(region: RegionNode, locale: string): string {
+  if (locale === 'ja') return region.nameJa
+  if (locale === 'zh') return region.nameZh
+  return region.nameEn
+}
+
+// Walk the area -> city -> prefecture chain for a selected (area) region id, so an
+// edit prefills all three selects. Returns nulls for null / unknown / non-area ids.
+function chainFor(regions: readonly RegionNode[], regionId: string | null) {
+  if (regionId === null) return { prefectureId: null, cityId: null }
+  const byId = new Map(regions.map((r) => [r.id, r]))
+  const area = byId.get(regionId)
+  const city = area?.parentId != null ? byId.get(area.parentId) : undefined
+  return { prefectureId: city?.parentId ?? null, cityId: city?.id ?? null }
+}
+
+/**
+ * Operator region override (#651 Slice 2b): three dependent dropdowns
+ * (prefecture -> city -> area). Only the deepest AREA level is assignable, so only
+ * an area selection produces a real `regionId`; picking a prefecture/city resets the
+ * value to null until an area is chosen. Leaving everything blank lets the server
+ * loop guard auto-derive the nearest area from the location's address.
+ */
+export function RegionCascade({ regions, value, onChange, disabled }: RegionCascadeProps) {
+  const t = useTranslations('business.locations.form.region')
+  const locale = useLocale()
+
+  // Local navigation state: which prefecture/city is "open". Seeded from the current
+  // value so edit prefills the chain; the dialog's key={id} remount re-seeds it.
+  const seeded = chainFor(regions, value)
+  const [prefectureId, setPrefectureId] = useState<string | null>(seeded.prefectureId)
+  const [cityId, setCityId] = useState<string | null>(seeded.cityId)
+
+  const prefectures = regions.filter((r) => r.type === 'PREFECTURE')
+  const cities = regions.filter((r) => r.type === 'CITY' && r.parentId === prefectureId)
+  const areas = regions.filter(
+    (r) => r.type === 'AREA' && r.parentId === cityId && r.assignable && r.status === 'ACTIVE',
+  )
+
+  const handlePrefecture = (next: string) => {
+    setPrefectureId(next || null)
+    setCityId(null)
+    onChange(null)
+  }
+  const handleCity = (next: string) => {
+    setCityId(next || null)
+    onChange(null)
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+      <div>
+        <Label htmlFor="region-prefecture">{t('prefecture')}</Label>
+        <NativeSelect
+          id="region-prefecture"
+          value={prefectureId ?? ''}
+          disabled={disabled}
+          onChange={(e) => handlePrefecture(e.target.value)}
+        >
+          <option value="">{t('placeholder')}</option>
+          {prefectures.map((r) => (
+            <option key={r.id} value={r.id}>
+              {nameOf(r, locale)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+      <div>
+        <Label htmlFor="region-city">{t('city')}</Label>
+        <NativeSelect
+          id="region-city"
+          value={cityId ?? ''}
+          disabled={disabled || prefectureId === null}
+          onChange={(e) => handleCity(e.target.value)}
+        >
+          <option value="">{t('placeholder')}</option>
+          {cities.map((r) => (
+            <option key={r.id} value={r.id}>
+              {nameOf(r, locale)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+      <div>
+        <Label htmlFor="region-area">{t('area')}</Label>
+        <NativeSelect
+          id="region-area"
+          value={value ?? ''}
+          disabled={disabled || cityId === null}
+          onChange={(e) => onChange(e.target.value || null)}
+        >
+          <option value="">{t('placeholder')}</option>
+          {areas.map((r) => (
+            <option key={r.id} value={r.id}>
+              {nameOf(r, locale)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-locations/RegionCascade.tsx
+++ b/packages/web/src/vite/operator-locations/RegionCascade.tsx
@@ -52,6 +52,12 @@ export function RegionCascade({ regions, value, onChange, disabled }: RegionCasc
   const areas = regions.filter(
     (r) => r.type === 'AREA' && r.parentId === cityId && r.assignable && r.status === 'ACTIVE',
   )
+  // A previously-assigned region that is no longer selectable (went INACTIVE or was
+  // removed) still arrives as `value`; keep it visible as a fallback option so an edit
+  // shows the current assignment instead of a misleading blank that a blind re-save
+  // could misread.
+  const current = value !== null ? regions.find((r) => r.id === value) : undefined
+  const showCurrentFallback = value !== null && !areas.some((a) => a.id === value)
 
   const handlePrefecture = (next: string) => {
     setPrefectureId(next || null)
@@ -106,6 +112,9 @@ export function RegionCascade({ regions, value, onChange, disabled }: RegionCasc
           onChange={(e) => onChange(e.target.value || null)}
         >
           <option value="">{t('placeholder')}</option>
+          {showCurrentFallback && (
+            <option value={value ?? ''}>{current ? nameOf(current, locale) : (value ?? '')}</option>
+          )}
           {areas.map((r) => (
             <option key={r.id} value={r.id}>
               {nameOf(r, locale)}

--- a/packages/web/src/vite/operator-locations/api.ts
+++ b/packages/web/src/vite/operator-locations/api.ts
@@ -27,6 +27,10 @@ export interface OperatorLocation {
   // pin; PENDING = a throttle-skipped retry (#574); null = no pin found. Drives
   // the list's pin-state badge.
   coordinateSource: 'GEOCODED' | 'MANUAL' | 'PENDING' | null
+  // #651 2b: the assigned region (deepest AREA node id) or null when unassigned.
+  // Prefills the location form's prefecture->city->area cascade on edit; the
+  // server loop guard derives one from the address when the operator leaves it null.
+  regionId: string | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/web/src/vite/operator-locations/regions-api.ts
+++ b/packages/web/src/vite/operator-locations/regions-api.ts
@@ -1,0 +1,27 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { queryOptions } from '@tanstack/react-query'
+
+// #651 2b: the public hierarchical region taxonomy (prefecture -> city -> area) —
+// the flat list GET /regions returns. Powers the operator location cascade now; the
+// renter region picker (Slice 3) will reuse it, so lift this to a shared module when
+// that second consumer lands (kept here, beside its only caller, until then).
+const ONE_HOUR_MS = 60 * 60 * 1000
+
+export const REGIONS_QUERY_KEY = ['regions'] as const
+
+export async function fetchRegions(): Promise<RegionNode[]> {
+  // Public, unauthenticated read; credentials are harmless and keep one fetch shape.
+  const res = await fetch(`${getApiBaseUrl()}/regions`, { credentials: 'include' })
+  return unwrap<RegionNode[]>(res)
+}
+
+export function regionsQueryOptions() {
+  return queryOptions({
+    queryKey: REGIONS_QUERY_KEY,
+    queryFn: fetchRegions,
+    // Platform-global reference data the API already caches for an hour.
+    staleTime: ONE_HOUR_MS,
+  })
+}

--- a/packages/web/tests/vite/operator-locations/LocationForm.test.tsx
+++ b/packages/web/tests/vite/operator-locations/LocationForm.test.tsx
@@ -1,0 +1,90 @@
+import { LocationForm } from '@/vite/operator-locations/LocationForm'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+const node = (over: Partial<RegionNode> & Pick<RegionNode, 'id' | 'type'>): RegionNode => ({
+  parentId: null,
+  nameEn: over.id,
+  nameJa: over.id,
+  nameZh: over.id,
+  sortOrder: 0,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
+  ...over,
+})
+
+const REGIONS: RegionNode[] = [
+  node({ id: 'reg_osaka', type: 'PREFECTURE', nameEn: 'Osaka' }),
+  node({ id: 'reg_osaka_city', type: 'CITY', parentId: 'reg_osaka', nameEn: 'Osaka City' }),
+  node({
+    id: 'reg_namba',
+    type: 'AREA',
+    parentId: 'reg_osaka_city',
+    nameEn: 'Namba',
+    assignable: true,
+  }),
+]
+
+function renderCreate() {
+  const onSubmit = vi.fn().mockResolvedValue(undefined)
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <LocationForm onSubmit={onSubmit} regions={REGIONS} />
+    </IntlProvider>,
+  )
+  return onSubmit
+}
+
+describe('LocationForm region cascade (#651 Slice 2b)', () => {
+  it('submits the chosen region id after the operator picks an area', async () => {
+    const user = userEvent.setup()
+    const onSubmit = renderCreate()
+
+    await user.type(screen.getByLabelText('Location name'), 'Namba Branch')
+    await user.type(screen.getByLabelText('Address'), '1-2-3 Namba, Chuo-ku')
+    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
+    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
+    await user.selectOptions(screen.getByLabelText('Area'), 'reg_namba')
+    await user.click(screen.getByRole('button', { name: 'Save location' }))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ regionId: 'reg_namba' }))
+  })
+
+  it('submits a null region when the cascade is left blank (server auto-derives)', async () => {
+    const user = userEvent.setup()
+    const onSubmit = renderCreate()
+
+    await user.type(screen.getByLabelText('Location name'), 'Auto Branch')
+    await user.type(screen.getByLabelText('Address'), '1-2-3 Somewhere')
+    await user.click(screen.getByRole('button', { name: 'Save location' }))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ regionId: null }))
+  })
+
+  it('prefills the region chain in edit mode from defaultValues.regionId', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <IntlProvider locale="en" messages={en}>
+        <LocationForm
+          mode="edit"
+          onSubmit={onSubmit}
+          regions={REGIONS}
+          defaultValues={{ name: 'Namba Branch', address: '1-2-3 Namba', regionId: 'reg_namba' }}
+        />
+      </IntlProvider>,
+    )
+
+    expect(screen.getByLabelText('Prefecture')).toHaveValue('reg_osaka')
+    expect(screen.getByLabelText('City')).toHaveValue('reg_osaka_city')
+    expect(screen.getByLabelText('Area')).toHaveValue('reg_namba')
+  })
+})

--- a/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
+++ b/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
@@ -100,11 +100,24 @@ describe('RegionCascade (#651 Slice 2b)', () => {
     expect(screen.getByLabelText('Area')).toHaveValue('reg_namba')
   })
 
-  it('clears the value to null when the prefecture changes', async () => {
+  it('clears the value to null and resets the city when the prefecture changes', async () => {
     const user = userEvent.setup()
     const onChange = setup('reg_namba')
     await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_kyoto')
+    // Emits null (the parent then feeds value=null; here onChange is a stub, so we
+    // assert the cascade's own reset rather than a re-render that never happens).
     expect(onChange).toHaveBeenLastCalledWith(null)
-    expect(screen.getByLabelText('Area')).toHaveValue('')
+    expect(screen.getByLabelText('City')).toHaveValue('')
+  })
+
+  it('keeps a now-unselectable assigned region visible (INACTIVE) instead of blanking', () => {
+    setup('reg_retired')
+    expect(screen.getByLabelText('Area')).toHaveValue('reg_retired')
+    expect(screen.getByRole('option', { name: 'Retired' })).toBeInTheDocument()
+  })
+
+  it('renders without crashing when the assigned region is unknown (since deleted)', () => {
+    setup('reg_gone')
+    expect(screen.getByLabelText('Area')).toHaveValue('reg_gone')
   })
 })

--- a/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
+++ b/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
@@ -1,0 +1,110 @@
+import { RegionCascade } from '@/vite/operator-locations/RegionCascade'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+const node = (over: Partial<RegionNode> & Pick<RegionNode, 'id' | 'type'>): RegionNode => ({
+  parentId: null,
+  nameEn: over.id,
+  nameJa: over.id,
+  nameZh: over.id,
+  sortOrder: 0,
+  latitude: null,
+  longitude: null,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: null,
+  ...over,
+})
+
+// osaka -> osaka_city -> {namba, umeda} (+ retired INACTIVE, navonly non-assignable)
+// kyoto -> kyoto_city
+const REGIONS: RegionNode[] = [
+  node({ id: 'reg_osaka', type: 'PREFECTURE', nameEn: 'Osaka' }),
+  node({ id: 'reg_kyoto', type: 'PREFECTURE', nameEn: 'Kyoto' }),
+  node({ id: 'reg_osaka_city', type: 'CITY', parentId: 'reg_osaka', nameEn: 'Osaka City' }),
+  node({ id: 'reg_kyoto_city', type: 'CITY', parentId: 'reg_kyoto', nameEn: 'Kyoto City' }),
+  node({
+    id: 'reg_namba',
+    type: 'AREA',
+    parentId: 'reg_osaka_city',
+    nameEn: 'Namba',
+    assignable: true,
+  }),
+  node({
+    id: 'reg_umeda',
+    type: 'AREA',
+    parentId: 'reg_osaka_city',
+    nameEn: 'Umeda',
+    assignable: true,
+  }),
+  node({
+    id: 'reg_retired',
+    type: 'AREA',
+    parentId: 'reg_osaka_city',
+    nameEn: 'Retired',
+    assignable: true,
+    status: 'INACTIVE',
+  }),
+  node({ id: 'reg_navonly', type: 'AREA', parentId: 'reg_osaka_city', nameEn: 'NavOnly' }),
+]
+
+function setup(value: string | null = null) {
+  const onChange = vi.fn()
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <RegionCascade regions={REGIONS} value={value} onChange={onChange} />
+    </IntlProvider>,
+  )
+  return onChange
+}
+
+describe('RegionCascade (#651 Slice 2b)', () => {
+  it('disables city + area until their parent is chosen', () => {
+    setup()
+    expect(screen.getByLabelText('City')).toBeDisabled()
+    expect(screen.getByLabelText('Area')).toBeDisabled()
+    expect(screen.getByLabelText('Prefecture')).toBeEnabled()
+  })
+
+  it('emits the area id only after prefecture -> city -> area are all chosen', async () => {
+    const user = userEvent.setup()
+    const onChange = setup()
+
+    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
+    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
+    await user.selectOptions(screen.getByLabelText('Area'), 'reg_namba')
+
+    expect(onChange).toHaveBeenLastCalledWith('reg_namba')
+  })
+
+  it('lists only assignable, ACTIVE areas (excludes INACTIVE + navigation-only)', async () => {
+    const user = userEvent.setup()
+    setup()
+    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
+    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
+
+    expect(screen.getByRole('option', { name: 'Namba' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Umeda' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Retired' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'NavOnly' })).not.toBeInTheDocument()
+  })
+
+  it('prefills the prefecture -> city -> area chain from an existing value', () => {
+    setup('reg_namba')
+    expect(screen.getByLabelText('Prefecture')).toHaveValue('reg_osaka')
+    expect(screen.getByLabelText('City')).toHaveValue('reg_osaka_city')
+    expect(screen.getByLabelText('Area')).toHaveValue('reg_namba')
+  })
+
+  it('clears the value to null when the prefecture changes', async () => {
+    const user = userEvent.setup()
+    const onChange = setup('reg_namba')
+    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_kyoto')
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(screen.getByLabelText('Area')).toHaveValue('')
+  })
+})


### PR DESCRIPTION
## What

Slice 2b of #651 — the operator location **region cascade**. An operator can now set or override a location's region via prefecture → city → area dropdowns; leaving it blank lets the server loop guard (Slice 2, #798) auto-derive the nearest area from the address. This also rebuilds the rich `GET /regions` read that both this cascade and the renter picker (Slice 3) need.

## Changes

**API / shared** (`9c725ec`)
- New `@kuruma/shared/types/region` `RegionNode` (extends `RegionCandidate`).
- `GET /regions` now projects the full node (`type`/`lat`/`lng`/`assignable`/`status`/`slug`).
- Collapsed `findCandidates` into `findAll` — `RegionNode ⊃ RegionCandidate`, so one repository read feeds both the cascade and the location-save geo guard. `stores.Region` is now an alias of `RegionNode`.

**Web** (`06f3b03`)
- `RegionCascade` — 3 dependent selects; only assignable, ACTIVE areas are selectable.
- `fetchRegions` client + `OperatorLocation.regionId` for edit prefill; wired into the operator `LocationForm`; i18n en/ja/zh.
- **Relaxed `regionIdSchema` from `.uuid()` to a non-empty text id** — region ids are TEXT PKs (the seed uses `reg_*` ids); the service guard (422 on unknown/non-assignable) is the real validation. `.uuid()` would have 400'd every seeded region the cascade submits.

**Review fixes** (`9034349`)
- Keep a now-unselectable assigned region visible (fallback option) instead of blanking on edit.
- Key the cascade remount on the empty→loaded transition, not array length.
- Documented the deferred per-save region cache + the enriched public payload.

## Tests
- API: unit **1469**, integration **245** (incl. a `GET /regions` enrichment assertion + the loop guard on real pg, now off `findAll`).
- Web: **774** (RegionCascade 7, LocationForm 3).
- shared validator 58; all typechecks 0; `lint:boundaries` OK; `db:verify` 5/5 (no migration). Rebased onto current trunk (incl. #813 schema split, #726 route boundary).

## Reviews
code-reviewer: no CRITICAL/HIGH (both flagged decisions judged correct). architect: SHIP-WITH-FIXES — all fixes applied; the in-process region cache was deliberately deferred (pre-existing per-save read, trivial at this scale).

Part of #651. Slice 3 (renter region picker) reuses the `GET /regions` enrichment + `RegionNode` landed here.
