### PR TITLE
fix(api): point WEB_ORIGIN at the Pages origin

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -80,4 +80,8 @@ simple.period = 10
 # bucket_name = "kuruma-vehicle-photos"
 
 [vars]
-WEB_ORIGIN = "https://kuruma-rental.kanata-studio-dev.workers.dev"
+# The live web origin. First entry feeds CORS AND the post-login redirect,
+# Stripe return base, and provider-invite links (see resolveGoogleOAuthConfig
+# / webBaseUrl in src/index.ts). Must be the deployed Pages origin, not a
+# stale host, or those URLs send users to the wrong site.
+WEB_ORIGIN = "https://kuruma-web-pages.pages.dev"


### PR DESCRIPTION
## Why

`packages/api/wrangler.toml` still set `WEB_ORIGIN` to the retired `kuruma-rental.kanata-studio-dev.workers.dev` worker. That var's first entry feeds **more than CORS** — it's the base for:
- the OAuth **post-login redirect** (`resolveGoogleOAuthConfig` → `postLoginRedirect`, `src/index.ts:752`)
- the **Stripe** success/cancel return base (`src/index.ts:487`)
- **provider-invite** link bases

So a stale value drops users (and emailed links) on the dead host after a successful login. This was the root cause of the beta 'Google login bounces to the old site' bug.

## What

Point `WEB_ORIGIN` at the live Pages origin `https://kuruma-web-pages.pages.dev`.

## Relation to the live hotfix

The beta's live login was already restored by setting `AUTH_URL` + `WEB_POST_LOGIN_URL` secrets on the `kuruma-api` Worker (verified: `POST /auth/google/start` now returns `redirect_uri=…pages.dev/auth/google/callback`). This PR makes the **deployed default** correct so the `WEB_POST_LOGIN_URL` band-aid can be retired, and additionally fixes the Stripe/invite bases that the secret hotfix did *not* cover.

## Note

`wrangler.toml` `[vars]` are baked at deploy time, so this takes effect on the **next `kuruma-api` deploy** — no immediate runtime change.

## Test plan
- [ ] After next deploy: `POST https://kuruma-web-pages.pages.dev/auth/google/start` still returns a `…pages.dev` redirect_uri
- [ ] A real Google login lands on `…pages.dev/en/dashboard`
- [ ] (optional) remove the now-redundant `WEB_POST_LOGIN_URL` secret from kuruma-api