### PR TITLE
chore(deploy): wire R2 buckets, EMAIL_FROM, and RESEND_API_KEY for beta

### DIFF
--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -63,6 +63,10 @@ jobs:
           echo "${{ secrets.AUTH_GOOGLE_ID }}" | npx wrangler secret put AUTH_GOOGLE_ID
           echo "${{ secrets.AUTH_GOOGLE_SECRET }}" | npx wrangler secret put AUTH_GOOGLE_SECRET
           echo "${{ secrets.AUTH_URL }}" | npx wrangler secret put AUTH_URL
+          # Transactional email (Resend). RESEND_API_KEY is a secret; the email
+          # sender hard-throws in prod if absent (src/index.ts:154). EMAIL_FROM is
+          # a non-secret var in wrangler.toml, deployed with code (not rotated).
+          echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY
           # In-app Stripe payment (#461). Test-mode keys for the demo; both must be
           # set as GitHub Secrets first. The API gateway falls back to a throwing
           # sentinel when absent, so deploy.yml's presence check intentionally does

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -66,21 +66,31 @@ namespace_id = "1005"
 simple.limit = 1
 simple.period = 10
 
-# R2 bucket for vehicle photo uploads — DISABLED.
-# R2 is not enabled on the current Cloudflare account (blocked on #304 account
-# migration). Re-enable by uncommenting once R2 is provisioned:
-#   npx wrangler r2 bucket create kuruma-vehicle-photos
-#   npx wrangler r2 bucket dev-url-enable kuruma-vehicle-photos
-# With the binding commented out, wrangler deploy no longer calls the R2 API
-# (which was returning 10042 "Please enable R2"). Runtime: the composition
-# root falls back to DisabledPhotoStorage, which returns a clear 500 on any
-# upload attempt instead of silently accepting into ephemeral per-request memory.
-# [[r2_buckets]]
-# binding = "VEHICLE_PHOTOS"
-# bucket_name = "kuruma-vehicle-photos"
+# R2 buckets — R2 enabled on the account + buckets created 2026-06-14.
+# VEHICLE_PHOTOS: public car photos, served via VEHICLE_PHOTOS_PUBLIC_URL (below).
+# The composition root uses R2PhotoStorage only when BOTH the binding and that var
+# are present; otherwise DisabledPhotoStorage throws on upload (repositories.ts:281).
+# RENTER_DOCUMENTS: private renter ID docs, served through the Worker (no public URL).
+[[r2_buckets]]
+binding = "VEHICLE_PHOTOS"
+bucket_name = "kuruma-vehicle-photos"
+
+[[r2_buckets]]
+binding = "RENTER_DOCUMENTS"
+bucket_name = "kuruma-renter-documents"
 
 [vars]
 WEB_ORIGIN = "https://kuruma-rental.kanata-studio-dev.workers.dev"
+
+# Transactional email (Resend). EMAIL_FROM is the public "from" address (not a
+# secret), so it lives here as a var. RESEND_API_KEY is a Worker secret set via
+# rotate-secrets.yml. Must be on the Resend-verified sending domain.
+EMAIL_FROM = "noreply@mail.jack-li.dev"
+
+# Public base URL for vehicle photos (r2.dev public access on kuruma-vehicle-photos).
+# Required non-empty or photo upload falls back to DisabledPhotoStorage
+# (repositories.ts:281, r2-photo-storage.ts:38).
+VEHICLE_PHOTOS_PUBLIC_URL = "https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev"
 
 # Monitoring (#361). The deployed version id is exposed as CF_VERSION_METADATA
 # and used as the Sentry release tag so errors group per deploy.


### PR DESCRIPTION
## What

Beta-deploy infra wiring for the **existing personal Cloudflare account** (sole-proprietor beta; #304 account migration intentionally skipped).

- **`packages/api/wrangler.toml`**
  - Re-enable R2: `VEHICLE_PHOTOS` (public car photos) + `RENTER_DOCUMENTS` (private renter ID docs) bindings — buckets created on the account 2026-06-14.
  - Add vars `EMAIL_FROM` (Resend-verified `noreply@mail.jack-li.dev`) and `VEHICLE_PHOTOS_PUBLIC_URL` (r2.dev public base).
- **`.github/workflows/rotate-secrets.yml`**
  - Push `RESEND_API_KEY` onto the API Worker (Worker secret, not a var).

## Why it's safe

The composition root only activates real storage when its inputs are present, otherwise it throws loudly rather than silently dropping bytes:
- `R2PhotoStorage` requires **both** the `VEHICLE_PHOTOS` binding **and** `VEHICLE_PHOTOS_PUBLIC_URL`; else `DisabledPhotoStorage` (`repositories.ts:281`).
- `R2DocumentStorage` requires the `RENTER_DOCUMENTS` binding; else `DisabledDocumentStorage` (`repositories.ts:291`).
- Email sender hard-throws if `RESEND_API_KEY` absent (`index.ts:154`).

Binding names verified against the code reads. Config-only change; no app logic touched. Stripe stays a throwing sentinel (pay-at-pickup beta needs no Stripe at booking).

## Deploy sequence (post-merge, HITL)

1. Run **rotate-secrets** workflow → pushes `RESEND_API_KEY` (+ existing secrets) onto the API Worker.
2. Run **deploy** workflow on `marketplace-pivot` → migrates prod DB, deploys API + Pages, smoke-tests `/health`, `/en`, `/api/health`.
3. Seed beta data + verify renter/operator flows, login, email.

## Test plan

- [ ] CI green (typecheck, lint:boundaries, db-drift — config-only, expected pass)
- [ ] rotate-secrets dispatch succeeds; `wrangler secret list` shows `RESEND_API_KEY`
- [ ] deploy dispatch green; smoke endpoints 200
- [ ] photo upload returns a working r2.dev URL (not a 500)
- [ ] booking confirmation email delivered from `noreply@mail.jack-li.dev`