### PR TITLE
refactor(web): validate operator-bookings responses with Zod (#711 slice 3b)

### DIFF
--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -40,27 +40,34 @@ export interface BookingDto {
 // z.ZodType<...>` — the interfaces stay the single source for the shape, while a
 // drifted/dropped field now fails as a ParseError at the seam instead of
 // surfacing as `undefined` on the confirmation page or in My Bookings.
-const insuranceSnapshotSchema = z.object({
+// Exported (#711, 3b): the operator-bookings event-timeline payload schema reuses
+// these snapshot shapes — they are the SAME shared types embedded in a
+// BOOKING_CREATED audit payload, so it composes them rather than re-declaring.
+export const insuranceSnapshotSchema = z.object({
   insuranceOptionId: z.string(),
   name: z.string(),
   dailyPriceJpy: z.number(),
   deductibleJpy: z.number().nullable(),
 }) satisfies z.ZodType<InsuranceSnapshot>
 
-const feeSnapshotItemSchema = z.object({
+export const feeSnapshotItemSchema = z.object({
   feeType: z.enum(FEE_TYPES),
   unit: z.enum(FEE_UNITS),
   amountJpy: z.number(),
   vehicleClassId: z.string().nullable(),
 }) satisfies z.ZodType<FeeSnapshotItem>
 
-const addOnSnapshotSchema = z.object({
+export const addOnSnapshotSchema = z.object({
   addOnId: z.string(),
   name: z.string(),
   priceJpy: z.number(),
 }) satisfies z.ZodType<AddOnSnapshot>
 
-const bookingDtoSchema = z.object({
+// Exported (#711, 3b): operator-bookings reuses this as the base for its expanded
+// detail DTO (bookingDtoSchema.extend) and to validate its write responses (the
+// bare booking the substitute/status/cancel endpoints return — `operator` is
+// optional here, so a write body with no operator block validates cleanly).
+export const bookingDtoSchema = z.object({
   id: z.string(),
   bookingCode: z.string(),
   renterId: z.string(),

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -1,9 +1,24 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { BookingDto } from '@/vite/bookings/api'
-import type { BookingEventPayload, BookingEventType } from '@kuruma/shared/db/schema'
+import { type BookingDto, bookingDtoSchema } from '@/vite/bookings/api'
 import type { BookingStatus } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
+import {
+  type BookingEventDto,
+  type OperatorBookingDetailDto,
+  type RawOperatorBooking,
+  bookingEventSchema,
+  calendarVehicleRowSchema,
+  operatorBookingDetailSchema,
+  rawOperatorBookingSchema,
+  substitutionCandidateRowSchema,
+} from './schema'
+
+// #711 (3b): the response DTO types + schemas live in ./schema, inferred from /
+// pinned to the Zod schemas that validate each body at the network seam. The
+// detail + event types are re-exported so consumers import them from here
+// unchanged.
+export type { BookingEventDto, OperatorBookingDetailDto }
 
 // #512: operator booking view. The Vite shell owns these DTOs (it never imports
 // the frozen Next module's copy) so it stays self-contained and process.env-free.
@@ -31,22 +46,8 @@ export interface OperatorBookingRow {
   renter: { id: string; name: string | null; email: string | null } | null
 }
 
-/** The JSON shape of one `GET /bookings?expand=vehicle,renter` item we read. */
-interface RawOperatorBooking {
-  id: string
-  bookingCode: string
-  status: OperatorBookingStatus
-  startAt: string
-  endAt: string
-  // The turnaround-aware end (#551) and the server-assigned vehicle id (#392).
-  // Present on the list response; the calendar binds events to vehicle columns
-  // by `assignedVehicleId`, and draws the block out to `effectiveEndAt`.
-  effectiveEndAt?: string | undefined
-  assignedVehicleId?: string | null | undefined
-  totalPrice: number | null
-  vehicle?: { name: string; photos: string[] } | undefined
-  renter?: { id: string; name: string | null; email: string | null; language: string } | undefined
-}
+// The JSON shape of one `GET /bookings?expand=renter` item (RawOperatorBooking)
+// is validated by `rawOperatorBookingSchema` in ./schema.
 
 // #525: the operator calendar reads bookings over a date range. Unlike the list
 // row, it carries the assigned vehicle id (the resource-column key) and the
@@ -99,7 +100,7 @@ export async function fetchCalendarBookings(
   const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
     credentials: 'include',
   })
-  const data = await unwrap<RawOperatorBooking[]>(res)
+  const data = await unwrap(res, rawOperatorBookingSchema.array())
   return data.map(toCalendarRow)
 }
 
@@ -135,7 +136,7 @@ export async function fetchCalendarVehicles(): Promise<CalendarVehicle[]> {
     const res = await fetch(`${getApiBaseUrl()}/vehicles?limit=${VEHICLES_PAGE_LIMIT}`, {
       credentials: 'include',
     })
-    const data = await unwrap<Array<{ id: string; name: string }>>(res)
+    const data = await unwrap(res, calendarVehicleRowSchema.array())
     return data.map((v) => ({ id: v.id, name: v.name }))
   } catch {
     return []
@@ -152,10 +153,7 @@ export function operatorCalendarVehiclesQueryOptions() {
 // #549: the deep-linked trip-detail page has no list row, so it reads the single
 // booking WITH `expand=vehicle,renter` (slice 2) — a superset of the renter
 // BookingDto carrying the assigned car + renter on top of the operator block.
-export interface OperatorBookingDetailDto extends BookingDto {
-  vehicle?: { name: string; photos: string[] } | undefined
-  renter?: { id: string; name: string | null; email: string | null; language: string } | undefined
-}
+// The DTO + its schema (operatorBookingDetailSchema) live in ./schema.
 
 export async function fetchOperatorBookingDetail(
   id: string,
@@ -167,7 +165,7 @@ export async function fetchOperatorBookingDetail(
   // The single read is IDOR/tenant-sealed server-side (404 for a foreign or
   // missing booking); map it to null so the loader can fire notFound().
   if (res.status === 404) return null
-  return unwrap<OperatorBookingDetailDto>(res)
+  return unwrap(res, operatorBookingDetailSchema)
 }
 
 export function operatorBookingDetailQueryOptions(id: string) {
@@ -220,25 +218,18 @@ export async function substituteBooking(
       body: JSON.stringify(body),
     },
   )
-  return unwrap<BookingDto>(res)
+  return unwrap(res, bookingDtoSchema)
 }
 
-/** One lifecycle event as the operator timeline reads it (dates are ISO JSON). */
-export interface BookingEventDto {
-  id: string
-  type: BookingEventType
-  payload: BookingEventPayload
-  actorId: string | null
-  createdAt: string
-}
-
+// The lifecycle-event DTO (BookingEventDto) + its discriminated-payload schema
+// (bookingEventSchema) live in ./schema; the type is re-exported above.
 export async function fetchBookingEvents(id: string): Promise<BookingEventDto[]> {
   // Operator/management-only endpoint (#549) — a renter caller 403s, which
   // unwrap() surfaces as an ApiError to the route's error boundary.
   const res = await fetch(`${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/events`, {
     credentials: 'include',
   })
-  return unwrap<BookingEventDto[]>(res)
+  return unwrap(res, bookingEventSchema.array())
 }
 
 export function bookingEventsQueryOptions(id: string) {
@@ -271,7 +262,7 @@ export async function fetchSubstitutionCandidates(id: string): Promise<Substitut
     `${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/substitution-candidates`,
     { credentials: 'include' },
   )
-  const data = await unwrap<Array<{ id: string; name: string; licensePlate?: string | null }>>(res)
+  const data = await unwrap(res, substitutionCandidateRowSchema.array())
   return data.map((v) => ({ id: v.id, name: v.name, licensePlate: v.licensePlate ?? null }))
 }
 
@@ -305,7 +296,7 @@ async function writeBooking(
     },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   })
-  return unwrap<BookingDto>(res)
+  return unwrap(res, bookingDtoSchema)
 }
 
 export function updateBookingStatus(

--- a/packages/web/src/vite/operator-bookings/schema.ts
+++ b/packages/web/src/vite/operator-bookings/schema.ts
@@ -1,0 +1,143 @@
+import {
+  type BookingDto,
+  addOnSnapshotSchema,
+  bookingDtoSchema,
+  feeSnapshotItemSchema,
+  insuranceSnapshotSchema,
+} from '@/vite/bookings/api'
+import type { BookingEventPayload, BookingEventType } from '@kuruma/shared/db/schema'
+import {
+  BOOKING_EVENT_TYPES,
+  BOOKING_FULFILLMENT_MODES,
+  BOOKING_STATUSES,
+} from '@kuruma/shared/enums'
+import { z } from 'zod'
+
+// #711 (3b): Zod schemas for the operator-bookings *response* bodies, extracted to
+// a sibling schema.ts so `api.ts` can thread `unwrap(res, schema)` and stay z-free
+// (the #785 convention — large-DTO clients keep their response schemas here). The
+// schema is the single source: each owned DTO type is inferred from it, and the
+// DTOs that mirror a shared contract are pinned with `satisfies z.ZodType<T>` so
+// they cannot drift from that contract without a compile error.
+//
+// Wire shape: the API JSON-serializes its `Date` columns, so every date field
+// arrives as an ISO string — these schemas mirror the API projections with
+// `Date` -> `z.string()`. Enum members come from `@kuruma/shared/enums` (the
+// SSoT) so a renamed status fails to compile here, not silently at runtime.
+
+// The two expansion blocks the operator reads share one shape across the list
+// (calendar) and the single (detail) reads, so they are declared once.
+const vehicleBlockSchema = z.object({ name: z.string(), photos: z.array(z.string()) })
+const renterBlockSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  language: z.string(),
+})
+
+/**
+ * One `GET /bookings?expand=renter` item the calendar reads. `effectiveEndAt` and
+ * `assignedVehicleId` are always sent by the API but kept optional here (the
+ * mapper falls back), so this schema stays looser than the producer — never
+ * stricter, which would reject valid data.
+ */
+export const rawOperatorBookingSchema = z.object({
+  id: z.string(),
+  bookingCode: z.string(),
+  status: z.enum(BOOKING_STATUSES),
+  startAt: z.string(),
+  endAt: z.string(),
+  effectiveEndAt: z.string().optional(),
+  assignedVehicleId: z.string().nullable().optional(),
+  totalPrice: z.number().nullable(),
+  vehicle: vehicleBlockSchema.optional(),
+  renter: renterBlockSchema.optional(),
+})
+export type RawOperatorBooking = z.infer<typeof rawOperatorBookingSchema>
+
+/**
+ * A calendar day-view column / sidebar-filter row. The API's `GET /vehicles`
+ * returns full vehicle rows; this projects to `{id, name}` (Zod objects are
+ * non-strict, so the rest is stripped at the seam).
+ */
+export const calendarVehicleRowSchema = z.object({ id: z.string(), name: z.string() })
+
+/**
+ * `GET /bookings/:id?expand=vehicle,renter` — a superset of the renter BookingDto
+ * carrying the assigned car + renter on top of the operator block. Composed from
+ * the shared `bookingDtoSchema` so the base contract stays single-sourced.
+ */
+export interface OperatorBookingDetailDto extends BookingDto {
+  vehicle?: { name: string; photos: string[] } | undefined
+  renter?: { id: string; name: string | null; email: string | null; language: string } | undefined
+}
+export const operatorBookingDetailSchema = bookingDtoSchema.extend({
+  vehicle: vehicleBlockSchema.optional(),
+  renter: renterBlockSchema.optional(),
+}) satisfies z.ZodType<OperatorBookingDetailDto>
+
+// One AVAILABLE same-store, same-ACRISS replacement candidate. The API returns a
+// full vehicle row; this projects to the three fields the picker label needs.
+export const substitutionCandidateRowSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  licensePlate: z.string().nullable().optional(),
+})
+
+// --- Lifecycle events (#716 discriminated payload) ---------------------------
+// `payload` is the shared `BookingEventPayload`, a union keyed on `type` (the
+// storage-side discriminant the read mapper backfills). Each variant is pinned to
+// its shared member via the union's `satisfies z.ZodType<BookingEventPayload>`, so
+// a shape change in the shared union fails to compile here. The BOOKING_CREATED
+// variant embeds the same snapshots as a booking, so it reuses their schemas.
+const bookingCreatedPayloadSchema = z.object({
+  type: z.literal('BOOKING_CREATED'),
+  requestedVehicleId: z.string(),
+  assignedVehicleId: z.string(),
+  classId: z.string(),
+  fulfillmentMode: z.enum(BOOKING_FULFILLMENT_MODES),
+  startAt: z.string(),
+  endAt: z.string(),
+  totalPrice: z.number(),
+  insuranceSnapshot: insuranceSnapshotSchema.nullable(),
+  feeSnapshot: z.array(feeSnapshotItemSchema),
+  addOnSnapshot: z.array(addOnSnapshotSchema),
+})
+const vehicleSubstitutedPayloadSchema = z.object({
+  type: z.literal('VEHICLE_SUBSTITUTED'),
+  fromVehicleId: z.string(),
+  toVehicleId: z.string(),
+  reason: z.string().nullable(),
+})
+const bookingCancelledPayloadSchema = z.object({
+  type: z.literal('BOOKING_CANCELLED'),
+  cancellationFee: z.number().nullable(),
+  cancelledAt: z.string(),
+})
+const statusChangedPayloadSchema = z.object({
+  type: z.literal('STATUS_CHANGED'),
+  from: z.enum(BOOKING_STATUSES),
+  to: z.enum(BOOKING_STATUSES),
+})
+const bookingEventPayloadSchema = z.discriminatedUnion('type', [
+  bookingCreatedPayloadSchema,
+  vehicleSubstitutedPayloadSchema,
+  bookingCancelledPayloadSchema,
+  statusChangedPayloadSchema,
+]) satisfies z.ZodType<BookingEventPayload>
+
+/** One lifecycle event the operator timeline reads (dates are ISO JSON). */
+export interface BookingEventDto {
+  id: string
+  type: BookingEventType
+  payload: BookingEventPayload
+  actorId: string | null
+  createdAt: string
+}
+export const bookingEventSchema = z.object({
+  id: z.string(),
+  type: z.enum(BOOKING_EVENT_TYPES),
+  payload: bookingEventPayloadSchema,
+  actorId: z.string().nullable(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<BookingEventDto>

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/lib/api-error'
+import { ApiError, ParseError } from '@/lib/api-error'
 import {
   type OperatorBookingDetailDto,
   bookingEventsQueryOptions,
@@ -32,28 +32,49 @@ afterEach(() => {
 // #549: the deep-linked trip-detail page reads the single booking WITH expansion
 // (it has no list row) plus the lifecycle events for the timeline.
 
-const detailRaw = (over: Record<string, unknown> = {}) => ({
+// A full BookingDto as it arrives over JSON (dates = ISO strings). #711: now that
+// the client validates responses, fixtures must carry every required field — a
+// partial body would (correctly) fail at the seam. The substitute/status/cancel
+// writes return this bare shape (no operator/vehicle/renter block).
+const bookingRaw = (over: Record<string, unknown> = {}) => ({
   id: 'bk-1',
   bookingCode: 'ABCD2345',
   renterId: 'r-1',
-  status: 'CONFIRMED',
+  classId: 'cls-1',
+  requestedVehicleId: 'veh-req',
+  assignedVehicleId: 'veh-1',
+  pickupLocationId: 'loc-1',
+  dropoffLocationId: 'loc-1',
   startAt: '2026-07-01T01:00:00.000Z',
   endAt: '2026-07-03T01:00:00.000Z',
-  totalPrice: 24000,
+  effectiveEndAt: '2026-07-03T02:00:00.000Z',
+  status: 'CONFIRMED',
+  source: 'DIRECT',
+  insuranceOptionId: null,
   insuranceSnapshot: null,
   feeSnapshot: [],
   addOnSnapshot: [],
+  totalPrice: 24000,
   notes: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  ...over,
+})
+
+// The expanded single read = the bare booking + operator/vehicle/renter blocks.
+const detailRaw = (over: Record<string, unknown> = {}) => ({
+  ...bookingRaw(),
   operator: { name: 'Op', preAuthHandoffUrl: null },
   vehicle: { name: 'Toyota Aqua', photos: ['a.jpg'] },
   renter: { id: 'r-1', name: 'Jane', email: 'jane@example.com', language: 'en' },
   ...over,
 })
 
+// A valid lifecycle event: payload is the #716 discriminated union keyed on `type`.
 const eventRaw = (over: Record<string, unknown> = {}) => ({
   id: 'evt-1',
-  type: 'BOOKING_CREATED',
-  payload: { from: 'CONFIRMED', to: 'ACTIVE' },
+  type: 'STATUS_CHANGED',
+  payload: { type: 'STATUS_CHANGED', from: 'CONFIRMED', to: 'ACTIVE' },
   actorId: 'r-1',
   createdAt: '2026-07-01T01:00:00.000Z',
   ...over,
@@ -425,7 +446,7 @@ describe('substitutionCandidatesQueryOptions', () => {
 describe('updateBookingStatus', () => {
   it('PATCHes /bookings/:id/status with the status body, CSRF + JSON headers, credentials', async () => {
     const fetchMock = vi.fn(async () =>
-      jsonResponse({ success: true, data: { id: 'bk-1', status: 'ACTIVE' } }),
+      jsonResponse({ success: true, data: bookingRaw({ status: 'ACTIVE' }) }),
     )
     vi.stubGlobal('fetch', fetchMock)
 
@@ -462,7 +483,7 @@ describe('cancelBooking', () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse({
         success: true,
-        data: { id: 'bk-1', status: 'CANCELLED' },
+        data: bookingRaw({ status: 'CANCELLED' }),
         cancellation: { feeJpy: 0 },
       }),
     )
@@ -522,5 +543,69 @@ describe('substituteBooking', () => {
     await expect(substituteBooking('bk-1', 'veh-2', null, 'csrf-tok')).rejects.toBeInstanceOf(
       ApiError,
     )
+  })
+})
+
+// #711 (3b): each read/write now validates its response body at the seam, so a
+// drifted field (renamed/wrong-typed) throws a ParseError here instead of
+// surfacing as `undefined` deep in the calendar / timeline / actions panel.
+describe('response validation (#711)', () => {
+  it('fetchOperatorBookingDetail rejects with ParseError when the booking drifts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: detailRaw({ totalPrice: 'lots' }) })),
+    )
+    await expect(fetchOperatorBookingDetail('bk-1')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('fetchCalendarBookings rejects with ParseError when a row drifts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [calendarRaw({ totalPrice: 'lots' })],
+          nextCursor: null,
+        }),
+      ),
+    )
+    await expect(fetchCalendarBookings('a', 'b')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('fetchBookingEvents rejects with ParseError when the payload discriminant is unknown', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: [eventRaw({ payload: { type: 'NOT_A_KIND' } })] }),
+      ),
+    )
+    await expect(fetchBookingEvents('bk-1')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('fetchSubstitutionCandidates rejects with ParseError when a candidate drifts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [{ id: 'veh-2', name: 123 }] })),
+    )
+    await expect(fetchSubstitutionCandidates('bk-1')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('updateBookingStatus rejects with ParseError when the write body has an invalid status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: bookingRaw({ status: 'PENDING' }) })),
+    )
+    await expect(updateBookingStatus('bk-1', 'ACTIVE', 'csrf')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('fetchCalendarVehicles degrades to [] when a row drifts (validation error is caught)', async () => {
+    // The calendar must never blank on a vehicle-list error, so a ParseError here
+    // is swallowed by the same guard that catches network failures — proven by the
+    // empty result (the un-validated code would have returned the drifted row).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [{ id: 5, name: 'x' }] })),
+    )
+    expect(await fetchCalendarVehicles()).toEqual([])
   })
 })

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -80,7 +80,7 @@ function isForbiddenWebDbSpec(spec: string): boolean {
 //
 // After a drain, refresh in place with:
 //   bun run scripts/lint-module-boundaries.ts --update-baseline
-const DEPRECATED_WEB_TREE_BASELINE = 147
+const DEPRECATED_WEB_TREE_BASELINE = 148
 
 export type DeprecatedTreeStatus = {
   count: number


### PR DESCRIPTION
## What

Slice **3b** of #711 (Zod-validate `unwrap` response bodies). Migrates the **operator-bookings** client — the last customer-facing read boundary — so every response is `safeParse`d at the network seam instead of being a phantom `T` cast.

All **7** `unwrap<T>(res)` casts in `vite/operator-bookings/api.ts` become `unwrap(res, schema)`. A new sibling `schema.ts` holds the response schemas (the #785/#816 convention — `api.ts` stays `z`-free):

| Endpoint | Schema |
|---|---|
| `GET /bookings` (calendar) | `rawOperatorBookingSchema` |
| `GET /vehicles` (calendar columns) | `calendarVehicleRowSchema` |
| `GET /bookings/:id` (detail) | `operatorBookingDetailSchema` = `bookingDtoSchema.extend({vehicle, renter})` |
| `GET /bookings/:id/events` | `bookingEventSchema` (#716 discriminated-union payload) |
| `GET /bookings/:id/substitution-candidates` | `substitutionCandidateRowSchema` |
| `POST /substitute`, `PATCH /status`, `POST /cancel` | reused `bookingDtoSchema` |

## Why these choices

- **Writes reuse `bookingDtoSchema`.** Producer-verified: `/substitute`, `/status`, `/cancel` all return the *bare* `Booking` row (no `operator` enrichment). Since `bookingDtoSchema`'s only enrichment field is `operator: …optional()`, the bare body validates cleanly (extra fields stripped, non-strict). No #817-style deferral needed here — unlike operator-fleet, the schema isn't wider than the write body.
- **Looser-than-producer where intended.** `effectiveEndAt`/`assignedVehicleId` stay `.optional()` (the API always sends them, but the mapper falls back) — a web schema must never be *stricter* than the API or it rejects valid data.
- **Shared contracts pinned.** `operatorBookingDetailSchema` and the event payload union carry `satisfies z.ZodType<…>`, so a shape change in the shared `BookingDto` / `BookingEventPayload` fails to compile here. `bookingDtoSchema` + the 3 snapshot schemas are now exported from `bookings/api.ts` for reuse (DRY — the `BOOKING_CREATED` payload embeds the same snapshots).

## Acceptance criteria (#711)

- [x] Live booking client validates its payloads
- [x] A simulated drifted/renamed field produces a `ParseError` at the seam, not `undefined` in render — **6 new drift tests**
- [x] No raw `unwrap<T>`/`as ApiResponse<T>` cast remains in this migrated client

## Test plan

- `api.test.ts`: completed the now-validated fixtures (full `bookingRaw`/`detailRaw`, valid discriminated `eventRaw`) + 6 `ParseError` drift cases (detail, calendar, event-payload-discriminant, candidate, write-status, and calendar-vehicles degrade-to-`[]`). Demonstrated RED (partial fixtures fail validation) → GREEN.
- `@kuruma/web typecheck` exit 0 (validates the `satisfies` clauses), full web suite **784/784**, biome + `lint:modules` + `lint:size` green.
- Bumped `DEPRECATED_WEB_TREE_BASELINE` 147→148 (one new `vite/` file).

Part of #711. Next: 3c (small schemaless clients — fees, locations, add-ons, …, plus `operator-bookings/new-bookings.ts`).