### PR TITLE
feat: renter cancellation reason capture (#868 Slice 3b)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,4 +1,6 @@
+import type { CancellationReason } from '@kuruma/shared/db/schema'
 import {
+  cancelBookingSchema,
   createBookingSchema,
   substituteVehicleSchema,
   updateBookingStatusSchema,
@@ -228,7 +230,29 @@ export function createBookingRoutes(service: BookingService) {
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
 
-      const result = await service.cancel(ctx, idResult.id)
+      // #868 3b: an OPTIONAL renter cancellation reason. The body may be absent
+      // entirely — the operator cancel client sends none, and a renter who picks no
+      // reason sends `{}` — so parse defensively: a missing/non-JSON body means "no
+      // reason", while a present-but-malformed reason is a 400. The reason is never
+      // allowed to block the cancel itself.
+      let reason: CancellationReason | null = null
+      let rawBody: unknown
+      try {
+        rawBody = await c.req.json()
+      } catch {
+        rawBody = undefined
+      }
+      if (rawBody !== undefined && rawBody !== null) {
+        const parsed = cancelBookingSchema.safeParse(rawBody)
+        if (!parsed.success) {
+          return fail(c, parsed.error.flatten().fieldErrors as Record<string, unknown>, 400)
+        }
+        reason = parsed.data.reason
+          ? { code: parsed.data.reason.code, note: parsed.data.reason.note ?? null }
+          : null
+      }
+
+      const result = await service.cancel(ctx, idResult.id, reason)
       if (!result.ok) {
         return fail(c, result.error, result.status)
       }

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,4 +1,3 @@
-import type { CancellationReason } from '@kuruma/shared/db/schema'
 import {
   cancelBookingSchema,
   createBookingSchema,
@@ -230,27 +229,17 @@ export function createBookingRoutes(service: BookingService) {
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
 
-      // #868 3b: an OPTIONAL renter cancellation reason. The body may be absent
-      // entirely — the operator cancel client sends none, and a renter who picks no
-      // reason sends `{}` — so parse defensively: a missing/non-JSON body means "no
-      // reason", while a present-but-malformed reason is a 400. The reason is never
-      // allowed to block the cancel itself.
-      let reason: CancellationReason | null = null
-      let rawBody: unknown
-      try {
-        rawBody = await c.req.json()
-      } catch {
-        rawBody = undefined
-      }
-      if (rawBody !== undefined && rawBody !== null) {
-        const parsed = cancelBookingSchema.safeParse(rawBody)
-        if (!parsed.success) {
-          return fail(c, parsed.error.flatten().fieldErrors as Record<string, unknown>, 400)
-        }
-        reason = parsed.data.reason
-          ? { code: parsed.data.reason.code, note: parsed.data.reason.note ?? null }
-          : null
-      }
+      // #868 3b: the renter may attach an OPTIONAL cancellation reason. The body
+      // can be absent entirely — the operator cancel client sends none, and a
+      // renter who picks no reason sends `{}` — so allowEmpty treats a missing
+      // body as "no reason"; a present-but-malformed reason is still a 400. The
+      // reason never blocks the cancel itself.
+      const parsed = await parseBody(c, cancelBookingSchema, { allowEmpty: true })
+      if (!parsed.ok) return parsed.response
+
+      const reason = parsed.data.reason
+        ? { code: parsed.data.reason.code, note: parsed.data.reason.note ?? null }
+        : null
 
       const result = await service.cancel(ctx, idResult.id, reason)
       if (!result.ok) {

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -176,8 +176,23 @@ type ParseBodyFailure = { ok: false; response: Response }
 export async function parseBody<T>(
   c: Context,
   schema: z.ZodType<T>,
+  opts?: { allowEmpty?: boolean },
 ): Promise<ParseBodySuccess<T> | ParseBodyFailure> {
-  const body = await c.req.json()
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch (err) {
+    // A missing or non-JSON body is only tolerated when the caller opts in
+    // (an endpoint whose whole payload is optional); otherwise propagate.
+    if (!opts?.allowEmpty) throw err
+    body = undefined
+  }
+  // With allowEmpty, an absent body or literal JSON `null` parses as `{}`, so a
+  // schema of all-optional fields yields its defaults instead of a 400.
+  if (opts?.allowEmpty && (body === undefined || body === null)) {
+    body = {}
+  }
+
   const result = schema.safeParse(body)
 
   if (!result.success) {

--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -1,4 +1,8 @@
-import { type BookingStatus, VALID_BOOKING_TRANSITIONS } from '@kuruma/shared/db/schema'
+import {
+  type BookingStatus,
+  type CancellationReason,
+  VALID_BOOKING_TRANSITIONS,
+} from '@kuruma/shared/db/schema'
 import { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
@@ -280,6 +284,7 @@ export class BookingLifecycleService {
   async cancel(
     ctx: CallerContext,
     bookingId: string,
+    reason: CancellationReason | null = null,
     now: Date = new Date(),
   ): Promise<CancelResult> {
     const booking = await this.bookingRepo.findById(ctx, bookingId)
@@ -314,6 +319,7 @@ export class BookingLifecycleService {
           type: 'BOOKING_CANCELLED',
           cancellationFee: cancellation.feeAmount,
           cancelledAt: now.toISOString(),
+          cancellationReason: reason,
         },
       })
       return next

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -1,4 +1,4 @@
-import type { BookingStatus } from '@kuruma/shared/db/schema'
+import type { BookingStatus, CancellationReason } from '@kuruma/shared/db/schema'
 import { generateBookingCode } from '../lib/booking-code'
 import type { CallerContext } from '../middleware/auth'
 import type {
@@ -184,7 +184,12 @@ export class BookingService {
     return this.lifecycle.updateStatus(ctx, bookingId, newStatus)
   }
 
-  cancel(ctx: CallerContext, bookingId: string, now: Date = new Date()): Promise<CancelResult> {
-    return this.lifecycle.cancel(ctx, bookingId, now)
+  cancel(
+    ctx: CallerContext,
+    bookingId: string,
+    reason: CancellationReason | null = null,
+    now: Date = new Date(),
+  ): Promise<CancelResult> {
+    return this.lifecycle.cancel(ctx, bookingId, reason, now)
   }
 }

--- a/packages/api/tests/integration/booking-service-invariants.test.ts
+++ b/packages/api/tests/integration/booking-service-invariants.test.ts
@@ -363,7 +363,7 @@ describe('cancel persists the tiered cancellationFee (real pg)', () => {
     expect(expected.tier).toBe('MEDIUM')
     expect(expected.feeAmount).toBe(14000)
 
-    const res = await service.cancel(ctx, bookingId, now)
+    const res = await service.cancel(ctx, bookingId, null, now)
     expect(res.ok).toBe(true)
     if (!res.ok) throw new Error('cancel failed')
     expect(res.cancellation.feeAmount).toBe(14000)

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1183,6 +1183,35 @@ describe('Booking Routes', () => {
       expect(body.data.id).toBe(created.data.id)
     })
 
+    it('accepts an optional cancellation reason in the body (#868 3b)', async () => {
+      const createRes = await createBooking()
+      const created = await createRes.json()
+
+      const res = await app.request(`/bookings/${created.data.id}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: { code: 'TRIP_CANCELLED', note: 'flight cancelled' } }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.status).toBe('CANCELLED')
+    })
+
+    it('rejects a cancellation reason outside the taxonomy with 400 (#868 3b)', async () => {
+      const createRes = await createBooking()
+      const created = await createRes.json()
+
+      const res = await app.request(`/bookings/${created.data.id}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: { code: 'NOT_A_REASON' } }),
+      })
+
+      expect(res.status).toBe(400)
+      expect((await res.json()).success).toBe(false)
+    })
+
     it('rejects cancelling an already COMPLETED booking with 409', async () => {
       const createRes = await createBooking()
       const created = await createRes.json()

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1289,7 +1289,7 @@ describe('BookingService lifecycle events (#392 §3.1)', () => {
     expect(created.ok).toBe(true)
     if (!created.ok) return
 
-    const res = await h.service.cancel(renterCtx, created.booking.id, NOW)
+    const res = await h.service.cancel(renterCtx, created.booking.id, null, NOW)
     expect(res.ok).toBe(true)
     if (!res.ok) return
 
@@ -1301,7 +1301,46 @@ describe('BookingService lifecycle events (#392 §3.1)', () => {
     expect(events[1]).toMatchObject({
       type: 'BOOKING_CANCELLED',
       actorId: RENTER,
-      payload: { cancellationFee: res.cancellation.feeAmount, cancelledAt: NOW.toISOString() },
+      payload: {
+        cancellationFee: res.cancellation.feeAmount,
+        cancelledAt: NOW.toISOString(),
+        // #868 3b: a cancel with no reason supplied records null, not a missing key.
+        cancellationReason: null,
+      },
+    })
+  })
+
+  // #868 Slice 3b: an optional renter reason is captured into the BOOKING_CANCELLED
+  // event payload (operator/analytics insight). It never affects the fee or whether
+  // the cancel succeeds — only the audit record. Mutation guard: drop the reason in
+  // cancel() and this fails (the payload would carry null instead of the object).
+  it('records the renter cancellation reason in the BOOKING_CANCELLED payload (#868 3b)', async () => {
+    const h = await setup({ codes: ['LIFE3B01'] })
+    const { vehicleId, locationId } = await seedReady(h)
+    const created = await h.service.create(
+      renterCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+      }),
+      NOW,
+    )
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+
+    const reason = { code: 'FOUND_ALTERNATIVE', note: 'cheaper nearby' } as const
+    const res = await h.service.cancel(renterCtx, created.booking.id, reason, NOW)
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    const events = await h.repos.bookingEventRepo.findByBookingId(
+      SYSTEM_CONTEXT,
+      created.booking.id,
+    )
+    expect(events[1]).toMatchObject({
+      type: 'BOOKING_CANCELLED',
+      payload: { cancellationReason: { code: 'FOUND_ALTERNATIVE', note: 'cheaper nearby' } },
     })
   })
 
@@ -1397,7 +1436,7 @@ describe('BookingService — renter lifecycle notifications (#664)', () => {
     const { postCommit, run } = spyPostCommit()
     const h = await setupSub(postCommit)
     run.mockClear()
-    const result = await h.service.cancel(renterCtx, h.bookingId, NOW)
+    const result = await h.service.cancel(renterCtx, h.bookingId, null, NOW)
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(run).toHaveBeenCalledTimes(1)

--- a/packages/shared/src/db/booking-types.ts
+++ b/packages/shared/src/db/booking-types.ts
@@ -1,4 +1,10 @@
-import type { BookingFulfillmentMode, BookingStatus, FeeType, FeeUnit } from '../enums'
+import type {
+  BookingFulfillmentMode,
+  BookingStatus,
+  CancellationReasonCode,
+  FeeType,
+  FeeUnit,
+} from '../enums'
 
 // ---- Slice 6 (#392) booking snapshot + event payload types ----
 // Snapshots lock rates at booking time; operator edits to the live
@@ -49,10 +55,22 @@ export type VehicleSubstitutedPayload = {
   toVehicleId: string
   reason: string | null
 }
+// #868 Slice 3b: the optional renter-supplied reason, captured at cancel time and
+// stored ONLY inside the BOOKING_CANCELLED event payload (no bookings column).
+// `note` is a short freeform elaboration; `null` when the renter left it blank.
+export type CancellationReason = {
+  code: CancellationReasonCode
+  note: string | null
+}
 export type BookingCancelledPayload = {
   type: 'BOOKING_CANCELLED'
   cancellationFee: number | null
   cancelledAt: string
+  // #868 3b: null when the renter picked no reason. Legacy BOOKING_CANCELLED rows
+  // predate this field and simply omit it from their stored jsonb — no consumer
+  // reads it yet (the operator timeline shows only the fee), so the absence is
+  // benign and treated the same as "no reason given".
+  cancellationReason: CancellationReason | null
 }
 export type StatusChangedPayload = {
   type: 'STATUS_CHANGED'

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -125,6 +125,20 @@ export const CANCELLATION_FEE_SETTLEMENT_STATES = [
 ] as const
 export type CancellationFeeSettlement = (typeof CANCELLATION_FEE_SETTLEMENT_STATES)[number]
 
+// Renter cancellation reason (#868 Slice 3b). ALWAYS optional — it never gates the
+// cancel, never triggers approval; captured purely for operator/analytics insight
+// and stored event-payload-only (no bookings column — add one only if a query
+// needs it later). `text` + Zod union, NOT a pgEnum (the taxonomy churns; review
+// M4), so it is absent from the pgEnum SSoT tripwire and pinned by enums.test.ts.
+export const CANCELLATION_REASON_CODES = [
+  'CHANGE_OF_PLANS',
+  'FOUND_ALTERNATIVE',
+  'TRIP_CANCELLED',
+  'VEHICLE_OR_PRICE_CONCERN',
+  'OTHER',
+] as const
+export type CancellationReasonCode = (typeof CANCELLATION_REASON_CODES)[number]
+
 // LUGGAGE_SIZES already lives in lib/luggage.ts (#457) — re-exported here so the
 // enum SSoT is reachable from one subpath without duplicating its declaration.
 export { LUGGAGE_SIZES, type LuggageSize } from './lib/luggage'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,8 +9,10 @@ export {
   type UpdateVehicleInput,
 } from './validators/vehicle'
 export {
+  cancelBookingSchema,
   createBookingSchema,
   updateBookingStatusSchema,
+  type CancelBookingInput,
   type CreateBookingInput,
   type UpdateBookingStatusInput,
 } from './validators/booking'

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { BOOKING_SOURCES, BOOKING_STATUSES } from '../enums'
+import { BOOKING_SOURCES, BOOKING_STATUSES, CANCELLATION_REASON_CODES } from '../enums'
 
 // Slice 6 (#392): the renter books a CONCRETE vehicle chosen in the storefront
 // (slice 5) — `requestedVehicleId`. The server derives operatorId, classId,
@@ -73,6 +73,19 @@ export const substituteVehicleSchema = z.object({
   reason: z.string().optional(),
 })
 
+// #868 Slice 3b: optional renter cancellation reason on POST /bookings/:id/cancel.
+// ALWAYS optional — the cancel succeeds with or without it (the body may even be
+// absent: the operator cancel sends none). `note` is a short freeform elaboration,
+// trimmed + capped; an empty/whitespace note normalises away at the route.
+export const cancellationReasonSchema = z.object({
+  code: z.enum(CANCELLATION_REASON_CODES),
+  note: z.string().trim().max(500, 'Note must be 500 characters or fewer').optional(),
+})
+export const cancelBookingSchema = z.object({
+  reason: cancellationReasonSchema.optional(),
+})
+
 export type CreateBookingInput = z.infer<typeof createBookingSchema>
 export type UpdateBookingStatusInput = z.infer<typeof updateBookingStatusSchema>
 export type SubstituteVehicleInput = z.infer<typeof substituteVehicleSchema>
+export type CancelBookingInput = z.infer<typeof cancelBookingSchema>

--- a/packages/shared/tests/enums.test.ts
+++ b/packages/shared/tests/enums.test.ts
@@ -33,6 +33,7 @@ import {
   BOOKING_SOURCES,
   BOOKING_STATUSES,
   CANCELLATION_FEE_SETTLEMENT_STATES,
+  CANCELLATION_REASON_CODES,
   COORDINATE_SOURCES,
   DOCUMENT_STATUSES,
   DOCUMENT_TYPES,
@@ -131,6 +132,21 @@ describe('cancellation fee settlement states (#868 Slice 3a)', () => {
       'REFUND_DUE',
       'REFUNDED',
       'WAIVED',
+    ])
+  })
+})
+
+// Pins the renter reason taxonomy (#868 Slice 3b). It is a text union, not a
+// pgEnum, so nothing else guards it — adding/removing a code here is a deliberate
+// product change, and the web reason labels (i18n) must move with it.
+describe('cancellation reason codes (#868 Slice 3b)', () => {
+  it('lists the owner-approved renter reason taxonomy', () => {
+    expect([...CANCELLATION_REASON_CODES]).toEqual([
+      'CHANGE_OF_PLANS',
+      'FOUND_ALTERNATIVE',
+      'TRIP_CANCELLED',
+      'VEHICLE_OR_PRICE_CONCERN',
+      'OTHER',
     ])
   })
 })

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { createBookingSchema, updateBookingStatusSchema } from '../../src/validators/booking'
+import {
+  cancelBookingSchema,
+  createBookingSchema,
+  updateBookingStatusSchema,
+} from '../../src/validators/booking'
 
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
 const PICKUP_UUID = '550e8400-e29b-41d4-a716-446655440002'
@@ -148,6 +152,35 @@ describe('updateBookingStatusSchema', () => {
 
   it('rejects empty status', () => {
     expect(updateBookingStatusSchema.safeParse({ status: '' }).success).toBe(false)
+  })
+})
+
+describe('cancelBookingSchema (#868 Slice 3b)', () => {
+  it('accepts an empty body — the reason is always optional', () => {
+    expect(cancelBookingSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('accepts a reason code alone (note omitted)', () => {
+    const result = cancelBookingSchema.safeParse({ reason: { code: 'CHANGE_OF_PLANS' } })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.reason).toEqual({ code: 'CHANGE_OF_PLANS' })
+  })
+
+  it('accepts a reason code with a freeform note, trimmed', () => {
+    const result = cancelBookingSchema.safeParse({
+      reason: { code: 'OTHER', note: '  found a cheaper car  ' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.reason?.note).toBe('found a cheaper car')
+  })
+
+  it('rejects a reason code outside the taxonomy', () => {
+    expect(cancelBookingSchema.safeParse({ reason: { code: 'BANANA' } }).success).toBe(false)
+  })
+
+  it('rejects a note longer than 500 characters', () => {
+    const note = 'x'.repeat(501)
+    expect(cancelBookingSchema.safeParse({ reason: { code: 'OTHER', note } }).success).toBe(false)
   })
 })
 

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -887,7 +887,19 @@
       "keep": "Keep booking",
       "confirm": "Yes, cancel",
       "pending": "Cancelling…",
-      "error": "We couldn't cancel your booking. Please try again, or contact the operator."
+      "error": "We couldn't cancel your booking. Please try again, or contact the operator.",
+      "reason": {
+        "legend": "Why are you cancelling? (optional)",
+        "notePlaceholder": "Anything you'd like to add?",
+        "noteLabel": "Additional details",
+        "options": {
+          "CHANGE_OF_PLANS": "My plans changed",
+          "FOUND_ALTERNATIVE": "I found another option",
+          "TRIP_CANCELLED": "My trip was cancelled",
+          "VEHICLE_OR_PRICE_CONCERN": "Concern about the vehicle or price",
+          "OTHER": "Another reason"
+        }
+      }
     },
     "list": {
       "title": "My bookings",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -887,7 +887,19 @@
       "keep": "予約を維持する",
       "confirm": "はい、キャンセルします",
       "pending": "キャンセル中…",
-      "error": "予約をキャンセルできませんでした。もう一度お試しいただくか、オペレーターにご連絡ください。"
+      "error": "予約をキャンセルできませんでした。もう一度お試しいただくか、オペレーターにご連絡ください。",
+      "reason": {
+        "legend": "キャンセルの理由（任意）",
+        "notePlaceholder": "補足があればご記入ください",
+        "noteLabel": "補足",
+        "options": {
+          "CHANGE_OF_PLANS": "予定が変わった",
+          "FOUND_ALTERNATIVE": "他の選択肢が見つかった",
+          "TRIP_CANCELLED": "旅行が中止になった",
+          "VEHICLE_OR_PRICE_CONCERN": "車両または料金への懸念",
+          "OTHER": "その他の理由"
+        }
+      }
     },
     "list": {
       "title": "予約一覧",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -887,7 +887,19 @@
       "keep": "保留预订",
       "confirm": "确认取消",
       "pending": "取消中…",
-      "error": "无法取消您的预订。请重试，或联系运营商。"
+      "error": "无法取消您的预订。请重试，或联系运营商。",
+      "reason": {
+        "legend": "取消原因（可选）",
+        "notePlaceholder": "如有其他说明，请填写",
+        "noteLabel": "补充说明",
+        "options": {
+          "CHANGE_OF_PLANS": "我的计划有变",
+          "FOUND_ALTERNATIVE": "我找到了其他选择",
+          "TRIP_CANCELLED": "我的行程已取消",
+          "VEHICLE_OR_PRICE_CONCERN": "对车辆或价格有顾虑",
+          "OTHER": "其他原因"
+        }
+      }
     },
     "list": {
       "title": "我的预订",

--- a/packages/web/src/vite/bookings/CancelBookingDialog.tsx
+++ b/packages/web/src/vite/bookings/CancelBookingDialog.tsx
@@ -9,13 +9,20 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
 import { ApiError } from '@/lib/api-error'
 import { formatJpy } from '@/lib/format'
 import { BOOKINGS_KEY, cancelBooking } from '@/vite/bookings/api'
 import { buildCancellationPreview } from '@/vite/bookings/cancellation-preview'
+import type { CancellationReason } from '@kuruma/shared/db/schema'
+import { CANCELLATION_REASON_CODES, type CancellationReasonCode } from '@kuruma/shared/enums'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'react'
 import { useTranslations } from 'use-intl'
+
+// Cap mirrors the server's cancellationReasonSchema (#868 3b) so the textarea can't
+// submit a note the API would 400.
+const NOTE_MAX = 500
 
 interface CancelBookingDialogProps {
   readonly bookingId: string
@@ -46,6 +53,10 @@ export function CancelBookingDialog({
   const t = useTranslations('bookings.cancel')
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
+  // #868 3b: an OPTIONAL reason. No selection => no reason sent; the cancel never
+  // depends on it. The freeform note only travels when a category is also chosen.
+  const [reasonCode, setReasonCode] = useState<CancellationReasonCode | null>(null)
+  const [note, setNote] = useState('')
 
   function settle() {
     queryClient.invalidateQueries({ queryKey: BOOKINGS_KEY })
@@ -53,7 +64,7 @@ export function CancelBookingDialog({
   }
 
   const mutation = useMutation({
-    mutationFn: () => cancelBooking(bookingId, csrfToken),
+    mutationFn: (reason: CancellationReason | null) => cancelBooking(bookingId, csrfToken, reason),
     onSuccess: settle,
     onError: (error) => {
       // 409 = no longer cancellable: an operator-cancel (or a double-submit) got
@@ -73,7 +84,20 @@ export function CancelBookingDialog({
 
   function handleOpenChange(next: boolean) {
     setOpen(next)
-    if (next) mutation.reset()
+    if (next) {
+      mutation.reset()
+      setReasonCode(null)
+      setNote('')
+    }
+  }
+
+  function confirmCancel() {
+    if (inFlightRef.current || mutation.isPending) return
+    inFlightRef.current = true
+    const reason: CancellationReason | null = reasonCode
+      ? { code: reasonCode, note: note.trim() || null }
+      : null
+    mutation.mutate(reason)
   }
 
   // Price the cancellation as it stands right now — `new Date()` is read once per
@@ -116,19 +140,40 @@ export function CancelBookingDialog({
           </p>
         </div>
 
+        {/* #868 3b: optional reason capture — never gates the cancel. */}
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">{t('reason.legend')}</legend>
+          <div className="space-y-1.5">
+            {CANCELLATION_REASON_CODES.map((code) => (
+              <label key={code} className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="cancel-reason"
+                  className="size-4"
+                  checked={reasonCode === code}
+                  onChange={() => setReasonCode(code)}
+                />
+                <span>{t(`reason.options.${code}`)}</span>
+              </label>
+            ))}
+          </div>
+          {reasonCode && (
+            <Textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder={t('reason.notePlaceholder')}
+              aria-label={t('reason.noteLabel')}
+              rows={2}
+              maxLength={NOTE_MAX}
+            />
+          )}
+        </fieldset>
+
         {showError && <output className="block text-sm text-destructive">{t('error')}</output>}
 
         <DialogFooter>
           <DialogClose render={<Button type="button" variant="outline" />}>{t('keep')}</DialogClose>
-          <Button
-            variant="destructive"
-            disabled={mutation.isPending}
-            onClick={() => {
-              if (inFlightRef.current || mutation.isPending) return
-              inFlightRef.current = true
-              mutation.mutate()
-            }}
-          >
+          <Button variant="destructive" disabled={mutation.isPending} onClick={confirmCancel}>
             {mutation.isPending ? t('pending') : t('confirm')}
           </Button>
         </DialogFooter>

--- a/packages/web/src/vite/bookings/api.ts
+++ b/packages/web/src/vite/bookings/api.ts
@@ -1,6 +1,11 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { AddOnSnapshot, FeeSnapshotItem, InsuranceSnapshot } from '@kuruma/shared/db/schema'
+import type {
+  AddOnSnapshot,
+  CancellationReason,
+  FeeSnapshotItem,
+  InsuranceSnapshot,
+} from '@kuruma/shared/db/schema'
 import { BOOKING_STATUSES, type BookingStatus, FEE_TYPES, FEE_UNITS } from '@kuruma/shared/enums'
 import { queryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
@@ -239,16 +244,25 @@ export const BOOKINGS_KEY = ['bookings'] as const
 
 // #856: renter self-cancellation. POST /bookings/:id/cancel is IDOR-sealed and
 // caller-scoped server-side, so the renter hits the SAME endpoint the operator
-// does — no renter id is passed (ownership is the server's call, not ours). The
-// cancel is modelled as a bodyless, cookie-authed, CSRF-gated POST, so the caller
-// echoes the session token and sets no Content-Type (there is no JSON body to
-// declare). `unwrap` returns the now-CANCELLED booking, or throws an ApiError
-// carrying the status so the dialog can treat 409 (already cancelled) as benign.
-export async function cancelBooking(id: string, csrfToken: string): Promise<BookingDto> {
+// does — no renter id is passed (ownership is the server's call, not ours).
+// #868 3b: an OPTIONAL cancellation reason. When absent (the default, and the
+// operator-cancel path) the POST stays bodyless with no Content-Type — preserving
+// the original wire shape; when present it carries `{ reason }` as JSON. `unwrap`
+// returns the now-CANCELLED booking, or throws an ApiError carrying the status so
+// the dialog can treat 409 (already cancelled) as benign.
+export async function cancelBooking(
+  id: string,
+  csrfToken: string,
+  reason: CancellationReason | null = null,
+): Promise<BookingDto> {
   const res = await fetch(`${getApiBaseUrl()}/bookings/${encodeURIComponent(id)}/cancel`, {
     method: 'POST',
     credentials: 'include',
-    headers: { 'X-CSRF-Token': csrfToken },
+    headers: {
+      'X-CSRF-Token': csrfToken,
+      ...(reason ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(reason ? { body: JSON.stringify({ reason }) } : {}),
   })
   return unwrap(res, bookingDtoSchema)
 }

--- a/packages/web/src/vite/operator-bookings/schema.ts
+++ b/packages/web/src/vite/operator-bookings/schema.ts
@@ -10,6 +10,7 @@ import {
   BOOKING_EVENT_TYPES,
   BOOKING_FULFILLMENT_MODES,
   BOOKING_STATUSES,
+  CANCELLATION_REASON_CODES,
 } from '@kuruma/shared/enums'
 import { z } from 'zod'
 
@@ -127,6 +128,13 @@ const bookingCancelledPayloadSchema = z.object({
   type: z.literal('BOOKING_CANCELLED'),
   cancellationFee: z.number().nullable(),
   cancelledAt: z.string(),
+  // #868 3b: the optional renter reason. `.default(null)` is load-bearing —
+  // BOOKING_CANCELLED events stored before this slice have no such key, so the
+  // operator timeline must read them as "no reason" rather than fail to parse.
+  cancellationReason: z
+    .object({ code: z.enum(CANCELLATION_REASON_CODES), note: z.string().nullable() })
+    .nullable()
+    .default(null),
 })
 const statusChangedPayloadSchema = z.object({
   type: z.literal('STATUS_CHANGED'),

--- a/packages/web/tests/vite/bookings/CancelBookingDialog.test.tsx
+++ b/packages/web/tests/vite/bookings/CancelBookingDialog.test.tsx
@@ -56,7 +56,27 @@ describe('CancelBookingDialog (renter, #856)', () => {
     expect(spy).not.toHaveBeenCalled()
 
     await user.click(screen.getByRole('button', { name: c.confirm }))
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok'))
+    // #868 3b: no reason picked -> the third arg is null (bodyless cancel preserved).
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok', null))
+  })
+
+  it('passes the selected reason and trimmed note to the cancel call (#868 3b)', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    // The note field only appears once a reason category is chosen.
+    await user.click(screen.getByRole('radio', { name: c.reason.options.FOUND_ALTERNATIVE }))
+    await user.type(screen.getByLabelText(c.reason.noteLabel), '  cheaper nearby  ')
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok', {
+        code: 'FOUND_ALTERNATIVE',
+        note: 'cheaper nearby',
+      }),
+    )
   })
 
   it('previews the tiered fee and estimated refund for a cancellation before pickup', async () => {


### PR DESCRIPTION
Part of #868 (final slice). Closes #919.

Optional reason on renter self-cancel, captured for operator/analytics insight. Always optional — never gates the cancel, never triggers approval. Stored **event-payload-only** (no `bookings` column), never echoed in the cancellation email.

## What changed

**shared**
- `CANCELLATION_REASON_CODES` taxonomy — text union, not a `pgEnum` (pinned in `enums.test.ts`)
- `CancellationReason { code, note: string | null }`; extend `BookingCancelledPayload`
- `cancelBookingSchema` → `{ reason?: { code, note? } }`, note trimmed + capped at 500 chars

**api**
- `cancel(ctx, id, reason = null, now = new Date())` records the reason in the `BOOKING_CANCELLED` event payload
- Route parses the optional reason **defensively** — body may be absent (operator cancel + renter-no-reason send none); a malformed reason → 400
- 3 positional-`now` callers updated for the new 3rd param

**web**
- Optional reason radio + freeform note `Textarea` in the renter `CancelBookingDialog` (note appears only after a code is picked)
- `cancelBooking(id, csrf, reason?)` sends `{ reason }` JSON only when present (bodyless request preserved otherwise)
- en/ja/zh reason labels
- `operator-bookings/schema.ts` reads `cancellationReason` with `.nullable().default(null)` — load-bearing so pre-3b stored events still parse on the operator timeline

## Test plan
- [x] shared: enum + validator suites (580 pass)
- [x] api: `cancel()` service reason-capture + route 400-on-bad-reason
- [x] web: `CancelBookingDialog` (9) + operator-bookings (148) + typecheck
- [x] i18n parity 987×3 · biome clean · pre-commit (size/boundaries/tsc web+api)
- [ ] CI: full api real-pg integration, full web vitest sweep, real-db E2E

Capture-only: the reason is not surfaced in any UI yet and never appears in the email. Slice 4 (fee-waiver) stays deferred to #851.