### PR TITLE
refactor(web): harmonize NativeSelect interaction states with Input primitive (#622)

### DIFF
--- a/packages/web/src/components/ui/native-select.tsx
+++ b/packages/web/src/components/ui/native-select.tsx
@@ -12,7 +12,11 @@ function NativeSelect({ className, ...props }: React.ComponentProps<'select'>) {
     <select
       data-slot="native-select"
       className={cn(
-        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs',
+        // #622: interaction-state parity with ui/input.tsx (focus / disabled /
+        // aria-invalid + their dark variants). The select keeps its own h-9
+        // rounded-md dimensions and bg-transparent resting state — only the
+        // missing interaction-state styling is harmonized.
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/packages/web/tests/components/ui/native-select.test.tsx
+++ b/packages/web/tests/components/ui/native-select.test.tsx
@@ -1,0 +1,38 @@
+import { NativeSelect } from '@/components/ui/native-select'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+// #622: NativeSelect was extracted (#604) without the interaction-state styling
+// that the text-input primitive (ui/input.tsx) carries. These tests pin parity
+// on focus / disabled / aria-invalid so a future refactor can't silently drop it.
+describe('NativeSelect', () => {
+  it('carries focus / disabled / aria-invalid interaction-state styling (Input parity)', () => {
+    const { container } = render(<NativeSelect aria-label="region" />)
+    const select = container.querySelector('select')
+
+    // focus ring
+    expect(select).toHaveClass('focus-visible:border-ring')
+    expect(select).toHaveClass('focus-visible:ring-ring/50')
+    // disabled
+    expect(select).toHaveClass('disabled:cursor-not-allowed')
+    expect(select).toHaveClass('disabled:opacity-50')
+    // invalid (dormant until aria-invalid is set, exactly like Input)
+    expect(select).toHaveClass('aria-invalid:border-destructive')
+    expect(select).toHaveClass('aria-invalid:ring-destructive/20')
+    // dark-mode counterparts — the ones most likely to be silently dropped in a
+    // future sweep since nobody eyeballs dark mode, so pin them explicitly.
+    expect(select).toHaveClass('disabled:bg-input/50')
+    expect(select).toHaveClass('dark:disabled:bg-input/80')
+    expect(select).toHaveClass('dark:aria-invalid:border-destructive/50')
+    expect(select).toHaveClass('dark:aria-invalid:ring-destructive/40')
+  })
+
+  it('preserves its own dimensions and merges caller className', () => {
+    const { container } = render(<NativeSelect className="mt-4" />)
+    const select = container.querySelector('select')
+
+    expect(select).toHaveClass('h-9')
+    expect(select).toHaveClass('rounded-md')
+    expect(select).toHaveClass('mt-4')
+  })
+})


### PR DESCRIPTION
## What
`NativeSelect` was extracted in #604 as a faithful copy of the inline class string, which never carried the focus / disabled / `aria-invalid` styling the `Input` primitive (`ui/input.tsx`) has — so it rendered visually thinner than the text inputs beside it.

## Change
One primitive file: append Input's `focus-visible` / `disabled` / `aria-invalid` variants (plus their dark-mode counterparts) to `native-select.tsx`. Token-for-token copy from `input.tsx` — no new design-system classes.

## Scope decisions
- **Kept** the select's own `h-9 rounded-md` dimensions and `bg-transparent` resting state — did *not* harmonize to Input's `h-8 rounded-lg` or add Input's `dark:bg-input/30` resting bg. Dimension harmonization is optional per the issue and would shift layout across 6 operator-form sites for zero functional gain (YAGNI).
- **Did not** wire `aria-invalid` at call sites — Input's invalid variant is itself dormant until `aria-invalid` is set, so primitive-only achieves true parity. Left as a follow-up.

## Visible effect today
The `disabled:` styling is immediately load-bearing: `RegionCascade.tsx` drives three dependent selects via `disabled={...}`, so disabled region selects now correctly dim (`opacity-50` + not-allowed cursor). The `aria-invalid:` variant stays dormant until call sites opt in.

## Test
New `tests/components/ui/native-select.test.tsx` pins the focus / disabled / invalid tokens incl. the dark-mode variants (mutation-resistant parity lock) and guards the kept-dimensions decision + `cn` merge.

## Verification
- native-select test 2/2 · full web suite 776/776 · web + api tsc 0 · biome clean · pre-commit hook (size + module-boundaries) green
- code-reviewer agent: **Ship** — token parity exact, behavior-preserving, test mutation-resistant

Closes #622