### PR TITLE
fix(api): bind default fetch to globalThis so outbound email works on CF Workers (#887)

### DIFF
--- a/packages/api/src/services/email/resend-email-sender.ts
+++ b/packages/api/src/services/email/resend-email-sender.ts
@@ -22,7 +22,9 @@ export class ResendEmailSender implements EmailSender {
   constructor(
     private readonly apiKey: string,
     private readonly defaultFrom: string,
-    private readonly fetchFn: typeof fetch = fetch,
+    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
+    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
+    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
   ) {}
 
   async send(message: EmailMessage): Promise<SendResult> {

--- a/packages/api/src/services/geocoding/nominatim-geocoder.ts
+++ b/packages/api/src/services/geocoding/nominatim-geocoder.ts
@@ -26,7 +26,9 @@ export class NominatimGeocoder implements Geocoder {
   constructor(
     private readonly baseUrl: string,
     private readonly userAgent: string,
-    private readonly fetchFn: typeof fetch = fetch,
+    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
+    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
+    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
     // Optional auth token. LocationIQ is Nominatim-compatible but key-gated via
     // `?key=` (#574), so providing one makes it a pure env-var swap from public OSM.
     private readonly apiKey?: string,

--- a/packages/api/src/services/google-translation-provider.ts
+++ b/packages/api/src/services/google-translation-provider.ts
@@ -22,7 +22,9 @@ interface GoogleResponse {
 export class GoogleTranslationProvider implements TranslationProvider {
   constructor(
     private readonly apiKey: string,
-    private readonly fetchFn: typeof fetch = fetch,
+    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
+    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
+    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
   ) {}
 
   async translate(

--- a/packages/api/tests/services/email/resend-email-sender.test.ts
+++ b/packages/api/tests/services/email/resend-email-sender.test.ts
@@ -93,4 +93,23 @@ describe('ResendEmailSender', () => {
     const body = JSON.parse(fetchFn.mock.calls[0]![1]!.body as string)
     expect(body.from).toBe('configured@from')
   })
+
+  it('binds the default fetch to globalThis so a CF Workers send does not throw Illegal invocation (#887)', async () => {
+    // CF Workers' global fetch is a branded builtin that throws unless called with
+    // this === globalThis. Node/vitest don't brand it, so simulate the branding and
+    // exercise the DEFAULT fetchFn — the prod path that silently killed every email.
+    const brandedFetch = async function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
+      }
+      return jsonResponse({ id: 'resend-bound' })
+    }
+    vi.stubGlobal('fetch', brandedFetch)
+    try {
+      const result = await new ResendEmailSender('re_key', 'noreply@from').send(message)
+      expect(result).toEqual({ providerMessageId: 'resend-bound' })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/packages/api/tests/services/geocoding/nominatim-geocoder.test.ts
+++ b/packages/api/tests/services/geocoding/nominatim-geocoder.test.ts
@@ -96,4 +96,23 @@ describe('NominatimGeocoder', () => {
     const parsed = new URL(fetchFn.mock.calls[0]![0] as string)
     expect(parsed.searchParams.has('key')).toBe(false)
   })
+
+  it('binds the default fetch to globalThis so a CF Workers geocode does not silently miss (#887)', async () => {
+    // On CF Workers the global fetch throws "Illegal invocation" unless this === globalThis.
+    // geocode() swallows that as a network error and returns notFound, silently dropping
+    // coordinates. Exercise the DEFAULT fetchFn against a this-sensitive (branded) fetch.
+    const brandedFetch = async function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
+      }
+      return jsonResponse(osakaHit)
+    }
+    vi.stubGlobal('fetch', brandedFetch)
+    try {
+      const result = await new NominatimGeocoder(BASE, UA).geocode('Osaka')
+      expect(result).toEqual({ status: 'ok', lat: 34.6937, lng: 135.5023 })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/packages/api/tests/services/google-translation-provider.test.ts
+++ b/packages/api/tests/services/google-translation-provider.test.ts
@@ -117,4 +117,24 @@ describe('GoogleTranslationProvider', () => {
     await expect(provider.translate('x', null, 'en')).rejects.toThrow('still down')
     expect(fetchFn).toHaveBeenCalledTimes(2)
   })
+
+  it('binds the default fetch to globalThis so a CF Workers translate does not throw Illegal invocation (#887)', async () => {
+    // CF Workers brands the global fetch: calling it detached (this !== globalThis) throws.
+    // Exercise the DEFAULT fetchFn against a this-sensitive (branded) fetch stub.
+    const brandedFetch = async function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
+      }
+      return jsonResponse({
+        data: { translations: [{ translatedText: 'Hello', detectedSourceLanguage: 'ja' }] },
+      })
+    }
+    vi.stubGlobal('fetch', brandedFetch)
+    try {
+      const result = await new GoogleTranslationProvider('key').translate('こんにちは', null, 'en')
+      expect(result).toEqual({ translatedText: 'Hello', detectedLanguage: 'ja' })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/packages/api/tests/services/no-detached-fetch.test.ts
+++ b/packages/api/tests/services/no-detached-fetch.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// #887 recurrence guard. On CF Workers the global `fetch` is a branded builtin
+// that throws "Illegal invocation" unless called with `this === globalThis`.
+// Services here capture fetch as a class field and call it as `this.fetchFn(...)`,
+// so the constructor default MUST be `fetch.bind(globalThis)`, never a bare
+// `= fetch`. The bare form silently broke ALL outbound email in prod (every
+// notification_log row FAILED) and passed CI because node/vitest don't brand
+// fetch. This guard bans the bare pattern recurring anywhere under api/src.
+const SRC = join(fileURLToPath(import.meta.url), '../../../src')
+
+// `typeof fetch = fetch` NOT immediately followed by `.bind`. Allows the fix
+// (`= fetch.bind(globalThis)`) while flagging the footgun (`= fetch,`).
+const BARE_FETCH_DEFAULT = /typeof fetch\s*=\s*fetch(?!\.bind)/
+
+describe('no detached global fetch (#887)', () => {
+  it('no source file captures the default `fetch` without binding it to globalThis', () => {
+    const offenders = readdirSync(SRC, { recursive: true })
+      .filter((entry): entry is string => typeof entry === 'string' && entry.endsWith('.ts'))
+      .filter((file) => BARE_FETCH_DEFAULT.test(readFileSync(join(SRC, file), 'utf8')))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## The outage
On Cloudflare Workers the global `fetch` is a **branded builtin** that must be called with `this === globalThis`. Three services captured it detached as a class field and called it as a method:

```ts
private readonly fetchFn: typeof fetch = fetch   // captured unbound
await this.fetchFn(...)                            // this = instance -> Illegal invocation
```

So **every outbound email since beta launch failed silently** — `notification_log` rows `FAILED` with `error = "Illegal invocation: function called with incorrect 'this' reference"` (booking still succeeds, in-app alert still shows). `translate` + `geocode` shared the same latent bug. Node/vitest don't brand `fetch`, so CI stayed green.

## The fix
Default to `fetch.bind(globalThis)` in `resend-email-sender`, `google-translation-provider`, and `nominatim-geocoder`. The injectable test mock is unaffected — only the default binds. No schema change, no migration. `tsc` accepts the bound type (no cast needed).

## Tests
- **Behavioral reproduction (1 per service):** stub `globalThis.fetch` with a `this`-sensitive (branded) fetch and exercise the **default** `fetchFn`. RED with the bare default (Illegal invocation / silent `notFound`), GREEN once bound. These are real reproductions, not mock-tests-mock.
- **Recurrence guard** (`no-detached-fetch.test.ts`): scans `api/src` and bans `typeof fetch = fetch` unless `.bind`-ed. It bit 3 places; it will bite again.
- Full api unit suite: **1525 passed**.

## Out of scope (noted)
`packages/web/functions/_shared/proxy.ts` has the same default but calls it **bare** (`fetchImpl(...)`, `this = undefined`), which Workers accepts — not broken, left untouched. That's why the web→API proxy works in prod while email died.

## Deploy / verify
- PR #874 (deploy.yml smoke URL `kanata-studio`) already merged, so the API deploy is unblocked.
- After merge: deploy via `workflow_dispatch` → re-book a Best Car Rental car → `notification_log` rows flip to `SENT` and emails arrive at renter + owner. (The 2 already-FAILED rows won't auto-resend — no cron.)
- Land this **before** #888 (#878 alert fan-out) — that changes alert *recipients*; this is the *transport*.

Closes #887