### PR TITLE
refactor(web): gate search map at the render site too (#885 review follow-up)

### DIFF
--- a/packages/web/src/routes/$locale/search.tsx
+++ b/packages/web/src/routes/$locale/search.tsx
@@ -25,7 +25,8 @@ import { useTranslations } from 'use-intl'
 // the view toggle) link with only the fields they have, and `| undefined` keeps
 // validateSearch's undefined values assignable under exactOptionalPropertyTypes.
 // `class` keeps the repeatable string|string[] shape so it round-trips the URL.
-// `view` toggles the flat-map list against the slice-5 store grid (#458).
+// `view` toggles the flat-map list against the slice-5 store grid (#458), but only
+// when the search map flag is enabled (#885) — otherwise it's always the grid.
 interface StorefrontSearch {
   from?: string | undefined
   to?: string | undefined
@@ -51,8 +52,8 @@ function validateSearch(search: Record<string, unknown>): StorefrontSearch {
 
 // Renter search (#391, #458). Public — no auth. The form pushes wall-clock JST
 // date strings; without a valid range the loader returns null (the views render
-// the date prompt). `view=map` runs the cross-operator flat search (#458);
-// otherwise the slice-5 storefront grid. Only one of the two fetches runs.
+// the date prompt). `view=map` runs the cross-operator flat search (#458) when the
+// map flag is on (#885); otherwise the storefront grid. Only one fetch runs.
 export const Route = createFileRoute('/$locale/search')({
   validateSearch,
   // Seed a default range (next JST hour -> +3 days) when the renter arrives
@@ -177,7 +178,13 @@ export function StorefrontSearchRoute() {
           </div>
         )}
 
-        {data.view === 'map' ? (
+        {/* Defense in depth: the toggle is hidden and the loader collapses `view`
+            to 'stores' when the map is off, but gate the render too so the premium
+            map can never mount by accident (#885) — the no-leak guarantee lives at
+            the render site, not only in the loader. SearchMap still ships in the
+            bundle (static import, unreachable in beta); lazy-load only if a build
+            that strips it is ever required. */}
+        {isSearchMapEnabled() && data.view === 'map' ? (
           <SearchMap
             result={data.flat}
             anchor={mapAnchor}

--- a/packages/web/tests/vite/search/StorefrontSearchRoute.test.tsx
+++ b/packages/web/tests/vite/search/StorefrontSearchRoute.test.tsx
@@ -108,4 +108,15 @@ describe('StorefrontSearchRoute — search map gating (#885 Task 0)', () => {
     expect(screen.queryByTestId('store-grid')).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Map' })).toBeInTheDocument()
   })
+
+  it('map gated off + forced view=map (stale loader data): render stays on the store list', () => {
+    // Defense in depth: even if a future loader change leaked view='map' through with
+    // the flag off, the render-site guard keeps the premium map from mounting (#885).
+    state.mapEnabled = false
+    state.view = 'map'
+    renderRoute()
+
+    expect(screen.getByTestId('store-grid')).toBeInTheDocument()
+    expect(screen.queryByTestId('search-map')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Code-review follow-up to **#924** (already merged — gated the interactive search map behind `VITE_SEARCH_MAP_ENABLED` for beta).

## What

Co-locates the flag check on the **render branch** of the search route:

```diff
- {data.view === 'map' ? <SearchMap/> : <StoreGrid/>}
+ {isSearchMapEnabled() && data.view === 'map' ? <SearchMap/> : <StoreGrid/>}
```

## Why (review finding: defense in depth)

In #924 the no-leak guarantee rested on a single invariant in *another* function — the loader collapsing `view` to `'stores'` when the flag is off. The toggle was gated but the render site was not. If a future loader change ever returned `view: 'map'` directly (a new map entry point), the gated toggle would stay hidden yet the premium map would still mount. Moving the check to the render site makes the no-leak guarantee **structural** rather than provable-only-via-the-loader.

Also refreshes two pre-flag doc comments (`validateSearch` / `Route`) that still described the map as unconditional.

## Test

New render-guard case in `StorefrontSearchRoute.test.tsx`: flag off + forced `view='map'` (simulating stale loader data) asserts the **store list** renders, not the map. Mutation-resistant — it fails against the un-guarded `data.view === 'map'`.

- Web search suite: **94/94** (was 93; +1)
- `bun run --filter @kuruma/web typecheck`: **0**

refs #885

Learn: Defense in Depth (fail-safe gating)
A visibility/security gate enforced at only one layer holds only while a separate invariant elsewhere stays true; when that invariant silently changes, the feature leaks with no failing test. Heuristic: guard the dangerous render where it renders, not only where the data is shaped.