### PR TITLE
fix(web): explicit width/height on storefront card + gallery images (#440)

### DIFF
--- a/packages/web/src/vite/storefronts/PhotoGallery.tsx
+++ b/packages/web/src/vite/storefronts/PhotoGallery.tsx
@@ -45,7 +45,16 @@ export function PhotoGallery({ photos, alt }: PhotoGalleryProps) {
       {...(count > 1 ? { role: 'group', 'aria-label': alt } : {})}
     >
       {current && (
-        <img src={current} alt={alt} loading="lazy" className="h-full w-full object-cover" />
+        // 4:3 intrinsic hint lets the browser reserve the box before load (#440);
+        // h-full/w-full still drive the rendered size inside the aspect wrapper.
+        <img
+          src={current}
+          alt={alt}
+          loading="lazy"
+          width={400}
+          height={300}
+          className="h-full w-full object-cover"
+        />
       )}
       {count > 1 && (
         <>

--- a/packages/web/src/vite/storefronts/StorefrontCard.tsx
+++ b/packages/web/src/vite/storefronts/StorefrontCard.tsx
@@ -52,6 +52,10 @@ export function StorefrontCard({
           <img
             src={photo}
             alt={storefront.name}
+            // 4:3 intrinsic hint lets the browser reserve the box before load (#440);
+            // h-full/w-full still drive the rendered size inside the aspect wrapper.
+            width={400}
+            height={300}
             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
         ) : (

--- a/packages/web/tests/vite/storefronts/PhotoGallery.test.tsx
+++ b/packages/web/tests/vite/storefronts/PhotoGallery.test.tsx
@@ -34,6 +34,13 @@ describe('PhotoGallery', () => {
     expect(screen.getByRole('img')).toHaveAttribute('loading', 'lazy')
   })
 
+  it('declares explicit 4:3 width and height so the browser reserves the box (#440)', () => {
+    renderGallery(['/photos/a.jpg'])
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('width', '400')
+    expect(img).toHaveAttribute('height', '300')
+  })
+
   it('shows the first photo and advances to the next on Next', () => {
     renderGallery(['/photos/a.jpg', '/photos/b.jpg', '/photos/c.jpg'])
     expect(screen.getByRole('img')).toHaveAttribute('src', '/photos/a.jpg')

--- a/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
+++ b/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
@@ -83,4 +83,11 @@ describe('StorefrontCard', () => {
     expect(link).toHaveAttribute('data-from', '2026-07-01T10:00')
     expect(link).toHaveAttribute('data-rangeto', '2026-07-03T10:00')
   })
+
+  it('declares explicit 4:3 width and height on the photo so the browser reserves the box (#440)', () => {
+    renderCard(makeStorefront({ representativePhotos: ['/photos/store.jpg'] }))
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('width', '400')
+    expect(img).toHaveAttribute('height', '300')
+  })
 })


### PR DESCRIPTION
## What

Adds explicit `width={400} height={300}` (4:3) to the two storefront `<img>` elements Lighthouse flags for missing intrinsic dimensions:

- `StorefrontCard.tsx` — the representative store photo
- `PhotoGallery.tsx` — the renter store/vehicle gallery image (covers `AvailableVehicleCard` via `<PhotoGallery>`)

Both imgs already sit inside `aspect-[4/3]` wrappers, so this is **not** a live CLS bug — the dimensions are an intrinsic-ratio hint so the browser reserves the box before load and the Lighthouse audit passes. `h-full w-full object-cover` still drives the rendered size inside the wrapper, so there is no visual change.

## The other two items in #440 are intentional no-ops

- **operatingHours nullability** — the issue's premise is incorrect. Web `StorefrontCardData.operatingHours` (`{...} | null`) already matches the shared `LocationOperatingHours` contract (the jsonb column has no `.notNull()`; the validator is `.nullable()`). Tightening to non-null would reintroduce a type-lies divergence (cf. #817). No change.
- **Unbounded class-catalog load** — correct and tiny at MVP scale (YAGNI). No change.

## Test plan

- [x] TDD: added one failing assertion per component (img carries `width`/`height`), confirmed RED, then implemented → GREEN
- [x] `bun run --filter @kuruma/web test tests/vite/storefronts/` — 62/62
- [x] Full web suite — 788/788
- [x] `bun run --filter @kuruma/web typecheck` — clean
- [x] `biome check` — clean

Closes #440