### PR TITLE
refactor(web): validate provider/classes/documents/new-bookings responses with Zod (#711 3c-2)

### DIFF
--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -73,18 +73,22 @@ const TEST_STOREFRONT_DETAIL = {
   nextCursor: null,
 }
 
+// Mirrors the real toVehicleClass wire shape (#711 3c-2 validates it with Zod):
+// operatorId (notNull), luggageSize, and acrissCode are all served by the real
+// API, so the fixture must carry them or the catalog query fails its schema.
 const TEST_CLASS = {
   id: TEST_CLASS_ID,
+  operatorId: 'e2e-operator-1',
   name: 'E2E Test Compact',
   slug: TEST_CLASS_SLUG,
   description: 'Compact class used by the Playwright browse-flow spec.',
   photos: ['https://images.unsplash.com/photo-1734857039653-c1b0a4b3422a?w=600&q=80'],
   seats: 4,
   luggageCapacity: 2,
+  luggageSize: 'MEDIUM',
   transmission: 'AUTO',
   fuelType: 'Petrol',
-  dailyRateJpy: 5000,
-  hourlyRateJpy: null,
+  acrissCode: 'CCAR',
   sortOrder: 0,
   status: 'ACTIVE',
   createdAt: FROZEN_TIMESTAMP,

--- a/packages/web/src/vite/documents/api.ts
+++ b/packages/web/src/vite/documents/api.ts
@@ -1,24 +1,42 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { DOCUMENT_STATUSES, DOCUMENT_TYPES } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
-export type DocumentType = 'IDP' | 'PASSPORT'
-export type DocumentStatus = 'PENDING' | 'APPROVED' | 'REJECTED'
+// Enum domains anchor to the shared @kuruma/shared/enums SSoT (#688) so the web
+// validation can't drift from the DB pgEnums.
+const documentTypeSchema = z.enum(DOCUMENT_TYPES)
+const documentStatusSchema = z.enum(DOCUMENT_STATUSES)
+
+export type DocumentType = z.infer<typeof documentTypeSchema>
+export type DocumentStatus = z.infer<typeof documentStatusSchema>
 
 // JSON-serialized RenterDocument (#459) — dates arrive as ISO strings. The Vite
 // shell owns this DTO rather than importing the api module's copy so it stays
 // self-contained (the `lint:modules` boundary forbids reaching into modules).
-export interface RenterDocumentDto {
-  id: string
-  renterId: string
-  type: DocumentType
-  status: DocumentStatus
-  expiryDate: string | null
-  verifiedAt: string | null
-  rejectionReason: string | null
-  createdAt: string
-  updatedAt: string
-}
+// Inferred from the schema (#711) so the compile-time type and the runtime parse
+// at the seam share one source. The wire also carries server-only `storageKey`
+// and `verifierId`; this non-strict schema validates the renter-facing subset and
+// strips them. expiryDate/verifiedAt/rejectionReason stay null until approval.
+const renterDocumentSchema = z.object({
+  id: z.string(),
+  renterId: z.string(),
+  type: documentTypeSchema,
+  status: documentStatusSchema,
+  expiryDate: z.string().nullable(),
+  verifiedAt: z.string().nullable(),
+  rejectionReason: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type RenterDocumentDto = z.infer<typeof renterDocumentSchema>
+
+// Both endpoints wrap the row(s) one level inside `data`; unwrap() peels
+// {success,data}, these peel the inner {documents} / {document} envelope.
+const myDocumentsResponseSchema = z.object({ documents: z.array(renterDocumentSchema) })
+const uploadDocumentResponseSchema = z.object({ document: renterDocumentSchema })
 
 // The calling renter's own documents. Cookie-authenticated (the `_renter` guard
 // has already established a session), so `credentials: 'include'` carries it.
@@ -26,7 +44,7 @@ export async function fetchMyDocuments(): Promise<RenterDocumentDto[]> {
   const res = await fetch(`${getApiBaseUrl()}/documents/me`, {
     credentials: 'include',
   })
-  const data = await unwrap<{ documents: RenterDocumentDto[] }>(res)
+  const data = await unwrap(res, myDocumentsResponseSchema)
   return data.documents
 }
 
@@ -55,6 +73,6 @@ export async function uploadDocument(params: {
     headers: { 'X-CSRF-Token': params.csrfToken },
     body: form,
   })
-  const data = await unwrap<{ document: RenterDocumentDto }>(res)
+  const data = await unwrap(res, uploadDocumentResponseSchema)
   return data.document
 }

--- a/packages/web/src/vite/operator-bookings/new-bookings.ts
+++ b/packages/web/src/vite/operator-bookings/new-bookings.ts
@@ -1,6 +1,7 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import { type QueryClient, queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // #611: operator in-app "new order" red-dot badge. There is no server-side
 // unread/seen state (`/notifications` is an email-delivery log, not an inbox),
@@ -22,10 +23,14 @@ const NEW_ORDER_SCAN_LIMIT = 50
 // plenty; a tight loop would hammer the API for a cosmetic dot.
 const NEW_ORDER_REFETCH_MS = 60_000
 
-/** Minimal row the badge needs: just the creation timestamp (ISO JSON). */
-export interface NewOrderBooking {
-  createdAt: string
-}
+/** Minimal row the badge needs: just the creation timestamp (ISO JSON). The
+ *  /bookings rows carry ~25 other fields; this non-strict schema validates only
+ *  createdAt (always a non-null timestamptz) and strips the rest (#711). */
+const newOrderBookingSchema = z.object({
+  createdAt: z.string(),
+})
+
+export type NewOrderBooking = z.infer<typeof newOrderBookingSchema>
 
 /** Pure: how many bookings were created strictly after the last-seen instant. */
 export function countNewBookings(bookings: readonly NewOrderBooking[], lastSeenAt: string): number {
@@ -40,8 +45,9 @@ export async function fetchNewOrderBookings(): Promise<NewOrderBooking[]> {
   const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
     credentials: 'include',
   })
-  const data = await unwrap<NewOrderBooking[]>(res)
-  return data.map((b) => ({ createdAt: b.createdAt }))
+  // The schema strips every field but createdAt, so the parsed rows already are
+  // the minimal NewOrderBooking shape — no post-map narrowing needed.
+  return unwrap(res, newOrderBookingSchema.array())
 }
 
 export function newOrderBookingsQueryOptions(enabled: boolean) {

--- a/packages/web/src/vite/provider/api.ts
+++ b/packages/web/src/vite/provider/api.ts
@@ -1,14 +1,20 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { z } from 'zod'
 
 /** Public invite preview (#521 §7). Carries no email — only enough to render the
  *  acceptance page. `expiresAt` is the JSON-serialized ISO string; the API never
- *  exposes the invited address. `valid` gates the accept CTA. */
-export interface InvitePreviewData {
-  valid: boolean
-  operatorName?: string
-  expiresAt?: string
-}
+ *  exposes the invited address. `valid` gates the accept CTA. Inferred from the
+ *  schema (#711) so the compile-time type and the runtime parse at the seam share
+ *  one source. On an unknown/expired token the producer omits operatorName and
+ *  expiresAt (a bare `{ valid: false }`), so both stay optional. */
+const invitePreviewDataSchema = z.object({
+  valid: z.boolean(),
+  operatorName: z.string().optional(),
+  expiresAt: z.string().optional(),
+})
+
+export type InvitePreviewData = z.infer<typeof invitePreviewDataSchema>
 
 // Public endpoint — anonymous; the recipient has no session yet. Always a 200
 // ok() envelope (an unknown/expired token is `{ valid: false }`, not a 404), so
@@ -20,5 +26,5 @@ export async function fetchInvitePreview(token: string): Promise<InvitePreviewDa
       credentials: 'include',
     },
   )
-  return unwrap<InvitePreviewData>(res)
+  return unwrap(res, invitePreviewDataSchema)
 }

--- a/packages/web/src/vite/vehicles/classes.ts
+++ b/packages/web/src/vite/vehicles/classes.ts
@@ -1,29 +1,39 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { LuggageSize } from '@kuruma/shared/lib/luggage'
+import { LUGGAGE_SIZES, TRANSMISSIONS, VEHICLE_CLASS_STATUSES } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // JSON-serialized VehicleClass — dates arrive as ISO strings from the API. The
 // Vite shell owns this DTO (rather than importing the frozen Next module's copy)
 // so it stays self-contained once `modules/classes` is deleted at cutover.
-export interface VehicleClassData {
-  id: string
-  operatorId?: string
-  name: string
-  slug: string
-  description: string | null
-  photos: string[]
-  seats: number
-  luggageCapacity: number
-  luggageSize: LuggageSize
-  transmission: 'AUTO' | 'MANUAL'
-  fuelType: string | null
-  acrissCode: string | null
-  sortOrder: number
-  status: 'ACTIVE' | 'ARCHIVED'
-  createdAt: string
-  updatedAt: string
-}
+// Inferred from the schema (#711) so the compile-time type and the runtime parse
+// at the seam share one source. Mirrors operator-classes/api.ts — the same
+// `toVehicleClass` producer feeds both. Enum domains anchor to the shared
+// @kuruma/shared/enums SSoT so they can't drift from the DB pgEnums (#688).
+// operatorId is pinned required (DB notNull; all three read endpoints serialize
+// it, incl. the public ones), so an absent value fails as drift here rather than
+// as `undefined` deep in render.
+const vehicleClassSchema = z.object({
+  id: z.string(),
+  operatorId: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  photos: z.array(z.string()),
+  seats: z.number(),
+  luggageCapacity: z.number(),
+  luggageSize: z.enum(LUGGAGE_SIZES),
+  transmission: z.enum(TRANSMISSIONS),
+  fuelType: z.string().nullable(),
+  acrissCode: z.string().nullable(),
+  sortOrder: z.number(),
+  status: z.enum(VEHICLE_CLASS_STATUSES),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type VehicleClassData = z.infer<typeof vehicleClassSchema>
 
 // Renter-facing catalog: the public /vehicle-classes endpoint, status-filtered to
 // ACTIVE and sorted server-side by sortOrder. No auth — anonymous visitors browse.
@@ -31,7 +41,7 @@ export async function fetchActiveClasses(): Promise<VehicleClassData[]> {
   const res = await fetch(`${getApiBaseUrl()}/vehicle-classes?status=ACTIVE`, {
     credentials: 'include',
   })
-  return unwrap<VehicleClassData[]>(res)
+  return unwrap(res, vehicleClassSchema.array())
 }
 
 // Public slug lookup. A 404 is "no such class" (returns null so the route renders
@@ -44,7 +54,7 @@ export async function fetchClassBySlug(slug: string): Promise<VehicleClassData |
     },
   )
   if (res.status === 404) return null
-  return unwrap<VehicleClassData>(res)
+  return unwrap(res, vehicleClassSchema)
 }
 
 // Protected single-class read for the booking confirmation label (#511). Unlike
@@ -58,7 +68,7 @@ export async function fetchClassById(id: string): Promise<VehicleClassData | nul
     credentials: 'include',
   })
   if (res.status === 404) return null
-  return unwrap<VehicleClassData>(res)
+  return unwrap(res, vehicleClassSchema)
 }
 
 export function activeClassesQueryOptions() {

--- a/packages/web/tests/vite/documents/api.test.ts
+++ b/packages/web/tests/vite/documents/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { fetchMyDocuments, uploadDocument } from '@/vite/documents/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -40,6 +41,27 @@ describe('fetchMyDocuments', () => {
     fetchMock.mockResolvedValue(jsonResponse({ success: false, error: 'boom' }, 500))
     await expect(fetchMyDocuments()).rejects.toThrow('boom')
   })
+
+  it('strips server-only fields (storageKey, verifierId) the DTO omits (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { documents: [{ ...documentData, storageKey: 'r2/key', verifierId: null }] },
+      }),
+    )
+    // Non-strict schema: only the renter-facing subset comes back, server keys gone.
+    expect(await fetchMyDocuments()).toEqual([documentData])
+  })
+
+  it('rejects with a ParseError when a document has an unknown status (drift #711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { documents: [{ ...documentData, status: 'EXPIRED' }] },
+      }),
+    )
+    await expect(fetchMyDocuments()).rejects.toBeInstanceOf(ParseError)
+  })
 })
 
 describe('uploadDocument', () => {
@@ -70,6 +92,16 @@ describe('uploadDocument', () => {
     const file = new File(['x'], 'x.png', { type: 'image/png' })
     await expect(uploadDocument({ type: 'PASSPORT', file, csrfToken: 't' })).rejects.toThrow(
       'too large',
+    )
+  })
+
+  it('rejects with a ParseError when the uploaded document is malformed (drift #711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { document: { id: 'd1' } } }, 201),
+    )
+    const file = new File(['x'], 'x.png', { type: 'image/png' })
+    await expect(uploadDocument({ type: 'IDP', file, csrfToken: 't' })).rejects.toBeInstanceOf(
+      ParseError,
     )
   })
 })

--- a/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
+++ b/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
@@ -1,12 +1,22 @@
+import { ParseError } from '@/lib/api-error'
 import {
   LAST_SEEN_STORAGE_KEY,
   NEW_ORDER_SCAN_QUERY_KEY,
   countNewBookings,
+  fetchNewOrderBookings,
   getStoredLastSeenAt,
   markBookingsSeen,
 } from '@/vite/operator-bookings/new-bookings'
 import { QueryClient } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
 
 beforeEach(() => {
   window.localStorage.clear()
@@ -78,5 +88,42 @@ describe('markBookingsSeen', () => {
       new Date('2020-01-01T00:00:00.000Z').getTime(),
     )
     expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
+  })
+})
+
+describe('fetchNewOrderBookings', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('requests CONFIRMED bookings (limit 50) and strips every field but createdAt', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: [
+          {
+            id: 'b1',
+            status: 'CONFIRMED',
+            totalPrice: 30000,
+            createdAt: '2026-06-13T05:00:00.000Z',
+          },
+        ],
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchNewOrderBookings()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/bookings?status=CONFIRMED&limit=50', {
+      credentials: 'include',
+    })
+    // The badge only needs createdAt; the ~25 other booking fields are stripped.
+    expect(result).toEqual([{ createdAt: '2026-06-13T05:00:00.000Z' }])
+  })
+
+  it('rejects with a ParseError when a row lacks createdAt (drift #711)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [{ id: 'b1', status: 'CONFIRMED' }] })),
+    )
+    await expect(fetchNewOrderBookings()).rejects.toBeInstanceOf(ParseError)
   })
 })

--- a/packages/web/tests/vite/provider/api.test.ts
+++ b/packages/web/tests/vite/provider/api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { fetchInvitePreview } from '@/vite/provider/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -45,5 +46,25 @@ describe('fetchInvitePreview', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/provider-invites/a%2Fb%20token/preview', {
       credentials: 'include',
     })
+  })
+
+  it('rejects with a ParseError when the preview is missing `valid` (drift #711)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: { operatorName: 'X' } })),
+    )
+    await expect(fetchInvitePreview('tok')).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('rejects with a ParseError naming `valid` when it is the wrong type', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: { valid: 'yes' } })),
+    )
+    const error = await fetchInvitePreview('tok').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ParseError)
+    expect((error as ParseError).issues).toContainEqual(
+      expect.objectContaining({ path: expect.arrayContaining(['valid']) }),
+    )
   })
 })

--- a/packages/web/tests/vite/vehicles/classes.test.ts
+++ b/packages/web/tests/vite/vehicles/classes.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { fetchActiveClasses, fetchClassById, fetchClassBySlug } from '@/vite/vehicles/classes'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,14 +15,19 @@ vi.stubGlobal('fetch', fetchMock)
 
 afterEach(() => fetchMock.mockReset())
 
+// A complete VehicleClassData row — the response schema (#711) now rejects
+// partials, so a fixture exercising a validated path must carry every field
+// (operatorId + luggageSize included, both required).
 const classData = {
   id: 'c1',
+  operatorId: 'op1',
   name: 'Compact',
   slug: 'compact',
   description: null,
   photos: [],
   seats: 5,
   luggageCapacity: 2,
+  luggageSize: 'MEDIUM',
   transmission: 'AUTO',
   fuelType: null,
   acrissCode: 'CDAR',
@@ -97,5 +103,31 @@ describe('fetchClassById', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/a%2Fb', {
       credentials: 'include',
     })
+  })
+})
+
+describe('vehicle-class response validation (#711)', () => {
+  it('rejects the list naming `operatorId` when the producer omits it (drift)', async () => {
+    // operatorId is DB notNull and served on every endpoint; an absent value is
+    // contract drift, not a legacy shape — the schema must fail at the seam.
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [{ ...classData, operatorId: undefined }] }),
+    )
+    const error = await fetchActiveClasses().catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ParseError)
+    expect((error as ParseError).issues).toContainEqual(
+      expect.objectContaining({ path: expect.arrayContaining(['operatorId']) }),
+    )
+  })
+
+  it('rejects a single class naming `status` when it is an unknown enum value', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { ...classData, status: 'DELETED' } }),
+    )
+    const error = await fetchClassBySlug('compact').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ParseError)
+    expect((error as ParseError).issues).toContainEqual(
+      expect.objectContaining({ path: expect.arrayContaining(['status']) }),
+    )
   })
 })


### PR DESCRIPTION
## What

Slice **3c-2** of #711 — migrate the remaining small operator/renter web API clients from the phantom `unwrap<T>(res)` cast to runtime `unwrap(res, schema)` Zod validation. Continues merged slices 3a/3b/3c-1.

| Client | DTO | Notes |
|---|---|---|
| `provider/api.ts` | `InvitePreviewData` | `valid` required; `operatorName`/`expiresAt` optional (producer omits them on the unknown-token path) |
| `vehicles/classes.ts` | `VehicleClassData` (×3 read endpoints) | mirrors `operator-classes/api.ts` (same `toVehicleClass` producer); `operatorId` pinned **required** (DB notNull, served on every endpoint incl. public) |
| `documents/api.ts` | `RenterDocumentDto` + `{documents}`/`{document}` envelopes | non-strict: server-only `storageKey`/`verifierId` stripped; 3 nullable fields; `status` allows `PENDING` |
| `operator-bookings/new-bookings.ts` | `/bookings` badge scan | validates only `createdAt`, strips the ~25 other booking fields (redundant `.map()` removed) |

DTOs are now inferred from their schemas (`z.infer`); enum domains anchor to the `@kuruma/shared/enums` SSoT tuples (`DOCUMENT_TYPES`, `DOCUMENT_STATUSES`, `TRANSMISSIONS`, `VEHICLE_CLASS_STATUSES`, `LUGGAGE_SIZES`) so web validation can't drift from the DB pgEnums. No new src files → the `vite/` deprecation ratchet stays **148**.

## Producer-verified

Every field's nullability + enum domain was checked field-by-field against `packages/api/src/{routes,services,repositories}` + `packages/shared/src/db/` before pinning anything required/non-null — a web schema stricter than the wire would throw `ParseError` on valid data. No schema is stricter than its producer.

## Tests

Drift test per client asserts `ParseError` on a malformed body (field-pinned issue paths where claimed); strip tests prove the non-strict behavior matches the real wire. Web suite **810/810**, tsc ×3 (web/api/shared) clean, biome + lint:size + lint:modules clean.

## Reviews

- **code-review: SHIP** — zero findings; all 4 producers verified, no over-strict schema.
- **architect: SHIP** — boundary-clean; the one MEDIUM (inline enum literals vs shared SSoT tuples) was **applied in this PR**, not deferred.

Remaining `unwrap<T>` casts are all accounted for elsewhere: storefronts (slice 3d), operator-fleet writes (#817), admin revenue/anomalies (#744).

Part of #711