### PR TITLE
fix(#868): accept note:null on cancel reason

### DIFF
--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1198,6 +1198,20 @@ describe('Booking Routes', () => {
       expect(body.data.status).toBe('CANCELLED')
     })
 
+    it('accepts a reason with a null note — the web sends note:null when blank (#922)', async () => {
+      const createRes = await createBooking()
+      const created = await createRes.json()
+
+      const res = await app.request(`/bookings/${created.data.id}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: { code: 'CHANGE_OF_PLANS', note: null } }),
+      })
+
+      expect(res.status).toBe(200)
+      expect((await res.json()).data.status).toBe('CANCELLED')
+    })
+
     it('rejects a cancellation reason outside the taxonomy with 400 (#868 3b)', async () => {
       const createRes = await createBooking()
       const created = await createRes.json()

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -76,10 +76,13 @@ export const substituteVehicleSchema = z.object({
 // #868 Slice 3b: optional renter cancellation reason on POST /bookings/:id/cancel.
 // ALWAYS optional — the cancel succeeds with or without it (the body may even be
 // absent: the operator cancel sends none). `note` is a short freeform elaboration,
-// trimmed + capped; an empty/whitespace note normalises away at the route.
+// trimmed + capped. `nullish`, not `optional`: the web sends `note: null` (not an
+// absent key) when the renter leaves it blank — matching CancellationReason.note's
+// `string | null` — so the validator must accept null too. An empty/whitespace/null
+// note normalises away at the route (`note ?? null`).
 export const cancellationReasonSchema = z.object({
   code: z.enum(CANCELLATION_REASON_CODES),
-  note: z.string().trim().max(500, 'Note must be 500 characters or fewer').optional(),
+  note: z.string().trim().max(500, 'Note must be 500 characters or fewer').nullish(),
 })
 export const cancelBookingSchema = z.object({
   reason: cancellationReasonSchema.optional(),

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -174,6 +174,12 @@ describe('cancelBookingSchema (#868 Slice 3b)', () => {
     if (result.success) expect(result.data.reason?.note).toBe('found a cheaper car')
   })
 
+  it('accepts a null note — the web sends note:null when the renter leaves it blank (#922)', () => {
+    const result = cancelBookingSchema.safeParse({ reason: { code: 'OTHER', note: null } })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.reason).toEqual({ code: 'OTHER', note: null })
+  })
+
   it('rejects a reason code outside the taxonomy', () => {
     expect(cancelBookingSchema.safeParse({ reason: { code: 'BANANA' } }).success).toBe(false)
   })


### PR DESCRIPTION
Closes #922

## Problem

A renter who picks a cancellation reason but leaves the note blank gets a **400 and the cancel fails**. Verified end-to-end, not theoretical.

`CancelBookingDialog.tsx` sends `{ reason: { code, note: null } }` — matching the shared `CancellationReason.note: string | null` — when the note is blank. But `cancellationReasonSchema.note` was `.optional()` (string-or-**absent**, not nullable), so `safeParse` rejected `null`. The validator was out of sync with the type it validates.

## Fix

`note: z.string().trim().max(500).optional()` → `.nullish()` in `packages/shared/src/validators/booking.ts`. The route already normalizes `note ?? null`, so no route change is needed.

One line + 2 tests (TDD RED→GREEN). Added `note: null → success` coverage at both layers (both were RED before the fix):
- `packages/shared/tests/validators/booking.test.ts`
- `packages/api/tests/routes/bookings.test.ts`

## Verification

shared 581 (+1) · api 1565 (+1) · web/api/shared typecheck 0 · pre-commit (biome/size/boundaries/tsc) all passed.

Follow-up bug from the code review of #868 Slice 3b (merged #920).