### PR TITLE
fix(web): key booking 403 docs prompt off the document-gate code

### DIFF
--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -10,10 +10,15 @@ import type { z } from 'zod'
 export class ApiError extends Error {
   readonly name = 'ApiError'
   readonly status: number
+  /** Machine-readable failure code from the envelope (`fail(c, …, { code })`),
+   *  when present. Lets callers distinguish same-status failures (e.g. a
+   *  document-gate 403 vs a plain authorization deny) without parsing messages. */
+  readonly code: string | undefined
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, code?: string) {
     super(message)
     this.status = status
+    this.code = code
   }
 }
 
@@ -57,7 +62,7 @@ export async function unwrap<T>(res: Response, schema?: z.ZodType<T>): Promise<T
   }))) as ApiResponse<T>
 
   if (!body.success) {
-    throw new ApiError(body.error ?? `HTTP ${res.status}`, res.status)
+    throw new ApiError(body.error ?? `HTTP ${res.status}`, res.status, body.code)
   }
 
   if (!schema) return body.data
@@ -74,6 +79,10 @@ export async function unwrap<T>(res: Response, schema?: z.ZodType<T>): Promise<T
 }
 
 export const OPERATOR_REQUIRED = 'OPERATOR_REQUIRED'
+
+/** Envelope `code` the booking API returns when the #459 document-verification
+ *  gate blocks a booking. Matches `documentVerificationGate` on the API side. */
+export const DOCUMENT_VERIFICATION_REQUIRED = 'DOCUMENT_VERIFICATION_REQUIRED'
 
 /**
  * Recognises the write-path "operator must be named" rejection: a 422 whose

--- a/packages/web/src/vite/reservation/PaymentStep.tsx
+++ b/packages/web/src/vite/reservation/PaymentStep.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { ApiError } from '@/lib/api-error'
+import { ApiError, DOCUMENT_VERIFICATION_REQUIRED } from '@/lib/api-error'
 import { type CreateBookingInput, createBooking } from '@/vite/bookings/api'
 import { useSession } from '@/vite/session'
 import { useMutation } from '@tanstack/react-query'
@@ -19,8 +19,9 @@ interface PaymentStepProps {
  * + idempotency key) and, on the CONFIRMED booking, routes to the confirmation
  * page. There is no online payment in this path (user decision): the renter pays
  * at pickup via the operator's pre-auth handoff link shown on confirmation. Errors
- * map the endpoint's real status union — 409 (vehicle just taken), 403 (document
- * verification, defensive: the gate is OFF for the demo, #511), else generic.
+ * map the endpoint's real status union — 409 (vehicle just taken), 403 *with the
+ * DOCUMENT_VERIFICATION_REQUIRED code* (the #459 gate, defensive: OFF by default),
+ * else generic.
  */
 export function PaymentStep({ locale, bookingInput, onBack }: PaymentStepProps) {
   const t = useTranslations('reservation')
@@ -57,7 +58,15 @@ export function PaymentStep({ locale, bookingInput, onBack }: PaymentStepProps) 
     // remedy for the renter: go back and pick another car.
     if (error instanceof ApiError && (error.status === 409 || error.status === 400))
       return t('payment.errorConflict')
-    if (error instanceof ApiError && error.status === 403) return t('payment.errorDocs')
+    // Only the document-gate 403 (#459) means "upload documents"; key off the
+    // machine code, not the bare status, so an unrelated 403 (e.g. an operator
+    // booking outside its scope) doesn't dead-end the renter on a docs prompt.
+    if (
+      error instanceof ApiError &&
+      error.status === 403 &&
+      error.code === DOCUMENT_VERIFICATION_REQUIRED
+    )
+      return t('payment.errorDocs')
     if (error instanceof ApiError && error.status === 401) return t('payment.errorAuth')
     return t('payment.errorGeneric')
   })()

--- a/packages/web/tests/lib/api-error.test.ts
+++ b/packages/web/tests/lib/api-error.test.ts
@@ -34,6 +34,31 @@ describe('unwrap', () => {
     const res = new Response('<html>502</html>', { status: 502 })
     await expect(unwrap(res)).rejects.toMatchObject({ status: 502 })
   })
+
+  it('carries the failure body `code` so callers can discriminate failures', async () => {
+    // The document-gate 403 and an operator-scope 403 share a status; only the
+    // machine-readable `code` distinguishes "upload documents" from a plain deny.
+    const res = jsonResponse(
+      {
+        success: false,
+        error: 'An approved International Driving Permit is required to book.',
+        code: 'DOCUMENT_VERIFICATION_REQUIRED',
+      },
+      403,
+    )
+    const err = (await unwrap(res).catch((e) => e)) as ApiError
+    expect(err).toBeInstanceOf(ApiError)
+    expect(err.status).toBe(403)
+    expect(err.code).toBe('DOCUMENT_VERIFICATION_REQUIRED')
+  })
+
+  it('leaves `code` undefined when the failure body carries none', async () => {
+    const err = (await unwrap(jsonResponse({ success: false, error: 'nope' }, 403)).catch(
+      (e) => e,
+    )) as ApiError
+    expect(err).toBeInstanceOf(ApiError)
+    expect(err.code).toBeUndefined()
+  })
 })
 
 describe('unwrap with a Zod schema', () => {

--- a/packages/web/tests/vite/reservation/PaymentStep.test.tsx
+++ b/packages/web/tests/vite/reservation/PaymentStep.test.tsx
@@ -137,6 +137,46 @@ describe('PaymentStep (instant-book submit, #511)', () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
+  it('shows the upload-documents message only for a 403 carrying DOCUMENT_VERIFICATION_REQUIRED', async () => {
+    mockCreateBooking.mockRejectedValue(
+      new ApiError(
+        'An approved International Driving Permit is required to book.',
+        403,
+        'DOCUMENT_VERIFICATION_REQUIRED',
+      ),
+    )
+    const user = userEvent.setup()
+    renderStep()
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Reserve now' }))
+
+    expect(
+      await screen.findByText(
+        'Document verification is required before you can book. Please upload your documents first.',
+      ),
+    ).toBeInTheDocument()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('routes an unrelated 403 (no document code) to the generic message, not the docs prompt', async () => {
+    // e.g. an operator-scope deny: same status, but the renter has no documents
+    // to upload — telling them to "upload documents" would be a dead end.
+    mockCreateBooking.mockRejectedValue(
+      new ApiError('Cannot book for a renter outside your customers', 403),
+    )
+    const user = userEvent.setup()
+    renderStep()
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Reserve now' }))
+
+    expect(
+      await screen.findByText("We couldn't create your booking. Please review and try again."),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/upload your documents first/)).not.toBeInTheDocument()
+  })
+
   it('calls onBack when the back button is pressed', async () => {
     const { onBack } = renderStep()
     await userEvent.setup().click(screen.getByRole('button', { name: 'Back' }))

--- a/packages/web/tests/vite/reservation/PaymentStep.test.tsx
+++ b/packages/web/tests/vite/reservation/PaymentStep.test.tsx
@@ -177,6 +177,22 @@ describe('PaymentStep (instant-book submit, #511)', () => {
     expect(screen.queryByText(/upload your documents first/)).not.toBeInTheDocument()
   })
 
+  it('routes a 403 carrying a DIFFERENT code to the generic message, not the docs prompt', async () => {
+    // Pins the check to `=== DOCUMENT_VERIFICATION_REQUIRED`, not merely "a code
+    // is present": some other coded 403 must still fall through to generic.
+    mockCreateBooking.mockRejectedValue(new ApiError('forbidden', 403, 'SOME_OTHER_CODE'))
+    const user = userEvent.setup()
+    renderStep()
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Reserve now' }))
+
+    expect(
+      await screen.findByText("We couldn't create your booking. Please review and try again."),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/upload your documents first/)).not.toBeInTheDocument()
+  })
+
   it('calls onBack when the back button is pressed', async () => {
     const { onBack } = renderStep()
     await userEvent.setup().click(screen.getByRole('button', { name: 'Back' }))


### PR DESCRIPTION
## What
On the renter booking flow (`PaymentStep`, step 5), **any** 403 from `POST /bookings` showed *"Document verification is required… Please upload your documents first."* — including an operator-scope deny that no document upload can resolve.

## Why it was wrong
The booking API returns two distinct 403s:
1. the #459 document gate — `code: DOCUMENT_VERIFICATION_REQUIRED`
2. an operator booking outside its customer scope — no code

`ApiError` discarded the envelope `code` (`unwrap`), so the web couldn't tell them apart and keyed off bare `status === 403`.

## Change
- `ApiError` carries `code`; `unwrap` propagates `body.code` (the wire already sent it via `fail(c, …, { code })`).
- `PaymentStep` shows `errorDocs` only for `DOCUMENT_VERIFICATION_REQUIRED`; other 403s fall through to the generic message.
- New `DOCUMENT_VERIFICATION_REQUIRED` constant mirrors the existing `OPERATOR_REQUIRED` pattern.

## Tests (TDD, RED→GREEN)
- `api-error.test.ts`: ApiError carries body `code`; `undefined` when absent.
- `PaymentStep.test.tsx`: doc-code 403 → docs prompt; unrelated 403 → generic (not docs).

## Verification
- `@kuruma/web` test: **1020 passed**
- `@kuruma/web` typecheck: clean · biome: clean · pre-commit (size/boundaries/tsc web+api): clean

Closes #931. Context: surfaced while diagnosing the beta document-gate config issue. Follow-up #932 (operator approval UI) is separate, not beta-blocking.