### PR TITLE
feat(api): operator manual booking for existing customers (#589 API slice)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -370,7 +370,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     notificationDispatcher,
   )
   const availabilityService = new AvailabilityService(availabilityRepo)
-  const customerService = new CustomerService(customerRepo, userRepo)
+  const customerService = new CustomerService(customerRepo, userRepo, bookingRepo)
   const messageService = new MessageService(threadRepo, messageRepo)
   const userDirectoryService = new UserDirectoryService(userRepo, threadRepo)
   const maintenanceService = new MaintenanceService(

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -21,6 +21,14 @@ export class DrizzleBookingRepository implements BookingRepository {
     return []
   }
 
+  async listRenterIdsForOperator(operatorId: string): Promise<string[]> {
+    const rows = await this.db
+      .selectDistinct({ renterId: bookings.renterId })
+      .from(bookings)
+      .where(eq(bookings.operatorId, operatorId))
+    return rows.map((r) => r.renterId)
+  }
+
   async findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]> {
     const scoped = this.scopeConditions(ctx)
     if (scoped === null) return []

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -53,6 +53,14 @@ export class InMemoryBookingRepository implements BookingRepository {
     return all
   }
 
+  async listRenterIdsForOperator(operatorId: string): Promise<string[]> {
+    const ids = new Set<string>()
+    for (const b of this.store.values()) {
+      if (b.operatorId === operatorId) ids.add(b.renterId)
+    }
+    return [...ids]
+  }
+
   private isVisible(ctx: CallerContext, booking: Booking): boolean {
     const scope = bookingReadScope(ctx)
     if (scope.kind === 'none') return false

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -377,6 +377,12 @@ export interface BookingRepository {
    *  given location as pickup OR dropoff. Guards archiving a location still in
    *  live use (#412). */
   countActiveForLocation(locationId: string): Promise<number>
+  /** Distinct renter IDs with at least one booking with the given operator.
+   *  Powers the #589 operator manual-booking customer picker: an operator may
+   *  only resolve renters within its own tenant boundary (a prior booking with
+   *  it), never enumerate the global user table (#396/#475). operatorId comes
+   *  from the caller's own validated context, never from client input. */
+  listRenterIdsForOperator(operatorId: string): Promise<string[]>
   create(
     ctx: CallerContext,
     data: Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -144,15 +144,16 @@ export function createBookingRoutes(service: BookingService) {
       const parsed = await parseBody(c, createBookingSchema)
       if (!parsed.ok) return parsed.response
 
-      // Staff/admin can create bookings on behalf of a customer (manual bookings).
-      // Non-staff always book as themselves and source is forced to DIRECT to
-      // prevent advance-booking-hours bypass via source=MANUAL. OPERATOR_* are
-      // deliberately NOT manual bookers: UserRepository is not tenant-scoped, so
-      // letting an operator resolve an arbitrary renterId reopens the #396
-      // cross-tenant user-enumeration vector (operator-user-isolation.test.ts).
-      const isStaff = STAFF_ROLES.has(ctx.role)
-      const renterId = isStaff && parsed.data.renterId ? parsed.data.renterId : ctx.userId
-      const source = isStaff ? parsed.data.source : 'DIRECT'
+      // #589: STAFF and OPERATOR_* are "manual bookers" — they may book on behalf
+      // of a renter (renterId) and set source=MANUAL. An operator's renterId is
+      // authorized in the service against its OWN customer scope (renters with a
+      // prior booking with it), scope-first so it never probes the user table for
+      // an arbitrary id — preserving the #396/#475 enumeration defense
+      // (operator-user-isolation.test.ts). Everyone else books as themselves with
+      // source forced to DIRECT (no advance-booking-hours bypass via MANUAL).
+      const isManualBooker = STAFF_ROLES.has(ctx.role) || isOperatorRole(ctx.role)
+      const renterId = isManualBooker && parsed.data.renterId ? parsed.data.renterId : ctx.userId
+      const source = isManualBooker ? parsed.data.source : 'DIRECT'
 
       // #613: a renter self-serve booking must accept the liability disclaimer
       // (免责声明) at checkout — the IDP/license must be valid at pickup or the

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -1,5 +1,6 @@
 import { quickCreateCustomerSchema } from '@kuruma/shared/validators/customer'
 import { Hono } from 'hono'
+import { toCallerContext } from '../auth/context'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
 import type { CustomerService } from '../services/customer'
 import { fail, ok, parseBody, parseId, parseLimit } from './helpers'
@@ -9,17 +10,19 @@ const ALLOWED_SORTS = new Set(['lastBookingAt', 'bookingCount', 'name'])
 export function createCustomerRoutes(service: CustomerService) {
   const app = new Hono()
 
-  // Platform-staff-only by design. requireStaff -> STAFF_ROLES admits
-  // PLATFORM_ADMIN only (legacy STAFF/ADMIN revoked by #487) and excludes OPERATOR_*. These routes are
-  // intentionally unscoped: findById returns full cross-operator booking history
-  // and /search is a flat user-table lookup. That is safe ONLY while operators
-  // cannot reach them. If operator manual-booking is ever added, thread
-  // CallerContext + operator scoping (bookingReadScope-style) through
-  // service.findById/search BEFORE widening this gate — otherwise every operator's
-  // customer list and booking history leaks (cf. #396, which already defended
-  // /users against this same enumeration vector).
+  // /customers (full list) and /customers/:id return cross-operator data and stay
+  // PLATFORM_ADMIN-only; /customers/quick-create likewise (operator walk-ins are
+  // created atomically via POST /bookings instead — #589). /customers/search is
+  // the ONE operator-reachable route: CustomerService.search scopes an OPERATOR_*
+  // caller to its own renters (prior-booking), so it can't enumerate the global
+  // user table (cf. #396/#475). Anything not explicitly operator-allowed → 403.
   app.use('/customers', requireStaff)
-  app.use('/customers/*', requireStaff)
+  app.use('/customers/*', async (c, next) => {
+    const ctx = toCallerContext(requireUser(c))
+    if (STAFF_ROLES.has(ctx.role)) return next()
+    if (c.req.path.endsWith('/customers/search') && ctx.operatorId) return next()
+    return fail(c, 'Forbidden', 403)
+  })
 
   return app
     .get('/customers', async (c) => {
@@ -48,7 +51,7 @@ export function createCustomerRoutes(service: CustomerService) {
       if (!q || q.length < 2) {
         return fail(c, 'Search query must be at least 2 characters', 400)
       }
-      const customers = await service.search(q)
+      const customers = await service.search(q, toCallerContext(requireUser(c)))
       return ok(c, customers)
     })
     .post('/customers/quick-create', async (c) => {

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -1,6 +1,7 @@
 import type { AddOnSnapshot, InsuranceSnapshot } from '@kuruma/shared/db/schema'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
+import { isOperatorRole } from '../auth/roles'
 import { generateBookingCode } from '../lib/booking-code'
 import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import { BOOKING_CODE_CONSTRAINT, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
@@ -56,16 +57,33 @@ export class BookingCreationService {
     input: CreateBookingInput,
     now: Date = new Date(),
   ): Promise<CreateBookingResult> {
-    // Staff/admin override path: validate the target renterId exists and is a
-    // RENTER — prevents bookings attached to other staff/admin accounts and
-    // surfaces FK failures as a friendly 400 rather than a generic 500.
-    if (input.renterId !== ctx.userId && this.userRepo) {
-      const [renter] = await this.userRepo.findByIds([input.renterId])
-      if (!renter) {
-        return { ok: false, status: 400, error: 'Renter not found' }
-      }
-      if ((renter.role ?? 'RENTER') !== 'RENTER') {
-        return { ok: false, status: 400, error: 'Target user is not a renter' }
+    // Manual-booking on behalf of a renter (#314, #589). For an OPERATOR_* caller
+    // the check is scope-FIRST: the renter must be in the operator's own customer
+    // set (a prior booking with it). Membership IS the authorization + existence
+    // check (a prior-booking renter necessarily exists), and any out-of-scope id
+    // returns a uniform 403 WITHOUT touching the user table — so it never leaks
+    // whether an arbitrary renterId exists (#396/#475). Staff/bypass keep the
+    // existence + role probe (surfaces FK failures as a friendly 400, not a 500).
+    if (input.renterId !== ctx.userId) {
+      if (isOperatorRole(ctx.role)) {
+        const scoped = ctx.operatorId
+          ? await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId)
+          : []
+        if (!scoped.includes(input.renterId)) {
+          return {
+            ok: false,
+            status: 403,
+            error: 'Cannot book for a renter outside your customers',
+          }
+        }
+      } else if (this.userRepo) {
+        const [renter] = await this.userRepo.findByIds([input.renterId])
+        if (!renter) {
+          return { ok: false, status: 400, error: 'Renter not found' }
+        }
+        if ((renter.role ?? 'RENTER') !== 'RENTER') {
+          return { ok: false, status: 400, error: 'Target user is not a renter' }
+        }
       }
     }
 

--- a/packages/api/src/services/customer.ts
+++ b/packages/api/src/services/customer.ts
@@ -1,5 +1,11 @@
 import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
-import type { CustomerListFilters, CustomerRepository, UserRepository } from '../repositories/types'
+import type { CallerContext } from '../auth/context'
+import type {
+  BookingRepository,
+  CustomerListFilters,
+  CustomerRepository,
+  UserRepository,
+} from '../repositories/types'
 import type { User } from '../stores'
 
 export interface CustomerListQuery {
@@ -10,19 +16,21 @@ export interface CustomerListQuery {
 }
 
 /**
- * Platform-staff-only by design — enforced by the requireStaff gate in routes/customers.ts.
- * findById returns a customer's full cross-operator booking history and search() is
- * a flat user-table lookup; neither takes a CallerContext, so neither is
- * operator-scoped. That is intentional and safe ONLY because the route gate admits
- * PLATFORM_ADMIN exclusively (legacy STAFF/ADMIN revoked by #487; never OPERATOR_*). Before any
- * future operator manual-booking access, thread ctx + operator scoping through
- * findById/search first, or every operator's customer list and booking history
- * leaks (the #396 enumeration defense on /users is the precedent to follow).
+ * Customer directory for the platform screen + operator manual booking (#589).
+ *
+ * findAllPaginated (full list) and findById (cross-operator booking history) stay
+ * PLATFORM_ADMIN-only — they take no scope and would leak every operator's
+ * customers if widened. search() is the ONE operator-reachable method: it threads
+ * CallerContext and scopes an OPERATOR_* caller to renters within its own tenant
+ * boundary (those with a prior booking with it), so manual-booking can't become a
+ * global user-enumeration vector (#396/#475). Bypass roles still search the full
+ * user table. The route gate (routes/customers.ts) mirrors this split.
  */
 export class CustomerService {
   constructor(
     private readonly customerRepo: CustomerRepository,
     private readonly userRepo: UserRepository,
+    private readonly bookingRepo: BookingRepository,
   ) {}
 
   async findAllPaginated(
@@ -46,8 +54,20 @@ export class CustomerService {
     return this.customerRepo.findByIdWithBookings(id)
   }
 
-  async search(query: string): Promise<User[]> {
-    return this.userRepo.search(query)
+  async search(query: string, ctx: CallerContext): Promise<User[]> {
+    const matches = await this.userRepo.search(query)
+    // Bypass roles (PLATFORM_ADMIN/PARTNER) search the full user table.
+    if (ctx.bypassScope) return matches
+    // An operator only resolves renters within its own tenant boundary — those
+    // with a prior booking with it — so manual-booking can't enumerate the global
+    // user table (#396/#475). Fail closed if somehow operator-less.
+    if (!ctx.operatorId) return []
+    const allowed = new Set(await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId))
+    // NOTE (MVP): userRepo.search caps at 20 by text first, so for an operator
+    // with a very large customer base an in-scope name past that cap could be
+    // missed. Fine for the picker at MVP scale; push the operator filter into the
+    // query if it ever bites.
+    return matches.filter((u) => allowed.has(u.id))
   }
 
   async quickCreate(input: {

--- a/packages/api/tests/routes/operator-user-isolation.test.ts
+++ b/packages/api/tests/routes/operator-user-isolation.test.ts
@@ -322,7 +322,12 @@ describe('#396 — OPERATOR_* cannot enumerate users via any current ingress', (
     expect(userRepo.findByIdsArgs.flat()).not.toContain(FOREIGN_ID)
   })
 
-  it('POST /bookings forces renterId to self — no arbitrary user lookup for a foreign renterId', async () => {
+  it('POST /bookings rejects an operator booking for a renter outside its customers — uniform 403, no user-table probe', async () => {
+    // #589: the operator is now a manual booker, so the route lets renterId
+    // through — but FOREIGN has never booked with this operator, so the service
+    // 403s on scope membership. The check is scope-FIRST (prior-booking set), so
+    // it never probes the user table for FOREIGN: a real vs non-existent id are
+    // indistinguishable (no enumeration oracle, #396/#475).
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
@@ -333,21 +338,49 @@ describe('#396 — OPERATOR_* cannot enumerate users via any current ingress', (
         requestedVehicleId: vehicle.id,
         pickupLocationId: locationId,
         dropoffLocationId: locationId,
-        renterId: FOREIGN_ID, // attempt to book on behalf of another user
+        renterId: FOREIGN_ID,
         startAt: startAt.toISOString(),
         endAt: endAt.toISOString(),
-        source: 'DIRECT',
+        source: 'MANUAL',
       }),
     })
 
-    // OPERATOR_* is not a STAFF role, so the route forces renterId = ctx.userId
-    // (the operator's own id). The booking is created for SELF, not FOREIGN...
-    expect(res.status).toBe(201)
-    const body = (await res.json()) as { data: { renterId: string } }
-    expect(body.data.renterId).toBe(SELF_ID)
-    expect(body.data.renterId).not.toBe(FOREIGN_ID)
-    // ...and the service's staff-override branch (userRepo.findByIds([renterId]))
-    // never ran for the foreign id. If the route forcing regresses, this catches it.
+    expect(res.status).toBe(403)
     expect(userRepo.findByIdsArgs.flat()).not.toContain(FOREIGN_ID)
+  })
+
+  it('POST /bookings lets an operator manually book for its own prior-booking customer (source=MANUAL)', async () => {
+    // OWN_RENTER has a prior booking with this operator → a customer in scope.
+    await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingInput({
+        operatorId: OPERATOR_ID,
+        renterId: OWN_RENTER_ID,
+        requestedVehicleId: 'veh-prior',
+        assignedVehicleId: 'veh-prior',
+      }),
+    )
+
+    const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
+    const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
+
+    const res = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await operatorBearer(SELF_ID)) },
+      body: JSON.stringify({
+        requestedVehicleId: vehicle.id,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: OWN_RENTER_ID,
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        source: 'MANUAL',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: { renterId: string; source: string } }
+    expect(body.data.renterId).toBe(OWN_RENTER_ID)
+    expect(body.data.source).toBe('MANUAL')
   })
 })

--- a/packages/api/tests/routes/operator-user-isolation.test.ts
+++ b/packages/api/tests/routes/operator-user-isolation.test.ts
@@ -170,10 +170,45 @@ describe('#396 — OPERATOR_* cannot enumerate users via any current ingress', (
     expect(res.status).toBe(403)
   })
 
-  it('GET /customers/search is STAFF-gated — operator gets 403', async () => {
-    const res = await app.request('/customers/search?q=re', {
+  it('GET /customers/search returns only the operator’s own-tenant (prior-booking) renters, never a foreign tenant’s', async () => {
+    // #589: operator manual-booking needs to find an existing customer, but the
+    // search MUST stay #396-safe — scoped to renters who have booked with THIS
+    // operator. OWN_RENTER booked with OPERATOR_ID (in scope); FOREIGN booked with
+    // another tenant (out of scope). Both mkUser names contain "User", so a hit on
+    // FOREIGN would prove an enumeration leak, not an incidental text match.
+    await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingInput({
+        operatorId: OPERATOR_ID,
+        renterId: OWN_RENTER_ID,
+        requestedVehicleId: vehicle.id,
+        assignedVehicleId: vehicle.id,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+      }),
+    )
+    await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingInput({
+        operatorId: OTHER_OPERATOR_ID,
+        renterId: FOREIGN_ID,
+        requestedVehicleId: 'veh-foreign',
+        assignedVehicleId: 'veh-foreign',
+      }),
+    )
+
+    const res = await app.request('/customers/search?q=User', {
       headers: await operatorBearer(SELF_ID),
     })
+
+    expect(res.status).toBe(200)
+    const ids = ((await res.json()) as { data: { id: string }[] }).data.map((u) => u.id)
+    expect(ids).toContain(OWN_RENTER_ID)
+    expect(ids).not.toContain(FOREIGN_ID)
+  })
+
+  it('GET /customers (full list) stays STAFF-gated — operator still gets 403', async () => {
+    const res = await app.request('/customers', { headers: await operatorBearer(SELF_ID) })
     expect(res.status).toBe(403)
   })
 


### PR DESCRIPTION
Part of #589. The **API security slice** that unblocks operator manual booking — split from the web dialog (a follow-up) because it's a security-sensitive write surface. Walk-in (brand-new customer) creation is a separate follow-up (touches the shared `createBookingSchema`).

Background: the API *deliberately* forbade operator manual-booking (`bookings.ts`, guarded by `operator-user-isolation.test.ts`) to prevent the #396/#475 cross-tenant user-enumeration vector. The in-code blueprint (`customers.ts`) said to thread `CallerContext` + operator scope before widening any gate. This PR does exactly that.

## 1a — operator-scoped customer search (`d82d60bc`)
- `GET /customers/search` is now reachable by OPERATOR_*, but `CustomerService.search(query, ctx)` scopes an operator to renters **within its own tenant boundary** — those with a prior booking with it (`BookingRepository.listRenterIdsForOperator`). Bypass roles still search the full table.
- The full list, `findById`, and `quick-create` stay PLATFORM_ADMIN-only.

## 1b — operator manual-booking authz (`bee12adf`)
- `POST /bookings`: STAFF **and** OPERATOR_* are "manual bookers" — may set `renterId` + `source=MANUAL`.
- An operator's `renterId` is authorized **scope-first** against its own customer set: any out-of-scope id returns a **uniform 403 without probing the user table**, so it never leaks whether an arbitrary `renterId` exists. Staff/bypass keep the existence+role probe. Everyone else still books as themselves (`source=DIRECT`).

## Safety
`operator-user-isolation.test.ts` extended, all #396 invariants preserved:
- `/customers/search` returns own-tenant renters, **excludes a foreign tenant's even on a matching name**.
- foreign `renterId` on `POST /bookings` → **403, user table never probed**; own prior customer → 201, `source=MANUAL`.
- `/customers` full-list + `quick-create` stay 403 for operators; `/users` self-only; booking enrichment tenant-scoped — all unchanged.

## Verification
- [x] `bun run --filter @kuruma/api typecheck` + web typecheck (0)
- [x] `bun run --filter @kuruma/api test` — 1508/1508
- [x] husky gates (biome + size + module boundaries) on every commit

## Deferred (follow-ups)
- **Walk-in create** (new customers): atomic inline `name`+`phone` on `createBookingSchema` (name+phone only → no global-email enumeration oracle, no migration).
- **Web slice**: `ManualBookingDialog` + `CustomerPicker` + re-add the `selectable`/`onSelectSlot` seam + role-gate on `isOperatorSession`.