### PR TITLE
refactor(api,web): hoist booking-total pricing to shared (#867)

### DIFF
--- a/packages/api/src/services/booking-pricing-helpers.ts
+++ b/packages/api/src/services/booking-pricing-helpers.ts
@@ -1,29 +1,9 @@
-// Pure time/price helpers shared by the booking creation and lifecycle services
-// (#713 split). Kept in one place so substitution re-pricing and initial pricing
-// round insurance days identically.
+// Pricing helpers for the booking creation and lifecycle services (#713 split).
+// rentalDays + composeBookingTotal now live in @kuruma/shared/lib/pricing (#867)
+// so the web reservation estimate composes the booking total through the exact
+// same function as the server's authoritative charge — re-exported here so the
+// existing service + test import lines stay untouched.
+export { composeBookingTotal, rentalDays } from '@kuruma/shared/lib/pricing'
 
+// Turnaround buffer math (booking-creation effectiveEndAt) — API-only, stays here.
 export const MS_PER_MINUTE = 60 * 1000
-// Module-local: only rentalDays() below needs it; other modules define their own.
-const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE
-
-// Insurance is priced per rental day (ceil), min 1 — matches the daily-rate
-// rounding the base price uses for whole-day rentals.
-export function rentalDays(startAt: Date, endAt: Date): number {
-  return Math.max(1, Math.ceil((endAt.getTime() - startAt.getTime()) / MS_PER_DAY))
-}
-
-// The single composition of a booking's totalPrice: base + insurance-per-day ×
-// days + every selected add-on's flat charge. Both initial creation and
-// substitute() re-pricing MUST go through here so they can never desync — #855
-// was a silent undercharge on every vehicle swap because the add-on term was
-// folded into one path and not the other (#862). Pure: unit-tested once, both
-// call sites provably identical (Functional Core / Imperative Shell).
-export function composeBookingTotal(input: {
-  baseJpy: number
-  insurancePerDayJpy: number
-  days: number
-  addOns: ReadonlyArray<{ priceJpy: number }>
-}): number {
-  const addOnsJpy = input.addOns.reduce((sum, addOn) => sum + addOn.priceJpy, 0)
-  return input.baseJpy + input.insurancePerDayJpy * input.days + addOnsJpy
-}

--- a/packages/shared/src/lib/pricing.ts
+++ b/packages/shared/src/lib/pricing.ts
@@ -70,3 +70,26 @@ export function calculateBookingPrice(
     breakdown: { days, remainderHours, dailyRateJpy: daily, hourlyRateJpy: hourly },
   }
 }
+
+// Rental length in whole days (ceil, min 1) — the unit insurance is billed in,
+// matching the daily-rate rounding the base price uses for whole-day rentals.
+export function rentalDays(startAt: Date, endAt: Date): number {
+  return Math.max(1, Math.ceil((endAt.getTime() - startAt.getTime()) / (HOURS_PER_DAY * HOUR_MS)))
+}
+
+// The single composition of a booking's totalPrice: base + insurance-per-day ×
+// days + every selected add-on's flat charge. The API (initial creation and
+// substitute() re-pricing) and the web reservation estimate BOTH compose through
+// here so the renter's up-front quote can never desync from the server's
+// authoritative charge — #855 was a silent undercharge when the add-on term was
+// folded into one path and not the other (#862, #867). Pure (FC/IS): unit-tested
+// once, every call site provably identical.
+export function composeBookingTotal(input: {
+  baseJpy: number
+  insurancePerDayJpy: number
+  days: number
+  addOns: ReadonlyArray<{ priceJpy: number }>
+}): number {
+  const addOnsJpy = input.addOns.reduce((sum, addOn) => sum + addOn.priceJpy, 0)
+  return input.baseJpy + input.insurancePerDayJpy * input.days + addOnsJpy
+}

--- a/packages/shared/tests/lib/pricing.test.ts
+++ b/packages/shared/tests/lib/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { calculateBookingPrice } from '../../src/lib/pricing'
+import { calculateBookingPrice, composeBookingTotal, rentalDays } from '../../src/lib/pricing'
 
 describe('calculateBookingPrice', () => {
   test('hourly-only rate, 1h duration → 1 × hourly rate', () => {
@@ -135,5 +135,58 @@ describe('calculateBookingPrice', () => {
       expect(result.breakdown.days).toBe(1)
       expect(result.breakdown.remainderHours).toBe(10)
     }
+  })
+})
+
+describe('rentalDays', () => {
+  test('whole days → exact day count', () => {
+    expect(rentalDays(new Date('2026-07-01T10:00:00Z'), new Date('2026-07-03T10:00:00Z'))).toBe(2)
+  })
+
+  test('a partial day rounds up (insurance is billed per started day)', () => {
+    expect(rentalDays(new Date('2026-07-01T10:00:00Z'), new Date('2026-07-03T11:00:00Z'))).toBe(3)
+  })
+
+  test('a sub-day rental still bills one day (min 1)', () => {
+    expect(rentalDays(new Date('2026-07-01T10:00:00Z'), new Date('2026-07-01T11:00:00Z'))).toBe(1)
+  })
+})
+
+describe('composeBookingTotal', () => {
+  test('returns the bare base with no insurance and no add-ons', () => {
+    expect(
+      composeBookingTotal({ baseJpy: 30000, insurancePerDayJpy: 0, days: 3, addOns: [] }),
+    ).toBe(30000)
+  })
+
+  test('adds insurance priced per rental day', () => {
+    // 30000 + 1500/day * 3 days = 34500
+    expect(
+      composeBookingTotal({ baseJpy: 30000, insurancePerDayJpy: 1500, days: 3, addOns: [] }),
+    ).toBe(34500)
+  })
+
+  test('sums every selected add-on as a flat per-booking charge', () => {
+    // 30000 + (2000 + 3000) = 35000 — the #855 swap-undercharge guard.
+    expect(
+      composeBookingTotal({
+        baseJpy: 30000,
+        insurancePerDayJpy: 0,
+        days: 3,
+        addOns: [{ priceJpy: 2000 }, { priceJpy: 3000 }],
+      }),
+    ).toBe(35000)
+  })
+
+  test('composes base + insurance-days + add-ons together', () => {
+    // 30000 + 1500*2 + 2500 = 35500
+    expect(
+      composeBookingTotal({
+        baseJpy: 30000,
+        insurancePerDayJpy: 1500,
+        days: 2,
+        addOns: [{ priceJpy: 2500 }],
+      }),
+    ).toBe(35500)
   })
 })

--- a/packages/web/src/vite/reservation/pricing.ts
+++ b/packages/web/src/vite/reservation/pricing.ts
@@ -1,15 +1,12 @@
-import { type VehicleRates, calculateBookingPrice } from '@kuruma/shared/lib/pricing'
+import {
+  type VehicleRates,
+  calculateBookingPrice,
+  composeBookingTotal,
+  rentalDays,
+} from '@kuruma/shared/lib/pricing'
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000
-
-/**
- * Rental length in whole days (ceil, min 1) — the unit insurance is billed in.
- * Mirrors the API's private `rentalDays` (services/booking.ts) so the wizard's
- * insurance line matches the eventual server charge.
- */
-export function rentalDays(from: Date, to: Date): number {
-  return Math.max(1, Math.ceil((to.getTime() - from.getTime()) / MS_PER_DAY))
-}
+// Re-exported so DateRangeStep can keep importing rentalDays from this module.
+export { rentalDays }
 
 export interface ReservationEstimateInput {
   vehicle: VehicleRates
@@ -30,8 +27,10 @@ export interface ReservationEstimate {
 
 /**
  * Client-side price estimate for the reservation wizard (#460). Mirrors the
- * server total (services/booking.ts `submitInTx`): base off the assigned
- * vehicle's rates, insurance at `dailyPrice × rentalDays`, each add-on flat.
+ * server total: base off the assigned vehicle's rates, insurance at
+ * `dailyPrice × rentalDays`, each add-on flat. The total is composed through the
+ * shared `composeBookingTotal` (#867) — the same function the API uses for the
+ * authoritative charge — so the renter's up-front quote can never desync from it.
  *
  * Fees are intentionally excluded — they live on `feeSnapshot` as informational
  * post-rental charges and are never added to `totalPrice`. The authoritative
@@ -41,10 +40,15 @@ export interface ReservationEstimate {
 export function estimateReservation(input: ReservationEstimateInput): ReservationEstimate {
   const pricing = calculateBookingPrice(input.vehicle, input.from, input.to)
   const baseJpy = pricing.ok ? pricing.totalPriceJpy : 0
-  const insuranceJpy =
-    input.insuranceDailyPriceJpy != null
-      ? input.insuranceDailyPriceJpy * rentalDays(input.from, input.to)
-      : 0
+  const days = rentalDays(input.from, input.to)
+  const insurancePerDayJpy = input.insuranceDailyPriceJpy ?? 0
+  const insuranceJpy = insurancePerDayJpy * days
   const addOnsJpy = input.addOnPricesJpy.reduce((sum, price) => sum + price, 0)
-  return { baseJpy, insuranceJpy, addOnsJpy, totalJpy: baseJpy + insuranceJpy + addOnsJpy }
+  const totalJpy = composeBookingTotal({
+    baseJpy,
+    insurancePerDayJpy,
+    days,
+    addOns: input.addOnPricesJpy.map((priceJpy) => ({ priceJpy })),
+  })
+  return { baseJpy, insuranceJpy, addOnsJpy, totalJpy }
 }


### PR DESCRIPTION
Closes #867

## Why
Three hand-rolled copies of the booking-total formula (`base + insurance×days + add-ons`) had drifted apart. #862 unified the two API paths (creation + `substitute()`) behind `composeBookingTotal()`. The **web reservation estimate was the third copy** — the renter's up-front quote could silently desync from the server's authoritative charge (the #855 undercharge class).

## What
- **Slice 1** (already landed `717116b3`): added `rentalDays()` + `composeBookingTotal()` to `@kuruma/shared/lib/pricing` with 7 exact-yen tests.
- **Slice 2** — `packages/api/.../booking-pricing-helpers.ts` now re-exports both from shared (kept `MS_PER_MINUTE` for the booking-creation turnaround buffer). Every service + test import line is unchanged — zero call-site churn.
- **Slice 3** (the fix) — web `estimateReservation` composes `totalJpy` through the shared `composeBookingTotal`. The `{ baseJpy, insuranceJpy, addOnsJpy, totalJpy }` breakdown shape is preserved, so the wizard render and existing tests are untouched.

The renter quote and the server charge are now provably the same function.

## Verification
- `@kuruma/api` 1512/1512 · `@kuruma/web` 891/891 · `@kuruma/shared` 557/557
- tsc clean: api, web, shared
- biome + module-boundaries + file-size: clean

## Notes
- Base is `marketplace-pivot` (not the default branch) so `Closes #867` will not auto-close on merge — will close manually.