### PR TITLE
refactor(api): dedup RenderedEmail/vehicleLabel onto shared layout.ts (#682)

### DIFF
--- a/packages/api/src/services/email/templates/operator-alert.ts
+++ b/packages/api/src/services/email/templates/operator-alert.ts
@@ -1,6 +1,6 @@
-import { escapeHtml, formatDateTime, formatJpy } from './format'
+import { formatDateTime, formatJpy } from './format'
+import { type RenderedEmail, renderRowsEmail, vehicleLabel } from './layout'
 import { emailStrings } from './messages'
-import type { RenderedEmail } from './renter-confirmation'
 
 export interface OperatorAlertData {
   bookingCode: string
@@ -11,10 +11,6 @@ export interface OperatorAlertData {
   endAt: Date
   renterName: string | null
   totalPriceJpy: number | null
-}
-
-function vehicleLabel(v: OperatorAlertData['vehicle']): string {
-  return v.licensePlate ? `${v.name} (${v.licensePlate})` : v.name
 }
 
 /**
@@ -33,11 +29,5 @@ export function renderOperatorAlert(data: OperatorAlertData, locale: string): Re
   if (data.totalPriceJpy != null) rows.push([m.totalLabel, formatJpy(data.totalPriceJpy)])
 
   const subject = `${m.operatorSubject} ${data.bookingCode}`
-  const htmlRows = rows
-    .map(([l, v]) => `<tr><td><strong>${escapeHtml(l)}</strong></td><td>${escapeHtml(v)}</td></tr>`)
-    .join('')
-  const html = `<p>${escapeHtml(m.operatorHeading)}</p><table>${htmlRows}</table>`
-  const text = `${m.operatorHeading}\n\n${rows.map(([l, v]) => `${l}: ${v}`).join('\n')}`
-
-  return { subject, html, text }
+  return { subject, ...renderRowsEmail(m.operatorHeading, rows) }
 }

--- a/packages/api/src/services/email/templates/renter-confirmation.ts
+++ b/packages/api/src/services/email/templates/renter-confirmation.ts
@@ -1,5 +1,6 @@
 import type { FeeSnapshotItem } from '@kuruma/shared/db/schema'
 import { escapeHtml, formatDateTime, formatJpy } from './format'
+import { type RenderedEmail, vehicleLabel } from './layout'
 import { emailStrings } from './messages'
 
 export interface RenterConfirmationData {
@@ -14,16 +15,6 @@ export interface RenterConfirmationData {
   fees: FeeSnapshotItem[]
   preAuthHandoffUrl: string | null
   totalPriceJpy: number | null
-}
-
-export interface RenderedEmail {
-  subject: string
-  html: string
-  text: string
-}
-
-function vehicleLabel(v: RenterConfirmationData['vehicle']): string {
-  return v.licensePlate ? `${v.name} (${v.licensePlate})` : v.name
 }
 
 /**


### PR DESCRIPTION
Closes #682.

## What
Two legacy lifecycle-email templates held private copies of `RenderedEmail` and `vehicleLabel` that the shared `templates/layout.ts` (#664) already exports. Point them at the shared module and delete the dupes.

- **`renter-confirmation.ts`** — import `RenderedEmail` + `vehicleLabel` from `./layout`; delete the private copies. Keeps its own renderer (it interleaves fee + pre-auth blocks that `renderRowsEmail` doesn't model).
- **`operator-alert.ts`** — repoint the `RenderedEmail` import off the legacy file onto `./layout`; delete its private `vehicleLabel`; collapse its hand-rolled html/text boilerplate onto `renderRowsEmail(heading, rows)` (it's a pure heading+rows email — exactly what layout exists for).

Net: −23 / +4 lines, one surviving `vehicleLabel` definition.

## Why safe (behavior-preserving)
- `renderRowsEmail`'s format strings are **character-for-character identical** to operator-alert's old inline html/text (verified in review).
- Shared `vehicleLabel({ name, licensePlate })` accepts the callers' wider `vehicle` objects via structural typing; only those two fields were ever read.
- `tests/services/email/templates.test.ts` — **16/16 green before and after**.

## Test plan
- [x] `templates.test.ts` 16/16 (baseline + post-refactor)
- [x] `tsc --noEmit` (api + web, via pre-commit)
- [x] biome check, lint:size, lint:modules, lint:boundaries
- [x] code-reviewer agent: no findings, output byte-identical
- [ ] CI green

Note: base is `marketplace-pivot` (not default `main`), so #682 will be closed manually on merge.