### PR TITLE
feat: operator profile & business settings UI + scoped PATCH /operators/:id (#903)

### DIFF
--- a/e2e/real-db/operator-settings.auth.spec.ts
+++ b/e2e/real-db/operator-settings.auth.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test'
+import { OPERATOR_SEED_EMAIL } from './constants'
+import { testSql } from './pg'
+
+// #903: authenticated, real-DB coverage for the operator settings page. The
+// minted session cookie (auth.setup.ts) is the Best Car Rental OWNER, so this
+// exercises the real web -> Hono PATCH /operators/:id -> seeded Neon branch.
+//
+// The owner persona is scoped to a SHARED seeded operator, so we capture its
+// original profile in beforeAll and restore it in afterAll — otherwise renaming
+// it would leak "Best Car Rental" out from under every other spec (workers: 1,
+// so the restore lands before the next file runs).
+test.describe('operator settings (authenticated, real DB)', () => {
+  let original: { id: string; name: string; preAuthHandoffUrl: string | null }
+
+  test.beforeAll(async () => {
+    const sql = testSql()
+    try {
+      const rows = await sql<{ id: string; name: string; preAuthHandoffUrl: string | null }[]>`
+        SELECT o.id, o.name, o.pre_auth_handoff_url AS "preAuthHandoffUrl"
+        FROM operators o
+        JOIN users u ON u."operatorId" = o.id
+        WHERE u.email = ${OPERATOR_SEED_EMAIL}
+        LIMIT 1`
+      const row = rows[0]
+      if (!row)
+        throw new Error(`No operator for ${OPERATOR_SEED_EMAIL} — seed the e2e branch first`)
+      original = row
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+
+  test.afterAll(async () => {
+    const sql = testSql()
+    try {
+      await sql`
+        UPDATE operators
+        SET name = ${original.name},
+            pre_auth_handoff_url = ${original.preAuthHandoffUrl},
+            "updatedAt" = now()
+        WHERE id = ${original.id}`
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+
+  test('owner edits business name + payment handoff URL and it round-trips (P1)', async ({
+    page,
+  }) => {
+    const newName = `E2E Settings ${Date.now()}`
+    const newUrl = `https://pay.e2e.example/${Date.now()}`
+
+    await page.goto('/en/manage/settings')
+    // The operator session is honoured — no redirect to sign-in.
+    await expect(page).toHaveURL(/\/en\/manage\/settings\/?$/)
+
+    // Prefilled with the current profile; the handoff field is editable for an owner.
+    await expect(page.locator('#settings-name')).toHaveValue(original.name)
+    const handoff = page.locator('#settings-handoff')
+    await expect(handoff).toBeEnabled()
+
+    await page.locator('#settings-name').fill(newName)
+    await handoff.fill(newUrl)
+    await page.getByRole('button', { name: 'Save changes' }).click()
+
+    await expect(page.getByText('Settings saved.')).toBeVisible()
+
+    // Persisted through the API to the DB (not just an optimistic UI update).
+    const sql = testSql()
+    try {
+      const rows = await sql<{ name: string; preAuthHandoffUrl: string | null }[]>`
+        SELECT name, pre_auth_handoff_url AS "preAuthHandoffUrl"
+        FROM operators WHERE id = ${original.id} LIMIT 1`
+      expect(rows[0]?.name).toBe(newName)
+      expect(rows[0]?.preAuthHandoffUrl).toBe(newUrl)
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+})

--- a/packages/api/src/auth/guards.ts
+++ b/packages/api/src/auth/guards.ts
@@ -1,7 +1,7 @@
 import { OPERATOR_ROLES, PLATFORM_ROLES } from '@kuruma/shared/auth/roles'
 
 import type { CallerContext } from './context'
-import { FLEET_WRITE_ROLES, MANAGEMENT_READ_ROLES } from './roles'
+import { FLEET_WRITE_ROLES, MANAGEMENT_READ_ROLES, OPERATOR_OWNER_WRITE_ROLES } from './roles'
 
 /**
  * Thrown by repo-layer guards when a non-authorised caller hits a
@@ -70,6 +70,23 @@ export function requirePlatformRead(ctx: CallerContext): void {
 export function requireFleetWriteScope(ctx: CallerContext): void {
   if (!FLEET_WRITE_ROLES.has(ctx.role)) {
     throw new ForbiddenError('fleet write scope required')
+  }
+  requireOperatorScope(ctx)
+}
+
+/**
+ * Guard for owner-tier writes to operator money-flow fields (`preAuthHandoffUrl`,
+ * #903). Admits `OPERATOR_OWNER_WRITE_ROLES` (the operator OWNER plus the
+ * platform/legacy base) and EXCLUDES OPERATOR_STAFF — a staff edit could redirect
+ * every renter's pre-auth payment handoff to a phishing page (the #386 http(s)
+ * refine blocks `javascript:`/`ftp:` but NOT `https://attacker.example`). A
+ * tenant-scoped owner missing its operatorId still fails closed via
+ * `requireOperatorScope`. Throws `ForbiddenError` (-> 403). Call AFTER the
+ * load-then-authorize 404 check so a foreign id never reveals a 403.
+ */
+export function requireOperatorOwnerWrite(ctx: CallerContext): void {
+  if (!OPERATOR_OWNER_WRITE_ROLES.has(ctx.role)) {
+    throw new ForbiddenError('operator owner scope required')
   }
   requireOperatorScope(ctx)
 }

--- a/packages/api/src/auth/roles.ts
+++ b/packages/api/src/auth/roles.ts
@@ -1,6 +1,7 @@
 import {
   ALL_ROLES,
   BUSINESS_ROLES,
+  OPERATOR_OWNER_WRITE_ROLES,
   OPERATOR_ROLES,
   PLATFORM_ROLES,
   type UserRole,
@@ -63,3 +64,10 @@ export function isAuthUser(v: unknown): v is AuthUser {
 export const STAFF_ROLES = PLATFORM_ROLES
 export const FLEET_WRITE_ROLES = BUSINESS_ROLES
 export const MANAGEMENT_READ_ROLES = BUSINESS_ROLES
+
+/**
+ * Owner-tier writes for operator money-flow fields (`preAuthHandoffUrl`, #903) —
+ * FLEET_WRITE_ROLES minus OPERATOR_STAFF. Re-exported from the single source so
+ * the api gate can't drift from the web's owner-gating of the same field.
+ */
+export { OPERATOR_OWNER_WRITE_ROLES }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -33,6 +33,7 @@ export {
   rejectOperatorContextUntilScoped,
   requireFleetWriteScope,
   requireManagementRead,
+  requireOperatorOwnerWrite,
   requireOperatorScope,
   requirePlatformAdmin,
   requirePlatformRead,

--- a/packages/api/src/repositories/drizzle/operator.ts
+++ b/packages/api/src/repositories/drizzle/operator.ts
@@ -1,7 +1,7 @@
 import { operators } from '@kuruma/shared/db/schema'
 import { asc, eq } from 'drizzle-orm'
 import type { Operator } from '../../stores'
-import type { OperatorRepository } from '../types'
+import type { OperatorRepository, OperatorUpdatePatch } from '../types'
 import type { Db } from './shared'
 
 export class DrizzleOperatorRepository implements OperatorRepository {
@@ -42,6 +42,18 @@ export class DrizzleOperatorRepository implements OperatorRepository {
       .values({ name: data.name, slug: data.slug, preAuthHandoffUrl: data.preAuthHandoffUrl })
       .returning()
     if (!row) throw new Error('Failed to create operator')
+    return row
+  }
+
+  async update(id: string, patch: OperatorUpdatePatch): Promise<Operator | undefined> {
+    // `set(patch)` only writes the keys present (an absent field is left
+    // unchanged; `preAuthHandoffUrl: null` clears the column). RETURNING gives
+    // the post-update row, or nothing when the id matched no operator.
+    const [row] = await this.db
+      .update(operators)
+      .set(patch)
+      .where(eq(operators.id, id))
+      .returning()
     return row
   }
 }

--- a/packages/api/src/repositories/in-memory/operator.ts
+++ b/packages/api/src/repositories/in-memory/operator.ts
@@ -1,5 +1,5 @@
 import type { Operator } from '../../stores'
-import type { OperatorRepository } from '../types'
+import type { OperatorRepository, OperatorUpdatePatch } from '../types'
 
 export class InMemoryOperatorRepository implements OperatorRepository {
   private readonly store: Map<string, Operator>
@@ -44,5 +44,16 @@ export class InMemoryOperatorRepository implements OperatorRepository {
     }
     this.store.set(operator.id, operator)
     return operator
+  }
+
+  async update(id: string, patch: OperatorUpdatePatch): Promise<Operator | undefined> {
+    const existing = this.store.get(id)
+    if (!existing) return undefined
+    // New object, never a mutation of the stored row (mirrors the immutability
+    // a Drizzle `UPDATE ... RETURNING` gives). Spreading `patch` only overwrites
+    // the keys present, so an absent field is left at its existing value.
+    const updated: Operator = { ...existing, ...patch }
+    this.store.set(id, updated)
+    return updated
   }
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -74,6 +74,16 @@ export type {
 } from './types-notification'
 
 /** Operator (tenant) data access. Admin bootstrap (#386) + slug/id resolution (#387). */
+// Partial profile patch (#903). Only the keys present are written; an absent key
+// leaves the column unchanged, `preAuthHandoffUrl: null` clears it. `updatedAt`
+// is always supplied by the service (the column has no `$onUpdate`). Caller
+// scoping (operator may only patch its own) is decided in OperatorService.
+export interface OperatorUpdatePatch {
+  name?: string
+  preAuthHandoffUrl?: string | null
+  updatedAt: Date
+}
+
 export interface OperatorRepository {
   create(data: {
     name: string
@@ -89,6 +99,9 @@ export interface OperatorRepository {
   // Caller scoping (operator sees only its own) is applied in OperatorService.
   list(): Promise<Operator[]>
   findBySlug(slug: string): Promise<Operator | undefined>
+  // #903: apply a partial profile patch and return the updated row, or undefined
+  // if no operator has that id (never inserts).
+  update(id: string, patch: OperatorUpdatePatch): Promise<Operator | undefined>
 }
 
 export interface LocationFilters {

--- a/packages/api/src/routes/operators.ts
+++ b/packages/api/src/routes/operators.ts
@@ -1,7 +1,8 @@
+import { updateOperatorSchema } from '@kuruma/shared/validators/operator'
 import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import type { OperatorService } from '../services/operator'
-import { fail, ok, parseId } from './helpers'
+import { fail, ok, parseBody, parseId } from './helpers'
 
 /**
  * Read-only operator resolution for the business portal (#387). The web layout
@@ -51,6 +52,24 @@ export function createOperatorRoutes(service: OperatorService) {
         const operator = await service.getById(toCallerContext(user), idResult.id)
         if (!operator) return fail(c, 'Operator not found', 404)
         return ok(c, operator)
+      })
+      // Operator self-service profile update (#903). FLEET_WRITE gate is the
+      // baseline (an OPERATOR_STAFF may edit the display name); the owner-only
+      // `preAuthHandoffUrl` is enforced in the service AFTER the 404 check, so a
+      // foreign id never surfaces as a 403. The service projects the response.
+      .patch('/operators/:id', async (c) => {
+        const user = requireUser(c)
+        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+
+        const parsed = await parseBody(c, updateOperatorSchema)
+        if (!parsed.ok) return parsed.response
+
+        const profile = await service.update(toCallerContext(user), idResult.id, parsed.data)
+        if (!profile) return fail(c, 'Operator not found', 404)
+        return ok(c, profile)
       })
   )
 }

--- a/packages/api/src/routes/operators.ts
+++ b/packages/api/src/routes/operators.ts
@@ -1,7 +1,7 @@
 import { updateOperatorSchema } from '@kuruma/shared/validators/operator'
 import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
-import type { OperatorService } from '../services/operator'
+import { type OperatorService, toOperatorProfile } from '../services/operator'
 import { fail, ok, parseBody, parseId } from './helpers'
 
 /**
@@ -40,7 +40,7 @@ export function createOperatorRoutes(service: OperatorService) {
 
         const operator = await service.getBySlug(toCallerContext(user), c.req.param('slug'))
         if (!operator) return fail(c, 'Operator not found', 404)
-        return ok(c, operator)
+        return ok(c, toOperatorProfile(operator))
       })
       .get('/operators/:id', async (c) => {
         const user = requireUser(c)
@@ -51,7 +51,7 @@ export function createOperatorRoutes(service: OperatorService) {
 
         const operator = await service.getById(toCallerContext(user), idResult.id)
         if (!operator) return fail(c, 'Operator not found', 404)
-        return ok(c, operator)
+        return ok(c, toOperatorProfile(operator))
       })
       // Operator self-service profile update (#903). FLEET_WRITE gate is the
       // baseline (an OPERATOR_STAFF may edit the display name); the owner-only

--- a/packages/api/src/services/operator.ts
+++ b/packages/api/src/services/operator.ts
@@ -9,10 +9,13 @@ import type { Operator, OperatorRepository } from '../repositories/types'
 import { resolveUniqueSlug, slugify } from './slug'
 
 /**
- * Deliberate wire projection for the operator profile (#903) — the settings
- * response. Excludes `createdAt`/`updatedAt` (Date fields that would leak as raw
- * timestamps) so the contract is exactly the editable surface plus the
- * read-only slug.
+ * The canonical operator wire shape (#903) — the SINGLE shape every detail
+ * endpoint for an operator returns: `GET /operators/:id`, `GET /operators/by-slug/
+ * :slug`, and `PATCH /operators/:id` all project through {@link toOperatorProfile}.
+ * Excludes `createdAt`/`updatedAt` (raw Date columns) so reads and writes agree on
+ * one contract instead of the route leaking the full row on read and a projection
+ * on write. The admin picker `list` returns a leaner `{id,name,slug}` summary by
+ * design (collection vs detail), which is the expected REST asymmetry.
  */
 export interface OperatorProfile {
   id: string
@@ -21,7 +24,7 @@ export interface OperatorProfile {
   preAuthHandoffUrl: string | null
 }
 
-function toProfile(op: Operator): OperatorProfile {
+export function toOperatorProfile(op: Operator): OperatorProfile {
   return { id: op.id, name: op.name, slug: op.slug, preAuthHandoffUrl: op.preAuthHandoffUrl }
 }
 
@@ -107,6 +110,6 @@ export class OperatorService {
         : {}),
       updatedAt: new Date(),
     })
-    return updated ? toProfile(updated) : undefined
+    return updated ? toOperatorProfile(updated) : undefined
   }
 }

--- a/packages/api/src/services/operator.ts
+++ b/packages/api/src/services/operator.ts
@@ -1,7 +1,29 @@
-import type { CreateOperatorInput } from '@kuruma/shared/validators/operator'
-import { type CallerContext, isOperatorRole, requirePlatformAdmin } from '../middleware/auth'
+import type { CreateOperatorInput, UpdateOperatorInput } from '@kuruma/shared/validators/operator'
+import {
+  type CallerContext,
+  isOperatorRole,
+  requireOperatorOwnerWrite,
+  requirePlatformAdmin,
+} from '../middleware/auth'
 import type { Operator, OperatorRepository } from '../repositories/types'
 import { resolveUniqueSlug, slugify } from './slug'
+
+/**
+ * Deliberate wire projection for the operator profile (#903) — the settings
+ * response. Excludes `createdAt`/`updatedAt` (Date fields that would leak as raw
+ * timestamps) so the contract is exactly the editable surface plus the
+ * read-only slug.
+ */
+export interface OperatorProfile {
+  id: string
+  name: string
+  slug: string
+  preAuthHandoffUrl: string | null
+}
+
+function toProfile(op: Operator): OperatorProfile {
+  return { id: op.id, name: op.name, slug: op.slug, preAuthHandoffUrl: op.preAuthHandoffUrl }
+}
 
 export class OperatorService {
   constructor(private readonly repo: OperatorRepository) {}
@@ -52,5 +74,39 @@ export class OperatorService {
       slug,
       preAuthHandoffUrl: input.preAuthHandoffUrl ?? null,
     })
+  }
+
+  /**
+   * Self-service operator profile update (#903). Load-then-authorize: resolve the
+   * row through `scopeToCaller` first so a foreign/absent id reads as `undefined`
+   * (the route 404s, never leaking existence) BEFORE any field-level gate runs.
+   * Only then is the owner-only `preAuthHandoffUrl` gate applied — so a staff
+   * caller patching another tenant's handoff still gets a 404, not a 403 that
+   * would confirm the tenant exists. Writes `updatedAt` (the column has no
+   * `$onUpdate`). Returns the wire projection, or `undefined` when not found.
+   */
+  async update(
+    ctx: CallerContext,
+    id: string,
+    input: UpdateOperatorInput,
+  ): Promise<OperatorProfile | undefined> {
+    const existing = this.scopeToCaller(ctx, await this.repo.findById(id))
+    if (!existing) return undefined
+
+    // `preAuthHandoffUrl` is a renter-facing money-flow control — owner-only,
+    // even though `name` is open to all fleet-write roles. The key being present
+    // (string OR explicit null) is the write attempt; an absent key is not.
+    if ('preAuthHandoffUrl' in input) requireOperatorOwnerWrite(ctx)
+
+    // Spread only the keys the patch actually carries — passing `name: undefined`
+    // would overwrite the column (in-memory) and breaks exactOptionalPropertyTypes.
+    const updated = await this.repo.update(id, {
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...('preAuthHandoffUrl' in input
+        ? { preAuthHandoffUrl: input.preAuthHandoffUrl ?? null }
+        : {}),
+      updatedAt: new Date(),
+    })
+    return updated ? toProfile(updated) : undefined
   }
 }

--- a/packages/api/tests/routes/operators.test.ts
+++ b/packages/api/tests/routes/operators.test.ts
@@ -71,6 +71,21 @@ describe('GET /operators/:id', () => {
     expect((await res.json()).data.slug).toBe('best-car-rental')
   })
 
+  it('returns the operator profile projection — same shape as PATCH, no raw timestamps', async () => {
+    const res = await mountFor('OPERATOR_STAFF', opA.id).request(`/operators/${opA.id}`)
+    const { data } = await res.json()
+    // One resource, one wire shape: the read must match the PATCH projection
+    // exactly (#903 arch review) — never the full row with createdAt/updatedAt.
+    expect(data).toEqual({
+      id: opA.id,
+      name: 'Best Car Rental',
+      slug: 'best-car-rental',
+      preAuthHandoffUrl: null,
+    })
+    expect(data).not.toHaveProperty('createdAt')
+    expect(data).not.toHaveProperty('updatedAt')
+  })
+
   it('returns 404 when an OPERATOR_STAFF reads another operator', async () => {
     const res = await mountFor('OPERATOR_STAFF', opA.id).request(`/operators/${opB.id}`)
     expect(res.status).toBe(404)

--- a/packages/api/tests/routes/operators.test.ts
+++ b/packages/api/tests/routes/operators.test.ts
@@ -132,3 +132,88 @@ describe('Operator routes — auth', () => {
     expect((await app.request(`/operators/${opA.id}`)).status).toBe(401)
   })
 })
+
+function patchReq(app: Hono, id: string, body: unknown) {
+  return app.request(`/operators/${id}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /operators/:id', () => {
+  it('lets an owner rename its own operator and returns the projection', async () => {
+    const res = await patchReq(mountFor('OPERATOR_OWNER', opA.id), opA.id, { name: 'Renamed' })
+    expect(res.status).toBe(200)
+    expect((await res.json()).data).toEqual({
+      id: opA.id,
+      name: 'Renamed',
+      slug: 'best-car-rental',
+      preAuthHandoffUrl: null,
+    })
+  })
+
+  it('lets an owner set the preAuthHandoffUrl', async () => {
+    const res = await patchReq(mountFor('OPERATOR_OWNER', opA.id), opA.id, {
+      preAuthHandoffUrl: 'https://pay.best.example/h',
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.preAuthHandoffUrl).toBe('https://pay.best.example/h')
+  })
+
+  it('lets an OPERATOR_STAFF edit the display name', async () => {
+    const res = await patchReq(mountFor('OPERATOR_STAFF', opA.id), opA.id, { name: 'Staff Edit' })
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.name).toBe('Staff Edit')
+  })
+
+  it('forbids an OPERATOR_STAFF from changing preAuthHandoffUrl (403)', async () => {
+    const res = await patchReq(mountFor('OPERATOR_STAFF', opA.id), opA.id, {
+      preAuthHandoffUrl: 'https://evil.example',
+    })
+    expect(res.status).toBe(403)
+    expect((await repo.findById(opA.id))?.preAuthHandoffUrl).toBeNull()
+  })
+
+  it('returns 404 for a cross-tenant patch AND leaves the target row unchanged', async () => {
+    const res = await patchReq(mountFor('OPERATOR_OWNER', opA.id), opB.id, { name: 'Hijacked' })
+    expect(res.status).toBe(404)
+    expect((await repo.findById(opB.id))?.name).toBe('Acme Cars')
+  })
+
+  it('rejects a javascript: scheme handoff URL with 400', async () => {
+    const res = await patchReq(mountFor('OPERATOR_OWNER', opA.id), opA.id, {
+      preAuthHandoffUrl: 'javascript:alert(1)',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an empty patch with 400', async () => {
+    const res = await patchReq(mountFor('OPERATOR_OWNER', opA.id), opA.id, {})
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 for a RENTER', async () => {
+    const res = await patchReq(mountFor('RENTER'), opA.id, { name: 'X' })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 for a malformed (non-uuid) id', async () => {
+    const res = await patchReq(mountFor('PLATFORM_ADMIN'), 'nope', { name: 'X' })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for a valid-but-unknown id (admin)', async () => {
+    const res = await patchReq(mountFor('PLATFORM_ADMIN'), '00000000-0000-4000-8000-0000000000ff', {
+      name: 'X',
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    const app = new Hono()
+    setupGlobalHandlers(app)
+    app.route('/', createOperatorRoutes(new OperatorService(repo)))
+    expect((await patchReq(app, opA.id, { name: 'X' })).status).toBe(401)
+  })
+})

--- a/packages/api/tests/services/operator.test.ts
+++ b/packages/api/tests/services/operator.test.ts
@@ -90,3 +90,131 @@ describe('OperatorService.create', () => {
     await expect(service.create(ownerCtx, { name: 'Sneaky' })).rejects.toThrow(ForbiddenError)
   })
 })
+
+describe('InMemoryOperatorRepository.update', () => {
+  test('applies a partial patch, preserves untouched fields, and returns the row', async () => {
+    const repo = new InMemoryOperatorRepository()
+    const op = await repo.create({
+      name: 'Old Name',
+      slug: 'old-slug',
+      preAuthHandoffUrl: 'https://old.example',
+    })
+    const at = new Date('2030-01-01T00:00:00.000Z')
+    const updated = await repo.update(op.id, { name: 'New Name', updatedAt: at })
+    expect(updated).toMatchObject({
+      id: op.id,
+      name: 'New Name',
+      slug: 'old-slug', // untouched
+      preAuthHandoffUrl: 'https://old.example', // untouched (absent key)
+      updatedAt: at,
+    })
+  })
+
+  test('clears preAuthHandoffUrl when the patch carries null', async () => {
+    const repo = new InMemoryOperatorRepository()
+    const op = await repo.create({ name: 'A', slug: 'a', preAuthHandoffUrl: 'https://x.example' })
+    const updated = await repo.update(op.id, { preAuthHandoffUrl: null, updatedAt: new Date() })
+    expect(updated?.preAuthHandoffUrl).toBeNull()
+  })
+
+  test('returns undefined for an unknown id (no insert)', async () => {
+    const repo = new InMemoryOperatorRepository()
+    expect(await repo.update('nope', { name: 'X', updatedAt: new Date() })).toBeUndefined()
+    expect(await repo.list()).toEqual([])
+  })
+
+  test('does not mutate the stored object in place (immutability)', async () => {
+    const repo = new InMemoryOperatorRepository()
+    const op = await repo.create({ name: 'A', slug: 'a', preAuthHandoffUrl: null })
+    const before = await repo.findById(op.id)
+    await repo.update(op.id, { name: 'B', updatedAt: new Date() })
+    expect(before?.name).toBe('A') // the snapshot read earlier is unchanged
+  })
+})
+
+describe('OperatorService.update', () => {
+  async function seedOne(preAuthHandoffUrl: string | null = null) {
+    const { repo, service } = makeService()
+    const op = await repo.create({ name: 'Owner Co', slug: 'owner-co', preAuthHandoffUrl })
+    const ctx: CallerContext = { ...ownerCtx, operatorId: op.id }
+    return { repo, service, op, ctx }
+  }
+
+  test('returns a projection (no createdAt/updatedAt) when an owner edits its name', async () => {
+    const { service, op, ctx } = await seedOne()
+    const result = await service.update(ctx, op.id, { name: 'Renamed Co' })
+    expect(result).toEqual({
+      id: op.id,
+      name: 'Renamed Co',
+      slug: 'owner-co',
+      preAuthHandoffUrl: null,
+    })
+    expect(result).not.toHaveProperty('createdAt')
+    expect(result).not.toHaveProperty('updatedAt')
+  })
+
+  test('an owner can set preAuthHandoffUrl, and it persists', async () => {
+    const { repo, service, op, ctx } = await seedOne()
+    const result = await service.update(ctx, op.id, { preAuthHandoffUrl: 'https://pay.x/h' })
+    expect(result?.preAuthHandoffUrl).toBe('https://pay.x/h')
+    expect((await repo.findById(op.id))?.preAuthHandoffUrl).toBe('https://pay.x/h')
+  })
+
+  test('an owner can clear preAuthHandoffUrl to null', async () => {
+    const { repo, service, op, ctx } = await seedOne('https://pay.x/h')
+    await service.update(ctx, op.id, { preAuthHandoffUrl: null })
+    expect((await repo.findById(op.id))?.preAuthHandoffUrl).toBeNull()
+  })
+
+  test('bumps updatedAt on a successful patch', async () => {
+    const { repo, service, op, ctx } = await seedOne()
+    const before = (await repo.findById(op.id))?.updatedAt
+    await new Promise((r) => setTimeout(r, 2))
+    await service.update(ctx, op.id, { name: 'Bumped' })
+    const after = (await repo.findById(op.id))?.updatedAt
+    expect(after?.getTime()).toBeGreaterThan(before?.getTime() ?? 0)
+  })
+
+  test('OPERATOR_STAFF cannot change preAuthHandoffUrl (owner-only) — ForbiddenError', async () => {
+    const { repo, service, op } = await seedOne()
+    const staffCtx: CallerContext = { ...ownerCtx, role: 'OPERATOR_STAFF', operatorId: op.id }
+    await expect(
+      service.update(staffCtx, op.id, { preAuthHandoffUrl: 'https://evil.example' }),
+    ).rejects.toThrow(ForbiddenError)
+    // and the field is unchanged
+    expect((await repo.findById(op.id))?.preAuthHandoffUrl).toBeNull()
+  })
+
+  test('OPERATOR_STAFF may still edit the display name', async () => {
+    const { service, op } = await seedOne()
+    const staffCtx: CallerContext = { ...ownerCtx, role: 'OPERATOR_STAFF', operatorId: op.id }
+    const result = await service.update(staffCtx, op.id, { name: 'Staff Renamed' })
+    expect(result?.name).toBe('Staff Renamed')
+  })
+
+  test('a cross-tenant patch resolves to undefined (404) and leaves the target row unchanged', async () => {
+    const { repo, service } = makeService()
+    const a = await repo.create({ name: 'A Co', slug: 'a-co', preAuthHandoffUrl: null })
+    const b = await repo.create({ name: 'B Co', slug: 'b-co', preAuthHandoffUrl: null })
+    const ctxA: CallerContext = { ...ownerCtx, operatorId: a.id }
+    expect(await service.update(ctxA, b.id, { name: 'Hijacked' })).toBeUndefined()
+    expect((await repo.findById(b.id))?.name).toBe('B Co')
+  })
+
+  test('a cross-tenant handoff patch 404s BEFORE the owner-gate (no 403 existence leak)', async () => {
+    const { repo, service } = makeService()
+    const a = await repo.create({ name: 'A Co', slug: 'a-co', preAuthHandoffUrl: null })
+    const b = await repo.create({ name: 'B Co', slug: 'b-co', preAuthHandoffUrl: null })
+    // A staff of tenant A patches tenant B's money-flow field: must read as 404
+    // (undefined), never a 403 that would confirm B exists.
+    const staffA: CallerContext = { ...ownerCtx, role: 'OPERATOR_STAFF', operatorId: a.id }
+    expect(
+      await service.update(staffA, b.id, { preAuthHandoffUrl: 'https://evil.example' }),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined for an unknown id', async () => {
+    const { service } = await seedOne()
+    expect(await service.update(SYSTEM_CONTEXT, 'unknown-id', { name: 'X' })).toBeUndefined()
+  })
+})

--- a/packages/shared/src/auth/roles.ts
+++ b/packages/shared/src/auth/roles.ts
@@ -74,6 +74,16 @@ export const MANAGEMENT_BASE_ROLES = roleSet('STAFF', 'ADMIN', 'PLATFORM_ADMIN')
 export const BUSINESS_ROLES = union(MANAGEMENT_BASE_ROLES, OPERATOR_ROLES)
 
 /**
+ * Owner-tier writes — operator-profile money-flow fields, currently
+ * `preAuthHandoffUrl` (#903). Business management MINUS the OPERATOR_STAFF role:
+ * one staff edit could redirect every renter's pre-auth pay-at-pickup handoff to
+ * a phishing page, so the field is gated to the operator OWNER (plus the platform
+ * tier, which can already act on any tenant). Composed from MANAGEMENT_BASE_ROLES
+ * so it tracks the platform/legacy base automatically. Do NOT add OPERATOR_STAFF.
+ */
+export const OPERATOR_OWNER_WRITE_ROLES = union(MANAGEMENT_BASE_ROLES, roleSet('OPERATOR_OWNER'))
+
+/**
  * Cross-tenant read bypass — the platform tier PLUS PARTNER (Trip.com reads
  * bookings across tenants). Drives `CallerContext.bypassScope`. A distinct
  * instance from {@link PRIVILEGED_ROLES} (same members) because the two gate

--- a/packages/shared/src/validators/operator.ts
+++ b/packages/shared/src/validators/operator.ts
@@ -21,9 +21,28 @@ const httpUrl = z
     { message: 'must be an http(s) URL' },
   )
 
+// Single source for the operator display-name rule so create and update can't
+// drift (#903). Trimmed, 1–100 chars.
+const nameSchema = z.string().trim().min(1).max(100)
+
 export const createOperatorSchema = z.object({
-  name: z.string().trim().min(1).max(100),
+  name: nameSchema,
   preAuthHandoffUrl: httpUrl.optional(),
 })
 
 export type CreateOperatorInput = z.infer<typeof createOperatorSchema>
+
+// Operator self-service profile patch (#903). Every field is optional, but an
+// empty patch is rejected (nothing to do). preAuthHandoffUrl is 3-state: key
+// absent -> leave column unchanged; explicit null -> clear to NULL; string ->
+// must pass the http(s) refine (it is a renter-facing money-flow control).
+export const updateOperatorSchema = z
+  .object({
+    name: nameSchema.optional(),
+    preAuthHandoffUrl: httpUrl.nullable().optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: 'at least one field is required',
+  })
+
+export type UpdateOperatorInput = z.infer<typeof updateOperatorSchema>

--- a/packages/shared/tests/auth/roles.test.ts
+++ b/packages/shared/tests/auth/roles.test.ts
@@ -3,6 +3,7 @@ import {
   ALL_ROLES,
   BUSINESS_ROLES,
   MANAGEMENT_BASE_ROLES,
+  OPERATOR_OWNER_WRITE_ROLES,
   OPERATOR_ROLES,
   PLATFORM_ROLES,
   PRIVILEGED_ROLES,
@@ -38,6 +39,19 @@ describe('canonical role sets (#487 prep — single source of truth)', () => {
       'PLATFORM_ADMIN',
       'STAFF',
     ])
+  })
+
+  it('OPERATOR_OWNER_WRITE_ROLES = BUSINESS_ROLES minus OPERATOR_STAFF (owner-tier money-flow writes — #903)', () => {
+    expect(members(OPERATOR_OWNER_WRITE_ROLES)).toEqual([
+      'ADMIN',
+      'OPERATOR_OWNER',
+      'PLATFORM_ADMIN',
+      'STAFF',
+    ])
+    // OPERATOR_STAFF is the one business role excluded — it must not redirect the
+    // renter-facing pre-auth payment handoff.
+    expect(OPERATOR_OWNER_WRITE_ROLES.has('OPERATOR_STAFF')).toBe(false)
+    expect(BUSINESS_ROLES.has('OPERATOR_STAFF')).toBe(true)
   })
 
   it('SCOPE_BYPASS_ROLES and PRIVILEGED_ROLES = PARTNER + PLATFORM_ADMIN — legacy STAFF/ADMIN revoked (#487), distinct instances', () => {

--- a/packages/shared/tests/validators/operator.test.ts
+++ b/packages/shared/tests/validators/operator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { createOperatorSchema } from '../../src/validators/operator'
+import { createOperatorSchema, updateOperatorSchema } from '../../src/validators/operator'
 
 describe('createOperatorSchema', () => {
   test('accepts a name and trims it', () => {
@@ -49,5 +49,47 @@ describe('createOperatorSchema', () => {
       createOperatorSchema.safeParse({ name: 'Acme', preAuthHandoffUrl: 'http://pay.acme.example' })
         .success,
     ).toBe(true)
+  })
+})
+
+describe('updateOperatorSchema', () => {
+  test('accepts and trims a name-only patch', () => {
+    const parsed = updateOperatorSchema.parse({ name: '  Renamed Co  ' })
+    expect(parsed).toEqual({ name: 'Renamed Co' })
+  })
+
+  test('reuses the create name constraints (max 100)', () => {
+    expect(updateOperatorSchema.safeParse({ name: 'a'.repeat(101) }).success).toBe(false)
+    expect(updateOperatorSchema.safeParse({ name: '   ' }).success).toBe(false)
+  })
+
+  // 3-state preAuthHandoffUrl semantics — the column is nullable, so the patch
+  // must distinguish "leave unchanged" / "clear to NULL" / "set".
+  test('absent key leaves the field out of the parsed patch (unchanged)', () => {
+    const parsed = updateOperatorSchema.parse({ name: 'X' })
+    expect('preAuthHandoffUrl' in parsed).toBe(false)
+  })
+
+  test('explicit null is preserved (clear to NULL)', () => {
+    const parsed = updateOperatorSchema.parse({ preAuthHandoffUrl: null })
+    expect(parsed).toEqual({ preAuthHandoffUrl: null })
+  })
+
+  test('accepts an http(s) string', () => {
+    const parsed = updateOperatorSchema.parse({ preAuthHandoffUrl: 'https://pay.x.example/h' })
+    expect(parsed.preAuthHandoffUrl).toBe('https://pay.x.example/h')
+  })
+
+  test('rejects a javascript: scheme (renter-facing, money-flow field)', () => {
+    expect(
+      updateOperatorSchema.safeParse({
+        // biome-ignore lint/suspicious/noExplicitAny: testing a hostile value
+        preAuthHandoffUrl: 'javascript:alert(1)' as any,
+      }).success,
+    ).toBe(false)
+  })
+
+  test('rejects an empty patch ({} -> 400)', () => {
+    expect(updateOperatorSchema.safeParse({}).success).toBe(false)
   })
 })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -84,7 +84,8 @@
     "browse": "Browse",
     "myBookings": "My Bookings",
     "documents": "Documents",
-    "newBookings": "{count, plural, one {# new booking} other {# new bookings}}"
+    "newBookings": "{count, plural, one {# new booking} other {# new bookings}}",
+    "settings": "Settings"
   },
   "acriss": {
     "MCAR": "Mini",
@@ -783,6 +784,24 @@
       "title": "Messages",
       "subtitle": "Customer conversations",
       "empty": "No conversations yet. Messages will appear when customers contact you."
+    },
+    "settings": {
+      "title": "Settings",
+      "subtitle": "Manage your business profile and renter payment handoff.",
+      "loadError": "Couldn't load settings",
+      "retry": "Try again",
+      "saved": "Settings saved.",
+      "noOperatorContext": "This page edits a single operator's profile. Use the admin portal to manage operators.",
+      "form": {
+        "name": "Business name",
+        "namePlaceholder": "e.g. Osaka Car Rental",
+        "handoffUrl": "Payment handoff URL",
+        "handoffUrlPlaceholder": "https://pay.example.com/handoff",
+        "handoffUrlHint": "Where renters are sent to pay at pickup. Must be an http(s) link; leave blank to clear.",
+        "handoffOwnerOnly": "Only an owner can change the payment handoff URL.",
+        "save": "Save changes",
+        "saving": "Saving..."
+      }
     }
   },
   "messaging": {
@@ -1089,8 +1108,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "Overview", "revenue": "Partner Revenue" },
-    "home": { "title": "Platform Admin", "subtitle": "Platform operations" },
+    "nav": {
+      "overview": "Overview",
+      "revenue": "Partner Revenue"
+    },
+    "home": {
+      "title": "Platform Admin",
+      "subtitle": "Platform operations"
+    },
     "revenue": {
       "title": "Partner Revenue",
       "subtitle": "Monthly payout per partner",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -84,7 +84,8 @@
     "browse": "車を探す",
     "myBookings": "予約一覧",
     "documents": "書類",
-    "newBookings": "新規予約 {count}件"
+    "newBookings": "新規予約 {count}件",
+    "settings": "設定"
   },
   "acriss": {
     "MCAR": "ミニ",
@@ -783,6 +784,24 @@
       "title": "メッセージ",
       "subtitle": "お客様との会話",
       "empty": "まだ会話はありません。お客様からの連絡があるとここに表示されます。"
+    },
+    "settings": {
+      "title": "設定",
+      "subtitle": "事業者プロフィールと利用者の支払い受け渡し先を管理します。",
+      "loadError": "設定を読み込めませんでした",
+      "retry": "再試行",
+      "saved": "設定を保存しました。",
+      "noOperatorContext": "このページは単一の事業者プロフィールを編集します。事業者の管理は管理ポータルをご利用ください。",
+      "form": {
+        "name": "事業者名",
+        "namePlaceholder": "例：大阪レンタカー",
+        "handoffUrl": "支払い受け渡しURL",
+        "handoffUrlPlaceholder": "https://pay.example.com/handoff",
+        "handoffUrlHint": "受取時に利用者を支払いへ誘導するURL。http(s)リンクが必要です。空欄にすると解除されます。",
+        "handoffOwnerOnly": "支払い受け渡しURLを変更できるのはオーナーのみです。",
+        "save": "変更を保存",
+        "saving": "保存中..."
+      }
     }
   },
   "messaging": {
@@ -1089,8 +1108,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "概要", "revenue": "パートナー収益" },
-    "home": { "title": "プラットフォーム管理", "subtitle": "プラットフォーム運営" },
+    "nav": {
+      "overview": "概要",
+      "revenue": "パートナー収益"
+    },
+    "home": {
+      "title": "プラットフォーム管理",
+      "subtitle": "プラットフォーム運営"
+    },
     "revenue": {
       "title": "パートナー収益",
       "subtitle": "パートナーごとの月次支払い",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -84,7 +84,8 @@
     "browse": "浏览车辆",
     "myBookings": "我的预订",
     "documents": "证件",
-    "newBookings": "{count} 个新订单"
+    "newBookings": "{count} 个新订单",
+    "settings": "设置"
   },
   "acriss": {
     "MCAR": "微型车",
@@ -783,6 +784,24 @@
       "title": "消息",
       "subtitle": "客户对话",
       "empty": "暂无对话。客户联系您时消息会显示在这里。"
+    },
+    "settings": {
+      "title": "设置",
+      "subtitle": "管理您的商家资料与租客支付跳转。",
+      "loadError": "无法加载设置",
+      "retry": "重试",
+      "saved": "设置已保存。",
+      "noOperatorContext": "此页面用于编辑单个运营商的资料。请使用管理门户来管理运营商。",
+      "form": {
+        "name": "商家名称",
+        "namePlaceholder": "例如：大阪租车",
+        "handoffUrl": "支付跳转链接",
+        "handoffUrlPlaceholder": "https://pay.example.com/handoff",
+        "handoffUrlHint": "取车时引导租客前往支付的链接。必须为 http(s) 链接；留空则清除。",
+        "handoffOwnerOnly": "只有所有者可以更改支付跳转链接。",
+        "save": "保存更改",
+        "saving": "保存中..."
+      }
     }
   },
   "messaging": {
@@ -1089,8 +1108,14 @@
     }
   },
   "admin": {
-    "nav": { "overview": "概览", "revenue": "合作伙伴收益" },
-    "home": { "title": "平台管理", "subtitle": "平台运营" },
+    "nav": {
+      "overview": "概览",
+      "revenue": "合作伙伴收益"
+    },
+    "home": {
+      "title": "平台管理",
+      "subtitle": "平台运营"
+    },
     "revenue": {
       "title": "合作伙伴收益",
       "subtitle": "按合作伙伴的月度结算",

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as LocaleVehiclesClassesSlugRouteImport } from './routes/$locale/
 import { Route as LocaleProviderInviteTokenRouteImport } from './routes/$locale/provider/invite/$token'
 import { Route as LocaleRenterBookingsNewRouteImport } from './routes/$locale/_renter/bookings/new'
 import { Route as LocaleRenterBookingsConfirmationRouteImport } from './routes/$locale/_renter/bookings/confirmation'
+import { Route as LocaleBusinessManageSettingsRouteImport } from './routes/$locale/_business/manage/settings'
 import { Route as LocaleBusinessManageLocationsRouteImport } from './routes/$locale/_business/manage/locations'
 import { Route as LocaleBusinessManageInsuranceRouteImport } from './routes/$locale/_business/manage/insurance'
 import { Route as LocaleBusinessManageFeesRouteImport } from './routes/$locale/_business/manage/fees'
@@ -148,6 +149,12 @@ const LocaleRenterBookingsConfirmationRoute =
     path: '/confirmation',
     getParentRoute: () => LocaleRenterBookingsRoute,
   } as any)
+const LocaleBusinessManageSettingsRoute =
+  LocaleBusinessManageSettingsRouteImport.update({
+    id: '/manage/settings',
+    path: '/manage/settings',
+    getParentRoute: () => LocaleBusinessRoute,
+  } as any)
 const LocaleBusinessManageLocationsRoute =
   LocaleBusinessManageLocationsRouteImport.update({
     id: '/manage/locations',
@@ -227,6 +234,7 @@ export interface FileRoutesByFullPath {
   '/$locale/manage/fees': typeof LocaleBusinessManageFeesRoute
   '/$locale/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/manage/locations': typeof LocaleBusinessManageLocationsRoute
+  '/$locale/manage/settings': typeof LocaleBusinessManageSettingsRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -255,6 +263,7 @@ export interface FileRoutesByTo {
   '/$locale/manage/fees': typeof LocaleBusinessManageFeesRoute
   '/$locale/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/manage/locations': typeof LocaleBusinessManageLocationsRoute
+  '/$locale/manage/settings': typeof LocaleBusinessManageSettingsRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -289,6 +298,7 @@ export interface FileRoutesById {
   '/$locale/_business/manage/fees': typeof LocaleBusinessManageFeesRoute
   '/$locale/_business/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/_business/manage/locations': typeof LocaleBusinessManageLocationsRoute
+  '/$locale/_business/manage/settings': typeof LocaleBusinessManageSettingsRoute
   '/$locale/_renter/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/_renter/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -321,6 +331,7 @@ export interface FileRouteTypes {
     | '/$locale/manage/fees'
     | '/$locale/manage/insurance'
     | '/$locale/manage/locations'
+    | '/$locale/manage/settings'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -349,6 +360,7 @@ export interface FileRouteTypes {
     | '/$locale/manage/fees'
     | '/$locale/manage/insurance'
     | '/$locale/manage/locations'
+    | '/$locale/manage/settings'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -382,6 +394,7 @@ export interface FileRouteTypes {
     | '/$locale/_business/manage/fees'
     | '/$locale/_business/manage/insurance'
     | '/$locale/_business/manage/locations'
+    | '/$locale/_business/manage/settings'
     | '/$locale/_renter/bookings/confirmation'
     | '/$locale/_renter/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -549,6 +562,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleRenterBookingsConfirmationRouteImport
       parentRoute: typeof LocaleRenterBookingsRoute
     }
+    '/$locale/_business/manage/settings': {
+      id: '/$locale/_business/manage/settings'
+      path: '/manage/settings'
+      fullPath: '/$locale/manage/settings'
+      preLoaderRoute: typeof LocaleBusinessManageSettingsRouteImport
+      parentRoute: typeof LocaleBusinessRoute
+    }
     '/$locale/_business/manage/locations': {
       id: '/$locale/_business/manage/locations'
       path: '/manage/locations'
@@ -643,6 +663,7 @@ interface LocaleBusinessRouteChildren {
   LocaleBusinessManageFeesRoute: typeof LocaleBusinessManageFeesRoute
   LocaleBusinessManageInsuranceRoute: typeof LocaleBusinessManageInsuranceRoute
   LocaleBusinessManageLocationsRoute: typeof LocaleBusinessManageLocationsRoute
+  LocaleBusinessManageSettingsRoute: typeof LocaleBusinessManageSettingsRoute
   LocaleBusinessManageBookingsBookingIdRoute: typeof LocaleBusinessManageBookingsBookingIdRoute
   LocaleBusinessManageFleetVehicleIdRoute: typeof LocaleBusinessManageFleetVehicleIdRoute
   LocaleBusinessManageBookingsIndexRoute: typeof LocaleBusinessManageBookingsIndexRoute
@@ -656,6 +677,7 @@ const LocaleBusinessRouteChildren: LocaleBusinessRouteChildren = {
   LocaleBusinessManageFeesRoute: LocaleBusinessManageFeesRoute,
   LocaleBusinessManageInsuranceRoute: LocaleBusinessManageInsuranceRoute,
   LocaleBusinessManageLocationsRoute: LocaleBusinessManageLocationsRoute,
+  LocaleBusinessManageSettingsRoute: LocaleBusinessManageSettingsRoute,
   LocaleBusinessManageBookingsBookingIdRoute:
     LocaleBusinessManageBookingsBookingIdRoute,
   LocaleBusinessManageFleetVehicleIdRoute:

--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -1,0 +1,125 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorOwnerSession } from '@/vite/guards'
+import { SettingsForm } from '@/vite/operator-settings/SettingsForm'
+import {
+  operatorProfileQueryKey,
+  operatorProfileQueryOptions,
+  updateOperatorProfile,
+} from '@/vite/operator-settings/api'
+import { sessionQueryOptions } from '@/vite/session'
+import type { UpdateOperatorInput } from '@kuruma/shared/validators/operator'
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+// Operator profile & business settings (#903). URL `/<locale>/manage/settings`,
+// behind the `_business` guard. The loader prefetches the session and the
+// caller's OWN operator profile (resolved by the session's operatorId, never a
+// foreign tenant) so there is no FOUC; the component reads the same options via
+// useSuspenseQuery. A bypass role (no operatorId) sees a not-applicable notice —
+// it has no single operator to edit and manages operators via the admin portal.
+export const Route = createFileRoute('/$locale/_business/manage/settings')({
+  loader: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
+    const operatorId = session?.user.operatorId
+    if (operatorId) {
+      await context.queryClient.ensureQueryData(operatorProfileQueryOptions(operatorId))
+    }
+  },
+  pendingComponent: PageSkeleton,
+  errorComponent: OperatorSettingsError,
+  component: OperatorSettingsRoute,
+})
+
+export function OperatorSettingsRoute() {
+  const t = useTranslations('business.settings')
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  const operatorId = session?.user.operatorId
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
+          <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
+        </header>
+        {operatorId ? (
+          <OperatorSettings
+            operatorId={operatorId}
+            csrfToken={session.csrfToken}
+            canEditHandoff={isOperatorOwnerSession(session)}
+          />
+        ) : (
+          <p className="text-muted-foreground">{t('noOperatorContext')}</p>
+        )}
+      </div>
+    </main>
+  )
+}
+
+function OperatorSettings({
+  operatorId,
+  csrfToken,
+  canEditHandoff,
+}: {
+  operatorId: string
+  csrfToken: string
+  canEditHandoff: boolean
+}) {
+  const t = useTranslations('business.settings')
+  const queryClient = useQueryClient()
+  const { data: profile } = useSuspenseQuery(operatorProfileQueryOptions(operatorId))
+  const [saved, setSaved] = useState(false)
+
+  const { mutateAsync, isPending, error } = useMutation({
+    mutationFn: (input: UpdateOperatorInput) => updateOperatorProfile(operatorId, input, csrfToken),
+    onSuccess: (updated) => {
+      // PATCH returns the same projection the read uses, so seed the cache
+      // directly (no refetch) and remount the form on the new values.
+      queryClient.setQueryData(operatorProfileQueryKey(operatorId), updated)
+      setSaved(true)
+    },
+  })
+
+  return (
+    <>
+      {error && (
+        <p className="text-sm text-destructive mb-4">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+      {saved && <output className="block text-sm text-emerald-600 mb-4">{t('saved')}</output>}
+      <SettingsForm
+        key={`${profile.name}:${profile.preAuthHandoffUrl ?? ''}`}
+        defaultValues={{ name: profile.name, preAuthHandoffUrl: profile.preAuthHandoffUrl }}
+        canEditHandoff={canEditHandoff}
+        isSubmitting={isPending}
+        onSubmit={async (input) => {
+          setSaved(false)
+          await mutateAsync(input)
+        }}
+      />
+    </>
+  )
+}
+
+function OperatorSettingsError(_props: ErrorComponentProps) {
+  const t = useTranslations('business.settings')
+  const router = useRouter()
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl py-20 text-center">
+        <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+        <button
+          type="button"
+          onClick={() => router.invalidate()}
+          className="mt-4 rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/packages/web/src/vite/guards.ts
+++ b/packages/web/src/vite/guards.ts
@@ -29,6 +29,15 @@ export function isOperatorSession(session: Session | null): boolean {
   return Boolean(session?.user.operatorId)
 }
 
+// Owner-tier session — gates the renter-facing `preAuthHandoffUrl` field in the
+// settings UI (#903), mirroring the API's OPERATOR_OWNER_WRITE_ROLES gate. Only an
+// operator OWNER may edit that money-flow control; OPERATOR_STAFF sees it disabled.
+// Bypass roles never reach a writable settings page (they carry no operatorId, so
+// `isOperatorSession` is already false). UX only — the API is the real boundary.
+export function isOperatorOwnerSession(session: Session | null): boolean {
+  return session?.user.role === 'OPERATOR_OWNER'
+}
+
 export function adminGuard(session: Session | null): GuardResult {
   if (!session) return { type: 'login' }
   // Narrower than businessGuard: tenant-scoped OPERATOR_* roles clear the business

--- a/packages/web/src/vite/nav/business-nav-items.ts
+++ b/packages/web/src/vite/nav/business-nav-items.ts
@@ -17,6 +17,7 @@ export const businessNavItems = [
   { to: '/$locale/manage/insurance', labelKey: 'insurance' },
   { to: '/$locale/manage/fees', labelKey: 'fees' },
   { to: '/$locale/manage/add-ons', labelKey: 'addOns' },
+  { to: '/$locale/manage/settings', labelKey: 'settings' },
 ] as const
 
 // Derived so the union can never drift from the array above.

--- a/packages/web/src/vite/operator-settings/SettingsForm.tsx
+++ b/packages/web/src/vite/operator-settings/SettingsForm.tsx
@@ -1,0 +1,93 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { type UpdateOperatorInput, updateOperatorSchema } from '@kuruma/shared/validators/operator'
+import { type FormEvent, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface SettingsFormProps {
+  defaultValues: { name: string; preAuthHandoffUrl: string | null }
+  // Mirrors the API's OPERATOR_OWNER_WRITE_ROLES gate (#903): only an owner may
+  // edit the renter-facing `preAuthHandoffUrl`. For a non-owner the field is
+  // disabled AND its value is omitted from the patch — the API 403s any staff
+  // request that names the field at all, even unchanged.
+  canEditHandoff: boolean
+  isSubmitting?: boolean
+  onSubmit: (input: UpdateOperatorInput) => Promise<void>
+}
+
+export function SettingsForm({
+  defaultValues,
+  canEditHandoff,
+  isSubmitting,
+  onSubmit,
+}: SettingsFormProps) {
+  const t = useTranslations('business.settings')
+  const [name, setName] = useState(defaultValues.name)
+  const [handoff, setHandoff] = useState(defaultValues.preAuthHandoffUrl ?? '')
+  // Required-but-nullable keys (not optional) so an explicit `undefined` reset is
+  // legal under exactOptionalPropertyTypes.
+  const [errors, setErrors] = useState<{
+    name: string | undefined
+    preAuthHandoffUrl: string | undefined
+  }>({ name: undefined, preAuthHandoffUrl: undefined })
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    // 3-state on the handoff: an empty input clears it to null; a non-empty value
+    // is sent verbatim (the schema enforces http(s)). A non-owner omits the key.
+    const trimmedHandoff = handoff.trim()
+    const input: UpdateOperatorInput = canEditHandoff
+      ? { name, preAuthHandoffUrl: trimmedHandoff === '' ? null : trimmedHandoff }
+      : { name }
+
+    const parsed = updateOperatorSchema.safeParse(input)
+    if (!parsed.success) {
+      const fields = parsed.error.flatten().fieldErrors
+      setErrors({ name: fields.name?.[0], preAuthHandoffUrl: fields.preAuthHandoffUrl?.[0] })
+      return
+    }
+    setErrors({ name: undefined, preAuthHandoffUrl: undefined })
+    await onSubmit(parsed.data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
+      <div>
+        <Label htmlFor="settings-name">{t('form.name')}</Label>
+        <Input
+          id="settings-name"
+          value={name}
+          placeholder={t('form.namePlaceholder')}
+          onChange={(e) => setName(e.target.value)}
+        />
+        {errors.name && <p className="text-sm text-destructive mt-1">{errors.name}</p>}
+      </div>
+
+      <div>
+        <Label htmlFor="settings-handoff">{t('form.handoffUrl')}</Label>
+        <Input
+          id="settings-handoff"
+          type="url"
+          value={handoff}
+          disabled={!canEditHandoff}
+          placeholder={t('form.handoffUrlPlaceholder')}
+          onChange={(e) => setHandoff(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground mt-1">{t('form.handoffUrlHint')}</p>
+        {!canEditHandoff && (
+          <p className="text-xs text-muted-foreground mt-1">{t('form.handoffOwnerOnly')}</p>
+        )}
+        {errors.preAuthHandoffUrl && (
+          <p className="text-sm text-destructive mt-1">{errors.preAuthHandoffUrl}</p>
+        )}
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? t('form.saving') : t('form.save')}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/packages/web/src/vite/operator-settings/api.ts
+++ b/packages/web/src/vite/operator-settings/api.ts
@@ -1,0 +1,64 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import type { UpdateOperatorInput } from '@kuruma/shared/validators/operator'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// #903: operator profile & business settings. Cookie-based and operator-scoped
+// server-side — the client resolves its OWN operator by id (from the session's
+// operatorId) and never names a foreign tenant. The write threads the session
+// CSRF token (mirrors operator-fees/operator-insurance).
+
+export type { UpdateOperatorInput }
+
+/**
+ * The settings projection the API returns from GET and PATCH `/operators/:id`
+ * (the deliberate `{ id, name, slug, preAuthHandoffUrl }` shape — no timestamps).
+ * Pinned with `satisfies` so a field drift fails to compile here. The GET read
+ * returns the full operator row; this non-strict schema drops the extra columns.
+ */
+export interface OperatorProfile {
+  id: string
+  name: string
+  slug: string
+  preAuthHandoffUrl: string | null
+}
+
+const operatorProfileSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  preAuthHandoffUrl: z.string().nullable(),
+}) satisfies z.ZodType<OperatorProfile>
+
+export const operatorProfileQueryKey = (operatorId: string) =>
+  ['operator-profile', operatorId] as const
+
+async function fetchOperatorProfile(operatorId: string): Promise<OperatorProfile> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/${encodeURIComponent(operatorId)}`, {
+    credentials: 'include',
+  })
+  return unwrap(res, operatorProfileSchema)
+}
+
+export function operatorProfileQueryOptions(operatorId: string) {
+  return queryOptions({
+    queryKey: operatorProfileQueryKey(operatorId),
+    queryFn: () => fetchOperatorProfile(operatorId),
+  })
+}
+
+// Cookie-authed PATCH — CSRF-gated, so the session token rides in the header.
+export async function updateOperatorProfile(
+  operatorId: string,
+  input: UpdateOperatorInput,
+  csrfToken: string,
+): Promise<OperatorProfile> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/${encodeURIComponent(operatorId)}`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify(input),
+  })
+  return unwrap(res, operatorProfileSchema)
+}

--- a/packages/web/src/vite/operator-settings/api.ts
+++ b/packages/web/src/vite/operator-settings/api.ts
@@ -14,8 +14,9 @@ export type { UpdateOperatorInput }
 /**
  * The settings projection the API returns from GET and PATCH `/operators/:id`
  * (the deliberate `{ id, name, slug, preAuthHandoffUrl }` shape — no timestamps).
- * Pinned with `satisfies` so a field drift fails to compile here. The GET read
- * returns the full operator row; this non-strict schema drops the extra columns.
+ * The API projects reads and writes through one shape (#903), so GET and PATCH
+ * agree. Pinned with `satisfies` so a field drift fails to compile here; the
+ * schema stays non-strict as defence in depth against an unexpected extra column.
  */
 export interface OperatorProfile {
   id: string

--- a/packages/web/tests/vite/nav/business-nav-items.test.ts
+++ b/packages/web/tests/vite/nav/business-nav-items.test.ts
@@ -18,6 +18,7 @@ describe('businessNavItems', () => {
       '/$locale/manage/insurance',
       '/$locale/manage/fees',
       '/$locale/manage/add-ons',
+      '/$locale/manage/settings',
     ])
   })
 

--- a/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
@@ -1,0 +1,73 @@
+import { OperatorSettingsRoute } from '@/routes/$locale/_business/manage/settings'
+import { type OperatorProfile, operatorProfileQueryKey } from '@/vite/operator-settings/api'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+const en = enMessages.business.settings
+
+const OP_ID = 'op_1'
+
+function profile(): OperatorProfile {
+  return {
+    id: OP_ID,
+    name: 'Acme Cars',
+    slug: 'acme-cars',
+    preAuthHandoffUrl: 'https://pay.acme/h',
+  }
+}
+
+const ownerSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: OP_ID, operatorSlug: 'acme-cars' },
+  csrfToken: 't',
+}
+const staffSession: Session = {
+  user: { id: 'u', role: 'OPERATOR_STAFF', operatorId: OP_ID, operatorSlug: 'acme-cars' },
+  csrfToken: 't',
+}
+const bypassSession: Session = {
+  user: { id: 'u', role: 'PLATFORM_ADMIN' },
+  csrfToken: 't',
+}
+
+// Seed both queries the route reads via useSuspenseQuery so they resolve from
+// cache (no fetch, no router). The profile is keyed by operatorId.
+function renderRoute(session: Session) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
+  })
+  queryClient.setQueryData(['session'], session)
+  queryClient.setQueryData(operatorProfileQueryKey(OP_ID), profile())
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorSettingsRoute />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('OperatorSettingsRoute (#903)', () => {
+  it('prefills the profile and lets an owner edit the handoff URL', () => {
+    renderRoute(ownerSession)
+    expect(screen.getByLabelText(en.form.name)).toHaveValue('Acme Cars')
+    const handoff = screen.getByLabelText(en.form.handoffUrl)
+    expect(handoff).toHaveValue('https://pay.acme/h')
+    expect(handoff).not.toBeDisabled()
+  })
+
+  it('disables the handoff URL and shows the owner-only note for OPERATOR_STAFF', () => {
+    renderRoute(staffSession)
+    expect(screen.getByLabelText(en.form.handoffUrl)).toBeDisabled()
+    expect(screen.getByText(en.form.handoffOwnerOnly)).toBeInTheDocument()
+  })
+
+  it('shows a not-applicable notice (no form) for a bypass role with no operatorId', () => {
+    renderRoute(bypassSession)
+    expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
+    expect(screen.queryByLabelText(en.form.name)).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-settings/SettingsForm.test.tsx
+++ b/packages/web/tests/vite/operator-settings/SettingsForm.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('use-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+import { SettingsForm } from '@/vite/operator-settings/SettingsForm'
+
+const ownerDefaults = { name: 'Owner Co', preAuthHandoffUrl: 'https://pay.old.example/h' }
+
+describe('SettingsForm', () => {
+  afterEach(() => cleanup())
+
+  it('prefills the current name and handoff URL', () => {
+    render(<SettingsForm defaultValues={ownerDefaults} canEditHandoff onSubmit={vi.fn()} />)
+    expect(screen.getByLabelText('form.name')).toHaveValue('Owner Co')
+    expect(screen.getByLabelText('form.handoffUrl')).toHaveValue('https://pay.old.example/h')
+  })
+
+  it('an owner submits both the renamed name and the new handoff URL', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<SettingsForm defaultValues={ownerDefaults} canEditHandoff onSubmit={onSubmit} />)
+
+    await user.clear(screen.getByLabelText('form.name'))
+    await user.type(screen.getByLabelText('form.name'), 'Renamed Co')
+    await user.clear(screen.getByLabelText('form.handoffUrl'))
+    await user.type(screen.getByLabelText('form.handoffUrl'), 'https://pay.new.example/h')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][0]).toEqual({
+      name: 'Renamed Co',
+      preAuthHandoffUrl: 'https://pay.new.example/h',
+    })
+  })
+
+  it('an owner clearing the handoff field submits null (clear to NULL)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<SettingsForm defaultValues={ownerDefaults} canEditHandoff onSubmit={onSubmit} />)
+
+    await user.clear(screen.getByLabelText('form.handoffUrl'))
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][0]).toEqual({ name: 'Owner Co', preAuthHandoffUrl: null })
+  })
+
+  it('disables the handoff field for a non-owner and OMITS it from the patch', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(
+      <SettingsForm defaultValues={ownerDefaults} canEditHandoff={false} onSubmit={onSubmit} />,
+    )
+
+    expect(screen.getByLabelText('form.handoffUrl')).toBeDisabled()
+
+    await user.clear(screen.getByLabelText('form.name'))
+    await user.type(screen.getByLabelText('form.name'), 'Staff Renamed')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    // The money-flow field must not ride along — the API would 403 a staff patch
+    // that names preAuthHandoffUrl at all (even unchanged).
+    expect(onSubmit.mock.calls[0][0]).toEqual({ name: 'Staff Renamed' })
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty('preAuthHandoffUrl')
+  })
+
+  it('rejects an empty name without calling onSubmit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<SettingsForm defaultValues={ownerDefaults} canEditHandoff onSubmit={onSubmit} />)
+
+    await user.clear(screen.getByLabelText('form.name'))
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-http(s) handoff URL without calling onSubmit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<SettingsForm defaultValues={ownerDefaults} canEditHandoff onSubmit={onSubmit} />)
+
+    await user.clear(screen.getByLabelText('form.handoffUrl'))
+    await user.type(screen.getByLabelText('form.handoffUrl'), 'not-a-url')
+    await user.click(screen.getByRole('button', { name: 'form.save' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #903. Part of #902 (operator cold-start).

A new operator can now self-configure its business profile through the portal — the cold-start gap that blocked checkout for a freshly-minted operator (no payment handoff destination).

## What
A `/manage/settings` page where an operator edits:
- **Business name** — any fleet-write role.
- **Pre-auth payment handoff URL** — **OWNER-only** (money-flow control).

Backed by a new scoped `PATCH /operators/:id`.

## Security (the crux — issue H2)
`preAuthHandoffUrl` is the renter-facing pay-at-pickup destination. One OPERATOR_STAFF edit could redirect every future renter to a phishing page (the #386 http(s) refine blocks `javascript:`/`ftp:` but not `https://attacker.example`). So:
- New `OPERATOR_OWNER_WRITE_ROLES` set (= business management **minus** OPERATOR_STAFF) + `requireOperatorOwnerWrite` guard. `name` stays on `FLEET_WRITE_ROLES`.
- **Load-then-authorize**: the service resolves + tenant-scopes the row first, so a foreign/unknown id 404s **before** the owner-gate runs — a cross-tenant staff patch can never leak a 403 existence oracle.
- The web form omits `preAuthHandoffUrl` from the patch entirely for non-owners (disabled field) — the API 403s any staff request that even names it.

## Slices
1. **API** (`cc5c1cdc`) — `updateOperatorSchema` (3-state preAuthHandoffUrl), shared `nameSchema`, owner role-set + guard, `OperatorRepository.update` (drizzle + in-memory), `OperatorService.update` returning a deliberate `{id,name,slug,preAuthHandoffUrl}` projection, `PATCH /operators/:id`.
2. **Web** (`1f5a6818`) — settings page + form + api client, `isOperatorOwnerSession` guard, nav entry, en/ja/zh i18n, route tree regen.
3. **E2E** (`0d89cd4a`) — real-DB round-trip (owner edits name + handoff → asserts DB persisted → restores seed).

## Decisions (from the reviewed issue body)
- **slug NOT editable** — `UNIQUE NOT NULL` + JWT caches `operatorSlug`; rename needs the collision dance. Out of the editable set.
- **No schema/migration** — `name`/`slug`/`pre_auth_handoff_url` already exist. `updatedAt` written in the patch (column has no `$onUpdate`).
- Response is a projection, not the raw row (no `createdAt`/`updatedAt` leakage).

## Tests / verification
- shared 574 ✓ · api 1560 (49 operator-specific) ✓ · web 972 (9 settings + nav) ✓
- typecheck (shared/api/web) ✓ · boundary linter ✓ · biome ✓
- **Real-DB E2E executed locally: 4/4 passed** (round-trip persists + restores).
- Independent code review: clean, no CRITICAL/HIGH/MEDIUM.

## Follow-ups (filed, not silently omitted)
- #914 — audit-log `preAuthHandoffUrl` changes (no audit infra exists yet).
- Optimistic concurrency — explicitly YAGNI for a 2-field form.