### PR TITLE
refactor(api): extract notification interfaces to types-notification.ts (#837)

### DIFF
--- a/packages/api/src/repositories/types-notification.ts
+++ b/packages/api/src/repositories/types-notification.ts
@@ -1,0 +1,55 @@
+// Notification-log persistence contract (#393 Slice 7, #483): the SENDING-lease
+// and delivery-cap consts plus the data-access interface. Extracted from ./types
+// to keep that barrel under the file-size cap (#837); re-exported there so callers
+// keep importing from ../types.
+import type { CallerContext } from '../middleware/auth'
+import type { NotificationLog } from '../stores'
+
+/**
+ * Slice 7 (#393): how long a SENDING lease is honoured before another sender may
+ * reclaim the row (§3). A crash mid-send leaves a SENDING row that is reclaimable
+ * ONLY after this window — a live lease is never reclaimed (else double-send).
+ */
+export const SEND_LEASE_MS = 5 * 60 * 1000
+
+/**
+ * #483: after this many delivery attempts a notification is marked terminal DEAD
+ * instead of FAILED. The claim predicate reclaims QUEUED / FAILED / expired
+ * SENDING but NEVER DEAD — so a permanently-bad recipient (hard bounce, malformed
+ * address) stops being re-sent on every booking replay and operator resend. The
+ * cap counts the attempt being recorded: markFailed sees the already-incremented
+ * `attempts` (claim bumped it) and flips to DEAD when `attempts >= cap`.
+ */
+export const MAX_NOTIFICATION_ATTEMPTS = 5
+
+export interface NotificationLogUpsert {
+  bookingId: string
+  operatorId: string
+  kind: NotificationLog['kind']
+  recipient: string
+  locale: string
+  idempotencyKey: string
+}
+
+export interface NotificationLogFilters {
+  bookingId?: string
+  operatorId?: string
+}
+
+export interface NotificationLogRepository {
+  // Insert a QUEUED row keyed by idempotencyKey. If a row already exists (a
+  // post-commit replay), return it UNCHANGED — the unique key seals one row per
+  // (booking, kind), so a replay never creates a duplicate to double-send.
+  upsertQueued(data: NotificationLogUpsert): Promise<NotificationLog>
+  // Atomic lease claim (§3): flips QUEUED / FAILED / an EXPIRED SENDING to
+  // SENDING and bumps attempts, returning the row. Returns undefined when a LIVE
+  // SENDING lease holds it — the concurrent-send guard. Unscoped (keyed by id;
+  // the resend route scopes via findById first).
+  claim(id: string): Promise<NotificationLog | undefined>
+  markSent(id: string, providerMessageId: string): Promise<void>
+  markFailed(id: string, error: string): Promise<void>
+  // Operator-portal list (management-read guarded, operator-scoped).
+  findAll(ctx: CallerContext, filters?: NotificationLogFilters): Promise<NotificationLog[]>
+  // Scoped single read (resend route: cross-operator id -> undefined -> 404).
+  findById(ctx: CallerContext, id: string): Promise<NotificationLog | undefined>
+}

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -41,7 +41,6 @@ import type {
   Location,
   MaintenanceLog,
   Message,
-  NotificationLog,
   Operator,
   OperatorMembership,
   ProviderInvite,
@@ -62,6 +61,16 @@ export type {
   PaymentAnomalyRepository,
   PaymentEventRepository,
 } from './types-payment'
+
+// Notification persistence: SENDING-lease + delivery-cap consts (#393, #483) and
+// the notification_log data-access interface (#393) live in their own module to
+// keep this barrel under the file-size cap (#837); re-exported for callers.
+export { MAX_NOTIFICATION_ATTEMPTS, SEND_LEASE_MS } from './types-notification'
+export type {
+  NotificationLogFilters,
+  NotificationLogRepository,
+  NotificationLogUpsert,
+} from './types-notification'
 
 /** Operator (tenant) data access. Admin bootstrap (#386) + slug/id resolution (#387). */
 export interface OperatorRepository {
@@ -329,55 +338,6 @@ export interface UserRepository {
     userId: string,
     access: { role: OperatorRole; operatorId: string },
   ): Promise<void>
-}
-
-/**
- * Slice 7 (#393): how long a SENDING lease is honoured before another sender may
- * reclaim the row (§3). A crash mid-send leaves a SENDING row that is reclaimable
- * ONLY after this window — a live lease is never reclaimed (else double-send).
- */
-export const SEND_LEASE_MS = 5 * 60 * 1000
-
-/**
- * #483: after this many delivery attempts a notification is marked terminal DEAD
- * instead of FAILED. The claim predicate reclaims QUEUED / FAILED / expired
- * SENDING but NEVER DEAD — so a permanently-bad recipient (hard bounce, malformed
- * address) stops being re-sent on every booking replay and operator resend. The
- * cap counts the attempt being recorded: markFailed sees the already-incremented
- * `attempts` (claim bumped it) and flips to DEAD when `attempts >= cap`.
- */
-export const MAX_NOTIFICATION_ATTEMPTS = 5
-
-export interface NotificationLogUpsert {
-  bookingId: string
-  operatorId: string
-  kind: NotificationLog['kind']
-  recipient: string
-  locale: string
-  idempotencyKey: string
-}
-
-export interface NotificationLogFilters {
-  bookingId?: string
-  operatorId?: string
-}
-
-export interface NotificationLogRepository {
-  // Insert a QUEUED row keyed by idempotencyKey. If a row already exists (a
-  // post-commit replay), return it UNCHANGED — the unique key seals one row per
-  // (booking, kind), so a replay never creates a duplicate to double-send.
-  upsertQueued(data: NotificationLogUpsert): Promise<NotificationLog>
-  // Atomic lease claim (§3): flips QUEUED / FAILED / an EXPIRED SENDING to
-  // SENDING and bumps attempts, returning the row. Returns undefined when a LIVE
-  // SENDING lease holds it — the concurrent-send guard. Unscoped (keyed by id;
-  // the resend route scopes via findById first).
-  claim(id: string): Promise<NotificationLog | undefined>
-  markSent(id: string, providerMessageId: string): Promise<void>
-  markFailed(id: string, error: string): Promise<void>
-  // Operator-portal list (management-read guarded, operator-scoped).
-  findAll(ctx: CallerContext, filters?: NotificationLogFilters): Promise<NotificationLog[]>
-  // Scoped single read (resend route: cross-operator id -> undefined -> 404).
-  findById(ctx: CallerContext, id: string): Promise<NotificationLog | undefined>
 }
 
 export interface CustomerListFilters {


### PR DESCRIPTION
Closes #837

## Why
`packages/api/src/repositories/types.ts` had reached 799/800 lines — one line under the hard `lint:size` cap. Adding any notification field would break the build. This extracts the notification-repository contract into its own bounded file, mirroring the existing `types-payment.ts` pattern.

## What moved → `repositories/types-notification.ts`
- Consts: `SEND_LEASE_MS`, `MAX_NOTIFICATION_ATTEMPTS`
- Interfaces: `NotificationLogUpsert`, `NotificationLogFilters`, `NotificationLogRepository`, `NotificationLogNoRecipient`

`types.ts` re-exports all of them (values via `export { … }`, types via `export type { … }`) so **all ~17 consumers keep importing from `../types` — zero call-site changes**. `types.ts` drops 793→754, back under cap.

## Note on #681/#838
PR #838 (NO_RECIPIENT terminal state) landed mid-work, adding `NotificationLogNoRecipient` + `recordNoRecipient()` to the block being moved. Both were re-homed into `types-notification.ts` and added to the re-export; trunk is fully merged in.

## Verification (post-merge of trunk)
- `bun run --filter @kuruma/api typecheck` → 0 errors
- `bun run --filter @kuruma/api test` → 1488 passed (129 files)
- `bun run --filter @kuruma/api lint:boundaries` → OK
- `bun run lint:size` → no hard-cap violation (types.ts 754 < 800)
- biome clean, 0 conflict markers