### PR TITLE
ci(rotate-secrets): assert AUTH_URL + Google creds onto API Worker

### DIFF
--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -52,11 +52,20 @@ jobs:
       # the pending state and makes the new secrets active.
       # IMPORTANT: AUTH_SECRET and DATABASE_URL must match between API
       # and Web workers. If you add a shared secret, add it to BOTH.
+      #
+      # Google OAuth + AUTH_URL live on the API Worker because OAuth moved
+      # off the web app (#378 Phase 2). AUTH_URL is the public web origin
+      # used to build the Google redirect_uri; if it drifts to a stale
+      # host the post-login redirect lands on the wrong site. Set the
+      # GitHub Secret AUTH_URL to the live web origin before running this.
       - name: Rotate API Worker secrets
         working-directory: packages/api
         run: |
           echo "${{ secrets.PROD_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
           echo "${{ secrets.AUTH_SECRET }}" | npx wrangler secret put AUTH_SECRET
+          echo "${{ secrets.AUTH_GOOGLE_ID }}" | npx wrangler secret put AUTH_GOOGLE_ID
+          echo "${{ secrets.AUTH_GOOGLE_SECRET }}" | npx wrangler secret put AUTH_GOOGLE_SECRET
+          echo "${{ secrets.AUTH_URL }}" | npx wrangler secret put AUTH_URL
           npx wrangler deploy
 
       # Web Worker needs a build before deploy. Build config MUST match


### PR DESCRIPTION
## Why

The beta site's Google login redirects back to the **old** `kanata-studio-dev` origin after authenticating. Root cause: OAuth moved off the web app onto the `kuruma-api` Worker (#378 Phase 2), but `rotate-secrets.yml` still only rotated `DATABASE_URL` + `AUTH_SECRET` onto the API Worker. **`AUTH_URL` was never asserted**, so it drifted to a stale host — and `AUTH_URL` is what Auth.js uses to build the post-login redirect.

## What

Add to the **Rotate API Worker secrets** step:
- `AUTH_GOOGLE_ID`
- `AUTH_GOOGLE_SECRET`
- `AUTH_URL`

So a manual `rotate-secrets.yml` run keeps the API Worker's OAuth config in sync with GitHub Secrets (the source of truth).

## Scope

Additive only — zero regression risk. The stale **Web Worker** build/rotate block (the old `kuruma-rental` Worker, retired by the CF Pages migration #378 §7.5) is intentionally left untouched here; that branch removes it as part of the larger restructure.

## Test plan

- [ ] Set GitHub Secret `AUTH_URL` = live web origin (`https://kuruma-web-pages.pages.dev`)
- [ ] Run `gh workflow run rotate-secrets.yml`
- [ ] Confirm Google login on the beta stays on the Pages origin (no bounce to old host)