### PR TITLE
test(api): typechecked makeBooking fixture chokepoint + migrate drifting fixtures (#900)

### DIFF
--- a/packages/api/tests/helpers/booking.test.ts
+++ b/packages/api/tests/helpers/booking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { makeBooking } from './booking'
+
+// #900: makeBooking is the single typechecked chokepoint for full-Booking
+// fixtures. The compile-time guarantee (tests/helpers/** is in the api typecheck
+// project, makeBooking returns `: Booking`) is the real regression guard against
+// field drift; these runtime checks pin the factory's contract so it can't be
+// gutted without a test failure.
+describe('makeBooking fixture factory (#900)', () => {
+  it('stamps the server-derived settlement default (ADVISORY) and a CONFIRMED status', () => {
+    const booking = makeBooking()
+
+    expect(booking.cancellationFeeSettlement).toBe('ADVISORY')
+    expect(booking.status).toBe('CONFIRMED')
+    expect(booking.id).toMatch(/[0-9a-f-]{36}/)
+    expect(booking.cancellationFee).toBeNull()
+  })
+
+  it('lets a caller override persistence + settlement fields over the defaults', () => {
+    const booking = makeBooking({
+      id: 'bk-fixed',
+      status: 'CANCELLED',
+      cancellationFee: 9_000,
+      cancellationFeeSettlement: 'WAIVED',
+    })
+
+    expect(booking.id).toBe('bk-fixed')
+    expect(booking.status).toBe('CANCELLED')
+    expect(booking.cancellationFee).toBe(9_000)
+    expect(booking.cancellationFeeSettlement).toBe('WAIVED')
+  })
+
+  it('gives each call a distinct id and bookingCode so multi-row tests never collide', () => {
+    const a = makeBooking()
+    const b = makeBooking()
+
+    expect(a.id).not.toBe(b.id)
+    expect(a.bookingCode).not.toBe(b.bookingCode)
+  })
+})

--- a/packages/api/tests/helpers/booking.ts
+++ b/packages/api/tests/helpers/booking.ts
@@ -60,3 +60,27 @@ export function bookingInput(overrides: Partial<NewBooking> = {}): NewBooking {
     ...overrides,
   }
 }
+
+/**
+ * Build a COMPLETE persisted `Booking` (#900): `bookingInput` plus the
+ * server-stamped persistence fields (`id`, `createdAt`, `updatedAt`) and the
+ * server-derived `cancellationFeeSettlement` default. Use this anywhere a test
+ * needs a full booking row rather than a create input; callers override only the
+ * fields their assertion cares about.
+ *
+ * This is the single typechecked fixture chokepoint. `tests/helpers/**` is in the
+ * api typecheck project (tsconfig.json), so the `: Booking` return type means a
+ * NEW required field on `Booking` fails `tsc` HERE — instead of silently leaving
+ * an untypechecked test-body fixture incomplete, which is the drift #900 closes.
+ */
+export function makeBooking(overrides: Partial<Booking> = {}): Booking {
+  const stampedAt = new Date('2026-04-09T00:00:00Z')
+  return {
+    ...bookingInput(overrides),
+    id: crypto.randomUUID(),
+    createdAt: stampedAt,
+    updatedAt: stampedAt,
+    cancellationFeeSettlement: 'ADVISORY',
+    ...overrides,
+  }
+}

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -6,12 +6,12 @@ import { createCustomerRoutes } from '../../src/routes/customers'
 import { CustomerService } from '../../src/services/customer'
 import type { Booking, User } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 const USER1 = '00000000-0000-4000-8000-0000000000a1'
 const USER2 = '00000000-0000-4000-8000-0000000000a2'
 const USER3 = '00000000-0000-4000-8000-0000000000a3'
 const ADMIN = '00000000-0000-4000-8000-0000000000ad'
-const V1 = '00000000-0000-4000-8000-000000000001'
 
 let app: Hono
 
@@ -31,25 +31,16 @@ function mkUser(id: string, overrides: Partial<User> = {}): User {
 function mkBooking(b: Partial<Booking> & { id: string; renterId: string }): Booking {
   const startAt = b.startAt ?? new Date('2026-04-01T00:00:00Z')
   const endAt = b.endAt ?? new Date('2026-04-02T00:00:00Z')
-  return {
-    id: b.id,
-    renterId: b.renterId,
-    vehicleId: V1,
+  return makeBookingFixture({
+    status: 'COMPLETED',
     startAt,
     endAt,
     effectiveEndAt: endAt,
-    status: 'COMPLETED',
-    source: 'DIRECT',
-    externalId: null,
-    notes: null,
     totalPrice: 10000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: startAt,
     updatedAt: startAt,
     ...b,
-  }
+  })
 }
 
 function setup({

--- a/packages/api/tests/routes/notifications.test.ts
+++ b/packages/api/tests/routes/notifications.test.ts
@@ -13,6 +13,7 @@ import { NotificationService } from '../../src/services/notification'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
 import type { Booking, NotificationLog } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 // HTTP-boundary tests for createNotificationRoutes (#706). The notification
 // ledger is operator-private: the role gate (RENTER/PARTNER -> 403) and the
@@ -26,36 +27,21 @@ const RENTER_ID = 'renter-1'
 const NOW = new Date('2026-07-01T00:00:00Z')
 
 function makeBooking(over: Partial<Booking>): Booking {
-  return {
+  return makeBookingFixture({
     id: 'bk-a',
     operatorId: OP_A,
     renterId: RENTER_ID,
     classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
     dropoffLocationId: 'loc-2',
     startAt: NOW,
     endAt: NOW,
     effectiveEndAt: NOW,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
-    fulfillmentMode: 'SPECIFIC',
     bookingCode: 'ABCD2345',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 24000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: NOW,
     updatedAt: NOW,
     ...over,
-  }
+  })
 }
 
 /**

--- a/packages/api/tests/routes/payments.test.ts
+++ b/packages/api/tests/routes/payments.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../src/services/payment/payment-gateway'
 import type { Booking } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 // Bookings carry DB-generated UUIDs; the route now validates `:bookingId` as a
 // uuid at the boundary (#691), so the fixture id must be a real uuid too.
@@ -22,33 +23,17 @@ const BOOKING_ID = '00000000-0000-4000-8000-0000000000b1'
 
 function makeBooking(): Booking {
   const now = new Date('2026-06-09T00:00:00Z')
-  return {
+  return makeBookingFixture({
     id: BOOKING_ID,
-    operatorId: 'op-1',
-    renterId: 'renter-1',
     classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
-    dropoffLocationId: 'loc-1',
     startAt: now,
     endAt: now,
     effectiveEndAt: now,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
     bookingCode: 'ABCD2345',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 100_000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: now,
     updatedAt: now,
-  }
+  })
 }
 
 class StubGateway implements PaymentGateway {

--- a/packages/api/tests/services/booking-operator-projection.test.ts
+++ b/packages/api/tests/services/booking-operator-projection.test.ts
@@ -5,6 +5,7 @@ import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/ope
 import type { RunInTransaction, TransactionRepos } from '../../src/repositories/types'
 import { BookingService } from '../../src/services/booking'
 import type { Booking } from '../../src/stores'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 // §4h: the web confirmation page needs the operator's pre-auth URL, but it has no
 // DB access and /operators/:id is management-gated. So BookingService.findById
@@ -17,35 +18,19 @@ const runInTransaction: RunInTransaction = async (fn) => fn({} as TransactionRep
 
 function makeBooking(operatorId: string): Booking {
   const now = new Date('2026-07-01T00:00:00Z')
-  return {
+  return makeBookingFixture({
     id: 'bk-1',
     operatorId,
     renterId: RENTER,
     classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
-    dropoffLocationId: 'loc-1',
     startAt: now,
     endAt: now,
     effectiveEndAt: now,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
-    fulfillmentMode: 'SPECIFIC',
     bookingCode: 'ABCD2345',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 24000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: now,
     updatedAt: now,
-  }
+  })
 }
 
 async function setup() {

--- a/packages/api/tests/services/location.test.ts
+++ b/packages/api/tests/services/location.test.ts
@@ -9,6 +9,7 @@ import { InMemoryBookingRepository } from '../../src/repositories/in-memory/book
 import type { Geocoder } from '../../src/services/geocoding/types'
 import { LocationService } from '../../src/services/location'
 import type { Booking, Region } from '../../src/stores'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 // Fake Geocoders for the #531 write-decision matrix. The real adapter never
 // throws; `throwingGeocoder` proves the service is resilient even if a future
@@ -72,35 +73,19 @@ function createInput(operatorId: string, name: string) {
 
 function seedBooking(store: Map<string, Booking>, overrides: Partial<Booking>): void {
   const now = new Date('2026-07-01T00:00:00Z')
-  const booking: Booking = {
-    id: crypto.randomUUID(),
+  const booking = makeBookingFixture({
     operatorId: opA,
-    renterId: 'renter-1',
-    classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
     pickupLocationId: 'loc-x',
     dropoffLocationId: 'loc-x',
     startAt: now,
     endAt: now,
     effectiveEndAt: now,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
     bookingCode: `BK${store.size}`,
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 12000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,
-  }
+  })
   store.set(booking.id, booking)
 }
 

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -13,41 +13,27 @@ import {
   TRIGGER_KINDS,
 } from '../../src/services/notification-dispatcher'
 import type { Booking, OperatorMembership, User } from '../../src/stores'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 const OP = 'op-1'
 const RENTER = 'renter-1'
 
 function makeBooking(): Booking {
   const now = new Date('2026-07-01T00:00:00Z')
-  return {
+  return makeBookingFixture({
     id: 'bk-1',
     operatorId: OP,
     renterId: RENTER,
     classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
     dropoffLocationId: 'loc-2',
     startAt: now,
     endAt: now,
     effectiveEndAt: now,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
-    fulfillmentMode: 'SPECIFIC',
     bookingCode: 'ABCD2345',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 24000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: now,
     updatedAt: now,
-  }
+  })
 }
 
 const fakeVehicleRepo = {

--- a/packages/api/tests/services/notification-service.test.ts
+++ b/packages/api/tests/services/notification-service.test.ts
@@ -14,6 +14,7 @@ import type { EmailSender } from '../../src/services/email/email-sender'
 import { NotificationService } from '../../src/services/notification'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
 import type { Booking, User } from '../../src/stores'
+import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
 const OP1 = 'op-1'
 const OP2 = 'op-2'
@@ -33,35 +34,20 @@ const op2Ctx: CallerContext = {
 
 function makeBooking(): Booking {
   const now = new Date('2026-07-01T00:00:00Z')
-  return {
+  return makeBookingFixture({
     id: 'bk-1',
     operatorId: OP1,
     renterId: RENTER,
     classId: 'cls-1',
-    requestedVehicleId: 'veh-1',
-    assignedVehicleId: 'veh-1',
-    pickupLocationId: 'loc-1',
     dropoffLocationId: 'loc-2',
     startAt: now,
     endAt: now,
     effectiveEndAt: now,
-    status: 'CONFIRMED',
-    source: 'DIRECT',
-    fulfillmentMode: 'SPECIFIC',
     bookingCode: 'ABCD2345',
-    insuranceOptionId: null,
-    insuranceSnapshot: null,
-    feeSnapshot: [],
-    addOnSnapshot: [],
-    externalId: null,
-    notes: null,
     totalPrice: 24000,
-    cancellationFee: null,
-    cancelledAt: null,
-    idempotencyKey: null,
     createdAt: now,
     updatedAt: now,
-  }
+  })
 }
 
 const fakeVehicleRepo = {

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,6 +6,10 @@
       "@kuruma/shared/*": ["../shared/src/*"]
     }
   },
-  "include": ["src/**/*.ts"],
+  // tests/** is broadly NOT typechecked (it carries pre-existing type drift, #900),
+  // but tests/helpers/** IS — it is the typechecked chokepoint for shared fixture
+  // factories (e.g. makeBooking). A required field added to a domain type then fails
+  // `tsc` at the factory instead of silently drifting an untypechecked test body.
+  "include": ["src/**/*.ts", "tests/helpers/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #900.

## Problem
`packages/api/tsconfig.json` had `include: ["src/**/*.ts"]`, so **`tests/` was never typechecked**. When a required field is added to the domain `Booking` (`src/stores.ts`), hand-rolled fixtures typed `: Booking` keep compiling while silently missing the field — invisible until something reads it (then `undefined`). PR #899 (`cancellationFeeSettlement`) surfaced **7** such drifters.

Full typecheck of `tests/` is **not** viable here — it has **1329 pre-existing type errors** accumulated over time (its own cleanup epic). So this PR closes the *drift class* at a single chokepoint instead.

## Fix
1. **Typecheck `tests/helpers/**`** (0 new errors) — a narrow, controlled slice of `tests/`.
2. **`makeBooking(overrides?: Partial<Booking>): Booking`** factory in `tests/helpers/booking.ts` (beside the existing create-shape `bookingInput`). Because the helpers dir is now in the api typecheck project, the `: Booking` return type makes this the single compile-time chokepoint: a new required `Booking` field fails `tsc` **here** instead of drifting an untypechecked test body.
3. **Routed all 7 drifting fixtures through it** — each passes only its distinctive defaults; the factory fills the rest (incl. the previously-missing `cancellationFeeSettlement`, and for several: `fulfillmentMode` / `addOnSnapshot` / disclaimer fields). `customers.test.ts` also shed a dead pre-marketplace shape (a bogus `vehicleId` field, no `bookingCode`); its aggregation reads `renterId`/`status`/`totalPrice`/`startAt` only — all preserved.

## Proof
- Removing the field from the factory **fails `tsc`** (`Property 'cancellationFeeSettlement' ... required in type 'Booking'`) — the guard fires.
- `bun run --filter @kuruma/api typecheck` → exit 0.
- Full api unit suite **1536 passed**; the 3 new factory tests pin the contract.

## Scope note
Deliberately does **not** typecheck all of `tests/` (1329 errors) — that's a separate incremental cleanup. This PR makes the *fixture-drift* class structurally impossible for any fixture that uses the factory, and migrates the known drifters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)