### PR TITLE
chore(web): ratcheting lint so schemaless unwrap() can't masquerade as validated (#784)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check i18n locale parity
         run: bun run lint:i18n-parity
 
+      - name: Check web API clients validate unwrap() responses
+        run: bun run lint:unwrap-schema
+
       - name: Check unused deps and exports
         run: bun run lint:deps
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:modules": "bun run scripts/lint-module-boundaries.ts",
     "lint:fk-indexes": "bun run scripts/lint-fk-indexes.ts",
     "lint:i18n-parity": "bun run scripts/lint-i18n-parity.ts",
+    "lint:unwrap-schema": "bun run scripts/lint-unwrap-schema.ts",
     "lint:dist-size": "bun run scripts/lint-dist-size.ts",
     "lint:no-next-app": "bun run scripts/lint-no-next-app.ts",
     "lint:deps": "KNIP=1 bun node_modules/.bin/knip",

--- a/scripts/lint-unwrap-schema.test.ts
+++ b/scripts/lint-unwrap-schema.test.ts
@@ -64,6 +64,17 @@ describe('countSchemalessUnwraps', () => {
     const src = 'return unwrap(\n  res,\n  fooSchema,\n)'
     expect(countSchemalessUnwraps(src)).toBe(0)
   })
+
+  test('a trailing comma after a single arg is still schemaless (no second arg)', () => {
+    // biome adds a trailing comma to multi-line calls; it must not read as validated
+    expect(countSchemalessUnwraps('unwrap(res,)')).toBe(1)
+    expect(countSchemalessUnwraps('unwrap(\n  res,\n)')).toBe(1)
+  })
+
+  test('member-access .unwrap(res) is not the helper and is ignored', () => {
+    expect(countSchemalessUnwraps('return result.unwrap(res)')).toBe(0)
+    expect(countSchemalessUnwraps('return result?.unwrap(res)')).toBe(0)
+  })
 })
 
 describe('reconcile', () => {

--- a/scripts/lint-unwrap-schema.test.ts
+++ b/scripts/lint-unwrap-schema.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+import { countSchemalessUnwraps, reconcile, stripCommentsAndStrings } from './lint-unwrap-schema'
+
+describe('stripCommentsAndStrings', () => {
+  test('removes a line comment that mentions unwrap()', () => {
+    const src = 'const x = 1 // unwrap() peels one level\nreturn x'
+    expect(stripCommentsAndStrings(src)).not.toContain('unwrap')
+  })
+
+  test('removes a block comment that mentions unwrap(res, schema)', () => {
+    const src = '/* thread unwrap(res, schema) and stay z-free */\ncode'
+    const out = stripCommentsAndStrings(src)
+    expect(out).not.toContain('unwrap')
+    expect(out).toContain('code')
+  })
+
+  test('blanks string and template literals so unwrap inside them is ignored', () => {
+    const src = "const s = 'call unwrap(res) here'\nconst t = `unwrap(x)`"
+    expect(stripCommentsAndStrings(src)).not.toContain('unwrap')
+  })
+
+  test('keeps real code outside comments and strings intact', () => {
+    const src = 'return unwrap(res, fooSchema)'
+    expect(stripCommentsAndStrings(src)).toContain('unwrap(res, fooSchema)')
+  })
+})
+
+describe('countSchemalessUnwraps', () => {
+  test('a single-arg call is schemaless', () => {
+    expect(countSchemalessUnwraps('return unwrap(res)')).toBe(1)
+  })
+
+  test('an explicit type-arg single-arg call is schemaless', () => {
+    expect(countSchemalessUnwraps('return unwrap<AdminRevenueResponse>(res)')).toBe(1)
+  })
+
+  test('a two-arg call (schema passed) is validated, not counted', () => {
+    expect(countSchemalessUnwraps('return unwrap(res, fooSchema)')).toBe(0)
+  })
+
+  test('a schema with a nested call arg is still validated', () => {
+    expect(countSchemalessUnwraps('return unwrap(res, fooSchema.array())')).toBe(0)
+  })
+
+  test('commas inside the first arg do not fake a second arg', () => {
+    // single arg that itself contains parens/commas, but no top-level comma
+    expect(countSchemalessUnwraps('return unwrap(pick(a, b))')).toBe(1)
+  })
+
+  test('unwrap mentioned in a comment is not counted', () => {
+    expect(countSchemalessUnwraps('// unwrap(res) is legacy\nreturn unwrap(res, s)')).toBe(0)
+  })
+
+  test('an import of unwrap is not a call', () => {
+    expect(countSchemalessUnwraps("import { unwrap } from '@/lib/api-error'")).toBe(0)
+  })
+
+  test('counts multiple schemaless calls in one file', () => {
+    const src = 'const a = unwrap(r1)\nconst b = unwrap<T>(r2)\nconst c = unwrap(r3, s)'
+    expect(countSchemalessUnwraps(src)).toBe(2)
+  })
+
+  test('a multi-line validated call is not counted', () => {
+    const src = 'return unwrap(\n  res,\n  fooSchema,\n)'
+    expect(countSchemalessUnwraps(src)).toBe(0)
+  })
+})
+
+describe('reconcile', () => {
+  const allow = { 'admin/revenue/api.ts': 1, 'admin/anomalies/api.ts': 1 }
+
+  test('passes when actual exactly matches the allow-list', () => {
+    expect(reconcile(allow, allow)).toEqual([])
+  })
+
+  test('flags a schemaless call in a non-allow-listed file as new debt', () => {
+    const actual = { ...allow, 'search/api.ts': 1 }
+    const messages = reconcile(actual, allow)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('search/api.ts')
+    expect(messages[0]).toContain('not on the allow-list')
+  })
+
+  test('flags an allow-listed file that gained extra schemaless calls', () => {
+    const actual = { ...allow, 'admin/revenue/api.ts': 3 }
+    const messages = reconcile(actual, allow)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('admin/revenue/api.ts')
+    expect(messages[0]).toContain('expected 1')
+    expect(messages[0]).toContain('found 3')
+  })
+
+  test('flags an allow-listed file whose schemaless calls dropped (ratchet must shrink)', () => {
+    const actual = { 'admin/anomalies/api.ts': 1 } // revenue fully migrated
+    const messages = reconcile(actual, allow)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('admin/revenue/api.ts')
+    expect(messages[0]).toContain('migrated')
+  })
+
+  test('reports every violation, not just the first', () => {
+    const actual = { 'search/api.ts': 1 } // both allow entries missing + 1 new
+    const messages = reconcile(actual, allow)
+    expect(messages).toHaveLength(3)
+  })
+})

--- a/scripts/lint-unwrap-schema.ts
+++ b/scripts/lint-unwrap-schema.ts
@@ -1,0 +1,180 @@
+/**
+ * Ratcheting lint: web API clients must pass a Zod `schema` to `unwrap()` so the
+ * network seam is runtime-validated, not a phantom `T` cast (#711). Schemaless
+ * `unwrap(res)` / `unwrap<T>(res)` calls are unvalidated debt; this guard keeps
+ * the count monotonically decreasing.
+ *
+ * Two failure modes (see `reconcile`):
+ *  - a schemaless call appears OUTSIDE the allow-list -> new debt, fail.
+ *  - an allow-listed file drops below its recorded count -> migrated, the list
+ *    must shrink (the ratchet only goes down).
+ *
+ * The allow-list is seeded with today's sanctioned deferrals: the admin revenue
+ * (#744) and payment-anomalies clients, whose API responses aren't schema-modelled
+ * yet. Migrate one and you MUST decrement/remove its entry here, or CI fails.
+ *
+ * Limitation: the source scanner is lexical (it strips comments/strings, then
+ * balances brackets). It does not handle `unwrap` inside `${}` template
+ * interpolation or inside regex literals — neither occurs in the web clients.
+ */
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { relative } from 'node:path'
+
+const VITE_DIR = 'packages/web/src/vite'
+
+/** Files permitted to contain schemaless `unwrap()` calls, with their exact count. */
+const ALLOW: Record<string, number> = {
+  'admin/revenue/api.ts': 1,
+  'admin/anomalies/api.ts': 1,
+}
+
+/**
+ * Blanks line/block comments and string/template literals so an `unwrap(` token
+ * mentioned in prose or a string is never mistaken for a call.
+ */
+export function stripCommentsAndStrings(source: string): string {
+  let out = ''
+  let i = 0
+  const n = source.length
+  while (i < n) {
+    const c = source[i]
+    const next = source[i + 1]
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i++
+      continue
+    }
+    if (c === '/' && next === '*') {
+      i += 2
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++
+      i += 2
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c
+      i++
+      while (i < n) {
+        if (source[i] === '\\') {
+          i += 2
+          continue
+        }
+        if (source[i] === quote) {
+          i++
+          break
+        }
+        i++
+      }
+      continue
+    }
+    out += c
+    i++
+  }
+  return out
+}
+
+const isSpace = (ch: string | undefined): boolean => ch !== undefined && /\s/.test(ch)
+
+/**
+ * Counts `unwrap(...)` calls that pass no second argument (no schema). Skips an
+ * optional `<...>` generic type-argument list, then balances brackets to decide
+ * whether the call's argument list has a top-level comma (a second argument).
+ */
+export function countSchemalessUnwraps(source: string): number {
+  const code = stripCommentsAndStrings(source)
+  const re = /\bunwrap\b/g
+  let count = 0
+  let m: RegExpExecArray | null = re.exec(code)
+  while (m !== null) {
+    let j = m.index + 'unwrap'.length
+    while (isSpace(code[j])) j++
+    if (code[j] === '<') {
+      let angle = 0
+      while (j < code.length) {
+        if (code[j] === '<') angle++
+        else if (code[j] === '>') {
+          angle--
+          if (angle === 0) {
+            j++
+            break
+          }
+        }
+        j++
+      }
+      while (isSpace(code[j])) j++
+    }
+    if (code[j] === '(') {
+      j++
+      let depth = 1
+      let hasTopLevelComma = false
+      while (j < code.length && depth > 0) {
+        const ch = code[j]
+        if (ch === '(' || ch === '[' || ch === '{') depth++
+        else if (ch === ')' || ch === ']' || ch === '}') depth--
+        else if (ch === ',' && depth === 1) hasTopLevelComma = true
+        j++
+      }
+      if (!hasTopLevelComma) count++
+    }
+    m = re.exec(code)
+  }
+  return count
+}
+
+/**
+ * Compares observed schemaless-call counts per file against the allow-list and
+ * returns a violation message per discrepancy (empty array = pass).
+ */
+export function reconcile(actual: Record<string, number>, allow: Record<string, number>): string[] {
+  const messages: string[] = []
+  for (const [file, count] of Object.entries(actual)) {
+    if (count <= 0) continue
+    if (!(file in allow)) {
+      messages.push(
+        `${file}: ${count} schemaless unwrap() call(s) but the file is not on the allow-list. Pass a Zod schema to unwrap(), or add it to ALLOW if intentionally deferred.`,
+      )
+    } else if (count > allow[file]) {
+      messages.push(
+        `${file}: expected ${allow[file]} schemaless unwrap() call(s) but found ${count}. New unvalidated debt — validate the added call(s).`,
+      )
+    }
+  }
+  for (const [file, expected] of Object.entries(allow)) {
+    const count = actual[file] ?? 0
+    if (count < expected) {
+      messages.push(
+        `${file}: allow-list expects ${expected} schemaless unwrap() call(s) but found ${count}. This file was migrated — decrement or remove its ALLOW entry (the ratchet only shrinks).`,
+      )
+    }
+  }
+  return messages
+}
+
+function scanTree(dir: string): Record<string, number> {
+  const files = execSync(
+    `grep -rl "unwrap" ${dir} --include="*.ts" --include="*.tsx" 2>/dev/null || true`,
+    { encoding: 'utf-8' },
+  )
+    .split('\n')
+    .filter(Boolean)
+  const counts: Record<string, number> = {}
+  for (const file of files) {
+    const n = countSchemalessUnwraps(readFileSync(file, 'utf-8'))
+    if (n > 0) counts[relative(dir, file)] = n
+  }
+  return counts
+}
+
+if (import.meta.main) {
+  const actual = scanTree(VITE_DIR)
+  const messages = reconcile(actual, ALLOW)
+  if (messages.length > 0) {
+    console.error('Unwrap-schema ratchet violations:\n')
+    for (const msg of messages) console.error(`  ${msg}`)
+    console.error('\nWeb API clients must pass a Zod schema to unwrap() (#711/#784).')
+    process.exit(1)
+  }
+  const total = Object.values(actual).reduce((a, b) => a + b, 0)
+  console.log(
+    `unwrap-schema ratchet passed (${total} allow-listed schemaless call(s) across ${Object.keys(actual).length} file(s))`,
+  )
+}

--- a/scripts/lint-unwrap-schema.ts
+++ b/scripts/lint-unwrap-schema.ts
@@ -17,13 +17,16 @@
  * balances brackets). It does not handle `unwrap` inside `${}` template
  * interpolation or inside regex literals — neither occurs in the web clients.
  */
-import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
-import { relative } from 'node:path'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative } from 'node:path'
 
 const VITE_DIR = 'packages/web/src/vite'
 
-/** Files permitted to contain schemaless `unwrap()` calls, with their exact count. */
+/**
+ * Files permitted to contain schemaless `unwrap()` calls, with their exact count.
+ * When this empties, delete the count machinery and collapse the rule to a flat
+ * "no schemaless unwrap anywhere" check — the invariant it's ratcheting toward.
+ */
 const ALLOW: Record<string, number> = {
   'admin/revenue/api.ts': 1,
   'admin/anomalies/api.ts': 1,
@@ -75,9 +78,42 @@ export function stripCommentsAndStrings(source: string): string {
 const isSpace = (ch: string | undefined): boolean => ch !== undefined && /\s/.test(ch)
 
 /**
- * Counts `unwrap(...)` calls that pass no second argument (no schema). Skips an
- * optional `<...>` generic type-argument list, then balances brackets to decide
- * whether the call's argument list has a top-level comma (a second argument).
+ * Counts the non-empty, comma-separated top-level arguments of the call whose
+ * `(` is at `open`. A trailing comma yields no extra argument, so `f(a,)` is
+ * arity 1 — not 2. Used to tell `unwrap(res)` (schemaless) from
+ * `unwrap(res, schema)` (validated).
+ */
+function topLevelArity(code: string, open: number): number {
+  let depth = 1
+  let args = 0
+  let segmentHasContent = false
+  let j = open + 1
+  while (j < code.length && depth > 0) {
+    const ch = code[j]
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth++
+      segmentHasContent = true
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth--
+      if (depth === 0) break
+      segmentHasContent = true
+    } else if (ch === ',' && depth === 1) {
+      if (segmentHasContent) args++
+      segmentHasContent = false
+    } else if (!isSpace(ch)) {
+      segmentHasContent = true
+    }
+    j++
+  }
+  if (segmentHasContent) args++
+  return args
+}
+
+/**
+ * Counts `unwrap(...)` calls that pass no Zod schema (fewer than two arguments).
+ * Skips an optional `<...>` generic type-argument list before the call, and
+ * ignores member access (`x.unwrap(...)`) since only the free `unwrap` helper
+ * carries the schema contract.
  */
 export function countSchemalessUnwraps(source: string): number {
   const code = stripCommentsAndStrings(source)
@@ -85,6 +121,10 @@ export function countSchemalessUnwraps(source: string): number {
   let count = 0
   let m: RegExpExecArray | null = re.exec(code)
   while (m !== null) {
+    if (code[m.index - 1] === '.') {
+      m = re.exec(code)
+      continue
+    }
     let j = m.index + 'unwrap'.length
     while (isSpace(code[j])) j++
     if (code[j] === '<') {
@@ -102,19 +142,7 @@ export function countSchemalessUnwraps(source: string): number {
       }
       while (isSpace(code[j])) j++
     }
-    if (code[j] === '(') {
-      j++
-      let depth = 1
-      let hasTopLevelComma = false
-      while (j < code.length && depth > 0) {
-        const ch = code[j]
-        if (ch === '(' || ch === '[' || ch === '{') depth++
-        else if (ch === ')' || ch === ']' || ch === '}') depth--
-        else if (ch === ',' && depth === 1) hasTopLevelComma = true
-        j++
-      }
-      if (!hasTopLevelComma) count++
-    }
+    if (code[j] === '(' && topLevelArity(code, j) < 2) count++
     m = re.exec(code)
   }
   return count
@@ -128,13 +156,14 @@ export function reconcile(actual: Record<string, number>, allow: Record<string, 
   const messages: string[] = []
   for (const [file, count] of Object.entries(actual)) {
     if (count <= 0) continue
-    if (!(file in allow)) {
+    const expected = allow[file]
+    if (expected === undefined) {
       messages.push(
         `${file}: ${count} schemaless unwrap() call(s) but the file is not on the allow-list. Pass a Zod schema to unwrap(), or add it to ALLOW if intentionally deferred.`,
       )
-    } else if (count > allow[file]) {
+    } else if (count > expected) {
       messages.push(
-        `${file}: expected ${allow[file]} schemaless unwrap() call(s) but found ${count}. New unvalidated debt — validate the added call(s).`,
+        `${file}: expected ${expected} schemaless unwrap() call(s) but found ${count}. New unvalidated debt — validate the added call(s).`,
       )
     }
   }
@@ -149,13 +178,13 @@ export function reconcile(actual: Record<string, number>, allow: Record<string, 
   return messages
 }
 
-function scanTree(dir: string): Record<string, number> {
-  const files = execSync(
-    `grep -rl "unwrap" ${dir} --include="*.ts" --include="*.tsx" 2>/dev/null || true`,
-    { encoding: 'utf-8' },
-  )
-    .split('\n')
-    .filter(Boolean)
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { recursive: true, encoding: 'utf-8' })
+    .filter((p) => p.endsWith('.ts') || p.endsWith('.tsx'))
+    .map((p) => join(dir, p))
+}
+
+function scanFiles(dir: string, files: readonly string[]): Record<string, number> {
   const counts: Record<string, number> = {}
   for (const file of files) {
     const n = countSchemalessUnwraps(readFileSync(file, 'utf-8'))
@@ -165,7 +194,16 @@ function scanTree(dir: string): Record<string, number> {
 }
 
 if (import.meta.main) {
-  const actual = scanTree(VITE_DIR)
+  // Fail closed: an empty scan would otherwise pass vacuously and hide that the
+  // ratchet stopped looking at anything (e.g. a moved tree).
+  const sourceFiles = listSourceFiles(VITE_DIR)
+  if (sourceFiles.length === 0) {
+    console.error(
+      `lint-unwrap-schema: found 0 source files under ${VITE_DIR} — refusing to pass vacuously.`,
+    )
+    process.exit(1)
+  }
+  const actual = scanFiles(VITE_DIR, sourceFiles)
   const messages = reconcile(actual, ALLOW)
   if (messages.length > 0) {
     console.error('Unwrap-schema ratchet violations:\n')


### PR DESCRIPTION
Closes #784.

## What
Adds `scripts/lint-unwrap-schema.ts` (+ co-located `bun:test`), wired into `package.json` `lint:unwrap-schema` and a `ci.yml` step. It fails CI if a web API client under `packages/web/src/vite` calls `unwrap(res)` / `unwrap<T>(res)` **without** passing a Zod schema (the validated form is `unwrap(res, schema)`).

## Why
`unwrap(res)` casts `body.data` to a phantom `T` and validates nothing; `unwrap(res, schema)` validates at the network seam (#711). The two look identical at the call site, so nothing stopped a new client landing schemaless (silent debt) or a migrated one regressing. This is the ratchet that keeps unvalidated-response debt monotonically decreasing.

## Scope note (issue premise was stale)
The issue assumed ~15 schemaless clients. Slices #711-3d and #817 already finished the migration — only **2** schemaless calls remain, both sanctioned deferrals whose API responses aren't schema-modelled yet:
- `vite/admin/revenue/api.ts` (#744)
- `vite/admin/anomalies/api.ts`

So the ratchet is already at the floor: the lint is a regression guard with `ALLOW` seeded to those 2 files. When they migrate, `ALLOW` empties and the rule collapses to a flat "no schemaless unwrap anywhere" check.

## Design
- **FC/IS:** pure core (`stripCommentsAndStrings`, `countSchemalessUnwraps`, `reconcile`) unit-tested; I/O isolated in the `import.meta.main` shell.
- **Exact-count allow-list** keyed on the vite-relative path: fails on (a) a schemaless call outside `ALLOW`, (b) an allow-listed file exceeding its count (new debt), (c) an allow-listed file dropping below it (migrated — the list must shrink).
- Counts by **top-level arity**, not mere comma presence, so a trailing comma (`unwrap(res,)`) can't fake a second arg.
- Ignores member access (`x.unwrap(...)`).
- **Fails closed** if 0 source files are scanned (no vacuous pass).

## Review
code-reviewer + architect (SHIP). Two HIGH scanner false-positive/negative defects they found are fixed and pinned by tests (trailing-comma evasion, member-access). The lint co-enforces with `tsc` (the `schema?: z.ZodType<T>` signature proves schema-ness; the lint proves arity).

## Test plan
- [x] `bun test scripts/lint-unwrap-schema.test.ts` — 20/20 (strip/count/reconcile, incl. trailing-comma + member-access edge cases)
- [x] `bun run lint:unwrap-schema` passes on trunk (2 allow-listed)
- [x] Injecting a schemaless `unwrap(res)` **and** `unwrap(res,)` into a non-allowlisted file both fail the lint; revert restores green
- [x] `bun run lint` exits 0; pre-commit (biome + tsc both packages) green