### PR TITLE
fix(ci): close lint-fetch-binding cast/alias bypass (#892 follow-up)

### DIFF
--- a/scripts/lint-fetch-binding.test.ts
+++ b/scripts/lint-fetch-binding.test.ts
@@ -74,6 +74,32 @@ describe('findDetachedFetchDefaults', () => {
     ].join('\n')
     expect(findDetachedFetchDefaults(src)).toEqual([1, 3])
   })
+
+  // #892 follow-up: a TS cast must not let the unbound capture slip past — and
+  // `as typeof fetch` already appears (correctly) on the bound form, so the
+  // cast-without-bind shape is one copy-paste away.
+  test('flags `= fetch as typeof fetch` — an unbound cast must not bypass the guard', () => {
+    const src = '    private readonly fetchFn: typeof fetch = fetch as typeof fetch,'
+    expect(findDetachedFetchDefaults(src)).toEqual([1])
+  })
+
+  test('flags a qualified unbound cast `= globalThis.fetch as typeof fetch`', () => {
+    const src = 'fetchFn: typeof fetch = globalThis.fetch as typeof fetch,'
+    expect(findDetachedFetchDefaults(src)).toEqual([1])
+  })
+
+  test('flags an unbound cast when the closing paren is on the next line', () => {
+    const src = 'function f(\n  fetchImpl: typeof fetch = fetch as typeof fetch\n) {}'
+    expect(findDetachedFetchDefaults(src)).toEqual([2])
+  })
+
+  test('flags the `= window.fetch` capture (DOM-typed web alias of the global)', () => {
+    const src = [
+      'a: typeof fetch = window.fetch,',
+      'b: typeof fetch = window.fetch as typeof fetch)',
+    ].join('\n')
+    expect(findDetachedFetchDefaults(src)).toEqual([1, 2])
+  })
 })
 
 describe('scanRoots', () => {
@@ -86,6 +112,8 @@ describe('scanRoots', () => {
     mkdirSync(join(root, 'tests'), { recursive: true })
     writeFileSync(join(root, 'service.ts'), BAD) // scanned -> violation
     writeFileSync(join(root, 'widget.tsx'), BAD) // .tsx scanned -> violation
+    writeFileSync(join(root, 'edge.cts'), BAD) // .cts scanned -> violation
+    writeFileSync(join(root, 'legacy.js'), BAD) // .js scanned -> violation
     writeFileSync(join(root, 'service.test.ts'), BAD) // excluded (real fetch ok in tests)
     writeFileSync(join(root, 'tests', 'helper.ts'), BAD) // excluded (tests/ dir)
     writeFileSync(join(root, 'clean.ts'), 'const ok = fetch.bind(globalThis)') // bound -> clean
@@ -93,11 +121,11 @@ describe('scanRoots', () => {
 
   afterAll(() => rmSync(cwd, { recursive: true, force: true }))
 
-  test('reports prod .ts/.tsx violations and skips tests + bound files', () => {
+  test('reports prod .ts/.tsx/.cts/.js violations and skips tests + bound files', () => {
     const files = scanRoots(['src'], cwd)
       .map((v) => v.file)
       .sort()
-    expect(files).toEqual(['src/service.ts', 'src/widget.tsx'])
+    expect(files).toEqual(['src/edge.cts', 'src/legacy.js', 'src/service.ts', 'src/widget.tsx'])
   })
 
   test('returns the offending line number for each violation', () => {

--- a/scripts/lint-fetch-binding.ts
+++ b/scripts/lint-fetch-binding.ts
@@ -31,12 +31,16 @@ const RUNTIME_ROOTS = [
 ]
 
 // A default initializer set to the bare global fetch: `= fetch` (optionally
-// `globalThis.`/`self.`-qualified — `= globalThis.fetch` captures it just as
-// detached) followed by a `,` / `)` that closes the param, or end-of-line when
-// the `)` is on the next line (a last param without a trailing comma).
-// `= fetch.bind(...)` has a `.` after `fetch` and `= fetch(url)` has a `(`, so
-// neither matches — only the un-bound capture does.
-const DETACHED_FETCH_DEFAULT = /=\s*(?:globalThis\.|self\.)?fetch\s*(?:[,)]|$)/
+// `globalThis.`/`self.`/`window.`-qualified — each captures it just as detached),
+// with an OPTIONAL `as <type>` cast, followed by a `,` / `)` that closes the
+// param, or end-of-line when the `)` is on the next line (a last param without a
+// trailing comma). The `(?!\s*[.(])` right after `fetch` rejects the safe forms:
+// `= fetch.bind(...)` (a `.`) and `= fetch(url)` (a `(`). A cast does NOT launder
+// the bug — `= fetch as typeof fetch` is still an unbound capture (and that exact
+// `as typeof fetch` shape already rides on the bound fix, one copy-paste away) —
+// so the cast is matched and flagged unless `.bind` precedes it.
+const DETACHED_FETCH_DEFAULT =
+  /=\s*(?:globalThis\.|self\.|window\.)?fetch\b(?!\s*[.(])(?:\s+as\s+[^,)]+?)?\s*(?:[,)]|$)/
 
 /**
  * Blanks line comments, block comments, and string/template literals while
@@ -102,7 +106,7 @@ function collectTsFiles(dir: string): string[] {
     if (statSync(full).isDirectory()) {
       if (entry === 'tests' || entry === '__tests__') continue
       files.push(...collectTsFiles(full))
-    } else if (/\.(ts|tsx|mts)$/.test(entry) && !/\.test\.(ts|tsx)$/.test(entry)) {
+    } else if (/\.(c|m)?[jt]sx?$/.test(entry) && !/\.test\.(c|m)?[jt]sx?$/.test(entry)) {
       files.push(full)
     }
   }


### PR DESCRIPTION
Follow-up to #892 (merged), from its code review.

## Gap
`lint-fetch-binding` anchored a terminator immediately after `fetch`, so a TS cast laundered the detached-fetch footgun:
- `= fetch as typeof fetch` → **not flagged** (confirmed empirically). And `as typeof fetch` already rides on the bound fix, so the cast-without-bind shape is one copy-paste from re-breaking the branded CF Workers/Pages runtime.
- `= window.fetch` (a DOM-typed web alias of the global) → not flagged.
- Non-`.ts` runtime files (`.cts/.js/...`) weren't scanned.

## Fix
- **regex:** allow an optional `as <type>` cast before the terminator + a `window.` qualifier; still reject `= fetch.bind(...)` and `= fetch(url)` via the `(?!\s*[.(])` lookahead.
- **scan:** widen to the full JS+TS family (`.cts/.js/.mjs/.cjs` + `tsx/jsx`).
- **tests:** 4 new bypass cases (unbound cast, qualified cast, cast-at-EOL, `window.`) + `.cts`/`.js` scan fixtures.

## Verify
- `bun test scripts/lint-fetch-binding.test.ts` → **19 pass**.
- `bun run scripts/lint-fetch-binding.ts` → **0 violations** (tighter regex + wider scan introduce no false positives — no non-`.ts` files exist in the runtime roots today).

Refs #887, follows #892.