### PR TITLE
refactor(web): Zod-validate small operator API clients (#711 3c-1)

### DIFF
--- a/packages/web/src/vite/operator-add-ons/api.ts
+++ b/packages/web/src/vite/operator-add-ons/api.ts
@@ -1,7 +1,9 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { ADD_ON_STATUSES } from '@kuruma/shared/enums'
 import type { CreateAddOnInput, UpdateAddOnInput } from '@kuruma/shared/validators/add-on'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #585: operator add-on management. Mirrors the #530 insurance client — the Vite
 // shell owns this cookie-based client and never imports a hono-client/Bearer copy.
@@ -14,17 +16,19 @@ import { queryOptions } from '@tanstack/react-query'
 
 export type { CreateAddOnInput, UpdateAddOnInput }
 
-/** JSON-serialized AddOn — dates arrive as ISO strings from the API. */
-export interface AddOnData {
-  id: string
-  operatorId: string
-  name: string
-  description: string | null
-  priceJpy: number
-  status: 'ACTIVE' | 'ARCHIVED'
-  createdAt: string
-  updatedAt: string
-}
+// JSON-serialized AddOn — dates arrive as ISO strings (#711: schema validates
+// `data` at the network seam; the row type is inferred from it).
+const addOnSchema = z.object({
+  id: z.string(),
+  operatorId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  priceJpy: z.number(),
+  status: z.enum(ADD_ON_STATUSES),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type AddOnData = z.infer<typeof addOnSchema>
 
 export const ADDON_QUERY_KEY = ['operator-add-ons'] as const
 
@@ -35,7 +39,7 @@ export async function fetchAddOns(): Promise<AddOnData[]> {
   const res = await fetch(`${getApiBaseUrl()}/add-ons?includeArchived=true&includeAll=true`, {
     credentials: 'include',
   })
-  return unwrap<AddOnData[]>(res)
+  return unwrap(res, addOnSchema.array())
 }
 
 export function addOnsQueryOptions() {
@@ -52,23 +56,23 @@ export function addOnsQueryOptions() {
 // copy for writes — it omits the header.) Each unwraps ok() and throws ApiError
 // on failure so a useMutation onError can surface it.
 
-async function writeJson<T>(
+async function writeJson(
   path: string,
   method: 'POST' | 'PATCH',
   body: unknown,
   csrfToken: string,
-): Promise<T> {
+): Promise<AddOnData> {
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
     body: JSON.stringify(body),
   })
-  return unwrap<T>(res)
+  return unwrap(res, addOnSchema)
 }
 
 export async function createAddOn(input: CreateAddOnInput, csrfToken: string): Promise<AddOnData> {
-  return writeJson<AddOnData>('/add-ons', 'POST', input, csrfToken)
+  return writeJson('/add-ons', 'POST', input, csrfToken)
 }
 
 export async function updateAddOn(
@@ -76,7 +80,7 @@ export async function updateAddOn(
   input: UpdateAddOnInput,
   csrfToken: string,
 ): Promise<AddOnData> {
-  return writeJson<AddOnData>(`/add-ons/${encodeURIComponent(id)}`, 'PATCH', input, csrfToken)
+  return writeJson(`/add-ons/${encodeURIComponent(id)}`, 'PATCH', input, csrfToken)
 }
 
 // Soft-archive (DELETE flips status to ARCHIVED). No body — the CSRF header still
@@ -87,5 +91,5 @@ export async function archiveAddOn(id: string, csrfToken: string): Promise<AddOn
     credentials: 'include',
     headers: { 'X-CSRF-Token': csrfToken },
   })
-  return unwrap<AddOnData>(res)
+  return unwrap(res, addOnSchema)
 }

--- a/packages/web/src/vite/operator-dashboard/api.ts
+++ b/packages/web/src/vite/operator-dashboard/api.ts
@@ -2,6 +2,7 @@ import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // Operator dashboard overview (#524). Cookie-based (credentials: 'include') so
 // the tenant is derived server-side from the session — never a query param.
@@ -9,11 +10,20 @@ import { queryOptions } from '@tanstack/react-query'
 // `dashboard-stats.ts`, which hits the platform-wide X-API-Key /stats endpoint.
 export const OPERATOR_OVERVIEW_QUERY_KEY = ['operator-overview'] as const
 
+// Network-seam validator for the dashboard overview (#711). Pinned to
+// OperatorOverview with `satisfies` so a renamed/added headline count fails to
+// compile. All three are required non-null numbers (the repo coalesces to 0).
+const operatorOverviewSchema = z.object({
+  totalBookings: z.number(),
+  activeVehicles: z.number(),
+  upcomingBookings: z.number(),
+}) satisfies z.ZodType<OperatorOverview>
+
 export async function fetchOperatorOverview(): Promise<OperatorOverview> {
   const res = await fetch(`${getApiBaseUrl()}/dashboard/overview`, {
     credentials: 'include',
   })
-  return unwrap<OperatorOverview>(res)
+  return unwrap(res, operatorOverviewSchema)
 }
 
 export function operatorOverviewQueryOptions() {

--- a/packages/web/src/vite/operator-fees/api.ts
+++ b/packages/web/src/vite/operator-fees/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { FEE_SCHEDULE_STATUSES, FEE_TYPES, FEE_UNITS } from '@kuruma/shared/enums'
 import type {
   CreateFeeScheduleInput,
   FeeType,
@@ -7,6 +8,7 @@ import type {
   UpdateFeeScheduleInput,
 } from '@kuruma/shared/validators/fee-schedule'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #530: operator fee-schedule management. Mirrors the operator-insurance data
 // layer — cookie-based, operator-scoped server-side (the client passes no
@@ -15,19 +17,21 @@ import { queryOptions } from '@tanstack/react-query'
 
 export type { CreateFeeScheduleInput, UpdateFeeScheduleInput, FeeType, FeeUnit }
 
-/** JSON-serialized FeeSchedule — dates arrive as ISO strings from the API. */
-export interface FeeScheduleData {
-  id: string
-  operatorId: string
-  /** null = operator-wide; otherwise scoped to a single vehicle class. */
-  vehicleClassId: string | null
-  feeType: FeeType
-  unit: FeeUnit
-  amountJpy: number
-  status: 'ACTIVE' | 'ARCHIVED'
-  createdAt: string
-  updatedAt: string
-}
+// JSON-serialized FeeSchedule — dates arrive as ISO strings (#711: the schema
+// validates `data` at the network seam; the row type is inferred from it).
+const feeScheduleSchema = z.object({
+  id: z.string(),
+  operatorId: z.string(),
+  // null = operator-wide; otherwise scoped to a single vehicle class.
+  vehicleClassId: z.string().nullable(),
+  feeType: z.enum(FEE_TYPES),
+  unit: z.enum(FEE_UNITS),
+  amountJpy: z.number(),
+  status: z.enum(FEE_SCHEDULE_STATUSES),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type FeeScheduleData = z.infer<typeof feeScheduleSchema>
 
 export const FEE_QUERY_KEY = ['operator-fees'] as const
 
@@ -37,7 +41,7 @@ export async function fetchFeeSchedules(): Promise<FeeScheduleData[]> {
   const res = await fetch(`${getApiBaseUrl()}/fee-schedules?includeArchived=true`, {
     credentials: 'include',
   })
-  return unwrap<FeeScheduleData[]>(res)
+  return unwrap(res, feeScheduleSchema.array())
 }
 
 export function feeSchedulesQueryOptions() {
@@ -49,26 +53,26 @@ export function feeSchedulesQueryOptions() {
 
 // --- Mutations (cookie-based, CSRF-gated) ------------------------------------
 
-async function writeJson<T>(
+async function writeJson(
   path: string,
   method: 'POST' | 'PATCH',
   body: unknown,
   csrfToken: string,
-): Promise<T> {
+): Promise<FeeScheduleData> {
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
     body: JSON.stringify(body),
   })
-  return unwrap<T>(res)
+  return unwrap(res, feeScheduleSchema)
 }
 
 export async function createFeeSchedule(
   input: CreateFeeScheduleInput,
   csrfToken: string,
 ): Promise<FeeScheduleData> {
-  return writeJson<FeeScheduleData>('/fee-schedules', 'POST', input, csrfToken)
+  return writeJson('/fee-schedules', 'POST', input, csrfToken)
 }
 
 export async function updateFeeSchedule(
@@ -76,12 +80,7 @@ export async function updateFeeSchedule(
   input: UpdateFeeScheduleInput,
   csrfToken: string,
 ): Promise<FeeScheduleData> {
-  return writeJson<FeeScheduleData>(
-    `/fee-schedules/${encodeURIComponent(id)}`,
-    'PATCH',
-    input,
-    csrfToken,
-  )
+  return writeJson(`/fee-schedules/${encodeURIComponent(id)}`, 'PATCH', input, csrfToken)
 }
 
 // Soft-archive (DELETE flips status to ARCHIVED). The CSRF header still rides
@@ -92,5 +91,5 @@ export async function archiveFeeSchedule(id: string, csrfToken: string): Promise
     credentials: 'include',
     headers: { 'X-CSRF-Token': csrfToken },
   })
-  return unwrap<FeeScheduleData>(res)
+  return unwrap(res, feeScheduleSchema)
 }

--- a/packages/web/src/vite/operator-insurance/api.ts
+++ b/packages/web/src/vite/operator-insurance/api.ts
@@ -1,10 +1,12 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { INSURANCE_STATUSES } from '@kuruma/shared/enums'
 import type {
   CreateInsuranceOptionInput,
   UpdateInsuranceOptionInput,
 } from '@kuruma/shared/validators/insurance-option'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #530: operator insurance-option management. Mirrors the operator-fleet read
 // projection — the Vite shell owns this cookie-based client and never imports
@@ -16,18 +18,21 @@ import { queryOptions } from '@tanstack/react-query'
 
 export type { CreateInsuranceOptionInput, UpdateInsuranceOptionInput }
 
-/** JSON-serialized InsuranceOption — dates arrive as ISO strings from the API. */
-export interface InsuranceOptionData {
-  id: string
-  operatorId: string
-  name: string
-  description: string | null
-  dailyPriceJpy: number
-  deductibleJpy: number | null
-  status: 'ACTIVE' | 'ARCHIVED'
-  createdAt: string
-  updatedAt: string
-}
+// JSON-serialized InsuranceOption — dates arrive as ISO strings (#711: schema
+// validates `data` at the network seam; the row type is inferred from it).
+const insuranceOptionSchema = z.object({
+  id: z.string(),
+  operatorId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  dailyPriceJpy: z.number(),
+  // null = full cover (no deductible).
+  deductibleJpy: z.number().nullable(),
+  status: z.enum(INSURANCE_STATUSES),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type InsuranceOptionData = z.infer<typeof insuranceOptionSchema>
 
 export const INSURANCE_QUERY_KEY = ['operator-insurance'] as const
 
@@ -37,7 +42,7 @@ export async function fetchInsuranceOptions(): Promise<InsuranceOptionData[]> {
   const res = await fetch(`${getApiBaseUrl()}/insurance-options?includeArchived=true`, {
     credentials: 'include',
   })
-  return unwrap<InsuranceOptionData[]>(res)
+  return unwrap(res, insuranceOptionSchema.array())
 }
 
 export function insuranceOptionsQueryOptions() {
@@ -54,26 +59,26 @@ export function insuranceOptionsQueryOptions() {
 // copy for writes — it omits the header.) Each unwraps ok() and throws ApiError
 // on failure so a useMutation onError can surface it.
 
-async function writeJson<T>(
+async function writeJson(
   path: string,
   method: 'POST' | 'PATCH',
   body: unknown,
   csrfToken: string,
-): Promise<T> {
+): Promise<InsuranceOptionData> {
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
     body: JSON.stringify(body),
   })
-  return unwrap<T>(res)
+  return unwrap(res, insuranceOptionSchema)
 }
 
 export async function createInsuranceOption(
   input: CreateInsuranceOptionInput,
   csrfToken: string,
 ): Promise<InsuranceOptionData> {
-  return writeJson<InsuranceOptionData>('/insurance-options', 'POST', input, csrfToken)
+  return writeJson('/insurance-options', 'POST', input, csrfToken)
 }
 
 export async function updateInsuranceOption(
@@ -81,12 +86,7 @@ export async function updateInsuranceOption(
   input: UpdateInsuranceOptionInput,
   csrfToken: string,
 ): Promise<InsuranceOptionData> {
-  return writeJson<InsuranceOptionData>(
-    `/insurance-options/${encodeURIComponent(id)}`,
-    'PATCH',
-    input,
-    csrfToken,
-  )
+  return writeJson(`/insurance-options/${encodeURIComponent(id)}`, 'PATCH', input, csrfToken)
 }
 
 // Soft-archive (DELETE flips status to ARCHIVED). No body — the CSRF header still
@@ -100,5 +100,5 @@ export async function archiveInsuranceOption(
     credentials: 'include',
     headers: { 'X-CSRF-Token': csrfToken },
   })
-  return unwrap<InsuranceOptionData>(res)
+  return unwrap(res, insuranceOptionSchema)
 }

--- a/packages/web/src/vite/operator-locations/api.ts
+++ b/packages/web/src/vite/operator-locations/api.ts
@@ -1,9 +1,11 @@
 import { ApiError, unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { COORDINATE_SOURCES, LOCATION_STATUSES } from '@kuruma/shared/enums'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
 import type { CreateLocationInput, UpdateLocationInput } from '@kuruma/shared/validators/location'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #529: operator locations/storefronts management — Vite port of the frozen
 // `modules/locations` admin. Cookie-based and operator-scoped server-side (the
@@ -35,6 +37,25 @@ export interface OperatorLocation {
   updatedAt: string
 }
 
+// Network-seam validator for the read/write shape above (#711). Pinned to
+// OperatorLocation with `satisfies` so a field drift fails to compile here, not
+// silently in render. Non-strict, so the wire's server-only latitude/longitude
+// (#531) are dropped — the DTO deliberately omits them until a map view needs them.
+const locationSchema = z.object({
+  id: z.string(),
+  operatorId: z.string(),
+  name: z.string(),
+  address: z.string(),
+  operatingHours: z.object({ openTime: z.string(), closeTime: z.string() }).nullable(),
+  timezone: z.string(),
+  defaultTurnaroundMinutes: z.number(),
+  status: z.enum(LOCATION_STATUSES),
+  coordinateSource: z.enum(COORDINATE_SOURCES).nullable(),
+  regionId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}) satisfies z.ZodType<OperatorLocation>
+
 export const LOCATIONS_QUERY_KEY = ['operator-locations'] as const
 
 export async function fetchOperatorLocations(): Promise<OperatorLocation[]> {
@@ -50,7 +71,7 @@ export async function fetchOperatorLocations(): Promise<OperatorLocation[]> {
   const res = await fetch(`${getApiBaseUrl()}/locations?includeArchived=true&includeAll=true`, {
     credentials: 'include',
   })
-  return unwrap<OperatorLocation[]>(res)
+  return unwrap(res, locationSchema.array())
 }
 
 export function operatorLocationsQueryOptions() {
@@ -76,7 +97,7 @@ async function writeJson(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  return unwrap<OperatorLocation>(res)
+  return unwrap(res, locationSchema)
 }
 
 export function createLocation(data: CreateLocationInput): Promise<OperatorLocation> {

--- a/packages/web/src/vite/operator-locations/regions-api.ts
+++ b/packages/web/src/vite/operator-locations/regions-api.ts
@@ -1,7 +1,9 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { REGION_STATUSES, REGION_TYPES } from '@kuruma/shared/enums'
 import type { RegionNode } from '@kuruma/shared/types/region'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #651 2b: the public hierarchical region taxonomy (prefecture -> city -> area) —
 // the flat list GET /regions returns. Powers the operator location cascade now; the
@@ -11,10 +13,28 @@ const ONE_HOUR_MS = 60 * 60 * 1000
 
 export const REGIONS_QUERY_KEY = ['regions'] as const
 
+// Network-seam validator for one GET /regions node (#711). Pinned to RegionNode
+// with `satisfies` so a taxonomy field drift fails to compile. Note the status
+// domain is ACTIVE|INACTIVE (not ARCHIVED); createdAt/updatedAt are NOT projected.
+const regionNodeSchema = z.object({
+  id: z.string(),
+  parentId: z.string().nullable(),
+  nameEn: z.string(),
+  nameJa: z.string(),
+  nameZh: z.string(),
+  sortOrder: z.number(),
+  type: z.enum(REGION_TYPES).nullable(),
+  latitude: z.number().nullable(),
+  longitude: z.number().nullable(),
+  assignable: z.boolean(),
+  status: z.enum(REGION_STATUSES),
+  slug: z.string().nullable(),
+}) satisfies z.ZodType<RegionNode>
+
 export async function fetchRegions(): Promise<RegionNode[]> {
   // Public, unauthenticated read; credentials are harmless and keep one fetch shape.
   const res = await fetch(`${getApiBaseUrl()}/regions`, { credentials: 'include' })
-  return unwrap<RegionNode[]>(res)
+  return unwrap(res, regionNodeSchema.array())
 }
 
 export function regionsQueryOptions() {

--- a/packages/web/tests/vite/operator-add-ons/api.test.ts
+++ b/packages/web/tests/vite/operator-add-ons/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import {
   ADDON_QUERY_KEY,
   addOnsQueryOptions,
@@ -54,6 +55,13 @@ describe('fetchAddOns', () => {
   it('throws an ApiError carrying the status on a failure envelope', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ success: false, error: 'Forbidden' }, 403))
     await expect(fetchAddOns()).rejects.toThrow('Forbidden')
+  })
+
+  it('throws a ParseError when a row drifts from the schema (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...addOn, priceJpy: 'oops' }] }),
+    )
+    await expect(fetchAddOns()).rejects.toBeInstanceOf(ParseError)
   })
 })
 

--- a/packages/web/tests/vite/operator-dashboard/api.test.ts
+++ b/packages/web/tests/vite/operator-dashboard/api.test.ts
@@ -1,0 +1,52 @@
+import { ParseError } from '@/lib/api-error'
+import {
+  OPERATOR_OVERVIEW_QUERY_KEY,
+  fetchOperatorOverview,
+  operatorOverviewQueryOptions,
+} from '@/vite/operator-dashboard/api'
+import type { OperatorOverview } from '@kuruma/shared/types/overview'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+afterEach(() => fetchMock.mockReset())
+
+const overview: OperatorOverview = {
+  totalBookings: 12,
+  activeVehicles: 5,
+  upcomingBookings: 3,
+}
+
+describe('fetchOperatorOverview', () => {
+  it('GETs /api/dashboard/overview with credentials and unwraps the validated overview', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: overview }))
+
+    const result = await fetchOperatorOverview()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/dashboard/overview', { credentials: 'include' })
+    expect(result).toEqual(overview)
+  })
+
+  it('throws a ParseError when a headline count drifts to null (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { ...overview, totalBookings: null } }),
+    )
+    await expect(fetchOperatorOverview()).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('operatorOverviewQueryOptions', () => {
+  it('exposes the stable OPERATOR_OVERVIEW_QUERY_KEY for cache reuse', () => {
+    expect(OPERATOR_OVERVIEW_QUERY_KEY).toEqual(['operator-overview'])
+    expect(operatorOverviewQueryOptions().queryKey).toEqual(['operator-overview'])
+  })
+})

--- a/packages/web/tests/vite/operator-fees/api.test.ts
+++ b/packages/web/tests/vite/operator-fees/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import {
   FEE_QUERY_KEY,
   archiveFeeSchedule,
@@ -55,6 +56,15 @@ describe('fetchFeeSchedules', () => {
   it('throws an ApiError carrying the status on a failure envelope', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ success: false, error: 'Forbidden' }, 403))
     await expect(fetchFeeSchedules()).rejects.toThrow('Forbidden')
+  })
+
+  it('throws a ParseError when a row drifts from the schema (#711)', async () => {
+    // A success body whose `amountJpy` arrived as a string (a contract drift)
+    // must fail at the seam, not surface as a NaN deep in the fee table.
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...fee, amountJpy: 'oops' }] }),
+    )
+    await expect(fetchFeeSchedules()).rejects.toBeInstanceOf(ParseError)
   })
 })
 

--- a/packages/web/tests/vite/operator-insurance/api.test.ts
+++ b/packages/web/tests/vite/operator-insurance/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import {
   INSURANCE_QUERY_KEY,
   archiveInsuranceOption,
@@ -55,6 +56,13 @@ describe('fetchInsuranceOptions', () => {
   it('throws an ApiError carrying the status on a failure envelope', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ success: false, error: 'Forbidden' }, 403))
     await expect(fetchInsuranceOptions()).rejects.toThrow('Forbidden')
+  })
+
+  it('throws a ParseError when a row drifts from the schema (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...option, dailyPriceJpy: 'oops' }] }),
+    )
+    await expect(fetchInsuranceOptions()).rejects.toBeInstanceOf(ParseError)
   })
 })
 

--- a/packages/web/tests/vite/operator-locations/api.test.ts
+++ b/packages/web/tests/vite/operator-locations/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { fetchOperatorLocations } from '@/vite/operator-locations/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,6 +7,21 @@ function jsonResponse(body: unknown): Response {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   })
+}
+
+const location = {
+  id: 'loc_1',
+  operatorId: 'op_1',
+  name: 'Namba Hub',
+  address: '1-1 Namba, Osaka',
+  operatingHours: { openTime: '09:00', closeTime: '18:00' },
+  timezone: 'Asia/Tokyo',
+  defaultTurnaroundMinutes: 60,
+  status: 'ACTIVE',
+  coordinateSource: 'GEOCODED',
+  regionId: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
 }
 
 describe('fetchOperatorLocations', () => {
@@ -28,5 +44,22 @@ describe('fetchOperatorLocations', () => {
     // Cookie carries the tenant — the client never names an operator.
     expect(url).not.toContain('operatorId')
     expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ credentials: 'include' })
+  })
+
+  it('strips the wire latitude/longitude the projection deliberately omits (#711)', async () => {
+    // The API row carries lat/lng (#531); the DTO omits them until a map view
+    // needs them. The schema is non-strict, so those keys are dropped at the seam.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...location, latitude: 34.66, longitude: 135.5 }] }),
+    )
+    const result = await fetchOperatorLocations()
+    expect(result).toEqual([location])
+  })
+
+  it('throws a ParseError when a row drifts from the schema (#711)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...location, defaultTurnaroundMinutes: 'oops' }] }),
+    )
+    await expect(fetchOperatorLocations()).rejects.toBeInstanceOf(ParseError)
   })
 })

--- a/packages/web/tests/vite/operator-locations/regions-api.test.ts
+++ b/packages/web/tests/vite/operator-locations/regions-api.test.ts
@@ -1,0 +1,70 @@
+import { ParseError } from '@/lib/api-error'
+import {
+  REGIONS_QUERY_KEY,
+  fetchRegions,
+  regionsQueryOptions,
+} from '@/vite/operator-locations/regions-api'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+afterEach(() => fetchMock.mockReset())
+
+const region: RegionNode = {
+  id: 'osaka',
+  parentId: null,
+  nameEn: 'Osaka',
+  nameJa: '大阪府',
+  nameZh: '大阪府',
+  sortOrder: 0,
+  type: 'PREFECTURE',
+  latitude: 34.69,
+  longitude: 135.5,
+  assignable: false,
+  status: 'ACTIVE',
+  slug: 'osaka',
+}
+
+describe('fetchRegions', () => {
+  it('GETs /api/regions with credentials and unwraps the validated tree', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: [region] }))
+
+    const result = await fetchRegions()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/regions', { credentials: 'include' })
+    expect(result).toEqual([region])
+  })
+
+  it('accepts the INACTIVE status — regions use ACTIVE|INACTIVE, not ARCHIVED (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...region, status: 'INACTIVE' }] }),
+    )
+    const result = await fetchRegions()
+    expect(result[0]?.status).toBe('INACTIVE')
+  })
+
+  it('throws a ParseError when a node carries an out-of-domain status (#711)', async () => {
+    // ARCHIVED is a location/fee status, never a region one — must reject at the seam.
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...region, status: 'ARCHIVED' }] }),
+    )
+    await expect(fetchRegions()).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('regionsQueryOptions', () => {
+  it('exposes the stable REGIONS_QUERY_KEY for cache reuse', () => {
+    expect(REGIONS_QUERY_KEY).toEqual(['regions'])
+    expect(regionsQueryOptions().queryKey).toEqual(['regions'])
+  })
+})


### PR DESCRIPTION
## What

Slice **3c-1** of #711: migrate six small web API clients from the schemaless `unwrap<T>(res)` cast to `unwrap(res, schema)`, validating each response `data` with a Zod schema at the network seam. A drifted API response now fails with a typed `ParseError` instead of surfacing as `undefined`/`NaN` deep in render.

Clients migrated: **fees, add-ons, insurance, locations, regions, dashboard**.

## How

- **fees / add-ons / insurance** — inline Zod schema as the SSoT (`type = z.infer<...>`); de-generic the single-DTO `writeJson` helper now the schema carries the type.
- **locations** — schema pinned `satisfies z.ZodType<OperatorLocation>`. Non-strict, so the wire's server-only `latitude`/`longitude` (#531) are stripped, preserving the DTO's deliberate omission (a test pins this).
- **regions / dashboard** — schemas pinned to the shared `RegionNode` / `OperatorOverview`.
- Enums/statuses sourced from `@kuruma/shared/enums`. Region status is `ACTIVE|INACTIVE` (not `ARCHIVED`) and `createdAt`/`updatedAt` are not projected — both verified against the producer.

Every field's nullability + enum domain was **producer-verified** against the API routes/services/repositories before tightening, so no schema is stricter than the wire.

`archiveLocation` keeps its hand-rolled body parse (it needs the `activeBookingsCount` discriminator `unwrap` discards) — its success row is the same shape the validated list read already covers.

## Test plan

- Drift tests assert `rejects.toBeInstanceOf(ParseError)`; happy paths assert the full fixture round-trips; a locations test pins the lat/lng strip; a regions test pins `INACTIVE` accepted / `ARCHIVED` rejected.
- `bun run --filter @kuruma/web test` → 798 pass. tsc×3 + `bun run lint` green. No new `src/vite` files, so the vite-deprecation ratchet is unchanged (148).
- code-reviewer pass: SHIP (schemas producer-verified, one optional LOW deferred as YAGNI).

Part of #711.