### PR TITLE
feat(web): renter self-cancellation on booking confirmation (#856)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -857,6 +857,19 @@
       "viewBookings": "View my bookings",
       "backToVehicles": "Browse more vehicles"
     },
+    "cancel": {
+      "action": "Cancel booking",
+      "dialogTitle": "Cancel this booking?",
+      "dialogDescription": "Review the cancellation fee below, then confirm. This can't be undone.",
+      "feeLine": "Cancellation fee: {fee} ({percent}%)",
+      "refundLine": "Estimated refund: {refund}",
+      "noShowNotice": "The pickup time has passed. The full fee ({fee}) applies.",
+      "advisory": "The fee is settled with {operator} at pickup. Nothing is charged online now.",
+      "keep": "Keep booking",
+      "confirm": "Yes, cancel",
+      "pending": "Cancelling…",
+      "error": "We couldn't cancel your booking. Please try again, or contact the operator."
+    },
     "list": {
       "title": "My bookings",
       "subtitle": "Your upcoming and past reservations",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -857,6 +857,19 @@
       "viewBookings": "予約一覧を見る",
       "backToVehicles": "他の車両を見る"
     },
+    "cancel": {
+      "action": "予約をキャンセル",
+      "dialogTitle": "この予約をキャンセルしますか？",
+      "dialogDescription": "下記のキャンセル料をご確認のうえ、確定してください。この操作は取り消せません。",
+      "feeLine": "キャンセル料：{fee}（{percent}%）",
+      "refundLine": "返金見込み：{refund}",
+      "noShowNotice": "受取時刻を過ぎています。全額のキャンセル料（{fee}）が適用されます。",
+      "advisory": "キャンセル料は受取時に {operator} とのあいだで精算されます。オンラインでの請求はありません。",
+      "keep": "予約を維持する",
+      "confirm": "はい、キャンセルします",
+      "pending": "キャンセル中…",
+      "error": "予約をキャンセルできませんでした。もう一度お試しいただくか、オペレーターにご連絡ください。"
+    },
     "list": {
       "title": "予約一覧",
       "subtitle": "今後の予約と過去の予約",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -857,6 +857,19 @@
       "viewBookings": "查看我的预订",
       "backToVehicles": "浏览更多车辆"
     },
+    "cancel": {
+      "action": "取消预订",
+      "dialogTitle": "取消此预订？",
+      "dialogDescription": "请查看下方的取消费用，然后确认。此操作无法撤销。",
+      "feeLine": "取消费用：{fee}（{percent}%）",
+      "refundLine": "预计退款：{refund}",
+      "noShowNotice": "取车时间已过，将收取全额费用（{fee}）。",
+      "advisory": "费用将在取车时与 {operator} 结算，现在不会在线收取。",
+      "keep": "保留预订",
+      "confirm": "确认取消",
+      "pending": "取消中…",
+      "error": "无法取消您的预订。请重试，或联系运营商。"
+    },
     "list": {
       "title": "我的预订",
       "subtitle": "您的即将到来和过去的预订",

--- a/packages/web/src/routes/$locale/_renter/bookings/confirmation.tsx
+++ b/packages/web/src/routes/$locale/_renter/bookings/confirmation.tsx
@@ -1,6 +1,8 @@
 import { BookingConfirmationView } from '@/vite/bookings/BookingConfirmationView'
 import { bookingByIdQueryOptions } from '@/vite/bookings/api'
+import { useSession } from '@/vite/session'
 import { classByIdQueryOptions } from '@/vite/vehicles/classes'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 
 interface ConfirmationSearch {
@@ -34,11 +36,24 @@ export const Route = createFileRoute('/$locale/_renter/bookings/confirmation')({
 })
 
 function BookingConfirmationRoute() {
-  const { booking, vehicleClass } = Route.useLoaderData()
+  const { booking: initialBooking, vehicleClass } = Route.useLoaderData()
+  // Re-read the booking from the query cache the loader warmed, so a successful
+  // self-cancel — which invalidates ['bookings'] — re-renders this page in its
+  // CANCELLED state and drops the cancel control (mirrors the operator trip-detail
+  // page, #616). Loader data is a one-shot snapshot that would stay stale.
+  const { data: booking } = useSuspenseQuery(bookingByIdQueryOptions(initialBooking.id))
+  // CSRF for the self-cancel write; cached by the `_renter` layout, so this reads
+  // instantly. `null` (signed-out edge) simply hides the cancel control.
+  const { data: session } = useSession()
+  if (!booking) throw notFound()
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
-      <BookingConfirmationView booking={booking} vehicleClass={vehicleClass} />
+      <BookingConfirmationView
+        booking={booking}
+        vehicleClass={vehicleClass}
+        csrfToken={session?.csrfToken ?? null}
+      />
     </main>
   )
 }

--- a/packages/web/src/vite/bookings/BookingConfirmationView.tsx
+++ b/packages/web/src/vite/bookings/BookingConfirmationView.tsx
@@ -2,6 +2,7 @@ import { buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { formatDateTime, formatJpy } from '@/lib/format'
 import { cn } from '@/lib/utils'
+import { CancelBookingDialog } from '@/vite/bookings/CancelBookingDialog'
 import { PreAuthHandoffCard } from '@/vite/bookings/PreAuthHandoffCard'
 import type { BookingDto } from '@/vite/bookings/api'
 import type { VehicleClassData } from '@/vite/vehicles/classes'
@@ -13,6 +14,8 @@ interface BookingConfirmationViewProps {
   readonly booking: BookingDto
   /** Resolved class label, or `null` when archived/unknown — the row is omitted. */
   readonly vehicleClass: VehicleClassData | null
+  /** Session CSRF token for the self-cancel write; `null` hides the cancel control (#856). */
+  readonly csrfToken: string | null
 }
 
 // Instant-book confirmation (#511, ported from the frozen Next page). Pure
@@ -21,7 +24,11 @@ interface BookingConfirmationViewProps {
 // the operator pre-auth handoff CTA, and any drop-off fees (feeSnapshot — empty
 // => no block). Ownership is server-enforced (GET /bookings/:id is IDOR-sealed,
 // #396), so there is no client-side renter check.
-export function BookingConfirmationView({ booking, vehicleClass }: BookingConfirmationViewProps) {
+export function BookingConfirmationView({
+  booking,
+  vehicleClass,
+  csrfToken,
+}: BookingConfirmationViewProps) {
   const t = useTranslations('bookings.confirmation')
   const locale = useLocale()
 
@@ -114,6 +121,21 @@ export function BookingConfirmationView({ booking, vehicleClass }: BookingConfir
           {t('backToVehicles')}
         </Link>
       </div>
+
+      {/* #856: self-cancel is offered only for a CONFIRMED booking (an ACTIVE/
+          COMPLETED/CANCELLED one is past the renter's reach) and only when a CSRF
+          token is present to authorize the write. */}
+      {booking.status === 'CONFIRMED' && csrfToken && (
+        <div className="mt-8 flex justify-center border-t border-border pt-6">
+          <CancelBookingDialog
+            bookingId={booking.id}
+            csrfToken={csrfToken}
+            startAt={booking.startAt}
+            totalPrice={booking.totalPrice}
+            operatorName={booking.operator?.name ?? null}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/web/src/vite/bookings/CancelBookingDialog.tsx
+++ b/packages/web/src/vite/bookings/CancelBookingDialog.tsx
@@ -1,0 +1,138 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { ApiError } from '@/lib/api-error'
+import { formatJpy } from '@/lib/format'
+import { BOOKINGS_KEY, cancelBooking } from '@/vite/bookings/api'
+import { buildCancellationPreview } from '@/vite/bookings/cancellation-preview'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRef, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface CancelBookingDialogProps {
+  readonly bookingId: string
+  readonly csrfToken: string
+  /** ISO pickup time — drives the fee tier and the no-show framing (#868 H2/H3). */
+  readonly startAt: string
+  /** Booking total in yen; `null` only for a not-yet-priced class booking (#464). */
+  readonly totalPrice: number | null
+  /** Operator name for the settlement advisory (#868 M5). */
+  readonly operatorName: string | null
+}
+
+// #856: a renter cancels their own CONFIRMED booking. Wires to the SAME
+// IDOR-sealed POST /bookings/:id/cancel the operator uses; the server applies the
+// tiered fee (72h free / 48h 30% / 24h 70% / same-day 100%) and is authoritative.
+// We preview that fee client-side from the shared schedule so the renter sees the
+// cost BEFORE committing — the cancel() response only returns it AFTER mutating.
+// Advisory only (#868 M5): the fee settles with the operator at pickup, nothing is
+// charged online. On success (or a benign 409 = already cancelled) it invalidates
+// the renter bookings prefix so the list + this page reflect the CANCELLED state.
+export function CancelBookingDialog({
+  bookingId,
+  csrfToken,
+  startAt,
+  totalPrice,
+  operatorName,
+}: CancelBookingDialogProps) {
+  const t = useTranslations('bookings.cancel')
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+
+  function settle() {
+    queryClient.invalidateQueries({ queryKey: BOOKINGS_KEY })
+    setOpen(false)
+  }
+
+  const mutation = useMutation({
+    mutationFn: () => cancelBooking(bookingId, csrfToken),
+    onSuccess: settle,
+    onError: (error) => {
+      // 409 = no longer cancellable: an operator-cancel (or a double-submit) got
+      // there first. The renter's intent is already met, so refresh to the
+      // CANCELLED state and close rather than surface a scary error.
+      if (error instanceof ApiError && error.status === 409) settle()
+    },
+  })
+
+  // Synchronous in-flight guard: isPending only flips between renders, so two
+  // clicks in one frame would both fire the destructive cancel. A ref flips
+  // synchronously (mirrors the operator dialog / AddOnArchiveDialog).
+  const inFlightRef = useRef(false)
+  if (!mutation.isPending && inFlightRef.current) {
+    inFlightRef.current = false
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (next) mutation.reset()
+  }
+
+  // Price the cancellation as it stands right now — `new Date()` is read once per
+  // render, display-only, never stored.
+  const preview = buildCancellationPreview(new Date(startAt), new Date(), totalPrice ?? 0)
+  // A benign 409 closes the dialog via settle(); the only error worth surfacing
+  // here is a genuine failure the renter should retry.
+  const isBenign409 = mutation.error instanceof ApiError && mutation.error.status === 409
+  const showError = mutation.isError && !isBenign409
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button variant="outline" size="sm" />}>{t('action')}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('dialogTitle')}</DialogTitle>
+          <DialogDescription>{t('dialogDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1 text-sm">
+          {preview.mode === 'no-show' ? (
+            <p className="font-medium">
+              {t('noShowNotice', { fee: formatJpy(preview.feeAmount) })}
+            </p>
+          ) : (
+            <>
+              <p className="font-medium">
+                {t('feeLine', {
+                  fee: formatJpy(preview.feeAmount),
+                  percent: Math.round(preview.feePercentage * 100),
+                })}
+              </p>
+              <p className="text-muted-foreground">
+                {t('refundLine', { refund: formatJpy(preview.refundAmount) })}
+              </p>
+            </>
+          )}
+          <p className="text-xs text-muted-foreground">
+            {t('advisory', { operator: operatorName ?? '' })}
+          </p>
+        </div>
+
+        {showError && <output className="block text-sm text-destructive">{t('error')}</output>}
+
+        <DialogFooter>
+          <DialogClose render={<Button type="button" variant="outline" />}>{t('keep')}</DialogClose>
+          <Button
+            variant="destructive"
+            disabled={mutation.isPending}
+            onClick={() => {
+              if (inFlightRef.current || mutation.isPending) return
+              inFlightRef.current = true
+              mutation.mutate()
+            }}
+          >
+            {mutation.isPending ? t('pending') : t('confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -229,3 +229,26 @@ export function myBookingsQueryOptions(renterId: string) {
     queryFn: () => fetchMyBookings(renterId),
   })
 }
+
+// #856: the stable prefix every renter bookings query is keyed under
+// (`['bookings', id]` for the detail/confirmation read, `['bookings', 'mine',
+// renterId]` for My Bookings). A self-cancel invalidates THIS key; React Query's
+// prefix match refreshes both in one call, so the mutation never enumerates the
+// sub-keys it touched (mirrors operator OPERATOR_BOOKINGS_KEY).
+export const BOOKINGS_KEY = ['bookings'] as const
+
+// #856: renter self-cancellation. POST /bookings/:id/cancel is IDOR-sealed and
+// caller-scoped server-side, so the renter hits the SAME endpoint the operator
+// does — no renter id is passed (ownership is the server's call, not ours). The
+// cancel is modelled as a bodyless, cookie-authed, CSRF-gated POST, so the caller
+// echoes the session token and sets no Content-Type (there is no JSON body to
+// declare). `unwrap` returns the now-CANCELLED booking, or throws an ApiError
+// carrying the status so the dialog can treat 409 (already cancelled) as benign.
+export async function cancelBooking(id: string, csrfToken: string): Promise<BookingDto> {
+  const res = await fetch(`${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/cancel`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'X-CSRF-Token': csrfToken },
+  })
+  return unwrap(res, bookingDtoSchema)
+}

--- a/packages/web/src/vite/bookings/cancellation-preview.ts
+++ b/packages/web/src/vite/bookings/cancellation-preview.ts
@@ -1,0 +1,49 @@
+import {
+  type CancellationTier,
+  calculateCancellationFee,
+} from '@kuruma/shared/lib/cancellation-policy'
+
+/**
+ * The two ways the renter cancel dialog presents a cancellation (#856/#868),
+ * modelled as a discriminated union so the no-show case can't carry refund
+ * fields and the dialog's refund line is unreachable unless a refund exists.
+ *  - `no-show`: `now` is at/after pickup — the tiered schedule no longer applies
+ *    and the full fee is owed (#868 H2); only the fee is shown.
+ *  - `tiered`: the shared schedule's breakdown (fee + percentage + estimated
+ *    refund). A same-day cancel is FULL (100% fee / 0 refund) but still *before*
+ *    pickup, so it stays a tier display — the discriminant is past-pickup, not FULL.
+ */
+export type CancellationPreview =
+  | { readonly mode: 'no-show'; readonly feeAmount: number }
+  | {
+      readonly mode: 'tiered'
+      readonly tier: CancellationTier
+      /** 0 | 0.3 | 0.7 | 1 — the tier as a fraction; surfaced as a percentage. */
+      readonly feePercentage: number
+      readonly feeAmount: number
+      readonly refundAmount: number
+    }
+
+/**
+ * Functional core for the renter cancel dialog (#856): given the booking's
+ * pickup time, the current instant and the total price, return the fee the
+ * renter would owe and the refund they'd get back. Pure — `now` is injected so
+ * the no-show boundary is testable without mocking the clock (the shell passes
+ * `new Date()`). Amounts come straight from the shared schedule so the preview
+ * can never drift from the server's authoritative cancel-time computation.
+ */
+export function buildCancellationPreview(
+  startAt: Date,
+  now: Date,
+  totalPrice: number,
+): CancellationPreview {
+  const { tier, feePercentage, feeAmount, refundAmount } = calculateCancellationFee(
+    startAt,
+    now,
+    totalPrice,
+  )
+  if (now.getTime() >= startAt.getTime()) {
+    return { mode: 'no-show', feeAmount }
+  }
+  return { mode: 'tiered', tier, feePercentage, feeAmount, refundAmount }
+}

--- a/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
+++ b/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
@@ -2,6 +2,7 @@ import { formatDateTime, formatJpy } from '@/lib/format'
 import { BookingConfirmationView } from '@/vite/bookings/BookingConfirmationView'
 import type { BookingDto } from '@/vite/bookings/api'
 import type { VehicleClassData } from '@/vite/vehicles/classes'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
@@ -54,11 +55,21 @@ function makeBooking(overrides: Partial<BookingDto> = {}): BookingDto {
   }
 }
 
-function renderView(booking: BookingDto, vehicleClass: VehicleClassData | null = null) {
+function renderView(
+  booking: BookingDto,
+  vehicleClass: VehicleClassData | null = null,
+  csrfToken: string | null = 'csrf-tok',
+) {
   return render(
-    <IntlProvider locale="en" messages={en}>
-      <BookingConfirmationView booking={booking} vehicleClass={vehicleClass} />
-    </IntlProvider>,
+    <QueryClientProvider client={new QueryClient()}>
+      <IntlProvider locale="en" messages={en}>
+        <BookingConfirmationView
+          booking={booking}
+          vehicleClass={vehicleClass}
+          csrfToken={csrfToken}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
   )
 }
 
@@ -139,5 +150,26 @@ describe('BookingConfirmationView', () => {
       'data-to',
       '/$locale/vehicles',
     )
+  })
+
+  // #856: the renter can self-cancel only a CONFIRMED booking they own, and only
+  // when a CSRF token is available to authorize the write.
+  it('offers a cancel control for a confirmed booking', () => {
+    renderView(makeBooking({ status: 'CONFIRMED' }))
+    expect(screen.getByRole('button', { name: en.bookings.cancel.action })).toBeInTheDocument()
+  })
+
+  it('hides the cancel control once the booking is no longer confirmed', () => {
+    renderView(makeBooking({ status: 'ACTIVE' }))
+    expect(
+      screen.queryByRole('button', { name: en.bookings.cancel.action }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the cancel control when no CSRF token is available', () => {
+    renderView(makeBooking({ status: 'CONFIRMED' }), null, null)
+    expect(
+      screen.queryByRole('button', { name: en.bookings.cancel.action }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/web/tests/vite/bookings/CancelBookingDialog.test.tsx
+++ b/packages/web/tests/vite/bookings/CancelBookingDialog.test.tsx
@@ -1,0 +1,164 @@
+import { ApiError } from '@/lib/api-error'
+import { formatJpy } from '@/lib/format'
+import { CancelBookingDialog } from '@/vite/bookings/CancelBookingDialog'
+import * as api from '@/vite/bookings/api'
+import { BOOKINGS_KEY } from '@/vite/bookings/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const c = enMessages.bookings.cancel
+
+// The dialog reads the clock at render, so anchor pickup times relative to NOW.
+// 50h leaves a 2h margin to the 48h boundary -> stable LOW (30%) tier without
+// faking timers (fake timers would deadlock userEvent's internal timers).
+const hoursFromNow = (h: number) => new Date(Date.now() + h * 3_600_000).toISOString()
+const START_LOW = hoursFromNow(50)
+const PAST_PICKUP = hoursFromNow(-1)
+
+interface Overrides {
+  startAt?: string
+  totalPrice?: number | null
+  operatorName?: string | null
+}
+
+function renderDialog(overrides: Overrides = {}, queryClient = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <CancelBookingDialog
+          bookingId="bk-1"
+          csrfToken="csrf-tok"
+          startAt={overrides.startAt ?? START_LOW}
+          totalPrice={overrides.totalPrice === undefined ? 20000 : overrides.totalPrice}
+          operatorName={
+            overrides.operatorName === undefined ? 'Best Car Rental' : overrides.operatorName
+          }
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('CancelBookingDialog (renter, #856)', () => {
+  it('does not cancel until the dialog is opened and confirmed', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    renderDialog()
+
+    // The trigger alone must not fire the destructive call.
+    await user.click(screen.getByRole('button', { name: c.action }))
+    expect(spy).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok'))
+  })
+
+  it('previews the tiered fee and estimated refund for a cancellation before pickup', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    renderDialog() // LOW tier, 20,000 total -> 6,000 fee / 14,000 refund
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+
+    expect(screen.getByText(`Cancellation fee: ${formatJpy(6000)} (30%)`)).toBeInTheDocument()
+    expect(screen.getByText(`Estimated refund: ${formatJpy(14000)}`)).toBeInTheDocument()
+  })
+
+  it('shows the no-show full-fee notice instead of the tiered breakdown once pickup has passed', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    renderDialog({ startAt: PAST_PICKUP }) // full fee = 20,000
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+
+    expect(
+      screen.getByText(`The pickup time has passed. The full fee (${formatJpy(20000)}) applies.`),
+    ).toBeInTheDocument()
+    // No tiered refund line in the no-show case.
+    expect(screen.queryByText(/Estimated refund/)).not.toBeInTheDocument()
+  })
+
+  it('frames the fee as settled with the operator at pickup, not charged online', async () => {
+    const user = userEvent.setup()
+    renderDialog({ operatorName: 'Best Car Rental' })
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    expect(
+      screen.getByText(
+        'The fee is settled with Best Car Rental at pickup. Nothing is charged online now.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('invalidates the bookings prefix and closes on success', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    renderDialog({}, queryClient)
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: BOOKINGS_KEY }))
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: c.confirm })).not.toBeInTheDocument(),
+    )
+  })
+
+  it('treats a 409 (already cancelled) as benign: refreshes and closes without an error', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'cancelBooking').mockRejectedValue(
+      new ApiError('Booking is not cancellable', 409),
+    )
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    renderDialog({}, queryClient)
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: BOOKINGS_KEY }))
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: c.confirm })).not.toBeInTheDocument(),
+    )
+    expect(screen.queryByText(c.error)).not.toBeInTheDocument()
+  })
+
+  it('surfaces an error and stays open when the cancellation fails for another reason', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(api, 'cancelBooking').mockRejectedValue(new ApiError('Server error', 500))
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+
+    expect(await screen.findByText(c.error)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: c.confirm })).toBeInTheDocument()
+  })
+
+  it('fires exactly one cancel request when confirm is double-clicked before a re-render', async () => {
+    const user = userEvent.setup()
+    // Never resolves: the mutation stays in-flight. Both clicks land inside one
+    // act() flush, so isPending has not flipped yet — only the synchronous
+    // inFlightRef guard can stop the second destructive POST. Drop the ref and
+    // disabled={isPending} alone lets the second click through, failing this test.
+    const spy = vi.spyOn(api, 'cancelBooking').mockReturnValue(new Promise<never>(() => {}))
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    const confirm = screen.getByRole('button', { name: c.confirm })
+    act(() => {
+      confirm.click()
+      confirm.click()
+    })
+
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/web/tests/vite/bookings/api.test.ts
+++ b/packages/web/tests/vite/bookings/api.test.ts
@@ -1,5 +1,8 @@
 import { ApiError, ParseError } from '@/lib/api-error'
 import {
+  BOOKINGS_KEY,
+  bookingByIdQueryOptions,
+  cancelBooking,
   createBooking,
   fetchBookingById,
   fetchMyBookings,
@@ -230,6 +233,47 @@ describe('fetchMyBookings', () => {
 describe('myBookingsQueryOptions', () => {
   it('keys by the renter so two principals never collide on cache', () => {
     expect(myBookingsQueryOptions('me-42').queryKey).toEqual(['bookings', 'mine', 'me-42'])
+  })
+})
+
+// #856: renter self-cancellation. Wires to the SAME IDOR-sealed POST
+// /bookings/:id/cancel the operator uses — the server scopes the action to the
+// caller, so this client passes no renter id. Mirrors the operator writeBooking
+// shape (bodyless CSRF-gated POST) but stays in the renter `vite/bookings` client.
+describe('cancelBooking', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('POSTs /api/bookings/:id/cancel bodyless with credentials + CSRF and unwraps the cancelled booking', async () => {
+    const cancelled = { ...sampleBooking, status: 'CANCELLED' as const }
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: cancelled }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(cancelBooking('b-1', 'csrf-9')).resolves.toEqual(cancelled)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/bookings/b-1/cancel')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect(init.headers).toMatchObject({ 'X-CSRF-Token': 'csrf-9' })
+    // Bodyless POST: it must not claim a JSON body it isn't sending.
+    expect(init.body).toBeUndefined()
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+  })
+
+  it('propagates a 409 as an ApiError so the dialog can treat an already-cancelled booking as benign', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'Booking is not cancellable' }, 409)),
+    )
+    await expect(cancelBooking('b-1', 'c')).rejects.toMatchObject({ status: 409 })
+  })
+})
+
+describe('BOOKINGS_KEY', () => {
+  it('prefixes every renter bookings query so one invalidation cascades to the list + detail', () => {
+    expect(BOOKINGS_KEY).toEqual(['bookings'])
+    expect(myBookingsQueryOptions('me-42').queryKey.slice(0, 1)).toEqual(BOOKINGS_KEY)
+    expect(bookingByIdQueryOptions('b-1').queryKey.slice(0, 1)).toEqual(BOOKINGS_KEY)
   })
 })
 

--- a/packages/web/tests/vite/bookings/cancellation-preview.test.ts
+++ b/packages/web/tests/vite/bookings/cancellation-preview.test.ts
@@ -1,0 +1,47 @@
+import { buildCancellationPreview } from '@/vite/bookings/cancellation-preview'
+import { describe, expect, it } from 'vitest'
+
+// `buildCancellationPreview` is the functional core the renter cancel dialog
+// renders (#856/#868). It wraps the shared `calculateCancellationFee` (whose
+// tier math is tested in @kuruma/shared) and adds the one renter-facing decision
+// the schedule alone can't express: whether `now` is already past pickup, in
+// which case the tiered breakdown is moot and the full fee applies (#868 H2).
+const NOW = new Date('2026-07-01T00:00:00.000Z')
+const TOTAL = 20000
+
+describe('buildCancellationPreview', () => {
+  it('carries the shared tier breakdown for a cancellation before pickup', () => {
+    // 50h before pickup -> LOW tier, 30% fee on a 20,000 total.
+    const preview = buildCancellationPreview(new Date('2026-07-03T02:00:00.000Z'), NOW, TOTAL)
+    expect(preview).toEqual({
+      mode: 'tiered',
+      tier: 'LOW',
+      feePercentage: 0.3,
+      feeAmount: 6000,
+      refundAmount: 14000,
+    })
+  })
+
+  it('flags a no-show (now past pickup) and applies the full fee', () => {
+    const preview = buildCancellationPreview(new Date('2026-06-30T23:00:00.000Z'), NOW, TOTAL)
+    expect(preview).toEqual({ mode: 'no-show', feeAmount: 20000 })
+  })
+
+  it('treats the exact pickup instant as a no-show', () => {
+    expect(buildCancellationPreview(NOW, NOW, TOTAL).mode).toBe('no-show')
+  })
+
+  it('keeps a same-day FULL cancellation (still before pickup) as a tier display', () => {
+    // 12h before pickup: same-day -> FULL tier (100% fee, 0 refund), but pickup
+    // has NOT passed, so it's a tiered breakdown, not a no-show. Guards the
+    // discriminant against being collapsed into `tier === 'FULL'`.
+    const preview = buildCancellationPreview(new Date('2026-07-01T12:00:00.000Z'), NOW, TOTAL)
+    expect(preview).toEqual({
+      mode: 'tiered',
+      tier: 'FULL',
+      feePercentage: 1,
+      feeAmount: 20000,
+      refundAmount: 0,
+    })
+  })
+})

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -80,7 +80,7 @@ function isForbiddenWebDbSpec(spec: string): boolean {
 //
 // After a drain, refresh in place with:
 //   bun run scripts/lint-module-boundaries.ts --update-baseline
-const DEPRECATED_WEB_TREE_BASELINE = 151
+const DEPRECATED_WEB_TREE_BASELINE = 155
 
 export type DeprecatedTreeStatus = {
   count: number


### PR DESCRIPTION
Renters can cancel their own CONFIRMED booking directly from the confirmation page, instead of being told to contact the operator.

**Web-only** — wires to the existing IDOR-sealed `POST /bookings/:id/cancel` (no API/schema change). The server stays authoritative for the fee; the dialog previews it from the *same* shared `calculateCancellationFee`, so the quoted fee and the charged fee can't drift (the #855 class of bug is structurally impossible here).

## What's in the slice
- **`cancellation-preview.ts`** — pure `buildCancellationPreview()` (FC/IS) over shared `calculateCancellationFee`, returning a discriminated union `{ mode: 'no-show' } | { mode: 'tiered' }` so a no-show can't carry refund fields and the refund line is unreachable unless a refund exists.
- **`api.ts`** — `cancelBooking()` (bodyless CSRF POST) + `BOOKINGS_KEY` invalidation; one cascade refreshes *My Bookings* and the detail page.
- **`CancelBookingDialog.tsx`** — fee/refund preview (H3), no-show full-fee copy (H2), operator-settlement advisory (M5), synchronous `inFlightRef` double-submit guard, benign-409 handling (an operator-cancel that wins the race closes cleanly).
- **`BookingConfirmationView`** gates the control on `CONFIRMED && csrf`; the route re-reads the booking from cache so a cancel live-updates to CANCELLED (mirrors the operator side).
- **i18n** — `bookings.cancel.*` across all 3 locales (en / ja / zh).

## Reviews
Code review (**SHIP-WITH-FIXES** → applied: a double-submit test pinning the load-bearing `inFlightRef` guard) + architect review (**sound to merge as-is**, no blocker). The no-show boundary was verified **non-divergent from the server by construction** — both sides call the same shared fee function with the same arguments; `mode` is presentation-only with no server counterpart.

## Deferred follow-ups (from architect review)
- **Slice 3a/3b:** `cancelBooking()` discards the response `meta.cancellation`. Once settlement is real (not advisory), surface the *authoritative* server fee on success rather than the preview.
- **#464:** `totalPrice ?? 0` previews/charges a *free* cancel for a not-yet-priced class booking (both client and server agree, latent — the dialog only renders for CONFIRMED). Make it a conscious decision when class-combo lands.

## Test plan
- web **909/909** — 5 verticals + the double-submit guard (proven mutation-resistant: neutering the ref fails the test) + a discriminant test (same-day FULL *before* pickup stays `tiered`, not `no-show`).
- typecheck exit 0; full lint clean (biome + size + modules + unwrap-schema + i18n-parity).

Closes #856. Refs #868.

> Base is `marketplace-pivot`, so `Closes #856` won't auto-close on merge — close it manually after squash.
