### PR TITLE
ci(deploy): point API smoke test at kanata-studio (post account-consolidation)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ permissions:
 env:
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  API_WORKER_URL: https://kuruma-api.kanata-studio-dev.workers.dev
+  API_WORKER_URL: https://kuruma-api.kanata-studio.workers.dev
   WEB_PAGES_URL: https://kuruma-web-pages.pages.dev
 
 jobs:


### PR DESCRIPTION
## What
`deploy.yml` env `API_WORKER_URL` still pointed at the retired `kuruma-api.kanata-studio-dev.workers.dev` subdomain. The beta was consolidated onto the personal CF account `569d…`, where the API now lives at `kuruma-api.kanata-studio.workers.dev`.

## Why
On a push to `main`/`marketplace-pivot`, the deploy workflow smoke-tests `$API_WORKER_URL/health` and **blocks the Pages (web) deploy** on it. With the dead URL that step fails. Current beta deploys only work because they're dispatched from this branch (workflow_dispatch).

## Change
One line: `API_WORKER_URL` → `https://kuruma-api.kanata-studio.workers.dev`. Verified the live worker returns 200 at `/health` on that subdomain.