### PR TITLE
refactor(web): anchor operator-classes enum literals to shared tuples (#858)

### DIFF
--- a/packages/web/src/vite/operator-classes/api.ts
+++ b/packages/web/src/vite/operator-classes/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { LUGGAGE_SIZES, TRANSMISSIONS, VEHICLE_CLASS_STATUSES } from '@kuruma/shared/enums'
 import type {
   CreateVehicleClassInput,
   UpdateVehicleClassInput,
@@ -38,12 +39,12 @@ export const operatorClassSchema = z.object({
   photos: z.array(z.string()),
   seats: z.number(),
   luggageCapacity: z.number(),
-  luggageSize: z.enum(['SMALL', 'MEDIUM', 'LARGE']),
-  transmission: z.enum(['AUTO', 'MANUAL']),
+  luggageSize: z.enum(LUGGAGE_SIZES),
+  transmission: z.enum(TRANSMISSIONS),
   fuelType: z.string().nullable(),
   acrissCode: z.string().nullable(),
   sortOrder: z.number(),
-  status: z.enum(['ACTIVE', 'ARCHIVED']),
+  status: z.enum(VEHICLE_CLASS_STATUSES),
   createdAt: z.string(),
   updatedAt: z.string(),
 })


### PR DESCRIPTION
Closes #858. P3 drift-proofing (behavior-preserving), sibling of #847/#854.

`operatorClassSchema` (`packages/web/src/vite/operator-classes/api.ts`) inlined three closed-set enums with no compile-time link to the pgEnum SSoT:
- `luggageSize: z.enum(['SMALL','MEDIUM','LARGE'])` → `z.enum(LUGGAGE_SIZES)`
- `transmission: z.enum(['AUTO','MANUAL'])` → `z.enum(TRANSMISSIONS)`
- `status: z.enum(['ACTIVE','ARCHIVED'])` → `z.enum(VEHICLE_CLASS_STATUSES)`

All three tuples are exported from `@kuruma/shared/enums` (edge-safe, drizzle-free) with identical members, so `OperatorClass = z.infer<...>` and every consumer are unchanged. This was the last drifting 3c client; it now matches its sibling `vehicles/classes.ts`, killing the #688 class of failure (a future SSoT rename compiling green on web then ParseError-ing on valid rows).

### Test plan
- [x] `bun run --filter @kuruma/web test` — **891 passed**
- [x] tsc (web + api) + biome clean; pre-commit gates green
- [ ] CI green