### PR TITLE
refactor(web): anchor renter storefront add-on/insurance projections to shared DTOs (#864)

### DIFF
--- a/packages/api/src/services/storefront-detail.ts
+++ b/packages/api/src/services/storefront-detail.ts
@@ -1,5 +1,6 @@
 import { type LuggageSize, resolveLuggage } from '@kuruma/shared/lib/luggage'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
+import type { StorefrontAddOnData, StorefrontInsuranceData } from '@kuruma/shared/types/storefront'
 import type { CallerContext } from '../middleware/auth'
 import type {
   AddOnRepository,
@@ -61,35 +62,25 @@ export type StorefrontDetailResult =
   | { ok: false; error: string; status: number }
 
 /**
- * Renter-safe insurance projection (#392): the four fields a renter needs to
- * choose coverage at booking. Operator-internal columns (operatorId, status,
- * timestamps) are intentionally absent — same column-whitelist discipline as
- * the public vehicle catalog.
+ * Renter-safe insurance projection (#392). Anchored to the shared wire DTO (#864)
+ * so a field rename fails `typecheck` on both producer and the web reservation
+ * schema, not as a render-time ParseError. Operator-internal columns (operatorId,
+ * status, timestamps) stay absent — same column-whitelist discipline as the
+ * public vehicle catalog.
  */
-export interface StorefrontInsuranceOption {
-  id: string
-  name: string
-  description: string | null
-  dailyPriceJpy: number
-  deductibleJpy: number | null
-}
+export type StorefrontInsuranceOption = StorefrontInsuranceData
 
 export type StorefrontInsuranceResult =
   | { ok: true; data: StorefrontInsuranceOption[] }
   | { ok: false; error: string; status: number }
 
 /**
- * Renter-safe add-on projection (#460): the fields a renter needs to pick paid
- * extras (baby seat etc.) at booking. Operator-internal columns (operatorId,
- * status, timestamps) are intentionally absent — same column-whitelist
- * discipline as the public vehicle catalog + insurance options.
+ * Renter-safe add-on projection (#460). Anchored to the shared wire DTO (#864):
+ * the fields a renter needs to pick paid extras (baby seat etc.) at booking.
+ * Operator-internal columns (operatorId, status, timestamps) stay absent — same
+ * column-whitelist discipline as the public vehicle catalog + insurance options.
  */
-export interface StorefrontAddOn {
-  id: string
-  name: string
-  description: string | null
-  priceJpy: number
-}
+export type StorefrontAddOn = StorefrontAddOnData
 
 export type StorefrontAddOnResult =
   | { ok: true; data: StorefrontAddOn[] }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,6 +30,7 @@
     "./types/fee-schedule": "./src/types/fee-schedule.ts",
     "./types/add-on": "./src/types/add-on.ts",
     "./types/insurance-option": "./src/types/insurance-option.ts",
+    "./types/storefront": "./src/types/storefront.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/commission": "./src/lib/commission.ts",
     "./lib/admin-revenue": "./src/lib/admin-revenue.ts",

--- a/packages/shared/src/types/storefront.ts
+++ b/packages/shared/src/types/storefront.ts
@@ -1,0 +1,43 @@
+/**
+ * Renter-safe storefront projection wire contracts (#392/#460, compile-pinned #864).
+ *
+ * The JSON shapes the public storefront endpoints return and the reservation
+ * wizard consumes:
+ *   - `GET /storefronts/:id/add-ons`          -> StorefrontAddOnData[]
+ *   - `GET /storefronts/:id/insurance-options` -> StorefrontInsuranceData[]
+ *
+ * These are NARROWER than the operator add-on/insurance rows (#847): only the
+ * catalog-visible fields a renter needs to choose extras + coverage at booking.
+ * Operator internals (operatorId, status, timestamps) are intentionally absent —
+ * the same column-whitelist discipline as the public vehicle catalog.
+ *
+ * Unlike the #847 operator DTOs, the API producer here is a hand-written service
+ * projection (not a Drizzle row), so it can BE this type directly — one source,
+ * no `wire-contract` fence. The producer aliases these in
+ * `services/storefront-detail.ts`; the web schema pins to them with
+ * `satisfies z.ZodType<…>`. A producer-side field rename therefore fails
+ * `typecheck` on both ends instead of surfacing as a render-time ParseError in
+ * the reservation wizard.
+ *
+ * Pure type module, no runtime deps. No Date fields — these projections carry no
+ * timestamps, so there is nothing to ISO-stringify. Exposed via the explicit
+ * subpath export "./types/storefront" in package.json (no types/index barrel).
+ */
+
+export interface StorefrontAddOnData {
+  id: string
+  name: string
+  description: string | null
+  /** Flat price charged once per booking (not per-day). */
+  priceJpy: number
+}
+
+export interface StorefrontInsuranceData {
+  id: string
+  name: string
+  description: string | null
+  /** Per-day coverage price (billed × rental days). */
+  dailyPriceJpy: number
+  /** null = full cover (no deductible). */
+  deductibleJpy: number | null
+}

--- a/packages/web/src/vite/reservation/api.ts
+++ b/packages/web/src/vite/reservation/api.ts
@@ -1,25 +1,28 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import type { StorefrontAddOnData, StorefrontInsuranceData } from '@kuruma/shared/types/storefront'
 import { z } from 'zod'
 
 // JSON shapes returned by the public storefront endpoints the reservation wizard
-// consumes (#460/#392). The Vite shell owns these DTOs so it stays free of the
-// frozen Next module's process.env path. The API serializes to JSON, so there
-// are no Date instances. These mirror the renter-safe projections in
-// services/storefront-detail.ts (StorefrontAddOn / StorefrontInsuranceOption).
+// consumes (#460/#392). The Vite shell owns the runtime schema so it stays free
+// of the frozen Next module's process.env path. The API serializes to JSON, so
+// there are no Date instances.
 
-// #711: the schema is the single source — the DTO type is inferred from it, so
-// web's compile-time shape and the runtime parse at the seam derive from one
-// definition and cannot drift. A renamed/dropped field fails as a ParseError in
-// the fetch helpers below instead of surfacing as `undefined` deep in the wizard.
+// #711/#864: the shared `Storefront*Data` DTO is the single source. The schema
+// pins to it with `satisfies z.ZodType<…>`, and the API producer (storefront-
+// detail.ts) aliases the SAME DTO, so web's compile-time shape and the producer
+// derive from one definition and cannot drift. A producer-side field rename
+// fails `typecheck` on both ends; a runtime body that drifts fails as a
+// ParseError in the fetch helpers below instead of surfacing as `undefined` deep
+// in the wizard.
 export const reservationAddOnSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string().nullable(),
   /** Flat price charged once per booking (not per-day). */
   priceJpy: z.number(),
-})
-export type ReservationAddOn = z.infer<typeof reservationAddOnSchema>
+}) satisfies z.ZodType<StorefrontAddOnData>
+export type ReservationAddOn = StorefrontAddOnData
 
 export const reservationInsuranceOptionSchema = z.object({
   id: z.string(),
@@ -28,8 +31,8 @@ export const reservationInsuranceOptionSchema = z.object({
   /** Per-day coverage price (billed × rental days). */
   dailyPriceJpy: z.number(),
   deductibleJpy: z.number().nullable(),
-})
-export type ReservationInsuranceOption = z.infer<typeof reservationInsuranceOptionSchema>
+}) satisfies z.ZodType<StorefrontInsuranceData>
+export type ReservationInsuranceOption = StorefrontInsuranceData
 
 // Public endpoints — no auth. ACTIVE-only, single-operator reads (the API seals
 // cross-tenant leaks). A 404 (unknown/archived storefront) surfaces as an


### PR DESCRIPTION
## What
Closes the **last** fee/add-on/insurance wire seam left runtime-only after #847 — the **renter-safe storefront projections** consumed by the reservation wizard.

- **Producer:** `services/storefront-detail.ts` projections `StorefrontInsuranceOption` (#392) / `StorefrontAddOn` (#460), served by `GET /storefronts/:id/insurance-options` and `.../add-ons`.
- **Consumer:** `web/src/vite/reservation/api.ts` `reservationAddOnSchema` / `reservationInsuranceOptionSchema` previously self-inferred via `z.infer` with **no** compile-time pin to the API projection.

**Gap (the #847 drift class, on the projection seam):** a producer rename (e.g. `StorefrontAddOn.priceJpy`) surfaced as a render-time `ParseError` in the wizard, not a `typecheck` failure.

## How
- New shared **`StorefrontAddOnData` / `StorefrontInsuranceData`** (`@kuruma/shared/types/storefront`) — drizzle-free, no timestamps — become the single source.
- Unlike #847 (producer = Drizzle row → needed a `wire-contract` fence), these producers are **hand-written service projections**, so they alias the shared DTO **directly**: one type, no fence (DRY).
- Web schemas pin with `satisfies z.ZodType<…>`; the `Reservation*` type names stay (aliased to the DTO) so the 5 wizard consumers are untouched.

## Proof the pin bites (both ends)
Temporarily renaming a shared DTO field (`priceJpy`→`priceAmount`) fails `typecheck` simultaneously on:
- producer `storefront-detail.ts` (TS2322 — projection literal no longer matches the DTO), and
- consumer `api.ts` `satisfies` (TS1360) + wizard field-access (TS2339).

Drift now fails `typecheck`, not at render time. Restored after verifying.

## Tests
- Existing `reservation/api.test.ts` runtime-drift coverage unchanged — **5/5** green.
- api storefront tests **58/58**; `@kuruma/shared` + `@kuruma/web` typecheck clean; biome + boundaries + size gates pass.

Behavior-preserving. Net-negative diff (two interfaces collapsed into shared-DTO aliases).

Part of #711. Sibling of #817. Closes #864.