### PR TITLE
test(api): guard totalPrice backfill on substitution into a null-total booking (#429)

### DIFF
--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1022,6 +1022,39 @@ describe('BookingService.substitute — operator vehicle swap (#392 §5.5)', () 
     })
   })
 
+  it('backfills totalPrice when a vehicle is assigned to a null-total class-only booking (#429)', async () => {
+    const h = await setupSub()
+    const replacement = await addVehicle(h) // class A @ Osaka, 15000/day
+
+    // A class-only booking (#464 CLASS_COMBO): no vehicle assigned at creation,
+    // so it was never priced (totalPrice null). Assigning a vehicle via
+    // substitute() must SNAPSHOT the price off that vehicle, not preserve null —
+    // a null total would later cancel for a ¥0 fee via the `totalPrice ?? 0`
+    // floor in the cancel path. This is #429's named backfill guard.
+    const classOnly = await h.repos.bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingRow({
+        classId: h.classA.id,
+        requestedVehicleId: h.v1Id,
+        assignedVehicleId: null,
+        totalPrice: null,
+        pickupLocationId: h.locationId,
+        dropoffLocationId: h.locationId,
+        bookingCode: 'CLASSONLY',
+      }),
+    )
+
+    const result = await h.service.substitute(opCtxA, classOnly.id, replacement.id, null)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.assignedVehicleId).toBe(replacement.id)
+    expect(result.booking.totalPrice).toBe(30000) // 2 days * 15000, backfilled from null
+    // Persisted, not just returned on the result object.
+    const stored = await h.repos.bookingRepo.findById(opCtxA, classOnly.id)
+    expect(stored?.totalPrice).toBe(30000)
+  })
+
   it('rejects a replacement already booked for the range (409, no event appended)', async () => {
     const h = await setupSub()
     const replacement = await addVehicle(h)


### PR DESCRIPTION
## What

Adds a service-level guard test pinning #429's named backfill behavior: assigning a vehicle (via `substitute()`) to a **null-total class-only booking** snapshots `totalPrice` off the assigned vehicle instead of leaving it `null`.

## Why

`substitute()` already re-snapshots `totalPrice` (`booking-lifecycle.ts`), and the normal swap path is covered (existing `booking.test.ts` swap test, 20000 -> 30000). But the specific case #429 worried about — a **null-total** booking getting a vehicle assigned — was untested. A surviving `null` would later cancel for a 0 JPY fee via the `booking.totalPrice ?? 0` floor in the cancel path.

**Mutation-proven, not vacuous:** breaking the re-snapshot to keep the prior total fails this with `expected null to be 30000` — the exact null-survives-assignment -> 0-fee bug. No production change; the behavior already ships, this pins it.

## #429 checkbox disposition

- [x] **Compute + persist totalPrice on vehicle assignment** — already implemented (`substitute()` re-snapshot) and tested (existing swap test + this PR's null-total guard).
- [x] **Guard test: assigning a vehicle to a null-total booking backfills totalPrice** — this PR.
- [ ] **Revisit the cancellation fee for previously null-total bookings** — deferred. Null-total bookings cannot be created today: the only path is `CLASS_COMBO` / class-only, which is **#464** (post-demo). The cancel-path `?? 0` fee-semantics clarification also overlaps **#679** (dedup CANCELLED paths + clarify fee semantics). It belongs there, not here — and touching the cancel path now would collide with #679's in-flight work.

## Test plan

- [x] `bun run --filter @kuruma/api test` — 1489 passed
- [x] `bun run --filter @kuruma/api typecheck` — clean (strict)
- [x] biome / `lint:size` / `lint:boundaries` — clean
- [x] Mutation check: regression injected into the re-snapshot -> both guards fail (`expected 20000/null to be 30000`); reverted

Part of #429
