### PR TITLE
refactor(web): harden search geo-context per architect review (#885 slice 3a)

### DIFF
--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -69,17 +69,17 @@ export function SearchMapList({
   }, [items])
 
   // Derive each location's geo-context label once (the shell), so the leaf row and
-  // popup take a dumb string and `regions` stays out of them. Co-located cars share
-  // one label (keyed by locationId). Absent until the region query resolves.
+  // popup take a dumb string and `regions` stays out of them. Iterate per location
+  // (not per car) — the label is keyed by locationId and co-located cars share it, so
+  // walking the region taxonomy once per group avoids redundant work. Absent until
+  // the region query resolves.
   const geoLabelById = useMemo(() => {
     const byId = new Map<string, string>()
-    for (const item of items) {
-      const label = formatGeoContext(
-        resolveGeoContext(item.location, regions, geoAnchor),
-        locale,
-        t,
-      )
-      if (label) byId.set(item.location.locationId, label)
+    for (const group of groupByLocation(items)) {
+      const location = group.items[0]?.location
+      if (!location) continue
+      const label = formatGeoContext(resolveGeoContext(location, regions, geoAnchor), locale, t)
+      if (label) byId.set(group.locationId, label)
     }
     return byId
   }, [items, regions, geoAnchor, locale, t])

--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -79,8 +79,10 @@ function minRate(
 
 /** Derived "where in Japan" context for a result row, before localization. */
 export interface GeoContext {
-  /** Nearest AREA region to the pickup store (always present when non-null). */
-  area: RegionNode
+  /** Nearest AREA region to the pickup store. Always coordinate-bearing (the
+   *  producer only matches coord-carrying AREA nodes), so callers may read its
+   *  lat/lng without a non-null assertion — banked for a future area-centre pin. */
+  area: RegionNode & GeoPoint
   /** The AREA's prefecture ancestor, or null when the chain is broken. */
   prefecture: RegionNode | null
   /** Anchor -> pickup distance in km, or null with no anchor / no store coords. */
@@ -89,11 +91,16 @@ export interface GeoContext {
 
 /**
  * Locate a pickup store in the region taxonomy (#885 slice 3a). Pure: finds the
- * nearest assignable AREA by coords, derives its prefecture by reusing the already
- * cycle-guarded `regionChain` (do NOT hand-roll a second parent walk — it runs on
- * the public region list and would freeze the tab on a malformed self-FK row), and
- * measures the searched anchor -> store distance. Returns null when the store has no
- * coordinates or sits beyond the area sanity radius (graceful degrade: no label).
+ * nearest assignable AREA by coords — restricted to `type === 'AREA'` so a future
+ * assignable city/prefecture node can never be mislabelled as "the area" (the
+ * "nearest assignable" set coincides with AREAs only by current seed convention, not
+ * by type) — derives its prefecture by reusing the already cycle-guarded
+ * `regionChain` (do NOT hand-roll a second parent walk — it runs on the public
+ * region list and would freeze the tab on a malformed self-FK row), and measures the
+ * searched anchor -> store distance. `location` is the PICKUP store; a one-way
+ * dropoff label (#882) would be an additive second call, not a change here. Returns
+ * null when the store has no coordinates or no AREA sits within the sanity radius
+ * (graceful degrade: no label).
  */
 export function resolveGeoContext(
   location: ResultLocation,
@@ -102,7 +109,10 @@ export function resolveGeoContext(
 ): GeoContext | null {
   if (location.latitude === null || location.longitude === null) return null
   const point: GeoPoint = { latitude: location.latitude, longitude: location.longitude }
-  const area = nearestAssignableRegion(regions, point)
+  const area = nearestAssignableRegion(
+    regions.filter((region) => region.type === 'AREA'),
+    point,
+  )
   if (area === null) return null
   return {
     area,
@@ -131,8 +141,8 @@ export function formatGeoContext(
   if (ctx === null) return null
   const areaName = localizedRegionName(ctx.area, locale)
   const prefectureName = ctx.prefecture ? localizedRegionName(ctx.prefecture, locale) : null
-  const hasDistance = ctx.distanceKm !== null && Number(ctx.distanceKm.toFixed(1)) !== 0
   const km = ctx.distanceKm !== null ? ctx.distanceKm.toFixed(1) : ''
+  const hasDistance = ctx.distanceKm !== null && Number(km) !== 0
   if (prefectureName === null || prefectureName === areaName) {
     return hasDistance
       ? t('map.geoContextAreaOnly', { area: areaName, km })

--- a/packages/web/tests/vite/search/result.test.ts
+++ b/packages/web/tests/vite/search/result.test.ts
@@ -235,6 +235,23 @@ describe('resolveGeoContext', () => {
     expect(ctx?.area.id).toBe('A')
     expect(ctx?.prefecture).toBeNull()
   })
+
+  it('labels the nearest AREA, never a closer assignable non-AREA node', () => {
+    // The "area" is AREA-scoped. A future assignable CITY sitting right on the store
+    // (0 km) must NOT be picked over Namba — nearest-by-coords alone would grab it.
+    const assignableCity = area({
+      id: 'reg_some_city',
+      nameEn: 'Some City',
+      type: 'CITY',
+      assignable: true,
+      latitude: 34.66,
+      longitude: 135.5,
+      sortOrder: 0,
+    })
+    const ctx = resolveGeoContext(storeAt(34.66, 135.5), [...OSAKA_REGIONS, assignableCity], null)
+    expect(ctx?.area.id).toBe('reg_namba')
+    expect(ctx?.area.type).toBe('AREA')
+  })
 })
 
 describe('formatGeoContext', () => {


### PR DESCRIPTION
Follow-up to #943 (search geo-context labels). Applies the three "fix-now" findings from the post-merge **architect review** of slice 3a. Behavior-preserving for current seed data; behind `VITE_SEARCH_MAP_ENABLED` like the original.

## Findings addressed

**1. (Important) AREA invariant held by convention, not code.** `resolveGeoContext` picked the *nearest assignable* region and named it "the area" — but `assignable ⟺ type==='AREA'` is only true by current seed data. If an assignable city/prefecture node is ever added, the label would silently mislabel (e.g. a PREFECTURE match collapses to area-only). Fix: restrict the candidate set to `type === 'AREA'`, so the type's promise (`area` *is* an AREA) is enforced in code. Added a regression test: an assignable CITY sitting 0 km from the store must not be picked over the nearest AREA.

> Note: the architect's *first-choice* phrasing (`regionChain(...).area ?? match`) does **not** actually fix this — walking up from a CITY match has no AREA ancestor, so it falls back to the city. The `type === 'AREA'` filter is the correct enforcement.

**2. (Minor) Type honesty.** `GeoContext.area` narrowed `RegionNode → RegionNode & GeoPoint`. The producer (`nearestAssignableRegion`) only ever returns coord-bearing nodes, so this banks the narrowing (a future area-centre pin can read lat/lng without a `!`).

**3. (Minor, perf) Redundant per-car derivation.** `geoLabelById` now iterates `groupByLocation(items)` (per location) instead of per car — the label is keyed by `locationId` and co-located cars share it, so this drops repeated region-taxonomy walks. Negligible at Kansai scale today; matters at national region counts.

Also: collapsed a double `.toFixed(1)` in `formatGeoContext`; documented that `location` is the **pickup** store (a one-way dropoff label, #882, is an additive future call).

## Deferred (tracked, not in this PR)
- Hoist `regionGeoContext` + `regionName(node, locale)` into `@kuruma/shared/lib/` when a 2nd consumer (3b/#882) lands.
- Pass a prebuilt region `Map` into `regionChain` when national rollout grows the region count.
- No cross-locale i18n key-parity test (pre-existing gap).

## Verification
- `result.test` 24 (+1 regression) · `SearchMapList` 22 · full web suite green · `typecheck` clean.

Architect verdict on the parent slice: SHIP-WITH-FOLLOWUPS — this PR is those follow-ups.