### PR TITLE
fix(api): point WEB_ORIGIN at the live Pages origin

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -80,7 +80,11 @@ binding = "RENTER_DOCUMENTS"
 bucket_name = "kuruma-renter-documents"
 
 [vars]
-WEB_ORIGIN = "https://kuruma-rental.kanata-studio-dev.workers.dev"
+# The live web origin. First entry feeds CORS AND the post-login redirect,
+# Stripe return base, and provider-invite links (see resolveGoogleOAuthConfig
+# / webBaseUrl in src/index.ts). Must be the deployed Pages origin, not a
+# stale host, or those URLs send users to the wrong site.
+WEB_ORIGIN = "https://kuruma-web-pages.pages.dev"
 
 # Transactional email (Resend). EMAIL_FROM is the public "from" address (not a
 # secret), so it lives here as a var. RESEND_API_KEY is a Worker secret set via


### PR DESCRIPTION
## Why

`packages/api/wrangler.toml` still set `WEB_ORIGIN` to the retired `kuruma-rental.kanata-studio-dev.workers.dev` worker. That var's first entry feeds **more than CORS** — it's the base for:
- the OAuth **post-login redirect** (`resolveGoogleOAuthConfig` → `postLoginRedirect`, `src/index.ts`)
- the **Stripe** success/cancel return base (`webBaseUrl`, `src/index.ts`)
- **provider-invite** link bases

So a stale value drops users (and emailed links) on the dead host after a successful login. It is the **only non-docs old-host reference left on `marketplace-pivot`** — mp's CI/deploy already point at the new account.

## What

Point `WEB_ORIGIN` at the live Pages origin `https://kuruma-web-pages.pages.dev`.

## Relation to the live hotfix

The beta's live login was already restored by setting `AUTH_URL` + `WEB_POST_LOGIN_URL` secrets on the `kuruma-api` Worker (verified: `POST /auth/google/start` returns `redirect_uri=…pages.dev/auth/google/callback`). This PR makes the **deployed default** correct so the `WEB_POST_LOGIN_URL` band-aid can be retired, and additionally fixes the Stripe/invite bases the secret hotfix did not cover.

## Note

`wrangler.toml` `[vars]` bake at deploy time, so this takes effect on the **next `kuruma-api` deploy** — no immediate runtime change.

## Why mp and not #708

Supersedes #917, which mistakenly targeted `fix/708-knip-vite-entry` — a 2-commit feature branch 117 commits behind mp that isn't the deploy source. The live beta deploys from `marketplace-pivot`, where the stale value actually lives.