### PR TITLE
fix(api): localize booking-email datetimes to JST, labelled (#680)

### DIFF
--- a/packages/api/src/services/email/templates/format.ts
+++ b/packages/api/src/services/email/templates/format.ts
@@ -18,7 +18,28 @@ export function formatJpy(amountJpy: number): string {
   return `¥${new Intl.NumberFormat('en-US').format(amountJpy)}`
 }
 
-/** Deterministic UTC datetime (no host-timezone surprises): "2026-07-01 10:00 UTC". */
+// Every operator is Japan-based, so booking datetimes render in Japan Standard Time
+// (Asia/Tokyo — a fixed UTC+9; Japan observes no DST). A pickup/return is a
+// location-anchored event the renter acts on while standing in Japan, and email can't
+// detect the recipient's own timezone, so we anchor to the pickup location and always
+// label it — never a bare or UTC time (#680). If operators outside Japan are ever
+// added, source the zone from the pickup location instead of this constant.
+const BOOKING_TIME_ZONE = 'Asia/Tokyo'
+const BOOKING_TIME_ZONE_LABEL = 'JST'
+
+/** Booking datetime in the pickup location's wall-clock time, labelled — e.g.
+ *  "2026-07-01 19:00 JST". Deterministic regardless of the host's own timezone. */
 export function formatDateTime(date: Date): string {
-  return `${date.toISOString().slice(0, 16).replace('T', ' ')} UTC`
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: BOOKING_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const part = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((p) => p.type === type)?.value ?? ''
+  return `${part('year')}-${part('month')}-${part('day')} ${part('hour')}:${part('minute')} ${BOOKING_TIME_ZONE_LABEL}`
 }

--- a/packages/api/src/services/email/templates/format.ts
+++ b/packages/api/src/services/email/templates/format.ts
@@ -23,7 +23,7 @@ export function formatJpy(amountJpy: number): string {
 // location-anchored event the renter acts on while standing in Japan, and email can't
 // detect the recipient's own timezone, so we anchor to the pickup location and always
 // label it — never a bare or UTC time (#680). If operators outside Japan are ever
-// added, source the zone from the pickup location instead of this constant.
+// added, source the zone from the pickup/dropoff location instead of this constant (#818).
 const BOOKING_TIME_ZONE = 'Asia/Tokyo'
 const BOOKING_TIME_ZONE_LABEL = 'JST'
 

--- a/packages/api/tests/services/email/format.test.ts
+++ b/packages/api/tests/services/email/format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { formatDateTime } from '../../../src/services/email/templates/format'
+
+// #680: a pickup/return is a location-anchored event the renter acts on while standing
+// in Japan, and email can't detect the recipient's own timezone — so booking datetimes
+// render in the pickup location's wall-clock time (JST, Asia/Tokyo, fixed UTC+9; Japan
+// observes no DST), always labelled, never a bare or UTC time. These pin the exact
+// rendered string so a mutant that reverts to UTC, uses the wrong offset, mishandles a
+// date rollover, or prints 24:00 at midnight fails.
+
+describe('formatDateTime', () => {
+  it('renders an instant in JST wall-clock with an explicit label', () => {
+    // 01:00 UTC + 9h = 10:00 JST, same calendar day.
+    expect(formatDateTime(new Date('2026-07-01T01:00:00Z'))).toBe('2026-07-01 10:00 JST')
+  })
+
+  it('rolls the date forward when +9h crosses midnight', () => {
+    // 18:00 UTC + 9h = 03:00 the NEXT day (this is the real booking endAt fixture).
+    expect(formatDateTime(new Date('2026-07-03T18:00:00Z'))).toBe('2026-07-04 03:00 JST')
+  })
+
+  it('prints midnight as 00:00 (not 24:00) and rolls month/day', () => {
+    // 15:30 UTC on Jun 30 + 9h = 00:30 JST on Jul 1.
+    expect(formatDateTime(new Date('2026-06-30T15:30:00Z'))).toBe('2026-07-01 00:30 JST')
+  })
+
+  it('is no longer a UTC rendering', () => {
+    const out = formatDateTime(new Date('2026-07-01T10:00:00Z'))
+    expect(out).not.toContain('UTC')
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} JST$/)
+  })
+})

--- a/packages/api/tests/services/email/templates.test.ts
+++ b/packages/api/tests/services/email/templates.test.ts
@@ -49,6 +49,16 @@ describe('renderRenterConfirmation', () => {
     expect(text.length).toBeGreaterThan(0)
   })
 
+  it('renders pickup/return in JST wall-clock with a label — incl. the +9h date rollover (#680)', () => {
+    const { html, text } = renderRenterConfirmation(baseRenter, 'en')
+    for (const body of [html, text]) {
+      // startAt 10:00 UTC -> 19:00 JST same day; endAt 18:00 UTC -> 03:00 JST NEXT day.
+      expect(body).toContain('2026-07-01 19:00 JST')
+      expect(body).toContain('2026-07-04 03:00 JST')
+      expect(body).not.toContain('UTC')
+    }
+  })
+
   it('renders the pre-auth CTA with the EXACT handoff URL when present', () => {
     const { html, text } = renderRenterConfirmation(baseRenter, 'en')
     expect(html).toContain('https://pay.bestcarrental.jp/handoff/ABCD2345')


### PR DESCRIPTION
Closes #680.

## Problem
Notification emails (booking confirmation, substitution, status-update, cancellation, operator alert) rendered pickup/return datetimes as **bare UTC** — e.g. `2026-07-01 10:00 UTC`. A renter standing in Osaka reads that as the wrong time, and email can't detect the recipient's own timezone.

## Change (1 helper, shared by all 5 templates)
`packages/api/src/services/email/templates/format.ts` — `formatDateTime()` now renders in **JST (Asia/Tokyo)** with an explicit label, e.g. `2026-07-01 19:00 JST`. Built from `Intl.DateTimeFormat(...).formatToParts` with `hourCycle: 'h23'`, so the host's own timezone never leaks in, midnight prints `00:00` (not `24:00`), and the `+9h` date rollover is handled by Intl. The only datetimes in email are `startAt`/`endAt`, so this is the whole surface.

## Why hardcoded `Asia/Tokyo` (not per-location)
Every operator is Japan-based and `location.timezone` is `notNull default 'Asia/Tokyo'`, so output is byte-identical to reading the column — true per-pickup/dropoff zoning (with derived labels) is real scope for a case that doesn't exist yet. Deferred under YAGNI and tracked as **#818**, with the extension seam documented in `format.ts`.

## Tests
- `tests/services/email/format.test.ts` (new) — 4 mutation-resistant cases: same-day, `+9h` midnight rollover, `00:00`-not-`24:00`, and a no-longer-UTC guard pinning the exact string.
- `tests/services/email/templates.test.ts` — +1 integration assertion proving `renderRenterConfirmation` wires JST into both html and text bodies incl. the cross-midnight `endAt`.

## Review
code-reviewer agent: **SHIP-WITH-FIXES**, no blockers. The one substantive finding (per-location zoning) is filed as #818; verified the Intl approach is host-TZ-independent and CF-Workers-portable (full ICU).

## Test plan
- [x] `bun run --filter @kuruma/api test -- tests/services/email/` → 27/27
- [x] `tsc --noEmit` (api) → 0
- [x] `lint:boundaries` → OK, biome clean
- [x] pre-commit hook (size/modules/tsc web+api) green