### PR TITLE
refactor(web): validate operator-fleet write responses against the bare-row schema (#817)

### DIFF
--- a/packages/web/src/vite/operator-fleet/api.ts
+++ b/packages/web/src/vite/operator-fleet/api.ts
@@ -7,6 +7,7 @@ import type {
   VehicleStatus,
 } from '@kuruma/shared/validators/vehicle'
 import { queryOptions } from '@tanstack/react-query'
+import type { ZodType } from 'zod'
 import {
   type DailyUtilizationDto,
   type FleetBookingSummary,
@@ -17,11 +18,14 @@ import {
   type VehicleDetailBookingDto,
   type VehicleDetailResponse,
   type VehicleMaintenanceLogDto,
+  type VehicleRow,
   operatorFleetListSchema,
   photoDeleteResultSchema,
   photoUploadResultSchema,
   vehicleClassOptionsListSchema,
   vehicleDetailResponseSchema,
+  vehicleRowListSchema,
+  vehicleRowSchema,
 } from './schema'
 
 // #526: operator fleet management. The Vite shell owns this read projection (it
@@ -48,6 +52,7 @@ export type {
   VehicleDetailBookingDto,
   VehicleDetailResponse,
   VehicleMaintenanceLogDto,
+  VehicleRow,
 }
 
 export const FLEET_QUERY_KEY = ['operator-fleet'] as const
@@ -71,57 +76,58 @@ export function operatorFleetQueryOptions() {
 // tenant. Each unwraps the ok() envelope and throws ApiError on failure so the
 // caller's useMutation onError can surface it.
 //
-// #711 scope note: these write endpoints return the *bare* vehicle row (no
-// fleet-overview enrichment — `utilization`, `currentBooking`, …), so the
-// `OperatorFleetVehicle` return annotation is wider than the wire body.
-// Validating it with `operatorFleetVehicleSchema` would reject every valid
-// write, so the writes keep the legacy passthrough; correcting the return type
-// (and its consumers) to the base-vehicle shape is a tracked follow-up.
+// #817: these write endpoints return the *bare* vehicle row (shared `Vehicle` =
+// `VehicleBase`, with none of the fleet-overview enrichment — `utilization`,
+// `currentBooking`, …). Each is therefore typed `VehicleRow` and validated with
+// `vehicleRowSchema`; the enriched `operatorFleetVehicleSchema` would reject
+// every valid write. The four mutation `onSuccess` handlers ignore the result,
+// so narrowing the return type from `OperatorFleetVehicle` is consumer-safe.
 
-async function writeJson<T>(path: string, method: 'POST' | 'PATCH', body: unknown): Promise<T> {
+async function writeJson<T>(
+  path: string,
+  method: 'POST' | 'PATCH',
+  body: unknown,
+  schema: ZodType<T>,
+): Promise<T> {
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  return unwrap<T>(res)
+  return unwrap(res, schema)
 }
 
-export function createVehicle(data: CreateVehicleInput): Promise<OperatorFleetVehicle> {
-  return writeJson<OperatorFleetVehicle>('/vehicles', 'POST', data)
+export function createVehicle(data: CreateVehicleInput): Promise<VehicleRow> {
+  return writeJson('/vehicles', 'POST', data, vehicleRowSchema)
 }
 
-export function updateVehicle(id: string, data: UpdateVehicleInput): Promise<OperatorFleetVehicle> {
-  return writeJson<OperatorFleetVehicle>(`/vehicles/${encodeURIComponent(id)}`, 'PATCH', data)
+export function updateVehicle(id: string, data: UpdateVehicleInput): Promise<VehicleRow> {
+  return writeJson(`/vehicles/${encodeURIComponent(id)}`, 'PATCH', data, vehicleRowSchema)
 }
 
 export function updateVehicleStatus(
   id: string,
   status: VehicleStatus,
   reason?: string,
-): Promise<OperatorFleetVehicle> {
+): Promise<VehicleRow> {
   const body = reason != null ? { status, reason } : { status }
-  return writeJson<OperatorFleetVehicle>(
-    `/vehicles/${encodeURIComponent(id)}/status`,
-    'PATCH',
-    body,
-  )
+  return writeJson(`/vehicles/${encodeURIComponent(id)}/status`, 'PATCH', body, vehicleRowSchema)
 }
 
 export function bulkUpdateVehicleStatus(
   vehicleIds: string[],
   status: BulkVehicleStatus,
-): Promise<OperatorFleetVehicle[]> {
-  return writeJson<OperatorFleetVehicle[]>('/vehicles/bulk-status', 'PATCH', { vehicleIds, status })
+): Promise<VehicleRow[]> {
+  return writeJson('/vehicles/bulk-status', 'PATCH', { vehicleIds, status }, vehicleRowListSchema)
 }
 
-export async function retireVehicle(id: string): Promise<OperatorFleetVehicle> {
+export async function retireVehicle(id: string): Promise<VehicleRow> {
   const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(id)}`, {
     method: 'DELETE',
     credentials: 'include',
   })
-  return unwrap<OperatorFleetVehicle>(res)
+  return unwrap(res, vehicleRowSchema)
 }
 
 export async function uploadVehiclePhotos(

--- a/packages/web/src/vite/operator-fleet/schema.ts
+++ b/packages/web/src/vite/operator-fleet/schema.ts
@@ -48,6 +48,17 @@ const vehicleBaseShape = {
   updatedAt: z.string(),
 } as const
 
+/**
+ * The bare vehicle row returned by every *write* endpoint (create / update /
+ * status / bulk-status / retire): the shared `Vehicle` (= `VehicleBase`) over
+ * JSON, with none of the fleet-overview enrichment. #817: the writes used to
+ * pass through unvalidated because the enriched `operatorFleetVehicleSchema`
+ * would reject a bare row — this is the schema that matches their wire body.
+ */
+export const vehicleRowSchema = z.object(vehicleBaseShape)
+export type VehicleRow = z.infer<typeof vehicleRowSchema>
+export const vehicleRowListSchema = z.array(vehicleRowSchema)
+
 /** A booking touching a fleet vehicle (current/next), dates as ISO strings. */
 export const fleetBookingSummarySchema = z.object({
   startAt: z.string(),

--- a/packages/web/tests/vite/operator-fleet/api.test.ts
+++ b/packages/web/tests/vite/operator-fleet/api.test.ts
@@ -1,9 +1,17 @@
 import { ApiError, ParseError } from '@/lib/api-error'
 import {
+  type CreateVehicleInput,
   type OperatorFleetVehicle,
+  type UpdateVehicleInput,
   type VehicleDetailResponse,
+  type VehicleRow,
+  bulkUpdateVehicleStatus,
+  createVehicle,
   fetchOperatorFleet,
   fetchVehicleDetail,
+  retireVehicle,
+  updateVehicle,
+  updateVehicleStatus,
   vehicleDetailQueryOptions,
   vehicleRowFromDetail,
 } from '@/vite/operator-fleet/api'
@@ -102,6 +110,40 @@ const fleetRaw = (over: Record<string, unknown> = {}): OperatorFleetVehicle => (
   },
   nextBooking: null,
   activeMaintenanceReason: null,
+  ...over,
+})
+
+// A bare vehicle row as the write endpoints (create/update/status/bulk/retire)
+// return it (#817): shared `VehicleBase` over JSON, WITHOUT the five
+// fleet-overview enrichment fields that `fleetRaw` carries.
+const vehicleRowRaw = (over: Record<string, unknown> = {}): VehicleRow => ({
+  id: 'veh-1',
+  operatorId: 'op-1',
+  classId: 'cls-1',
+  pickupLocationId: 'loc-1',
+  name: 'Toyota Alphard',
+  description: 'Luxury van',
+  photos: ['a.jpg'],
+  seats: 7,
+  luggageCapacity: 4,
+  luggageSize: 'LARGE',
+  transmission: 'AUTO',
+  fuelType: 'Hybrid',
+  licensePlate: 'なにわ 300 あ 12-34',
+  status: 'AVAILABLE',
+  minRentalHours: 4,
+  maxRentalHours: 72,
+  advanceBookingHours: null,
+  make: 'Toyota',
+  model: 'Alphard',
+  year: 2023,
+  color: 'White',
+  dailyRateJpy: 18000,
+  hourlyRateJpy: 2500,
+  shakenExpiryDate: '2027-03-31',
+  insuranceExpiryDate: '2027-03-31',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
   ...over,
 })
 
@@ -254,5 +296,129 @@ describe('fetchVehicleDetail (#711 response validation)', () => {
     )
 
     await expect(fetchVehicleDetail('veh-1')).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('operator-fleet writes (#817 response validation)', () => {
+  it('createVehicle POSTs to /vehicles and returns the bare validated row', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: vehicleRowRaw() }, 201))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const row = await createVehicle({} as CreateVehicleInput)
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/vehicles')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(row).toMatchObject({ id: 'veh-1', name: 'Toyota Alphard', status: 'AVAILABLE' })
+  })
+
+  it('createVehicle strips fleet-overview enrichment (bare schema, not the enriched one)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: { ...vehicleRowRaw(), utilization: 99 } }, 201),
+      ),
+    )
+
+    const row = await createVehicle({} as CreateVehicleInput)
+
+    expect(row).not.toHaveProperty('utilization')
+  })
+
+  it('updateVehicle PATCHes /vehicles/:id and returns the bare validated row', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: vehicleRowRaw() }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const row = await updateVehicle('veh-1', {} as UpdateVehicleInput)
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/vehicles/veh-1')
+    expect((init as RequestInit).method).toBe('PATCH')
+    expect(row).toMatchObject({ id: 'veh-1', status: 'AVAILABLE' })
+  })
+
+  it('updateVehicleStatus PATCHes /vehicles/:id/status with the new status and reason', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: vehicleRowRaw({ status: 'MAINTENANCE' }) }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const row = await updateVehicleStatus('veh-1', 'MAINTENANCE', 'Oil change')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/vehicles/veh-1/status')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      status: 'MAINTENANCE',
+      reason: 'Oil change',
+    })
+    expect(row.status).toBe('MAINTENANCE')
+  })
+
+  it('bulkUpdateVehicleStatus PATCHes /vehicles/bulk-status and validates every row', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: [vehicleRowRaw({ id: 'veh-1' }), vehicleRowRaw({ id: 'veh-2' })],
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const rows = await bulkUpdateVehicleStatus(['veh-1', 'veh-2'], 'MAINTENANCE')
+
+    expect(new URL(fetchMock.mock.calls[0]![0] as string, 'http://x').pathname).toBe(
+      '/api/vehicles/bulk-status',
+    )
+    expect(rows.map((r) => r.id)).toEqual(['veh-1', 'veh-2'])
+  })
+
+  it('retireVehicle DELETEs /vehicles/:id and returns the bare validated row', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: vehicleRowRaw({ status: 'RETIRED' }) }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const row = await retireVehicle('veh-1')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(new URL(url as string, 'http://x').pathname).toBe('/api/vehicles/veh-1')
+    expect((init as RequestInit).method).toBe('DELETE')
+    expect(row.status).toBe('RETIRED')
+  })
+
+  // Each of the three distinct unwrap paths must reject a drifted row:
+  it('createVehicle rejects with ParseError on a drifted row (single body via writeJson)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: vehicleRowRaw({ seats: 'lots' }) }, 201),
+      ),
+    )
+
+    await expect(createVehicle({} as CreateVehicleInput)).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('bulkUpdateVehicleStatus rejects with ParseError when one row drifts (array via writeJson)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [vehicleRowRaw(), vehicleRowRaw({ transmission: 'WARP' })],
+        }),
+      ),
+    )
+
+    await expect(bulkUpdateVehicleStatus(['veh-1', 'veh-2'], 'MAINTENANCE')).rejects.toBeInstanceOf(
+      ParseError,
+    )
+  })
+
+  it('retireVehicle rejects with ParseError on a drifted row (inline unwrap path)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: vehicleRowRaw({ createdAt: 42 }) })),
+    )
+
+    await expect(retireVehicle('veh-1')).rejects.toBeInstanceOf(ParseError)
   })
 })


### PR DESCRIPTION
## What

The five operator-fleet **write** clients (`createVehicle`, `updateVehicle`, `updateVehicleStatus`, `bulkUpdateVehicleStatus`, `retireVehicle`) returned `OperatorFleetVehicle` (the enriched fleet-overview row), but the API returns the **bare** `Vehicle` (= `VehicleBase`) row, and the bodies were `unwrap`ed with **no** Zod schema. The return type lied and nothing validated the wire body.

This adds `vehicleRowSchema = z.object(vehicleBaseShape)` (plus `VehicleRow` / `vehicleRowListSchema`), threads it through `writeJson(..., schema)` and the inline `retireVehicle` unwrap, and re-types the five returns to `VehicleRow`.

## Why it's safe

- **Producer proof:** writes return `result.vehicle` typed `Vehicle = VehicleBase`; `FleetVehicleOverview extends VehicleBase`; writes and the fleet-overview read serialize through the same `ok()` -> `c.json()` path. So `vehicleBaseShape` — which the fleet read already validates in prod — is the exact JSON projection of the write body. `VehicleBase`'s 27 fields match `vehicleBaseShape` field-for-field, nullability included. The status route returns only `result.vehicle` (ignores `result.log`), so no enrichment leaks onto the wire.
- **Consumer-safe narrowing:** all four mutation `onSuccess` handlers ignore the result; web `tsc` is green, confirming no call site relied on the wider type.

## Tests

Bare-row fixture + 9 cases: 5 happy paths (URL/method/body asserted), an enrichment-stripping mutation-killer (proves the *bare* schema is used, not the enriched one), and drift -> `ParseError` across all three unwrap paths (single / array / inline).

## Verification

- web suite: **844 passed** (139 files)
- web + api `tsc`: clean
- `lint:modules` / biome: clean
- code-reviewer agent: clean — no CRITICAL/HIGH/MEDIUM, "ship it"

Closes #817