### PR TITLE
refactor(api): extract shared composeBookingTotal() so create/substitute can't desync

### DIFF
--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -11,7 +11,7 @@ import type {
   UserRepository,
 } from '../repositories/types'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
-import { MS_PER_MINUTE, rentalDays } from './booking-pricing-helpers'
+import { MS_PER_MINUTE, composeBookingTotal, rentalDays } from './booking-pricing-helpers'
 import type {
   BookingVerificationGate,
   CreateBookingInput,
@@ -219,8 +219,6 @@ export class BookingCreationService {
         code: pricing.code,
       }
     }
-    let totalPrice = pricing.totalPriceJpy
-
     // Selected insurance: snapshot the chosen ACTIVE option from THIS operator.
     let insuranceOptionId: string | null = null
     let insuranceSnapshot: InsuranceSnapshot | null = null
@@ -236,7 +234,6 @@ export class BookingCreationService {
         dailyPriceJpy: opt.dailyPriceJpy,
         deductibleJpy: opt.deductibleJpy,
       }
-      totalPrice += opt.dailyPriceJpy * rentalDays(input.startAt, input.endAt)
     }
 
     // Fee snapshot: this operator's ACTIVE fees that are operator-wide or match
@@ -254,9 +251,10 @@ export class BookingCreationService {
         vehicleClassId: f.vehicleClassId,
       }))
 
-    // Selected paid add-ons (#460): each flat priceJpy is added to totalPrice and
-    // snapshotted. One ACTIVE-only, this-operator read validates membership +
-    // tenant + active in a single query (a foreign/archived id is simply absent
+    // Selected paid add-ons (#460): each flat priceJpy is snapshotted here and
+    // folded into the total below via composeBookingTotal. One ACTIVE-only,
+    // this-operator read validates membership + tenant + active in a single
+    // query (a foreign/archived id is simply absent
     // -> 400). De-dup so a repeated id is charged once (quantity is out of MVP).
     const addOnSnapshot: AddOnSnapshot[] = []
     if (input.addOnIds.length > 0) {
@@ -266,9 +264,16 @@ export class BookingCreationService {
         const addOn = availableById.get(addOnId)
         if (!addOn) return { ok: false, status: 400, error: 'Add-on is not available' }
         addOnSnapshot.push({ addOnId: addOn.id, name: addOn.name, priceJpy: addOn.priceJpy })
-        totalPrice += addOn.priceJpy
       }
     }
+
+    // One composition for create AND substitute() — never hand-summed twice (#862).
+    const totalPrice = composeBookingTotal({
+      baseJpy: pricing.totalPriceJpy,
+      insurancePerDayJpy: insuranceSnapshot?.dailyPriceJpy ?? 0,
+      days: rentalDays(input.startAt, input.endAt),
+      addOns: addOnSnapshot,
+    })
 
     const bookingCode = this.generateCode()
 

--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -11,7 +11,7 @@ import type {
 } from '../repositories/types'
 import type { Booking, Vehicle } from '../stores'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
-import { rentalDays } from './booking-pricing-helpers'
+import { composeBookingTotal, rentalDays } from './booking-pricing-helpers'
 import type { CancelResult, StatusTransitionResult, SubstituteResult } from './booking-types'
 import type { LifecycleTrigger } from './notification-dispatcher'
 
@@ -106,16 +106,16 @@ export class BookingLifecycleService {
             error: 'Replacement vehicle has no usable rate',
           }
         }
-        const insurancePerDay = booking.insuranceSnapshot?.dailyPriceJpy ?? 0
-        // Locked add-on charges (#460) ride along unchanged on a swap — the new
-        // base re-prices, but the renter still owes the same add-ons. Mirrors the
-        // canonical composition in booking-creation.ts (base + insurance + add-ons);
-        // omitting this undercharged by the add-on total on every swap (#855).
-        const addOnsTotal = booking.addOnSnapshot.reduce((sum, a) => sum + a.priceJpy, 0)
-        const totalPrice =
-          pricing.totalPriceJpy +
-          insurancePerDay * rentalDays(booking.startAt, booking.endAt) +
-          addOnsTotal
+        // Re-compose off the new vehicle's base through the SAME helper as
+        // creation so a swap can never desync: locked insurance + locked add-ons
+        // (#460) ride along unchanged, only the base re-prices. #855 was the
+        // missing add-on term here; #862 makes divergence structurally impossible.
+        const totalPrice = composeBookingTotal({
+          baseJpy: pricing.totalPriceJpy,
+          insurancePerDayJpy: booking.insuranceSnapshot?.dailyPriceJpy ?? 0,
+          days: rentalDays(booking.startAt, booking.endAt),
+          addOns: booking.addOnSnapshot,
+        })
 
         // Turnaround is location-only and the pickup location is unchanged, so
         // effectiveEndAt is preserved; the repo re-runs the exclusion check for

--- a/packages/api/src/services/booking-pricing-helpers.test.ts
+++ b/packages/api/src/services/booking-pricing-helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { composeBookingTotal } from './booking-pricing-helpers'
+
+// The single source of truth for a booking's totalPrice composition, shared by
+// initial creation and substitute() re-pricing (#862). #855 regressed precisely
+// because add-on charges were folded into creation but not the swap path.
+describe('composeBookingTotal', () => {
+  it('returns the bare base when there is no insurance and no add-ons', () => {
+    expect(
+      composeBookingTotal({ baseJpy: 30000, insurancePerDayJpy: 0, days: 3, addOns: [] }),
+    ).toBe(30000)
+  })
+
+  it('adds insurance priced per rental day', () => {
+    // 30000 base + 1500/day * 3 days = 34500
+    expect(
+      composeBookingTotal({ baseJpy: 30000, insurancePerDayJpy: 1500, days: 3, addOns: [] }),
+    ).toBe(34500)
+  })
+
+  it('folds every add-on flat charge into the total (the #855 regression)', () => {
+    // 30000 base + 1500*3 insurance + (2000 + 800) add-ons = 37300
+    expect(
+      composeBookingTotal({
+        baseJpy: 30000,
+        insurancePerDayJpy: 1500,
+        days: 3,
+        addOns: [{ priceJpy: 2000 }, { priceJpy: 800 }],
+      }),
+    ).toBe(37300)
+  })
+
+  it('charges add-ons exactly once and ignores non-price fields on the snapshot', () => {
+    // Real call sites pass full AddOnSnapshot objects (addOnId/name/priceJpy);
+    // only priceJpy must reach the sum. A typed variable (not a literal) mirrors
+    // that — base only + a single add-on => 32000.
+    const addOns = [{ addOnId: 'a1', name: 'Child seat', priceJpy: 2000 }]
+    expect(composeBookingTotal({ baseJpy: 30000, insurancePerDayJpy: 0, days: 1, addOns })).toBe(
+      32000,
+    )
+  })
+})

--- a/packages/api/src/services/booking-pricing-helpers.ts
+++ b/packages/api/src/services/booking-pricing-helpers.ts
@@ -11,3 +11,19 @@ const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE
 export function rentalDays(startAt: Date, endAt: Date): number {
   return Math.max(1, Math.ceil((endAt.getTime() - startAt.getTime()) / MS_PER_DAY))
 }
+
+// The single composition of a booking's totalPrice: base + insurance-per-day ×
+// days + every selected add-on's flat charge. Both initial creation and
+// substitute() re-pricing MUST go through here so they can never desync — #855
+// was a silent undercharge on every vehicle swap because the add-on term was
+// folded into one path and not the other (#862). Pure: unit-tested once, both
+// call sites provably identical (Functional Core / Imperative Shell).
+export function composeBookingTotal(input: {
+  baseJpy: number
+  insurancePerDayJpy: number
+  days: number
+  addOns: ReadonlyArray<{ priceJpy: number }>
+}): number {
+  const addOnsJpy = input.addOns.reduce((sum, addOn) => sum + addOn.priceJpy, 0)
+  return input.baseJpy + input.insurancePerDayJpy * input.days + addOnsJpy
+}


### PR DESCRIPTION
## What
Extracts a single pure `composeBookingTotal({ baseJpy, insurancePerDayJpy, days, addOns })` into `booking-pricing-helpers.ts` and routes **both** total-composition sites through it:
- `booking-creation.ts` (create) — now composes once after building snapshots; the incremental `let totalPrice` mutation is gone.
- `booking-lifecycle.ts` `substitute()` — drops its parallel hand-sum.

## Why
`totalPrice` (`base + insurance×days + Σ add-on charges`) was hand-written in two places. **#855** was a silent undercharge on every vehicle swap because the add-on term was folded into creation but never into `substitute()`. One pure core → both call sites provably identical (Functional Core / Imperative Shell). Divergence is now structurally impossible, not policed by comment.

## Behaviour
Pure refactor, zero behaviour change. Verified term-for-term identical at both sites (incl. null-insurance → `?? 0`, empty add-ons → `0`, integer JPY so no rounding drift). Both reviewers (code + architect) returned **SHIP**.

## Test plan
- [x] New `booking-pricing-helpers.test.ts` — 4 mutation-resistant exact-yen cases (incl. the #855 add-on-fold regression).
- [x] Existing exact-yen guards unchanged & green: substitute pins `35000` (`booking.test.ts`, the #855 guard), creation totals pinned.
- [x] Full API suite **1510/1510**, `tsc --noEmit` clean, `lint:boundaries` OK.

## Follow-up (not this PR)
Web's `estimateReservation` (`reservation/pricing.ts`) is a *third* hand-rolled copy of the same formula (+ duplicated `rentalDays`) — a quote-vs-charge desync one boundary over. Filing a separate issue to hoist `composeBookingTotal` + `rentalDays` into `@kuruma/shared/lib/pricing` (shared danger zone → own slice).

Closes #862