### PR TITLE
fix(api): harden R2PhotoStorage.delete key recovery (exact URL parsing)

### DIFF
--- a/docs/plans/2026-06-15-issue-678-photo-url-to-key-migration.md
+++ b/docs/plans/2026-06-15-issue-678-photo-url-to-key-migration.md
@@ -1,0 +1,28 @@
+# #678 — Decision: defer key-only photo persistence; ship the delete-parse hardening
+
+**Date:** 2026-06-15
+**Issue:** #678 · **Branch/worktree:** `feat/678-photo-key-migration` · `~/Dev/kuruma-678-photo-key`
+**Status:** DECIDED — deferred. One small hardening shipped on this branch.
+
+## What happened
+A first pass proposed migrating `vehicles.photos` / `vehicle_classes.photos` from full URLs to object **keys** ("store the key, derive the URL at read"). A code review (and verification against the code) showed that framing was too simple:
+
+- Both validators are `z.string().url()` — a bare key **fails validation**; create/update spread `photos` straight to the DB (`updateVehicleSchema`), and web `VehicleForm.tsx:95` round-trips `vehicle.photos`. So generic write paths reintroduce URLs.
+- No single serialization boundary — `/vehicles`, `/vehicles/:id`, fleet-overview, detail, booking-query, storefront/flat-search, and write responses all emit `photos` raw. Keys would leak to the operator UI.
+- Delete under mixed key/URL rows silently no-ops.
+- **The contract is "a list of image URLs" — and external URLs are valid.** So the column cannot be "pure key" without modeling source (R2 key vs external URL).
+
+## Decision
+**Defer the key-only persistence.** For a sole-proprietor beta with ~zero photo data and no bucket/domain move planned, the env-coupling is a speculative cost and the back-fill is just as trivial later as now (YAGNI/KISS). Doing it correctly is a real design — modeling `PhotoRef = { source:'r2', key } | { source:'external', url }` with one serializer across all surfaces — tracked in **#879**.
+
+- `vehicles.photos` / `vehicle_classes.photos` stay URL arrays for beta. No schema/data migration.
+- #678's architecture decision (R2; public/private; key-only target) is recorded and R2 is enabled (#869). #678 can close, with #879 carrying the deferred persistence work.
+
+## Shipped on this branch (the one thing worth doing now)
+Hardened `R2PhotoStorage.delete()` (review finding F4): replaced loose `startsWith(publicBaseUrl)` + `slice(len+1)` with exact URL parsing via a pure `toObjectKey(keyOrUrl, base)` helper.
+- Fixes a trailing-slash base eating a key character, and a look-alike host (`…com.evil/…`) being mis-sliced into a bogus key.
+- New `packages/api/tests/repositories/r2-photo-storage.test.ts` (7 tests, TDD: 2 red → green). Full API suite 1519 green, typecheck clean.
+
+## Follow-ups
+- **#879** — model photo source (PhotoRef); the real key-only work + the review's F1/F2/F3.
+- Private renter-document signed URLs (`R2DocumentStorage.getSignedUrl` still throws) — #459 track, needs an R2 S3 SigV4 token (HITL).

--- a/packages/api/src/repositories/r2-photo-storage.ts
+++ b/packages/api/src/repositories/r2-photo-storage.ts
@@ -17,6 +17,37 @@ const EXT_MAP: Record<string, string> = {
   'image/avif': 'avif',
 }
 
+/**
+ * Recover the object key from either a bare key or one of our public URLs.
+ *
+ * Exact origin + base-path matching via URL parsing — NOT a loose string
+ * prefix. A raw `startsWith(publicBaseUrl)` mis-handled a base with a trailing
+ * slash (sliced one character into the key) and a look-alike host
+ * (`https://cdn.example.com.evil/...` satisfies `startsWith` and got
+ * mis-sliced). Anything that isn't one of our public URLs — a bare key, an
+ * external URL, a different origin — is returned untouched and treated as a key
+ * (a no-op delete in R2). See #678 review.
+ */
+export function toObjectKey(keyOrUrl: string, publicBaseUrl: string): string {
+  let target: URL
+  try {
+    target = new URL(keyOrUrl)
+  } catch {
+    return keyOrUrl // relative value — already a key
+  }
+  let base: URL
+  try {
+    base = new URL(publicBaseUrl)
+  } catch {
+    return keyOrUrl // base not a URL (e.g. empty in dev) — can't be our URL
+  }
+  if (target.origin !== base.origin) return keyOrUrl
+  const basePath = base.pathname.replace(/\/+$/, '') // '' or '/sub'
+  const prefix = `${basePath}/`
+  if (!target.pathname.startsWith(prefix)) return keyOrUrl
+  return target.pathname.slice(prefix.length)
+}
+
 export class R2PhotoStorage implements PhotoStorage {
   constructor(
     private readonly bucket: R2BucketLike,
@@ -39,9 +70,6 @@ export class R2PhotoStorage implements PhotoStorage {
   }
 
   async delete(keyOrUrl: string): Promise<void> {
-    const key = keyOrUrl.startsWith(this.publicBaseUrl)
-      ? keyOrUrl.slice(this.publicBaseUrl.length + 1)
-      : keyOrUrl
-    await this.bucket.delete(key)
+    await this.bucket.delete(toObjectKey(keyOrUrl, this.publicBaseUrl))
   }
 }

--- a/packages/api/tests/repositories/r2-photo-storage.test.ts
+++ b/packages/api/tests/repositories/r2-photo-storage.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { type R2BucketLike, R2PhotoStorage } from '../../src/repositories/r2-photo-storage'
+
+const BASE = 'https://cdn.example.com'
+
+function fakeBucket() {
+  const deleted: string[] = []
+  const bucket: R2BucketLike = {
+    async put() {
+      return undefined
+    },
+    async delete(key) {
+      deleted.push(Array.isArray(key) ? key.join(',') : key)
+    },
+  }
+  return { bucket, deleted }
+}
+
+describe('R2PhotoStorage.put', () => {
+  it('returns the object key and the derived public URL', async () => {
+    const { bucket } = fakeBucket()
+    const file = new File([new ArrayBuffer(8)], 'car.jpg', { type: 'image/jpeg' })
+
+    const { key, url } = await new R2PhotoStorage(bucket, BASE).put('veh-1', file)
+
+    expect(key).toMatch(/^vehicles\/veh-1\/[0-9a-f-]+\.jpg$/)
+    expect(url).toBe(`${BASE}/${key}`)
+  })
+})
+
+describe('R2PhotoStorage.delete — key recovery', () => {
+  it('deletes a bare key unchanged', async () => {
+    const { bucket, deleted } = fakeBucket()
+    await new R2PhotoStorage(bucket, BASE).delete('vehicles/veh-1/abc.jpg')
+    expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
+  })
+
+  it('strips the public base URL to recover the key', async () => {
+    const { bucket, deleted } = fakeBucket()
+    await new R2PhotoStorage(bucket, BASE).delete(`${BASE}/vehicles/veh-1/abc.jpg`)
+    expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
+  })
+
+  it('recovers the key when the configured base has a trailing slash', async () => {
+    const { bucket, deleted } = fakeBucket()
+    await new R2PhotoStorage(bucket, `${BASE}/`).delete(`${BASE}/vehicles/veh-1/abc.jpg`)
+    expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
+  })
+
+  it('does not mis-slice a look-alike host (prefix collision)', async () => {
+    const { bucket, deleted } = fakeBucket()
+    const lookAlike = 'https://cdn.example.com.evil/vehicles/veh-1/abc.jpg'
+    await new R2PhotoStorage(bucket, BASE).delete(lookAlike)
+    // Not our object — passed through untouched, never mis-parsed into a key.
+    expect(deleted).toEqual([lookAlike])
+  })
+
+  it('passes a different-origin (external) URL through untouched', async () => {
+    const { bucket, deleted } = fakeBucket()
+    const external = 'https://images.unsplash.com/photo-123.jpg'
+    await new R2PhotoStorage(bucket, BASE).delete(external)
+    expect(deleted).toEqual([external])
+  })
+
+  it('strips a base that includes a path segment', async () => {
+    const { bucket, deleted } = fakeBucket()
+    await new R2PhotoStorage(bucket, `${BASE}/photos`).delete(
+      `${BASE}/photos/vehicles/veh-1/abc.jpg`,
+    )
+    expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
+  })
+})


### PR DESCRIPTION
Hardens `R2PhotoStorage.delete()` key recovery (#678 review finding F4): replaces the loose `startsWith(publicBaseUrl)` + `slice(len+1)` with a pure `toObjectKey()` helper that parses the URL and matches **origin + base path exactly**.

Fixes:
- a trailing-slash base eating a key character (`ehicles/...`)
- a look-alike host (`...com.evil/...`) satisfying `startsWith` and being mis-sliced into a bogus key

Adds the first tests for `R2PhotoStorage` (7, TDD: 2 red -> green). Full API suite **1519 green**, typecheck clean.

**Context — #678 decision:** the broader "store keys not URLs" migration is **deferred**. `photos` is contractually a list of *image URLs* (validators are `z.string().url()`) incl. external ones, so it needs source modeling, not a key swap (tracked in **#879**). Columns stay URL arrays for beta.

Part of #678.