### PR TITLE
ci: route CI/deploy to the develop/beta/main branch model

### DIFF
--- a/.github/workflows/ci-neon.yml
+++ b/.github/workflows/ci-neon.yml
@@ -10,9 +10,9 @@ name: CI (neon driver lane)
 # is exactly the #493 regression class, so package.json / bun.lock must trigger).
 on:
   push:
-    branches: [marketplace-pivot, main]
+    branches: [develop, main]
   pull_request:
-    branches: [marketplace-pivot, main]
+    branches: [develop, main]
     paths:
       - packages/shared/src/db/**
       - packages/api/src/repositories/drizzle/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, marketplace-pivot]
+    branches: [main, develop, beta]
   pull_request:
-    branches: [main, marketplace-pivot]
+    branches: [main, develop, beta]
 
 env:
   BUN_VERSION: "1.2.13"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy
 
-# Runs after CI passes on main, OR manually via the Actions tab (workflow_dispatch).
+# Runs after CI passes on beta, OR manually via the Actions tab (workflow_dispatch).
+# (beta = the live pre-contract environment: kuruma-web-pages.pages.dev + kuruma-api.
+# Production deploy from `main` is a separate, not-yet-wired pipeline.)
 # Deploys both Workers in a single pipeline with migrations applied first,
 # so schema changes always land before the code that depends on them.
 # This solves issue #27 ("apply pending migrations on deploy") and replaces
@@ -10,7 +12,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main]
+    branches: [beta]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to the branch-env cutover: `marketplace-pivot` was renamed to `develop` (now the default branch). Aligns workflow triggers to the new model.

- **ci.yml** → `[main, develop, beta]`. Unblocks PRs into develop — required checks (test-and-build, db-drift, e2e-real-db) all live here and currently don't run on develop PRs (the rename retargeted PRs but not the triggers).
- **ci-neon.yml** → `[develop, main]`.
- **deploy.yml** → workflow_run fires on CI completion for `beta` (was `main`). Merging to `beta` auto-deploys the live beta env (kuruma-web-pages.pages.dev + kuruma-api). Production deploy from `main` stays intentionally un-wired.

Part of the develop/beta/main environment cutover.