### PR TITLE
refactor(api): inject resolveOperatorRecipients into NotificationDispatcher (ISP) (#889)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -69,6 +69,7 @@ import { NotificationService } from './services/notification'
 import { NotificationDispatcher } from './services/notification-dispatcher'
 import { OperatorService } from './services/operator'
 import { createOperatorGrantService } from './services/operator-grant'
+import { makeResolveOperatorRecipients } from './services/operator-recipients'
 import { OperatorTeamService } from './services/operator-team'
 import { OverviewService } from './services/overview'
 import { PaymentAnomalyService } from './services/payment-anomaly'
@@ -337,12 +338,16 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const staffUserId = process.env.DEFAULT_STAFF_ID
   // Single post-commit seam (#393): thread autocreate (#335) + outbound
   // notifications, awaited in the service, each caught-and-logged.
+  const resolveOperatorRecipients = makeResolveOperatorRecipients({
+    membershipRepo: operatorMembershipRepo,
+    userRepo,
+  })
   const notificationDispatcher = new NotificationDispatcher(
     notificationLogRepo,
     operatorRepo,
     vehicleRepo,
     userRepo,
-    operatorMembershipRepo,
+    resolveOperatorRecipients,
     locationRepo,
     emailSender,
     {

--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -3,7 +3,6 @@ import {
   type LocationRepository,
   MAX_NOTIFICATION_ATTEMPTS,
   type NotificationLogRepository,
-  type OperatorMembershipRepository,
   type OperatorRepository,
   type UserRepository,
   type VehicleRepository,
@@ -15,6 +14,7 @@ import { renderRenterCancellation } from './email/templates/renter-cancellation'
 import { renderRenterConfirmation } from './email/templates/renter-confirmation'
 import { renderRenterStatusUpdate } from './email/templates/renter-status-update'
 import { renderRenterSubstitution } from './email/templates/renter-substitution'
+import type { ResolveOperatorRecipients } from './operator-recipients'
 
 type Kind = NotificationLog['kind']
 
@@ -89,7 +89,10 @@ export class NotificationDispatcher {
     private readonly operatorRepo: OperatorRepository,
     private readonly vehicleRepo: VehicleRepository,
     private readonly userRepo: UserRepository,
-    private readonly membershipRepo: OperatorMembershipRepository,
+    // #889: the operator-alert recipient set, injected as a single function so the
+    // dispatcher no longer depends on the membership ledger (ISP). Wired in the
+    // composition root from membershipRepo + userRepo via makeResolveOperatorRecipients.
+    private readonly resolveOperatorRecipients: ResolveOperatorRecipients,
     private readonly locationRepo: LocationRepository,
     private readonly emailSender: EmailSender,
     private readonly config: NotificationDispatcherConfig,
@@ -180,7 +183,7 @@ export class NotificationDispatcher {
     }
     // OPERATOR_BOOKING_ALERT (#878) — every ACTIVE member (owner + staff) of the
     // operator, sourced from the grant ledger so a revoked member never lingers.
-    const members = await this.resolveActiveMemberEmails(booking.operatorId)
+    const members = await this.resolveOperatorRecipients(booking.operatorId)
     if (members.length > 0) {
       // Bcc all members; `to` is the platform `from` (send-to-self) so no member's
       // address is disclosed to the others. The audit recipient is the full list.
@@ -195,24 +198,6 @@ export class NotificationDispatcher {
     const fallback = this.config.fallbackOperatorEmail
     if (!fallback) return undefined
     return { to: fallback, recipient: fallback, locale: DEFAULT_OPERATOR_LOCALE }
-  }
-
-  /**
-   * #878: the operator's active-member email set. Memberships are the recipient
-   * source of truth; users.findByIds resolves the addresses and masks the
-   * synthetic placeholder email to null (a seeded placeholder owner is dropped,
-   * not emailed). findActiveByOperator returns a deterministic (createdAt, id)
-   * order, preserved through the flatMap so the joined audit string is stable.
-   */
-  private async resolveActiveMemberEmails(operatorId: string): Promise<string[]> {
-    const members = await this.membershipRepo.findActiveByOperator(operatorId)
-    if (members.length === 0) return []
-    const users = await this.userRepo.findByIds(members.map((m) => m.userId))
-    const emailByUserId = new Map(users.map((u) => [u.id, u.email]))
-    return members.flatMap((m) => {
-      const email = emailByUserId.get(m.userId)
-      return email ? [email] : []
-    })
   }
 
   private async buildMessage(booking: Booking, kind: Kind, resolved: Resolved) {

--- a/packages/api/src/services/operator-recipients.ts
+++ b/packages/api/src/services/operator-recipients.ts
@@ -1,0 +1,37 @@
+import type { OperatorMembershipRepository, UserRepository } from '../repositories/types'
+
+/**
+ * Resolves the email recipient set for an operator alert (#878): every ACTIVE
+ * member of the operator. Injected into the NotificationDispatcher as a single
+ * function so the send pipeline never depends on the membership ledger directly
+ * (ISP — the dispatcher used the whole membership repo for one query). The
+ * concrete wiring lives in the composition root; this seam is testable alone.
+ */
+export type ResolveOperatorRecipients = (operatorId: string) => Promise<string[]>
+
+/**
+ * Builds the recipient resolver from its two data sources. Memberships are the
+ * source of truth; users.findByIds resolves the addresses and masks a synthetic
+ * placeholder email to null (a seeded placeholder owner is dropped, not emailed).
+ * findActiveByOperator returns a deterministic (createdAt, id) order, preserved
+ * through the flatMap so the joined audit string is stable across resends.
+ *
+ * Deps are narrowed with `Pick` to exactly the queries used — neither full repo
+ * is pulled in, which is the point of extracting the seam.
+ */
+export function makeResolveOperatorRecipients(deps: {
+  membershipRepo: Pick<OperatorMembershipRepository, 'findActiveByOperator'>
+  userRepo: Pick<UserRepository, 'findByIds'>
+}): ResolveOperatorRecipients {
+  const { membershipRepo, userRepo } = deps
+  return async (operatorId) => {
+    const members = await membershipRepo.findActiveByOperator(operatorId)
+    if (members.length === 0) return []
+    const users = await userRepo.findByIds(members.map((m) => m.userId))
+    const emailByUserId = new Map(users.map((u) => [u.id, u.email]))
+    return members.flatMap((m) => {
+      const email = emailByUserId.get(m.userId)
+      return email ? [email] : []
+    })
+  }
+}

--- a/packages/api/tests/integration/booking-created-notifications.test.ts
+++ b/packages/api/tests/integration/booking-created-notifications.test.ts
@@ -24,6 +24,7 @@ import { BookingService } from '../../src/services/booking'
 import { BookingPostCommitDispatcher } from '../../src/services/booking-post-commit-dispatcher'
 import type { EmailSender } from '../../src/services/email/email-sender'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
 import {
   cleanupLocations,
   cleanupUsers,
@@ -73,7 +74,7 @@ const notificationDispatcher = new NotificationDispatcher(
   operatorRepo,
   vehicleRepo,
   userRepo,
-  membershipRepo,
+  makeResolveOperatorRecipients({ membershipRepo, userRepo }),
   locationRepo,
   fakeEmailSender,
   { emailFrom: 'noreply@kuruma-test.com' },

--- a/packages/api/tests/integration/booking-substitution.test.ts
+++ b/packages/api/tests/integration/booking-substitution.test.ts
@@ -19,6 +19,7 @@ import { BookingService } from '../../src/services/booking'
 import { BookingPostCommitDispatcher } from '../../src/services/booking-post-commit-dispatcher'
 import type { EmailSender } from '../../src/services/email/email-sender'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
 import { bookingInput } from '../helpers/booking'
 import {
   cleanupLocations,
@@ -69,7 +70,7 @@ const notificationDispatcher = new NotificationDispatcher(
   operatorRepo,
   vehicleRepo,
   userRepo,
-  membershipRepo,
+  makeResolveOperatorRecipients({ membershipRepo, userRepo }),
   locationRepo,
   fakeEmailSender,
   { emailFrom: 'noreply@kuruma-test.com' },

--- a/packages/api/tests/routes/notifications.test.ts
+++ b/packages/api/tests/routes/notifications.test.ts
@@ -11,6 +11,7 @@ import { createNotificationRoutes } from '../../src/routes/notifications'
 import type { EmailSender } from '../../src/services/email/email-sender'
 import { NotificationService } from '../../src/services/notification'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
 import type { Booking, NotificationLog } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 import { makeBooking as makeBookingFixture } from '../helpers/booking'
@@ -126,34 +127,37 @@ async function setup() {
     userRepo,
     // #878: the operator alert resolves recipients from the membership ledger —
     // seed each operator's owner as an ACTIVE member so the seeded alert rows land.
-    new InMemoryOperatorMembershipRepository(
-      new Map([
-        [
-          'mem-a',
-          {
-            id: 'mem-a',
-            userId: 'owner-a',
-            operatorId: OP_A,
-            role: 'OPERATOR_OWNER' as const,
-            status: 'ACTIVE' as const,
-            createdAt: NOW,
-            updatedAt: NOW,
-          },
-        ],
-        [
-          'mem-b',
-          {
-            id: 'mem-b',
-            userId: 'owner-b',
-            operatorId: OP_B,
-            role: 'OPERATOR_OWNER' as const,
-            status: 'ACTIVE' as const,
-            createdAt: NOW,
-            updatedAt: NOW,
-          },
-        ],
-      ]),
-    ),
+    makeResolveOperatorRecipients({
+      userRepo,
+      membershipRepo: new InMemoryOperatorMembershipRepository(
+        new Map([
+          [
+            'mem-a',
+            {
+              id: 'mem-a',
+              userId: 'owner-a',
+              operatorId: OP_A,
+              role: 'OPERATOR_OWNER' as const,
+              status: 'ACTIVE' as const,
+              createdAt: NOW,
+              updatedAt: NOW,
+            },
+          ],
+          [
+            'mem-b',
+            {
+              id: 'mem-b',
+              userId: 'owner-b',
+              operatorId: OP_B,
+              role: 'OPERATOR_OWNER' as const,
+              status: 'ACTIVE' as const,
+              createdAt: NOW,
+              updatedAt: NOW,
+            },
+          ],
+        ]),
+      ),
+    }),
     fakeLocationRepo,
     sender,
     { emailFrom: 'noreply@kuruma.jp' },

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -12,6 +12,7 @@ import {
   NotificationDispatcher,
   TRIGGER_KINDS,
 } from '../../src/services/notification-dispatcher'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
 import type { Booking, OperatorMembership, User } from '../../src/stores'
 import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
@@ -137,7 +138,7 @@ function build(
     operatorRepo,
     fakeVehicleRepo,
     userRepo,
-    membershipRepo,
+    makeResolveOperatorRecipients({ membershipRepo, userRepo }),
     fakeLocationRepo,
     sender,
     {

--- a/packages/api/tests/services/notification-service.test.ts
+++ b/packages/api/tests/services/notification-service.test.ts
@@ -13,6 +13,7 @@ import {
 import type { EmailSender } from '../../src/services/email/email-sender'
 import { NotificationService } from '../../src/services/notification'
 import { NotificationDispatcher } from '../../src/services/notification-dispatcher'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
 import type { Booking, User } from '../../src/stores'
 import { makeBooking as makeBookingFixture } from '../helpers/booking'
 
@@ -132,7 +133,7 @@ function build(sender?: EmailSender) {
     operatorRepo,
     fakeVehicleRepo,
     userRepo,
-    membershipRepo,
+    makeResolveOperatorRecipients({ membershipRepo, userRepo }),
     fakeLocationRepo,
     okSender,
     { emailFrom: 'noreply@bcr.jp' },

--- a/packages/api/tests/services/operator-recipients.test.ts
+++ b/packages/api/tests/services/operator-recipients.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
+import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
+import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
+import type { OperatorMembership, User } from '../../src/stores'
+
+const OP = 'op-1'
+
+function user(id: string, email: string | null): User {
+  return {
+    id,
+    name: id,
+    email,
+    phone: null,
+    language: 'ja',
+    country: null,
+    role: 'OPERATOR_STAFF',
+    operatorId: OP,
+  }
+}
+
+function member(id: string, userId: string, createdAt: Date): OperatorMembership {
+  return {
+    id,
+    userId,
+    operatorId: OP,
+    role: 'OPERATOR_STAFF',
+    status: 'ACTIVE',
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+function build(members: OperatorMembership[], users: User[]) {
+  const membershipRepo = new InMemoryOperatorMembershipRepository(
+    new Map(members.map((m) => [m.id, m])),
+  )
+  const userRepo = new InMemoryUserRepository(new Map(users.map((u) => [u.id, u])))
+  return makeResolveOperatorRecipients({ membershipRepo, userRepo })
+}
+
+describe('makeResolveOperatorRecipients', () => {
+  it('returns active member emails in (createdAt, id) order — not membership insertion order', async () => {
+    // Insert the later member FIRST so a pass-through of Map order would put it first;
+    // the factory must defer to the repo's (createdAt, id) sort instead.
+    const late = member('mem-late', 'u-late', new Date('2026-01-02T00:00:00Z'))
+    const early = member('mem-early', 'u-early', new Date('2026-01-01T00:00:00Z'))
+    const resolve = build(
+      [late, early],
+      [user('u-late', 'late@op.com'), user('u-early', 'early@op.com')],
+    )
+
+    expect(await resolve(OP)).toEqual(['early@op.com', 'late@op.com'])
+  })
+
+  it('drops a member whose user email is masked to null (placeholder owner not emailed)', async () => {
+    const real = member('mem-real', 'u-real', new Date('2026-01-01T00:00:00Z'))
+    const placeholder = member('mem-ph', 'u-ph', new Date('2026-01-02T00:00:00Z'))
+    const resolve = build([real, placeholder], [user('u-real', 'real@op.com'), user('u-ph', null)])
+
+    expect(await resolve(OP)).toEqual(['real@op.com'])
+  })
+
+  it('returns an empty list when the operator has no active members', async () => {
+    const resolve = build([], [user('u-real', 'real@op.com')])
+
+    expect(await resolve(OP)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #889.

## What
Extracts the operator-alert (#878) recipient resolution out of `NotificationDispatcher` and injects it as a single function, so the dispatcher no longer depends on the membership ledger to send mail. Its constructor drops `membershipRepo` (8 → 7 deps).

- **New** `services/operator-recipients.ts` — `type ResolveOperatorRecipients = (operatorId) => Promise<string[]>` + `makeResolveOperatorRecipients({ membershipRepo, userRepo })` factory. Deps are `Pick`-narrowed to exactly `findActiveByOperator` + `findByIds`.
- **Dispatcher** — `membershipRepo` ctor dep → injected `resolveOperatorRecipients` (in place at index 4, so `locationRepo` stays index 5); `resolveRecipient` calls it directly; private `resolveActiveMemberEmails` removed.
- **Composition root** (`index.ts`) wires the factory from `operatorMembershipRepo` + `userRepo`.

## Why
`ISP Violation` — the dispatcher pulled in the whole membership repo to call one query. Injecting the function drops a ctor dep and lets recipient policy be tested in isolation from the send pipeline. (Follow-up from #878 / PR #888 review.)

## Behavior
**No change.** Ordering by `(createdAt, id)`, placeholder-email masking (drop null emails), and the empty-list case are all preserved (logic moved verbatim).

## Tests
- New isolated `tests/services/operator-recipients.test.ts` — order (insert-late-first to kill insertion-order mutant), masking, empty case; exact assertions on real InMemory repos.
- 5 existing dispatcher construction sites rewired through the factory; assertions unchanged.

## Verification (local)
- `tsc --noEmit` (api + web), biome lint, `lint:boundaries` — all green
- api unit suite: **1590 passed**
- real-pg integration (`booking-created-notifications`, `booking-substitution`) green on a clean migrated DB

Reviewed by code-reviewer agent: ship, no CRITICAL/HIGH/MEDIUM.