### PR TITLE
fix(api): include add-on charges in substitute() total (#855)

### DIFF
--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -107,8 +107,15 @@ export class BookingLifecycleService {
           }
         }
         const insurancePerDay = booking.insuranceSnapshot?.dailyPriceJpy ?? 0
+        // Locked add-on charges (#460) ride along unchanged on a swap — the new
+        // base re-prices, but the renter still owes the same add-ons. Mirrors the
+        // canonical composition in booking-creation.ts (base + insurance + add-ons);
+        // omitting this undercharged by the add-on total on every swap (#855).
+        const addOnsTotal = booking.addOnSnapshot.reduce((sum, a) => sum + a.priceJpy, 0)
         const totalPrice =
-          pricing.totalPriceJpy + insurancePerDay * rentalDays(booking.startAt, booking.endAt)
+          pricing.totalPriceJpy +
+          insurancePerDay * rentalDays(booking.startAt, booking.endAt) +
+          addOnsTotal
 
         // Turnaround is location-only and the pickup location is unchanged, so
         // effectiveEndAt is preserved; the repo re-runs the exclusion check for

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1055,6 +1055,43 @@ describe('BookingService.substitute — operator vehicle swap (#392 §5.5)', () 
     expect(stored?.totalPrice).toBe(30000)
   })
 
+  it('folds locked add-on charges into the re-snapshotted total on substitute (#855)', async () => {
+    const h = await setupSub()
+    const original = await addVehicle(h) // the add-on booking sits on its own vehicle
+    const replacement = await addVehicle(h) // class A @ Osaka, 15000/day
+
+    // A booking carrying paid add-ons (#460): their flat charges are locked into
+    // addOnSnapshot at creation. substitute() re-prices the base off the new
+    // vehicle and must re-add those charges — the canonical composition is
+    // base + insurance + Σ add-ons (booking-creation.ts). Dropping the add-ons
+    // silently undercharges the renter by their total on every vehicle swap.
+    const withAddOns = await h.repos.bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingRow({
+        classId: h.classA.id,
+        requestedVehicleId: original.id,
+        assignedVehicleId: original.id,
+        pickupLocationId: h.locationId,
+        dropoffLocationId: h.locationId,
+        bookingCode: 'ADDONS01',
+        addOnSnapshot: [
+          { addOnId: 'a-gps', name: 'GPS', priceJpy: 3000 },
+          { addOnId: 'a-seat', name: 'Child seat', priceJpy: 2000 },
+        ],
+      }),
+    )
+
+    const result = await h.service.substitute(opCtxA, withAddOns.id, replacement.id, null)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // 2 days * 15000 (new vehicle base) + 5000 (Σ add-on priceJpy). Insurance null.
+    expect(result.booking.totalPrice).toBe(35000)
+    // Persisted, not just returned.
+    const stored = await h.repos.bookingRepo.findById(opCtxA, withAddOns.id)
+    expect(stored?.totalPrice).toBe(35000)
+  })
+
   it('rejects a replacement already booked for the range (409, no event appended)', async () => {
     const h = await setupSub()
     const replacement = await addVehicle(h)


### PR DESCRIPTION
## Problem
`BookingLifecycleService.substitute()` recomputed `totalPrice` as **base + insurance only**, silently dropping locked `addOnSnapshot` charges (#460) on every operator vehicle swap. A renter with paid add-ons was undercharged by the full add-on total each time the vehicle was substituted — a real revenue leak. Pre-existing (not introduced by #849/#429); found via PR-watch review of #849.

## Fix
Fold `Σ addOnSnapshot.priceJpy` into the recomputed total so it matches the canonical composition in `booking-creation.ts` (base + insurance + add-ons). `addOnSnapshot` is `notNull default []`, so no null guard is needed.

## Test
Guard test in `booking.test.ts`: substitute a booking carrying non-empty add-ons; assert the **exact persisted total** = new base (2×15000) + Σ add-ons (5000) = 35000 (both returned and persisted via `findById`). RED→GREEN verified. The existing #429 re-snapshot test still pins 30000 (empty add-ons), proving the base path is unchanged.

## Verification
- `@kuruma/api` suite: **1505/1505** pass
- typecheck: clean; pre-commit gates (biome, file-size, module-boundaries, tsc ×2) green
- code-reviewer agent: **SHIP** (composition matches creation exactly; `feeSnapshot` correctly omitted — informational, never in the creation total either)

## Follow-up
The total formula now lives in two places (creation + substitute). Filing a follow-up to extract a shared `composeBookingTotal(...)` helper so the two paths can't desync again — that duplication is the root cause of this class of bug.

Closes #855