### PR TITLE
feat(api): audit-log operator preAuthHandoffUrl changes (#914)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -395,7 +395,9 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const adminRevenueService = new AdminRevenueService(paymentEventRepo, operatorRepo)
   const paymentAnomalyService = new PaymentAnomalyService(paymentAnomalyRepo)
   const vehicleDetailService = new VehicleDetailService(vehicleDetailRepo)
-  const operatorService = new OperatorService(operatorRepo)
+  const operatorService = new OperatorService(operatorRepo, (event) =>
+    console.info('[operator-audit] profile updated', event),
+  )
   // #407: the write-operator resolver is a pure policy function — sole-operator
   // inference is retired, so it no longer needs an operator lookup.
   const resolveWriteOperatorId: ResolveWriteOperatorId = (ctx, inputOperatorId) =>

--- a/packages/api/src/services/operator.ts
+++ b/packages/api/src/services/operator.ts
@@ -28,8 +28,32 @@ export function toOperatorProfile(op: Operator): OperatorProfile {
   return { id: op.id, name: op.name, slug: op.slug, preAuthHandoffUrl: op.preAuthHandoffUrl }
 }
 
+/**
+ * Structured audit of a change to an operator's renter-facing money-flow
+ * controls (#914). `preAuthHandoffUrl` is the pay-at-pickup handoff URL —
+ * owner-only to write (#903) — so each change records who/when and old->new.
+ * Mirrors {@link ProviderInviteAuditEvent}: an injected sink (never hardcoded)
+ * keeps the trail assertable in tests and swappable for a durable store later
+ * without touching the service.
+ */
+export interface OperatorProfileAuditEvent {
+  readonly type: 'OPERATOR_PROFILE_UPDATED'
+  readonly operatorId: string
+  readonly actorUserId: string
+  readonly field: 'preAuthHandoffUrl'
+  readonly oldValue: string | null
+  readonly newValue: string | null
+  readonly changedAt: Date
+}
+
+// index.ts wires a console-backed default.
+export type RecordOperatorProfileAudit = (event: OperatorProfileAuditEvent) => void
+
 export class OperatorService {
-  constructor(private readonly repo: OperatorRepository) {}
+  constructor(
+    private readonly repo: OperatorRepository,
+    private readonly recordAudit: RecordOperatorProfileAudit,
+  ) {}
 
   /**
    * Resolve an operator by id for the business portal (#387). An OPERATOR_*
@@ -110,6 +134,25 @@ export class OperatorService {
         : {}),
       updatedAt: new Date(),
     })
-    return updated ? toOperatorProfile(updated) : undefined
+    if (!updated) return undefined
+
+    // #914: trail the money-flow control change. The owner-gate above already
+    // ran; emit only when the value actually moved, so a no-op re-save stays
+    // silent (and a name-only patch carries no key, so it never emits).
+    if ('preAuthHandoffUrl' in input) {
+      const newValue = input.preAuthHandoffUrl ?? null
+      if (newValue !== existing.preAuthHandoffUrl) {
+        this.recordAudit({
+          type: 'OPERATOR_PROFILE_UPDATED',
+          operatorId: existing.id,
+          actorUserId: ctx.userId,
+          field: 'preAuthHandoffUrl',
+          oldValue: existing.preAuthHandoffUrl,
+          newValue,
+          changedAt: new Date(),
+        })
+      }
+    }
+    return toOperatorProfile(updated)
   }
 }

--- a/packages/api/tests/routes/operators.test.ts
+++ b/packages/api/tests/routes/operators.test.ts
@@ -25,7 +25,7 @@ function mountFor(role: UserRole, operatorId?: string) {
   const app = new Hono()
   setupGlobalHandlers(app)
   app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
-  app.route('/', createOperatorRoutes(new OperatorService(repo)))
+  app.route('/', createOperatorRoutes(new OperatorService(repo, () => {})))
   return app
 }
 
@@ -59,7 +59,7 @@ describe('GET /operators (list)', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = new Hono()
     setupGlobalHandlers(app)
-    app.route('/', createOperatorRoutes(new OperatorService(repo)))
+    app.route('/', createOperatorRoutes(new OperatorService(repo, () => {})))
     expect((await app.request('/operators')).status).toBe(401)
   })
 })
@@ -143,7 +143,7 @@ describe('GET /operators/by-slug/:slug', () => {
 describe('Operator routes — auth', () => {
   it('401 when unauthenticated', async () => {
     const app = new Hono()
-    app.route('/', createOperatorRoutes(new OperatorService(repo)))
+    app.route('/', createOperatorRoutes(new OperatorService(repo, () => {})))
     expect((await app.request(`/operators/${opA.id}`)).status).toBe(401)
   })
 })
@@ -228,7 +228,7 @@ describe('PATCH /operators/:id', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = new Hono()
     setupGlobalHandlers(app)
-    app.route('/', createOperatorRoutes(new OperatorService(repo)))
+    app.route('/', createOperatorRoutes(new OperatorService(repo, () => {})))
     expect((await patchReq(app, opA.id, { name: 'X' })).status).toBe(401)
   })
 })

--- a/packages/api/tests/services/operator.test.ts
+++ b/packages/api/tests/services/operator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { type CallerContext, ForbiddenError, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory'
-import { OperatorService } from '../../src/services/operator'
+import { type OperatorProfileAuditEvent, OperatorService } from '../../src/services/operator'
 
 const ownerCtx: CallerContext = {
   userId: 'u',
@@ -12,7 +12,9 @@ const ownerCtx: CallerContext = {
 
 function makeService() {
   const repo = new InMemoryOperatorRepository()
-  return { repo, service: new OperatorService(repo) }
+  const events: OperatorProfileAuditEvent[] = []
+  const service = new OperatorService(repo, (e) => events.push(e))
+  return { repo, service, events }
 }
 
 describe('InMemoryOperatorRepository.list', () => {
@@ -134,10 +136,10 @@ describe('InMemoryOperatorRepository.update', () => {
 
 describe('OperatorService.update', () => {
   async function seedOne(preAuthHandoffUrl: string | null = null) {
-    const { repo, service } = makeService()
+    const { repo, service, events } = makeService()
     const op = await repo.create({ name: 'Owner Co', slug: 'owner-co', preAuthHandoffUrl })
     const ctx: CallerContext = { ...ownerCtx, operatorId: op.id }
-    return { repo, service, op, ctx }
+    return { repo, service, events, op, ctx }
   }
 
   test('returns a projection (no createdAt/updatedAt) when an owner edits its name', async () => {
@@ -216,5 +218,80 @@ describe('OperatorService.update', () => {
   test('returns undefined for an unknown id', async () => {
     const { service } = await seedOne()
     expect(await service.update(SYSTEM_CONTEXT, 'unknown-id', { name: 'X' })).toBeUndefined()
+  })
+
+  test('an owner changing preAuthHandoffUrl emits one audit event (who/when/old→new)', async () => {
+    const { service, op, ctx, events } = await seedOne('https://old.example/pay')
+    await service.update(ctx, op.id, { preAuthHandoffUrl: 'https://new.example/pay' })
+    expect(events).toEqual([
+      {
+        type: 'OPERATOR_PROFILE_UPDATED',
+        operatorId: op.id,
+        actorUserId: ctx.userId,
+        field: 'preAuthHandoffUrl',
+        oldValue: 'https://old.example/pay',
+        newValue: 'https://new.example/pay',
+        changedAt: expect.any(Date),
+      },
+    ])
+  })
+
+  test('setting preAuthHandoffUrl for the first time (null → value) records oldValue: null', async () => {
+    const { service, op, ctx, events } = await seedOne(null)
+    await service.update(ctx, op.id, { preAuthHandoffUrl: 'https://pay.x/first' })
+    expect(events).toEqual([
+      {
+        type: 'OPERATOR_PROFILE_UPDATED',
+        operatorId: op.id,
+        actorUserId: ctx.userId,
+        field: 'preAuthHandoffUrl',
+        oldValue: null,
+        newValue: 'https://pay.x/first',
+        changedAt: expect.any(Date),
+      },
+    ])
+  })
+
+  test('clearing preAuthHandoffUrl to null emits an event capturing the prior value', async () => {
+    const { service, op, ctx, events } = await seedOne('https://old.example/pay')
+    await service.update(ctx, op.id, { preAuthHandoffUrl: null })
+    expect(events).toEqual([
+      {
+        type: 'OPERATOR_PROFILE_UPDATED',
+        operatorId: op.id,
+        actorUserId: ctx.userId,
+        field: 'preAuthHandoffUrl',
+        oldValue: 'https://old.example/pay',
+        newValue: null,
+        changedAt: expect.any(Date),
+      },
+    ])
+  })
+
+  test('re-saving the SAME preAuthHandoffUrl emits no event (compare-before-emit)', async () => {
+    const { service, op, ctx, events } = await seedOne('https://pay.x/h')
+    await service.update(ctx, op.id, { preAuthHandoffUrl: 'https://pay.x/h' })
+    expect(events).toEqual([])
+  })
+
+  test('a name-only patch emits no event even when a handoff URL is already set', async () => {
+    const { service, op, ctx, events } = await seedOne('https://pay.x/h')
+    await service.update(ctx, op.id, { name: 'Renamed Co' })
+    expect(events).toEqual([])
+  })
+
+  test('a cross-tenant handoff patch (404, owner-gate never reached) emits no event', async () => {
+    const { repo, service, events } = makeService()
+    const a = await repo.create({ name: 'A Co', slug: 'a-co', preAuthHandoffUrl: null })
+    const b = await repo.create({
+      name: 'B Co',
+      slug: 'b-co',
+      preAuthHandoffUrl: 'https://b.pay/h',
+    })
+    const ctxA: CallerContext = { ...ownerCtx, operatorId: a.id }
+    expect(
+      await service.update(ctxA, b.id, { preAuthHandoffUrl: 'https://hijack.example' }),
+    ).toBeUndefined()
+    expect(events).toEqual([])
   })
 })


### PR DESCRIPTION
## What
`preAuthHandoffUrl` is the renter-facing pay-at-pickup handoff URL. #903 made it owner-only to write but left **no trail of who changed it, when, or from what to what**. This adds that trail.

## Approach
A structured audit event emitted on change, mirroring the codebase's one existing audit pattern (`ProviderInviteAuditEvent` / `RecordProviderInviteAudit`): an **injected `RecordOperatorProfileAudit` sink**, console-backed at the composition root (`index.ts`).

**No DB table / migration** — YAGNI for beta (payments are built-but-off pre-contract). A durable `audit_log` table is the heavier path if/when audit needs to be queryable.

Event shape: `{ type: 'OPERATOR_PROFILE_UPDATED', operatorId, actorUserId, field, oldValue, newValue, changedAt }`.

Emit rules (in `OperatorService.update`):
- only after a **successful write**, behind the existing owner-write gate;
- only when the value **actually changed** (no-op re-saves stay silent);
- name-only patches (no key) emit nothing;
- cross-tenant 404s (resolved before the gate) emit nothing.

## Test plan
- `tests/services/operator.test.ts`: 6 new mutation-resistant cases — null→value, value→value, →null clear, no-op re-save, name-only, cross-tenant 404 — all exact-shape `toEqual` assertions.
- `@kuruma/api` typecheck exit 0 · `lint:boundaries` OK · full api suite **1586 passed**.

## Review
code-reviewer pass: **APPROVE**, no CRITICAL/HIGH. Verified old/new capture (no aliasing — in-memory `update` returns a fresh object like Drizzle `RETURNING`), emit ordering, and DIP adherence. Console-logging the URL is consistent with the provider-invite precedent (operator-owned infra, not PII/secret). Added the suggested `null → value` coverage.

Closes #914.

> Note: base is `develop` (not the GitHub default `main`), so `Closes #914` won't auto-close on merge — close #914 manually. Owner-merge (no \`--admin\`).