### PR TITLE
feat: operator self-service staff invites + team page (#904 slice 1)

### DIFF
--- a/e2e/real-db/operator-team.auth.spec.ts
+++ b/e2e/real-db/operator-team.auth.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import { OPERATOR_SEED_EMAIL } from './constants'
+import { testSql } from './pg'
+
+// #904: authenticated, real-DB coverage for the operator team page. The minted
+// session (auth.setup.ts) is the Best Car Rental OWNER, so this drives the real
+// web -> Hono POST /operators/me/invites -> seeded Neon branch. The invite is a
+// NEW row this test owns, so afterEach deletes it by email (no shared-state
+// restore needed, unlike operator-settings).
+test.describe('operator team invites (authenticated, real DB)', () => {
+  const email = `e2e-invite-${Date.now()}@example.test`
+
+  test.afterEach(async () => {
+    const sql = testSql()
+    try {
+      await sql`DELETE FROM provider_invites WHERE email = ${email}`
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+
+  test('owner invites a staff member; the pending row appears and persists as OPERATOR_STAFF (P1)', async ({
+    page,
+  }) => {
+    await page.goto('/en/manage/team')
+    // The operator session is honoured — no redirect to sign-in.
+    await expect(page).toHaveURL(/\/en\/manage\/team\/?$/)
+
+    await page.getByRole('button', { name: 'Invite staff' }).click()
+    await page.locator('#invite-email').fill(email)
+    await page.getByRole('button', { name: 'Send invite' }).click()
+
+    // Success reveal: the one-time invite URL is shown for the owner to copy.
+    await expect(page.getByText('Invite created')).toBeVisible()
+    const url = await page.locator('#invite-url').inputValue()
+    expect(url).toContain('/provider/invite/')
+
+    // Close the reveal; the new pending invite now renders in the team list.
+    await page.getByRole('button', { name: 'Done' }).click()
+    await expect(page.getByText(email)).toBeVisible()
+
+    // Persisted through the API to the DB — scoped to the owner's OWN operator,
+    // minted as OPERATOR_STAFF + PENDING. Asserting the role (not just existence)
+    // proves the client cannot escalate the grant to OPERATOR_OWNER.
+    const sql = testSql()
+    try {
+      const inviteRows = await sql<{ operatorId: string; role: string; status: string }[]>`
+        SELECT pi."operatorId", pi.role, pi.status
+        FROM provider_invites pi
+        WHERE pi.email = ${email}
+        LIMIT 1`
+      const invite = inviteRows[0]
+      expect(invite?.role).toBe('OPERATOR_STAFF')
+      expect(invite?.status).toBe('PENDING')
+
+      const ownerRows = await sql<{ operatorId: string }[]>`
+        SELECT u."operatorId" FROM users u WHERE u.email = ${OPERATOR_SEED_EMAIL} LIMIT 1`
+      expect(invite?.operatorId).toBe(ownerRows[0]?.operatorId)
+    } finally {
+      await sql.end({ timeout: 5 })
+    }
+  })
+})

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -27,6 +27,7 @@ import { createLocationRoutes } from './routes/locations'
 import { createMaintenanceLogRoutes } from './routes/maintenance-logs'
 import { createMessageRoutes } from './routes/messages'
 import { createNotificationRoutes } from './routes/notifications'
+import { createOperatorTeamRoutes } from './routes/operator-team'
 import { createOperatorRoutes } from './routes/operators'
 import { createOverviewRoutes } from './routes/overview'
 import { createPaymentAnomalyRoutes } from './routes/payment-anomalies'
@@ -68,6 +69,7 @@ import { NotificationService } from './services/notification'
 import { NotificationDispatcher } from './services/notification-dispatcher'
 import { OperatorService } from './services/operator'
 import { createOperatorGrantService } from './services/operator-grant'
+import { OperatorTeamService } from './services/operator-team'
 import { OverviewService } from './services/overview'
 import { PaymentAnomalyService } from './services/payment-anomaly'
 import { PaymentService } from './services/payment/payment'
@@ -235,6 +237,15 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     operatorRepo,
     { webBaseUrl },
     (event) => console.info('[provider-invite] created', event),
+  )
+  // #904: operator self-service team page. Reuses providerInviteService to mint
+  // (so the audit trail + TTL stay single-sourced); reads invites + members
+  // scoped to the caller's own operatorId.
+  const operatorTeamService = new OperatorTeamService(
+    providerInviteRepo,
+    operatorMembershipRepo,
+    userRepo,
+    providerInviteService,
   )
   // Operator-access grant decision (#521 §6) + slug resolver for the OAuth callback.
   // The slug is read from the STORED operators.slug (never re-derived from the name),
@@ -480,6 +491,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createFeeScheduleRoutes(feeScheduleService, resolveWriteOperatorId))
     .route('/', createNotificationRoutes(notificationService))
     .route('/', createOperatorRoutes(operatorService))
+    .route('/', createOperatorTeamRoutes(operatorTeamService))
     .route('/', createDocumentRoutes(renterDocumentService))
 }
 

--- a/packages/api/src/repositories/drizzle/provider-invite.ts
+++ b/packages/api/src/repositories/drizzle/provider-invite.ts
@@ -1,5 +1,5 @@
 import { providerInvites } from '@kuruma/shared/db/schema'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import type { ProviderInvite } from '../../stores'
 import type { ProviderInviteRepository } from '../types'
 import type { Db } from './shared'
@@ -39,6 +39,17 @@ export class DrizzleProviderInviteRepository implements ProviderInviteRepository
       .from(providerInvites)
       .where(eq(providerInvites.tokenHash, tokenHash))
     return row ? toProviderInvite(row) : undefined
+  }
+
+  // #904: the operator's PENDING invites for the self-service team page. Scoped
+  // (operatorId, status='PENDING'); ordered (createdAt, id) for a stable list.
+  async listByOperator(operatorId: string): Promise<ProviderInvite[]> {
+    const rows = await this.db
+      .select()
+      .from(providerInvites)
+      .where(and(eq(providerInvites.operatorId, operatorId), eq(providerInvites.status, 'PENDING')))
+      .orderBy(providerInvites.createdAt, providerInvites.id)
+    return rows.map(toProviderInvite)
   }
 
   // Consume the invite at acceptance (#521 §6). Runs tx-bound inside the grant

--- a/packages/api/src/repositories/in-memory/provider-invite.ts
+++ b/packages/api/src/repositories/in-memory/provider-invite.ts
@@ -39,6 +39,15 @@ export class InMemoryProviderInviteRepository implements ProviderInviteRepositor
     return [...this.store.values()].find((i) => i.tokenHash === tokenHash)
   }
 
+  // #904: the operator's PENDING invites for the self-service team page.
+  // Ordered by (createdAt, id) — mirrors the drizzle ORDER BY so list output is
+  // stable, not Map-insertion order.
+  async listByOperator(operatorId: string): Promise<ProviderInvite[]> {
+    return [...this.store.values()]
+      .filter((i) => i.operatorId === operatorId && i.status === 'PENDING')
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id))
+  }
+
   async markAccepted(id: string, acceptedByUserId: string): Promise<void> {
     const invite = this.store.get(id)
     if (!invite) return

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -229,6 +229,9 @@ export interface ProviderInviteRepository {
   /** Consume the invite at acceptance: PENDING -> ACCEPTED + stamp the redeemer.
    *  One of the three writes in the grant transaction (#521 §6). */
   markAccepted(id: string, acceptedByUserId: string): Promise<void>
+  /** #904: the operator's actionable (PENDING) invites — the self-service team
+   *  page. Scoped by operatorId; non-PENDING (accepted/revoked) rows drop off. */
+  listByOperator(operatorId: string): Promise<ProviderInvite[]>
 }
 
 // #521. `findActiveByUserId` is served by the partial-unique-active index

--- a/packages/api/src/routes/operator-team.ts
+++ b/packages/api/src/routes/operator-team.ts
@@ -1,0 +1,39 @@
+import { inviteStaffSchema } from '@kuruma/shared/validators/provider-invite'
+import { Hono } from 'hono'
+import { requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import type { OperatorTeamService } from '../services/operator-team'
+import { ok, parseBody } from './helpers'
+
+/**
+ * #904: operator self-service team management. The tenant is ALWAYS the caller's
+ * own operator — these are `/operators/me/*` paths with no id segment, so there
+ * is no foreign-id surface to scope-check or leak. Owner-vs-member gating and the
+ * absent-tenant seal live in `OperatorTeamService`; a denied write surfaces as a
+ * 403 via the global `ForbiddenError` handler, so the routes stay HTTP-only.
+ */
+export function createOperatorTeamRoutes(service: OperatorTeamService) {
+  const app = new Hono()
+
+  app.use('/operators/me/*', requireAuth())
+
+  return app
+    .post('/operators/me/invites', async (c) => {
+      const user = requireUser(c)
+      const parsed = await parseBody(c, inviteStaffSchema)
+      if (!parsed.ok) return parsed.response
+
+      const created = await service.inviteStaff(toCallerContext(user), parsed.data)
+      // The URL embeds the one-time token (never persisted in cleartext); the
+      // owner copies it to share. We omit the bare `token` field — the URL is the
+      // only form the page needs.
+      return ok(c, { inviteUrl: created.inviteUrl, expiresAt: created.expiresAt }, 201)
+    })
+    .get('/operators/me/invites', async (c) => {
+      const invites = await service.listInvites(toCallerContext(requireUser(c)))
+      return ok(c, invites)
+    })
+    .get('/operators/me/members', async (c) => {
+      const members = await service.listMembers(toCallerContext(requireUser(c)))
+      return ok(c, members)
+    })
+}

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -1,0 +1,91 @@
+import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
+import type { CallerContext } from '../auth/context'
+import { ForbiddenError, requireOperatorOwnerWrite, requireOperatorScope } from '../auth/guards'
+import type {
+  OperatorMembershipRepository,
+  ProviderInviteRepository,
+  UserRepository,
+} from '../repositories/types'
+import type { OperatorMembership, ProviderInvite, User } from '../stores'
+import type { CreatedInvite, ProviderInviteService } from './provider-invite'
+
+/**
+ * #904: operator self-service staff management. Every method derives the tenant
+ * from the caller's session (`ctx.operatorId`) — there is no foreign-id surface,
+ * so a tenant can only ever see or mutate its own team. Writes are owner-only;
+ * reads admit any operator member. The minted role is hard-coded OPERATOR_STAFF:
+ * an owner can never escalate an invitee to OPERATOR_OWNER through this path.
+ */
+export class OperatorTeamService {
+  constructor(
+    private readonly invites: ProviderInviteRepository,
+    private readonly memberships: OperatorMembershipRepository,
+    private readonly users: UserRepository,
+    private readonly inviteService: ProviderInviteService,
+  ) {}
+
+  async inviteStaff(ctx: CallerContext, input: { email: string }): Promise<CreatedInvite> {
+    requireOperatorOwnerWrite(ctx)
+    const operatorId = this.requireOwnOperator(ctx)
+    return this.inviteService.createInvite(
+      { email: input.email, operatorId, role: 'OPERATOR_STAFF' },
+      ctx.userId,
+    )
+  }
+
+  async listInvites(ctx: CallerContext): Promise<OperatorInviteData[]> {
+    requireOperatorScope(ctx)
+    const operatorId = this.requireOwnOperator(ctx)
+    const rows = await this.invites.listByOperator(operatorId)
+    return rows.map(toOperatorInviteData)
+  }
+
+  async listMembers(ctx: CallerContext): Promise<OperatorMemberData[]> {
+    requireOperatorScope(ctx)
+    const operatorId = this.requireOwnOperator(ctx)
+    const memberships = await this.memberships.findActiveByOperator(operatorId)
+    // One batched read, not a per-member query — the team is small but an N+1
+    // loop is still the wrong shape. `findActiveByOperator` already orders the rows.
+    const usersById = new Map(
+      (await this.users.findByIds(memberships.map((m) => m.userId))).map((u) => [u.id, u]),
+    )
+    return memberships.map((m) => toOperatorMemberData(m, usersById.get(m.userId)))
+  }
+
+  /**
+   * `requireOperatorScope` only fails OPERATOR_* roles missing an operatorId; a
+   * PLATFORM_ADMIN (not an OPERATOR_* role) slips through with no tenant. The
+   * `/me` surface is operator-only, so seal the absent tenant here rather than
+   * letting it reach the repo as `listByOperator(undefined)`.
+   */
+  private requireOwnOperator(ctx: CallerContext): string {
+    if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
+    return ctx.operatorId
+  }
+}
+
+function toOperatorInviteData(invite: ProviderInvite): OperatorInviteData {
+  return {
+    id: invite.id,
+    email: invite.email,
+    role: invite.role,
+    status: invite.status,
+    expiresAt: invite.expiresAt.toISOString(),
+    createdAt: invite.createdAt.toISOString(),
+  }
+}
+
+function toOperatorMemberData(
+  membership: OperatorMembership,
+  user: User | undefined,
+): OperatorMemberData {
+  return {
+    id: membership.id,
+    userId: membership.userId,
+    name: user?.name ?? null,
+    email: user?.email ?? null,
+    role: membership.role,
+    status: membership.status,
+    joinedAt: membership.createdAt.toISOString(),
+  }
+}

--- a/packages/api/tests/repositories/provider-invite.test.ts
+++ b/packages/api/tests/repositories/provider-invite.test.ts
@@ -69,4 +69,29 @@ describe('InMemoryProviderInviteRepository', () => {
     expect(found?.status).toBe('ACCEPTED')
     expect(found?.acceptedByUserId).toBe('user_42')
   })
+
+  describe('listByOperator (#904)', () => {
+    it('returns all PENDING invites for the operator', async () => {
+      await repo.create(inviteInput({ tokenHash: 'h1', email: 'a@x.com' }))
+      await repo.create(inviteInput({ tokenHash: 'h2', email: 'b@x.com' }))
+      const rows = await repo.listByOperator('op_test')
+      expect(rows.map((r) => r.email).sort()).toEqual(['a@x.com', 'b@x.com'])
+    })
+
+    it('excludes other operators (tenant scope)', async () => {
+      await repo.create(inviteInput({ tokenHash: 'h1', operatorId: 'op_a' }))
+      await repo.create(inviteInput({ tokenHash: 'h2', operatorId: 'op_b' }))
+      const rows = await repo.listByOperator('op_a')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.operatorId).toBe('op_a')
+    })
+
+    it('excludes non-PENDING invites (accepted/redeemed drop off the actionable list)', async () => {
+      const accepted = await repo.create(inviteInput({ tokenHash: 'h1' }))
+      await repo.markAccepted(accepted.id, 'user_1')
+      await repo.create(inviteInput({ tokenHash: 'h2', email: 'pending@x.com' }))
+      const rows = await repo.listByOperator('op_test')
+      expect(rows.map((r) => r.email)).toEqual(['pending@x.com'])
+    })
+  })
 })

--- a/packages/api/tests/routes/operator-team.test.ts
+++ b/packages/api/tests/routes/operator-team.test.ts
@@ -1,0 +1,172 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import type { UserRole } from '../../src/middleware/auth'
+import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
+import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
+import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
+import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
+import { createOperatorTeamRoutes } from '../../src/routes/operator-team'
+import { OperatorTeamService } from '../../src/services/operator-team'
+import { ProviderInviteService } from '../../src/services/provider-invite'
+import type { User } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+
+const FUTURE = new Date('2099-01-01T00:00:00Z')
+
+let inviteRepo: InMemoryProviderInviteRepository
+let membershipRepo: InMemoryOperatorMembershipRepository
+let userRepo: InMemoryUserRepository
+
+beforeEach(async () => {
+  inviteRepo = new InMemoryProviderInviteRepository()
+  membershipRepo = new InMemoryOperatorMembershipRepository()
+  userRepo = new InMemoryUserRepository(
+    new Map<string, User>([
+      ['u_owner', user('u_owner', 'Olive Owner', 'owner@op1.com')],
+      ['u_b', user('u_b', 'Bob B', 'bob@op2.com')],
+    ]),
+  )
+})
+
+function user(id: string, name: string, email: string): User {
+  return { id, name, email, phone: null, language: 'en', country: null, role: 'OPERATOR_OWNER' }
+}
+
+function mountFor(role: UserRole, operatorId?: string) {
+  const operatorRepo = new InMemoryOperatorRepository(
+    new Map([
+      [
+        'op_1',
+        {
+          id: 'op_1',
+          slug: 'one',
+          name: 'Op One',
+          preAuthHandoffUrl: null,
+          createdAt: FUTURE,
+          updatedAt: FUTURE,
+        },
+      ],
+      [
+        'op_2',
+        {
+          id: 'op_2',
+          slug: 'two',
+          name: 'Op Two',
+          preAuthHandoffUrl: null,
+          createdAt: FUTURE,
+          updatedAt: FUTURE,
+        },
+      ],
+    ]),
+  )
+  const inviteService = new ProviderInviteService(
+    inviteRepo,
+    operatorRepo,
+    { webBaseUrl: 'https://app.example.com' },
+    () => {},
+  )
+  const service = new OperatorTeamService(inviteRepo, membershipRepo, userRepo, inviteService)
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createOperatorTeamRoutes(service))
+  return app
+}
+
+describe('POST /operators/me/invites', () => {
+  it('mints an OPERATOR_STAFF invite for the caller operator (201) and returns the share URL', async () => {
+    const res = await mountFor('OPERATOR_OWNER', 'op_1').request('/operators/me/invites', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'New.Staff@op1.com' }),
+    })
+    expect(res.status).toBe(201)
+    const { data } = await res.json()
+    expect(data.inviteUrl).toContain('/provider/invite/')
+    expect(typeof data.expiresAt).toBe('string')
+
+    const stored = await inviteRepo.listByOperator('op_1')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.role).toBe('OPERATOR_STAFF')
+    expect(stored[0]?.email).toBe('new.staff@op1.com')
+  })
+
+  it('forbids an OPERATOR_STAFF caller (403)', async () => {
+    const res = await mountFor('OPERATOR_STAFF', 'op_1').request('/operators/me/invites', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'x@op1.com' }),
+    })
+    expect(res.status).toBe(403)
+    expect(await inviteRepo.listByOperator('op_1')).toHaveLength(0)
+  })
+
+  it('rejects a malformed email (400)', async () => {
+    const res = await mountFor('OPERATOR_OWNER', 'op_1').request('/operators/me/invites', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /operators/me/invites', () => {
+  it('returns only the caller operator pending invites, projected without the token', async () => {
+    await inviteRepo.create({
+      email: 'mine@op1.com',
+      operatorId: 'op_1',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h1',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_owner',
+      acceptedByUserId: null,
+    })
+    await inviteRepo.create({
+      email: 'theirs@op2.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h2',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_b',
+      acceptedByUserId: null,
+    })
+    const res = await mountFor('OPERATOR_OWNER', 'op_1').request('/operators/me/invites')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    expect(data).toHaveLength(1)
+    expect(data[0].email).toBe('mine@op1.com')
+    expect(data[0]).not.toHaveProperty('tokenHash')
+    expect(data[0]).not.toHaveProperty('invitedByUserId')
+  })
+})
+
+describe('GET /operators/me/members', () => {
+  it('returns the caller operator ACTIVE members joined to user name + email', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_b',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const res = await mountFor('OPERATOR_STAFF', 'op_1').request('/operators/me/members')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    expect(data).toHaveLength(1)
+    expect(data[0]).toMatchObject({
+      userId: 'u_owner',
+      name: 'Olive Owner',
+      email: 'owner@op1.com',
+      role: 'OPERATOR_OWNER',
+    })
+  })
+})

--- a/packages/api/tests/services/operator-team.test.ts
+++ b/packages/api/tests/services/operator-team.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../src/auth/context'
+import { ForbiddenError } from '../../src/auth/guards'
+import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
+import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
+import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
+import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
+import { OperatorTeamService } from '../../src/services/operator-team'
+import { ProviderInviteService } from '../../src/services/provider-invite'
+import type { Operator, User } from '../../src/stores'
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+const FUTURE = new Date('2099-01-01T00:00:00Z')
+
+const OWNER_CTX: CallerContext = { userId: 'u_owner', role: 'OPERATOR_OWNER', operatorId: 'op_1' }
+const STAFF_CTX: CallerContext = { userId: 'u_staff', role: 'OPERATOR_STAFF', operatorId: 'op_1' }
+// PLATFORM_ADMIN passes requireOperatorOwnerWrite but carries NO operatorId — the
+// `/operators/me/*` surface must reject it, not mint against `undefined`.
+const ADMIN_CTX: CallerContext = { userId: 'u_admin', role: 'PLATFORM_ADMIN' }
+
+function makeOperator(id: string, slug: string): Operator {
+  return {
+    id,
+    slug,
+    name: `Operator ${slug}`,
+    preAuthHandoffUrl: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }
+}
+
+function makeUser(id: string, name: string, email: string): User {
+  return { id, name, email, phone: null, language: 'en', country: null, role: 'OPERATOR_OWNER' }
+}
+
+let inviteRepo: InMemoryProviderInviteRepository
+let membershipRepo: InMemoryOperatorMembershipRepository
+let userRepo: InMemoryUserRepository
+let service: OperatorTeamService
+
+beforeEach(() => {
+  inviteRepo = new InMemoryProviderInviteRepository()
+  membershipRepo = new InMemoryOperatorMembershipRepository()
+  userRepo = new InMemoryUserRepository(
+    new Map([
+      ['u_owner', makeUser('u_owner', 'Olive Owner', 'owner@x.com')],
+      ['u_other', makeUser('u_other', 'Otto Other', 'other@x.com')],
+    ]),
+  )
+  const operatorRepo = new InMemoryOperatorRepository(
+    new Map([
+      ['op_1', makeOperator('op_1', 'one')],
+      ['op_2', makeOperator('op_2', 'two')],
+    ]),
+  )
+  const inviteService = new ProviderInviteService(
+    inviteRepo,
+    operatorRepo,
+    { webBaseUrl: 'https://app.example.com' },
+    () => {},
+  )
+  service = new OperatorTeamService(inviteRepo, membershipRepo, userRepo, inviteService)
+})
+
+describe('OperatorTeamService.inviteStaff', () => {
+  it('mints an OPERATOR_STAFF invite scoped to the caller operator, stamping the inviter', async () => {
+    const result = await service.inviteStaff(OWNER_CTX, { email: 'new@x.com' })
+    expect(result.inviteUrl).toContain('/provider/invite/')
+
+    const stored = await inviteRepo.listByOperator('op_1')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.role).toBe('OPERATOR_STAFF')
+    expect(stored[0]?.operatorId).toBe('op_1')
+    expect(stored[0]?.email).toBe('new@x.com')
+    expect(stored[0]?.invitedByUserId).toBe('u_owner')
+  })
+
+  it('refuses an OPERATOR_STAFF caller (403) and writes nothing', async () => {
+    await expect(service.inviteStaff(STAFF_CTX, { email: 'new@x.com' })).rejects.toThrow(
+      ForbiddenError,
+    )
+    expect(await inviteRepo.listByOperator('op_1')).toHaveLength(0)
+  })
+
+  it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) — never mints against undefined', async () => {
+    await expect(service.inviteStaff(ADMIN_CTX, { email: 'new@x.com' })).rejects.toThrow(
+      ForbiddenError,
+    )
+  })
+})
+
+describe('OperatorTeamService.listInvites', () => {
+  it('returns only the caller operator PENDING invites, projected without the token', async () => {
+    await service.inviteStaff(OWNER_CTX, { email: 'mine@x.com' })
+    await inviteRepo.create({
+      email: 'theirs@x.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_other',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_other',
+      acceptedByUserId: null,
+    })
+
+    const invites = await service.listInvites(OWNER_CTX)
+    expect(invites).toHaveLength(1)
+    expect(invites[0]?.email).toBe('mine@x.com')
+    expect(invites[0]?.role).toBe('OPERATOR_STAFF')
+    expect(invites[0]?.status).toBe('PENDING')
+    expect(invites[0]?.expiresAt).toMatch(ISO_RE)
+    expect(invites[0]?.createdAt).toMatch(ISO_RE)
+    // A token (or its hash / the inviter) must never reach the team page.
+    expect(invites[0]).not.toHaveProperty('tokenHash')
+    expect(invites[0]).not.toHaveProperty('invitedByUserId')
+  })
+
+  it('refuses a caller with no operatorId (403)', async () => {
+    await expect(service.listInvites(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  })
+})
+
+describe('OperatorTeamService.listMembers', () => {
+  it('returns only the caller operator ACTIVE members, joined to user name + email', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_other',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+
+    const members = await service.listMembers(OWNER_CTX)
+    expect(members).toHaveLength(1)
+    expect(members[0]?.userId).toBe('u_owner')
+    expect(members[0]?.name).toBe('Olive Owner')
+    expect(members[0]?.email).toBe('owner@x.com')
+    expect(members[0]?.role).toBe('OPERATOR_OWNER')
+    expect(members[0]?.status).toBe('ACTIVE')
+    expect(members[0]?.joinedAt).toMatch(ISO_RE)
+  })
+
+  it('refuses a caller with no operatorId (403)', async () => {
+    await expect(service.listMembers(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,7 @@
     "./types/add-on": "./src/types/add-on.ts",
     "./types/insurance-option": "./src/types/insurance-option.ts",
     "./types/storefront": "./src/types/storefront.ts",
+    "./types/operator-team": "./src/types/operator-team.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/commission": "./src/lib/commission.ts",
     "./lib/admin-revenue": "./src/lib/admin-revenue.ts",

--- a/packages/shared/src/types/operator-team.ts
+++ b/packages/shared/src/types/operator-team.ts
@@ -1,0 +1,44 @@
+/**
+ * Operator team wire contract (#904).
+ *
+ * The JSON shape the operator self-service team endpoints (`/operators/me/*`)
+ * return and the web team client consumes. Web cannot import the Drizzle schema
+ * or the API store types, so the shapes live here, drizzle-free; the role/status
+ * unions come from `@kuruma/shared/enums`.
+ *
+ * These are hand-written PROJECTIONS, not verbatim store rows: the invite shape
+ * deliberately OMITS `tokenHash`, `invitedByUserId`, and `acceptedByUserId` (a
+ * leaked team page must never disclose a token or the inviter); the member shape
+ * is a membership joined to its user. The API projection functions annotate their
+ * return type as these DTOs and the web schemas pin to them via
+ * `satisfies z.ZodType<T>`, so a field rename fails `typecheck` on both ends.
+ *
+ * Dates are ISO 8601 strings (JSON has no Date).
+ */
+
+import type { OperatorMembershipStatus, OperatorRole, ProviderInviteStatus } from '../enums'
+
+/** A pending staff invite an operator owner can see (and, in slice 2, revoke). */
+export interface OperatorInviteData {
+  id: string
+  email: string
+  role: OperatorRole
+  status: ProviderInviteStatus
+  /** ISO 8601 (UTC). Invite expiry. */
+  expiresAt: string
+  /** ISO 8601 (UTC). When the invite was sent. */
+  createdAt: string
+}
+
+/** An active operator member (owner or staff), joined to its user identity. */
+export interface OperatorMemberData {
+  /** The membership id (not the user id) — the handle for slice-2 deactivate. */
+  id: string
+  userId: string
+  name: string | null
+  email: string | null
+  role: OperatorRole
+  status: OperatorMembershipStatus
+  /** ISO 8601 (UTC). When the member joined (membership creation). */
+  joinedAt: string
+}

--- a/packages/shared/src/validators/provider-invite.ts
+++ b/packages/shared/src/validators/provider-invite.ts
@@ -9,18 +9,30 @@ import { OPERATOR_ROLES } from '../enums'
 export const operatorRoleSchema = z.enum(OPERATOR_ROLES)
 export type OperatorRole = z.infer<typeof operatorRoleSchema>
 
-// Platform-admin mints a provider invite (#521 §7). Email is lowercased here so
-// the stored value and the verified-email compare at accept both use one form
-// (emails treated as opaque — no Gmail dot canonicalization).
+// Email is lowercased here so the stored value and the verified-email compare at
+// accept both use one form (emails treated as opaque — no Gmail dot
+// canonicalization). Shared by the platform-admin and operator-self invite paths.
+const inviteEmailSchema = z
+  .string()
+  .trim()
+  .min(1, 'Email is required')
+  .email('Must be a valid email')
+  .transform((value) => value.toLowerCase())
+
+// Platform-admin mints a provider invite (#521 §7).
 export const createProviderInviteSchema = z.object({
-  email: z
-    .string()
-    .trim()
-    .min(1, 'Email is required')
-    .email('Must be a valid email')
-    .transform((value) => value.toLowerCase()),
+  email: inviteEmailSchema,
   operatorId: z.string().trim().min(1, 'operatorId is required'),
   role: operatorRoleSchema,
 })
 
 export type CreateProviderInviteInput = z.infer<typeof createProviderInviteSchema>
+
+// #904: an operator OWNER self-invites staff. Email only — the operatorId comes
+// from the session and the role is hard-coded OPERATOR_STAFF in the service, so
+// the client can neither target another tenant nor escalate the grant.
+export const inviteStaffSchema = z.object({
+  email: inviteEmailSchema,
+})
+
+export type InviteStaffInput = z.infer<typeof inviteStaffSchema>

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -85,7 +85,8 @@
     "myBookings": "My Bookings",
     "documents": "Documents",
     "newBookings": "{count, plural, one {# new booking} other {# new bookings}}",
-    "settings": "Settings"
+    "settings": "Settings",
+    "team": "Team"
   },
   "acriss": {
     "MCAR": "Mini",
@@ -802,6 +803,44 @@
         "save": "Save changes",
         "saving": "Saving..."
       }
+    },
+    "team": {
+      "title": "Team",
+      "subtitle": "Invite staff and manage who can access your operator account.",
+      "invite": "Invite staff",
+      "inviteTitle": "Invite a staff member",
+      "inviteSubtitle": "They'll get access to your operator portal after accepting.",
+      "inviteSuccessTitle": "Invite created",
+      "inviteSuccessSubtitle": "Share this one-time link with your staff member. It expires in 7 days.",
+      "inviteUrlLabel": "Invite link",
+      "copy": "Copy link",
+      "copied": "Copied",
+      "done": "Done",
+      "staffNotice": "Only an owner can invite staff.",
+      "noOperatorContext": "This page manages a single operator's team. Use the admin portal to manage operators.",
+      "unknownName": "Unnamed",
+      "roleOwner": "Owner",
+      "roleStaff": "Staff",
+      "members": {
+        "title": "Members",
+        "empty": "No members yet.",
+        "joined": "Joined {date}"
+      },
+      "invites": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "expires": "Expires {date}",
+        "pending": "Pending"
+      },
+      "form": {
+        "email": "Email",
+        "emailPlaceholder": "staff@example.com",
+        "cancel": "Cancel",
+        "submit": "Send invite",
+        "submitting": "Sending..."
+      },
+      "loadError": "Couldn't load your team",
+      "retry": "Try again"
     }
   },
   "messaging": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -85,7 +85,8 @@
     "myBookings": "予約一覧",
     "documents": "書類",
     "newBookings": "新規予約 {count}件",
-    "settings": "設定"
+    "settings": "設定",
+    "team": "チーム"
   },
   "acriss": {
     "MCAR": "ミニ",
@@ -802,6 +803,44 @@
         "save": "変更を保存",
         "saving": "保存中..."
       }
+    },
+    "team": {
+      "title": "チーム",
+      "subtitle": "スタッフを招待し、事業者アカウントにアクセスできるメンバーを管理します。",
+      "invite": "スタッフを招待",
+      "inviteTitle": "スタッフを招待する",
+      "inviteSubtitle": "承認後、事業者ポータルにアクセスできるようになります。",
+      "inviteSuccessTitle": "招待を作成しました",
+      "inviteSuccessSubtitle": "このワンタイムリンクをスタッフに共有してください。7日間有効です。",
+      "inviteUrlLabel": "招待リンク",
+      "copy": "リンクをコピー",
+      "copied": "コピーしました",
+      "done": "完了",
+      "staffNotice": "スタッフを招待できるのはオーナーのみです。",
+      "noOperatorContext": "このページは単一の事業者のチームを管理します。事業者の管理は管理ポータルを使用してください。",
+      "unknownName": "名前未設定",
+      "roleOwner": "オーナー",
+      "roleStaff": "スタッフ",
+      "members": {
+        "title": "メンバー",
+        "empty": "メンバーはまだいません。",
+        "joined": "{date} に参加"
+      },
+      "invites": {
+        "title": "保留中の招待",
+        "empty": "保留中の招待はありません。",
+        "expires": "{date} に期限切れ",
+        "pending": "保留中"
+      },
+      "form": {
+        "email": "メールアドレス",
+        "emailPlaceholder": "staff@example.com",
+        "cancel": "キャンセル",
+        "submit": "招待を送信",
+        "submitting": "送信中..."
+      },
+      "loadError": "チームを読み込めませんでした",
+      "retry": "再試行"
     }
   },
   "messaging": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -85,7 +85,8 @@
     "myBookings": "我的预订",
     "documents": "证件",
     "newBookings": "{count} 个新订单",
-    "settings": "设置"
+    "settings": "设置",
+    "team": "团队"
   },
   "acriss": {
     "MCAR": "微型车",
@@ -802,6 +803,44 @@
         "save": "保存更改",
         "saving": "保存中..."
       }
+    },
+    "team": {
+      "title": "团队",
+      "subtitle": "邀请员工并管理可以访问您运营商账户的成员。",
+      "invite": "邀请员工",
+      "inviteTitle": "邀请员工",
+      "inviteSubtitle": "接受邀请后，他们将可以访问您的运营商门户。",
+      "inviteSuccessTitle": "邀请已创建",
+      "inviteSuccessSubtitle": "请将此一次性链接分享给您的员工。链接7天后失效。",
+      "inviteUrlLabel": "邀请链接",
+      "copy": "复制链接",
+      "copied": "已复制",
+      "done": "完成",
+      "staffNotice": "只有所有者才能邀请员工。",
+      "noOperatorContext": "此页面管理单个运营商的团队。请使用管理门户来管理运营商。",
+      "unknownName": "未命名",
+      "roleOwner": "所有者",
+      "roleStaff": "员工",
+      "members": {
+        "title": "成员",
+        "empty": "暂无成员。",
+        "joined": "加入于 {date}"
+      },
+      "invites": {
+        "title": "待处理邀请",
+        "empty": "暂无待处理邀请。",
+        "expires": "{date} 到期",
+        "pending": "待处理"
+      },
+      "form": {
+        "email": "邮箱",
+        "emailPlaceholder": "staff@example.com",
+        "cancel": "取消",
+        "submit": "发送邀请",
+        "submitting": "发送中..."
+      },
+      "loadError": "无法加载您的团队",
+      "retry": "重试"
     }
   },
   "messaging": {

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as LocaleVehiclesClassesSlugRouteImport } from './routes/$locale/
 import { Route as LocaleProviderInviteTokenRouteImport } from './routes/$locale/provider/invite/$token'
 import { Route as LocaleRenterBookingsNewRouteImport } from './routes/$locale/_renter/bookings/new'
 import { Route as LocaleRenterBookingsConfirmationRouteImport } from './routes/$locale/_renter/bookings/confirmation'
+import { Route as LocaleBusinessManageTeamRouteImport } from './routes/$locale/_business/manage/team'
 import { Route as LocaleBusinessManageSettingsRouteImport } from './routes/$locale/_business/manage/settings'
 import { Route as LocaleBusinessManageLocationsRouteImport } from './routes/$locale/_business/manage/locations'
 import { Route as LocaleBusinessManageInsuranceRouteImport } from './routes/$locale/_business/manage/insurance'
@@ -149,6 +150,12 @@ const LocaleRenterBookingsConfirmationRoute =
     path: '/confirmation',
     getParentRoute: () => LocaleRenterBookingsRoute,
   } as any)
+const LocaleBusinessManageTeamRoute =
+  LocaleBusinessManageTeamRouteImport.update({
+    id: '/manage/team',
+    path: '/manage/team',
+    getParentRoute: () => LocaleBusinessRoute,
+  } as any)
 const LocaleBusinessManageSettingsRoute =
   LocaleBusinessManageSettingsRouteImport.update({
     id: '/manage/settings',
@@ -235,6 +242,7 @@ export interface FileRoutesByFullPath {
   '/$locale/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/manage/locations': typeof LocaleBusinessManageLocationsRoute
   '/$locale/manage/settings': typeof LocaleBusinessManageSettingsRoute
+  '/$locale/manage/team': typeof LocaleBusinessManageTeamRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -264,6 +272,7 @@ export interface FileRoutesByTo {
   '/$locale/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/manage/locations': typeof LocaleBusinessManageLocationsRoute
   '/$locale/manage/settings': typeof LocaleBusinessManageSettingsRoute
+  '/$locale/manage/team': typeof LocaleBusinessManageTeamRoute
   '/$locale/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -299,6 +308,7 @@ export interface FileRoutesById {
   '/$locale/_business/manage/insurance': typeof LocaleBusinessManageInsuranceRoute
   '/$locale/_business/manage/locations': typeof LocaleBusinessManageLocationsRoute
   '/$locale/_business/manage/settings': typeof LocaleBusinessManageSettingsRoute
+  '/$locale/_business/manage/team': typeof LocaleBusinessManageTeamRoute
   '/$locale/_renter/bookings/confirmation': typeof LocaleRenterBookingsConfirmationRoute
   '/$locale/_renter/bookings/new': typeof LocaleRenterBookingsNewRoute
   '/$locale/provider/invite/$token': typeof LocaleProviderInviteTokenRoute
@@ -332,6 +342,7 @@ export interface FileRouteTypes {
     | '/$locale/manage/insurance'
     | '/$locale/manage/locations'
     | '/$locale/manage/settings'
+    | '/$locale/manage/team'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -361,6 +372,7 @@ export interface FileRouteTypes {
     | '/$locale/manage/insurance'
     | '/$locale/manage/locations'
     | '/$locale/manage/settings'
+    | '/$locale/manage/team'
     | '/$locale/bookings/confirmation'
     | '/$locale/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -395,6 +407,7 @@ export interface FileRouteTypes {
     | '/$locale/_business/manage/insurance'
     | '/$locale/_business/manage/locations'
     | '/$locale/_business/manage/settings'
+    | '/$locale/_business/manage/team'
     | '/$locale/_renter/bookings/confirmation'
     | '/$locale/_renter/bookings/new'
     | '/$locale/provider/invite/$token'
@@ -562,6 +575,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleRenterBookingsConfirmationRouteImport
       parentRoute: typeof LocaleRenterBookingsRoute
     }
+    '/$locale/_business/manage/team': {
+      id: '/$locale/_business/manage/team'
+      path: '/manage/team'
+      fullPath: '/$locale/manage/team'
+      preLoaderRoute: typeof LocaleBusinessManageTeamRouteImport
+      parentRoute: typeof LocaleBusinessRoute
+    }
     '/$locale/_business/manage/settings': {
       id: '/$locale/_business/manage/settings'
       path: '/manage/settings'
@@ -664,6 +684,7 @@ interface LocaleBusinessRouteChildren {
   LocaleBusinessManageInsuranceRoute: typeof LocaleBusinessManageInsuranceRoute
   LocaleBusinessManageLocationsRoute: typeof LocaleBusinessManageLocationsRoute
   LocaleBusinessManageSettingsRoute: typeof LocaleBusinessManageSettingsRoute
+  LocaleBusinessManageTeamRoute: typeof LocaleBusinessManageTeamRoute
   LocaleBusinessManageBookingsBookingIdRoute: typeof LocaleBusinessManageBookingsBookingIdRoute
   LocaleBusinessManageFleetVehicleIdRoute: typeof LocaleBusinessManageFleetVehicleIdRoute
   LocaleBusinessManageBookingsIndexRoute: typeof LocaleBusinessManageBookingsIndexRoute
@@ -678,6 +699,7 @@ const LocaleBusinessRouteChildren: LocaleBusinessRouteChildren = {
   LocaleBusinessManageInsuranceRoute: LocaleBusinessManageInsuranceRoute,
   LocaleBusinessManageLocationsRoute: LocaleBusinessManageLocationsRoute,
   LocaleBusinessManageSettingsRoute: LocaleBusinessManageSettingsRoute,
+  LocaleBusinessManageTeamRoute: LocaleBusinessManageTeamRoute,
   LocaleBusinessManageBookingsBookingIdRoute:
     LocaleBusinessManageBookingsBookingIdRoute,
   LocaleBusinessManageFleetVehicleIdRoute:

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -1,0 +1,101 @@
+import { Button } from '@/components/ui/button'
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorOwnerSession, isOperatorSession } from '@/vite/guards'
+import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
+import { TeamView } from '@/vite/operator-team/TeamView'
+import { teamInvitesQueryOptions, teamMembersQueryOptions } from '@/vite/operator-team/api'
+import { sessionQueryOptions } from '@/vite/session'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { UserPlus } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+// Operator self-service team management (#904). URL `/<locale>/manage/team` —
+// behind the `_business` guard. The loader prefetches the session + members +
+// pending invites (no FOUC); the component reads the same options via
+// useSuspenseQuery. Tenant scoping is server-side (the client names no
+// operatorId). Inviting is owner-only (isOperatorOwnerSession), mirroring the
+// API's requireOperatorOwnerWrite gate; staff and bypass roles see read-only.
+export const Route = createFileRoute('/$locale/_business/manage/team')({
+  loader: async ({ context }) => {
+    await Promise.all([
+      context.queryClient.ensureQueryData(sessionQueryOptions()),
+      context.queryClient.ensureQueryData(teamMembersQueryOptions()),
+      context.queryClient.ensureQueryData(teamInvitesQueryOptions()),
+    ])
+  },
+  pendingComponent: PageSkeleton,
+  errorComponent: OperatorTeamError,
+  component: OperatorTeamRoute,
+})
+
+export function OperatorTeamRoute() {
+  const t = useTranslations('business.team')
+  const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  const { data: members } = useSuspenseQuery(teamMembersQueryOptions())
+  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions())
+  const [inviteOpen, setInviteOpen] = useState(false)
+
+  // A bypass role (PLATFORM_ADMIN / legacy STAFF·ADMIN) carries no operatorId and
+  // has no single team to manage — it onboards operators via the admin portal.
+  const hasOperator = isOperatorSession(session)
+  // Inviting is owner-only; staff see the team read-only (API is the real gate).
+  const canInvite = isOperatorOwnerSession(session)
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
+            <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
+          </div>
+          {canInvite && (
+            <Button onClick={() => setInviteOpen(true)} className="shrink-0">
+              <UserPlus className="size-4" />
+              {t('invite')}
+            </Button>
+          )}
+        </header>
+
+        {hasOperator ? (
+          <>
+            {!canInvite && <p className="mb-6 text-sm text-muted-foreground">{t('staffNotice')}</p>}
+            <TeamView members={members} invites={invites} />
+          </>
+        ) : (
+          <p className="text-muted-foreground">{t('noOperatorContext')}</p>
+        )}
+
+        {canInvite && session && (
+          <InviteStaffDialog
+            open={inviteOpen}
+            onOpenChange={setInviteOpen}
+            csrfToken={session.csrfToken}
+          />
+        )}
+      </div>
+    </main>
+  )
+}
+
+function OperatorTeamError(_props: ErrorComponentProps) {
+  const t = useTranslations('business.team')
+  const router = useRouter()
+
+  return (
+    <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl py-20 text-center">
+        <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+        <button
+          type="button"
+          onClick={() => router.invalidate()}
+          className="mt-4 rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/packages/web/src/vite/nav/business-nav-items.ts
+++ b/packages/web/src/vite/nav/business-nav-items.ts
@@ -17,6 +17,7 @@ export const businessNavItems = [
   { to: '/$locale/manage/insurance', labelKey: 'insurance' },
   { to: '/$locale/manage/fees', labelKey: 'fees' },
   { to: '/$locale/manage/add-ons', labelKey: 'addOns' },
+  { to: '/$locale/manage/team', labelKey: 'team' },
   { to: '/$locale/manage/settings', labelKey: 'settings' },
 ] as const
 

--- a/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
+++ b/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
@@ -50,8 +50,14 @@ export function InviteStaffDialog({ open, onOpenChange, csrfToken }: InviteStaff
 
   const handleCopy = async () => {
     if (!created) return
-    await navigator.clipboard.writeText(created.inviteUrl)
-    setCopied(true)
+    try {
+      await navigator.clipboard.writeText(created.inviteUrl)
+      setCopied(true)
+    } catch {
+      // Clipboard can reject on an insecure context or denied permission. The URL
+      // stays visible in the readonly input as the fallback, so swallow rather
+      // than leave an unhandled rejection.
+    }
   }
 
   return (

--- a/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
+++ b/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
@@ -1,0 +1,123 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { TEAM_INVITES_QUERY_KEY, inviteStaff } from '@/vite/operator-team/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface InviteStaffDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  csrfToken: string
+}
+
+// #904: owner-only staff invite. On success the dialog does NOT close — it
+// reveals the one-time invite URL (the token is never persisted in cleartext and
+// no email is sent yet), so the owner copies it to share. The new pending row is
+// pulled in by invalidating the invites query. Closing resets both the mutation
+// and the local form/copy state so a prior reveal never lingers on reopen.
+export function InviteStaffDialog({ open, onOpenChange, csrfToken }: InviteStaffDialogProps) {
+  const t = useTranslations('business.team')
+  const queryClient = useQueryClient()
+  const [email, setEmail] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  const mutation = useMutation({
+    mutationFn: (value: string) => inviteStaff({ email: value }, csrfToken),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TEAM_INVITES_QUERY_KEY })
+    },
+  })
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      mutation.reset()
+      setEmail('')
+      setCopied(false)
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const created = mutation.data
+
+  const handleCopy = async () => {
+    if (!created) return
+    await navigator.clipboard.writeText(created.inviteUrl)
+    setCopied(true)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{created ? t('inviteSuccessTitle') : t('inviteTitle')}</DialogTitle>
+          <DialogDescription>
+            {created ? t('inviteSuccessSubtitle') : t('inviteSubtitle')}
+          </DialogDescription>
+        </DialogHeader>
+
+        {created ? (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="invite-url">{t('inviteUrlLabel')}</Label>
+              <Input
+                id="invite-url"
+                readOnly
+                value={created.inviteUrl}
+                onFocus={(e) => e.currentTarget.select()}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={handleCopy}>
+                {copied ? t('copied') : t('copy')}
+              </Button>
+              <Button type="button" onClick={() => handleOpenChange(false)}>
+                {t('done')}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              mutation.mutate(email.trim())
+            }}
+            className="space-y-4"
+          >
+            {mutation.error && (
+              <p className="px-1 text-sm text-destructive">{mutation.error.message}</p>
+            )}
+            <div className="space-y-1.5">
+              <Label htmlFor="invite-email">{t('form.email')}</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                required
+                autoComplete="off"
+                placeholder={t('form.emailPlaceholder')}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                {t('form.cancel')}
+              </Button>
+              <Button type="submit" disabled={mutation.isPending || email.trim().length === 0}>
+                {mutation.isPending ? t('form.submitting') : t('form.submit')}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/vite/operator-team/TeamView.tsx
+++ b/packages/web/src/vite/operator-team/TeamView.tsx
@@ -1,0 +1,82 @@
+import { Badge } from '@/components/ui/badge'
+import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
+import { useFormatter, useTranslations } from 'use-intl'
+
+interface TeamViewProps {
+  members: OperatorMemberData[]
+  invites: OperatorInviteData[]
+}
+
+// #904: read-only projection of the operator's team — active members and the
+// pending staff invites. Owner-only write affordances live on the route; this
+// component stays a pure render of the rows.
+export function TeamView({ members, invites }: TeamViewProps) {
+  const t = useTranslations('business.team')
+  const f = useFormatter()
+
+  return (
+    <div className="space-y-10">
+      <section aria-labelledby="team-members-heading">
+        <h2 id="team-members-heading" className="mb-3 text-xl font-semibold">
+          {t('members.title')}
+        </h2>
+        {members.length === 0 ? (
+          <p className="text-muted-foreground">{t('members.empty')}</p>
+        ) : (
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {members.map((m) => (
+              <li key={m.id} className="flex items-center justify-between gap-4 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{m.name ?? t('unknownName')}</p>
+                  <p className="truncate text-sm text-muted-foreground">{m.email ?? '—'}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-3">
+                  <Badge variant="secondary">{roleLabel(t, m.role)}</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    {t('members.joined', {
+                      date: f.dateTime(new Date(m.joinedAt), { dateStyle: 'medium' }),
+                    })}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-labelledby="team-invites-heading">
+        <h2 id="team-invites-heading" className="mb-3 text-xl font-semibold">
+          {t('invites.title')}
+        </h2>
+        {invites.length === 0 ? (
+          <p className="text-muted-foreground">{t('invites.empty')}</p>
+        ) : (
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {invites.map((i) => (
+              <li key={i.id} className="flex items-center justify-between gap-4 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{i.email}</p>
+                  <p className="truncate text-sm text-muted-foreground">
+                    {t('invites.expires', {
+                      date: f.dateTime(new Date(i.expiresAt), { dateStyle: 'medium' }),
+                    })}
+                  </p>
+                </div>
+                <Badge variant="outline" className="shrink-0">
+                  {t('invites.pending')}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function roleLabel(
+  t: ReturnType<typeof useTranslations>,
+  role: OperatorMemberData['role'],
+): string {
+  return role === 'OPERATOR_OWNER' ? t('roleOwner') : t('roleStaff')
+}

--- a/packages/web/src/vite/operator-team/api.ts
+++ b/packages/web/src/vite/operator-team/api.ts
@@ -1,0 +1,84 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import {
+  OPERATOR_MEMBERSHIP_STATUSES,
+  OPERATOR_ROLES,
+  PROVIDER_INVITE_STATUSES,
+} from '@kuruma/shared/enums'
+import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
+import type { InviteStaffInput } from '@kuruma/shared/validators/provider-invite'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// #904: operator self-service team page. Cookie-based and operator-scoped
+// server-side — the client names NO operatorId, so a cross-tenant read/write is
+// impossible by construction (the API derives the tenant from the session). The
+// invite POST threads the session CSRF token (global double-submit guard).
+
+// Network-seam validators pinned to the shared DTOs with `satisfies` so a field
+// drift fails to compile here, not silently at render.
+const inviteSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  role: z.enum(OPERATOR_ROLES),
+  status: z.enum(PROVIDER_INVITE_STATUSES),
+  expiresAt: z.string(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<OperatorInviteData>
+
+const memberSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  role: z.enum(OPERATOR_ROLES),
+  status: z.enum(OPERATOR_MEMBERSHIP_STATUSES),
+  joinedAt: z.string(),
+}) satisfies z.ZodType<OperatorMemberData>
+
+export const TEAM_INVITES_QUERY_KEY = ['operator-team', 'invites'] as const
+export const TEAM_MEMBERS_QUERY_KEY = ['operator-team', 'members'] as const
+
+export async function fetchTeamInvites(): Promise<OperatorInviteData[]> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, { credentials: 'include' })
+  return unwrap(res, inviteSchema.array())
+}
+
+export async function fetchTeamMembers(): Promise<OperatorMemberData[]> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/members`, { credentials: 'include' })
+  return unwrap(res, memberSchema.array())
+}
+
+export function teamInvitesQueryOptions() {
+  return queryOptions({ queryKey: TEAM_INVITES_QUERY_KEY, queryFn: fetchTeamInvites })
+}
+
+export function teamMembersQueryOptions() {
+  return queryOptions({ queryKey: TEAM_MEMBERS_QUERY_KEY, queryFn: fetchTeamMembers })
+}
+
+/** The one-time invite reveal: the URL embeds the token (never persisted in
+ *  cleartext), so the owner copies it to share. Mirrors the API response shape. */
+export interface CreatedInviteResult {
+  inviteUrl: string
+  expiresAt: string
+}
+
+const createdInviteSchema = z.object({
+  inviteUrl: z.string(),
+  expiresAt: z.string(),
+}) satisfies z.ZodType<CreatedInviteResult>
+
+// Cookie-authed POST — CSRF-gated, so the session token rides in the header.
+export async function inviteStaff(
+  input: InviteStaffInput,
+  csrfToken: string,
+): Promise<CreatedInviteResult> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify(input),
+  })
+  return unwrap(res, createdInviteSchema)
+}

--- a/packages/web/tests/vite/nav/business-nav-items.test.ts
+++ b/packages/web/tests/vite/nav/business-nav-items.test.ts
@@ -18,6 +18,7 @@ describe('businessNavItems', () => {
       '/$locale/manage/insurance',
       '/$locale/manage/fees',
       '/$locale/manage/add-ons',
+      '/$locale/manage/team',
       '/$locale/manage/settings',
     ])
   })

--- a/packages/web/tests/vite/operator-team-api.test.ts
+++ b/packages/web/tests/vite/operator-team-api.test.ts
@@ -1,0 +1,123 @@
+import { fetchTeamInvites, fetchTeamMembers, inviteStaff } from '@/vite/operator-team/api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('inviteStaff', () => {
+  it('POSTs the email with the CSRF header and returns the one-time share URL', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: {
+          inviteUrl: 'https://app/provider/invite/tok',
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await inviteStaff({ email: 'new@x.com' }, 'csrf-1')
+    expect(result).toEqual({
+      inviteUrl: 'https://app/provider/invite/tok',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    })
+
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/operators/me/invites')
+    expect(opts.method).toBe('POST')
+    expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
+    expect(opts.credentials).toBe('include')
+    expect(JSON.parse(opts.body as string)).toEqual({ email: 'new@x.com' })
+  })
+
+  it('throws on a CSRF rejection (403) so the dialog surfaces it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: 'CSRF token mismatch' }, 403)),
+    )
+    await expect(inviteStaff({ email: 'x@x.com' }, 'stale')).rejects.toThrow()
+  })
+})
+
+describe('fetchTeamMembers', () => {
+  it('parses the active members joined to name + email', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [
+            {
+              id: 'm1',
+              userId: 'u1',
+              name: 'Olive Owner',
+              email: 'owner@x.com',
+              role: 'OPERATOR_OWNER',
+              status: 'ACTIVE',
+              joinedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ),
+    )
+    const members = await fetchTeamMembers()
+    expect(members).toHaveLength(1)
+    expect(members[0]).toMatchObject({ userId: 'u1', name: 'Olive Owner', role: 'OPERATOR_OWNER' })
+  })
+
+  it('tolerates a null name/email (walk-in-style user) without throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [
+            {
+              id: 'm1',
+              userId: 'u1',
+              name: null,
+              email: null,
+              role: 'OPERATOR_STAFF',
+              status: 'ACTIVE',
+              joinedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ),
+    )
+    const members = await fetchTeamMembers()
+    expect(members[0]?.name).toBeNull()
+  })
+})
+
+describe('fetchTeamInvites', () => {
+  it('parses the pending invites', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          success: true,
+          data: [
+            {
+              id: 'i1',
+              email: 'pending@x.com',
+              role: 'OPERATOR_STAFF',
+              status: 'PENDING',
+              expiresAt: '2099-01-01T00:00:00.000Z',
+              createdAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ),
+    )
+    const invites = await fetchTeamInvites()
+    expect(invites[0]).toMatchObject({ email: 'pending@x.com', status: 'PENDING' })
+  })
+})


### PR DESCRIPTION
Part of #904 (epic #902 operator cold-start). **Slice 1 of 2** — invite + view team, no schema change. Slice 2 (revoke/deactivate + enum migration) follows; the epic stays open.

## What this enables
An operator **owner** invites staff and views their team entirely in-portal (Manage → Team), with **every write scoped to their own operatorId derived from the session** — no platform-admin, no DB/curl. The minted role is hard-coded `OPERATOR_STAFF` (no client-side role control → no privilege escalation). Reads admit any operator member; writes are owner-only.

## Design
- **Endpoints `/operators/me/*`** (session-scoped, no path id) — there is no foreign-id surface to scope-check or leak (IDOR designed out, not guarded).
- New `OperatorTeamService` wraps `ProviderInviteService.createInvite` (keeps token/TTL/audit single-sourced) and reuses `findActiveByOperator` + `UserRepository.findByIds` (batched, no N+1) for the member join.
- Hand-written projection DTOs (`OperatorInviteData`/`OperatorMemberData`) deliberately omit `tokenHash`/`invitedByUserId`; pinned two-sided (producer return type + web `satisfies z.ZodType<T>`).
- `requireOwnOperator` seals the absent-operatorId case (a PLATFORM_ADMIN clears `requireOperatorOwnerWrite`/`requireOperatorScope` but carries no tenant) → 403, never `listByOperator(undefined)`.
- Web invite POST threads the session CSRF token (global double-submit guard).

## Slice breakdown
- **API** — `ProviderInviteRepository.listByOperator` (InMemory + Drizzle, PENDING); `OperatorTeamService`; routes `POST/GET /operators/me/invites`, `GET /operators/me/members`; DI wiring.
- **Shared** — DTOs + `inviteStaffSchema` (email-only).
- **Web** — `/manage/team` page, `vite/operator-team/*` (api + TeamView + owner-only InviteStaffDialog with one-time URL reveal), nav item, i18n en/ja/zh.

## Tests
- Unit: repo (8), service (7), route (5) — mutation-resistant; negatives at every layer (staff→403, cross-tenant scope, absent-operatorId→403, role=OPERATOR_STAFF, no token/inviter leak).
- Web: api client (5) — CSRF header, parse, 403.
- E2E real-db: owner invites → success reveal + pending row appears + DB row scoped to own operator as OPERATOR_STAFF/PENDING (runs in CI `e2e-real-db`).
- Gates green: shared 581 · api 1581 · web 1006 · typechecks · `lint:boundaries` · i18n parity (1018 keys ×3) · db-drift.

## Reviews
code-reviewer + architect both **SHIP** (no CRITICAL/HIGH). Applied the one in-scope LOW (clipboard-reject guard). Two carry-forwards recorded on #904 for slice 2: defer the `(operatorId,email) WHERE status='PENDING'` unique index to slice 2 (revoke gives re-invite a natural resolution; membership unique index already prevents any double-grant), and guard `markAccepted` with `WHERE status='PENDING'` once revoke can race it.