### PR TITLE
refactor(shared): db/ fragments → leaf imports + region enums SSoT (#814)

### DIFF
--- a/packages/shared/src/db/add-on.ts
+++ b/packages/shared/src/db/add-on.ts
@@ -11,7 +11,7 @@ import {
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { ADD_ON_STATUSES } from '../enums'
-import { operators } from './schema'
+import { operators } from './auth'
 
 export const addOnStatusEnum = pgEnum('add_on_status', ADD_ON_STATUSES)
 

--- a/packages/shared/src/db/booking-types.ts
+++ b/packages/shared/src/db/booking-types.ts
@@ -1,4 +1,4 @@
-import type { BookingFulfillmentMode, BookingStatus, FeeType, FeeUnit } from './schema'
+import type { BookingFulfillmentMode, BookingStatus, FeeType, FeeUnit } from '../enums'
 
 // ---- Slice 6 (#392) booking snapshot + event payload types ----
 // Snapshots lock rates at booking time; operator edits to the live

--- a/packages/shared/src/db/provider-access.ts
+++ b/packages/shared/src/db/provider-access.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm'
 import { index, pgEnum, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core'
 import { OPERATOR_MEMBERSHIP_STATUSES, OPERATOR_ROLES, PROVIDER_INVITE_STATUSES } from '../enums'
-import { operators, users } from './schema'
+import { operators, users } from './auth'
 
 // #521 — provider authorization model. Google proves identity; these tables
 // grant authority. `operator_memberships` is the source-of-truth grant ledger;

--- a/packages/shared/src/db/regions.ts
+++ b/packages/shared/src/db/regions.ts
@@ -10,13 +10,16 @@ import {
   timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
+// Enum value sets sourced from the zero-import ../enums SSoT (#688/#814) so the
+// pgEnum, validators, and web type imports all share one declaration.
+import { REGION_STATUSES, REGION_TYPES } from '../enums'
 
 // Taxonomy level of a region node (#651 Slice 1). Drives the renter cascade
 // (prefecture -> city -> area dropdowns) and marks which level is assignable.
-export const regionTypeEnum = pgEnum('region_type', ['PREFECTURE', 'CITY', 'AREA'])
+export const regionTypeEnum = pgEnum('region_type', REGION_TYPES)
 // Lifecycle of a region node. INACTIVE nodes are hidden from search + never
 // matched by `nearestAssignableRegion` (assignment requires ACTIVE).
-export const regionStatusEnum = pgEnum('region_status', ['ACTIVE', 'INACTIVE'])
+export const regionStatusEnum = pgEnum('region_status', REGION_STATUSES)
 
 // #394 hierarchical region taxonomy (prefecture -> city -> area). PLATFORM-GLOBAL
 // reference data — NO operatorId: every operator searches the same tree. Adjacency

--- a/packages/shared/src/db/renter-documents.ts
+++ b/packages/shared/src/db/renter-documents.ts
@@ -1,6 +1,6 @@
 import { date, index, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 import { DOCUMENT_STATUSES, DOCUMENT_TYPES } from '../enums'
-import { users } from './schema'
+import { users } from './auth'
 
 // Renter identity documents (#459, §1.3/§4). Metadata ONLY — the scan lives in
 // Cloudflare R2; we keep the verdict (status + expiry), never the bytes or a URL

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -99,6 +99,16 @@ export type OperatorMembershipStatus = (typeof OPERATOR_MEMBERSHIP_STATUSES)[num
 export const PROVIDER_INVITE_STATUSES = ['PENDING', 'ACCEPTED'] as const
 export type ProviderInviteStatus = (typeof PROVIDER_INVITE_STATUSES)[number]
 
+// Region taxonomy levels (#394/#651): prefecture -> city -> area. Order is
+// contractual — the region_type CREATE TYPE lists them positionally.
+export const REGION_TYPES = ['PREFECTURE', 'CITY', 'AREA'] as const
+export type RegionType = (typeof REGION_TYPES)[number]
+
+// Region lifecycle. Note INACTIVE (not ARCHIVED): INACTIVE nodes are hidden from
+// search + never matched by nearestAssignableRegion.
+export const REGION_STATUSES = ['ACTIVE', 'INACTIVE'] as const
+export type RegionStatus = (typeof REGION_STATUSES)[number]
+
 // LUGGAGE_SIZES already lives in lib/luggage.ts (#457) — re-exported here so the
 // enum SSoT is reachable from one subpath without duplicating its declaration.
 export { LUGGAGE_SIZES, type LuggageSize } from './lib/luggage'

--- a/packages/shared/src/types/region.ts
+++ b/packages/shared/src/types/region.ts
@@ -1,11 +1,10 @@
+import type { RegionType } from '../enums'
 import type { RegionCandidate } from '../lib/region-distance'
 
-/**
- * Taxonomy level of a region node (#651). Mirrors `regionTypeEnum` in
- * `db/regions.ts`. Nullable on a node because the column is nullable-on-add
- * (the seed populates every row).
- */
-export type RegionType = 'PREFECTURE' | 'CITY' | 'AREA'
+// RegionType (PREFECTURE | CITY | AREA) is the enums SSoT (#814); db/regions.ts'
+// regionTypeEnum derives from the same const. Re-exported here so existing
+// `@kuruma/shared/types/region` consumers keep a single import path.
+export type { RegionType }
 
 /**
  * A full region taxonomy row as returned by `GET /regions` (#651 Slice 2b).

--- a/packages/shared/tests/enums.test.ts
+++ b/packages/shared/tests/enums.test.ts
@@ -7,6 +7,7 @@ import {
   operatorRoleEnum,
   providerInviteStatusEnum,
 } from '../src/db/provider-access'
+import { regionStatusEnum, regionTypeEnum } from '../src/db/regions'
 import { documentStatusEnum, documentTypeEnum } from '../src/db/renter-documents'
 import {
   bookingEventTypeEnum,
@@ -43,6 +44,8 @@ import {
   OPERATOR_ROLES,
   PAYMENT_EVENT_STATUSES,
   PROVIDER_INVITE_STATUSES,
+  REGION_STATUSES,
+  REGION_TYPES,
   ROLES,
   TRANSMISSIONS,
   VEHICLE_CLASS_STATUSES,
@@ -82,6 +85,8 @@ describe('enum SSoT — pgEnum.enumValues === src/enums.ts array (#688)', () => 
       OPERATOR_MEMBERSHIP_STATUSES,
     ],
     ['provider_invite_status', providerInviteStatusEnum.enumValues, PROVIDER_INVITE_STATUSES],
+    ['region_type', regionTypeEnum.enumValues, REGION_TYPES],
+    ['region_status', regionStatusEnum.enumValues, REGION_STATUSES],
   ]
 
   for (const [name, enumValues, sourceArray] of cases) {


### PR DESCRIPTION
Closes #814. Child of #725 (PR #813 god-file split). Behavior-preserving refactor of `packages/shared` — type/import-only, **zero DDL or runtime value change** (`bun run db:generate` = "No schema changes").

## What

**Part 1 — break the fragment→barrel→fragment import cycle.** The four db/ fragments still routing table/enum imports through the `./schema` barrel (`add-on`, `booking-types`, `provider-access`, `renter-documents`) now import from leaf modules directly — tables from `./auth`, enum-types from `../enums`. This matches the convention every other context module already follows; they were the last outliers. The db/ graph is now acyclic (`schema.ts` aggregates upward; no fragment imports it back).

**Part 2 — region taxonomy SSoT (#688 parity).** `enums.ts` gains `REGION_TYPES = ['PREFECTURE','CITY','AREA']` and `REGION_STATUSES = ['ACTIVE','INACTIVE']` (+ derived `RegionType`/`RegionStatus`). `db/regions.ts` derives its pgEnums from these consts. Note: status is `INACTIVE` (not `ARCHIVED`). Two drift-guard cases added to `tests/enums.test.ts` pin `regionTypeEnum`/`regionStatusEnum` values **and order** to the consts.

**Part 3 — dedupe a post-branch regression.** PR #815 (merged after this branch forked) reintroduced a hand-written `RegionType = 'PREFECTURE'|'CITY'|'AREA'` literal union in `types/region.ts` that, per its own comment, mirrors `regionTypeEnum`. Re-pointed it at the `../enums` SSoT. Public surface unchanged — still exported from `@kuruma/shared/types/region`.

## Scope note
Folding Part 3 in was deliberate (it reconciles a regression of the exact type Part 2 canonicalizes). Two **pre-existing** in-package literal duplicates were left out as a tighter-scoped follow-up (`lib/region-distance.ts` `RegionCandidate.status`; `db/seed-data/regions.ts` `DemoRegion.type`) — see follow-up issue.

## Reviews
code-reviewer: **SHIP** (no findings). architect: **SHIP** (both structural goals met; cycle eliminated not relocated; `enums.ts` is a true enforced leaf).

## Test plan
- [x] shared tsc / api tsc / web tsc — all exit 0
- [x] shared 546 · api 1469 · web 774 — all green
- [x] `db:generate` no-op (DDL byte-identical) · module + size + boundary lints exit 0
- [ ] CI runs integration suite (excluded from local `test` by config)