### PR TITLE
feat(web): hide the orphaned renter Documents tab in the beta demo

### DIFF
--- a/packages/web/src/routes/$locale/_renter/documents.tsx
+++ b/packages/web/src/routes/$locale/_renter/documents.tsx
@@ -1,9 +1,18 @@
+import { isRenterDocumentsEnabled } from '@/vite/config/features'
 import { DocumentUploadCard } from '@/vite/documents/DocumentUploadCard'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 // Renter document upload (#459). Sits under `_renter`, so it inherits the
-// session guard (redirect to login if signed out) without its own beforeLoad.
+// session guard (redirect to login if signed out).
 export const Route = createFileRoute('/$locale/_renter/documents')({
+  // Post-MVP feature, hidden in the beta demo: the instant-book flow doesn't
+  // gate on uploaded documents, so this page is orphaned. The nav link is
+  // filtered out; this blocks a direct URL too, falling back to search.
+  beforeLoad: ({ params }) => {
+    if (!isRenterDocumentsEnabled()) {
+      throw redirect({ to: '/$locale/search', params: { locale: params.locale } })
+    }
+  },
   component: DocumentsRoute,
 })
 

--- a/packages/web/src/vite/config/features.ts
+++ b/packages/web/src/vite/config/features.ts
@@ -33,3 +33,8 @@ export function isOperatorTeamEnabled(): boolean {
 export function isOperatorSettingsEnabled(): boolean {
   return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_SETTINGS)
 }
+
+/** Renter identity-document upload + verification (#459). Orphaned by instant-book. */
+export function isRenterDocumentsEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_RENTER_DOCUMENTS)
+}

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { isRenterDocumentsEnabled } from '@/vite/config/features'
 import { LocaleSwitcher } from '@/vite/nav/LocaleSwitcher'
 import { MobileMenu, type NavItem } from '@/vite/nav/MobileMenu'
 import { NavBadge } from '@/vite/nav/NavBadge'
@@ -35,7 +36,11 @@ export function Navbar() {
   const renterNavItems: readonly NavItem[] = isRenter
     ? [
         { to: '/$locale/bookings', label: t('myBookings') },
-        { to: '/$locale/documents', label: t('documents') },
+        // Documents (IDP upload, #459) is gated OFF for the beta demo: the
+        // instant-book flow no longer requires it. See vite/config/features.ts.
+        ...(isRenterDocumentsEnabled()
+          ? [{ to: '/$locale/documents' as const, label: t('documents') }]
+          : []),
       ]
     : []
 

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -14,6 +14,7 @@ interface ImportMetaEnv {
   readonly VITE_FEATURE_OPERATOR_MANUAL_BOOKING?: string
   readonly VITE_FEATURE_OPERATOR_TEAM?: string
   readonly VITE_FEATURE_OPERATOR_SETTINGS?: string
+  readonly VITE_FEATURE_RENTER_DOCUMENTS?: string
   // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
   // injected by CI at build time; environment defaults to 'production'.
   readonly VITE_SENTRY_DSN?: string

--- a/packages/web/tests/vite/config/features.test.ts
+++ b/packages/web/tests/vite/config/features.test.ts
@@ -3,6 +3,7 @@ import {
   isOperatorManualBookingEnabled,
   isOperatorSettingsEnabled,
   isOperatorTeamEnabled,
+  isRenterDocumentsEnabled,
 } from '@/vite/config/features'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +15,7 @@ const FLAGS = [
   { name: 'VITE_FEATURE_OPERATOR_MANUAL_BOOKING', read: isOperatorManualBookingEnabled },
   { name: 'VITE_FEATURE_OPERATOR_TEAM', read: isOperatorTeamEnabled },
   { name: 'VITE_FEATURE_OPERATOR_SETTINGS', read: isOperatorSettingsEnabled },
+  { name: 'VITE_FEATURE_RENTER_DOCUMENTS', read: isRenterDocumentsEnabled },
 ] as const
 
 describe('post-MVP feature flags', () => {

--- a/packages/web/tests/vite/documents/documents.route.test.ts
+++ b/packages/web/tests/vite/documents/documents.route.test.ts
@@ -1,0 +1,34 @@
+import { Route } from '@/routes/$locale/_renter/documents'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The beta MVP demo hides the renter document-upload page (#459) behind a build
+// flag — the instant-book flow no longer gates on it. The nav link is filtered
+// out elsewhere; the load-bearing block against a direct URL / bookmark is THIS
+// beforeLoad redirect, so it gets its own test.
+const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+
+describe('/documents feature-flag guard', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('redirects a direct URL to /search when the documents flag is off (beta default)', () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', undefined)
+    let thrown: unknown
+    try {
+      beforeLoad({ params: { locale: 'en' } })
+    } catch (err) {
+      thrown = err
+    }
+    // TanStack's redirect() throws a Response-like object carrying the target
+    // under `.options` — assert the destination, not just that something threw.
+    expect(thrown).toMatchObject({
+      options: { to: '/$locale/search', params: { locale: 'en' } },
+    })
+  })
+
+  it('does not redirect when the documents flag is enabled (full build)', () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
+    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+  })
+})

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -183,6 +183,9 @@ describe('Navbar', () => {
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {
     // Even with a non-zero count, the operator badge is gated to business view.
     mockUseBadge.mockReturnValue({ count: 5 })
+    // Documents is a post-MVP add-on gated behind a flag; enable it so this
+    // "full renter nav" assertion sees it (the OFF case is its own test below).
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
     const { container } = renderNavbar(renter)
     expect(screen.getByText('Browse').closest('a')).toHaveAttribute('data-to', '/$locale/search')
     expect(screen.getByText('My Bookings').closest('a')).toHaveAttribute(
@@ -200,6 +203,15 @@ describe('Navbar', () => {
     expect(client).toHaveAttribute('data-can-switch', 'false')
     // Desktop + mobile share the same derived navItems (Browse + 2 renter-only).
     expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '3')
+  })
+
+  it('hides Documents in the beta MVP demo (renter-documents flag off)', () => {
+    renderNavbar(renter)
+    expect(screen.getByText('Browse')).toBeInTheDocument()
+    expect(screen.getByText('My Bookings')).toBeInTheDocument()
+    // The orphaned IDP-upload page is filtered out — Browse + My Bookings only.
+    expect(screen.queryByText('Documents')).toBeNull()
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '2')
   })
 
   it('hides My Bookings/Documents for an operator in renter view — gating is by role, not view (P1, AC6)', () => {

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
         VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
         VITE_FEATURE_OPERATOR_TEAM: 'true',
         VITE_FEATURE_OPERATOR_SETTINGS: 'true',
+        VITE_FEATURE_RENTER_DOCUMENTS: 'true',
       },
     },
   ],


### PR DESCRIPTION
Follow-up to #937 (beta demo = canonical MVP only).

## Why
The renter **Documents** tab (IDP upload + verification, #459) is still live on beta, but the instant-book flow stopped gating on it (#511/#613 → liability disclaimer + pay-at-pickup). It's an orphaned page that tells renters to "upload your IDP before you book" while nothing requires it — confusing in a demo.

## What
Hide it behind a new fail-safe-OFF `VITE_FEATURE_RENTER_DOCUMENTS` flag, same pattern as #937:
- Renter-nav item filtered out (`Navbar.tsx`)
- Route `beforeLoad` redirect to `/$locale/search` when off (`_renter/documents.tsx`) — blocks a direct URL, not just the nav link
- `playwright.real-db.config.ts` enables it so full-product e2e coverage is unchanged; the beta Pages build sets nothing → demo hides it

Decision: **hide, not remove** — online IDV is real built work still on the roadmap (verification is just in-person for now), so it's a billable add-on, not dead code.

## Test plan
- Flag unit test (table now 5 flags), `documents.route.test.ts` asserts the redirect, Navbar test covers shown-vs-hidden.
- Web typecheck clean; affected suites green.