### PR TITLE
feat(api): operator walk-in booking — inline fresh-renter creation (#589 1c)

### DIFF
--- a/packages/api/src/repositories/drizzle/user.ts
+++ b/packages/api/src/repositories/drizzle/user.ts
@@ -92,6 +92,28 @@ export class DrizzleUserRepository implements UserRepository {
     return existing
   }
 
+  async createWalkInRenter(data: { name: string; phone: string }): Promise<User> {
+    // #589 1c: ALWAYS a fresh renter — never dedup by phone, so an operator can't
+    // attach a booking to (or probe the existence of) another tenant's customer
+    // (#396/#475). The placeholder email is random (never collides → no
+    // ON CONFLICT path); phone is stored as-is (not a unique column); role
+    // defaults to RENTER so the customer is findable in the operator's later
+    // scoped search (#589 1a).
+    const [inserted] = await this.db
+      .insert(users)
+      .values({
+        name: data.name,
+        email: `walkin-${crypto.randomUUID()}${PLACEHOLDER_EMAIL_SUFFIX}`,
+        phone: data.phone,
+        language: 'en',
+      })
+      .returning(userColumns)
+    if (!inserted) {
+      throw new Error('createWalkInRenter: insert returned no row')
+    }
+    return maskPlaceholderEmail(inserted) as User
+  }
+
   async findByEmail(email: string): Promise<User | undefined> {
     const [row] = await this.db
       .select(userColumns)

--- a/packages/api/src/repositories/in-memory/user.ts
+++ b/packages/api/src/repositories/in-memory/user.ts
@@ -59,6 +59,22 @@ export class InMemoryUserRepository implements UserRepository {
     return user
   }
 
+  async createWalkInRenter(data: { name: string; phone: string }): Promise<User> {
+    // #589 1c: ALWAYS a fresh renter — never dedup (mirrors the Drizzle impl's
+    // random-placeholder-email insert). See UserRepository for the security note.
+    const user: User = {
+      id: crypto.randomUUID(),
+      name: data.name,
+      email: null,
+      phone: data.phone,
+      language: 'en',
+      country: null,
+      role: 'RENTER',
+    }
+    this.store.set(user.id, user)
+    return user
+  }
+
   async findByEmail(email: string): Promise<User | undefined> {
     const target = email.toLowerCase()
     return [...this.store.values()].find((u) => u.email?.toLowerCase() === target)

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -324,6 +324,12 @@ export interface UserRepository {
     phone: string | null
     language: string
   }): Promise<User>
+  // #589 1c: register a brand-new walk-in/phone customer. ALWAYS inserts a fresh
+  // RENTER (random synthetic placeholder email; phone stored as-is) and NEVER
+  // dedups by phone/email — distinct from quickCreate's get-or-create. Critical:
+  // deduping a walk-in onto an existing user would let an operator attach a
+  // booking to (or probe the existence of) another tenant's customer (#396/#475).
+  createWalkInRenter(data: { name: string; phone: string }): Promise<User>
   findByEmail(email: string): Promise<User | undefined>
   findByPhone(phone: string): Promise<User | undefined>
   // Slice 7 (#393): the operator's OPERATOR_OWNER contact users, for the booking

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -152,6 +152,9 @@ export function createBookingRoutes(service: BookingService) {
       // (operator-user-isolation.test.ts). Everyone else books as themselves with
       // source forced to DIRECT (no advance-booking-hours bypass via MANUAL).
       const isManualBooker = STAFF_ROLES.has(ctx.role) || isOperatorRole(ctx.role)
+      // #589 1c: only manual bookers may register a walk-in customer inline; a
+      // renter's walkInCustomer is ignored (they book as themselves).
+      const walkInCustomer = isManualBooker ? parsed.data.walkInCustomer : undefined
       const renterId = isManualBooker && parsed.data.renterId ? parsed.data.renterId : ctx.userId
       const source = isManualBooker ? parsed.data.source : 'DIRECT'
 
@@ -171,6 +174,9 @@ export function createBookingRoutes(service: BookingService) {
         insuranceOptionId: parsed.data.insuranceOptionId ?? null,
         addOnIds: parsed.data.addOnIds,
         renterId,
+        // #589 1c: include walkInCustomer only when present, never as explicit
+        // undefined (exactOptionalPropertyTypes); the service prefers it over renterId.
+        ...(walkInCustomer ? { walkInCustomer } : {}),
         startAt: new Date(parsed.data.startAt),
         endAt: new Date(parsed.data.endAt),
         source,

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -57,32 +57,50 @@ export class BookingCreationService {
     input: CreateBookingInput,
     now: Date = new Date(),
   ): Promise<CreateBookingResult> {
-    // Manual-booking on behalf of a renter (#314, #589). For an OPERATOR_* caller
-    // the check is scope-FIRST: the renter must be in the operator's own customer
-    // set (a prior booking with it). Membership IS the authorization + existence
-    // check (a prior-booking renter necessarily exists), and any out-of-scope id
-    // returns a uniform 403 WITHOUT touching the user table — so it never leaks
-    // whether an arbitrary renterId exists (#396/#475). Staff/bypass keep the
-    // existence + role probe (surfaces FK failures as a friendly 400, not a 500).
-    if (input.renterId !== ctx.userId) {
-      if (isOperatorRole(ctx.role)) {
-        const scoped = ctx.operatorId
-          ? await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId)
-          : []
-        if (!scoped.includes(input.renterId)) {
-          return {
-            ok: false,
-            status: 403,
-            error: 'Cannot book for a renter outside your customers',
+    // Resolve the booking's renter (#314, #589). Three cases:
+    //  - WALK-IN (1c): the operator registers a brand-new customer inline.
+    //    createWalkInRenter ALWAYS makes a fresh renter (never deduped by phone),
+    //    so a booking can't be attached to — nor the existence probed of — another
+    //    tenant's customer (#396/#475). The walk-in IS the authorization, so it
+    //    skips the scope check below. Created pre-tx: a rare failed booking orphans
+    //    a childless renter, which is invisible (no booking => never in operator
+    //    scope) — YAGNI vs widening TransactionRepos with a userRepo for this.
+    //  - EXISTING renter (1b): operator authz is scope-FIRST — membership IS the
+    //    authorization + existence check; any out-of-scope id returns a uniform
+    //    403 WITHOUT touching the user table (no enumeration oracle). Staff/bypass
+    //    keep the exists+role probe (FK failures => friendly 400, not 500).
+    //  - SELF: renterId === ctx.userId (renter self-serve).
+    let renterId: string
+    if (input.walkInCustomer) {
+      if (!this.userRepo) {
+        // Invariant: the composition root always wires userRepo. Throw (→ 500 at
+        // the boundary) rather than silently book without creating the renter.
+        throw new Error('createWalkInRenter requires a userRepo (composition wiring)')
+      }
+      const renter = await this.userRepo.createWalkInRenter(input.walkInCustomer)
+      renterId = renter.id
+    } else {
+      renterId = input.renterId
+      if (renterId !== ctx.userId) {
+        if (isOperatorRole(ctx.role)) {
+          const scoped = ctx.operatorId
+            ? await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId)
+            : []
+          if (!scoped.includes(renterId)) {
+            return {
+              ok: false,
+              status: 403,
+              error: 'Cannot book for a renter outside your customers',
+            }
           }
-        }
-      } else if (this.userRepo) {
-        const [renter] = await this.userRepo.findByIds([input.renterId])
-        if (!renter) {
-          return { ok: false, status: 400, error: 'Renter not found' }
-        }
-        if ((renter.role ?? 'RENTER') !== 'RENTER') {
-          return { ok: false, status: 400, error: 'Target user is not a renter' }
+        } else if (this.userRepo) {
+          const [renter] = await this.userRepo.findByIds([renterId])
+          if (!renter) {
+            return { ok: false, status: 400, error: 'Renter not found' }
+          }
+          if ((renter.role ?? 'RENTER') !== 'RENTER') {
+            return { ok: false, status: 400, error: 'Target user is not a renter' }
+          }
         }
       }
     }
@@ -100,7 +118,10 @@ export class BookingCreationService {
     // on), an unverified renter is blocked here — before any booking work. Runs
     // AFTER idempotency replay so a previously-accepted booking stays replayable
     // even if the renter's document later expires.
-    if (this.verificationGate) {
+    // #589 1c: a walk-in is an operator-initiated manual booking — like other
+    // manual bookings it captures verification operationally at pickup, not via the
+    // renter document gate (the freshly-created customer has no documents on file).
+    if (this.verificationGate && !input.walkInCustomer) {
       const gate = await this.verificationGate(ctx, input)
       if (!gate.ok) return gate
     }
@@ -113,7 +134,7 @@ export class BookingCreationService {
     for (let attempt = 0; attempt < MAX_BOOKING_CODE_ATTEMPTS; attempt++) {
       try {
         const result = await this.runInTransaction((repos) =>
-          this.submitInTx(ctx, input, now, repos),
+          this.submitInTx(ctx, input, renterId, now, repos),
         )
         if (!result.ok) return result // domain validation failure — never retried
         // Post-commit side effects (#335 thread + #393 notifications) — never in
@@ -160,6 +181,9 @@ export class BookingCreationService {
   private async submitInTx(
     ctx: CallerContext,
     input: CreateBookingInput,
+    // Resolved in `create` (walk-in → freshly created renter; otherwise the
+    // authorized existing renter or self). Never input.renterId, which is optional.
+    renterId: string,
     now: Date,
     repos: TransactionRepos,
   ): Promise<CreateBookingResult> {
@@ -299,7 +323,7 @@ export class BookingCreationService {
     // event append, so a rolled-back insert leaves no orphan event (atomicity).
     const booking = await repos.bookingRepo.create(ctx, {
       operatorId,
-      renterId: input.renterId,
+      renterId,
       classId,
       requestedVehicleId: input.requestedVehicleId,
       assignedVehicleId,

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -62,9 +62,12 @@ export class BookingCreationService {
     //    createWalkInRenter ALWAYS makes a fresh renter (never deduped by phone),
     //    so a booking can't be attached to — nor the existence probed of — another
     //    tenant's customer (#396/#475). The walk-in IS the authorization, so it
-    //    skips the scope check below. Created pre-tx: a rare failed booking orphans
-    //    a childless renter, which is invisible (no booking => never in operator
-    //    scope) — YAGNI vs widening TransactionRepos with a userRepo for this.
+    //    skips the scope check below. Created pre-tx (NOT atomic): a failed booking
+    //    (409 double-book / exhausted code-retries) orphans a childless renter. It
+    //    has no operatorId so it can't be mis-scoped, but it IS reachable via the
+    //    operator customer-search, and a retry-on-409 mints a new one each attempt.
+    //    Accepted as low-severity data noise here; atomic creation (userRepo in the
+    //    booking tx) is tracked as #875.
     //  - EXISTING renter (1b): operator authz is scope-FIRST — membership IS the
     //    authorization + existence check; any out-of-scope id returns a uniform
     //    403 WITHOUT touching the user table (no enumeration oracle). Staff/bypass

--- a/packages/api/src/services/booking-types.ts
+++ b/packages/api/src/services/booking-types.ts
@@ -13,7 +13,14 @@ export interface CreateBookingInput {
   // Selected paid add-on ids (#460). Required at the service boundary (the
   // validator defaults it to []); the route forwards parsed.data.addOnIds.
   addOnIds: string[]
+  // The booking's renter — the route always fills it: the authenticated caller for
+  // a self-serve booking, or a target renter for a staff/operator manual booking.
+  // For a walk-in (#589 1c) it is ignored: walkInCustomer takes over and the
+  // service creates + uses a fresh renter instead.
   renterId: string
+  // #589 1c: operator walk-in — create a fresh renter (name + phone, no email)
+  // and book for them. The service resolves this to the concrete renterId it uses.
+  walkInCustomer?: { name: string; phone: string }
   startAt: Date
   endAt: Date
   source: Booking['source']

--- a/packages/api/tests/routes/operator-user-isolation.test.ts
+++ b/packages/api/tests/routes/operator-user-isolation.test.ts
@@ -383,4 +383,74 @@ describe('#396 — OPERATOR_* cannot enumerate users via any current ingress', (
     expect(body.data.renterId).toBe(OWN_RENTER_ID)
     expect(body.data.source).toBe('MANUAL')
   })
+
+  it('operator walk-in booking creates a fresh RENTER and books for them (#589 1c, source=MANUAL)', async () => {
+    // A brand-new walk-in/phone customer the operator registers inline: no prior
+    // booking, no renterId — the walk-in itself is the authorization.
+    const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
+    const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
+
+    const res = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await operatorBearer(SELF_ID)) },
+      body: JSON.stringify({
+        requestedVehicleId: vehicle.id,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        walkInCustomer: { name: 'Hanako Tourist', phone: '+81-90-0000-1111' },
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        source: 'MANUAL',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: { renterId: string; source: string } }
+    expect(body.data.source).toBe('MANUAL')
+    // A brand-new renter — not the operator, not any seeded user.
+    expect(body.data.renterId).not.toBe(SELF_ID)
+    expect([OWN_RENTER_ID, FOREIGN_ID]).not.toContain(body.data.renterId)
+    const [created] = await userRepo.findByIds([body.data.renterId])
+    expect(created?.role).toBe('RENTER')
+    expect(created?.name).toBe('Hanako Tourist')
+    expect(created?.phone).toBe('+81-90-0000-1111')
+  })
+
+  it('walk-in never attaches to an existing phone holder — fresh row even on a phone match (#396/#475)', async () => {
+    // An existing renter (think: ANOTHER tenant's customer) already has this phone.
+    // A walk-in with the SAME phone must NOT dedup onto them — that would attach a
+    // booking to a foreign user and leak that the phone exists.
+    const SHARED_PHONE = '+81-90-9999-0000'
+    const existing = await userRepo.quickCreate({
+      name: 'Existing Person',
+      email: null,
+      phone: SHARED_PHONE,
+      language: 'en',
+    })
+
+    const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
+    const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
+    const res = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await operatorBearer(SELF_ID)) },
+      body: JSON.stringify({
+        requestedVehicleId: vehicle.id,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        walkInCustomer: { name: 'Different Person', phone: SHARED_PHONE },
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        source: 'MANUAL',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: { renterId: string } }
+    expect(body.data.renterId).not.toBe(existing.id) // fresh row, no dedup-attach
+    const [created] = await userRepo.findByIds([body.data.renterId])
+    expect(created?.name).toBe('Different Person')
+    // The pre-existing phone holder is untouched.
+    const [foreign] = await userRepo.findByIds([existing.id])
+    expect(foreign?.name).toBe('Existing Person')
+  })
 })

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -23,6 +23,18 @@ export const createBookingSchema = z
     // Staff-override path only: book on behalf of a renter (#314). Non-staff
     // routes ignore this and use the authenticated user.
     renterId: z.string().uuid('Renter ID must be a valid UUID').optional(),
+    // #589 1c: operator walk-in path — book for a brand-new customer inline by
+    // name + phone. NO email field by design: email is globally unique, so a
+    // create-by-email would leak whether an address already exists (#396/#475);
+    // phone → synthetic placeholder email avoids the oracle. Used in place of
+    // renterId (mutually exclusive — see refine below); the service creates a
+    // fresh renter and books atomically.
+    walkInCustomer: z
+      .object({
+        name: z.string().trim().min(1, 'Name is required'),
+        phone: z.string().trim().min(1, 'Phone is required'),
+      })
+      .optional(),
     startAt: z.string().datetime({ message: 'Must be ISO datetime' }),
     endAt: z.string().datetime({ message: 'Must be ISO datetime' }),
     notes: z.string().optional(),
@@ -38,6 +50,13 @@ export const createBookingSchema = z
   .refine((data) => new Date(data.endAt) > new Date(data.startAt), {
     message: 'End time must be after start time',
     path: ['endAt'],
+  })
+  // #589 1c: renterId (book for an existing customer) and walkInCustomer (create
+  // a brand-new one inline) are two mutually exclusive customer sources — never
+  // both on one request.
+  .refine((data) => !(data.renterId && data.walkInCustomer), {
+    message: 'Provide either renterId or walkInCustomer, not both',
+    path: ['walkInCustomer'],
   })
 
 export const updateBookingStatusSchema = z.object({

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -28,7 +28,7 @@ export const createBookingSchema = z
     // create-by-email would leak whether an address already exists (#396/#475);
     // phone → synthetic placeholder email avoids the oracle. Used in place of
     // renterId (mutually exclusive — see refine below); the service creates a
-    // fresh renter and books atomically.
+    // fresh renter, then books (pre-tx ordering / orphan tradeoff: #875).
     walkInCustomer: z
       .object({
         name: z.string().trim().min(1, 'Name is required'),

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -153,6 +153,63 @@ describe('updateBookingStatusSchema', () => {
 
 // Paid add-ons (#460): the renter selects 0+ of the operator's active add-ons in
 // the wizard. The server validates each against the operator + snapshots them.
+describe('createBookingSchema walk-in customer (#589 1c)', () => {
+  const base = {
+    requestedVehicleId: VALID_UUID,
+    pickupLocationId: PICKUP_UUID,
+    dropoffLocationId: DROPOFF_UUID,
+    startAt: '2026-04-10T09:00:00Z',
+    endAt: '2026-04-10T17:00:00Z',
+  }
+
+  it('accepts an inline walk-in customer (name + phone) in place of renterId', () => {
+    const result = createBookingSchema.safeParse({
+      ...base,
+      source: 'MANUAL',
+      walkInCustomer: { name: 'Taro Yamada', phone: '+81-90-1234-5678' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.walkInCustomer).toEqual({
+        name: 'Taro Yamada',
+        phone: '+81-90-1234-5678',
+      })
+      expect(result.data.renterId).toBeUndefined()
+    }
+  })
+
+  it('rejects renterId and walkInCustomer together (one customer source, not both)', () => {
+    const result = createBookingSchema.safeParse({
+      ...base,
+      source: 'MANUAL',
+      renterId: RENTER_UUID,
+      walkInCustomer: { name: 'Taro Yamada', phone: '+81-90-1234-5678' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('strips an email injected into walkInCustomer (no create-by-email oracle)', () => {
+    const result = createBookingSchema.safeParse({
+      ...base,
+      source: 'MANUAL',
+      walkInCustomer: { name: 'Taro', phone: '+81-90-1234-5678', email: 'probe@victim.com' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.walkInCustomer).not.toHaveProperty('email')
+    }
+  })
+
+  it('requires a non-empty phone on a walk-in customer', () => {
+    const result = createBookingSchema.safeParse({
+      ...base,
+      source: 'MANUAL',
+      walkInCustomer: { name: 'Taro', phone: '  ' },
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
 describe('createBookingSchema addOnIds (#460)', () => {
   const validInput = {
     requestedVehicleId: VALID_UUID,

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -188,6 +188,17 @@ describe('createBookingSchema walk-in customer (#589 1c)', () => {
     expect(result.success).toBe(false)
   })
 
+  // The mutual-exclusion refine blocks BOTH sources; it must still permit NEITHER —
+  // that is the renter self-serve case (the route defaults renterId to ctx.userId).
+  it('accepts neither renterId nor walkInCustomer (renter self-serve books as themselves)', () => {
+    const result = createBookingSchema.safeParse({ ...base, source: 'DIRECT' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.renterId).toBeUndefined()
+      expect(result.data.walkInCustomer).toBeUndefined()
+    }
+  })
+
   it('strips an email injected into walkInCustomer (no create-by-email oracle)', () => {
     const result = createBookingSchema.safeParse({
       ...base,


### PR DESCRIPTION
Part of #589 (operator manual booking, Slice E of #525); follows #865 (existing-customer API slice).

## What
Lets an operator book a brand-new **walk-in** customer in one `POST /bookings` via `walkInCustomer {name, phone}` (no `renterId`). The service creates an always-fresh RENTER inline, then runs normal booking creation.

## How
- **Schema** (`createBookingSchema`): optional `walkInCustomer {name, phone}` — deliberately **no email** (email is globally unique → a create-by-email would leak whether an address already exists, #396/#475). `.refine` makes it mutually exclusive with `renterId`.
- **Service** (`booking-creation.create`): walk-in → new `UserRepository.createWalkInRenter` (drizzle + in-memory) = always-fresh RENTER (synthetic non-deliverable email, phone NOT deduped, role RENTER). Skips the 1b operator scope check + the renter document-verification gate — the in-person walk-in IS the authorization, verified operationally at pickup. Existing-renter path unchanged.
- **Route**: threads `walkInCustomer` for manual-bookers only (a RENTER/PARTNER forging it is dropped before the service ever sees it).

## Why `createWalkInRenter`, not `quickCreate`
In-memory `quickCreate` dedups by phone; drizzle does not. Reusing it would be secure in prod but insecure in tests (divergent behavior). The explicit always-fresh `createWalkInRenter` guarantees no cross-tenant attach on either backend.

## Review
Code-reviewed **SHIP-WITH-FIXES**. The three security-critical surfaces are confirmed airtight: authz bypass (forged `walkInCustomer` dropped for non-manual-bookers; doc gate still fires for renters), cross-tenant attach (bare insert, no dedup), synthetic-email oracle (non-deliverable UUID `.local`).

Fixes applied in `52a2fc2f`:
- Corrected misleading comments — a failed-booking orphan renter is **not** "invisible": it's reachable via operator customer-search and retry-on-409 mints a new one each attempt.
- Added the "neither source → valid (self-serve)" validator test (pins that the mutual-exclusion refine blocks both sources but permits neither).

Deferred: **#875** — make walk-in renter creation atomic with the booking tx (currently pre-tx → rare orphan on booking failure; MEDIUM, data-quality only, not security/correctness).

## Verify
api 1514/1514 · shared 562/562 · typecheck 0 · husky (biome/size/boundaries/tsc) green · merged latest trunk (incl. #867 pricing hoist), clean.

## Review note
⚠️ Security-sensitive (creates user accounts + bypasses an authz gate). **Owner-review-gated — please do not `--admin` merge.**