### PR TITLE
refactor(web): validate storefront search/detail responses with Zod (#711 3d)

### DIFF
--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -23,13 +23,31 @@ const TEST_STOREFRONT_CARD = {
   name: 'Best Car Rental Osaka',
   address: '1-2-3 Namba, Chuo-ku, Osaka',
   operatingHours: TEST_OPERATING_HOURS,
+  // #711 3d: the real /storefronts/search wire carries turnaround, per-class
+  // luggage, and store coords — the storefront response schema validates them
+  // now, so the fixture must carry them too (a missing key ParseErrors → 0 cards).
+  turnaroundMinutes: 180,
   classSummaries: [
-    { acrissCode: 'CCAR', label: 'Compact', availableCount: 4 },
-    { acrissCode: 'MVAR', label: 'Minivan', availableCount: 2 },
+    {
+      acrissCode: 'CCAR',
+      label: 'Compact',
+      luggageCapacity: 2,
+      luggageSize: 'SMALL',
+      availableCount: 4,
+    },
+    {
+      acrissCode: 'MVAR',
+      label: 'Minivan',
+      luggageCapacity: 4,
+      luggageSize: 'LARGE',
+      availableCount: 2,
+    },
   ],
   fromDailyPriceJpy: 4500,
   fromHourlyPriceJpy: null,
   representativePhotos: [TEST_STORE_PHOTO],
+  latitude: 34.6658,
+  longitude: 135.5022,
 }
 
 const TEST_STOREFRONT_DETAIL = {
@@ -39,6 +57,10 @@ const TEST_STOREFRONT_DETAIL = {
     address: '1-2-3 Namba, Chuo-ku, Osaka',
     operatorName: 'Best Car Rental',
     operatingHours: TEST_OPERATING_HOURS,
+    // #711 3d: real /storefronts/:id/vehicles sends turnaround on the summary and
+    // per-vehicle luggage; the detail schema validates both (missing key → 404-ish
+    // empty render via ParseError), so the fixture mirrors the wire.
+    turnaroundMinutes: 180,
   },
   vehicles: [
     {
@@ -48,6 +70,8 @@ const TEST_STOREFRONT_DETAIL = {
       model: 'Fit',
       year: 2024,
       seats: 5,
+      luggageCapacity: 2,
+      luggageSize: 'SMALL',
       transmission: 'AUTO',
       acrissCode: 'CCAR',
       classLabel: 'Compact',
@@ -62,6 +86,8 @@ const TEST_STOREFRONT_DETAIL = {
       model: 'Sienta',
       year: 2023,
       seats: 7,
+      luggageCapacity: 4,
+      luggageSize: 'LARGE',
       transmission: 'AUTO',
       acrissCode: 'MVAR',
       classLabel: 'Minivan',

--- a/packages/web/src/vite/storefronts/api.ts
+++ b/packages/web/src/vite/storefronts/api.ts
@@ -1,85 +1,27 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { LuggageSize } from '@kuruma/shared/lib/luggage'
+import {
+  type StorefrontDetailData,
+  type StorefrontSearchResultData,
+  storefrontDetailResultSchema,
+  storefrontSearchResultSchema,
+} from '@/vite/storefronts/schema'
 
-// JSON-serialized shapes returned by the public storefront endpoints (#391).
-// The Vite shell owns these DTOs (rather than importing the frozen Next module's
-// copy) so it stays self-contained and free of that module's process.env path.
-// These supersede `modules/storefronts/api.ts` — delete that file at cutover
-// (#378). The API serializes everything to JSON, so there are no Date instances.
-
-export interface OperatingHoursData {
-  openTime: string
-  closeTime: string
-}
-
-export interface ClassSummaryData {
-  /** ACRISS code, or null when the class has no mapped code (#388). */
-  acrissCode: string | null
-  /** Operator-entered class name; the web localizes via acrissCode. */
-  label: string
-  // #457 D6: class-default luggage for compare-on-search badges.
-  luggageCapacity: number | null
-  luggageSize: LuggageSize | null
-  availableCount: number
-}
-
-export interface StorefrontCardData {
-  locationId: string
-  operatorId: string
-  operatorName: string
-  name: string
-  address: string
-  operatingHours: OperatingHoursData | null
-  /** #551: operator turnaround buffer (minutes) between rentals at this store. */
-  turnaroundMinutes: number
-  classSummaries: ClassSummaryData[]
-  fromDailyPriceJpy: number | null
-  fromHourlyPriceJpy: number | null
-  representativePhotos: string[]
-  /** #651 Slice 3: store coords (WGS84) for distance labels + nearest-first sort. */
-  latitude: number | null
-  longitude: number | null
-}
-
-export interface StorefrontSearchResultData {
-  storefronts: StorefrontCardData[]
-  nextCursor: string | null
-}
-
-export interface AvailableVehicleData {
-  id: string
-  name: string
-  make: string | null
-  model: string | null
-  year: number | null
-  seats: number
-  // #457: effective luggage (vehicle override resolved against the class default).
-  luggageCapacity: number | null
-  luggageSize: LuggageSize | null
-  transmission: 'AUTO' | 'MANUAL'
-  acrissCode: string | null
-  classLabel: string
-  dailyRateJpy: number | null
-  hourlyRateJpy: number | null
-  photos: string[]
-}
-
-export interface StorefrontSummaryData {
-  locationId: string
-  name: string
-  address: string
-  operatorName: string
-  operatingHours: OperatingHoursData | null
-  /** #551: operator turnaround buffer (minutes) between rentals at this store. */
-  turnaroundMinutes: number
-}
-
-export interface StorefrontDetailData {
-  storefront: StorefrontSummaryData
-  vehicles: AvailableVehicleData[]
-  nextCursor: string | null
-}
+// JSON-serialized shapes returned by the public storefront endpoints (#391) are
+// defined as Zod schemas in ./schema (the #711/#785 convention) and inferred into
+// the DTO types re-exported below, so existing consumers keep importing them from
+// this client. The API serializes everything to JSON, so there are no Date
+// instances. This module supersedes `modules/storefronts/api.ts` — delete that
+// file at cutover (#378).
+export type {
+  AvailableVehicleData,
+  ClassSummaryData,
+  OperatingHoursData,
+  StorefrontCardData,
+  StorefrontDetailData,
+  StorefrontSearchResultData,
+  StorefrontSummaryData,
+} from '@/vite/storefronts/schema'
 
 export interface StorefrontSearchParams {
   from: Date
@@ -131,7 +73,7 @@ export async function fetchStorefronts(
   const res = await fetch(`${getApiBaseUrl()}/storefronts/search?${sp.toString()}`, {
     credentials: 'include',
   })
-  return unwrap<StorefrontSearchResultData>(res)
+  return unwrap(res, storefrontSearchResultSchema)
 }
 
 // Public endpoint — returns null on 404 (unknown/archived store) so the route
@@ -147,5 +89,5 @@ export async function fetchStorefrontDetail(
     { credentials: 'include' },
   )
   if (res.status === 404) return null
-  return unwrap<StorefrontDetailData>(res)
+  return unwrap(res, storefrontDetailResultSchema)
 }

--- a/packages/web/src/vite/storefronts/schema.ts
+++ b/packages/web/src/vite/storefronts/schema.ts
@@ -1,0 +1,96 @@
+import { LUGGAGE_SIZES, TRANSMISSIONS } from '@kuruma/shared/enums'
+import { z } from 'zod'
+
+// #711/#785: Zod schemas for the public storefront *response* bodies (#391),
+// extracted to a sibling schema.ts so `api.ts` can thread `unwrap(res, schema)`
+// without the composite DTOs crowding the client (the #785 convention).
+//
+// The Vite shell OWNS these DTOs (it does not import the frozen Next module's
+// copy), so each schema is the single source and its type is inferred from it —
+// `export type X = z.infer<typeof xSchema>`. The API serializes everything to
+// JSON, so there are no Date instances. Every field's nullability + enum domain
+// was producer-verified against packages/api storefront-search / storefront-detail
+// services before pinning, so the schema can't be stricter than the wire.
+
+const operatingHoursSchema = z.object({
+  openTime: z.string(),
+  closeTime: z.string(),
+})
+
+const classSummarySchema = z.object({
+  /** ACRISS code, or null when the class has no mapped code (#388). */
+  acrissCode: z.string().nullable(),
+  /** Operator-entered class name; the web localizes via acrissCode. */
+  label: z.string(),
+  // #457 D6: class-default luggage for compare-on-search badges.
+  luggageCapacity: z.number().nullable(),
+  luggageSize: z.enum(LUGGAGE_SIZES).nullable(),
+  availableCount: z.number(),
+})
+
+const storefrontCardSchema = z.object({
+  locationId: z.string(),
+  operatorId: z.string(),
+  operatorName: z.string(),
+  name: z.string(),
+  address: z.string(),
+  operatingHours: operatingHoursSchema.nullable(),
+  /** #551: operator turnaround buffer (minutes) between rentals at this store. */
+  turnaroundMinutes: z.number(),
+  classSummaries: z.array(classSummarySchema),
+  fromDailyPriceJpy: z.number().nullable(),
+  fromHourlyPriceJpy: z.number().nullable(),
+  representativePhotos: z.array(z.string()),
+  /** #651 Slice 3: store coords (WGS84) for distance labels + nearest-first sort. */
+  latitude: z.number().nullable(),
+  longitude: z.number().nullable(),
+})
+
+export const storefrontSearchResultSchema = z.object({
+  storefronts: z.array(storefrontCardSchema),
+  nextCursor: z.string().nullable(),
+})
+
+const availableVehicleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  make: z.string().nullable(),
+  model: z.string().nullable(),
+  year: z.number().nullable(),
+  seats: z.number(),
+  // #457: effective luggage (vehicle override resolved against the class default).
+  luggageCapacity: z.number().nullable(),
+  luggageSize: z.enum(LUGGAGE_SIZES).nullable(),
+  transmission: z.enum(TRANSMISSIONS),
+  acrissCode: z.string().nullable(),
+  // Class name, or '' when the vehicle has no class (never null — service falls
+  // back to an empty string).
+  classLabel: z.string(),
+  dailyRateJpy: z.number().nullable(),
+  hourlyRateJpy: z.number().nullable(),
+  photos: z.array(z.string()),
+})
+
+const storefrontSummarySchema = z.object({
+  locationId: z.string(),
+  name: z.string(),
+  address: z.string(),
+  operatorName: z.string(),
+  operatingHours: operatingHoursSchema.nullable(),
+  /** #551: operator turnaround buffer (minutes) between rentals at this store. */
+  turnaroundMinutes: z.number(),
+})
+
+export const storefrontDetailResultSchema = z.object({
+  storefront: storefrontSummarySchema,
+  vehicles: z.array(availableVehicleSchema),
+  nextCursor: z.string().nullable(),
+})
+
+export type OperatingHoursData = z.infer<typeof operatingHoursSchema>
+export type ClassSummaryData = z.infer<typeof classSummarySchema>
+export type StorefrontCardData = z.infer<typeof storefrontCardSchema>
+export type StorefrontSearchResultData = z.infer<typeof storefrontSearchResultSchema>
+export type AvailableVehicleData = z.infer<typeof availableVehicleSchema>
+export type StorefrontSummaryData = z.infer<typeof storefrontSummarySchema>
+export type StorefrontDetailData = z.infer<typeof storefrontDetailResultSchema>

--- a/packages/web/tests/vite/storefronts/api.test.ts
+++ b/packages/web/tests/vite/storefronts/api.test.ts
@@ -1,0 +1,209 @@
+import { ParseError } from '@/lib/api-error'
+import { fetchStorefrontDetail, fetchStorefronts } from '@/vite/storefronts/api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// Wire-shaped fixtures (typed loosely so drift/laxness overrides below can drop a
+// key or send an out-of-domain value without fighting the inferred DTO types).
+const fullClassSummary: Record<string, unknown> = {
+  acrissCode: 'CCAR',
+  label: 'Compact',
+  luggageCapacity: 2,
+  luggageSize: 'SMALL',
+  availableCount: 4,
+}
+
+const fullCard: Record<string, unknown> = {
+  locationId: 'loc1',
+  operatorId: 'op1',
+  operatorName: 'Osaka Cars',
+  name: 'Namba Pickup',
+  address: '1-1 Namba',
+  operatingHours: { openTime: '09:00', closeTime: '20:00' },
+  turnaroundMinutes: 180,
+  classSummaries: [fullClassSummary],
+  fromDailyPriceJpy: 8000,
+  fromHourlyPriceJpy: null,
+  representativePhotos: ['a.jpg'],
+  latitude: 34.6,
+  longitude: 135.5,
+}
+
+const fullVehicle: Record<string, unknown> = {
+  id: 'v1',
+  name: 'Toyota Aqua',
+  make: 'Toyota',
+  model: 'Aqua',
+  year: 2022,
+  seats: 5,
+  luggageCapacity: 2,
+  luggageSize: 'SMALL',
+  transmission: 'AUTO',
+  acrissCode: 'CDMR',
+  classLabel: 'Compact',
+  dailyRateJpy: 8000,
+  hourlyRateJpy: null,
+  photos: ['a.jpg'],
+}
+
+const fullDetail: Record<string, unknown> = {
+  storefront: {
+    locationId: 'loc1',
+    name: 'Namba Pickup',
+    address: '1-1 Namba',
+    operatorName: 'Osaka Cars',
+    operatingHours: { openTime: '09:00', closeTime: '20:00' },
+    turnaroundMinutes: 180,
+  },
+  vehicles: [fullVehicle],
+  nextCursor: null,
+}
+
+const range = {
+  from: new Date('2026-07-01T01:00:00.000Z'),
+  to: new Date('2026-07-03T01:00:00.000Z'),
+}
+
+describe('fetchStorefronts', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('serializes range + filters and unwraps the grouped storefront list', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: { storefronts: [fullCard], nextCursor: 'cur-2' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchStorefronts({
+      ...range,
+      pickupLocationId: 'loc1',
+      regionId: 'reg-9',
+      classes: ['CCAR', 'MVAR'],
+      limit: 20,
+      cursor: 'cur-1',
+    })
+
+    expect(result).toEqual({ storefronts: [fullCard], nextCursor: 'cur-2' })
+    const url = new URL((fetchMock.mock.calls[0] as [string])[0], 'http://x')
+    expect(url.pathname).toBe('/api/storefronts/search')
+    expect(url.searchParams.get('from')).toBe('2026-07-01T01:00:00.000Z')
+    expect(url.searchParams.get('to')).toBe('2026-07-03T01:00:00.000Z')
+    expect(url.searchParams.get('pickupLocationId')).toBe('loc1')
+    expect(url.searchParams.get('regionId')).toBe('reg-9')
+    expect(url.searchParams.getAll('class')).toEqual(['CCAR', 'MVAR'])
+    expect(url.searchParams.get('limit')).toBe('20')
+    expect(url.searchParams.get('cursor')).toBe('cur-1')
+  })
+
+  it('parses null operatingHours / prices / coords / class fields (the schema laxness margin)', async () => {
+    // The API legitimately sends null hours, null rates, ungeocoded null coords, and
+    // a class with no ACRISS/luggage. These must parse, not throw — guarding against
+    // a later "tidy-up" that wrongly tightens a `.nullable()` to required.
+    const sparseCard = {
+      ...fullCard,
+      operatingHours: null,
+      fromDailyPriceJpy: null,
+      fromHourlyPriceJpy: null,
+      latitude: null,
+      longitude: null,
+      classSummaries: [
+        {
+          acrissCode: null,
+          label: 'Misc',
+          luggageCapacity: null,
+          luggageSize: null,
+          availableCount: 1,
+        },
+      ],
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: { storefronts: [sparseCard], nextCursor: null } }),
+      ),
+    )
+    await expect(fetchStorefronts(range)).resolves.toEqual({
+      storefronts: [sparseCard],
+      nextCursor: null,
+    })
+  })
+
+  it('rejects with a ParseError when a card drifts (missing turnaroundMinutes)', async () => {
+    const brokenCard = { ...fullCard, turnaroundMinutes: undefined }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: { storefronts: [brokenCard], nextCursor: null } }),
+      ),
+    )
+    await expect(fetchStorefronts(range)).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('rejects with a ParseError when a class summary has an unknown luggageSize', async () => {
+    const badCard = {
+      ...fullCard,
+      classSummaries: [{ ...fullClassSummary, luggageSize: 'GIGANTIC' }],
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ success: true, data: { storefronts: [badCard], nextCursor: null } }),
+      ),
+    )
+    await expect(fetchStorefronts(range)).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('fetchStorefrontDetail', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('unwraps the storefront summary + available vehicles', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: fullDetail }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchStorefrontDetail('loc1', {
+      ...range,
+      classes: ['CCAR'],
+      limit: 10,
+      cursor: 'c1',
+    })
+
+    expect(result).toEqual(fullDetail)
+    const url = new URL((fetchMock.mock.calls[0] as [string])[0], 'http://x')
+    expect(url.pathname).toBe('/api/storefronts/loc1/vehicles')
+    expect(url.searchParams.getAll('class')).toEqual(['CCAR'])
+    expect(url.searchParams.get('limit')).toBe('10')
+    expect(url.searchParams.get('cursor')).toBe('c1')
+  })
+
+  it('returns null on 404 (unknown/archived store) without parsing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: { code: 'NOT_FOUND' } }, 404)),
+    )
+    await expect(fetchStorefrontDetail('ghost', range)).resolves.toBeNull()
+  })
+
+  it('rejects with a ParseError when a vehicle has an invalid transmission', async () => {
+    const badDetail = { ...fullDetail, vehicles: [{ ...fullVehicle, transmission: 'CVT' }] }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: badDetail })),
+    )
+    await expect(fetchStorefrontDetail('loc1', range)).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('rejects with a ParseError when a vehicle drifts (missing luggageSize key)', async () => {
+    const badDetail = { ...fullDetail, vehicles: [{ ...fullVehicle, luggageSize: undefined }] }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: badDetail })),
+    )
+    await expect(fetchStorefrontDetail('loc1', range)).rejects.toBeInstanceOf(ParseError)
+  })
+})

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -80,7 +80,7 @@ function isForbiddenWebDbSpec(spec: string): boolean {
 //
 // After a drain, refresh in place with:
 //   bun run scripts/lint-module-boundaries.ts --update-baseline
-const DEPRECATED_WEB_TREE_BASELINE = 148
+const DEPRECATED_WEB_TREE_BASELINE = 151
 
 export type DeprecatedTreeStatus = {
   count: number


### PR DESCRIPTION
## What

Slice **3d** of #711 — replace casting storefront API response bodies (`unwrap<T>(res)`) with runtime Zod validation (`unwrap(res, schema)`). Covers the two **public** storefront clients:

- `fetchStorefronts` → `GET /storefronts/search`
- `fetchStorefrontDetail` → `GET /storefronts/:id/vehicles`

The DTOs are locally-owned by the web shell, so per the #785 convention they move into a sibling `vite/storefronts/schema.ts` as `z.object` schemas; types are `z.infer`'d and **re-exported from `api.ts`** so the 8 existing consumers are unchanged. Wire drift now fails as a `ParseError` at the seam instead of surfacing as `undefined` deep in the card/vehicle render.

## Producer-verified (no false-positive ParseError)

Every field's nullability + enum domain was checked against `storefront-search.ts` / `storefront-detail.ts` (and the DB schema) before pinning:
- search carries **no** `transmission` and **no** `kind` union (the union lives in flat-search, not here);
- detail's `classLabel` is never null (`''` fallback); `turnaroundMinutes` is NOT NULL;
- `operatingHours`, coords, prices, ACRISS, and per-class/per-vehicle luggage are all genuinely nullable.
- Enums anchor to the `@kuruma/shared/enums` tuples (`LUGGAGE_SIZES`, `TRANSMISSIONS`).

## Also

- **`e2e/mock-api.ts`**: the real wire carries `turnaroundMinutes`, per-class/per-vehicle luggage, and store coords — the stricter schema would `ParseError` the stale fixtures (the mock-e2e-fail / real-db-pass tell). Fixtures completed.
- **#719 web-tree baseline 148→151** (+1 for `schema.ts`; absorbs trunk drift). Non-failing ratchet.

## Test plan

- [x] New `tests/vite/storefronts/api.test.ts` (8): positive unwrap + URL-param serialization, a `.nullable()` laxness-margin guard, and drift tests asserting `ParseError` on missing-key / out-of-domain-enum for both endpoints; 404→null pinned.
- [x] Web suite **852/852**, web typecheck 0, `bun run lint` exit 0 (biome/size/modules).
- [x] code-review: **SHIP** (invariant re-verified field-by-field).
- [ ] CI: lint + unit + mock-e2e + real-db-e2e.

Part of #711.