### PR TITLE
fix(web): explicit width/height on remaining vite imgs (#846)

### DIFF
--- a/packages/web/src/vite/landing/FeaturedVehicles.tsx
+++ b/packages/web/src/vite/landing/FeaturedVehicles.tsx
@@ -77,6 +77,10 @@ export function FeaturedVehicles() {
                 <img
                   src={vehicle.image}
                   alt={vehicle.name}
+                  // 4:3 intrinsic hint lets the browser reserve the box before load (#846);
+                  // h-full/w-full still drive the rendered size inside the aspect wrapper.
+                  width={400}
+                  height={300}
                   className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                 />
               </div>

--- a/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetVehicleCard.tsx
@@ -50,7 +50,15 @@ export function FleetVehicleCard({
         )}
         <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-muted">
           {photo ? (
-            <img src={photo} alt={vehicle.name} className="h-full w-full object-cover" />
+            <img
+              src={photo}
+              alt={vehicle.name}
+              // 3:2 intrinsic hint lets the browser reserve the box before load (#846);
+              // h-full/w-full still drive the rendered size inside the fixed wrapper.
+              width={300}
+              height={200}
+              className="h-full w-full object-cover"
+            />
           ) : (
             <div className="flex h-full w-full items-center justify-center">
               <Car className="size-6 text-muted-foreground/30" />

--- a/packages/web/src/vite/operator-fleet/VehicleDetail.tsx
+++ b/packages/web/src/vite/operator-fleet/VehicleDetail.tsx
@@ -61,7 +61,15 @@ export function VehicleDetail({ detail, locale, canWrite }: VehicleDetailProps) 
       <div className="flex items-start gap-4">
         <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-muted">
           {primaryPhoto ? (
-            <img src={primaryPhoto} alt={detail.name} className="h-full w-full object-cover" />
+            <img
+              src={primaryPhoto}
+              alt={detail.name}
+              // 3:2 intrinsic hint lets the browser reserve the box before load (#846);
+              // h-full/w-full still drive the rendered size inside the fixed wrapper.
+              width={300}
+              height={200}
+              className="h-full w-full object-cover"
+            />
           ) : (
             <div className="flex h-full w-full items-center justify-center">
               <Car className="size-6 text-muted-foreground/30" />
@@ -162,6 +170,10 @@ export function VehicleDetail({ detail, locale, canWrite }: VehicleDetailProps) 
                   <img
                     src={url}
                     alt={`${detail.name} ${idx + 1}`}
+                    // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
+                    // h-full/w-full still drive the rendered size inside the square wrapper.
+                    width={300}
+                    height={300}
                     className="h-full w-full rounded-md border object-cover"
                   />
                 </li>

--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -40,7 +40,15 @@ function SpecificRow({ item }: { readonly item: SpecificSearchResult }) {
     <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
       <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
         {photo ? (
-          <img src={photo} alt={item.name} className="h-full w-full object-cover" />
+          <img
+            src={photo}
+            alt={item.name}
+            // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
+            // h-full/w-full still drive the rendered size inside the square wrapper.
+            width={300}
+            height={300}
+            className="h-full w-full object-cover"
+          />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <Car className="size-8 text-muted-foreground/30" />

--- a/packages/web/src/vite/vehicles/ClassCatalogCard.tsx
+++ b/packages/web/src/vite/vehicles/ClassCatalogCard.tsx
@@ -35,6 +35,10 @@ export function ClassCatalogCard({ vehicleClass }: ClassCatalogCardProps) {
           <img
             src={photo}
             alt={vehicleClass.name}
+            // 4:3 intrinsic hint lets the browser reserve the box before load (#846);
+            // h-full/w-full still drive the rendered size inside the aspect wrapper.
+            width={400}
+            height={300}
             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
           />
         ) : (

--- a/packages/web/src/vite/vehicles/ClassDetailView.tsx
+++ b/packages/web/src/vite/vehicles/ClassDetailView.tsx
@@ -50,13 +50,29 @@ export function ClassDetailView({ vehicleClass: vc }: ClassDetailViewProps) {
           {primaryPhoto ? (
             <div className="space-y-3">
               <div className="aspect-[4/3] overflow-hidden rounded-xl bg-muted">
-                <img src={primaryPhoto} alt={vc.name} className="w-full h-full object-cover" />
+                <img
+                  src={primaryPhoto}
+                  alt={vc.name}
+                  // 4:3 intrinsic hint lets the browser reserve the box before load (#846);
+                  // h-full/w-full still drive the rendered size inside the aspect wrapper.
+                  width={400}
+                  height={300}
+                  className="w-full h-full object-cover"
+                />
               </div>
               {photos.length > 1 && (
                 <div className="grid grid-cols-3 gap-3">
                   {photos.slice(1, 4).map((photo) => (
                     <div key={photo} className="aspect-[4/3] overflow-hidden rounded-lg bg-muted">
-                      <img src={photo} alt={vc.name} className="w-full h-full object-cover" />
+                      <img
+                        src={photo}
+                        alt={vc.name}
+                        // 4:3 intrinsic hint lets the browser reserve the box before load (#846);
+                        // h-full/w-full still drive the rendered size inside the aspect wrapper.
+                        width={400}
+                        height={300}
+                        className="w-full h-full object-cover"
+                      />
                     </div>
                   ))}
                 </div>

--- a/packages/web/tests/vite/landing/FeaturedVehicles.test.tsx
+++ b/packages/web/tests/vite/landing/FeaturedVehicles.test.tsx
@@ -45,4 +45,14 @@ describe('FeaturedVehicles', () => {
       expect(link).toHaveAttribute('data-locale', 'en')
     }
   })
+
+  it('gives every featured image explicit 4:3 dimensions so the box reserves space before load', () => {
+    renderFeatured()
+    const images = screen.getAllByRole('img')
+    expect(images.length).toBeGreaterThan(0)
+    for (const img of images) {
+      expect(img).toHaveAttribute('width', '400')
+      expect(img).toHaveAttribute('height', '300')
+    }
+  })
 })

--- a/packages/web/tests/vite/operator-fleet/FleetVehicleCard.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/FleetVehicleCard.test.tsx
@@ -1,0 +1,76 @@
+import { FleetVehicleCard } from '@/vite/operator-fleet/FleetVehicleCard'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}))
+
+function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'v1',
+    operatorId: 'op_1',
+    classId: null,
+    pickupLocationId: null,
+    name: 'Toyota Aqua',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'なにわ 300 あ 12-34',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: 'Toyota',
+    model: 'Aqua',
+    year: 2022,
+    color: null,
+    dailyRateJpy: 6800,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-01-01',
+    insuranceExpiryDate: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+// canWrite={false} drops the checkbox + FleetRowActions (which needs a QueryClient),
+// leaving the thumbnail to render on its own.
+function renderCard(v: OperatorFleetVehicle) {
+  return render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <FleetVehicleCard
+        vehicle={v}
+        selected={false}
+        onToggleSelect={vi.fn()}
+        onEdit={vi.fn()}
+        canWrite={false}
+        todayIso="2026-01-01"
+        locale="en"
+      />
+    </IntlProvider>,
+  )
+}
+
+describe('FleetVehicleCard', () => {
+  it('gives the thumbnail explicit 3:2 dimensions when a photo is present', () => {
+    renderCard(vehicle({ name: 'Toyota Aqua', photos: ['https://cdn.example/aqua.jpg'] }))
+    const img = screen.getByRole('img', { name: 'Toyota Aqua' })
+    expect(img).toHaveAttribute('width', '300')
+    expect(img).toHaveAttribute('height', '200')
+  })
+})

--- a/packages/web/tests/vite/operator-fleet/VehicleDetail.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/VehicleDetail.test.tsx
@@ -115,6 +115,20 @@ describe('VehicleDetail', () => {
     expect(img).toHaveAttribute('src', 'https://cdn.example/aqua-1.jpg')
   })
 
+  it('gives the header thumbnail (3:2) and gallery images (1:1) explicit dimensions', () => {
+    renderDetail(detail({ name: 'Toyota Aqua', photos: ['a.jpg', 'b.jpg'] }), false)
+
+    const header = screen.getByRole('img', { name: 'Toyota Aqua' })
+    expect(header).toHaveAttribute('width', '300')
+    expect(header).toHaveAttribute('height', '200')
+
+    for (const name of ['Toyota Aqua 1', 'Toyota Aqua 2']) {
+      const thumb = screen.getByRole('img', { name })
+      expect(thumb).toHaveAttribute('width', '300')
+      expect(thumb).toHaveAttribute('height', '300')
+    }
+  })
+
   it('renders the empty / zeroed state when there are no bookings or revenue', () => {
     renderDetail(
       detail({

--- a/packages/web/tests/vite/search/SearchResultRow.test.tsx
+++ b/packages/web/tests/vite/search/SearchResultRow.test.tsx
@@ -67,6 +67,13 @@ describe('SearchResultRow', () => {
     expect(screen.getByText('Price on request')).toBeInTheDocument()
   })
 
+  it('gives the thumbnail explicit square dimensions when a photo is present', () => {
+    renderRow(makeSpecific({ photos: ['https://cdn.example/yaris.jpg'] }))
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('width', '300')
+    expect(img).toHaveAttribute('height', '300')
+  })
+
   it('renders the select CTA as an inert disabled button (booking deferred)', () => {
     renderRow(makeSpecific())
     const select = screen.getByRole('button', { name: 'Select' })

--- a/packages/web/tests/vite/vehicles/ClassCatalogCard.test.tsx
+++ b/packages/web/tests/vite/vehicles/ClassCatalogCard.test.tsx
@@ -1,0 +1,49 @@
+import { ClassCatalogCard } from '@/vite/vehicles/ClassCatalogCard'
+import type { VehicleClassData } from '@/vite/vehicles/classes'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}))
+
+function makeClass(overrides: Partial<VehicleClassData> = {}): VehicleClassData {
+  return {
+    id: 'c1',
+    name: 'Compact',
+    slug: 'compact',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    acrissCode: null,
+    sortOrder: 0,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderCard(vc: VehicleClassData) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <ClassCatalogCard vehicleClass={vc} />
+    </IntlProvider>,
+  )
+}
+
+describe('ClassCatalogCard', () => {
+  it('gives the class photo explicit 4:3 dimensions when present', () => {
+    renderCard(makeClass({ name: 'Compact', photos: ['https://cdn.example/compact.jpg'] }))
+    const img = screen.getByRole('img', { name: 'Compact' })
+    expect(img).toHaveAttribute('width', '400')
+    expect(img).toHaveAttribute('height', '300')
+  })
+})

--- a/packages/web/tests/vite/vehicles/ClassDetailView.test.tsx
+++ b/packages/web/tests/vite/vehicles/ClassDetailView.test.tsx
@@ -57,4 +57,14 @@ describe('ClassDetailView', () => {
     renderDetail(makeClass({ luggageCapacity: 1, luggageSize: 'SMALL' }))
     expect(screen.getByText('1 bag')).toBeInTheDocument()
   })
+
+  it('gives every gallery image explicit 4:3 dimensions', () => {
+    renderDetail(makeClass({ photos: ['p0.jpg', 'p1.jpg', 'p2.jpg'] }))
+    const images = screen.getAllByRole('img')
+    expect(images.length).toBeGreaterThan(1)
+    for (const img of images) {
+      expect(img).toHaveAttribute('width', '400')
+      expect(img).toHaveAttribute('height', '300')
+    }
+  })
 })


### PR DESCRIPTION
Closes #846.

Follow-up to #843/#440. Extends the explicit `width`/`height` intrinsic-ratio hint to the six remaining `vite/` components that render a raw `<img>` inside a fixed-aspect wrapper, so Lighthouse's "image elements do not have explicit width and height" audit passes and the browser can reserve the box before load. `h-full`/`w-full` still drive the rendered size — these are ratio hints, not a layout change.

## Changes (ratio → dims)
| Component | Wrapper | Dims |
|---|---|---|
| `landing/FeaturedVehicles` | `aspect-[4/3]` | 400×300 |
| `vehicles/ClassCatalogCard` | `aspect-[4/3]` | 400×300 |
| `vehicles/ClassDetailView` (primary + thumbs) | `aspect-[4/3]` | 400×300 |
| `search/SearchResultRow` | `size-24/28` (square) | 300×300 |
| `operator-fleet/FleetVehicleCard` | `h-16 w-24` | 300×200 |
| `operator-fleet/VehicleDetail` header | `h-16 w-24` | 300×200 |
| `operator-fleet/VehicleDetail` gallery | `aspect-square` | 300×300 |

## PhotoUpload — intentionally skipped (flagged for review)
The issue says to skip `PhotoUpload` (upload preview). I honored that. **Note the contradiction:** `PhotoUpload`'s `<img>` is structurally identical to the `VehicleDetail` gallery thumbnail we *did* fix (both `aspect-square` + `object-cover`), and `object-cover` makes the "could distort" concern moot. Left as-is per the issue; reviewer can decide if they want parity (would be a one-line follow-up).

## Tests
TDD `toHaveAttribute('width'/'height')` per fixed-aspect component — 2 new test files (`ClassCatalogCard`, `FleetVehicleCard`), 4 extended (`FeaturedVehicles`, `SearchResultRow`, `ClassDetailView`, `VehicleDetail`). Each was RED before the attrs, GREEN after.

- [x] `bun run --filter @kuruma/web typecheck` (0)
- [x] `bun run --filter @kuruma/web test` (807/807)
- [x] `bun run lint` (biome + size + modules, exit 0)

Web-only, no DB, no API.