### PR TITLE
feat(web): gate interactive search map behind VITE_SEARCH_MAP_ENABLED (#885)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ PLATFORM_ADMIN_EMAILS=you@yourdomain.example
 #
 # NOTE: local dev has no GEOCODE_LIMITER binding (unthrottled). Point at LocationIQ
 # or a self-host before any bulk seed/import so you don't trip an OSM IP ban.
+
+# Interactive search map (#885) — a post-MVP / post-contract premium feature.
+# Build-time only (baked into the Vite client bundle). Beta and local dev leave it
+# UNSET → search renders a pure store list (no map pane, no Stores|Map toggle). A
+# full build opts in with the exact string 'true'; anything else fails safe to OFF.
+# Set this when developing the map (search Slice 3) or for a post-contract build.
+# VITE_SEARCH_MAP_ENABLED=true

--- a/packages/web/src/routes/$locale/search.tsx
+++ b/packages/web/src/routes/$locale/search.tsx
@@ -3,6 +3,7 @@ import { regionsQueryOptions } from '@/vite/regions/regions-api'
 import { SearchMap } from '@/vite/search/SearchMap'
 import { type ResultView, SearchViewToggle } from '@/vite/search/SearchViewToggle'
 import { fetchSearchResults } from '@/vite/search/api'
+import { isSearchMapEnabled, resolveResultView } from '@/vite/search/flags'
 import { StoreGrid } from '@/vite/storefronts/StoreGrid'
 import { StorefrontSearchForm } from '@/vite/storefronts/StorefrontSearchForm'
 import { fetchStorefronts } from '@/vite/storefronts/api'
@@ -74,7 +75,9 @@ export const Route = createFileRoute('/$locale/search')({
     pickupLocationId: search.pickupLocationId,
     region: search.region,
     classes: normalizeClassFilter(search.class),
-    view: search.view ?? 'stores',
+    // Map gated off (beta) → a stale ?view=map link collapses to the store list so
+    // the loader never fetches flat results with no map to render them (#885 Task 0).
+    view: resolveResultView(search.view, isSearchMapEnabled()),
   }),
   loader: async ({ deps, context }) => {
     const range = parseSearchRange(deps.from, deps.to)
@@ -131,7 +134,7 @@ function SearchError(_props: ErrorComponentProps) {
   )
 }
 
-function StorefrontSearchRoute() {
+export function StorefrontSearchRoute() {
   const t = useTranslations('search')
   const { locale } = Route.useParams()
   const { from, to, class: classFilter, pickupLocationId, region } = Route.useSearch()
@@ -166,9 +169,13 @@ function StorefrontSearchRoute() {
           />
         </div>
 
-        <div className="mb-8 flex justify-end">
-          <SearchViewToggle view={data.view} locale={locale} />
-        </div>
+        {/* The Stores|Map data-mode toggle is a map-only affordance — hidden in
+            beta where the map is gated off, so search is a pure store list (#885). */}
+        {isSearchMapEnabled() && (
+          <div className="mb-8 flex justify-end">
+            <SearchViewToggle view={data.view} locale={locale} />
+          </div>
+        )}
 
         {data.view === 'map' ? (
           <SearchMap

--- a/packages/web/src/vite/search/flags.ts
+++ b/packages/web/src/vite/search/flags.ts
@@ -1,0 +1,28 @@
+import type { ResultView } from './SearchViewToggle'
+
+/**
+ * Build-time gate for the interactive search map (#885).
+ *
+ * The map + list experience is a post-MVP / post-contract premium feature, so beta
+ * builds ship it OFF and the search page renders the store list only. A full build
+ * opts in by baking `VITE_SEARCH_MAP_ENABLED=true` at build time.
+ *
+ * Strict-string on purpose: only the literal `'true'` enables it, so a missing or
+ * typo'd value fails safe to OFF — a premium feature must never leak on by accident.
+ */
+export function isSearchMapEnabled(): boolean {
+  return import.meta.env.VITE_SEARCH_MAP_ENABLED === 'true'
+}
+
+/**
+ * The effective results view. With the map gated off (beta) the map view is
+ * unreachable, so a stale `?view=map` link collapses to the store list instead of
+ * loading a map that will never render. `mapEnabled` is passed in (not read here)
+ * so this stays a pure function — the route composes it with `isSearchMapEnabled()`.
+ */
+export function resolveResultView(
+  requested: ResultView | undefined,
+  mapEnabled: boolean,
+): ResultView {
+  return mapEnabled && requested === 'map' ? 'map' : 'stores'
+}

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -5,6 +5,9 @@
 // app keeps process.env.* typing.
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string
+  // Build-time gate for the premium interactive search map (#885). Unset/anything
+  // but 'true' → map OFF (beta ships a pure store list). See vite/search/flags.ts.
+  readonly VITE_SEARCH_MAP_ENABLED?: string
   // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
   // injected by CI at build time; environment defaults to 'production'.
   readonly VITE_SENTRY_DSN?: string

--- a/packages/web/tests/vite/search/StorefrontSearchRoute.test.tsx
+++ b/packages/web/tests/vite/search/StorefrontSearchRoute.test.tsx
@@ -1,0 +1,111 @@
+import { regionsQueryOptions } from '@/vite/regions/regions-api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Mutable harness state, hoisted so the vi.mock factories below can read it. Each
+// test sets the build-time gate + the loader's resolved view, then renders.
+const state = vi.hoisted(() => ({
+  mapEnabled: false,
+  view: 'stores' as 'stores' | 'map',
+}))
+
+// Drive the build-time gate directly (the route's single source of truth) instead
+// of stubbing import.meta.env — resolveResultView stays real.
+vi.mock('@/vite/search/flags', async () => ({
+  ...(await vi.importActual<typeof import('@/vite/search/flags')>('@/vite/search/flags')),
+  isSearchMapEnabled: () => state.mapEnabled,
+}))
+
+// Stand in for the heavy views + form — their own tests cover internals; here we
+// only assert which view the route mounts and whether the toggle is gated.
+vi.mock('@/vite/storefronts/StoreGrid', () => ({
+  StoreGrid: () => <div data-testid="store-grid" />,
+}))
+vi.mock('@/vite/search/SearchMap', () => ({
+  SearchMap: () => <div data-testid="search-map" />,
+}))
+vi.mock('@/vite/storefronts/StorefrontSearchForm', () => ({
+  StorefrontSearchForm: () => <form data-testid="search-form" />,
+}))
+
+// Render the route component outside a RouterProvider: stub Route.use* via
+// createFileRoute and Link -> anchor (the toggle renders Links).
+vi.mock('@tanstack/react-router', async () => ({
+  ...(await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')),
+  createFileRoute: () => () => ({
+    useParams: () => ({ locale: 'en' }),
+    useSearch: () => ({ from: '2026-07-01T10:00', to: '2026-07-03T10:00' }),
+    useLoaderData: () => ({ view: state.view, storefronts: null, flat: null }),
+  }),
+  Link: ({
+    to,
+    params: _p,
+    search: _s,
+    children,
+    ...rest
+  }: { to: string; children: ReactNode }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Imported after the mocks (vitest hoists vi.mock above imports).
+import { StorefrontSearchRoute } from '@/routes/$locale/search'
+
+function renderRoute() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  })
+  queryClient.setQueryData(regionsQueryOptions().queryKey, [])
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        <StorefrontSearchRoute />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('StorefrontSearchRoute — search map gating (#885 Task 0)', () => {
+  afterEach(() => {
+    state.mapEnabled = false
+    state.view = 'stores'
+  })
+
+  it('beta (map gated off): renders the store list with no map and no view toggle', () => {
+    state.mapEnabled = false
+    state.view = 'stores'
+    renderRoute()
+
+    expect(screen.getByTestId('store-grid')).toBeInTheDocument()
+    expect(screen.queryByTestId('search-map')).not.toBeInTheDocument()
+    // The Stores|Map data-mode toggle is hidden entirely in beta.
+    expect(screen.queryByRole('link', { name: 'Map' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Stores' })).not.toBeInTheDocument()
+  })
+
+  it('map enabled: shows the view toggle alongside the store list', () => {
+    state.mapEnabled = true
+    state.view = 'stores'
+    renderRoute()
+
+    expect(screen.getByTestId('store-grid')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Stores' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Map' })).toBeInTheDocument()
+  })
+
+  it('map enabled + view=map: mounts the map view with the toggle', () => {
+    state.mapEnabled = true
+    state.view = 'map'
+    renderRoute()
+
+    expect(screen.getByTestId('search-map')).toBeInTheDocument()
+    expect(screen.queryByTestId('store-grid')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Map' })).toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/search/flags.test.ts
+++ b/packages/web/tests/vite/search/flags.test.ts
@@ -1,0 +1,41 @@
+import { isSearchMapEnabled, resolveResultView } from '@/vite/search/flags'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('isSearchMapEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('is OFF (beta default) when VITE_SEARCH_MAP_ENABLED is unset', () => {
+    vi.stubEnv('VITE_SEARCH_MAP_ENABLED', undefined)
+    expect(isSearchMapEnabled()).toBe(false)
+  })
+
+  it('is ON only for the exact string "true"', () => {
+    vi.stubEnv('VITE_SEARCH_MAP_ENABLED', 'true')
+    expect(isSearchMapEnabled()).toBe(true)
+  })
+
+  it("stays OFF for a typo'd, mis-cased, or empty value (fail-safe)", () => {
+    for (const value of ['false', '1', 'TRUE', 'yes', '']) {
+      vi.stubEnv('VITE_SEARCH_MAP_ENABLED', value)
+      expect(isSearchMapEnabled()).toBe(false)
+    }
+  })
+})
+
+describe('resolveResultView', () => {
+  it('keeps the map view when the map is enabled and explicitly requested', () => {
+    expect(resolveResultView('map', true)).toBe('map')
+  })
+
+  it('defaults to the store list when no view is requested', () => {
+    expect(resolveResultView(undefined, true)).toBe('stores')
+    expect(resolveResultView('stores', true)).toBe('stores')
+  })
+
+  it('collapses a stale ?view=map link to the store list when the map is gated off (beta)', () => {
+    expect(resolveResultView('map', false)).toBe('stores')
+    expect(resolveResultView(undefined, false)).toBe('stores')
+  })
+})


### PR DESCRIPTION
## What

Gates the interactive search map behind a build-time flag `VITE_SEARCH_MAP_ENABLED`. Beta leaves the var **unset → map OFF** (fail-safe). Search renders as a clean store list; the map pane and `SearchViewToggle` are hidden.

## Why

Owner decision (2026-06-17): the map is a **post-MVP / post-contract premium** feature — hide it in beta.

Beta intentionally keeps **`StoreGrid` (store-first)** as the default view, *not* the car-first `SearchResultRow` list:
- Car rows have no distance label yet (geo-context is Slice 3, unbuilt) — beta would lose the nearest-first signal.
- The #840 real-DB e2e (`region-search.auth.spec.ts`) asserts `StoreGrid` (store headings, `~X.X km`, `/storefronts/{UUID}` drill); a car list would break it.

The car-first cutover happens later, when Slice 3 (geo-context) lands behind this same flag (dark launch).

## How

- New `packages/web/src/vite/search/flags.ts`: `isSearchMapEnabled()` (reads `import.meta.env.VITE_SEARCH_MAP_ENABLED === 'true'`, fail-safe OFF) + pure `resolveResultView(requested, mapEnabled)` that collapses a stale `?view=map` → `stores` when the map is off (so no flat fetch in beta).
- `routes/$locale/search.tsx`: `loaderDeps.view` runs through `resolveResultView(...)`; `SearchViewToggle` wrapped in `isSearchMapEnabled() &&`; `StorefrontSearchRoute` exported for test. The `view==='map'` → `SearchMap` branch is dead in beta (loader never returns map).
- `vite/vite-env.d.ts` type + `.env.example` doc. `deploy.yml` untouched — beta leaves the var unset (correct).

## Test plan

- `flags.test.ts` (6) — flag parsing + `resolveResultView` collapse logic
- `StorefrontSearchRoute.test.tsx` (3) — toggle hidden / map branch unreachable when off
- Full web search suite: **93/93** (11 files) green
- `bun run --filter @kuruma/web typecheck`: **0 errors**

refs #885 (epic stays open for Slice 3)