### PR TITLE
fix(#868): collapse empty/whitespace cancel-reason note to null

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -238,7 +238,7 @@ export function createBookingRoutes(service: BookingService) {
       if (!parsed.ok) return parsed.response
 
       const reason = parsed.data.reason
-        ? { code: parsed.data.reason.code, note: parsed.data.reason.note ?? null }
+        ? { code: parsed.data.reason.code, note: parsed.data.reason.note || null }
         : null
 
       const result = await service.cancel(ctx, idResult.id, reason)

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -1212,6 +1212,28 @@ describe('Booking Routes', () => {
       expect((await res.json()).data.status).toBe('CANCELLED')
     })
 
+    it('normalises a whitespace-only note to null in the persisted reason (#868 3b)', async () => {
+      const createRes = await createBooking()
+      const created = await createRes.json()
+
+      const res = await app.request(`/bookings/${created.data.id}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: { code: 'OTHER', note: '   ' } }),
+      })
+
+      expect(res.status).toBe(200)
+
+      // The SERVER — not just the web dialog — collapses an empty/whitespace note to
+      // null, so a non-web caller (Trip.com) can't persist a meaningless "" note.
+      const events = await bookingEventRepo.findByBookingId(SYSTEM_CONTEXT, created.data.id)
+      const cancelled = events.find((e) => e.type === 'BOOKING_CANCELLED')
+      expect(cancelled).toMatchObject({
+        type: 'BOOKING_CANCELLED',
+        payload: { cancellationReason: { code: 'OTHER', note: null } },
+      })
+    })
+
     it('rejects a cancellation reason outside the taxonomy with 400 (#868 3b)', async () => {
       const createRes = await createBooking()
       const created = await createRes.json()

--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -78,8 +78,9 @@ export const substituteVehicleSchema = z.object({
 // absent: the operator cancel sends none). `note` is a short freeform elaboration,
 // trimmed + capped. `nullish`, not `optional`: the web sends `note: null` (not an
 // absent key) when the renter leaves it blank — matching CancellationReason.note's
-// `string | null` — so the validator must accept null too. An empty/whitespace/null
-// note normalises away at the route (`note ?? null`).
+// `string | null` — so the validator must accept null too. The validator trims, then
+// the route collapses an empty/whitespace/null note to null (`note || null`) so no
+// caller — web or Trip.com — can persist a meaningless "" note.
 export const cancellationReasonSchema = z.object({
   code: z.enum(CANCELLATION_REASON_CODES),
   note: z.string().trim().max(500, 'Note must be 500 characters or fewer').nullish(),


### PR DESCRIPTION
Closes #925

Follow-up from the code review of #868 Slice 3b (reason capture, #920 + #923).

## Problem

The cancel route built the reason with `note: parsed.data.reason.note ?? null`. `??` only nulls `null`/`undefined` — not the empty string the validator's `.trim()` can produce. A non-web caller (Trip.com hits the same routes) sending `note: "   "` persisted a meaningless `""` into the `BOOKING_CANCELLED` event payload instead of `null`. The web dialog already normalizes (`note.trim() || null`), so there was **zero UI impact** — but the API is the source of truth for every caller, and the validator comment claimed this normalization already held (it didn't).

## Fix

- Route: `note ?? null` → `note || null` (the validator already trims → empty/whitespace → falsy → null). The server now guarantees the empty→null invariant for all callers.
- Corrected the validator comment.

## Test (TDD RED→GREEN)

Added a route-level test that POSTs a whitespace-only note and asserts the **persisted** `BOOKING_CANCELLED` payload carries `cancellationReason.note === null` (end-to-end through validator → route → event store). RED before the fix (`note: ""`), GREEN after.

## Verification

api 1566 (+1) · shared 581 · web/api/shared typecheck 0 · lint:boundaries OK · pre-commit (biome/size/boundaries/tsc) all passed.

Capture-only field — hardening + comment accuracy, no functional/security change today.