### PR TITLE
docs(plans): search results map↔list redesign — decision brief (Option B)

### DIFF
--- a/docs/plans/2026-06-15-search-map-list-redesign.md
+++ b/docs/plans/2026-06-15-search-map-list-redesign.md
@@ -1,6 +1,6 @@
 # Search results: map ↔ list interaction redesign
 
-**Status:** PROPOSAL — for review & decision (not yet approved) · 2026-06-15
+**Status:** DIRECTION AGREED — **Option B (car-first)**, pending final colleague sign-off · updated 2026-06-15
 **Author:** (Jack + Claude)
 **Decision owner:** Jack + colleague
 **Supersedes the UX of:** #458 (`feat: map + flat-list search results`, closed — original build)
@@ -11,7 +11,7 @@
 
 ## 1. Why we're touching this
 
-The search-results screen is the core of the renter funnel: it's where "I need a car in Kyoto on these dates" turns into a booking. Today it under-delivers, and the problems are structural, not cosmetic.
+The search-results screen is the core of the renter funnel: it's where "I need a car in Kyoto on these dates" turns into a booking. Today it under-delivers, and the problems are structural, not cosmetic. **The renter is a foreign tourist** — they don't read store names or know Osaka-vs-Kyoto geography, so seeing *where in Japan* a car is picked up is a primary need, not a nicety.
 
 ### What exists today (two half-views behind one toggle)
 
@@ -19,10 +19,10 @@ The top-right **门店 / 地图** control is **not a layout toggle — it swaps 
 
 | View (`?view=`) | Component | Card granularity | Map? |
 |---|---|---|---|
-| `stores` (default) | `StoreGrid` → `StorefrontCard` | **one card per store** (location) | **no map** |
+| `stores` (default) | `StoreGrid` → `StorefrontCard` | one card per store (location) | **no map** |
 | `map` | `SearchMap` → `SearchMapList` → `PigeonMapAdapter` | **one card per vehicle** | yes (right side) |
 
-So a renter gets *either* a store list with no map, *or* a car list with a map — never a coherent "browse on the map" experience. The screenshot bugs are all in the **`map`** view.
+So a renter gets *either* a store list with no map, *or* a car list with a map — never a coherent "browse cars on the map" experience. The screenshot bugs are all in the **`map`** view.
 
 ### The root mismatch
 
@@ -45,106 +45,101 @@ The established pattern is the **synchronized list–map split view**, used by A
 2. **Bidirectional sync** — hover/select a card → its pin enlarges/recolors; click a pin → its card highlights and **scrolls into view**. The link is always **1:1 and visible**.
 3. **Informative pins** — show **price** ("¥8,000" pills, à la Airbnb/Zillow) or a count, not generic dots. Selected pin inverts color.
 4. **Pin → mini-card popup** — clicking a pin opens a callout (photo · price · name) linking to detail. *(We have none — the biggest single gap.)*
-5. **Clustering for co-located results** — several results at one spot collapse to **one marker with a count**, clicking it expands to a popup carousel/list. *(Our exact "3 cars at Kyoto Station" case.)*
+5. **Clustering / carousel for co-located results** — results at one *point* collapse to a popup **carousel**; distinct results *near* each other collapse to a numbered cluster that **splits on zoom**.
 6. **List drives the decision; the map answers "where / how convenient."**
 
 The standard is not a single layout — it's *how you execute* whatever you decide a "result" is:
 - **Booking.com / hotels model** = result is a **property** → one card per property, pin per property (1:1).
-- **Turo / car model** = result is a **car** → one card per car, **map clusters** co-located cars.
+- **Turo / car model** = result is a **car** → one card per car, **map carousel/cluster** for co-located cars. ← **our choice**
 
 ---
 
-## 3. Options
+## 3. Options considered
 
-### Option A — Store-first grouping  ⭐ recommended
+### Option A — Store-first grouping
 
-Result = **store**. Unify the two views into one synchronized map+list. Card = storefront (name · area · distance · available class chips · "from ¥X/day"), expandable or linking to the **existing** storefront detail page to pick a car. Map = **one price-labeled pin per store, 1:1 with a card.**
+Result = **store**. One card *and* one pin per store (1:1), expandable/linking to the storefront detail page to pick a car. *Pros:* 1:1 pin↔card dissolves the bugs by construction; short list; clean map. *Cons:* the bookable unit (a specific car) is one level down — weaker for a foreigner who wants to see *this car* on the map.
 
-```
-LIST (per store)            MAP
-┌──────────────────────┐   ┌─────────────────┐
-│ Sakura Mobility       │   │   ╭────────────╮│
-│ Kyoto Station · 2.1km │◄─►│   │Sakura Mob. ││
-│ Compact·Kei·SUV       │   │   │3 cars ¥6.5k+││
-│ from ¥6,500/day       │   │   ╰──📍─────────╯│
-│ [View cars ▾]         │   │  📍   📍         │
-└──────────────────────┘   └─────────────────┘
-click card → map flies + popup ·  click pin → its one card
-```
+### Option B — Car-first + co-location carousel (Turo model)  ⭐ chosen
 
-- **Pros:** 1:1 pin↔card **dissolves the bugs by construction** (no clustering needed); short, scannable list (kills the repeated "Sakura Mobility · Kyoto Station ×3" noise visible today); matches the store-pickup business and the existing `门店` view + storefront detail page; clean, uncrowded map.
-- **Cons:** the bookable unit (a specific car) is one level down — renter expands or opens store detail to compare cars.
-
-### Option B — Car-first + clustering (Turo model)
-
-Result = **car**. Keep one card per vehicle. Map clusters co-located cars into a numbered marker; clicking a cluster opens a **popup carousel** of those cars. Add fly-to-pin on card click and hover sync.
-
-- **Pros:** the thing they book is always visible; matches Turo; good when comparing specific models/prices across stores is the main job.
-- **Cons:** pin↔cards stays **many-to-1** (needs real clustering + a carousel popup — more to build); long, repetitive list with many cars per store; busier map.
+Result = **car / combo**. One card per vehicle or class-combo. Map pin per **pickup store**; co-located cars share a pin whose click opens a **swipeable carousel**. Card focus flies the map to + opens a popup on its pickup pin. *Pros:* the bookable thing is always visible and instantly placed on a map of Japan — exactly the foreigner geo-feedback goal; matches Turo. *Cons:* pin↔cards is many-to-1 (handled by the carousel, not a blocker).
 
 ### Option C — Map-driven list ("search this area")
 
-The map is the primary control: panning/zooming re-filters the list to what's in view, with a "Search this area" button (Airbnb's move-map-to-search).
-
-- **Pros:** powerful for area browsing.
-- **Cons:** biggest behavior change; re-query plumbing; **largely redundant with our region picker + chips**, which already scope the search. **Recommend deferring** — it's an enhancement layered on A or B, not a base choice.
+The map is primary: panning/zooming re-filters the list, with a "Search this area" button. *Largely redundant with our region picker + chips.* **Deferred** — an enhancement on top of B, not a base choice.
 
 ---
 
-## 4. Recommendation: Option A (Store-first)
+## 4. Decision: Option B (car-first)
 
-**Reasoning, in priority order:**
+**Chosen 2026-06-15** for one overriding reason the store-first analysis under-weighted: **the renter is a foreign tourist who needs instant "where in Japan can I pick this up?" feedback.** Seeing the specific car they're considering pinned on a map beats a tidy store list for that user. Result granularity = **individual cars + class-combos**, each tied to its pickup-store pin.
 
-1. **Store-pickup is the real-world unit.** The renter physically collects the car at a 门店; the store is where the transaction happens. Our platform is operators-with-storefronts.
-2. **It reuses the architecture we already have.** The default `门店` view is already store-grouped, and the storefront detail page (`/$locale/storefronts/$locationId`) already exists to list/select cars. Store-first *unifies* these; car-first fights them.
-3. **Few stores, many cars per store.** With ~40–50 vehicles across a handful of stores, car-first means a long, repetitive list and a crowded/clustered map. Store-first keeps the list to a few cards and the map clean.
-4. **1:1 pin↔card fixes the bugs structurally** — no clustering machinery. Pin = card = store; the "selects all" condition literally cannot arise; the popup carries real info; card-click moves the map.
-5. **One coherent screen** replaces two confusing half-views and the data-swapping toggle.
+**The co-location mechanic (the one real constraint):** a car's "where" *is* its pickup store's coordinates, so cars at the same store share one pin — there is nothing to geographically separate. "Show where *this* car is" = focus a card → the map **flies to + highlights + opens a popup** on that car's **pickup** pin. Clicking a pin that holds N cars opens an **Airbnb-style swipeable carousel** of those cars/combos (industry standard for multiple results on one point). Distinct *nearby* stores still cluster and **split on zoom**.
 
-**How A fixes each reported bug:**
+**How B fixes each reported bug:**
 
-| Reported | Fix under A |
+| Reported | Fix under B |
 |---|---|
-| Clicking a card does nothing | Card click flies the map to its pin + opens the popup (and "View cars" → store detail) |
-| "在地图上显示" does nothing | Replaced: the whole card is the affordance; the map visibly responds |
-| Pin highlights all cards, no info | Pin is now 1:1 with one store card; click opens an informative popup; highlights exactly that card |
+| Clicking a card does nothing | Card focus flies the map to its pickup pin + opens the popup |
+| "在地图上显示" does nothing | Replaced: focusing the card is the affordance; the map visibly responds (fly + popup) |
+| Pin highlights all cards, no info | Pin click opens a **carousel popup** of exactly the cars/combos at that store — no more silent "all highlighted" |
 
-**Concretely, A is:** store cards with class chips + "from ¥X" + distance; a **sticky** map with price-labeled pins (selected inverts); a **pin popup** (store · N cars · from ¥X · "View cars"); **bidirectional hover/selection sync** + **fly-to on select**; on mobile, a **Map toggle** with a bottom-sheet card on pin tap. Car comparison happens on the existing storefront detail page (or an optional inline expand of the top 2–3 classes).
+**The real geo-feedback win is context, not the dot:** each card + popup shows nearest **landmark/station · distance · prefecture** (e.g. "Kyoto Station · 2.1 km from downtown"). For a foreigner that conveys "where" far better than a pin alone.
 
----
+**Concretely, B is:** per-car / per-combo cards (name · class · price · pickup store + geo-context); a **sticky** map with price-labeled pins (selected inverts); a **pin popup carousel** for co-located results; **bidirectional hover/selection sync** + **fly-to on focus**; on mobile, a **Map toggle** + bottom-sheet card on pin tap.
 
-## 5. The decision for you + colleague
-
-**The one fork that changes everything:** *Is the renter's result a STORE (pick a place, then a car) or a CAR (compare cars; location is an attribute)?*
-
-- **Store → Option A** (recommended).
-- **Car → Option B** (Turo-style + clustering). Pick this if comparing specific models/prices across stores is the primary job, **or** if you expect many single-car stores (then grouping adds nothing).
-
-**Secondary questions to settle in review:**
-
-1. **Card depth:** store card links straight to the detail page, or inline-expands the top 2–3 classes with a Select button (Booking.com "rooms from" pattern)?
-2. **Pin label:** price ("¥6,500+", scannable, our standard recommendation) vs a count ("3") vs plain selected/unselected dots?
-3. **Mobile:** Map toggle + bottom sheet (recommended) vs a shrunk split.
-4. **Keep the 门店/地图 toggle**, or replace with one unified view + a "hide map" option?
-5. **"Search this area" (Option C):** in scope now, or a later enhancement? (Recommend later.)
+*Revisit Option A only if* the catalog grows to many stores with one car each (grouping then adds nothing anyway) **or** store-pickup convenience eclipses model choice in user testing.
 
 ---
 
-## 6. Scope & impact (rough — for cost sense, not a plan)
+## 5. Decisions & remaining open questions
 
-**Mostly web** (`packages/web/src/vite/search/*`, `…/storefronts/*`, the search route). Likely **no schema change**.
+**Resolved:**
+- **Result granularity → individual cars + combos** (Option B). *[decided]*
+- **Store-vs-car result → car**, for the foreigner geo-feedback goal. *[decided]*
+- **Pin click with N co-located cars → Airbnb-style swipeable carousel popup.** *[decided — industry standard]*
+- **Pin label → price** ("¥8,000" / "from ¥6,500"), the scannable Airbnb/Zillow standard. *[leaning — industry standard]*
+- **Mobile → Map toggle + bottom sheet.** *[leaning — industry standard]*
 
-- **New:** a real **pin popup/callout** in `PigeonMapAdapter` (pigeon-maps `<Overlay>`); **fly-to / recenter on selection** (`viewport.ts` already centers on a region anchor — extend to per-selection); **store-grouped cards in the map view** (reuse the `StorefrontCard` / `StoreGrid` model); **bidirectional sync** (`SearchMapList` already tracks a `locationId` selection — extend to fly + popup + scroll-into-view).
-- **Verify (API):** the storefront-grouped search payload (`StorefrontSearchResultData`) carries **lat/lng + min price + class counts per store** (the stores view already renders min price + class counts, so likely present — confirm lat/lng).
-- **Tests:** extend `SearchMapList.test`, `viewport.test`, `StoreGrid.test`; add popup, fly-to, and sync tests. Don't regress the region anchor (#840) or `e2e/real-db/region-search.auth.spec.ts`.
-- **Suggested slicing:** (1) unify to a store-grouped synchronized map+list with 1:1 sync + pin popup + fly-to; (2) price-labeled pins + mobile Map toggle; (3) optional inline car expand. Each is an independent vertical slice / PR.
-
-**Risks:** storefront search must carry coordinates + min price (verify); pigeon-maps overlay ergonomics; preserving region-centering and the existing e2e.
+**Still open:**
+1. **Card / popup target:** link to the vehicle/combo detail page, or an inline quick-view? *(Lean: link to existing detail.)*
+2. **Keep the 门店/地图 toggle**, or make one unified map+list the default with a "hide map" option? *(Lean: unified default.)*
+3. **Later enhancements, designed-for not built-now:** "Search this area" (Option C) and **one-way rentals** (§6).
 
 ---
 
-## 7. Next steps
+## 6. Future consideration: one-way rentals (pickup ≠ dropoff)
 
-1. Review this with the colleague; settle §5 (mainly: store-result vs car-result).
-2. On decision, file a tracking issue (the redesign of closed #458) with the chosen option.
-3. Finalize the approved design → implementation plan (vertical slices above) → TDD build.
+A renter picks up at store A and drops off at store B (a.k.a. one-way / relocation rental). **Not in scope now**, but the redesign should not preclude it.
+
+**Industry-standard UX** (Hertz/Avis/Kayak/Turo): the search form gains a **"Return to a different location"** toggle that reveals a **dropoff** field (default off = same location); results show cars valid for that pickup→dropoff route; a **one-way / drop fee** is added; the card shows a "One-way OK · drop fee ¥X" badge.
+
+**Forward-compat guardrails to bake into THIS build (cheap now, expensive to retrofit):**
+1. **Label the pin/popup as the _pickup_ pin explicitly**; treat `result.location` as pickup-specific, not "the location."
+2. **Map adapter takes a _list of points / an optional route_ per selection**, even though today it's always one pin — so a future dropoff pin or a pickup→dropoff route line is additive (pigeon-maps supports multiple markers + overlays).
+3. **Result DTO leaves room for an optional dropoff dimension**; don't bake a "one location per car" assumption into the card/popup types.
+4. **Pricing is already extensible** — a drop/relocation fee is just another fee term (`feeSnapshot` + the shared `composeBookingTotal`), no architectural change.
+
+**Honest cost split:** the map UX above is the easy part. One-way's real cost is the **inventory/fleet model** — a vehicle now *ends* at a different location, so availability becomes per-location-over-time and the Postgres exclusion constraint (double-booking prevention) must account for relocation and rebalancing. That's a backend epic, largely orthogonal to this redesign. **So: design the UI to not block it; defer the inventory work to its own project.**
+
+---
+
+## 7. Scope & impact (rough — for cost sense, not a plan)
+
+**Mostly web** (`packages/web/src/vite/search/*`, the search route). Likely **no schema change** for the core redesign.
+
+- **New:** a real **pin popup / carousel** in/around `PigeonMapAdapter` (pigeon-maps `<Overlay>`); **fly-to / recenter on focus** (`viewport.ts` already centers on a region anchor — extend to per-selection); **bidirectional sync** (`SearchMapList` already tracks a `locationId` selection — extend to fly + popup + scroll-into-view); **price-labeled pins**; **geo-context labels** (landmark/station · distance · prefecture) on card + popup.
+- **Verify (API):** the flat search payload (`SearchResultsData`) carries **lat/lng per pickup location** (it does — pins render today) and that a **min/representative price** is available for pin labels. Geo-context (nearest landmark/region name) may reuse the region data from #651.
+- **Build with the §6 guardrails** so one-way is additive later (pickup-labeled pins; multi-point-capable adapter; dropoff-open DTO).
+- **Tests:** extend `SearchMapList.test`, `viewport.test`, `PigeonMapAdapter.test`; add carousel, fly-to, and sync tests. Don't regress the region anchor (#840) or `e2e/real-db/region-search.auth.spec.ts`.
+- **Suggested slicing (independent vertical PRs):** (1) card↔pin sync + fly-to + pin popup (single-car case); (2) co-location **carousel** + price pins; (3) **geo-context** labels + mobile Map toggle.
+
+**Risks:** pigeon-maps overlay/carousel ergonomics; preserving region-centering + the existing e2e; sourcing a clean "nearest landmark" label for geo-context.
+
+---
+
+## 8. Next steps
+
+1. Final colleague sign-off on §5 (mostly the two "leaning" calls + the two still-open questions).
+2. File a tracking issue (UX redesign of closed #458) referencing this brief and the chosen Option B.
+3. Finalize the approved design → implementation plan (the vertical slices in §7) → TDD build.

--- a/docs/plans/2026-06-15-search-map-list-redesign.md
+++ b/docs/plans/2026-06-15-search-map-list-redesign.md
@@ -1,0 +1,150 @@
+# Search results: map ↔ list interaction redesign
+
+**Status:** PROPOSAL — for review & decision (not yet approved) · 2026-06-15
+**Author:** (Jack + Claude)
+**Decision owner:** Jack + colleague
+**Supersedes the UX of:** #458 (`feat: map + flat-list search results`, closed — original build)
+**Related design:** `docs/plans/2026-06-12-renter-location-search-niconico.md` (region search), shipped via #651
+**Surface:** renter search results, route `packages/web/src/routes/$locale/search.tsx`
+
+---
+
+## 1. Why we're touching this
+
+The search-results screen is the core of the renter funnel: it's where "I need a car in Kyoto on these dates" turns into a booking. Today it under-delivers, and the problems are structural, not cosmetic.
+
+### What exists today (two half-views behind one toggle)
+
+The top-right **门店 / 地图** control is **not a layout toggle — it swaps to a different page with different data**:
+
+| View (`?view=`) | Component | Card granularity | Map? |
+|---|---|---|---|
+| `stores` (default) | `StoreGrid` → `StorefrontCard` | **one card per store** (location) | **no map** |
+| `map` | `SearchMap` → `SearchMapList` → `PigeonMapAdapter` | **one card per vehicle** | yes (right side) |
+
+So a renter gets *either* a store list with no map, *or* a car list with a map — never a coherent "browse on the map" experience. The screenshot bugs are all in the **`map`** view.
+
+### The root mismatch
+
+In the `map` view, **cards are per-vehicle but map pins are per-location.** When 3 cars sit at *Sakura Mobility · Kyoto Station*, they share **one pin**. Selection is keyed by `locationId` (`SearchMapList.tsx`), so:
+
+- **Clicking the pin highlights all 3 cards** — technically correct (all 3 *are* there), but it carries no information and reads as a bug.
+- **The pin reveals nothing** — `PigeonMapAdapter` has **no popup/callout component at all**.
+- **"在地图上显示" feels dead** — it *is* wired (toggles a faint ring + recolors the pin) but **never moves the map or shows info**.
+- **The card body does nothing** — only "在地图上显示" and the (disabled) "选择" button are interactive.
+
+**Net:** selection has no payload and the map never responds. That's a design problem, so we're redesigning rather than patching.
+
+---
+
+## 2. Industry standard for list + map result views
+
+The established pattern is the **synchronized list–map split view**, used by Airbnb, Booking.com, Zillow, Redfin, Google Hotels, and — our closest analog — **Turo** (peer-to-peer car rental). The conventions that are genuinely standard:
+
+1. **Split layout** — scrollable list + *sticky* map (desktop); list with a **Map toggle** (full-screen map ⇄ list) or a bottom-sheet on mobile.
+2. **Bidirectional sync** — hover/select a card → its pin enlarges/recolors; click a pin → its card highlights and **scrolls into view**. The link is always **1:1 and visible**.
+3. **Informative pins** — show **price** ("¥8,000" pills, à la Airbnb/Zillow) or a count, not generic dots. Selected pin inverts color.
+4. **Pin → mini-card popup** — clicking a pin opens a callout (photo · price · name) linking to detail. *(We have none — the biggest single gap.)*
+5. **Clustering for co-located results** — several results at one spot collapse to **one marker with a count**, clicking it expands to a popup carousel/list. *(Our exact "3 cars at Kyoto Station" case.)*
+6. **List drives the decision; the map answers "where / how convenient."**
+
+The standard is not a single layout — it's *how you execute* whatever you decide a "result" is:
+- **Booking.com / hotels model** = result is a **property** → one card per property, pin per property (1:1).
+- **Turo / car model** = result is a **car** → one card per car, **map clusters** co-located cars.
+
+---
+
+## 3. Options
+
+### Option A — Store-first grouping  ⭐ recommended
+
+Result = **store**. Unify the two views into one synchronized map+list. Card = storefront (name · area · distance · available class chips · "from ¥X/day"), expandable or linking to the **existing** storefront detail page to pick a car. Map = **one price-labeled pin per store, 1:1 with a card.**
+
+```
+LIST (per store)            MAP
+┌──────────────────────┐   ┌─────────────────┐
+│ Sakura Mobility       │   │   ╭────────────╮│
+│ Kyoto Station · 2.1km │◄─►│   │Sakura Mob. ││
+│ Compact·Kei·SUV       │   │   │3 cars ¥6.5k+││
+│ from ¥6,500/day       │   │   ╰──📍─────────╯│
+│ [View cars ▾]         │   │  📍   📍         │
+└──────────────────────┘   └─────────────────┘
+click card → map flies + popup ·  click pin → its one card
+```
+
+- **Pros:** 1:1 pin↔card **dissolves the bugs by construction** (no clustering needed); short, scannable list (kills the repeated "Sakura Mobility · Kyoto Station ×3" noise visible today); matches the store-pickup business and the existing `门店` view + storefront detail page; clean, uncrowded map.
+- **Cons:** the bookable unit (a specific car) is one level down — renter expands or opens store detail to compare cars.
+
+### Option B — Car-first + clustering (Turo model)
+
+Result = **car**. Keep one card per vehicle. Map clusters co-located cars into a numbered marker; clicking a cluster opens a **popup carousel** of those cars. Add fly-to-pin on card click and hover sync.
+
+- **Pros:** the thing they book is always visible; matches Turo; good when comparing specific models/prices across stores is the main job.
+- **Cons:** pin↔cards stays **many-to-1** (needs real clustering + a carousel popup — more to build); long, repetitive list with many cars per store; busier map.
+
+### Option C — Map-driven list ("search this area")
+
+The map is the primary control: panning/zooming re-filters the list to what's in view, with a "Search this area" button (Airbnb's move-map-to-search).
+
+- **Pros:** powerful for area browsing.
+- **Cons:** biggest behavior change; re-query plumbing; **largely redundant with our region picker + chips**, which already scope the search. **Recommend deferring** — it's an enhancement layered on A or B, not a base choice.
+
+---
+
+## 4. Recommendation: Option A (Store-first)
+
+**Reasoning, in priority order:**
+
+1. **Store-pickup is the real-world unit.** The renter physically collects the car at a 门店; the store is where the transaction happens. Our platform is operators-with-storefronts.
+2. **It reuses the architecture we already have.** The default `门店` view is already store-grouped, and the storefront detail page (`/$locale/storefronts/$locationId`) already exists to list/select cars. Store-first *unifies* these; car-first fights them.
+3. **Few stores, many cars per store.** With ~40–50 vehicles across a handful of stores, car-first means a long, repetitive list and a crowded/clustered map. Store-first keeps the list to a few cards and the map clean.
+4. **1:1 pin↔card fixes the bugs structurally** — no clustering machinery. Pin = card = store; the "selects all" condition literally cannot arise; the popup carries real info; card-click moves the map.
+5. **One coherent screen** replaces two confusing half-views and the data-swapping toggle.
+
+**How A fixes each reported bug:**
+
+| Reported | Fix under A |
+|---|---|
+| Clicking a card does nothing | Card click flies the map to its pin + opens the popup (and "View cars" → store detail) |
+| "在地图上显示" does nothing | Replaced: the whole card is the affordance; the map visibly responds |
+| Pin highlights all cards, no info | Pin is now 1:1 with one store card; click opens an informative popup; highlights exactly that card |
+
+**Concretely, A is:** store cards with class chips + "from ¥X" + distance; a **sticky** map with price-labeled pins (selected inverts); a **pin popup** (store · N cars · from ¥X · "View cars"); **bidirectional hover/selection sync** + **fly-to on select**; on mobile, a **Map toggle** with a bottom-sheet card on pin tap. Car comparison happens on the existing storefront detail page (or an optional inline expand of the top 2–3 classes).
+
+---
+
+## 5. The decision for you + colleague
+
+**The one fork that changes everything:** *Is the renter's result a STORE (pick a place, then a car) or a CAR (compare cars; location is an attribute)?*
+
+- **Store → Option A** (recommended).
+- **Car → Option B** (Turo-style + clustering). Pick this if comparing specific models/prices across stores is the primary job, **or** if you expect many single-car stores (then grouping adds nothing).
+
+**Secondary questions to settle in review:**
+
+1. **Card depth:** store card links straight to the detail page, or inline-expands the top 2–3 classes with a Select button (Booking.com "rooms from" pattern)?
+2. **Pin label:** price ("¥6,500+", scannable, our standard recommendation) vs a count ("3") vs plain selected/unselected dots?
+3. **Mobile:** Map toggle + bottom sheet (recommended) vs a shrunk split.
+4. **Keep the 门店/地图 toggle**, or replace with one unified view + a "hide map" option?
+5. **"Search this area" (Option C):** in scope now, or a later enhancement? (Recommend later.)
+
+---
+
+## 6. Scope & impact (rough — for cost sense, not a plan)
+
+**Mostly web** (`packages/web/src/vite/search/*`, `…/storefronts/*`, the search route). Likely **no schema change**.
+
+- **New:** a real **pin popup/callout** in `PigeonMapAdapter` (pigeon-maps `<Overlay>`); **fly-to / recenter on selection** (`viewport.ts` already centers on a region anchor — extend to per-selection); **store-grouped cards in the map view** (reuse the `StorefrontCard` / `StoreGrid` model); **bidirectional sync** (`SearchMapList` already tracks a `locationId` selection — extend to fly + popup + scroll-into-view).
+- **Verify (API):** the storefront-grouped search payload (`StorefrontSearchResultData`) carries **lat/lng + min price + class counts per store** (the stores view already renders min price + class counts, so likely present — confirm lat/lng).
+- **Tests:** extend `SearchMapList.test`, `viewport.test`, `StoreGrid.test`; add popup, fly-to, and sync tests. Don't regress the region anchor (#840) or `e2e/real-db/region-search.auth.spec.ts`.
+- **Suggested slicing:** (1) unify to a store-grouped synchronized map+list with 1:1 sync + pin popup + fly-to; (2) price-labeled pins + mobile Map toggle; (3) optional inline car expand. Each is an independent vertical slice / PR.
+
+**Risks:** storefront search must carry coordinates + min price (verify); pigeon-maps overlay ergonomics; preserving region-centering and the existing e2e.
+
+---
+
+## 7. Next steps
+
+1. Review this with the colleague; settle §5 (mainly: store-result vs car-result).
+2. On decision, file a tracking issue (the redesign of closed #458) with the chosen option.
+3. Finalize the approved design → implementation plan (vertical slices above) → TDD build.

--- a/docs/plans/2026-06-15-search-map-list-redesign.md
+++ b/docs/plans/2026-06-15-search-map-list-redesign.md
@@ -66,7 +66,7 @@ Result = **car / combo**. One card per vehicle or class-combo. Map pin per **pic
 
 ### Option C — Map-driven list ("search this area")
 
-The map is primary: panning/zooming re-filters the list, with a "Search this area" button. *Largely redundant with our region picker + chips.* **Deferred** — an enhancement on top of B, not a base choice.
+The map is primary: panning/zooming re-filters the list, with a "Search this area" button. *Largely redundant with our region picker + chips.* **Deferred** — an enhancement on top of B, not a base choice. *(tracked as #883.)*
 
 ---
 
@@ -104,11 +104,11 @@ The map is primary: panning/zooming re-filters the list, with a "Search this are
 **Still open:**
 1. **Card / popup target:** link to the vehicle/combo detail page, or an inline quick-view? *(Lean: link to existing detail.)*
 2. **Keep the 门店/地图 toggle**, or make one unified map+list the default with a "hide map" option? *(Lean: unified default.)*
-3. **Later enhancements, designed-for not built-now:** "Search this area" (Option C) and **one-way rentals** (§6).
+3. **Later enhancements, designed-for not built-now:** "Search this area" (Option C → #883) and **one-way rentals** (§6 → #882).
 
 ---
 
-## 6. Future consideration: one-way rentals (pickup ≠ dropoff)
+## 6. Future consideration: one-way rentals (pickup ≠ dropoff) — tracked as #882
 
 A renter picks up at store A and drops off at store B (a.k.a. one-way / relocation rental). **Not in scope now**, but the redesign should not preclude it.
 

--- a/docs/plans/2026-06-15-search-map-list-redesign.md
+++ b/docs/plans/2026-06-15-search-map-list-redesign.md
@@ -1,6 +1,6 @@
 # Search results: map ↔ list interaction redesign
 
-**Status:** DIRECTION AGREED — **Option B (car-first)**, pending final colleague sign-off · updated 2026-06-15
+**Status:** SIGNED OFF — **Option B (car-first)**, §5 resolved (colleague review 2026-06-15); ready for the implementation plan · updated 2026-06-15
 **Author:** (Jack + Claude)
 **Decision owner:** Jack + colleague
 **Supersedes the UX of:** #458 (`feat: map + flat-list search results`, closed — original build)
@@ -88,23 +88,23 @@ The map is primary: panning/zooming re-filters the list, with a "Search this are
 
 **Concretely, B is:** per-car / per-combo cards (name · class · price · pickup store + geo-context); a **sticky** map with price-labeled pins (selected inverts); a **pin popup carousel** for co-located results; **bidirectional hover/selection sync** + **fly-to on focus**; on mobile, a **Map toggle** + bottom-sheet card on pin tap.
 
+**Interaction precision (review note — prevents a regression):** the card's **hover/focus drives the map** (highlight the pin → fly-to → open the popup); navigation to the **detail page happens *only* via an explicit CTA** ("View details" / "Select") on the card *and* in the popup. **Do NOT wrap the whole card in a navigation link** — today's `StorefrontCard` is a whole-card `<Link>`, and carrying that pattern over would swallow the card-focuses-pin behavior. The card and popup *are* the quick preview (photo · price · pickup landmark · key specs · CTA) — so there is **no separate inline quick-view**.
+
 *Revisit Option A only if* the catalog grows to many stores with one car each (grouping then adds nothing anyway) **or** store-pickup convenience eclipses model choice in user testing.
 
 ---
 
-## 5. Decisions & remaining open questions
+## 5. Decisions (all resolved — colleague sign-off 2026-06-15)
 
-**Resolved:**
-- **Result granularity → individual cars + combos** (Option B). *[decided]*
-- **Store-vs-car result → car**, for the foreigner geo-feedback goal. *[decided]*
-- **Pin click with N co-located cars → Airbnb-style swipeable carousel popup.** *[decided — industry standard]*
-- **Pin label → price** ("¥8,000" / "from ¥6,500"), the scannable Airbnb/Zillow standard. *[leaning — industry standard]*
-- **Mobile → Map toggle + bottom sheet.** *[leaning — industry standard]*
+- **Result granularity → individual cars + combos** (Option B).
+- **Store-vs-car result → car**, for the foreigner geo-feedback goal.
+- **Pin click with N co-located cars → Airbnb-style swipeable carousel popup** (industry standard).
+- **Pin label → price** ("¥8,000" / "from ¥6,500"), the scannable Airbnb/Zillow standard.
+- **Card / popup target → detail page via an explicit CTA** (no inline quick-view). The card/popup are the quick preview (photo · price · pickup landmark · key specs · CTA); **card hover/focus drives the map, only the CTA navigates** — see §4 *Interaction precision*.
+- **Retire the 门店/地图 data-mode toggle → one unified desktop map+list default.** If a control is wanted, a quiet **"Hide map / Show map" *presentation* toggle** — never a data-mode switch.
+- **Mobile → list default with a sticky "Map" button**; tapping it opens a **full-screen map + bottom-sheet carousel** on pin tap.
 
-**Still open:**
-1. **Card / popup target:** link to the vehicle/combo detail page, or an inline quick-view? *(Lean: link to existing detail.)*
-2. **Keep the 门店/地图 toggle**, or make one unified map+list the default with a "hide map" option? *(Lean: unified default.)*
-3. **Later enhancements, designed-for not built-now:** "Search this area" (Option C → #883) and **one-way rentals** (§6 → #882).
+**Deferred to their own issues (designed-for, not built now):** "Search this area" (Option C → #883), one-way rentals (§6 → #882).
 
 ---
 
@@ -127,6 +127,8 @@ A renter picks up at store A and drops off at store B (a.k.a. one-way / relocati
 ## 7. Scope & impact (rough — for cost sense, not a plan)
 
 **Mostly web** (`packages/web/src/vite/search/*`, the search route). Likely **no schema change** for the core redesign.
+
+> **Stack / paths — verified against `marketplace-pivot` 2026-06-15.** Web is a **Vite SPA + TanStack Router**. File routes live under `packages/web/src/routes/$locale/*.tsx`; feature code under `packages/web/src/vite/*`. Concretely: search route `packages/web/src/routes/$locale/search.tsx`; map/list `packages/web/src/vite/search/{SearchMap,SearchMapList,PigeonMapAdapter,SearchResultRow,SearchViewToggle,viewport,result,api}`; cards `packages/web/src/vite/storefronts/{StorefrontCard,StoreGrid}.tsx`. **There is no `packages/web/src/app/[locale]/…`** — the Next.js App Router tree was removed in #714 (epic #689) when web migrated to Vite. Any `app/[locale]` path is the *pre-migration* structure (a 259-commits-behind checkout shows it); confirm with `git ls-tree origin/marketplace-pivot:packages/web/src`.
 
 - **New:** a real **pin popup / carousel** in/around `PigeonMapAdapter` (pigeon-maps `<Overlay>`); **fly-to / recenter on focus** (`viewport.ts` already centers on a region anchor — extend to per-selection); **bidirectional sync** (`SearchMapList` already tracks a `locationId` selection — extend to fly + popup + scroll-into-view); **price-labeled pins**; **geo-context labels** (landmark/station · distance · prefecture) on card + popup.
 - **Verify (API):** the flat search payload (`SearchResultsData`) carries **lat/lng per pickup location** (it does — pins render today) and that a **min/representative price** is available for pin labels. Geo-context (nearest landmark/region name) may reuse the region data from #651.

--- a/docs/plans/2026-06-15-search-map-slice1-plan.md
+++ b/docs/plans/2026-06-15-search-map-slice1-plan.md
@@ -1,0 +1,425 @@
+# Search map↔list — Slice 1 Implementation Plan (fly-to + pin popup)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make selecting a result (via the row's "show on map" control *or* a map pin) **recenter the map on that pickup pin** and **open an info popup** on it — fixing "the pin reveals nothing" and "show on map does nothing visible," for the single-car (one card per pin) case.
+
+**Architecture:** Reuse the existing two-way selection (`SearchMapList` owns `selectedId`, keyed by `locationId`; the row button and `PigeonMapAdapter` markers both set it). Add two behaviors driven off that same `selectedId`: (1) a pure `focusViewport()` that centers on the selected pin, fed into the existing uncontrolled-map remount; (2) a pigeon-maps `<Overlay>` popup whose *content* is supplied by the view via a new optional `renderSelected` prop, so the adapter stays library-only (the view keeps i18n/presentation). No route, schema, or data-shape changes.
+
+**Tech Stack:** Vite SPA + TanStack Router; React 19; pigeon-maps; use-intl; vitest + @testing-library/react (happy-dom). Run web tests: `bun run --filter @kuruma/web test`.
+
+**Branch/worktree:** implement on a fresh slice branch off `marketplace-pivot` (this plan + the brief live on `feat/search-map-redesign` / PR #886). Tracking issue: #885. Out of scope (follow-ups): co-location carousel + price-labeled pins (Slice 2, #885), geo-context labels + mobile Map toggle (Slice 3), card-as-affordance + explicit detail CTA wiring (needs `from`/`to` threaded into `SearchMapList`; deferred with the booking flow).
+
+---
+
+## File structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `packages/web/src/vite/search/viewport.ts` | modify | add pure `focusViewport(pins, anchor, selectedId)` |
+| `packages/web/tests/vite/search/viewport.test.ts` | modify | cover `focusViewport` |
+| `packages/web/src/vite/search/MapAdapter.ts` | modify | add optional `renderSelected` to `MapAdapterProps` |
+| `packages/web/src/vite/search/PigeonMapAdapter.tsx` | modify | recenter on selection; render `<Overlay>` popup |
+| `packages/web/tests/vite/search/PigeonMapAdapter.test.tsx` | modify | recenter + overlay tests (mock `Overlay`) |
+| `packages/web/src/vite/search/result.ts` | modify | add `resultTitle(item)` + `resultPriceLabel(item, t)` |
+| `packages/web/tests/vite/search/result.test.ts` | create | unit-test the two formatters |
+| `packages/web/src/vite/search/SearchResultRow.tsx` | modify | reuse `resultPriceLabel` (DRY, behavior unchanged) |
+| `packages/web/src/vite/search/SearchMapList.tsx` | modify | pass `renderSelected` (popup: title · store · price) |
+| `packages/web/tests/vite/search/SearchMapList.test.tsx` | modify | popup shows when selected; absent otherwise |
+
+---
+
+## Task 1: `focusViewport` — center on the selected pin
+
+**Files:** Modify `packages/web/src/vite/search/viewport.ts`; Test `packages/web/tests/vite/search/viewport.test.ts`.
+
+- [ ] **Step 1: Write the failing tests** — append to `viewport.test.ts` (it already imports from `../../../src/vite/search/viewport`; add `focusViewport` to that import):
+
+```ts
+describe('focusViewport', () => {
+  const pins = [
+    { id: 'loc_namba', lat: 34.6627, lng: 135.5023 },
+    { id: 'loc_umeda', lat: 34.7025, lng: 135.4959 },
+  ]
+
+  it('centers on the selected pin at the single-pin zoom', () => {
+    expect(focusViewport(pins, null, 'loc_umeda')).toEqual({
+      center: [34.7025, 135.4959],
+      zoom: SINGLE_PIN_ZOOM,
+    })
+  })
+
+  it('overrides the region anchor when a pin is selected (the selection wins)', () => {
+    expect(focusViewport(pins, [34.99, 135.99], 'loc_namba').center).toEqual([34.6627, 135.5023])
+  })
+
+  it('falls back to computeViewport when nothing is selected', () => {
+    expect(focusViewport(pins, null, null)).toEqual(computeViewport(pins, null))
+  })
+
+  it('falls back to computeViewport when the selected id matches no pin', () => {
+    expect(focusViewport(pins, null, 'loc_ghost')).toEqual(computeViewport(pins, null))
+  })
+})
+```
+
+Add `SINGLE_PIN_ZOOM` and `computeViewport` to the test's existing import line if not present.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `bun run --filter @kuruma/web test viewport`
+Expected: FAIL — `focusViewport is not a function`.
+
+- [ ] **Step 3: Implement** — append to `viewport.ts`:
+
+```ts
+/** Viewport when a result is selected: center on its pin at a close zoom so the
+ *  renter sees exactly where that car is picked up. The selection wins over the
+ *  fit-all / region-anchor viewport; with nothing selected (or an unknown id) it
+ *  defers to computeViewport. Pure. */
+export function focusViewport(
+  pins: Pin[],
+  anchor: [number, number] | null,
+  selectedId: string | null,
+): { center: [number, number]; zoom: number } {
+  const selected = selectedId === null ? null : (pins.find((p) => p.id === selectedId) ?? null)
+  if (selected) return { center: [selected.lat, selected.lng], zoom: SINGLE_PIN_ZOOM }
+  return computeViewport(pins, anchor)
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** — `bun run --filter @kuruma/web test viewport`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/search/viewport.ts packages/web/tests/vite/search/viewport.test.ts
+git commit -m "feat(web): focusViewport centers the map on the selected pin (#885 slice 1)"
+```
+
+---
+
+## Task 2: PigeonMapAdapter recenters on selection
+
+**Files:** Modify `PigeonMapAdapter.tsx`; Test `PigeonMapAdapter.test.tsx`.
+
+- [ ] **Step 1: Write the failing test** — add inside `describe('PigeonMapAdapter', ...)`:
+
+```ts
+it('recenters on the selected pin (fly-to) when one is selected', () => {
+  render(
+    <PigeonMapAdapter
+      items={[
+        carAt('loc_namba', { latitude: 34.6627, longitude: 135.5023 }),
+        carAt('loc_umeda', { latitude: 34.7025, longitude: 135.4959 }),
+      ]}
+      selectedId="loc_umeda"
+      onSelect={() => {}}
+    />,
+  )
+  const map = screen.getByTestId('pigeon-map')
+  expect(map).toHaveAttribute('data-center', '34.7025,135.4959')
+  expect(map).toHaveAttribute('data-zoom', '12') // SINGLE_PIN_ZOOM
+})
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `bun run --filter @kuruma/web test PigeonMapAdapter`
+Expected: FAIL — `data-center` is the fit-all midpoint, not the selected pin.
+
+- [ ] **Step 3: Implement** — in `PigeonMapAdapter.tsx`, swap the viewport call and add `selectedId` to the remount key so a selection re-centers (consistent with the existing uncontrolled-map pattern):
+
+```tsx
+import { type Pin, focusViewport } from './viewport'
+// ...
+const viewport = focusViewport(pins, anchor, selectedId)
+// ...
+<PigeonMap
+  key={`${selectedId ?? ''}:${anchor ? anchor.join(',') : 'fit'}:${pins.map((p) => p.id).join(',')}`}
+  provider={gsiTileProvider}
+  attribution={GSI_ATTRIBUTION}
+  attributionPrefix={false}
+  defaultCenter={viewport.center}
+  defaultZoom={viewport.zoom}
+>
+```
+
+(Replace the old `computeViewport(pins, anchor)` line and the old `key=` line; remove the now-unused `computeViewport` import.)
+
+- [ ] **Step 4: Run, expect PASS** — `bun run --filter @kuruma/web test PigeonMapAdapter`
+The existing "fits the pins when no anchor" test still passes (`selectedId={null}` → `focusViewport` defers to `computeViewport`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/search/PigeonMapAdapter.tsx packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
+git commit -m "feat(web): map recenters on the selected pin (#885 slice 1)"
+```
+
+> Note: selection remounts the map (re-fetches tiles, resets pan) — acceptable for Slice 1's "jump to the pin." Smooth animated fly + pan-preservation (controlled `center`/`onBoundsChanged`) is a deliberate later polish.
+
+---
+
+## Task 3: `renderSelected` prop + Overlay popup in the adapter
+
+**Files:** Modify `MapAdapter.ts`, `PigeonMapAdapter.tsx`; Test `PigeonMapAdapter.test.tsx`.
+
+- [ ] **Step 1: Extend the contract** — in `MapAdapter.ts` add to `MapAdapterProps` (and `import type { ComponentType, ReactNode } from 'react'`):
+
+```ts
+  /** Renders the popup body for the selected location. The VIEW owns presentation
+   *  (i18n, router links); the adapter only positions it at the pin. Absent = no
+   *  popup. */
+  renderSelected?: (item: SearchResultItem) => ReactNode
+```
+
+- [ ] **Step 2: Write the failing tests** — extend the `vi.mock('pigeon-maps', ...)` factory with an `Overlay`, and add a test:
+
+```ts
+// add to the mock's returned object:
+Overlay: ({ children, anchor }: { children: ReactNode; anchor: [number, number] }) => (
+  <div data-testid="overlay" data-anchor={anchor.join(',')}>
+    {children}
+  </div>
+),
+```
+
+```ts
+it('renders the selected popup at its pin via renderSelected, and nothing when unselected', () => {
+  const renderSelected = (item: SpecificSearchResult) => (
+    <div data-testid="popup">{item.location.locationId}</div>
+  )
+  const props = {
+    items: [carAt('loc_namba', { latitude: 34.6627, longitude: 135.5023 })],
+    onSelect: () => {},
+    renderSelected,
+  }
+  const { rerender } = render(<PigeonMapAdapter {...props} selectedId={null} />)
+  expect(screen.queryByTestId('popup')).toBeNull()
+
+  rerender(<PigeonMapAdapter {...props} selectedId="loc_namba" />)
+  const overlay = screen.getByTestId('overlay')
+  expect(overlay).toHaveAttribute('data-anchor', '34.6627,135.5023')
+  expect(screen.getByTestId('popup')).toHaveTextContent('loc_namba')
+})
+```
+
+- [ ] **Step 3: Run, expect FAIL** — `bun run --filter @kuruma/web test PigeonMapAdapter`
+Expected: FAIL — no overlay rendered.
+
+- [ ] **Step 4: Implement** — in `PigeonMapAdapter.tsx`: add `Overlay` to the pigeon-maps import, destructure `renderSelected`, resolve the selected pin+item, and render the overlay:
+
+```tsx
+import { Marker, Overlay, Map as PigeonMap } from 'pigeon-maps'
+// ...
+export function PigeonMapAdapter({ items, selectedId, onSelect, anchor = null, renderSelected }: MapAdapterProps) {
+  const pins = items
+    .map((item) => ({ id: item.location.locationId, lat: item.location.latitude, lng: item.location.longitude }))
+    .filter((p): p is Pin => p.lat !== null && p.lng !== null)
+
+  const viewport = focusViewport(pins, anchor, selectedId)
+  const selectedPin = selectedId === null ? null : (pins.find((p) => p.id === selectedId) ?? null)
+  const selectedItem =
+    selectedId === null ? null : (items.find((i) => i.location.locationId === selectedId) ?? null)
+
+  return (
+    <PigeonMap /* ...props as Task 2... */>
+      {pins.map((pin) => (
+        <Marker
+          key={pin.id}
+          anchor={[pin.lat, pin.lng]}
+          color={pin.id === selectedId ? SELECTED_COLOR : MARKER_COLOR}
+          onClick={() => onSelect(pin.id)}
+        />
+      ))}
+      {selectedPin && selectedItem && renderSelected && (
+        <Overlay anchor={[selectedPin.lat, selectedPin.lng]} offset={[120, 20]}>
+          {renderSelected(selectedItem)}
+        </Overlay>
+      )}
+    </PigeonMap>
+  )
+}
+```
+
+(The `offset` is a pixel nudge so the popup clears the marker; tune visually during review.)
+
+- [ ] **Step 5: Run, expect PASS** — `bun run --filter @kuruma/web test PigeonMapAdapter`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/web/src/vite/search/MapAdapter.ts packages/web/src/vite/search/PigeonMapAdapter.tsx packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
+git commit -m "feat(web): pin popup overlay via renderSelected seam (#885 slice 1)"
+```
+
+---
+
+## Task 4: Shared `resultTitle` + `resultPriceLabel` (DRY the row, reuse in the popup)
+
+**Files:** Modify `result.ts`, `SearchResultRow.tsx`; Test (create) `result.test.ts`.
+
+- [ ] **Step 1: Write the failing tests** — create `packages/web/tests/vite/search/result.test.ts`:
+
+```ts
+import { resultPriceLabel, resultTitle } from '@/vite/search/result'
+import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import { describe, expect, it } from 'vitest'
+
+const base: SpecificSearchResult = {
+  kind: 'SPECIFIC', location: { locationId: 'l', operatorId: 'o', operatorName: 'Op', name: 'Namba', address: 'Osaka', latitude: 34.6, longitude: 135.5 },
+  dailyRateJpy: 8000, hourlyRateJpy: null, classLabel: 'Compact', acrissCode: 'CCAR', seats: 5, photos: [],
+  vehicleId: 'v1', name: 'Toyota Yaris', make: 'Toyota', model: 'Yaris', year: 2023, transmission: 'AUTO',
+}
+const t = (key: string, values?: Record<string, unknown>) => (values ? `${key}:${values.price}` : key)
+
+describe('resultTitle', () => {
+  it('uses the car name for a SPECIFIC result', () => {
+    expect(resultTitle(base)).toBe('Toyota Yaris')
+  })
+})
+
+describe('resultPriceLabel', () => {
+  it('formats a daily rate with thousands separators', () => {
+    expect(resultPriceLabel(base, t)).toBe('fromDaily:8,000')
+  })
+  it('falls back to hourly, then to no-price', () => {
+    expect(resultPriceLabel({ ...base, dailyRateJpy: null, hourlyRateJpy: 500 }, t)).toBe('fromHourly:500')
+    expect(resultPriceLabel({ ...base, dailyRateJpy: null, hourlyRateJpy: null }, t)).toBe('noPrice')
+  })
+})
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `bun run --filter @kuruma/web test result`
+Expected: FAIL — exports don't exist.
+
+- [ ] **Step 3: Implement** — append to `result.ts` (`searchResultKey` stays):
+
+```ts
+type Translate = (key: string, values?: Record<string, unknown>) => string
+
+/** Human title of a result row: the car name (SPECIFIC) or class label (CLASS_COMBO). */
+export function resultTitle(item: SearchResultItem): string {
+  return item.kind === 'SPECIFIC' ? item.name : item.classLabel
+}
+
+/** "From ¥X / day" (or hourly, or price-on-request) — shared by the list row and
+ *  the map popup so they never drift. `t` is the use-intl translator. */
+export function resultPriceLabel(item: SearchResultItem, t: Translate): string {
+  if (item.dailyRateJpy != null) return t('fromDaily', { price: item.dailyRateJpy.toLocaleString('en-US') })
+  if (item.hourlyRateJpy != null) return t('fromHourly', { price: item.hourlyRateJpy.toLocaleString('en-US') })
+  return t('noPrice')
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** — `bun run --filter @kuruma/web test result`
+
+- [ ] **Step 5: Refactor `SearchResultRow.tsx` to reuse it (behavior unchanged)** — replace the inline `priceLabel` block with `const priceLabel = resultPriceLabel(item, t)` and import `resultPriceLabel` from `./result`. Run the existing row test to confirm green: `bun run --filter @kuruma/web test SearchResult`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/web/src/vite/search/result.ts packages/web/src/vite/search/SearchResultRow.tsx packages/web/tests/vite/search/result.test.ts
+git commit -m "refactor(web): share resultTitle/resultPriceLabel between row and popup (#885 slice 1)"
+```
+
+---
+
+## Task 5: SearchMapList supplies the popup content
+
+**Files:** Modify `SearchMapList.tsx`; Test `SearchMapList.test.tsx`.
+
+- [ ] **Step 1: Update the fake adapter to exercise the seam, then write the failing test** — in `SearchMapList.test.tsx`, make `FakeMapAdapter` invoke `renderSelected` for the selected item so the view's popup content is observable:
+
+```tsx
+const FakeMapAdapter: MapAdapter = ({ items, selectedId, onSelect, anchor, renderSelected }) => {
+  const selected = items.find((i) => i.location.locationId === selectedId) ?? null
+  return (
+    <div data-testid="fake-map" data-selected={selectedId ?? ''} data-anchor={anchor?.join(',') ?? ''}>
+      {items.map((item) => (
+        <button key={item.location.locationId} type="button" data-testid={`marker-${item.location.locationId}`} onClick={() => onSelect(item.location.locationId)}>
+          marker
+        </button>
+      ))}
+      {selected && renderSelected && <div data-testid="map-popup">{renderSelected(selected)}</div>}
+    </div>
+  )
+}
+```
+
+Add the test:
+
+```ts
+it('renders a map popup (title · store · price) for the selected location', () => {
+  renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
+  expect(screen.queryByTestId('map-popup')).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: /show on map/i }))
+
+  const popup = screen.getByTestId('map-popup')
+  expect(popup).toHaveTextContent('Toyota Yaris')
+  expect(popup).toHaveTextContent('Best Car Rental')
+  expect(popup).toHaveTextContent(/8,000/)
+})
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `bun run --filter @kuruma/web test SearchMapList`
+Expected: FAIL — `SearchMapList` passes no `renderSelected`, so no popup.
+
+- [ ] **Step 3: Implement** — in `SearchMapList.tsx`, import the formatters and pass `renderSelected` to the adapter:
+
+```tsx
+import { resultPriceLabel, resultTitle, searchResultKey } from './result'
+// ...inside the component, the adapter call becomes:
+<Adapter
+  items={mapItems}
+  selectedId={selectedId}
+  onSelect={setSelectedId}
+  anchor={anchor}
+  renderSelected={(item) => (
+    <div className="min-w-44 rounded-lg border border-border bg-card p-3 text-sm shadow-md">
+      <p className="font-semibold leading-tight">{resultTitle(item)}</p>
+      <p className="mt-0.5 text-muted-foreground">
+        {item.location.operatorName} · {item.location.name}
+      </p>
+      <p className="mt-1 font-medium text-foreground">{resultPriceLabel(item, t)}</p>
+    </div>
+  )}
+/>
+```
+
+- [ ] **Step 4: Run, expect PASS** — `bun run --filter @kuruma/web test SearchMapList`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/search/SearchMapList.tsx packages/web/tests/vite/search/SearchMapList.test.tsx
+git commit -m "feat(web): map popup shows the selected car (title, store, price) (#885 slice 1)"
+```
+
+---
+
+## Task 6: Green gate + PR
+
+- [ ] **Step 1: Full web suite** — `bun run --filter @kuruma/web test` → all pass.
+- [ ] **Step 2: Types** — `bun run --filter @kuruma/web typecheck` → exit 0.
+- [ ] **Step 3: Format/lint** — `bunx biome check --write packages/web/src/vite/search packages/web/tests/vite/search` then re-run typecheck if it reorders imports.
+- [ ] **Step 4: Manual check** (optional) — `bun run dev`, open `/en/search?...&view=map`, click a pin → map recenters + popup shows; click "Show on map" on a row → same.
+- [ ] **Step 5: PR** — push the slice branch; open a PR "feat(web): search map fly-to + pin popup (#885 slice 1)" base `marketplace-pivot`, body references #885 and this plan. Do NOT close #885 (slices 2–3 remain).
+
+---
+
+## Follow-ups (NOT this slice)
+
+- **Slice 2 (#885):** co-located cars → carousel popup; price-labeled pins.
+- **Slice 3 (#885):** geo-context labels (landmark · distance · prefecture); mobile list-default + sticky "Map" toggle + bottom sheet.
+- **Slice 1b:** card *body* as the map affordance (replacing the "show on map" button) + explicit detail CTA in card+popup → storefront detail; requires threading `from`/`to` into `SearchMapList` (route change in `routes/$locale/search.tsx`). Honors the brief's interaction-precision rule (no whole-card `<Link>`).
+- **Polish:** animated fly + pan-preservation via controlled `center`/`onBoundsChanged` instead of remount.
+
+---
+
+## Self-review
+
+- **Spec coverage:** brief §4/§7 Slice 1 = "card↔pin sync + fly-to + pin popup (single-car)." Sync pre-exists; fly-to = Tasks 1–2; popup = Tasks 3–5. ✓ Card-as-affordance + CTA explicitly deferred to Slice 1b with rationale (avoids `from`/`to` route churn) — noted, not dropped.
+- **Type consistency:** `renderSelected?: (item: SearchResultItem) => ReactNode` defined in `MapAdapter.ts` (Task 3), consumed in `SearchMapList` (Task 5) and the fake adapter (test); `focusViewport(pins, anchor, selectedId)` signature identical in Tasks 1–2; `resultTitle`/`resultPriceLabel` signatures identical in Tasks 4–5.
+- **Placeholders:** none — every code step is concrete.
+- **Risk:** `Overlay` must be added to the pigeon-maps mock (Task 3 Step 2) or the adapter test throws "Overlay is not a function." Remount-on-select is intentional (noted).


### PR DESCRIPTION
Decision brief for the search-results map↔list redesign — **for review, not code.** Draft until sign-off.

Adds `docs/plans/2026-06-15-search-map-list-redesign.md`: diagnosis of today's broken map view, the industry-standard list–map pattern, three options with trade-offs, and the decision (**Option B — car-first**), plus a forward-compat section for one-way rentals.

**Why Option B:** the renter is a foreign tourist who needs instant *"where in Japan can I pick this up?"* feedback. Cards stay per-car/per-combo, each tied to its pickup-store pin; co-located cars share a pin that opens an Airbnb-style carousel popup; card focus flies the map + opens a popup. Fixes all three reported bugs by construction.

**Review ask — the open questions in §5:**
1. Card/popup → detail page vs inline quick-view (lean: link to detail).
2. Keep the 门店/地图 toggle, or unify into one map+list default (lean: unify).
Plus two leaning calls: price-labeled pins, mobile Map toggle.

**Issue trail:**
- Tracking (the build): #885
- Future-track split-outs: #882 (one-way rentals), #883 ("search this area")
- UX rebuild of closed #458

Once §5 is signed off, next step is the implementation plan → TDD build (slices in §7). This PR can merge to preserve the brief, or stay open as the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)