### PR TITLE
refactor(shared): typed ErrorCode union as SSoT for envelope codes (#941)

### DIFF
--- a/packages/api/src/error-handlers.ts
+++ b/packages/api/src/error-handlers.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import * as Sentry from '@sentry/cloudflare'
 import type { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
@@ -28,7 +29,10 @@ export function setupGlobalHandlers(app: Hono): void {
     if (err instanceof OperatorRequiredError) {
       // Self-describing envelope code so the web discriminates this 422 by `code`
       // rather than regex-matching the message (a reword/i18n change can't break it) (#934).
-      return c.json({ success: false, error: err.message, code: 'OPERATOR_REQUIRED' }, 422)
+      return c.json(
+        { success: false, error: err.message, code: 'OPERATOR_REQUIRED' satisfies ErrorCode },
+        422,
+      )
     }
     // #904: operator self-service action against an id that doesn't resolve in
     // the caller's own tenant (unknown/terminal invite or member). 404.

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import {
   cancelBookingSchema,
   createBookingSchema,
@@ -165,7 +166,9 @@ export function createBookingRoutes(service: BookingService) {
       // Staff/manual bookings capture acknowledgement operationally and are exempt.
       // The service stamps disclaimerAcknowledgedAt + the terms version on the row.
       if (ctx.role === 'RENTER' && !parsed.data.disclaimerAccepted) {
-        return fail(c, 'Liability disclaimer must be accepted', 400, { code: 'CONSENT_REQUIRED' })
+        return fail(c, 'Liability disclaimer must be accepted', 400, {
+          code: 'CONSENT_REQUIRED' satisfies ErrorCode,
+        })
       }
 
       const createResult = await service.create(ctx, {

--- a/packages/api/src/services/booking-types.ts
+++ b/packages/api/src/services/booking-types.ts
@@ -1,4 +1,5 @@
 import type { calculateCancellationFee } from '@kuruma/shared/lib/cancellation-policy'
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import type { CallerContext } from '../middleware/auth'
 import type { Booking } from '../stores'
 
@@ -39,7 +40,7 @@ export type CreateBookingResult =
       ok: false
       status: 400 | 403 | 409
       error: string | Record<string, string[]>
-      code?: string
+      code?: ErrorCode
       details?: { required: number; actual: number }
     }
 

--- a/packages/api/src/services/document-verification-gate.ts
+++ b/packages/api/src/services/document-verification-gate.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import type { BookingVerificationGate } from './booking-types'
 import type { RenterDocumentService } from './renter-document'
 
@@ -16,7 +17,7 @@ export function documentVerificationGate(service: RenterDocumentService): Bookin
       status: 403,
       error:
         'An approved International Driving Permit valid through your return date is required to book.',
-      code: 'DOCUMENT_VERIFICATION_REQUIRED',
+      code: 'DOCUMENT_VERIFICATION_REQUIRED' satisfies ErrorCode,
     }
   }
 }

--- a/packages/api/src/services/fee-schedule.ts
+++ b/packages/api/src/services/fee-schedule.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import {
   type FeeType,
   type FeeUnit,
@@ -32,7 +33,7 @@ const invalidVehicleClassResult = (): FeeScheduleResult => ({
   ok: false,
   error: INVALID_VEHICLE_CLASS_MESSAGE,
   status: 400,
-  code: 'INVALID_VEHICLE_CLASS',
+  code: 'INVALID_VEHICLE_CLASS' satisfies ErrorCode,
 })
 
 export class FeeScheduleService {

--- a/packages/api/src/services/location.ts
+++ b/packages/api/src/services/location.ts
@@ -1,4 +1,5 @@
 import type { CoordinateSource } from '@kuruma/shared/db/schema'
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import { nearestAssignableRegion } from '@kuruma/shared/lib/region-distance'
 import type { CallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
@@ -183,7 +184,7 @@ export class LocationService {
         ok: false,
         error: 'Cannot archive a location with active bookings',
         status: 409,
-        code: 'LOCATION_HAS_ACTIVE_BOOKINGS',
+        code: 'LOCATION_HAS_ACTIVE_BOOKINGS' satisfies ErrorCode,
         activeBookingsCount,
       }
     }

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import type {
   BookingRepository,
@@ -106,7 +107,7 @@ export class VehicleClassService {
           ok: false,
           error: 'Cannot archive a class with active bookings',
           status: 409,
-          code: 'CLASS_HAS_ACTIVE_BOOKINGS',
+          code: 'CLASS_HAS_ACTIVE_BOOKINGS' satisfies ErrorCode,
           activeBookingsCount,
         }
       }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,6 +34,7 @@
     "./types/operator-team": "./src/types/operator-team.ts",
     "./lib/bound-fetch": "./src/lib/bound-fetch.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
+    "./lib/error-codes": "./src/lib/error-codes.ts",
     "./lib/commission": "./src/lib/commission.ts",
     "./lib/admin-revenue": "./src/lib/admin-revenue.ts",
     "./lib/luggage": "./src/lib/luggage.ts",

--- a/packages/shared/src/lib/error-codes.test.ts
+++ b/packages/shared/src/lib/error-codes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+
+import { ERROR_CODES } from './error-codes'
+
+/**
+ * Contract test for the single source of truth (#941). `ERROR_CODES` pins the
+ * exact set of envelope failure codes the API emits and the web discriminates
+ * on. Producers append `satisfies ErrorCode` at each emit site (compile-time);
+ * this test pins the membership so a code can't be silently dropped — which
+ * would break web discrimination with no compile error on the consumer side.
+ */
+describe('ERROR_CODES', () => {
+  test('is the exhaustive set of envelope failure codes the API emits', () => {
+    expect([...ERROR_CODES].sort()).toEqual([
+      'CLASS_HAS_ACTIVE_BOOKINGS',
+      'CONSENT_REQUIRED',
+      'DOCUMENT_VERIFICATION_REQUIRED',
+      'INVALID_DURATION',
+      'INVALID_VEHICLE_CLASS',
+      'LOCATION_HAS_ACTIVE_BOOKINGS',
+      'NO_RATES_SET',
+      'OPERATOR_REQUIRED',
+      'RENTAL_RULE_ADVANCE_BOOKING',
+      'RENTAL_RULE_MAX_DURATION',
+      'RENTAL_RULE_MIN_DURATION',
+    ])
+  })
+
+  test('contains no duplicate codes', () => {
+    expect(new Set(ERROR_CODES).size).toBe(ERROR_CODES.length)
+  })
+})

--- a/packages/shared/src/lib/error-codes.ts
+++ b/packages/shared/src/lib/error-codes.ts
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for envelope failure codes carried in the API
+ * response `code` field (#941). The shared `ApiResponse` envelope types
+ * `code?: ErrorCode`, so a producer (`fail(c, …, { code })` / `c.json`) and a
+ * consumer (`body.code === '…'`, `ApiError.code`) agree at compile time — a
+ * typo or rename surfaces as a `tsc` error, not a silently `undefined` code.
+ *
+ * Expand-only: add a code here, append `satisfies ErrorCode` at the emit site,
+ * and pin it in `error-codes.test.ts`. YAGNI holds at this size — this is the
+ * Rule-of-Three cleanup, done once.
+ */
+export const ERROR_CODES = [
+  // Emitted directly at a route / error handler.
+  'OPERATOR_REQUIRED',
+  'DOCUMENT_VERIFICATION_REQUIRED',
+  'CONSENT_REQUIRED',
+  'INVALID_VEHICLE_CLASS',
+  'CLASS_HAS_ACTIVE_BOOKINGS',
+  'LOCATION_HAS_ACTIVE_BOOKINGS',
+  // Laundered onto the booking-create envelope via `CreateBookingResult.code`
+  // (booking-creation.ts → bookings.ts `fail(c, …, { code: createResult.code })`):
+  // pricing (`@kuruma/shared/lib/pricing`) and rental-rule (`…/lib/rental-rules`)
+  // checks. `CreateBookingResult.code` is narrowed to `ErrorCode`, so a new one
+  // can't reach the wire without being listed here.
+  'INVALID_DURATION',
+  'NO_RATES_SET',
+  'RENTAL_RULE_ADVANCE_BOOKING',
+  'RENTAL_RULE_MIN_DURATION',
+  'RENTAL_RULE_MAX_DURATION',
+] as const
+
+export type ErrorCode = (typeof ERROR_CODES)[number]

--- a/packages/shared/src/types/api-response.ts
+++ b/packages/shared/src/types/api-response.ts
@@ -7,11 +7,13 @@
  *
  * Consumer migration tracked in the feature-modules PR-2/PR-3 plan.
  */
+import type { ErrorCode } from '../lib/error-codes'
+
 export type ApiResponse<T> =
   | { success: true; data: T }
   | {
       success: false
       error: string
-      code?: string
+      code?: ErrorCode
       details?: Record<string, string[]>
     }

--- a/packages/web/src/lib/api-error.ts
+++ b/packages/web/src/lib/api-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import type { ApiResponse } from '@kuruma/shared/types/api-response'
 import type { z } from 'zod'
 
@@ -13,9 +14,9 @@ export class ApiError extends Error {
   /** Machine-readable failure code from the envelope (`fail(c, …, { code })`),
    *  when present. Lets callers distinguish same-status failures (e.g. a
    *  document-gate 403 vs a plain authorization deny) without parsing messages. */
-  readonly code: string | undefined
+  readonly code: ErrorCode | undefined
 
-  constructor(message: string, status: number, code?: string) {
+  constructor(message: string, status: number, code?: ErrorCode) {
     super(message)
     this.status = status
     this.code = code
@@ -78,11 +79,11 @@ export async function unwrap<T>(res: Response, schema?: z.ZodType<T>): Promise<T
   return parsed.data
 }
 
-export const OPERATOR_REQUIRED = 'OPERATOR_REQUIRED'
+export const OPERATOR_REQUIRED: ErrorCode = 'OPERATOR_REQUIRED'
 
 /** Envelope `code` the booking API returns when the #459 document-verification
  *  gate blocks a booking. Matches `documentVerificationGate` on the API side. */
-export const DOCUMENT_VERIFICATION_REQUIRED = 'DOCUMENT_VERIFICATION_REQUIRED'
+export const DOCUMENT_VERIFICATION_REQUIRED: ErrorCode = 'DOCUMENT_VERIFICATION_REQUIRED'
 
 /**
  * Recognises the write-path "operator must be named" rejection (a vehicle/class
@@ -91,6 +92,6 @@ export const DOCUMENT_VERIFICATION_REQUIRED = 'DOCUMENT_VERIFICATION_REQUIRED'
  * rather than regex-matching the message — copy or i18n changes can't break it
  * (#934). Matches the `OPERATOR_REQUIRED` code emitted by the API error handler.
  */
-export function operatorRequiredCode(e: unknown): string | undefined {
+export function operatorRequiredCode(e: unknown): ErrorCode | undefined {
   return e instanceof ApiError && e.code === OPERATOR_REQUIRED ? OPERATOR_REQUIRED : undefined
 }


### PR DESCRIPTION
## What

Introduces a typed `ErrorCode` union as the single source of truth for the API envelope `code` field, shared across the api↔web boundary. Producer and consumer now agree at **compile time** — a typo, rename, or i18n of a code constant surfaces as a `tsc` error instead of a silently `undefined` code that breaks discrimination.

Closes #941.

## Why

`ApiResponse.code` was a wide `string`, so a producer/consumer mismatch failed silently (consumer reads `undefined`, no compile error). Tests were the only guard, and only where they existed.

## Changes (expand-only, no behavior change)

- **`@kuruma/shared/lib/error-codes`** (new) — `ERROR_CODES` tuple + derived `ErrorCode` type, plus a contract test pinning the exhaustive set + no-duplicates.
- **`ApiResponse.code`** narrowed `string → ErrorCode`.
- **`CreateBookingResult.code`** narrowed `string → ErrorCode` — this closes the loose seam that **laundered pricing & rental-rule codes** (`INVALID_DURATION`, `NO_RATES_SET`, `RENTAL_RULE_*`) onto the booking-create envelope via `fail(c, …, { code: createResult.code })`. These never appeared as literal `code: '…'` greps, so the SSoT set is **11 codes**, not the 6 visible at direct emit sites. tsc now rejects any future code reaching this seam that isn't listed.
- **6 direct emit sites** annotated with `satisfies ErrorCode`.
- **web** — `ApiError.code` + the `api-error.ts` consts typed `ErrorCode`; consumer comparisons (`operator-locations`, `PaymentStep`) now compile-checked.

## Verification

- tsc clean on **shared / api / web**.
- Guard proven both directions: a typo'd literal at an emit site **and** a missing laundered code both fail `tsc` (with the full union surfaced).
- lint / biome / module-boundaries / export-drift all green.
- Tests: shared **585** · api **1625** · web **1083**, all pass.

## Review note

A code-reviewer pass caught that my first cut listed only the 6 direct codes and missed the 5 laundered ones — fixed by tracing the envelope *sink* (`CreateBookingResult.code`), not the literals, and narrowing that field so the gap is now structurally impossible. Service result `code?: string` fields that only ever hold their own annotated literal (fee-schedule / location / vehicle-class) are left loose by design (no cross-module laundering risk; guarded by `satisfies` + the contract test).