### PR TITLE
refactor(shared): boundFetch primitive — import safety, don't bind per-site (#893)

### DIFF
--- a/packages/api/src/services/email/resend-email-sender.ts
+++ b/packages/api/src/services/email/resend-email-sender.ts
@@ -1,3 +1,5 @@
+import { boundFetch } from '@kuruma/shared/lib/bound-fetch'
+
 import type { EmailMessage, EmailSender, SendResult } from './email-sender'
 
 const ENDPOINT = 'https://api.resend.com/emails'
@@ -22,9 +24,9 @@ export class ResendEmailSender implements EmailSender {
   constructor(
     private readonly apiKey: string,
     private readonly defaultFrom: string,
-    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
-    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
-    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
+    // boundFetch keeps this === globalThis when called detached as this.fetchFn;
+    // a bare global fetch throws "Illegal invocation" on CF Workers (#887/#893).
+    private readonly fetchFn: typeof fetch = boundFetch,
   ) {}
 
   async send(message: EmailMessage): Promise<SendResult> {

--- a/packages/api/src/services/geocoding/nominatim-geocoder.ts
+++ b/packages/api/src/services/geocoding/nominatim-geocoder.ts
@@ -1,3 +1,5 @@
+import { boundFetch } from '@kuruma/shared/lib/bound-fetch'
+
 import type { GeocodeOutcome, Geocoder } from './types'
 
 // A provider miss/error is un-geocodable as far as this adapter knows — retrying
@@ -26,9 +28,9 @@ export class NominatimGeocoder implements Geocoder {
   constructor(
     private readonly baseUrl: string,
     private readonly userAgent: string,
-    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
-    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
-    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
+    // boundFetch keeps this === globalThis when called detached as this.fetchFn;
+    // a bare global fetch throws "Illegal invocation" on CF Workers (#887/#893).
+    private readonly fetchFn: typeof fetch = boundFetch,
     // Optional auth token. LocationIQ is Nominatim-compatible but key-gated via
     // `?key=` (#574), so providing one makes it a pure env-var swap from public OSM.
     private readonly apiKey?: string,

--- a/packages/api/src/services/google-translation-provider.ts
+++ b/packages/api/src/services/google-translation-provider.ts
@@ -1,3 +1,5 @@
+import { boundFetch } from '@kuruma/shared/lib/bound-fetch'
+
 import type { TranslationProvider } from './translation-provider'
 
 const ENDPOINT = 'https://translation.googleapis.com/language/translate/v2'
@@ -22,9 +24,9 @@ interface GoogleResponse {
 export class GoogleTranslationProvider implements TranslationProvider {
   constructor(
     private readonly apiKey: string,
-    // Bound to globalThis: CF Workers' global fetch is a branded builtin that
-    // throws "Illegal invocation" if called detached (here, as this.fetchFn). #887
-    private readonly fetchFn: typeof fetch = fetch.bind(globalThis),
+    // boundFetch keeps this === globalThis when called detached as this.fetchFn;
+    // a bare global fetch throws "Illegal invocation" on CF Workers (#887/#893).
+    private readonly fetchFn: typeof fetch = boundFetch,
   ) {}
 
   async translate(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,6 +32,7 @@
     "./types/insurance-option": "./src/types/insurance-option.ts",
     "./types/storefront": "./src/types/storefront.ts",
     "./types/operator-team": "./src/types/operator-team.ts",
+    "./lib/bound-fetch": "./src/lib/bound-fetch.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/commission": "./src/lib/commission.ts",
     "./lib/admin-revenue": "./src/lib/admin-revenue.ts",

--- a/packages/shared/src/lib/bound-fetch.ts
+++ b/packages/shared/src/lib/bound-fetch.ts
@@ -1,0 +1,20 @@
+/**
+ * A `fetch` you can hand around safely.
+ *
+ * On the Cloudflare Workers/Pages runtime the global `fetch` is a branded builtin
+ * that must be called with `this === globalThis`. Captured detached — stored as a
+ * field/param and later invoked as `this.fetchFn(...)` (this = the instance) — it
+ * throws "Illegal invocation" and the call silently FAILS. Node/vitest don't brand
+ * `fetch`, so the bug is invisible in CI and only bites the live runtime. It bit
+ * four sites at once, silently killing every outbound email (#887).
+ *
+ * Import this instead of writing `fetch.bind(globalThis)` per call site: the safety
+ * is the default, not something each caller must remember. Injectable `fetchFn`
+ * params default to `boundFetch`; tests still pass their own mock to override it.
+ *
+ * It is a thin wrapper (not an eager `fetch.bind`) so it reads the *current* global
+ * `fetch` on each call — `apply(globalThis, …)` fixes the `this` — which keeps it
+ * stubbable in tests (`vi.stubGlobal('fetch', …)`) while staying Workers-correct.
+ */
+export const boundFetch: typeof fetch = ((...args: Parameters<typeof fetch>) =>
+  fetch.apply(globalThis, args)) as typeof fetch

--- a/packages/shared/tests/lib/bound-fetch.test.ts
+++ b/packages/shared/tests/lib/bound-fetch.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { boundFetch } from '../../src/lib/bound-fetch'
 
 describe('boundFetch', () => {
-  it('calls the global fetch with this === globalThis even when invoked detached (#887/#893)', async () => {
+  it('invokes the global fetch with this === globalThis even when called detached (#887/#893)', async () => {
     // CF Workers' global fetch is a branded builtin that throws "Illegal invocation"
-    // unless called with this === globalThis. Node/vitest don't brand it, so simulate
-    // the brand and prove boundFetch survives a DETACHED call (this = some other object)
-    // — the prod failure mode that silently killed every email/geocode/translate (#887).
+    // unless called with this === globalThis. Node/vitest don't brand it, so capture
+    // the `this` the wrapper forwards and assert it directly — the brand survival is
+    // the load-bearing assertion, not an incidental network failure on the mutant.
+    let observedThis: unknown = 'unset'
     const brandedFetch = async function (this: unknown): Promise<Response> {
+      observedThis = this
       if (this !== globalThis) {
         throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
       }
@@ -17,9 +19,10 @@ describe('boundFetch', () => {
     vi.stubGlobal('fetch', brandedFetch)
     try {
       // Invoke detached: as a property of an unrelated object, so `this` is that object.
-      // A bare `= fetch` capture would call brandedFetch with this = holder and throw.
+      // A bare `= fetch` capture would forward this = holder (or miss the stub entirely).
       const holder = { fetchFn: boundFetch }
       const response = await holder.fetchFn('https://example.test')
+      expect(observedThis).toBe(globalThis)
       expect(await response.text()).toBe('ok')
     } finally {
       vi.unstubAllGlobals()

--- a/packages/shared/tests/lib/bound-fetch.test.ts
+++ b/packages/shared/tests/lib/bound-fetch.test.ts
@@ -3,38 +3,38 @@ import { describe, expect, it, vi } from 'vitest'
 import { boundFetch } from '../../src/lib/bound-fetch'
 
 describe('boundFetch', () => {
-  it('invokes the global fetch with this === globalThis even when called detached (#887/#893)', async () => {
+  it('forwards every call to the current global fetch with this === globalThis, even when detached (#887/#893)', async () => {
     // CF Workers' global fetch is a branded builtin that throws "Illegal invocation"
-    // unless called with this === globalThis. Node/vitest don't brand it, so capture
-    // the `this` the wrapper forwards and assert it directly — the brand survival is
-    // the load-bearing assertion, not an incidental network failure on the mutant.
+    // unless called with this === globalThis. Prove BOTH properties via assertions —
+    // never via a network side effect: boundFetch (a) reads the CURRENT global fetch,
+    // so a stub installed after module load is seen, and (b) calls it with
+    // this === globalThis even when boundFetch is itself invoked detached.
     let observedThis: unknown = 'unset'
-    const brandedFetch = async function (this: unknown): Promise<Response> {
+    const stub = vi.fn(async function (this: unknown): Promise<Response> {
       observedThis = this
-      if (this !== globalThis) {
-        throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
-      }
       return new Response('ok')
-    }
-    vi.stubGlobal('fetch', brandedFetch)
+    })
+    vi.stubGlobal('fetch', stub)
     try {
-      // Invoke detached: as a property of an unrelated object, so `this` is that object.
-      // A bare `= fetch` capture would forward this = holder (or miss the stub entirely).
+      // Detached: as a property of an unrelated object, so a bare `= fetch` (or an
+      // eager `fetch.bind`) — which snapshots the global at module load — never reaches
+      // `stub` and the call escapes to the network. Swallow that so the discriminator
+      // is the assertion (`stub` was hit), not a non-deterministic DNS error.
       const holder = { fetchFn: boundFetch }
-      const response = await holder.fetchFn('https://example.test')
+      await holder.fetchFn('https://example.test').catch(() => undefined)
+      expect(stub).toHaveBeenCalledTimes(1)
       expect(observedThis).toBe(globalThis)
-      expect(await response.text()).toBe('ok')
     } finally {
       vi.unstubAllGlobals()
     }
   })
 
   it('forwards arguments to and returns the result of the current global fetch', async () => {
-    const spy = vi.fn(async () => new Response('payload', { status: 201 }))
-    vi.stubGlobal('fetch', spy)
+    const stub = vi.fn(async () => new Response('payload', { status: 201 }))
+    vi.stubGlobal('fetch', stub)
     try {
       const response = await boundFetch('https://example.test/x', { method: 'POST' })
-      expect(spy).toHaveBeenCalledWith('https://example.test/x', { method: 'POST' })
+      expect(stub).toHaveBeenCalledWith('https://example.test/x', { method: 'POST' })
       expect(response.status).toBe(201)
     } finally {
       vi.unstubAllGlobals()

--- a/packages/shared/tests/lib/bound-fetch.test.ts
+++ b/packages/shared/tests/lib/bound-fetch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { boundFetch } from '../../src/lib/bound-fetch'
+
+describe('boundFetch', () => {
+  it('calls the global fetch with this === globalThis even when invoked detached (#887/#893)', async () => {
+    // CF Workers' global fetch is a branded builtin that throws "Illegal invocation"
+    // unless called with this === globalThis. Node/vitest don't brand it, so simulate
+    // the brand and prove boundFetch survives a DETACHED call (this = some other object)
+    // — the prod failure mode that silently killed every email/geocode/translate (#887).
+    const brandedFetch = async function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation: function called with incorrect 'this' reference")
+      }
+      return new Response('ok')
+    }
+    vi.stubGlobal('fetch', brandedFetch)
+    try {
+      // Invoke detached: as a property of an unrelated object, so `this` is that object.
+      // A bare `= fetch` capture would call brandedFetch with this = holder and throw.
+      const holder = { fetchFn: boundFetch }
+      const response = await holder.fetchFn('https://example.test')
+      expect(await response.text()).toBe('ok')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('forwards arguments to and returns the result of the current global fetch', async () => {
+    const spy = vi.fn(async () => new Response('payload', { status: 201 }))
+    vi.stubGlobal('fetch', spy)
+    try {
+      const response = await boundFetch('https://example.test/x', { method: 'POST' })
+      expect(spy).toHaveBeenCalledWith('https://example.test/x', { method: 'POST' })
+      expect(response.status).toBe(201)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/packages/web/functions/_shared/proxy.ts
+++ b/packages/web/functions/_shared/proxy.ts
@@ -1,3 +1,5 @@
+import { boundFetch } from '@kuruma/shared/lib/bound-fetch'
+
 // Shared logic for the CF Pages Functions proxy (#378 Slice 0, Phase 4). The
 // `_shared` dir is underscore-prefixed and exports no onRequest handler, so CF
 // Pages never routes it — it's a plain helper module imported by the route
@@ -59,10 +61,10 @@ export async function proxyRequest(
   request: Request,
   apiOrigin: string,
   stripPrefix: string,
-  // CF Pages runtime: the global fetch must be called with this===globalThis.
-  // Bound here for uniformity with the API services (#887) — the param stays
-  // injectable for tests.
-  fetchImpl: typeof fetch = fetch.bind(globalThis) as typeof fetch,
+  // CF Pages runs with global_fetch_strictly_public, so the global fetch must be
+  // called with this===globalThis or it throws "Illegal invocation". boundFetch
+  // guarantees that (#887/#893); the param stays injectable for tests.
+  fetchImpl: typeof fetch = boundFetch,
 ): Promise<Response> {
   const upstreamUrl = resolveUpstreamUrl(request.url, apiOrigin, stripPrefix)
 

--- a/scripts/lint-fetch-binding.ts
+++ b/scripts/lint-fetch-binding.ts
@@ -11,8 +11,8 @@
  *
  * The fix: default to the shared `boundFetch` (`@kuruma/shared/lib/bound-fetch`)
  * instead of the bare global — it keeps `this === globalThis` and the injectable
- * test mock intact. An inline `fetch.bind(globalThis) as typeof fetch` is still
- * accepted (boundFetch is defined with it), but the import is the canonical fix.
+ * test mock intact. An inline `fetch.bind(globalThis) as typeof fetch` also passes
+ * the guard (a legacy spelling of the same safety), but the import is canonical.
  *
  * Scope = every DEPLOYED runtime surface (scan by runtime, not by package), and
  * production code only — `*.test.ts` and `tests/` legitimately pass a real fetch.

--- a/scripts/lint-fetch-binding.ts
+++ b/scripts/lint-fetch-binding.ts
@@ -9,8 +9,10 @@
  * don't brand `fetch`, so this is invisible in CI and only bites the live runtime.
  * It already bit 4 sites; this guard keeps it from coming back.
  *
- * The fix the guard enforces: default to `fetch.bind(globalThis) as typeof fetch`
- * (keeps the injectable test mock intact — only the default binds).
+ * The fix: default to the shared `boundFetch` (`@kuruma/shared/lib/bound-fetch`)
+ * instead of the bare global — it keeps `this === globalThis` and the injectable
+ * test mock intact. An inline `fetch.bind(globalThis) as typeof fetch` is still
+ * accepted (boundFetch is defined with it), but the import is the canonical fix.
  *
  * Scope = every DEPLOYED runtime surface (scan by runtime, not by package), and
  * production code only — `*.test.ts` and `tests/` legitimately pass a real fetch.
@@ -145,7 +147,8 @@ function main() {
     for (const v of violations) console.error(`  - ${v.file}:${v.line}`)
     console.error(
       '\nThe global fetch must be called with this===globalThis on CF Workers/Pages.\n' +
-        'Change `: typeof fetch = fetch` to `= fetch.bind(globalThis) as typeof fetch`.',
+        "Import the shared safe default: `import { boundFetch } from '@kuruma/shared/lib/bound-fetch'`\n" +
+        'then change `: typeof fetch = fetch` to `= boundFetch`.',
     )
     process.exit(1)
   }


### PR DESCRIPTION
Closes #893. Follow-up to #887/#892/#897 (the detached-fetch bug that silently killed every beta email on CF Workers).

## What
Replaces the four copy-pasted `fetch.bind(globalThis)` defaults with one shared `boundFetch` (`@kuruma/shared/lib/bound-fetch`). Detached-fetch safety is now the default callers *import*, not something each site must remember.

- `packages/shared/src/lib/bound-fetch.ts` — new primitive + subpath export in `package.json` (registered to pass the `lint-export-drift` CI gate).
- Swapped 4 sites: `resend-email-sender`, `nominatim-geocoder`, `google-translation-provider`, and the web Pages-Functions `proxy.ts`.
- `scripts/lint-fetch-binding.ts` guidance message now points violators at `boundFetch` (inline `.bind` still accepted as a legacy spelling).

## Key design decision: lazy wrapper, not eager bind
The issue text suggested `boundFetch = fetch.bind(globalThis)` (eager, at module load). I used a **lazy wrapper** `(...args) => fetch.apply(globalThis, args)` instead:
- Equally Workers-correct (`this === globalThis` every call).
- **Reads the *current* global fetch per call**, so `vi.stubGlobal('fetch', …)` still works — the existing #887 service tests stay green untouched. An eager module-load bind would capture the real fetch before any stub and break all 3.
- Full args/`AbortSignal`/`Request` passthrough; negligible per-call cost.

## proxy.ts (Pages Function) — first cross-package import in `functions/`
The dedicated subpath `@kuruma/shared/lib/bound-fetch` resolves the single dep-free file directly (bypasses the `src/index.ts` barrel that pulls drizzle/`getDb`), so the Edge bundle gains no DB deps. Verified `wrangler pages functions build` compiles and `fetch.apply(globalThis)` is present in the output worker.

## Verification
- shared 583 · api 1587 · web proxy 10 — all green
- typecheck (shared/api/web incl. `functions/`) clean
- `lint:fetch-binding`, `lint:export-drift`, api `lint:boundaries`, `bun test scripts/` (19+112) — all pass
- Reviewed by `code-reviewer` + `architect` agents: no CRITICAL/HIGH; both MEDIUMs (test-mechanism + lint-comment wording) fixed in the second commit.

## Follow-up (not this PR)
Architect suggested a `functions/` import-allowlist lint so this new shared-coupling edge can't silently grow into an Edge-bundle bloat incident. Worth a low-priority issue.