### PR TITLE
feat(web): gate post-MVP features behind build flags for the beta MVP demo

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorManualBookingEnabled } from '@/vite/config/features'
 import { isOperatorSession } from '@/vite/guards'
 import { BookingsCalendar } from '@/vite/operator-bookings/BookingsCalendar'
 import { CalendarSidebar } from '@/vite/operator-bookings/CalendarSidebar'
@@ -80,7 +81,9 @@ export function OperatorBookingsRoute() {
   // Operator-only write affordance: a manual booking needs a single target tenant,
   // which only a tenant-scoped operator session supplies (bypass roles read
   // cross-tenant and get a view-only calendar). The API re-enforces this (#589 §4.3).
-  const canManualBook = isOperatorSession(session ?? null)
+  // Manual/walk-in booking is a post-MVP add-on (#589): gated behind the feature
+  // flag AND the operator-session permission. OFF in the beta demo (flag unset).
+  const canManualBook = isOperatorManualBookingEnabled() && isOperatorSession(session ?? null)
 
   // The dialog's pickup/return store list — fetched for operators (the only role
   // that can manual-book), so it's ready the moment they open the dialog and a
@@ -173,14 +176,16 @@ export function OperatorBookingsRoute() {
           </div>
         </div>
       </div>
-      <ManualBookingDialog
-        open={bookingDialogOpen}
-        onOpenChange={setBookingDialogOpen}
-        vehicles={vehicles}
-        locations={manualBookingLocations}
-        csrfToken={session?.csrfToken ?? ''}
-        initialRange={slotRange ?? undefined}
-      />
+      {canManualBook && (
+        <ManualBookingDialog
+          open={bookingDialogOpen}
+          onOpenChange={setBookingDialogOpen}
+          vehicles={vehicles}
+          locations={manualBookingLocations}
+          csrfToken={session?.csrfToken ?? ''}
+          initialRange={slotRange ?? undefined}
+        />
+      )}
     </main>
   )
 }

--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -1,4 +1,5 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorSettingsEnabled } from '@/vite/config/features'
 import { isOperatorOwnerSession } from '@/vite/guards'
 import { SettingsForm } from '@/vite/operator-settings/SettingsForm'
 import {
@@ -9,7 +10,12 @@ import {
 import { sessionQueryOptions } from '@/vite/session'
 import type { UpdateOperatorInput } from '@kuruma/shared/validators/operator'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
-import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import {
+  type ErrorComponentProps,
+  createFileRoute,
+  redirect,
+  useRouter,
+} from '@tanstack/react-router'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 
@@ -20,6 +26,13 @@ import { useTranslations } from 'use-intl'
 // useSuspenseQuery. A bypass role (no operatorId) sees a not-applicable notice —
 // it has no single operator to edit and manages operators via the admin portal.
 export const Route = createFileRoute('/$locale/_business/manage/settings')({
+  // Post-MVP feature (#903), hidden in the beta demo. The nav link is already
+  // filtered out; this blocks a direct URL too, falling back to the bookings page.
+  beforeLoad: ({ params }) => {
+    if (!isOperatorSettingsEnabled()) {
+      throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
+    }
+  },
   loader: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
     const operatorId = session?.user.operatorId

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -1,12 +1,18 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
+import { isOperatorTeamEnabled } from '@/vite/config/features'
 import { isOperatorOwnerSession, isOperatorSession } from '@/vite/guards'
 import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
 import { TeamView } from '@/vite/operator-team/TeamView'
 import { teamInvitesQueryOptions, teamMembersQueryOptions } from '@/vite/operator-team/api'
 import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import {
+  type ErrorComponentProps,
+  createFileRoute,
+  redirect,
+  useRouter,
+} from '@tanstack/react-router'
 import { UserPlus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
@@ -18,6 +24,13 @@ import { useTranslations } from 'use-intl'
 // operatorId). Inviting is owner-only (isOperatorOwnerSession), mirroring the
 // API's requireOperatorOwnerWrite gate; staff and bypass roles see read-only.
 export const Route = createFileRoute('/$locale/_business/manage/team')({
+  // Post-MVP feature (#904), hidden in the beta demo. The nav link is already
+  // filtered out; this blocks a direct URL too, falling back to the bookings page.
+  beforeLoad: ({ params }) => {
+    if (!isOperatorTeamEnabled()) {
+      throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
+    }
+  },
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.ensureQueryData(sessionQueryOptions()),

--- a/packages/web/src/vite/bookings/BookingConfirmationView.tsx
+++ b/packages/web/src/vite/bookings/BookingConfirmationView.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { CancelBookingDialog } from '@/vite/bookings/CancelBookingDialog'
 import { PreAuthHandoffCard } from '@/vite/bookings/PreAuthHandoffCard'
 import type { BookingDto } from '@/vite/bookings/api'
+import { isCancellationEnabled } from '@/vite/config/features'
 import type { VehicleClassData } from '@/vite/vehicles/classes'
 import { Link } from '@tanstack/react-router'
 import { CheckCircle } from 'lucide-react'
@@ -125,7 +126,7 @@ export function BookingConfirmationView({
       {/* #856: self-cancel is offered only for a CONFIRMED booking (an ACTIVE/
           COMPLETED/CANCELLED one is past the renter's reach) and only when a CSRF
           token is present to authorize the write. */}
-      {booking.status === 'CONFIRMED' && csrfToken && (
+      {isCancellationEnabled() && booking.status === 'CONFIRMED' && csrfToken && (
         <div className="mt-8 flex justify-center border-t border-border pt-6">
           <CancelBookingDialog
             bookingId={booking.id}

--- a/packages/web/src/vite/config/features.ts
+++ b/packages/web/src/vite/config/features.ts
@@ -1,0 +1,35 @@
+/**
+ * Build-time gates for post-MVP features (beta demo = canonical MVP only).
+ *
+ * Every feature below was BUILT but sits outside the MVP we committed to, so it is
+ * a billable add-on rather than something the beta demo should show. Beta builds
+ * ship them OFF so the demo mirrors the contracted scope; a full/paid build opts
+ * each one in by baking the matching `VITE_FEATURE_*` var to the literal `'true'`.
+ *
+ * Strict-string on purpose: only `'true'` enables a flag, so a missing or typo'd
+ * value fails safe to OFF — a billable feature must never leak on by accident. This
+ * mirrors the sibling search-map gate in `vite/search/flags.ts` (#885).
+ */
+function isEnabled(value: string | undefined): boolean {
+  return value === 'true'
+}
+
+/** Renter + operator self-service cancellation, tiered fees, reason capture (#868). */
+export function isCancellationEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_CANCELLATION)
+}
+
+/** Operator-created walk-in / manual bookings (#589). */
+export function isOperatorManualBookingEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_MANUAL_BOOKING)
+}
+
+/** Operator self-service staff invites + team management (#904). */
+export function isOperatorTeamEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_TEAM)
+}
+
+/** Operator self-service business settings (#903). */
+export function isOperatorSettingsEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_SETTINGS)
+}

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -4,7 +4,7 @@ import { LocaleSwitcher } from '@/vite/nav/LocaleSwitcher'
 import { MobileMenu, type NavItem } from '@/vite/nav/MobileMenu'
 import { NavBadge } from '@/vite/nav/NavBadge'
 import { NavbarClient } from '@/vite/nav/NavbarClient'
-import { businessNavItems } from '@/vite/nav/business-nav-items'
+import { visibleBusinessNavItems } from '@/vite/nav/business-nav-items'
 import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import { useSession } from '@/vite/session'
 import { getViewMode, isBusiness } from '@/vite/view-mode'
@@ -40,7 +40,7 @@ export function Navbar() {
     : []
 
   const navItems: readonly NavItem[] = isBusinessView
-    ? businessNavItems.map((item) => ({
+    ? visibleBusinessNavItems().map((item) => ({
         to: item.to,
         label: t(item.labelKey),
         // exactOptionalPropertyTypes: only attach `badge` when there is one.

--- a/packages/web/src/vite/nav/business-nav-items.ts
+++ b/packages/web/src/vite/nav/business-nav-items.ts
@@ -1,3 +1,5 @@
+import { isOperatorSettingsEnabled, isOperatorTeamEnabled } from '@/vite/config/features'
+
 // Single source of truth for the business-view (operator) nav (#603). Both
 // Navbar (which builds the desktop list and passes it to MobileMenu) and
 // MobileMenu's `NavTo` union derive from THIS array, so adding a `/manage/*`
@@ -23,3 +25,16 @@ export const businessNavItems = [
 
 // Derived so the union can never drift from the array above.
 export type BusinessNavTo = (typeof businessNavItems)[number]['to']
+
+// Post-MVP routes the beta demo hides behind a feature flag (billable add-ons).
+// The array above stays the full source of truth so the `BusinessNavTo` union and
+// the nav-count test never drift; only the RENDERED list is filtered. The routes
+// themselves also redirect when their flag is OFF, so a direct URL can't reach them.
+const navItemGates: Partial<Record<BusinessNavTo, () => boolean>> = {
+  '/$locale/manage/team': isOperatorTeamEnabled,
+  '/$locale/manage/settings': isOperatorSettingsEnabled,
+}
+
+export function visibleBusinessNavItems(): readonly (typeof businessNavItems)[number][] {
+  return businessNavItems.filter((item) => navItemGates[item.to]?.() ?? true)
+}

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { isCancellationEnabled } from '@/vite/config/features'
 import { isOperatorSession } from '@/vite/guards'
 import { CancelBookingDialog } from '@/vite/operator-bookings/CancelBookingDialog'
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
@@ -91,7 +92,7 @@ export function BookingActionsPanel({
           {/* Only CONFIRMED bookings can be cancelled — the server 409s any other
               status. An ACTIVE (picked-up) trip is past the cancellation window, so
               we hide the button rather than offer a dead-end action. */}
-          {detail.status === 'CONFIRMED' && (
+          {isCancellationEnabled() && detail.status === 'CONFIRMED' && (
             <CancelBookingDialog bookingId={detail.id} csrfToken={csrfToken} />
           )}
         </div>

--- a/packages/web/src/vite/reservation/ConfirmStep.tsx
+++ b/packages/web/src/vite/reservation/ConfirmStep.tsx
@@ -1,4 +1,5 @@
 import { formatJpy } from '@/lib/format'
+import { isCancellationEnabled } from '@/vite/config/features'
 import { useTranslations } from 'use-intl'
 import { CancellationPolicy } from './CancellationPolicy'
 import type { ReservationAddOn } from './api'
@@ -66,7 +67,10 @@ export function ConfirmStep({
         </div>
       </dl>
       <p className="text-sm text-muted-foreground">{t('confirm.note')}</p>
-      <CancellationPolicy pickupAt={pickupAt} />
+      {/* #937: self-cancel is gated for the beta demo (#868), so don't advertise the
+          tiered policy at checkout when the feature is OFF — it would promise a flow
+          the booking confirmation then hides. */}
+      {isCancellationEnabled() && <CancellationPolicy pickupAt={pickupAt} />}
     </section>
   )
 }

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -8,6 +8,12 @@ interface ImportMetaEnv {
   // Build-time gate for the premium interactive search map (#885). Unset/anything
   // but 'true' → map OFF (beta ships a pure store list). See vite/search/flags.ts.
   readonly VITE_SEARCH_MAP_ENABLED?: string
+  // Build-time gates for post-MVP features billed as add-ons. Unset/anything but
+  // 'true' → OFF (the beta demo ships canonical MVP only). See vite/config/features.ts.
+  readonly VITE_FEATURE_CANCELLATION?: string
+  readonly VITE_FEATURE_OPERATOR_MANUAL_BOOKING?: string
+  readonly VITE_FEATURE_OPERATOR_TEAM?: string
+  readonly VITE_FEATURE_OPERATOR_SETTINGS?: string
   // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
   // injected by CI at build time; environment defaults to 'production'.
   readonly VITE_SENTRY_DSN?: string

--- a/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
+++ b/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 vi.mock('@tanstack/react-router', () => ({
@@ -24,6 +24,17 @@ vi.mock('@tanstack/react-router', () => ({
     </a>
   ),
 }))
+
+// #868 cancellation ships behind a feature flag (OFF for the beta MVP demo). These
+// tests cover the feature's behaviour, so they enable it; the OFF case is asserted
+// in its own test below.
+beforeEach(() => {
+  vi.stubEnv('VITE_FEATURE_CANCELLATION', 'true')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 const START = '2026-07-01T01:00:00.000Z'
 const END = '2026-07-03T01:00:00.000Z'
@@ -157,6 +168,14 @@ describe('BookingConfirmationView', () => {
   it('offers a cancel control for a confirmed booking', () => {
     renderView(makeBooking({ status: 'CONFIRMED' }))
     expect(screen.getByRole('button', { name: en.bookings.cancel.action })).toBeInTheDocument()
+  })
+
+  it('hides the cancel control in the beta MVP demo (cancellation feature flag off)', () => {
+    vi.stubEnv('VITE_FEATURE_CANCELLATION', undefined)
+    renderView(makeBooking({ status: 'CONFIRMED' }))
+    expect(
+      screen.queryByRole('button', { name: en.bookings.cancel.action }),
+    ).not.toBeInTheDocument()
   })
 
   it('hides the cancel control once the booking is no longer confirmed', () => {

--- a/packages/web/tests/vite/config/features.test.ts
+++ b/packages/web/tests/vite/config/features.test.ts
@@ -1,0 +1,42 @@
+import {
+  isCancellationEnabled,
+  isOperatorManualBookingEnabled,
+  isOperatorSettingsEnabled,
+  isOperatorTeamEnabled,
+} from '@/vite/config/features'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Every post-MVP feature ships OFF for the beta demo and turns on only for the
+// exact string 'true'. One table drives all four so a newly added flag can't skip
+// the fail-safe (a billable feature leaking on by accident).
+const FLAGS = [
+  { name: 'VITE_FEATURE_CANCELLATION', read: isCancellationEnabled },
+  { name: 'VITE_FEATURE_OPERATOR_MANUAL_BOOKING', read: isOperatorManualBookingEnabled },
+  { name: 'VITE_FEATURE_OPERATOR_TEAM', read: isOperatorTeamEnabled },
+  { name: 'VITE_FEATURE_OPERATOR_SETTINGS', read: isOperatorSettingsEnabled },
+] as const
+
+describe('post-MVP feature flags', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  for (const { name, read } of FLAGS) {
+    it(`${name} is OFF (beta MVP default) when unset`, () => {
+      vi.stubEnv(name, undefined)
+      expect(read()).toBe(false)
+    })
+
+    it(`${name} is ON only for the exact string "true"`, () => {
+      vi.stubEnv(name, 'true')
+      expect(read()).toBe(true)
+    })
+
+    it(`${name} stays OFF for a typo'd / mis-cased / empty value (fail-safe)`, () => {
+      for (const value of ['false', '1', 'TRUE', 'yes', ' true ', '']) {
+        vi.stubEnv(name, value)
+        expect(read()).toBe(false)
+      }
+    })
+  }
+})

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -7,7 +7,7 @@ import { useSession } from '@/vite/session'
 import { render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 vi.mock('@/vite/session', () => ({ useSession: vi.fn() }))
@@ -81,6 +81,10 @@ beforeEach(() => {
   document.cookie = 'kuruma-view=; max-age=0; path=/'
 })
 
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('Navbar', () => {
   it('links the logo to the locale home and shows no nav links when signed out', () => {
     renderNavbar(undefined)
@@ -93,6 +97,10 @@ describe('Navbar', () => {
 
   it('shows the dashboard, operator bookings + fleet + classes + insurance links and business markers for a business user', () => {
     mockUseBadge.mockReturnValue({ count: 3 })
+    // Team + Settings are post-MVP add-ons gated behind feature flags; turn them
+    // on so this "full operator nav" assertion sees every route.
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', 'true')
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', 'true')
     const { container } = renderNavbar(business)
     expect(screen.getByText('Dashboard').closest('a')).toHaveAttribute(
       'data-to',
@@ -131,6 +139,12 @@ describe('Navbar', () => {
       'data-to',
       '/$locale/manage/add-ons',
     )
+    // #904 / #903: shown only because the flags above are on (full build).
+    expect(screen.getByText('Team').closest('a')).toHaveAttribute('data-to', '/$locale/manage/team')
+    expect(screen.getByText('Settings').closest('a')).toHaveAttribute(
+      'data-to',
+      '/$locale/manage/settings',
+    )
     expect(container.querySelector('nav')?.hasAttribute('data-business-nav')).toBe(true)
     const client = screen.getByTestId('navbar-client')
     expect(client).toHaveAttribute('data-view-mode', 'business')
@@ -148,6 +162,22 @@ describe('Navbar', () => {
     expect(badge).toHaveAttribute('aria-label', '3 new bookings')
     // It is not duplicated onto another nav item.
     expect(screen.getAllByRole('status')).toHaveLength(1)
+  })
+
+  it('hides Team + Settings nav in the beta MVP demo (their post-MVP flags are off)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', undefined)
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', undefined)
+    renderNavbar(business)
+    // The MVP operator routes still render…
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Bookings')).toBeInTheDocument()
+    // …but the two add-on routes are filtered out of the rendered nav.
+    expect(screen.queryByText('Team')).toBeNull()
+    expect(screen.queryByText('Settings')).toBeNull()
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute(
+      'data-nav-count',
+      String(businessNavItems.length - 2),
+    )
   })
 
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {

--- a/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 const d = enMessages.bookings.operator.detail
@@ -66,7 +66,16 @@ function renderPanel(
   )
 }
 
-afterEach(() => vi.restoreAllMocks())
+// #868 cancellation is a post-MVP add-on gated behind a flag (OFF in the beta
+// demo). These tests cover the feature, so enable it; the OFF case is its own test.
+beforeEach(() => {
+  vi.stubEnv('VITE_FEATURE_CANCELLATION', 'true')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
 
 describe('BookingActionsPanel role gating', () => {
   it('renders nothing for a bypass role with no operatorId (read-only oversight)', () => {
@@ -103,6 +112,14 @@ describe('BookingActionsPanel actions by status', () => {
     expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: d.cancelBooking.action })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: d.markCompleted })).not.toBeInTheDocument()
+  })
+
+  it('hides cancel in the beta MVP demo (cancellation flag off) but keeps the other actions', () => {
+    vi.stubEnv('VITE_FEATURE_CANCELLATION', undefined)
+    renderPanel(operatorSession, detail({ status: 'CONFIRMED' }))
+    expect(screen.getByRole('button', { name: d.markActive })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: sub.action })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: d.cancelBooking.action })).not.toBeInTheDocument()
   })
 
   it('offers mark-returned and substitute, but NOT cancel, on an ACTIVE booking', () => {

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 const c = enMessages.bookings.operator.newBooking
@@ -97,8 +97,16 @@ function renderRoute(
   )
 }
 
+// Manual/walk-in booking (#589) is a post-MVP add-on gated behind a flag (OFF in
+// the beta demo). These tests cover the feature, so enable it; the OFF case below
+// asserts the affordance disappears entirely.
+beforeEach(() => {
+  vi.stubEnv('VITE_FEATURE_OPERATOR_MANUAL_BOOKING', 'true')
+})
+
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllEnvs()
   calendarProps = {}
 })
 
@@ -106,6 +114,13 @@ describe('OperatorBookingsRoute manual-booking affordance (#589 1d)', () => {
   it('shows the New Booking button for a tenant-scoped operator session', () => {
     renderRoute(operatorSession)
     expect(screen.getByRole('button', { name: c.action })).toBeInTheDocument()
+  })
+
+  it('hides the New Booking affordance in the beta MVP demo (manual-booking flag off)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_MANUAL_BOOKING', undefined)
+    renderRoute(operatorSession)
+    expect(screen.queryByRole('button', { name: c.action })).not.toBeInTheDocument()
+    expect(calendarProps.selectable).toBe(false)
   })
 
   it('hides the New Booking button for a bypass (non-operator) session', () => {

--- a/packages/web/tests/vite/operator-settings/settings.route.test.ts
+++ b/packages/web/tests/vite/operator-settings/settings.route.test.ts
@@ -1,0 +1,34 @@
+import { Route } from '@/routes/$locale/_business/manage/settings'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The beta MVP demo hides operator settings (#903) behind a build flag. The nav
+// link is filtered out elsewhere, but the load-bearing block against a direct URL /
+// bookmark is THIS beforeLoad redirect — so it gets its own test: hiding the link
+// is not the same guarantee as blocking the route.
+const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+
+describe('/manage/settings feature-flag guard', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('redirects a direct URL to /manage/bookings when the settings flag is off (beta default)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', undefined)
+    let thrown: unknown
+    try {
+      beforeLoad({ params: { locale: 'en' } })
+    } catch (err) {
+      thrown = err
+    }
+    // TanStack's redirect() throws a Response-like object carrying the target
+    // under `.options` — assert the destination, not just that something threw.
+    expect(thrown).toMatchObject({
+      options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
+    })
+  })
+
+  it('does not redirect when the settings flag is enabled (full build)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', 'true')
+    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+  })
+})

--- a/packages/web/tests/vite/operator-team/team.route.test.ts
+++ b/packages/web/tests/vite/operator-team/team.route.test.ts
@@ -1,0 +1,34 @@
+import { Route } from '@/routes/$locale/_business/manage/team'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The beta MVP demo hides operator team management (#904) behind a build flag. The
+// nav link is filtered out elsewhere, but the load-bearing block against a direct
+// URL / bookmark is THIS beforeLoad redirect — so it gets its own test: hiding the
+// link is not the same guarantee as blocking the route.
+const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+
+describe('/manage/team feature-flag guard', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('redirects a direct URL to /manage/bookings when the team flag is off (beta default)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', undefined)
+    let thrown: unknown
+    try {
+      beforeLoad({ params: { locale: 'en' } })
+    } catch (err) {
+      thrown = err
+    }
+    // TanStack's redirect() throws a Response-like object carrying the target
+    // under `.options` — assert the destination, not just that something threw.
+    expect(thrown).toMatchObject({
+      options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
+    })
+  })
+
+  it('does not redirect when the team flag is enabled (full build)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', 'true')
+    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+  })
+})

--- a/packages/web/tests/vite/reservation/ConfirmStep.test.tsx
+++ b/packages/web/tests/vite/reservation/ConfirmStep.test.tsx
@@ -2,7 +2,7 @@ import { ConfirmStep } from '@/vite/reservation/ConfirmStep'
 import type { ReservationAddOn } from '@/vite/reservation/api'
 import { render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 const addOns: ReservationAddOn[] = [
@@ -57,5 +57,26 @@ describe('ConfirmStep', () => {
     renderStep()
     expect(screen.getByText('Estimated total')).toBeInTheDocument()
     expect(screen.getByText('￥21,000')).toBeInTheDocument()
+  })
+
+  // #868 self-cancellation ships behind a feature flag (OFF for the beta demo).
+  // The policy schedule is part of that flow, so the checkout must not advertise a
+  // self-cancel tier table it then hides post-booking (#937 follow-up).
+  describe('cancellation policy (feature flag)', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    it('hides the cancellation policy when the feature flag is OFF (beta demo)', () => {
+      vi.stubEnv('VITE_FEATURE_CANCELLATION', 'false')
+      renderStep()
+      expect(screen.queryByRole('heading', { name: 'Cancellation policy' })).toBeNull()
+    })
+
+    it('shows the cancellation policy when the feature flag is ON', () => {
+      vi.stubEnv('VITE_FEATURE_CANCELLATION', 'true')
+      renderStep()
+      expect(screen.getByRole('heading', { name: 'Cancellation policy' })).toBeInTheDocument()
+    })
   })
 })

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -78,6 +78,15 @@ export default defineConfig({
       timeout: 120_000,
       env: {
         VITE_DEV_API_PROXY: API_URL,
+        // These real-DB specs exercise features the beta demo gates OFF —
+        // cancellation (#868), operator manual booking (#589), team (#904) and
+        // settings (#903). Enable them here so e2e covers the FULL product; the
+        // beta Pages build (deploy.yml) sets none of these, so the demo still
+        // hides them. Fail-safe-OFF default lives in vite/config/features.ts.
+        VITE_FEATURE_CANCELLATION: 'true',
+        VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
+        VITE_FEATURE_OPERATOR_TEAM: 'true',
+        VITE_FEATURE_OPERATOR_SETTINGS: 'true',
       },
     },
   ],


### PR DESCRIPTION
## Why
The beta is a pre-contract trial that should demo the **canonical MVP only**. Several already-built features sit *outside* that MVP scope, so they become billable add-ons. This hides them in the beta build without deleting the work.

## What
New config module `packages/web/src/vite/config/features.ts` — build-time flags, **fail-safe OFF**, mirroring the existing search-map gate (`vite/search/flags.ts`, #885). Beta builds set no vars → pure MVP demo, automatically. A full/paid build re-enables a feature by baking its flag to the literal `'true'`.

| Feature | Flag (set `=true` to re-enable) | Gated at |
|---|---|---|
| Cancellation — renter + operator (#868) | `VITE_FEATURE_CANCELLATION` | `BookingConfirmationView`, `operator-bookings/BookingActionsPanel` |
| Operator walk-in / manual booking (#589) | `VITE_FEATURE_OPERATOR_MANUAL_BOOKING` | `manage/bookings/index` (button + calendar slot + dialog) |
| Staff invites / team (#904) | `VITE_FEATURE_OPERATOR_TEAM` | nav link **+ route redirect** (`manage/team`) |
| Operator settings (#903) | `VITE_FEATURE_OPERATOR_SETTINGS` | nav link **+ route redirect** (`manage/settings`) |

Gated routes `beforeLoad`-redirect to `/manage/bookings` when off, so a direct URL / bookmark can't reach them — not just a hidden nav link.

## Scope note (accepted)
UI-only gating: the underlying API routes stay live but are unreachable from the demo UI. Acceptable for a trusted-tester beta; not a security boundary. No server-side flag was added (owner decision).

## Test plan
- New flag unit tests + mutation-resistant OFF-state tests (cancel hidden, New-Booking gone, nav drops 2 items).
- New `team.route.test.ts` / `settings.route.test.ts` assert the guard redirects to `/manage/bookings` when off and passes when on.
- Full web suite **1041/1041 green**, web + api typecheck clean, biome clean.

Part of the beta demo scoping (does not close #868/#589/#904/#903 — it gates them).