### PR TITLE
feat(web): search map↔list slice 2 — non-remount recenter, price pins, carousel (#885)

### DIFF
--- a/docs/plans/2026-06-16-search-map-slice2-plan.md
+++ b/docs/plans/2026-06-16-search-map-slice2-plan.md
@@ -1,0 +1,137 @@
+# Search map↔list redesign — Slice 2 (#885)
+
+## Context
+
+The search-results map is the renter funnel's core. Slice 1 (#895) added fly-to + a single-car
+pin popup; Slice 1b (#898) added an explicit "View cars" detail CTA. But the **fly-to remounts
+`<PigeonMap>`** (`selectedId` is in the remount `key`), so any per-row map interaction re-fetches
+all tiles — which is exactly why card-as-affordance hover/focus was built then **reverted** out of
+1b (code-review HIGH). Slice 2 (brief §7 + handoff) makes the map genuinely interactive:
+
+1. **Non-remount recenter** (controlled fly-to) — fly without remounting (kills the tile-thrash). *Foundation.*
+2. **Re-add card hover/focus** — now safe; reuse the reverted tests at reflog `17f9a8f6`.
+3. **Price-labeled pins** — Airbnb/Zillow "¥8,000" pills, selected inverts (replaces grey dots).
+4. **Co-location carousel popup** — N cars at one store-pin → a swipeable popup (Turo model).
+
+Signed-off design: `docs/plans/2026-06-15-search-map-list-redesign.md` §4–5 (Option B, car-first).
+
+## The crux: pigeon-maps non-remount fly-to (verified against v0.22.1 source)
+
+`<Map>` supports **controlled `center`/`zoom`** props. On a prop change its `componentDidUpdate`
+(`index.esm.js:1154`) calls `setCenterZoomTarget` → an **animated tween** (no remount). `onBoundsChanged`
+reports the post-move viewport — and `syncToProps` (which fires it) is **debounced 60ms** (`:1095`,
+`DEBOUNCE_DELAY:111`), while `componentDidUpdate` compares against the *animation target* mid-flight
+(`:1185`) and prop-equality-guards (`:1181`). So syncing `onBoundsChanged → state` does **not** truncate
+a programmatic fly-to (the debounce lets the tween settle before the prop re-syncs). Mechanism: hold
+`{center, zoom}` in state, sync from `onBoundsChanged`, push the selected pin's viewport on selection
+change → animated fly-to, no remount.
+
+**Drop the remount `key` entirely.** Re-fit on a new result set / region is handled by a controlled
+reset effect (below), which *animates* to the new fit (pigeon caps far jumps via `animateMaxScreens`,
+so a cross-country new search snaps instead of crawling). No `key` → the map never remounts → zero
+tile-thrash on any interaction.
+
+## Approach — 4 TDD tasks (dependency order), branch off `feat/search-map-s1b-card-cta`
+
+### Task 1 — Controlled-mode recenter (the no-remount foundation)
+- `PigeonMapAdapter.tsx`: replace `defaultCenter`/`defaultZoom` + `key` with controlled `center`/`zoom`
+  from `useState(() => focusViewport(pins, anchor, selectedId))`; wire `onBoundsChanged → setView`;
+  **remove the `key` prop entirely.** A **single** viewport-sync effect (one state → one precedence
+  function — this is the fix for the two-effect race): on a `targetSignature` of `selectedId` + `anchor`
+  + each pin's `id:lat:lng` → `setView(focusViewport(pins, anchor, selectedId))`. `focusViewport` already
+  encodes the precedence (**selected pin wins → else region anchor → else fit-all**), so a result-set
+  change with a *still-valid* selection stays flown-to that pin, while a *stale* selection (gone from the
+  new set) falls through to the new region/fit — no two effects can disagree. The signature includes
+  `lat:lng` (**P2**) so a coordinate change for the same location id still recenters. `onBoundsChanged`
+  preserves user pan/zoom — the effect only fires when selection/anchor/pins change, never clobbering a
+  manual pan. Deps = `[targetSignature]` (one `// eslint-disable-next-line`: the string encodes the inputs).
+- `viewport.ts`: unchanged — `focusViewport(pins, anchor, selectedId)` is reused as the **single** precedence
+  fn for both the initial state and the sync effect.
+- Tests (`PigeonMapAdapter.test.tsx`): extend the pigeon mock to (a) read `center`/`zoom`, (b) stamp a
+  **mount-instance id** (module counter in a mount effect) → `data-instance`, (c) expose `onBoundsChanged`.
+  Mutation-resistant tests:
+  1. **No remount:** select a pin → center moves AND `data-instance` unchanged (the tile-thrash guard).
+  2. **Reset / no drift:** region A → pan via `onBoundsChanged` → rerender region B (anchor B, selection
+     stale/cleared) → `center`==B anchor @ `REGION_ZOOM`, `data-instance` same.
+  3. **Selection wins on result change:** select loc1 → rerender a set that STILL has loc1 + a *new* anchor
+     → `center`==loc1 coords @ `SINGLE_PIN_ZOOM` (selection beats the new anchor; popup stays coherent).
+  4. **Stale selection falls to fit:** select loc1 → rerender a set WITHOUT loc1 + anchor B →
+     `center`==anchor B @ `REGION_ZOOM`.
+  5. **Coord change recenters (P2):** same location id, new lat/lng → `center` updates.
+  Update the existing recenter / center-from-default tests to controlled `center`/`zoom`.
+
+### Task 2 — Add card hover/focus (card-as-affordance, *additive*)
+- `SearchMapList.tsx`: add `onMouseEnter`/`onFocus` on each geocoded `<li>` → `setSelectedId(locationId)`
+  (idempotent — sets, never clears). List-only (null-coord) rows stay inert. **Keep the "Show on map"
+  button** (P3 — touch affordance; hover doesn't exist on touch and the mobile Map toggle is Slice 3) but
+  make it an **idempotent select, not a toggle**: `onClick={() => setSelectedId(locationId)}` and **drop
+  `aria-pressed`** (it's an action button now — selection state lives on the row's `aria-current` + ring).
+  This kills the focus/click race the reviewer flagged: with a toggle, focusing the button selects the row
+  via the `<li>` `onFocus`, then the ensuing click toggles it back *off*; idempotent-select makes
+  focus-then-click consistently *select*. Deselect isn't needed — selection follows hover/focus/tap forward.
+  `onFocus` on the `<li>` catches focus on the inner CTA via React's bubbling (focusin-based) → keyboard
+  parity.
+- Tests (`SearchMapList.test.tsx`): use **`userEvent.click`** (real focus→click order, not `fireEvent`) on
+  the button → row selected; click it **again → still selected** (proves idempotent, no toggle-off). Focus
+  the *real* `View cars` link (`within(row).getByRole('link')`), not the `<li>` → row `onFocus` selects the
+  map (**P2** keyboard path). Hover a geocoded row → selected; null-coord row hover inert. Replace the
+  slice-1 toggle-off / `aria-pressed` assertions (behavior intentionally changed).
+
+### Task 3 — Price-labeled pins
+- `MapAdapter.ts`: add `renderPin?: (item, { selected }) => ReactNode` (mirrors the `renderSelected`
+  seam — the **view** owns the whole interactive pill: i18n, min-price, `onClick`, `aria-label`, styling;
+  the adapter only positions it).
+- `PigeonMapAdapter.tsx`: when `renderPin` is given, position each pin's returned node in an `<Overlay>`
+  centered on the pin; fall back to the `<Marker>` dot (wired to `onSelect`) when absent — keeps the bare
+  adapter + its existing dot tests intact.
+- `result.ts`: add `groupByLocation(items)` and `pinPriceLabel(group, t)` (min `dailyRateJpy`, else min
+  `hourlyRateJpy`, else `noPrice`; "From ¥X" when group>1 else "¥X"). Pure → unit-tested in `result.test.ts`.
+- `SearchMapList.tsx`: pass `renderPin` rendering the styled pill `<button>` (selected inverts colors,
+  `onClick={()=>setSelectedId(locationId)}`) from the group. **P2 — accessible name:** the price text
+  alone ("¥8,000") is indistinguishable across pins, so set `aria-label` = store + price, e.g.
+  "Select Sakura Mobility · Namba, From ¥8,000", with a **no-price fallback** ("…, price on request") so a
+  price-less pin is never an unlabeled button.
+- i18n: `map.pinPrice` "¥{price}", `map.pinPriceFrom` "From ¥{price}", `map.pinSelect`
+  "Select {store}, {price}" in en/ja/zh.
+
+### Task 4 — Co-location carousel popup
+- New `MapPopupCarousel.tsx` (mirror `PhotoGallery.tsx`: index state, prev/next, dot jumps, wrap-around
+  modulo, `role="group"`). Each slide = car mini-card: photo · name · class · price · "View cars" Link
+  (same `carryForwardFilters` target as `SearchResultRow`). N=1 → no arrows. Threads locale/from/to/filters.
+- `SearchMapList.tsx`: `renderSelected(item)` now derives the group via `groupByLocation(items)` and renders
+  `<MapPopupCarousel>`. The only `MapAdapterProps` change this slice is the additive `renderPin` (Task 3);
+  the carousel needs none — the view's closure already holds full `items`, and the adapter keeps passing the
+  representative selected item for the anchor.
+- i18n: `map.popupPrev`, `map.popupNext`, `map.popupPosition` "{n} / {total}" in en/ja/zh.
+- Tests (`MapPopupCarousel.test.tsx` new + `SearchMapList.test.tsx`): single car → no arrows; N cars →
+  next/prev cycle + position label; each slide's CTA carries from/to + filters.
+
+### One-way (#882) guardrail — explicitly deferred (P3)
+The signed-off design §6 guardrail #2 ("adapter takes a list of points / optional route per selection")
+is **intentionally not built this slice.** Rationale (YAGNI): one-way rentals are a separate deferred epic
+(#882) with no consumer today, and the current contract does not *block* it — the adapter already takes a
+list (`items` = points) and a `selectedId`; a future dropoff pin / route line is an **additive** prop
+(`route?` / `secondaryPins?`) when #882 lands. Adding the seam now would be a speculative API with no caller.
+This is a conscious defer, not an oversight.
+
+## Files
+- Edit: `PigeonMapAdapter.tsx`, `MapAdapter.ts`, `SearchMapList.tsx`, `result.ts`, `messages/{en,ja,zh}.json`
+- New: `MapPopupCarousel.tsx` (+ `.test.tsx`)
+- Tests: `PigeonMapAdapter.test.tsx`, `SearchMapList.test.tsx`, `result.test.ts`
+- Reuse: `PhotoGallery.tsx` (carousel pattern), `viewport.ts`, `carryForwardFilters` (`storefronts/params`),
+  `resultTitle`/`resultPriceLabel`/`searchResultKey` (`result.ts`)
+
+## Verification
+- `bun run --filter @kuruma/web test` (vitest; per-task + full suite green — was 922/922 on s1b).
+- `bun run --filter @kuruma/web typecheck` (tests aren't typechecked; prod call-sites are).
+- `bunx biome check --write` before commit (pre-commit biome is read-only).
+- Don't regress the region anchor (#840) or `e2e/real-db/region-search.auth.spec.ts`.
+- code-reviewer agent before PR. Manual: `bun run dev`, search a region with co-located cars → hover a
+  row flies (map does NOT flash/reload tiles), pin pills show prices, click a multi-car pin → carousel.
+
+## PR strategy
+- Worktree `~/Dev/kuruma-map-s2` + `bun install`; branch `feat/search-map-s2-carousel-pins` off
+  `feat/search-map-s1b-card-cta` (s1b tip) while #895/#898 are open; rebase onto `marketplace-pivot` if
+  the owner merges the stack first. One Slice 2 PR, `refs #885`. **Owner-gated — do NOT `--admin`.**
+  Optional split if smaller reviews are wanted: 2a = Tasks 1–2 (recenter + hover), 2b = Tasks 3–4
+  (price pins + carousel).

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1077,7 +1077,10 @@
       "empty": "No cars are available for these dates."
     },
     "map": {
-      "noCoordinates": "Map view isn't available for these results yet."
+      "noCoordinates": "Map view isn't available for these results yet.",
+      "pinPrice": "¥{price}",
+      "pinPriceFrom": "From ¥{price}",
+      "pinSelect": "Select {store}, {price}"
     },
     "detail": {
       "backToSearch": "Back to search",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1080,7 +1080,10 @@
       "noCoordinates": "Map view isn't available for these results yet.",
       "pinPrice": "¥{price}",
       "pinPriceFrom": "From ¥{price}",
-      "pinSelect": "Select {store}, {price}"
+      "pinSelect": "Select {store}, {price}",
+      "popupPrev": "Previous car",
+      "popupNext": "Next car",
+      "popupPosition": "{n} / {total}"
     },
     "detail": {
       "backToSearch": "Back to search",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1080,7 +1080,10 @@
       "noCoordinates": "これらの結果はまだ地図に表示できません。",
       "pinPrice": "¥{price}",
       "pinPriceFrom": "¥{price}〜",
-      "pinSelect": "{store}、{price}を選択"
+      "pinSelect": "{store}、{price}を選択",
+      "popupPrev": "前のクルマ",
+      "popupNext": "次のクルマ",
+      "popupPosition": "{n} / {total}"
     },
     "detail": {
       "backToSearch": "検索に戻る",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1077,7 +1077,10 @@
       "empty": "選択した日程で利用できるクルマがありません。"
     },
     "map": {
-      "noCoordinates": "これらの結果はまだ地図に表示できません。"
+      "noCoordinates": "これらの結果はまだ地図に表示できません。",
+      "pinPrice": "¥{price}",
+      "pinPriceFrom": "¥{price}〜",
+      "pinSelect": "{store}、{price}を選択"
     },
     "detail": {
       "backToSearch": "検索に戻る",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1080,7 +1080,10 @@
       "noCoordinates": "这些结果暂时无法在地图上显示。",
       "pinPrice": "¥{price}",
       "pinPriceFrom": "¥{price}起",
-      "pinSelect": "选择{store}，{price}"
+      "pinSelect": "选择{store}，{price}",
+      "popupPrev": "上一辆",
+      "popupNext": "下一辆",
+      "popupPosition": "{n} / {total}"
     },
     "detail": {
       "backToSearch": "返回搜索",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1077,7 +1077,10 @@
       "empty": "所选日期没有可用车辆。"
     },
     "map": {
-      "noCoordinates": "这些结果暂时无法在地图上显示。"
+      "noCoordinates": "这些结果暂时无法在地图上显示。",
+      "pinPrice": "¥{price}",
+      "pinPriceFrom": "¥{price}起",
+      "pinSelect": "选择{store}，{price}"
     },
     "detail": {
       "backToSearch": "返回搜索",

--- a/packages/web/src/vite/search/MapAdapter.ts
+++ b/packages/web/src/vite/search/MapAdapter.ts
@@ -24,6 +24,10 @@ export interface MapAdapterProps {
    *  (i18n, router links); the adapter only positions it at the pin. Absent = no
    *  popup. */
   renderSelected?: (item: SearchResultItem) => ReactNode
+  /** Renders the interactive pin for a location (e.g. a price pill). The VIEW owns
+   *  the whole control — i18n, min-price, onClick, aria-label, styling — and the
+   *  adapter only positions it at the pin. Absent = the adapter's default dot. */
+  renderPin?: (item: SearchResultItem, state: { selected: boolean }) => ReactNode
 }
 
 export type MapAdapter = ComponentType<MapAdapterProps>

--- a/packages/web/src/vite/search/MapPopupCarousel.tsx
+++ b/packages/web/src/vite/search/MapPopupCarousel.tsx
@@ -1,0 +1,128 @@
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { carryForwardFilters } from '@/vite/storefronts/params'
+import type { SearchResultItem } from '@kuruma/shared/types/search-result'
+import { Link } from '@tanstack/react-router'
+import { Car, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+import { resultPriceLabel, resultTitle } from './result'
+
+interface MapPopupCarouselProps {
+  /** Every car at the selected pickup location (the map's co-located group). The
+   *  pin shows one dot per location; clicking it opens this swipeable popup so a
+   *  renter can flip through all cars at that store without leaving the map. */
+  readonly items: SearchResultItem[]
+  /** Search context threaded into each slide's detail CTA so the date range +
+   *  filters survive the drill-down (#885 1b), same target as `SearchResultRow`. */
+  readonly locale: string
+  readonly from: string
+  readonly to: string
+  readonly classFilter?: string | string[] | undefined
+  readonly pickupLocationId?: string | undefined
+  readonly region?: string | undefined
+}
+
+const CONTROL_CLASS =
+  'absolute top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-full bg-background/80 text-foreground shadow-sm transition hover:bg-background focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
+
+/**
+ * Co-location popup carousel (#885 slice 2). Mirrors `PhotoGallery`'s index/modulo
+ * cycling, but each slide is a car mini-card (photo · name · class · price · detail
+ * CTA) instead of a photo. One car → a static card, no controls; many → next/prev
+ * with wrap-around and a "n / total" position label. A position label replaces
+ * PhotoGallery's dot row: in a narrow map popup it reads cleaner and is the same
+ * affordance a screen reader needs.
+ */
+export function MapPopupCarousel({
+  items,
+  locale,
+  from,
+  to,
+  classFilter,
+  pickupLocationId,
+  region,
+}: MapPopupCarouselProps) {
+  const t = useTranslations('search')
+  const [index, setIndex] = useState(0)
+
+  const count = items.length
+  if (count === 0) return null
+  // Modulo keeps the index in range and lets prev/next wrap the ends.
+  const safeIndex = ((index % count) + count) % count
+  const current = items[safeIndex]
+  if (!current) return null
+
+  const photo = current.photos[0]
+  const title = resultTitle(current)
+
+  return (
+    <div
+      className="w-56 overflow-hidden rounded-lg border border-border bg-card text-sm shadow-md"
+      // Announce the multi-car controls as one group under the store name.
+      {...(count > 1 ? { role: 'group', 'aria-label': current.location.name } : {})}
+    >
+      <div className="relative aspect-[4/3] bg-muted">
+        {photo ? (
+          <img
+            src={photo}
+            alt={title}
+            loading="lazy"
+            width={400}
+            height={300}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <Car className="size-10 text-muted-foreground/30" aria-hidden />
+          </div>
+        )}
+        {count > 1 && (
+          <>
+            <button
+              type="button"
+              onClick={() => setIndex(safeIndex - 1)}
+              aria-label={t('map.popupPrev')}
+              className={`${CONTROL_CLASS} left-2`}
+            >
+              <ChevronLeft className="size-4" aria-hidden />
+            </button>
+            <button
+              type="button"
+              onClick={() => setIndex(safeIndex + 1)}
+              aria-label={t('map.popupNext')}
+              className={`${CONTROL_CLASS} right-2`}
+            >
+              <ChevronRight className="size-4" aria-hidden />
+            </button>
+            <span className="absolute right-2 bottom-2 rounded-full bg-background/80 px-1.5 py-0.5 text-xs font-medium text-foreground shadow-sm">
+              {t('map.popupPosition', { n: safeIndex + 1, total: count })}
+            </span>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1 p-3">
+        <div className="flex items-baseline justify-between gap-2">
+          <p className="font-semibold leading-tight">{title}</p>
+          <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+            {current.classLabel}
+          </span>
+        </div>
+        <p className="font-medium text-foreground">{resultPriceLabel(current, t)}</p>
+        <Link
+          to="/$locale/storefronts/$locationId"
+          params={{ locale, locationId: current.location.locationId }}
+          search={{
+            from,
+            to,
+            ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
+          }}
+          className={cn(buttonVariants({ variant: 'default', size: 'sm' }), 'mt-1 w-full')}
+        >
+          {t('viewStore')}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/vite/search/MapPopupCarousel.tsx
+++ b/packages/web/src/vite/search/MapPopupCarousel.tsx
@@ -102,7 +102,13 @@ export function MapPopupCarousel({
         )}
       </div>
 
-      <div className="flex flex-col gap-1 p-3">
+      <div
+        className="flex flex-col gap-1 p-3"
+        // Next/prev swaps this card's text in place; a polite live region announces
+        // the new car to a screen reader instead of changing silently. Scoped to the
+        // text (not the photo) so the image swap doesn't double-announce.
+        aria-live="polite"
+      >
         <div className="flex items-baseline justify-between gap-2">
           <p className="font-semibold leading-tight">{title}</p>
           <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">

--- a/packages/web/src/vite/search/PigeonMapAdapter.tsx
+++ b/packages/web/src/vite/search/PigeonMapAdapter.tsx
@@ -1,4 +1,5 @@
 import { Marker, Overlay, Map as PigeonMap } from 'pigeon-maps'
+import { useEffect, useState } from 'react'
 import type { MapAdapterProps } from './MapAdapter'
 import { type Pin, focusViewport } from './viewport'
 
@@ -36,13 +37,16 @@ const GSI_ATTRIBUTION = (
 /** Concrete `MapAdapter` (#458). Maps each geocoded result to a pigeon-maps
  *  `<Marker>`; a marker click reports its location id back to the view. The
  *  viewport fits ALL pins so a Kansai-wide result set isn't pinned to one store —
- *  unless a region `anchor` is given (#840), which centers the map on the chosen
- *  area instead. `key` on the map remounts it when the result set OR the anchor
- *  changes so the fit/center recomputes (region filtering keeps the same pins, so
- *  the anchor must be in the key), while leaving the user free to pan/zoom.
- *  Selecting a result is also in the key: each new selection remounts to recenter
- *  on that pin and reopen its popup (costs a tile re-fetch; animated fly-to is a
- *  Slice-1 follow-up, #885). */
+ *  unless a region `anchor` is given (#840), which centers on the chosen area, or a
+ *  result is selected, which flies to its pin (#885).
+ *
+ *  Controlled viewport (#885 slice 2): `center`/`zoom` live in state, synced from
+ *  `onBoundsChanged` so a user pan/zoom sticks. A single precedence effect retargets
+ *  on selection/anchor/pin changes via `focusViewport` (selected pin → region anchor
+ *  → fit-all). There is deliberately NO remount `key`: the old key remounted `<Map>`
+ *  on every selection, re-fetching all tiles. Controlled props animate an in-place
+ *  fly-to instead (pigeon `setCenterZoomTarget`), so per-row interaction never
+ *  thrashes tiles. */
 export function PigeonMapAdapter({
   items,
   selectedId,
@@ -58,7 +62,22 @@ export function PigeonMapAdapter({
     }))
     .filter((p): p is Pin => p.lat !== null && p.lng !== null)
 
-  const viewport = focusViewport(pins, anchor, selectedId)
+  // Controlled viewport: initial fit on mount, then synced from user pan/zoom
+  // (onBoundsChanged) and re-targeted by the precedence effect below.
+  const [view, setView] = useState(() => focusViewport(pins, anchor, selectedId))
+
+  // One precedence function (focusViewport) drives every programmatic recenter, so
+  // two effects can never disagree (selection vs anchor). The signature serializes
+  // exactly the inputs focusViewport reads — selection, anchor, and each pin's
+  // id:lat:lng — so a coord move for a stable location id still recenters (P2), while
+  // a manual pan (which changes none of them) is never clobbered.
+  const targetSignature = `${selectedId ?? ''}|${anchor ? anchor.join(',') : 'fit'}|${pins
+    .map((p) => `${p.id}:${p.lat}:${p.lng}`)
+    .join(',')}`
+  // biome-ignore lint/correctness/useExhaustiveDependencies: targetSignature serializes pins/anchor/selectedId — the real reactive inputs.
+  useEffect(() => {
+    setView(focusViewport(pins, anchor, selectedId))
+  }, [targetSignature])
 
   const selectedPin = selectedId === null ? null : (pins.find((p) => p.id === selectedId) ?? null)
   const selectedItem =
@@ -66,12 +85,12 @@ export function PigeonMapAdapter({
 
   return (
     <PigeonMap
-      key={`${selectedId ?? ''}:${anchor ? anchor.join(',') : 'fit'}:${pins.map((p) => p.id).join(',')}`}
       provider={gsiTileProvider}
       attribution={GSI_ATTRIBUTION}
       attributionPrefix={false}
-      defaultCenter={viewport.center}
-      defaultZoom={viewport.zoom}
+      center={view.center}
+      zoom={view.zoom}
+      onBoundsChanged={({ center, zoom }) => setView({ center, zoom })}
     >
       {pins.map((pin) => (
         <Marker

--- a/packages/web/src/vite/search/PigeonMapAdapter.tsx
+++ b/packages/web/src/vite/search/PigeonMapAdapter.tsx
@@ -53,6 +53,7 @@ export function PigeonMapAdapter({
   onSelect,
   anchor = null,
   renderSelected,
+  renderPin,
 }: MapAdapterProps) {
   const pins = items
     .map((item) => ({
@@ -92,14 +93,27 @@ export function PigeonMapAdapter({
       zoom={view.zoom}
       onBoundsChanged={({ center, zoom }) => setView({ center, zoom })}
     >
-      {pins.map((pin) => (
-        <Marker
-          key={pin.id}
-          anchor={[pin.lat, pin.lng]}
-          color={pin.id === selectedId ? SELECTED_COLOR : MARKER_COLOR}
-          onClick={() => onSelect(pin.id)}
-        />
-      ))}
+      {pins.map((pin) => {
+        // renderPin (#885 slice 2): the view supplies the whole interactive pill
+        // (price, onClick, aria-label) and the adapter only anchors it; without it,
+        // fall back to the default marker dot wired to onSelect.
+        const item = renderPin ? items.find((i) => i.location.locationId === pin.id) : undefined
+        if (renderPin && item) {
+          return (
+            <Overlay key={pin.id} anchor={[pin.lat, pin.lng]}>
+              {renderPin(item, { selected: pin.id === selectedId })}
+            </Overlay>
+          )
+        }
+        return (
+          <Marker
+            key={pin.id}
+            anchor={[pin.lat, pin.lng]}
+            color={pin.id === selectedId ? SELECTED_COLOR : MARKER_COLOR}
+            onClick={() => onSelect(pin.id)}
+          />
+        )
+      })}
       {selectedPin && selectedItem && renderSelected && (
         <Overlay anchor={[selectedPin.lat, selectedPin.lng]} offset={OVERLAY_OFFSET}>
           {renderSelected(selectedItem)}

--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -63,6 +63,13 @@ export function SearchMapList({
               key={searchResultKey(item)}
               data-location={locationId}
               aria-current={selected ? 'true' : undefined}
+              // Card-as-affordance (#885 slice 2): hovering or keyboard-focusing a
+              // geocoded row flies the map to its pin. Idempotent (sets, never clears)
+              // so focus-then-click can't race to a deselect; onFocus bubbles up from
+              // the row's CTA/button (focusin) for keyboard parity. Null-coord rows are
+              // list-only and stay inert.
+              onMouseEnter={geocoded ? () => setSelectedId(locationId) : undefined}
+              onFocus={geocoded ? () => setSelectedId(locationId) : undefined}
               className={cn(
                 'rounded-xl transition-shadow',
                 selected && 'ring-2 ring-primary ring-offset-2',
@@ -80,9 +87,8 @@ export function SearchMapList({
               {geocoded && (
                 <button
                   type="button"
-                  aria-pressed={selected}
-                  onClick={() => setSelectedId(selected ? null : locationId)}
-                  className="mt-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground aria-[pressed=true]:text-primary"
+                  onClick={() => setSelectedId(locationId)}
+                  className="mt-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <MapPin className="size-4" />
                   {t('showOnMap')}

--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -5,7 +5,13 @@ import { useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
 import type { MapAdapter } from './MapAdapter'
 import { SearchResultRow } from './SearchResultRow'
-import { resultPriceLabel, resultTitle, searchResultKey } from './result'
+import {
+  groupByLocation,
+  pinPriceLabel,
+  resultPriceLabel,
+  resultTitle,
+  searchResultKey,
+} from './result'
 
 interface SearchMapListProps {
   readonly items: SearchResultItem[]
@@ -45,6 +51,13 @@ export function SearchMapList({
   // Dedupe is keyed on the loader-stable `items`; memoizing keeps the plotted
   // array reference stable across selection-only re-renders (#737).
   const mapItems = useMemo(() => geocodedByLocation(items), [items])
+  // Co-located cars per location: the pin's price label is the group minimum, and
+  // (#885 slice 2 task 4) the popup carousel walks the whole group.
+  const groupItemsById = useMemo(() => {
+    const byId = new Map<string, SearchResultItem[]>()
+    for (const group of groupByLocation(items)) byId.set(group.locationId, group.items)
+    return byId
+  }, [items])
 
   return (
     <div className="grid gap-4 lg:grid-cols-2">
@@ -110,6 +123,31 @@ export function SearchMapList({
             selectedId={selectedId}
             onSelect={setSelectedId}
             anchor={anchor}
+            // Price-pill pin (#885 slice 2): the view owns the whole interactive
+            // control — group min-price, idempotent select, and a store+price
+            // accessible name (P2) so visually identical prices stay distinguishable
+            // for screen readers. The adapter only positions it at the pin.
+            renderPin={(item, { selected }) => {
+              const group = groupItemsById.get(item.location.locationId) ?? [item]
+              const price = pinPriceLabel(group, t)
+              const store = `${item.location.operatorName} · ${item.location.name}`
+              return (
+                <button
+                  type="button"
+                  aria-current={selected ? 'true' : undefined}
+                  aria-label={t('map.pinSelect', { store, price })}
+                  onClick={() => setSelectedId(item.location.locationId)}
+                  className={cn(
+                    '-translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border px-2.5 py-1 text-xs font-semibold shadow-md transition-colors',
+                    selected
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border bg-card text-foreground hover:bg-muted',
+                  )}
+                >
+                  {price}
+                </button>
+              )
+            }}
             renderSelected={(item) => (
               <div className="min-w-44 rounded-lg border border-border bg-card p-3 text-sm shadow-md">
                 <p className="font-semibold leading-tight">{resultTitle(item)}</p>

--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -4,14 +4,9 @@ import { MapPin } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
 import type { MapAdapter } from './MapAdapter'
+import { MapPopupCarousel } from './MapPopupCarousel'
 import { SearchResultRow } from './SearchResultRow'
-import {
-  groupByLocation,
-  pinPriceLabel,
-  resultPriceLabel,
-  resultTitle,
-  searchResultKey,
-} from './result'
+import { groupByLocation, pinPriceLabel, searchResultKey } from './result'
 
 interface SearchMapListProps {
   readonly items: SearchResultItem[]
@@ -148,14 +143,21 @@ export function SearchMapList({
                 </button>
               )
             }}
+            // The popup walks the full co-located group (#885 slice 2 task 4), not
+            // just the representative pin item — the view's closure holds every car.
+            // Key on the location so selecting a different pin remounts the carousel
+            // at its first car instead of leaking the previous slide index.
             renderSelected={(item) => (
-              <div className="min-w-44 rounded-lg border border-border bg-card p-3 text-sm shadow-md">
-                <p className="font-semibold leading-tight">{resultTitle(item)}</p>
-                <p className="mt-0.5 text-muted-foreground">
-                  {item.location.operatorName} · {item.location.name}
-                </p>
-                <p className="mt-1 font-medium text-foreground">{resultPriceLabel(item, t)}</p>
-              </div>
+              <MapPopupCarousel
+                key={item.location.locationId}
+                items={groupItemsById.get(item.location.locationId) ?? [item]}
+                locale={locale}
+                from={from}
+                to={to}
+                classFilter={classFilter}
+                pickupLocationId={pickupLocationId}
+                region={region}
+              />
             )}
           />
         )}

--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -22,3 +22,50 @@ export function resultPriceLabel(item: SearchResultItem, t: Translate): string {
     return t('fromHourly', { price: item.hourlyRateJpy.toLocaleString('en-US') })
   return t('noPrice')
 }
+
+/** All results at one pickup location, in input order. The map plots one pin per
+ *  location (a co-located cluster); the popup carousel (#885 slice 2) walks the whole
+ *  group and the pin's price label is the group minimum. */
+export interface LocationGroup {
+  locationId: string
+  items: SearchResultItem[]
+}
+
+/** Group results by pickup location, preserving first-seen order. Mirrors the map's
+ *  one-pin-per-location dedupe while keeping every co-located car for the popup. */
+export function groupByLocation(items: SearchResultItem[]): LocationGroup[] {
+  const order: string[] = []
+  const byId = new Map<string, SearchResultItem[]>()
+  for (const item of items) {
+    const id = item.location.locationId
+    const group = byId.get(id)
+    if (group) {
+      group.push(item)
+    } else {
+      byId.set(id, [item])
+      order.push(id)
+    }
+  }
+  return order.map((id) => ({ locationId: id, items: byId.get(id) ?? [] }))
+}
+
+/** Compact price for a map pin: the group's cheapest daily rate (else cheapest
+ *  hourly, else price-on-request), prefixed "From" when the pin covers more than one
+ *  car. Unit-less by design — a pin reads "¥8,000" while the popup carries the full
+ *  "/ day". Daily wins over hourly so a mixed group reads consistently. */
+export function pinPriceLabel(group: SearchResultItem[], t: Translate): string {
+  const price = minRate(group, (i) => i.dailyRateJpy) ?? minRate(group, (i) => i.hourlyRateJpy)
+  if (price == null) return t('noPrice')
+  const formatted = price.toLocaleString('en-US')
+  return group.length > 1
+    ? t('map.pinPriceFrom', { price: formatted })
+    : t('map.pinPrice', { price: formatted })
+}
+
+function minRate(
+  group: SearchResultItem[],
+  pick: (item: SearchResultItem) => number | null,
+): number | null {
+  const rates = group.map(pick).filter((rate): rate is number => rate != null)
+  return rates.length === 0 ? null : Math.min(...rates)
+}

--- a/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
+++ b/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
@@ -112,6 +112,19 @@ describe('MapPopupCarousel', () => {
     expect(screen.getByText('2 / 2')).toBeInTheDocument()
   })
 
+  it('announces the active car via a polite live region so advancing is not silent for screen readers', async () => {
+    const user = userEvent.setup()
+    renderCarousel([carAt('v1', 'Toyota Yaris'), carAt('v2', 'Honda Fit')])
+
+    // The car details sit in an aria-live region: clicking next swaps the card in
+    // place, so without it a SR user hears nothing about which car they landed on.
+    const live = screen.getByText('Toyota Yaris').closest('[aria-live="polite"]')
+    expect(live).not.toBeNull()
+
+    await user.click(screen.getByRole('button', { name: /next car/i }))
+    expect(live).toHaveTextContent('Honda Fit')
+  })
+
   it('carries from/to and filters into whichever slide is visible', async () => {
     const user = userEvent.setup()
     renderCarousel([carAt('v1', 'Toyota Yaris'), carAt('v2', 'Honda Fit')], {

--- a/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
+++ b/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
@@ -1,0 +1,148 @@
+import { MapPopupCarousel } from '@/vite/search/MapPopupCarousel'
+import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Stub the router Link as a plain anchor so the carried search is inspectable
+// without a RouterProvider (mirrors SearchMapList.test.tsx).
+vi.mock('@tanstack/react-router', async () => ({
+  ...(await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')),
+  Link: ({
+    to,
+    params,
+    search,
+    children,
+    ...rest
+  }: {
+    to: string
+    params?: { locale?: string; locationId?: string }
+    search?: Record<string, unknown>
+    children: ReactNode
+  }) => (
+    <a
+      href={to}
+      data-to={to}
+      data-location={params?.locationId}
+      data-search={JSON.stringify(search ?? {})}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
+}))
+
+function carAt(vehicleId: string, name: string): SpecificSearchResult {
+  return {
+    kind: 'SPECIFIC',
+    location: {
+      locationId: 'loc_namba',
+      operatorId: 'op_best',
+      operatorName: 'Best Car Rental',
+      name: 'Namba',
+      address: 'Osaka',
+      latitude: 34.66,
+      longitude: 135.5,
+    },
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    classLabel: 'Compact',
+    acrissCode: 'CCAR',
+    seats: 5,
+    photos: [],
+    vehicleId,
+    name,
+    make: 'Toyota',
+    model: 'Yaris',
+    year: 2023,
+    transmission: 'AUTO',
+  }
+}
+
+function renderCarousel(
+  items: SpecificSearchResult[],
+  ctx?: { classFilter?: string | string[]; region?: string },
+) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <MapPopupCarousel
+        items={items}
+        locale="en"
+        from="2026-07-01T10:00"
+        to="2026-07-04T10:00"
+        classFilter={ctx?.classFilter}
+        region={ctx?.region}
+      />
+    </IntlProvider>,
+  )
+}
+
+describe('MapPopupCarousel', () => {
+  it('shows a single car with no carousel controls', () => {
+    renderCarousel([carAt('v1', 'Toyota Yaris')])
+
+    expect(screen.getByText('Toyota Yaris')).toBeInTheDocument()
+    expect(screen.getByText(/8,000/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /next car/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /previous car/i })).toBeNull()
+  })
+
+  it('cycles co-located cars with next/prev (wrapping) and shows the position', async () => {
+    const user = userEvent.setup()
+    renderCarousel([carAt('v1', 'Toyota Yaris'), carAt('v2', 'Honda Fit')])
+
+    expect(screen.getByText('Toyota Yaris')).toBeInTheDocument()
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /next car/i }))
+    expect(screen.getByText('Honda Fit')).toBeInTheDocument()
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
+
+    // Next on the last slide wraps to the first.
+    await user.click(screen.getByRole('button', { name: /next car/i }))
+    expect(screen.getByText('Toyota Yaris')).toBeInTheDocument()
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+
+    // Prev on the first slide wraps to the last.
+    await user.click(screen.getByRole('button', { name: /previous car/i }))
+    expect(screen.getByText('Honda Fit')).toBeInTheDocument()
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
+  })
+
+  it('carries from/to and filters into whichever slide is visible', async () => {
+    const user = userEvent.setup()
+    renderCarousel([carAt('v1', 'Toyota Yaris'), carAt('v2', 'Honda Fit')], {
+      classFilter: 'COMPACT',
+      region: 'osaka',
+    })
+    const ctaSearch = () =>
+      JSON.parse(
+        screen.getByRole('link', { name: 'View cars' }).getAttribute('data-search') ?? '{}',
+      )
+
+    expect(ctaSearch()).toMatchObject({
+      from: '2026-07-01T10:00',
+      to: '2026-07-04T10:00',
+      class: 'COMPACT',
+      region: 'osaka',
+    })
+
+    await user.click(screen.getByRole('button', { name: /next car/i }))
+    expect(ctaSearch()).toMatchObject({
+      from: '2026-07-01T10:00',
+      to: '2026-07-04T10:00',
+      class: 'COMPACT',
+    })
+  })
+
+  it('targets the pickup store detail page for the current car', () => {
+    renderCarousel([carAt('v1', 'Toyota Yaris')])
+    const cta = screen.getByRole('link', { name: 'View cars' })
+
+    expect(cta).toHaveAttribute('data-to', '/$locale/storefronts/$locationId')
+    expect(cta).toHaveAttribute('data-location', 'loc_namba')
+  })
+})

--- a/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
+++ b/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
@@ -1,6 +1,6 @@
 import { PigeonMapAdapter, gsiTileProvider } from '@/vite/search/PigeonMapAdapter'
 import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -260,6 +260,44 @@ describe('PigeonMapAdapter', () => {
     const overlay = screen.getByTestId('overlay')
     expect(overlay).toHaveAttribute('data-anchor', '34.6627,135.5023')
     expect(screen.getByTestId('popup')).toHaveTextContent('loc_namba')
+  })
+
+  it('renders a custom pin node per location via renderPin (replacing the dot), flagging the selected one', () => {
+    render(
+      <PigeonMapAdapter
+        items={[
+          carAt('loc_namba', { latitude: 34.66, longitude: 135.5 }),
+          carAt('loc_umeda', { latitude: 34.7, longitude: 135.49 }),
+        ]}
+        selectedId="loc_umeda"
+        onSelect={() => {}}
+        renderPin={(item, { selected }) => (
+          <span data-testid={`pin-${item.location.locationId}`} data-selected={selected}>
+            {item.location.locationId}
+          </span>
+        )}
+      />,
+    )
+
+    // Custom pins render in place of the default marker dots, with the selected flag.
+    expect(screen.getByTestId('pin-loc_umeda')).toHaveAttribute('data-selected', 'true')
+    expect(screen.getByTestId('pin-loc_namba')).toHaveAttribute('data-selected', 'false')
+    expect(screen.queryAllByTestId('marker')).toHaveLength(0)
+  })
+
+  it('anchors each renderPin node at its location coordinates', () => {
+    render(
+      <PigeonMapAdapter
+        items={[carAt('loc_namba', { latitude: 34.66, longitude: 135.5 })]}
+        selectedId={null}
+        onSelect={() => {}}
+        renderPin={(item) => <span data-testid={`pin-${item.location.locationId}`} />}
+      />,
+    )
+
+    const overlay = screen.getByTestId('overlay')
+    expect(overlay).toHaveAttribute('data-anchor', '34.66,135.5')
+    expect(within(overlay).getByTestId('pin-loc_namba')).toBeInTheDocument()
   })
 
   it('flies to a newly selected pin without remounting the map (no tile-thrash)', () => {

--- a/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
+++ b/packages/web/tests/vite/search/PigeonMapAdapter.test.tsx
@@ -13,22 +13,44 @@ vi.mock('pigeon-maps', () => ({
     children,
     provider,
     attribution,
-    defaultCenter,
-    defaultZoom,
+    center,
+    zoom,
+    onBoundsChanged,
   }: {
     children: ReactNode
     provider?: (x: number, y: number, z: number) => string
     attribution?: ReactNode
-    defaultCenter?: [number, number]
-    defaultZoom?: number
+    center?: [number, number]
+    zoom?: number
+    onBoundsChanged?: (state: {
+      center: [number, number]
+      zoom: number
+      bounds: { ne: [number, number]; sw: [number, number] }
+      initial: boolean
+    }) => void
   }) => (
     <div
       data-testid="pigeon-map"
       data-tile-url={provider ? provider(3, 5, 12) : ''}
-      data-center={defaultCenter ? defaultCenter.join(',') : ''}
-      data-zoom={defaultZoom ?? ''}
+      data-center={center ? center.join(',') : ''}
+      data-zoom={zoom ?? ''}
     >
       {attribution}
+      {/* Controlled-mode sync: the real lib reports viewport moves (incl. user
+          pan/zoom) here, debounced 60ms. Tests fire it to assert the adapter folds
+          a manual pan into state without remounting. */}
+      <button
+        type="button"
+        data-testid="pan-map"
+        onClick={() =>
+          onBoundsChanged?.({
+            center: [10, 10],
+            zoom: 5,
+            bounds: { ne: [11, 11], sw: [9, 9] },
+            initial: false,
+          })
+        }
+      />
       {children}
     </div>
   ),
@@ -238,6 +260,121 @@ describe('PigeonMapAdapter', () => {
     const overlay = screen.getByTestId('overlay')
     expect(overlay).toHaveAttribute('data-anchor', '34.6627,135.5023')
     expect(screen.getByTestId('popup')).toHaveTextContent('loc_namba')
+  })
+
+  it('flies to a newly selected pin without remounting the map (no tile-thrash)', () => {
+    const props = {
+      items: [
+        carAt('loc_namba', { latitude: 34.6627, longitude: 135.5023 }),
+        carAt('loc_umeda', { latitude: 34.7025, longitude: 135.4959 }),
+      ],
+      onSelect: () => {},
+    }
+    const { rerender } = render(<PigeonMapAdapter {...props} selectedId={null} />)
+    const before = screen.getByTestId('pigeon-map')
+
+    rerender(<PigeonMapAdapter {...props} selectedId="loc_umeda" />)
+    const after = screen.getByTestId('pigeon-map')
+
+    // Same DOM node across the selection = React never remounted <Map>. The old
+    // remount-key impl replaced the node, re-fetching every tile on each select.
+    expect(after).toBe(before)
+    // ...and it still flew to the selected pin (controlled center/zoom).
+    expect(after).toHaveAttribute('data-center', '34.7025,135.4959')
+    expect(after).toHaveAttribute('data-zoom', '12') // SINGLE_PIN_ZOOM
+  })
+
+  it('folds a manual pan into state, then recenters on a new region without remounting (no drift)', () => {
+    const { rerender } = render(
+      <PigeonMapAdapter
+        items={[carAt('loc_a', { latitude: 34.7025, longitude: 135.4959 })]}
+        selectedId={null}
+        onSelect={() => {}}
+        anchor={[34.6655, 135.5023]}
+      />,
+    )
+    const node = screen.getByTestId('pigeon-map')
+    expect(node).toHaveAttribute('data-center', '34.6655,135.5023') // region A
+
+    fireEvent.click(screen.getByTestId('pan-map')) // user pans away
+    expect(node).toHaveAttribute('data-center', '10,10') // pan synced into controlled state
+
+    rerender(
+      <PigeonMapAdapter
+        items={[carAt('loc_b', { latitude: 35.0, longitude: 135.8 })]}
+        selectedId={null}
+        onSelect={() => {}}
+        anchor={[34.9, 135.9]}
+      />,
+    )
+    const after = screen.getByTestId('pigeon-map')
+    expect(after).toBe(node) // still no remount
+    expect(after).toHaveAttribute('data-center', '34.9,135.9') // reset to region B, pan discarded
+    expect(after).toHaveAttribute('data-zoom', '11') // REGION_ZOOM
+  })
+
+  it('keeps the map on a still-present selection when the result set changes', () => {
+    const loc1 = carAt('loc_1', { latitude: 34.5, longitude: 135.4 })
+    const { rerender } = render(
+      <PigeonMapAdapter items={[loc1]} selectedId="loc_1" onSelect={() => {}} />,
+    )
+    expect(screen.getByTestId('pigeon-map')).toHaveAttribute('data-center', '34.5,135.4')
+
+    // New result set still contains loc_1, plus a region anchor that must NOT win.
+    rerender(
+      <PigeonMapAdapter
+        items={[loc1, carAt('loc_2', { latitude: 35.0, longitude: 135.8 })]}
+        selectedId="loc_1"
+        onSelect={() => {}}
+        anchor={[34.9, 135.9]}
+      />,
+    )
+    const map = screen.getByTestId('pigeon-map')
+    expect(map).toHaveAttribute('data-center', '34.5,135.4') // selection beats the new anchor
+    expect(map).toHaveAttribute('data-zoom', '12') // SINGLE_PIN_ZOOM
+  })
+
+  it('falls through to the new region when the selection vanishes from the result set', () => {
+    const { rerender } = render(
+      <PigeonMapAdapter
+        items={[carAt('loc_1', { latitude: 34.5, longitude: 135.4 })]}
+        selectedId="loc_1"
+        onSelect={() => {}}
+      />,
+    )
+    // loc_1 is gone from the next set; the stale selection must not pin the viewport.
+    rerender(
+      <PigeonMapAdapter
+        items={[carAt('loc_2', { latitude: 35.0, longitude: 135.8 })]}
+        selectedId="loc_1"
+        onSelect={() => {}}
+        anchor={[34.9, 135.9]}
+      />,
+    )
+    const map = screen.getByTestId('pigeon-map')
+    expect(map).toHaveAttribute('data-center', '34.9,135.9') // stale selection → region B
+    expect(map).toHaveAttribute('data-zoom', '11') // REGION_ZOOM
+  })
+
+  it('recenters when the same location id reports new coordinates (P2)', () => {
+    const { rerender } = render(
+      <PigeonMapAdapter
+        items={[carAt('loc_1', { latitude: 34.5, longitude: 135.4 })]}
+        selectedId="loc_1"
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('pigeon-map')).toHaveAttribute('data-center', '34.5,135.4')
+
+    // Same id, moved coords: the target signature must include lat:lng or this drifts.
+    rerender(
+      <PigeonMapAdapter
+        items={[carAt('loc_1', { latitude: 35.1, longitude: 135.9 })]}
+        selectedId="loc_1"
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('pigeon-map')).toHaveAttribute('data-center', '35.1,135.9')
   })
 })
 

--- a/packages/web/tests/vite/search/SearchMap.test.tsx
+++ b/packages/web/tests/vite/search/SearchMap.test.tsx
@@ -7,13 +7,16 @@ import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 // The host injects the real PigeonMapAdapter → mock pigeon-maps so no tiles load.
+// The adapter drives the viewport with controlled `center`/`zoom` (#885 slice 2),
+// and positions price pills + the selected popup in <Overlay>s.
 vi.mock('pigeon-maps', () => ({
-  Map: ({ children, defaultCenter }: { children: ReactNode; defaultCenter?: [number, number] }) => (
-    <div data-testid="pigeon-map" data-center={defaultCenter ? defaultCenter.join(',') : ''}>
+  Map: ({ children, center }: { children: ReactNode; center?: [number, number] }) => (
+    <div data-testid="pigeon-map" data-center={center ? center.join(',') : ''}>
       {children}
     </div>
   ),
   Marker: () => <button type="button" data-testid="marker" />,
+  Overlay: ({ children }: { children: ReactNode }) => <div data-testid="overlay">{children}</div>,
 }))
 
 // Rows carry a detail-CTA Link (#885 1b); stub it so the host renders router-free.

--- a/packages/web/tests/vite/search/SearchMapList.test.tsx
+++ b/packages/web/tests/vite/search/SearchMapList.test.tsx
@@ -37,9 +37,10 @@ vi.mock('@tanstack/react-router', async () => ({
   ),
 }))
 
-// Fake adapter standing in for any map library: one button per plotted item,
-// click → onSelect(locationId). Asserts the MapAdapterProps seam — no real tiles.
-const FakeMapAdapter: MapAdapter = ({ items, selectedId, onSelect, anchor, renderSelected }) => {
+// Fake adapter standing in for any map library: one `pin-<id>` slot per plotted
+// item, filled by the view's `renderPin` (the price pill). Asserts the
+// MapAdapterProps seam — no real tiles.
+const FakeMapAdapter: MapAdapter = ({ items, selectedId, anchor, renderSelected, renderPin }) => {
   const selected = items.find((i) => i.location.locationId === selectedId) ?? null
   return (
     <div
@@ -48,14 +49,9 @@ const FakeMapAdapter: MapAdapter = ({ items, selectedId, onSelect, anchor, rende
       data-anchor={anchor?.join(',') ?? ''}
     >
       {items.map((item) => (
-        <button
-          key={item.location.locationId}
-          type="button"
-          data-testid={`marker-${item.location.locationId}`}
-          onClick={() => onSelect(item.location.locationId)}
-        >
-          marker
-        </button>
+        <div key={item.location.locationId} data-testid={`pin-${item.location.locationId}`}>
+          {renderPin?.(item, { selected: item.location.locationId === selectedId })}
+        </div>
       ))}
       {selected && renderSelected && <div data-testid="map-popup">{renderSelected(selected)}</div>}
     </div>
@@ -120,18 +116,18 @@ describe('SearchMapList', () => {
     ])
 
     expect(screen.getAllByRole('listitem')).toHaveLength(2)
-    expect(screen.getByTestId('marker-loc_namba')).toBeInTheDocument()
-    expect(screen.queryByTestId('marker-loc_umeda')).toBeNull()
+    expect(screen.getByTestId('pin-loc_namba')).toBeInTheDocument()
+    expect(screen.queryByTestId('pin-loc_umeda')).toBeNull()
   })
 
-  it('dedups markers by location (two cars at one store → one marker)', () => {
+  it('dedups markers by location (two cars at one store → one pin)', () => {
     renderMapList([
       carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
       carAt('v2', 'Honda Fit', 'loc_namba', GEOCODED),
     ])
 
     expect(screen.getAllByRole('listitem')).toHaveLength(2)
-    expect(screen.getByTestId('fake-map').querySelectorAll('button')).toHaveLength(1)
+    expect(screen.getByTestId('fake-map').querySelectorAll('[data-testid^="pin-"]')).toHaveLength(1)
   })
 
   it('highlights the matching rows when a marker is clicked and feeds selectedId back to the adapter', () => {
@@ -140,7 +136,7 @@ describe('SearchMapList', () => {
       carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
     ])
 
-    fireEvent.click(screen.getByTestId('marker-loc_namba'))
+    fireEvent.click(within(screen.getByTestId('pin-loc_namba')).getByRole('button'))
 
     const rows = screen.getAllByRole('listitem')
     const nambaRow = rows.find((o) => o.textContent?.includes('Toyota Yaris'))
@@ -255,6 +251,52 @@ describe('SearchMapList', () => {
     expect(popup).toHaveTextContent('Toyota Yaris')
     expect(popup).toHaveTextContent('Best Car Rental')
     expect(popup).toHaveTextContent(/8,000/)
+  })
+
+  it('plots a price-pill pin showing the bare price for a single-car location', () => {
+    renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
+    const pin = within(screen.getByTestId('pin-loc_namba')).getByRole('button')
+    expect(pin).toHaveTextContent('¥8,000')
+  })
+
+  it('labels a multi-car pin "From ¥{min}" using the cheapest car in the group', () => {
+    renderMapList([
+      { ...carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED), dailyRateJpy: 8000 },
+      { ...carAt('v2', 'Honda Fit', 'loc_namba', GEOCODED), dailyRateJpy: 6000 },
+    ])
+    const pin = within(screen.getByTestId('pin-loc_namba')).getByRole('button')
+    expect(pin).toHaveTextContent('From ¥6,000')
+  })
+
+  it('selects a location when its price pin is clicked (pin → row sync)', () => {
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
+    ])
+
+    fireEvent.click(within(screen.getByTestId('pin-loc_namba')).getByRole('button'))
+
+    const nambaRow = screen
+      .getAllByRole('listitem')
+      .find((o) => o.textContent?.includes('Toyota Yaris'))
+    expect(nambaRow).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
+  })
+
+  it('gives each price pin an accessible name of store + price so identical prices stay distinguishable (P2)', () => {
+    renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
+    const pin = within(screen.getByTestId('pin-loc_namba')).getByRole('button')
+    expect(pin).toHaveAccessibleName('Select Best Car Rental · Namba, ¥8,000')
+  })
+
+  it('marks the selected pin as current so it can invert its colors', () => {
+    renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
+    const pin = () => within(screen.getByTestId('pin-loc_namba')).getByRole('button')
+    expect(pin()).not.toHaveAttribute('aria-current')
+
+    fireEvent.click(pin())
+
+    expect(pin()).toHaveAttribute('aria-current', 'true')
   })
 
   it('threads the search context into each row CTA so the date range survives the drill-down', () => {

--- a/packages/web/tests/vite/search/SearchMapList.test.tsx
+++ b/packages/web/tests/vite/search/SearchMapList.test.tsx
@@ -241,7 +241,7 @@ describe('SearchMapList', () => {
     expect(screen.getByTestId('fake-map')).toHaveAttribute('data-anchor', '34.6655,135.5023')
   })
 
-  it('renders a map popup (title · store · price) for the selected location', () => {
+  it('opens a co-location carousel popup for the selected location', () => {
     renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
     expect(screen.queryByTestId('map-popup')).toBeNull()
 
@@ -249,8 +249,50 @@ describe('SearchMapList', () => {
 
     const popup = screen.getByTestId('map-popup')
     expect(popup).toHaveTextContent('Toyota Yaris')
-    expect(popup).toHaveTextContent('Best Car Rental')
     expect(popup).toHaveTextContent(/8,000/)
+    // One car at this store → a static card, no carousel arrows.
+    expect(within(popup).queryByRole('button', { name: /next car/i })).toBeNull()
+  })
+
+  it('threads the whole co-located group into the popup carousel (not just the pin item)', () => {
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_namba', GEOCODED),
+    ])
+
+    fireEvent.click(within(screen.getByTestId('pin-loc_namba')).getByRole('button'))
+
+    const popup = screen.getByTestId('map-popup')
+    expect(popup).toHaveTextContent('Toyota Yaris')
+    expect(within(popup).getByText('1 / 2')).toBeInTheDocument()
+    // The carousel cycles to the second co-located car — proof the group, not just
+    // the representative pin item, was threaded into renderSelected.
+    fireEvent.click(within(popup).getByRole('button', { name: /next car/i }))
+    expect(popup).toHaveTextContent('Honda Fit')
+  })
+
+  it('opens a freshly selected pin at its first car, not the previous carousel position', async () => {
+    const user = userEvent.setup()
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_namba', GEOCODED),
+      carAt('v3', 'Mazda Demio', 'loc_umeda', GEOCODED),
+      carAt('v4', 'Nissan Note', 'loc_umeda', GEOCODED),
+    ])
+
+    // Open Namba's popup and advance to its second car.
+    fireEvent.click(within(screen.getByTestId('pin-loc_namba')).getByRole('button'))
+    await user.click(
+      within(screen.getByTestId('map-popup')).getByRole('button', { name: /next car/i }),
+    )
+    expect(screen.getByTestId('map-popup')).toHaveTextContent('2 / 2')
+
+    // Switch to Umeda's pin: its popup must open at the first car. Without keying the
+    // carousel to the location the stale index leaks and it opens mid-carousel.
+    fireEvent.click(within(screen.getByTestId('pin-loc_umeda')).getByRole('button'))
+    const popup = screen.getByTestId('map-popup')
+    expect(within(popup).getByText('1 / 2')).toBeInTheDocument()
+    expect(popup).toHaveTextContent('Mazda Demio')
   })
 
   it('plots a price-pill pin showing the bare price for a single-car location', () => {

--- a/packages/web/tests/vite/search/SearchMapList.test.tsx
+++ b/packages/web/tests/vite/search/SearchMapList.test.tsx
@@ -2,6 +2,7 @@ import type { MapAdapter } from '@/vite/search/MapAdapter'
 import { SearchMapList } from '@/vite/search/SearchMapList'
 import type { SearchResultItem, SpecificSearchResult } from '@kuruma/shared/types/search-result'
 import { fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
@@ -149,7 +150,8 @@ describe('SearchMapList', () => {
     expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
   })
 
-  it('selects a row from its accessible "show on map" control (row → marker sync)', () => {
+  it('selects a row from its accessible "show on map" control (row → marker sync)', async () => {
+    const user = userEvent.setup()
     renderMapList([
       carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
       carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
@@ -160,27 +162,82 @@ describe('SearchMapList', () => {
     if (!nambaRow) throw new Error('expected the Namba row')
     const showOnMap = within(nambaRow).getByRole('button', { name: /show on map/i })
 
-    fireEvent.click(showOnMap)
+    // Real focus→click order (userEvent): the button focuses first — which selects
+    // the row via its onFocus — then the click lands. Idempotent-select keeps it on.
+    await user.click(showOnMap)
 
-    expect(showOnMap).toHaveAttribute('aria-pressed', 'true')
     expect(nambaRow).toHaveAttribute('aria-current', 'true')
     expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
   })
 
-  it('toggles the selection off when the pressed control is clicked again', () => {
+  it('keeps the row selected when the "show on map" control is clicked again (idempotent select, not a toggle)', async () => {
+    const user = userEvent.setup()
     renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
     const showOnMap = screen.getByRole('button', { name: /show on map/i })
 
-    fireEvent.click(showOnMap)
-    fireEvent.click(showOnMap)
+    await user.click(showOnMap)
+    await user.click(showOnMap)
 
-    expect(showOnMap).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', '')
+    // The old toggle deselected here; combined with the row onFocus that made
+    // focus-then-click flicker the selection off. Idempotent-select stays put.
+    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
+    expect(screen.getByRole('listitem')).toHaveAttribute('aria-current', 'true')
   })
 
   it('offers no "show on map" control for a list-only (null-coord) row', () => {
     renderMapList([carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS)])
     expect(screen.queryByRole('button', { name: /show on map/i })).toBeNull()
+  })
+
+  it('selects a geocoded row on hover (card-as-affordance)', async () => {
+    const user = userEvent.setup()
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
+    ])
+    const rows = screen.getAllByRole('listitem')
+    const nambaRow = rows.find((o) => o.textContent?.includes('Toyota Yaris'))
+    if (!nambaRow) throw new Error('expected the Namba row')
+
+    await user.hover(nambaRow)
+
+    expect(nambaRow).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
+  })
+
+  it('leaves a list-only (null-coord) row inert on hover', async () => {
+    const user = userEvent.setup()
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
+    ])
+    const rows = screen.getAllByRole('listitem')
+    const umedaRow = rows.find((o) => o.textContent?.includes('Honda Fit'))
+    if (!umedaRow) throw new Error('expected the Umeda row')
+
+    await user.hover(umedaRow)
+
+    expect(umedaRow).not.toHaveAttribute('aria-current')
+    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', '')
+  })
+
+  it('selects the row when keyboard focus reaches its "View cars" link (keyboard parity, P2)', async () => {
+    const user = userEvent.setup()
+    renderMapList([
+      carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED),
+      carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS),
+    ])
+    const rows = screen.getAllByRole('listitem')
+    const nambaRow = rows.find((o) => o.textContent?.includes('Toyota Yaris'))
+    if (!nambaRow) throw new Error('expected the Namba row')
+
+    // Tab moves keyboard focus to the first control — Namba's real "View cars" link —
+    // and the row's onFocus (focusin bubbles up from the CTA) selects its pin.
+    await user.tab()
+
+    expect(within(nambaRow).getByRole('link', { name: 'View cars' })).toHaveFocus()
+    expect(nambaRow).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByTestId('fake-map')).toHaveAttribute('data-selected', 'loc_namba')
   })
 
   it('threads the region anchor through to the map adapter (#840)', () => {

--- a/packages/web/tests/vite/search/result.test.ts
+++ b/packages/web/tests/vite/search/result.test.ts
@@ -1,4 +1,4 @@
-import { resultPriceLabel, resultTitle } from '@/vite/search/result'
+import { groupByLocation, pinPriceLabel, resultPriceLabel, resultTitle } from '@/vite/search/result'
 import type {
   ClassComboSearchResult,
   SpecificSearchResult,
@@ -65,5 +65,50 @@ describe('resultPriceLabel', () => {
     expect(resultPriceLabel({ ...base, dailyRateJpy: null, hourlyRateJpy: null }, t)).toBe(
       'noPrice',
     )
+  })
+})
+
+describe('groupByLocation', () => {
+  it('groups results by pickup location, preserving first-seen order', () => {
+    const a1 = { ...base, vehicleId: 'a1', location: { ...base.location, locationId: 'loc_a' } }
+    const b1 = { ...base, vehicleId: 'b1', location: { ...base.location, locationId: 'loc_b' } }
+    const a2 = { ...base, vehicleId: 'a2', location: { ...base.location, locationId: 'loc_a' } }
+
+    const groups = groupByLocation([a1, b1, a2])
+
+    expect(groups.map((g) => g.locationId)).toEqual(['loc_a', 'loc_b'])
+    expect(groups[0]?.items.map((i) => (i.kind === 'SPECIFIC' ? i.vehicleId : ''))).toEqual([
+      'a1',
+      'a2',
+    ])
+    expect(groups[1]?.items).toHaveLength(1)
+  })
+})
+
+describe('pinPriceLabel', () => {
+  it('shows the bare price for a single-car pin', () => {
+    expect(pinPriceLabel([base], t)).toBe('map.pinPrice:8,000')
+  })
+
+  it('shows the group minimum with a "From" prefix for a multi-car pin', () => {
+    const cheap = { ...base, vehicleId: 'v2', dailyRateJpy: 6500 }
+    const dear = { ...base, vehicleId: 'v3', dailyRateJpy: 12000 }
+    expect(pinPriceLabel([dear, cheap], t)).toBe('map.pinPriceFrom:6,500')
+  })
+
+  it('prefers a daily rate over hourly even when an hourly car is cheaper', () => {
+    const daily = { ...base, dailyRateJpy: 8000, hourlyRateJpy: null }
+    const hourly = { ...base, vehicleId: 'v2', dailyRateJpy: null, hourlyRateJpy: 500 }
+    expect(pinPriceLabel([daily, hourly], t)).toBe('map.pinPriceFrom:8,000')
+  })
+
+  it('falls back to the cheapest hourly rate when no car has a daily rate', () => {
+    const h1 = { ...base, dailyRateJpy: null, hourlyRateJpy: 700 }
+    const h2 = { ...base, vehicleId: 'v2', dailyRateJpy: null, hourlyRateJpy: 500 }
+    expect(pinPriceLabel([h1, h2], t)).toBe('map.pinPriceFrom:500')
+  })
+
+  it('returns price-on-request when no car in the group is priced', () => {
+    expect(pinPriceLabel([{ ...base, dailyRateJpy: null, hourlyRateJpy: null }], t)).toBe('noPrice')
   })
 })


### PR DESCRIPTION
## What & why

Slice 2 of the search map↔list redesign (#885), per the signed-off plan
`docs/plans/2026-06-16-search-map-slice2-plan.md`. Slice 1 (#895) added fly-to + a
single-car popup; 1b (#898) added the "View cars" detail CTA. But the fly-to
**remounted `<PigeonMap>`** (selectedId lived in the remount `key`), re-fetching
every tile on each row interaction — which is why card-as-affordance hover was
reverted out of 1b. Slice 2 makes the map genuinely interactive without the
tile-thrash.

## The 4 tasks (dependency order)

1. **Non-remount recenter** (`c11caf86`) — viewport (`center`/`zoom`) is now
   controlled state, synced from `onBoundsChanged` (user pan/zoom sticks) and
   retargeted by **one** precedence effect (`focusViewport`: selected pin → region
   anchor → fit-all). The remount `key` is gone, so a fly-to animates in place
   (pigeon `setCenterZoomTarget`) with zero tile re-fetch.
2. **Card hover/focus** (`4095caa5`) — hovering or keyboard-focusing a geocoded row
   flies the map to its pin. Idempotent select (sets, never clears) so focus→click
   can't race to a deselect; "Show on map" is now an idempotent action (no
   `aria-pressed` toggle), keeping the touch affordance for Slice 3.
3. **Price-labeled pins** (`1257b386`, `36fd995f`, `b2ec1d9d`) — additive
   `renderPin` seam on the adapter; the view owns the whole pill (group min price,
   `onClick`, styling, i18n). "From ¥X" for a multi-car store, "¥X" for one, "Price
   on request" otherwise. Selected pin inverts + `aria-current`. **P2 a11y:** each
   pill's accessible name is store + price (`map.pinSelect`) so visually identical
   prices stay distinguishable to screen readers.
4. **Co-location carousel popup** (`21adb72e`) — clicking a pin opens
   `MapPopupCarousel` over the **whole** `groupByLocation` group (mirrors
   `PhotoGallery`'s index/modulo cycling): photo · name · class · price · "View
   cars" CTA per slide, wrap-around next/prev, "n / total" position label. Keyed to
   the location so a new selection opens at the first car.

## Notable decisions

- **No remount `key`** is the crux — verified against pigeon-maps v0.22.1 source
  (controlled props animate via `setCenterZoomTarget`; `onBoundsChanged` is
  debounced 60ms so syncing it back doesn't truncate a programmatic fly-to). Reasoning in the plan.
- **Position label instead of PhotoGallery's dot row** in the carousel — reads
  cleaner in a narrow (`w-56`) popup and is the same affordance a screen reader needs.
- **One-way (#882) seam deferred** (YAGNI) — the adapter already takes a points
  list + selectedId; a dropoff pin / route is an additive prop when #882 lands.
- **Adapter contract stays clean (D1):** `SearchMapList` imports no map library;
  `renderPin`/`renderSelected` are pure `(item, state) => ReactNode` props, and the
  adapter only positions the returned nodes. `renderPin` falls back to the default
  `<Marker>` dot when absent, so the bare-adapter tests are intact.

## Test plan

- [x] `bun run --filter @kuruma/web test` — **990 pass / 150 files** (search group:
  19 SearchMapList, 4 MapPopupCarousel, 18 PigeonMapAdapter, 10 result).
- [x] `bun run --filter @kuruma/web typecheck` — clean (prod call-sites; tests aren't typechecked).
- [x] `biome check` — clean; pre-commit (file-size, module-boundaries, tsc web+api) green.
- [x] code-reviewer agent — one MEDIUM found (carousel index leaked across pin
  switches) → fixed with a `key` + regression test, folded into `21adb72e`.
- [ ] **Owner:** real-db Playwright (`region-search.auth.spec.ts`, #840 anchor) via CI.
- [ ] **Owner:** manual `bun run dev` — hover a row flies the map (no tile flash),
  pins show prices, click a multi-car pin → carousel.

Part of #885. **Owner-gated — please do not `--admin` merge.**