### PR TITLE
test(api): lock CANCELLED fee asymmetry + clarify the intentional split (#679)

### DIFF
--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -202,6 +202,14 @@ export class BookingLifecycleService {
     )
   }
 
+  /**
+   * Operator status transition (route-gated to MANAGEMENT_READ_ROLES, #643).
+   * Transitioning to CANCELLED is the operator cancel path and is deliberately
+   * FEE-FREE — operator non-delivery is the operator's fault, so the renter is made
+   * whole, never penalised for it. The tiered cancellation fee lives ONLY on renter
+   * self-cancel (`cancel()`); the two CANCELLED paths are intentionally divergent,
+   * not duplicated (#679) — do not merge them.
+   */
   async updateStatus(
     ctx: CallerContext,
     bookingId: string,
@@ -255,6 +263,13 @@ export class BookingLifecycleService {
     return { ok: true, booking: updated }
   }
 
+  /**
+   * Renter self-cancel — ALWAYS applies the tiered cancellation fee
+   * (`calculateCancellationFee`) and returns the breakdown so the renter sees what
+   * they forfeit vs are refunded. CONFIRMED-only by design; an operator cancels an
+   * ACTIVE booking via `updateStatus(-> CANCELLED)`, which charges nothing (#679).
+   * Keep the two paths separate — the fee asymmetry is the product rule, not dup.
+   */
   async cancel(
     ctx: CallerContext,
     bookingId: string,

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1195,6 +1195,51 @@ describe('BookingService lifecycle events (#392 §3.1)', () => {
       payload: { cancellationFee: res.cancellation.feeAmount, cancelledAt: NOW.toISOString() },
     })
   })
+
+  // #679: the two routes to CANCELLED are intentionally divergent on FEE, not only
+  // on notification. Renter self-cancel (cancel(), tiered fee — asserted above and in
+  // the route suite) ALWAYS applies the cancellation schedule; operator cancel
+  // (updateStatus -> CANCELLED) charges NOTHING. Operator non-delivery is the
+  // operator's fault, so the renter is made whole, never penalised for it. Guards
+  // against a "unify the two cancel paths" refactor silently charging renters.
+  it('operator cancel via updateStatus charges no fee, unlike renter self-cancel (#679)', async () => {
+    const h = await setup({ codes: ['LIFE0679'] })
+    const { vehicleId, locationId } = await seedReady(h)
+    const created = await h.service.create(
+      renterCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+      }),
+      NOW,
+    )
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+
+    // Only updateStatus can cancel a non-CONFIRMED booking, so an operator cancels
+    // by transitioning ACTIVE -> CANCELLED (the path #664 wired the email onto).
+    await h.service.updateStatus(opCtxA, created.booking.id, 'ACTIVE')
+    const cancelled = await h.service.updateStatus(opCtxA, created.booking.id, 'CANCELLED')
+    expect(cancelled.ok).toBe(true)
+    if (!cancelled.ok) return
+
+    expect(cancelled.booking.status).toBe('CANCELLED')
+    // No fee charged, and no fee breakdown returned — the renter owes nothing.
+    expect(cancelled.booking.cancellationFee).toBeNull()
+    expect('cancellation' in cancelled).toBe(false)
+    // Audit trail diverges too: operator cancel appends STATUS_CHANGED, never the
+    // fee-bearing BOOKING_CANCELLED that the renter path records.
+    const events = await h.repos.bookingEventRepo.findByBookingId(
+      SYSTEM_CONTEXT,
+      created.booking.id,
+    )
+    expect(events.map((e) => e.type)).toEqual([
+      'BOOKING_CREATED',
+      'STATUS_CHANGED',
+      'STATUS_CHANGED',
+    ])
+  })
 })
 
 describe('BookingService — renter lifecycle notifications (#664)', () => {


### PR DESCRIPTION
Closes #679

## The reframe
The issue title says "dedup dual path to CANCELLED." On investigation the two paths are **intentionally divergent, not accidentally duplicated** — a naive "unify both paths" refactor would be a bug, not a cleanup. So this PR *clarifies and guards* the split instead of merging it.

| | renter `POST /cancel` | operator `PATCH /status` -> CANCELLED |
|---|---|---|
| Fee | **always** tiered (`calculateCancellationFee`) | **never** — `cancellationFee` NULL |
| Authz | renter self-cancel (row-scoped) | `MANAGEMENT_READ_ROLES` gate (#643) |
| Event | `BOOKING_CANCELLED` (+fee) | `STATUS_CHANGED` |
| Valid from | CONFIRMED only | CONFIRMED / ACTIVE |
| Returns | `{ booking, cancellation }` | `{ booking }` |

## Fee semantics (the product question in the issue) — decided
Operator cancellation stays **free**: operator non-delivery is the operator's fault, so the renter is made whole (full refund), never penalised. Charging a fee on the operator path would mean the renter loses money because the *operator* failed — the opposite of standard marketplace behavior. Confirmed with the owner this session.

## What changed (no behavior change)
- **Guard test** (`booking.test.ts`): operator `updateStatus(-> CANCELLED)` leaves `cancellationFee` NULL, returns no fee breakdown, and appends `STATUS_CHANGED` (not the fee-bearing `BOOKING_CANCELLED`). Verified to go RED if a "unify" refactor attaches a fee to the operator path.
- **Docs**: fault-based fee rule on `cancel()` and `updateStatus()` JSDoc.

## Why no dedup
The only genuinely shared surface is the `'CANCELLED'` notification trigger — two call-sites of `postCommit.run(..., 'CANCELLED')`, no duplicated logic to extract. Merging the service methods would *add* branching (fee vs no-fee, gate vs no-gate), not remove it.

## Follow-up (separate concern, not this PR)
`cancel()` records the fee/refund amounts but doesn't call Stripe to issue the refund — refunds are operator-manual today. Filing a refund-automation issue; out of scope for fee *semantics*.

## Test plan
- [x] api typecheck (0), full api unit suite (1489 pass), import boundaries OK
- [x] biome clean, lint:size (no new warns), lint:modules OK
- [x] guard test proven to fail under a fee-attaching mutation, then revert -> green