### PR TITLE
feat(#879): PhotoRef photo-source model — repo-boundary r2:<key> encode/decode + backfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db:seed-bookings": "bun run scripts/seed-bookings.ts",
     "db:seed:tcp": "bun run scripts/seed-tcp.ts",
     "db:backfill-regions": "bun run scripts/backfill-location-regions.ts",
+    "db:backfill-photo-refs": "bun run scripts/backfill-photo-refs.ts",
     "db:verify": "bun run scripts/db-verify.ts",
     "db:drift-warn": "bun run scripts/db-drift-warn.ts",
     "prepare": "husky"

--- a/packages/api/src/composition/repositories.ts
+++ b/packages/api/src/composition/repositories.ts
@@ -1,5 +1,5 @@
 import { type RunTx, getDb, runTx } from '@kuruma/shared/db'
-import { photoRefsToWireUrls } from '@kuruma/shared/lib/photo-ref'
+import { photoRefsToWireUrls, wireUrlsToStoredRefs } from '@kuruma/shared/lib/photo-ref'
 import type { AppOverrides } from '../app-overrides'
 import { DrizzleOAuthAccountStore } from '../auth/drizzle-oauth-account-store'
 import { FetchGoogleOAuthProvider } from '../auth/fetch-google-oauth-provider'
@@ -267,7 +267,12 @@ export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
   // escape a repo and every read surface emits resolvable URLs.
   const photosPublicUrl = process.env.VEHICLE_PHOTOS_PUBLIC_URL ?? ''
   const decodePhotos = (photos: readonly string[]) => photoRefsToWireUrls(photos, photosPublicUrl)
-  const vehicleRepo = new DrizzleVehicleRepository(db, decodePhotos)
+  // The write-side inverse (#879 Slice 3): collapse our own public URLs back to
+  // r2:<key> before they hit the column, so stored rows hold refs and the same
+  // base round-trips losslessly. R2 storage is only constructed when
+  // photosPublicUrl is set, so the encoder and the bucket share one base.
+  const encodePhotos = (photos: readonly string[]) => wireUrlsToStoredRefs(photos, photosPublicUrl)
+  const vehicleRepo = new DrizzleVehicleRepository(db, decodePhotos, encodePhotos)
   const bookingRepo = new DrizzleBookingRepository(db)
   const userRepo = new DrizzleUserRepository(db)
   const operatorRepo = new DrizzleOperatorRepository(db)
@@ -299,7 +304,7 @@ export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
     ? new R2DocumentStorage(renterDocumentsBucket)
     : new DisabledDocumentStorage()
   return {
-    vehicleClassRepo: new DrizzleVehicleClassRepository(db, decodePhotos),
+    vehicleClassRepo: new DrizzleVehicleClassRepository(db, decodePhotos, encodePhotos),
     vehicleRepo,
     bookingRepo,
     availabilityRepo: new DrizzleAvailabilityRepository(db, decodePhotos),

--- a/packages/api/src/composition/repositories.ts
+++ b/packages/api/src/composition/repositories.ts
@@ -1,4 +1,5 @@
 import { type RunTx, getDb, runTx } from '@kuruma/shared/db'
+import { photoRefsToWireUrls } from '@kuruma/shared/lib/photo-ref'
 import type { AppOverrides } from '../app-overrides'
 import { DrizzleOAuthAccountStore } from '../auth/drizzle-oauth-account-store'
 import { FetchGoogleOAuthProvider } from '../auth/fetch-google-oauth-provider'
@@ -260,7 +261,13 @@ export function buildOverrideRepos(overrides: AppOverrides): Repos {
 export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
   const db = opts?.db ?? getDb()
   const tx = opts?.runTx ?? runTx
-  const vehicleRepo = new DrizzleVehicleRepository(db)
+  // #879: stored photos are R2 keys (r2:<key>) or external URLs. The read-
+  // serving repos decode them to wire URLs via this injected decoder — built
+  // here, the only place the public bucket base is known — so r2: refs never
+  // escape a repo and every read surface emits resolvable URLs.
+  const photosPublicUrl = process.env.VEHICLE_PHOTOS_PUBLIC_URL ?? ''
+  const decodePhotos = (photos: readonly string[]) => photoRefsToWireUrls(photos, photosPublicUrl)
+  const vehicleRepo = new DrizzleVehicleRepository(db, decodePhotos)
   const bookingRepo = new DrizzleBookingRepository(db)
   const userRepo = new DrizzleUserRepository(db)
   const operatorRepo = new DrizzleOperatorRepository(db)
@@ -275,7 +282,6 @@ export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
   const vehiclePhotosBucket = (globalThis as Record<string, unknown>).VEHICLE_PHOTOS as
     | R2BucketLike
     | undefined
-  const photosPublicUrl = process.env.VEHICLE_PHOTOS_PUBLIC_URL ?? ''
   // In the Drizzle branch (production) an InMemory fallback is dangerous —
   // each CF Worker request gets a fresh instance, so uploads "succeed" but
   // return URLs pointing at nothing. DisabledPhotoStorage throws loudly.
@@ -293,13 +299,13 @@ export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
     ? new R2DocumentStorage(renterDocumentsBucket)
     : new DisabledDocumentStorage()
   return {
-    vehicleClassRepo: new DrizzleVehicleClassRepository(db),
+    vehicleClassRepo: new DrizzleVehicleClassRepository(db, decodePhotos),
     vehicleRepo,
     bookingRepo,
-    availabilityRepo: new DrizzleAvailabilityRepository(db),
+    availabilityRepo: new DrizzleAvailabilityRepository(db, decodePhotos),
     userRepo,
-    fleetOverviewRepo: new DrizzleFleetOverviewRepository(db),
-    vehicleDetailRepo: new DrizzleVehicleDetailRepository(db),
+    fleetOverviewRepo: new DrizzleFleetOverviewRepository(db, decodePhotos),
+    vehicleDetailRepo: new DrizzleVehicleDetailRepository(db, decodePhotos),
     statsRepo: new DrizzleStatsRepository(db),
     overviewRepo: new DrizzleOverviewRepository(db),
     threadRepo: new DrizzleThreadRepository(db, tx),

--- a/packages/api/src/repositories/drizzle/availability.ts
+++ b/packages/api/src/repositories/drizzle/availability.ts
@@ -2,10 +2,21 @@ import { bookings, vehicles } from '@kuruma/shared/db/schema'
 import { type SQL, and, eq, inArray, sql } from 'drizzle-orm'
 import type { Booking, Vehicle } from '../../stores'
 import type { AvailabilityFilters, AvailabilityRepository } from '../types'
-import { type Db, bookingColumns, toBooking, toVehicle, vehicleColumns } from './shared'
+import {
+  type Db,
+  type PhotoDecoder,
+  bookingColumns,
+  identityPhotoDecoder,
+  toBooking,
+  toVehicle,
+  vehicleColumns,
+} from './shared'
 
 export class DrizzleAvailabilityRepository implements AvailabilityRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+  ) {}
 
   async findAvailableVehicles(
     from: Date,
@@ -44,7 +55,7 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
       .select(vehicleColumns)
       .from(vehicles)
       .where(and(...conditions))
-    return rows.map(toVehicle)
+    return rows.map((r) => toVehicle(r, this.decodePhotos))
   }
 
   async checkVehicleAvailability(
@@ -75,7 +86,7 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
 
     return {
       available: conflicts.length === 0,
-      vehicle: toVehicle(vehicle),
+      vehicle: toVehicle(vehicle, this.decodePhotos),
       conflicts: conflicts.map(toBooking),
     }
   }

--- a/packages/api/src/repositories/drizzle/fleet-overview.ts
+++ b/packages/api/src/repositories/drizzle/fleet-overview.ts
@@ -6,7 +6,14 @@ import type { CallerContext } from '../../middleware/auth'
 import type { Vehicle } from '../../stores'
 import { operatorReadScope } from '../../tenancy'
 import type { FleetOverviewRepository } from '../types'
-import { type Db, overlapHours, toVehicle, vehicleColumns } from './shared'
+import {
+  type Db,
+  type PhotoDecoder,
+  identityPhotoDecoder,
+  overlapHours,
+  toVehicle,
+  vehicleColumns,
+} from './shared'
 
 // Fleet overview: owner-facing aggregated read. Two round-trips instead
 // of N+1 -- one SELECT for all vehicles, one SELECT for all relevant
@@ -17,7 +24,10 @@ import { type Db, overlapHours, toVehicle, vehicleColumns } from './shared'
 const UTILIZATION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
 
 export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+  ) {}
 
   async findFleetOverview(ctx: CallerContext, now: Date): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_MS)
@@ -33,7 +43,7 @@ export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
     // Round-trip 1: this tenant's vehicles.
     const vehicleRows = (
       await this.db.select(vehicleColumns).from(vehicles).where(vehicleWhere)
-    ).map(toVehicle)
+    ).map((r) => toVehicle(r, this.decodePhotos))
     if (vehicleRows.length === 0) return []
     const vehicleIds = vehicleRows.map((v) => v.id)
 

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -307,14 +307,26 @@ type ThreadRow = ColumnRow<typeof threadColumns>
 type ThreadParticipantRow = ColumnRow<typeof participantColumns>
 type MaintenanceLogRow = ColumnRow<typeof maintenanceLogColumns>
 
-export function toVehicleClass(r: VehicleClassRow): VehicleClass {
+/**
+ * Decodes stored `photos` entries to wire URLs (#879). The composition root
+ * builds the real decoder from `VEHICLE_PHOTOS_PUBLIC_URL` (r2:<key> -> URL,
+ * external URLs pass through) and injects it into the read-serving repos;
+ * `identityPhotoDecoder` is the no-op fallback for paths that never carry r2:
+ * refs (the in-memory repos store domain objects directly; the tx-bound vehicle
+ * repo reads for consistency, not photo serving).
+ */
+export type PhotoDecoder = (photos: readonly string[]) => string[]
+
+export const identityPhotoDecoder: PhotoDecoder = (photos) => [...photos]
+
+export function toVehicleClass(r: VehicleClassRow, decodePhotos: PhotoDecoder): VehicleClass {
   return {
     id: r.id,
     operatorId: r.operatorId,
     name: r.name,
     slug: r.slug,
     description: r.description,
-    photos: r.photos,
+    photos: decodePhotos(r.photos),
     seats: r.seats,
     luggageCapacity: r.luggageCapacity,
     luggageSize: r.luggageSize,
@@ -422,7 +434,7 @@ export function toPaymentAnomaly(r: PaymentAnomalyRow): PaymentAnomaly {
   }
 }
 
-export function toVehicle(r: VehicleRow): Vehicle {
+export function toVehicle(r: VehicleRow, decodePhotos: PhotoDecoder): Vehicle {
   return {
     id: r.id,
     operatorId: r.operatorId,
@@ -430,7 +442,7 @@ export function toVehicle(r: VehicleRow): Vehicle {
     pickupLocationId: r.pickupLocationId,
     name: r.name,
     description: r.description,
-    photos: r.photos,
+    photos: decodePhotos(r.photos),
     seats: r.seats,
     luggageCapacity: r.luggageCapacity,
     luggageSize: r.luggageSize,

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -319,6 +319,20 @@ export type PhotoDecoder = (photos: readonly string[]) => string[]
 
 export const identityPhotoDecoder: PhotoDecoder = (photos) => [...photos]
 
+/**
+ * Encodes wire-URL `photos` entries to their stored form (#879) — the write-side
+ * inverse of {@link PhotoDecoder}. The composition root builds the real encoder
+ * from `VEHICLE_PHOTOS_PUBLIC_URL` (our public URL -> r2:<key>, external URLs
+ * pass through) and injects it into the photo-writing repos (vehicle +
+ * vehicle-class). `identityPhotoEncoder` is the no-op default for paths that
+ * never mint r2: refs (the in-memory repos store domain objects directly; the
+ * tx-bound vehicle repo never writes photos). Keeping encode here means r2:
+ * refs are minted in exactly one place — symmetric with decode on read.
+ */
+export type PhotoEncoder = (photos: readonly string[]) => string[]
+
+export const identityPhotoEncoder: PhotoEncoder = (photos) => [...photos]
+
 export function toVehicleClass(r: VehicleClassRow, decodePhotos: PhotoDecoder): VehicleClass {
   return {
     id: r.id,

--- a/packages/api/src/repositories/drizzle/vehicle-class.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-class.ts
@@ -4,10 +4,19 @@ import type { CallerContext } from '../../middleware/auth'
 import type { VehicleClass } from '../../stores'
 import { operatorReadScope } from '../../tenancy'
 import type { VehicleClassFilters, VehicleClassRepository } from '../types'
-import { type Db, toVehicleClass, vehicleClassColumns } from './shared'
+import {
+  type Db,
+  type PhotoDecoder,
+  identityPhotoDecoder,
+  toVehicleClass,
+  vehicleClassColumns,
+} from './shared'
 
 export class DrizzleVehicleClassRepository implements VehicleClassRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+  ) {}
 
   async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
     const scope = operatorReadScope(ctx)
@@ -31,7 +40,7 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
       .where(where)
       .orderBy(asc(vehicleClasses.sortOrder))
 
-    return rows.map(toVehicleClass)
+    return rows.map((r) => toVehicleClass(r, this.decodePhotos))
   }
 
   async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {
@@ -42,7 +51,7 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
 
     const [row] = await this.db.select(vehicleClassColumns).from(vehicleClasses).where(and(...conditions))
 
-    return row ? toVehicleClass(row) : undefined
+    return row ? toVehicleClass(row, this.decodePhotos) : undefined
   }
 
   async findBySlug(ctx: CallerContext, slug: string): Promise<VehicleClass | undefined> {
@@ -53,7 +62,7 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
 
     const [row] = await this.db.select(vehicleClassColumns).from(vehicleClasses).where(and(...conditions))
 
-    return row ? toVehicleClass(row) : undefined
+    return row ? toVehicleClass(row, this.decodePhotos) : undefined
   }
 
   async create(
@@ -79,7 +88,7 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
       .returning()
 
     if (!inserted) throw new Error('Failed to insert vehicle class')
-    return toVehicleClass(inserted)
+    return toVehicleClass(inserted, this.decodePhotos)
   }
 
   async update(
@@ -93,7 +102,7 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
       .where(eq(vehicleClasses.id, id))
       .returning()
 
-    return updated ? toVehicleClass(updated) : undefined
+    return updated ? toVehicleClass(updated, this.decodePhotos) : undefined
   }
 
   async archive(id: string): Promise<VehicleClass | undefined> {
@@ -103,6 +112,6 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
       .where(eq(vehicleClasses.id, id))
       .returning()
 
-    return archived ? toVehicleClass(archived) : undefined
+    return archived ? toVehicleClass(archived, this.decodePhotos) : undefined
   }
 }

--- a/packages/api/src/repositories/drizzle/vehicle-class.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-class.ts
@@ -7,7 +7,9 @@ import type { VehicleClassFilters, VehicleClassRepository } from '../types'
 import {
   type Db,
   type PhotoDecoder,
+  type PhotoEncoder,
   identityPhotoDecoder,
+  identityPhotoEncoder,
   toVehicleClass,
   vehicleClassColumns,
 } from './shared'
@@ -16,6 +18,8 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
   constructor(
     private readonly db: Db,
     private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+    // #879: wire URLs -> stored refs (r2:<key>) on write, symmetric with decode.
+    private readonly encodePhotos: PhotoEncoder = identityPhotoEncoder,
   ) {}
 
   async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
@@ -75,7 +79,9 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
         name: data.name,
         slug: data.slug,
         description: data.description,
-        photos: data.photos,
+        // undefined => omit so the column DB default ([]) applies; defined =>
+        // encode wire URLs to stored refs.
+        photos: data.photos === undefined ? undefined : this.encodePhotos(data.photos),
         seats: data.seats,
         luggageCapacity: data.luggageCapacity,
         luggageSize: data.luggageSize,
@@ -96,9 +102,14 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
     data: Partial<VehicleClass>,
   ): Promise<VehicleClass | undefined> {
     const { id: _id, createdAt: _createdAt, ...fields } = data
+    // #879: re-encode an edited photos array; absent key leaves it untouched.
+    const set =
+      fields.photos === undefined
+        ? fields
+        : { ...fields, photos: this.encodePhotos(fields.photos) }
     const [updated] = await this.db
       .update(vehicleClasses)
-      .set({ ...fields, updatedAt: sql`now()` })
+      .set({ ...set, updatedAt: sql`now()` })
       .where(eq(vehicleClasses.id, id))
       .returning()
 

--- a/packages/api/src/repositories/drizzle/vehicle-detail.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-detail.ts
@@ -7,6 +7,8 @@ import { operatorReadScope } from '../../tenancy'
 import type { VehicleDetailRepository } from '../types'
 import {
   type Db,
+  type PhotoDecoder,
+  identityPhotoDecoder,
   maintenanceLogColumns,
   overlapHours,
   toMaintenanceLog,
@@ -37,7 +39,10 @@ function dayStart(d: Date): Date {
 }
 
 export class DrizzleVehicleDetailRepository implements VehicleDetailRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+  ) {}
 
   async findVehicleDetail(
     ctx: CallerContext,
@@ -46,7 +51,7 @@ export class DrizzleVehicleDetailRepository implements VehicleDetailRepository {
   ): Promise<VehicleDetail | undefined> {
     const vehicleRow = await this.fetchVehicleRow(ctx, vehicleId)
     if (!vehicleRow) return undefined
-    const vehicle = toVehicle(vehicleRow)
+    const vehicle = toVehicle(vehicleRow, this.decodePhotos)
 
     const todayStart = dayStart(now)
     const windowStart = new Date(todayStart.getTime() - (UTILIZATION_WINDOW_DAYS - 1) * MS_PER_DAY)

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -9,12 +9,23 @@ import type {
   VehicleRepository,
   VehicleUpdateOptions,
 } from '../types'
-import { type Db, type PhotoDecoder, identityPhotoDecoder, toVehicle, vehicleColumns } from './shared'
+import {
+  type Db,
+  type PhotoDecoder,
+  type PhotoEncoder,
+  identityPhotoDecoder,
+  identityPhotoEncoder,
+  toVehicle,
+  vehicleColumns,
+} from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
   constructor(
     private readonly db: Db,
     private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+    // #879: wire URLs -> stored refs (r2:<key>) on write. Identity by default so
+    // the tx-bound vehicle repo (never writes photos) and tests stay unaffected.
+    private readonly encodePhotos: PhotoEncoder = identityPhotoEncoder,
   ) {}
 
   async findAll(ctx: CallerContext, filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
@@ -103,7 +114,9 @@ export class DrizzleVehicleRepository implements VehicleRepository {
         pickupLocationId: data.pickupLocationId,
         name: data.name,
         description: data.description,
-        photos: data.photos,
+        // undefined => omit so the column DB default ([]) applies; defined =>
+        // encode wire URLs to stored refs.
+        photos: data.photos === undefined ? undefined : this.encodePhotos(data.photos),
         seats: data.seats,
         luggageCapacity: data.luggageCapacity,
         luggageSize: data.luggageSize,
@@ -135,6 +148,13 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     // operatorId is the tenant anchor — never reassignable via an update, or a
     // caller could move a vehicle to another tenant (#386 F2). Strip it here.
     const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data
+    // #879: re-encode an edited photos array (wire URLs -> stored refs) so an
+    // edit round-trip never bakes the public host into the stored value. Absent
+    // key => leave the column untouched.
+    const set =
+      fields.photos === undefined
+        ? fields
+        : { ...fields, photos: this.encodePhotos(fields.photos) }
     const scope = operatorReadScope(ctx)
     const conditions = [eq(vehicles.id, id)]
     if (scope.kind === 'operator') conditions.push(eq(vehicles.operatorId, scope.operatorId))
@@ -143,7 +163,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     }
     const [updated] = await this.db
       .update(vehicles)
-      .set({ ...fields, updatedAt: sql`now()` })
+      .set({ ...set, updatedAt: sql`now()` })
       .where(and(...conditions))
       .returning()
 
@@ -196,10 +216,12 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     // cardinality stays within the cap. Concurrent callers serialize at
     // the row level, so two racing uploads cannot both pass the guard.
     // URLs are chained via array_append to keep them as bound parameters
-    // rather than interpolated literals.
+    // rather than interpolated literals. #879: store the encoded ref (our own
+    // uploads collapse to r2:<key>; external URLs pass through) so the column
+    // holds stored refs, never resolved wire URLs.
     let photosExpr: SQL = sql`${vehicles.photos}`
-    for (const url of urls) {
-      photosExpr = sql`array_append(${photosExpr}, ${url})`
+    for (const entry of this.encodePhotos(urls)) {
+      photosExpr = sql`array_append(${photosExpr}, ${entry})`
     }
     const conditions: SQL[] = [
       eq(vehicles.id, id),
@@ -224,13 +246,17 @@ export class DrizzleVehicleRepository implements VehicleRepository {
   ): Promise<Vehicle | undefined> {
     requireFleetWriteScope(ctx)
     const scope = operatorReadScope(ctx)
+    // #879: the caller passes a wire URL, but the column stores refs — encode it
+    // back to its stored form so array_remove/ANY match an r2:<key> row (the
+    // resolved URL never appears in the column).
+    const ref = this.encodePhotos([url])[0] ?? url
     // array_remove is atomic — no TOCTOU between read of photos and write.
-    const conditions: SQL[] = [eq(vehicles.id, id), sql`${url} = ANY(${vehicles.photos})`]
+    const conditions: SQL[] = [eq(vehicles.id, id), sql`${ref} = ANY(${vehicles.photos})`]
     if (scope.kind === 'operator') conditions.push(eq(vehicles.operatorId, scope.operatorId))
     const [updated] = await this.db
       .update(vehicles)
       .set({
-        photos: sql`array_remove(${vehicles.photos}, ${url})`,
+        photos: sql`array_remove(${vehicles.photos}, ${ref})`,
         updatedAt: sql`now()`,
       })
       .where(and(...conditions))

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -9,10 +9,13 @@ import type {
   VehicleRepository,
   VehicleUpdateOptions,
 } from '../types'
-import { type Db, toVehicle, vehicleColumns } from './shared'
+import { type Db, type PhotoDecoder, identityPhotoDecoder, toVehicle, vehicleColumns } from './shared'
 
 export class DrizzleVehicleRepository implements VehicleRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly decodePhotos: PhotoDecoder = identityPhotoDecoder,
+  ) {}
 
   async findAll(ctx: CallerContext, filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>> {
     const conditions: SQL[] = []
@@ -49,7 +52,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     ])
 
     return {
-      data: rows.map(toVehicle),
+      data: rows.map((r) => toVehicle(r, this.decodePhotos)),
       total: countResult[0]?.value ?? 0,
     }
   }
@@ -65,7 +68,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .from(vehicles)
       .where(and(...conditions))
 
-    return row ? toVehicle(row) : undefined
+    return row ? toVehicle(row, this.decodePhotos) : undefined
   }
 
   async findByIds(ctx: CallerContext, ids: string[]): Promise<Vehicle[]> {
@@ -78,7 +81,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .select(vehicleColumns)
       .from(vehicles)
       .where(and(...conditions))
-    return rows.map(toVehicle)
+    return rows.map((r) => toVehicle(r, this.decodePhotos))
   }
 
   async create(
@@ -119,7 +122,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .returning()
 
     if (!inserted) throw new Error('Failed to insert vehicle')
-    return toVehicle(inserted)
+    return toVehicle(inserted, this.decodePhotos)
   }
 
   async update(
@@ -144,7 +147,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .where(and(...conditions))
       .returning()
 
-    return updated ? toVehicle(updated) : undefined
+    return updated ? toVehicle(updated, this.decodePhotos) : undefined
   }
 
   async softDelete(ctx: CallerContext, id: string): Promise<Vehicle | undefined> {
@@ -158,7 +161,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .where(and(...conditions))
       .returning()
 
-    return retired ? toVehicle(retired) : undefined
+    return retired ? toVehicle(retired, this.decodePhotos) : undefined
   }
 
   async bulkUpdateStatus(
@@ -176,7 +179,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .set({ status, updatedAt: sql`now()` })
       .where(and(...conditions))
       .returning()
-    return rows.map(toVehicle)
+    return rows.map((r) => toVehicle(r, this.decodePhotos))
   }
 
   async appendPhotos(
@@ -209,7 +212,7 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       .where(and(...conditions))
       .returning()
 
-    if (updated) return { outcome: 'ok', vehicle: toVehicle(updated) }
+    if (updated) return { outcome: 'ok', vehicle: toVehicle(updated, this.decodePhotos) }
     const existing = await this.findById(ctx, id)
     return existing ? { outcome: 'cap_exceeded' } : { outcome: 'not_found' }
   }
@@ -232,6 +235,6 @@ export class DrizzleVehicleRepository implements VehicleRepository {
       })
       .where(and(...conditions))
       .returning()
-    return updated ? toVehicle(updated) : undefined
+    return updated ? toVehicle(updated, this.decodePhotos) : undefined
   }
 }

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -218,14 +218,16 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     // URLs are chained via array_append to keep them as bound parameters
     // rather than interpolated literals. #879: store the encoded ref (our own
     // uploads collapse to r2:<key>; external URLs pass through) so the column
-    // holds stored refs, never resolved wire URLs.
+    // holds stored refs, never resolved wire URLs. Encode once so the cap guard
+    // and the append agree on cardinality.
+    const refs = this.encodePhotos(urls)
     let photosExpr: SQL = sql`${vehicles.photos}`
-    for (const entry of this.encodePhotos(urls)) {
+    for (const entry of refs) {
       photosExpr = sql`array_append(${photosExpr}, ${entry})`
     }
     const conditions: SQL[] = [
       eq(vehicles.id, id),
-      sql`cardinality(${vehicles.photos}) + ${urls.length} <= ${maxPhotos}`,
+      sql`cardinality(${vehicles.photos}) + ${refs.length} <= ${maxPhotos}`,
     ]
     if (scope.kind === 'operator') conditions.push(eq(vehicles.operatorId, scope.operatorId))
     const [updated] = await this.db

--- a/packages/api/src/repositories/r2-photo-storage.ts
+++ b/packages/api/src/repositories/r2-photo-storage.ts
@@ -1,3 +1,4 @@
+import { toObjectKey } from '@kuruma/shared/lib/photo-ref'
 import type { PhotoStorage } from './types'
 
 /** Minimal R2Bucket shape so this file compiles without global workers-types. */
@@ -15,37 +16,6 @@ const EXT_MAP: Record<string, string> = {
   'image/png': 'png',
   'image/webp': 'webp',
   'image/avif': 'avif',
-}
-
-/**
- * Recover the object key from either a bare key or one of our public URLs.
- *
- * Exact origin + base-path matching via URL parsing — NOT a loose string
- * prefix. A raw `startsWith(publicBaseUrl)` mis-handled a base with a trailing
- * slash (sliced one character into the key) and a look-alike host
- * (`https://cdn.example.com.evil/...` satisfies `startsWith` and got
- * mis-sliced). Anything that isn't one of our public URLs — a bare key, an
- * external URL, a different origin — is returned untouched and treated as a key
- * (a no-op delete in R2). See #678 review.
- */
-export function toObjectKey(keyOrUrl: string, publicBaseUrl: string): string {
-  let target: URL
-  try {
-    target = new URL(keyOrUrl)
-  } catch {
-    return keyOrUrl // relative value — already a key
-  }
-  let base: URL
-  try {
-    base = new URL(publicBaseUrl)
-  } catch {
-    return keyOrUrl // base not a URL (e.g. empty in dev) — can't be our URL
-  }
-  if (target.origin !== base.origin) return keyOrUrl
-  const basePath = base.pathname.replace(/\/+$/, '') // '' or '/sub'
-  const prefix = `${basePath}/`
-  if (!target.pathname.startsWith(prefix)) return keyOrUrl
-  return target.pathname.slice(prefix.length)
 }
 
 export class R2PhotoStorage implements PhotoStorage {

--- a/packages/api/tests/integration/backfill-photo-refs.test.ts
+++ b/packages/api/tests/integration/backfill-photo-refs.test.ts
@@ -1,0 +1,121 @@
+import { backfillPhotoRefs } from '@kuruma/shared/db/backfill-photo-refs'
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { DEFAULT_DAILY_RATE_JPY, cleanupVehicleClasses, cleanupVehicles, db } from './setup'
+
+// A base unique to this file so the global backfill (it scans EVERY row) can be
+// asserted PER ROW without colliding with other concurrent integration files.
+const BASE = 'https://photos.backfill.example'
+
+// IDENTITY encoder (no 3rd ctor arg) => seed LEGACY rows that store wire URLs
+// verbatim — the pre-#879-Slice-3 state the backfill must migrate.
+const legacyRepo = new DrizzleVehicleRepository(db)
+const legacyClassRepo = new DrizzleVehicleClassRepository(db)
+
+const vehicleIds: string[] = []
+const classIds: string[] = []
+afterEach(async () => {
+  await cleanupVehicles(vehicleIds)
+  await cleanupVehicleClasses(classIds)
+  vehicleIds.length = 0
+  classIds.length = 0
+})
+
+async function rawVehiclePhotos(id: string): Promise<string[]> {
+  const [row] = await db
+    .select({ photos: vehicles.photos })
+    .from(vehicles)
+    .where(eq(vehicles.id, id))
+  return row?.photos ?? []
+}
+
+async function rawClassPhotos(id: string): Promise<string[]> {
+  const [row] = await db
+    .select({ photos: vehicleClasses.photos })
+    .from(vehicleClasses)
+    .where(eq(vehicleClasses.id, id))
+  return row?.photos ?? []
+}
+
+async function seedVehicle(photos: string[]): Promise<string> {
+  const v = await legacyRepo.create(SYSTEM_CONTEXT, {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    name: 'Backfill Car',
+    description: null,
+    photos,
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+  })
+  vehicleIds.push(v.id)
+  return v.id
+}
+
+async function seedClass(photos: string[]): Promise<string> {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const c = await legacyClassRepo.create({
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    name: `Backfill Class ${uniq}`,
+    slug: `backfill-class-${uniq}`,
+    description: null,
+    photos,
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    acrissCode: null,
+    sortOrder: 0,
+    status: 'ACTIVE',
+  })
+  classIds.push(c.id)
+  return c.id
+}
+
+describe('photo-ref backfill (#879 Slice 4)', () => {
+  it('rewrites our own wire URLs to r2 refs, leaving externals and existing refs untouched', async () => {
+    const ext = 'https://images.example/external.jpg'
+    const vId = await seedVehicle([`${BASE}/vehicles/v/a.jpg`, ext, 'r2:vehicles/v/already.jpg'])
+    const cId = await seedClass([`${BASE}/vehicles/class/c.jpg`, ext])
+
+    const report = await backfillPhotoRefs(db, BASE)
+
+    expect(report.vehiclesRewritten).toBeGreaterThanOrEqual(1)
+    expect(report.vehicleClassesRewritten).toBeGreaterThanOrEqual(1)
+    expect(await rawVehiclePhotos(vId)).toEqual([
+      'r2:vehicles/v/a.jpg',
+      ext,
+      'r2:vehicles/v/already.jpg',
+    ])
+    expect(await rawClassPhotos(cId)).toEqual(['r2:vehicles/class/c.jpg', ext])
+  })
+
+  it('is idempotent — a row with no wire URLs of ours is left byte-for-byte unchanged', async () => {
+    const ext = 'https://images.example/only-external.jpg'
+    const vId = await seedVehicle([ext, 'r2:vehicles/v/keep.jpg'])
+
+    const before = await rawVehiclePhotos(vId)
+    await backfillPhotoRefs(db, BASE)
+    const afterFirst = await rawVehiclePhotos(vId)
+    await backfillPhotoRefs(db, BASE)
+    const afterSecond = await rawVehiclePhotos(vId)
+
+    expect(afterFirst).toEqual(before)
+    expect(afterSecond).toEqual(before)
+  })
+})

--- a/packages/api/tests/integration/vehicle-photos-ref.test.ts
+++ b/packages/api/tests/integration/vehicle-photos-ref.test.ts
@@ -1,0 +1,178 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { vehicles } from '@kuruma/shared/db/schema'
+import { photoRefsToWireUrls, wireUrlsToStoredRefs } from '@kuruma/shared/lib/photo-ref'
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { DEFAULT_DAILY_RATE_JPY, cleanupVehicleClasses, cleanupVehicles, db } from './setup'
+
+// Mirror the composition root (#879): decode r2:<key> -> wire URL on read,
+// encode wire URL -> r2:<key> on write, both bound to ONE public base. The
+// repository is the single serialization boundary — stored rows carry r2: refs,
+// the wire only ever sees URLs. These assertions read the RAW column to prove
+// the encode actually lands an r2: ref (not just that read decode is a no-op).
+const BASE = 'https://photos.test.example'
+const decode = (photos: readonly string[]) => photoRefsToWireUrls(photos, BASE)
+const encode = (photos: readonly string[]) => wireUrlsToStoredRefs(photos, BASE)
+const repo = new DrizzleVehicleRepository(db, decode, encode)
+const classRepo = new DrizzleVehicleClassRepository(db, decode, encode)
+
+const vehicleIds: string[] = []
+const classIds: string[] = []
+afterEach(async () => {
+  await cleanupVehicles(vehicleIds)
+  await cleanupVehicleClasses(classIds)
+  vehicleIds.length = 0
+  classIds.length = 0
+})
+
+function vehicleInput(photos: string[]) {
+  return {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    name: 'Photo Ref Car',
+    description: null,
+    photos,
+    seats: 5,
+    transmission: 'AUTO' as const,
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE' as const,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+  }
+}
+
+function classInput(photos: string[]) {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  return {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    name: `Photo Class ${uniq}`,
+    slug: `photo-class-${uniq}`,
+    description: null,
+    photos,
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM' as const,
+    transmission: 'AUTO' as const,
+    fuelType: null,
+    acrissCode: null,
+    sortOrder: 0,
+    status: 'ACTIVE' as const,
+  }
+}
+
+async function rawVehiclePhotos(id: string): Promise<string[]> {
+  const [row] = await db
+    .select({ photos: vehicles.photos })
+    .from(vehicles)
+    .where(eq(vehicles.id, id))
+  return row?.photos ?? []
+}
+
+async function makeVehicle(photos: string[] = []): Promise<string> {
+  const v = await repo.create(SYSTEM_CONTEXT, vehicleInput(photos))
+  vehicleIds.push(v.id)
+  return v.id
+}
+
+describe('DrizzleVehicleRepository photo ref encoding (#879 Slice 3)', () => {
+  it('appendPhotos stores an r2 ref for our own URL and reads it back as a wire URL', async () => {
+    const id = await makeVehicle([])
+    const key = `vehicles/${id}/shot.jpg`
+    const wireUrl = `${BASE}/${key}`
+
+    const res = await repo.appendPhotos(SYSTEM_CONTEXT, id, [wireUrl], 10)
+
+    expect(res.outcome).toBe('ok')
+    expect(await rawVehiclePhotos(id)).toEqual([`r2:${key}`])
+    const found = await repo.findById(SYSTEM_CONTEXT, id)
+    expect(found?.photos).toEqual([wireUrl])
+  })
+
+  it('appendPhotos stores an external URL verbatim — never minted as r2', async () => {
+    const id = await makeVehicle([])
+    const ext = 'https://images.unsplash.com/photo-1734?w=800&q=80'
+
+    await repo.appendPhotos(SYSTEM_CONTEXT, id, [ext], 10)
+
+    expect(await rawVehiclePhotos(id)).toEqual([ext])
+    const found = await repo.findById(SYSTEM_CONTEXT, id)
+    expect(found?.photos).toEqual([ext])
+  })
+
+  it('create encodes a mixed photos array to stored refs and returns decoded URLs', async () => {
+    const key = 'vehicles/seed/c.jpg'
+    const ext = 'https://images.example/y.jpg'
+
+    const v = await repo.create(SYSTEM_CONTEXT, vehicleInput([`${BASE}/${key}`, ext]))
+    vehicleIds.push(v.id)
+
+    expect(await rawVehiclePhotos(v.id)).toEqual([`r2:${key}`, ext])
+    expect(v.photos).toEqual([`${BASE}/${key}`, ext])
+  })
+
+  it('update re-encodes a wire URL so an edit round-trip never bakes in the host', async () => {
+    const id = await makeVehicle([])
+    const key = `vehicles/${id}/d.jpg`
+
+    const updated = await repo.update(SYSTEM_CONTEXT, id, { photos: [`${BASE}/${key}`] })
+
+    expect(await rawVehiclePhotos(id)).toEqual([`r2:${key}`])
+    expect(updated?.photos).toEqual([`${BASE}/${key}`])
+  })
+
+  it('removePhotoByUrl removes an r2-stored photo addressed by its wire URL (F1)', async () => {
+    const id = await makeVehicle([])
+    const key = `vehicles/${id}/e.jpg`
+    const wireUrl = `${BASE}/${key}`
+    await repo.appendPhotos(SYSTEM_CONTEXT, id, [wireUrl], 10)
+    expect(await rawVehiclePhotos(id)).toEqual([`r2:${key}`])
+
+    const removed = await repo.removePhotoByUrl(SYSTEM_CONTEXT, id, wireUrl)
+
+    expect(removed).toBeDefined()
+    expect(removed?.photos).toEqual([])
+    expect(await rawVehiclePhotos(id)).toEqual([])
+  })
+})
+
+describe('DrizzleVehicleClassRepository photo ref encoding (#879 Slice 3)', () => {
+  async function rawClassPhotos(id: string): Promise<string[]> {
+    const { vehicleClasses } = await import('@kuruma/shared/db/schema')
+    const [row] = await db
+      .select({ photos: vehicleClasses.photos })
+      .from(vehicleClasses)
+      .where(eq(vehicleClasses.id, id))
+    return row?.photos ?? []
+  }
+
+  it('create encodes class photos to stored refs', async () => {
+    const key = 'vehicles/class/a.jpg'
+    const ext = 'https://images.example/z.jpg'
+
+    const created = await classRepo.create(classInput([`${BASE}/${key}`, ext]))
+    classIds.push(created.id)
+
+    expect(await rawClassPhotos(created.id)).toEqual([`r2:${key}`, ext])
+    expect(created.photos).toEqual([`${BASE}/${key}`, ext])
+  })
+
+  it('update re-encodes class photos', async () => {
+    const created = await classRepo.create(classInput([]))
+    classIds.push(created.id)
+    const key = `vehicles/class/${created.id}.jpg`
+
+    const updated = await classRepo.update(created.id, { photos: [`${BASE}/${key}`] })
+
+    expect(await rawClassPhotos(created.id)).toEqual([`r2:${key}`])
+    expect(updated?.photos).toEqual([`${BASE}/${key}`])
+  })
+})

--- a/packages/api/tests/repositories/drizzle/photo-decode.test.ts
+++ b/packages/api/tests/repositories/drizzle/photo-decode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { type PhotoDecoder, toVehicle, toVehicleClass } from '../../../src/repositories/drizzle/shared'
+
+// A stand-in decoder that expands r2:<key> refs against a fake bucket base and
+// passes external URLs through — the same contract the composition root injects
+// (#879). The point of these tests is to prove the row->domain mappers actually
+// route `photos` THROUGH the injected decoder, so a revert to `photos: r.photos`
+// fails here even though no r2: data exists in the rest of the suite yet.
+const decode: PhotoDecoder = (photos) =>
+  photos.map((p) => (p.startsWith('r2:') ? `https://cdn.example/${p.slice('r2:'.length)}` : p))
+
+const STORED = ['r2:vehicles/v1/a.jpg', 'https://images.example/b.jpg']
+const EXPECTED = ['https://cdn.example/vehicles/v1/a.jpg', 'https://images.example/b.jpg']
+
+describe('toVehicle photo decode (#879)', () => {
+  it('routes stored photos through the injected decoder', () => {
+    // Only `.photos` is asserted; the mapper reads the rest of the row but the
+    // test casts a minimal row (tests are not typechecked in this package).
+    const vehicle = toVehicle({ photos: STORED } as never, decode)
+    expect(vehicle.photos).toEqual(EXPECTED)
+  })
+})
+
+describe('toVehicleClass photo decode (#879)', () => {
+  it('routes stored photos through the injected decoder', () => {
+    const vehicleClass = toVehicleClass({ photos: STORED } as never, decode)
+    expect(vehicleClass.photos).toEqual(EXPECTED)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,6 +42,7 @@
     "./lib/rental-rules": "./src/lib/rental-rules.ts",
     "./lib/return-path": "./src/lib/return-path.ts",
     "./lib/region-distance": "./src/lib/region-distance.ts",
+    "./lib/photo-ref": "./src/lib/photo-ref.ts",
     "./validators/booking": "./src/validators/booking.ts",
     "./validators/vehicle": "./src/validators/vehicle.ts",
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,7 @@
     "./db/schema": "./src/db/schema.ts",
     "./db/constants": "./src/db/constants.ts",
     "./db/backfill-regions": "./src/db/backfill-regions.ts",
+    "./db/backfill-photo-refs": "./src/db/backfill-photo-refs.ts",
     "./validators/auth": "./src/validators/auth.ts",
     "./validators/message": "./src/validators/message.ts",
     "./types/stats": "./src/types/stats.ts",

--- a/packages/shared/src/db/backfill-photo-refs.ts
+++ b/packages/shared/src/db/backfill-photo-refs.ts
@@ -1,0 +1,62 @@
+import { eq } from 'drizzle-orm'
+import { wireUrlsToStoredRefs } from '../lib/photo-ref'
+import type { getDb } from './index'
+import { vehicleClasses, vehicles } from './schema'
+
+type Db = ReturnType<typeof getDb>
+
+export interface PhotoRefBackfillReport {
+  /** vehicles rows whose `photos` array gained at least one r2:<key> ref. */
+  vehiclesRewritten: number
+  /** vehicle_classes rows likewise rewritten. */
+  vehicleClassesRewritten: number
+}
+
+/**
+ * One-off, idempotent backfill (#879 Slice 4): rewrite legacy `photos` rows that
+ * stored a resolved public URL (`${base}/<key>`) into the canonical stored form
+ * (`r2:<key>`). External image URLs and rows already in r2: form pass through
+ * untouched — the decision is the pure {@link wireUrlsToStoredRefs} codec, so a
+ * second run is a no-op (a stored `r2:` ref is not one of our wire URLs and is
+ * never re-encoded). This function is the thin DB shell: read photos -> encode
+ * -> write only the rows that changed -> report.
+ *
+ * Injectable (DIP) like the other backfills: pass production's neon-http
+ * `getDb()` or a TCP postgres-js handle. `publicBaseUrl` MUST be the same
+ * `VEHICLE_PHOTOS_PUBLIC_URL` the repos resolve with, or our URLs won't match.
+ * `updatedAt` is deliberately not touched — this is a storage-format migration,
+ * not a content edit.
+ */
+export async function backfillPhotoRefs(
+  db: Db,
+  publicBaseUrl: string,
+): Promise<PhotoRefBackfillReport> {
+  const vehicleRows = await db.select({ id: vehicles.id, photos: vehicles.photos }).from(vehicles)
+  let vehiclesRewritten = 0
+  for (const row of vehicleRows) {
+    const encoded = wireUrlsToStoredRefs(row.photos, publicBaseUrl)
+    if (changed(encoded, row.photos)) {
+      await db.update(vehicles).set({ photos: encoded }).where(eq(vehicles.id, row.id))
+      vehiclesRewritten += 1
+    }
+  }
+
+  const classRows = await db
+    .select({ id: vehicleClasses.id, photos: vehicleClasses.photos })
+    .from(vehicleClasses)
+  let vehicleClassesRewritten = 0
+  for (const row of classRows) {
+    const encoded = wireUrlsToStoredRefs(row.photos, publicBaseUrl)
+    if (changed(encoded, row.photos)) {
+      await db.update(vehicleClasses).set({ photos: encoded }).where(eq(vehicleClasses.id, row.id))
+      vehicleClassesRewritten += 1
+    }
+  }
+
+  return { vehiclesRewritten, vehicleClassesRewritten }
+}
+
+/** True when encoding produced a different array (same length — map is 1:1). */
+function changed(encoded: readonly string[], original: readonly string[]): boolean {
+  return encoded.some((entry, i) => entry !== original[i])
+}

--- a/packages/shared/src/lib/photo-ref.ts
+++ b/packages/shared/src/lib/photo-ref.ts
@@ -49,3 +49,57 @@ export function photoRefToWireUrl(stored: string, publicBaseUrl: string): string
 export function photoRefsToWireUrls(stored: readonly string[], publicBaseUrl: string): string[] {
   return stored.map((entry) => photoRefToWireUrl(entry, publicBaseUrl))
 }
+
+/**
+ * Recover the R2 object key from one of our public wire URLs, or return the
+ * input unchanged when it is not one of ours (a bare key, an external image, a
+ * foreign origin). The inverse of {@link photoRefToWireUrl}'s `${base}/${key}`
+ * expansion, and the primitive {@link R2PhotoStorage.delete} needs to address an
+ * object in the bucket.
+ *
+ * Exact origin + base-path matching via URL parsing — NOT a loose string
+ * prefix. A raw `startsWith(publicBaseUrl)` mis-handled a base with a trailing
+ * slash (sliced one character into the key) and a look-alike host
+ * (`https://cdn.example.com.evil/...` satisfies `startsWith` and got
+ * mis-sliced). See #678 review.
+ */
+export function toObjectKey(keyOrUrl: string, publicBaseUrl: string): string {
+  let target: URL
+  try {
+    target = new URL(keyOrUrl)
+  } catch {
+    return keyOrUrl // relative value — already a key
+  }
+  let base: URL
+  try {
+    base = new URL(publicBaseUrl)
+  } catch {
+    return keyOrUrl // base not a URL (e.g. empty in dev) — can't be our URL
+  }
+  if (target.origin !== base.origin) return keyOrUrl
+  const basePath = base.pathname.replace(/\/+$/, '') // '' or '/sub'
+  const prefix = `${basePath}/`
+  if (!target.pathname.startsWith(prefix)) return keyOrUrl
+  return target.pathname.slice(prefix.length)
+}
+
+/**
+ * Encode a wire URL to its stored form (the write-side inverse of decode): one
+ * of our public URLs becomes `r2:<key>`; anything else (an external image)
+ * passes through unchanged. Repositories call this on write so an `r2:` ref is
+ * minted in exactly one place and external URLs are never mistaken for ours —
+ * a client cannot inject a key, since only a URL resolving to our own bucket
+ * origin is ever re-encoded.
+ */
+export function wireUrlToStoredRef(wireUrl: string, publicBaseUrl: string): string {
+  const key = toObjectKey(wireUrl, publicBaseUrl)
+  // toObjectKey returns the input verbatim when it is not one of our URLs; a
+  // matched URL is always strictly longer than its sliced key, so inequality
+  // is a sound "this was ours" signal.
+  return key === wireUrl ? wireUrl : encodeR2Ref(key)
+}
+
+/** Encode a wire-URL `photos` array to stored refs, preserving order. */
+export function wireUrlsToStoredRefs(wireUrls: readonly string[], publicBaseUrl: string): string[] {
+  return wireUrls.map((url) => wireUrlToStoredRef(url, publicBaseUrl))
+}

--- a/packages/shared/src/lib/photo-ref.ts
+++ b/packages/shared/src/lib/photo-ref.ts
@@ -1,0 +1,51 @@
+/**
+ * Photo source modeling (#879). A stored `photos` entry is one of two sources:
+ * an R2-managed object (referenced by its bucket key) or an arbitrary external
+ * image URL. Rather than a jsonb migration, the source is encoded into the
+ * existing `text[]`: R2 objects as `r2:<key>`, external images as the full URL.
+ *
+ * These pure functions are the single codec for that encoding — the one
+ * serialization boundary (#879 F3). Repositories decode stored entries to wire
+ * URLs on read (so every read surface emits URLs, never raw keys); the upload
+ * route encodes a freshly-stored key on write. No DB, no I/O — the decision is
+ * pure; the thin shells that read/write live in the repos and the upload route
+ * (Functional Core / Imperative Shell).
+ *
+ * Why the prefix is unambiguous: external images are validated as `z.string()
+ * .url()`, so a stored URL always carries a scheme like `https:` and never
+ * begins with the `r2:` sentinel. An R2 key (`vehicles/<id>/<uuid>.<ext>`) is
+ * never a URL. The two forms cannot collide.
+ */
+
+/** Sentinel marking a stored entry as an R2 object key rather than a URL. */
+export const R2_REF_PREFIX = 'r2:'
+
+/** The resolved source of a stored photo entry. */
+export type PhotoRef = { source: 'r2'; key: string } | { source: 'external'; url: string }
+
+/** Encode a raw R2 object key into its stored (`r2:<key>`) form. */
+export function encodeR2Ref(key: string): string {
+  return `${R2_REF_PREFIX}${key}`
+}
+
+/** Resolve a stored `text[]` entry to its source. */
+export function parsePhotoRef(stored: string): PhotoRef {
+  if (stored.startsWith(R2_REF_PREFIX)) {
+    return { source: 'r2', key: stored.slice(R2_REF_PREFIX.length) }
+  }
+  return { source: 'external', url: stored }
+}
+
+/**
+ * Decode a stored entry to a wire URL. R2 refs expand to `${base}/${key}`
+ * (mirroring `R2PhotoStorage.upload`); external URLs pass through unchanged.
+ */
+export function photoRefToWireUrl(stored: string, publicBaseUrl: string): string {
+  const ref = parsePhotoRef(stored)
+  return ref.source === 'r2' ? `${publicBaseUrl}/${ref.key}` : ref.url
+}
+
+/** Decode a stored `photos` array to wire URLs, preserving order. */
+export function photoRefsToWireUrls(stored: readonly string[], publicBaseUrl: string): string[] {
+  return stored.map((entry) => photoRefToWireUrl(entry, publicBaseUrl))
+}

--- a/packages/shared/tests/lib/photo-ref.test.ts
+++ b/packages/shared/tests/lib/photo-ref.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  R2_REF_PREFIX,
+  encodeR2Ref,
+  parsePhotoRef,
+  photoRefToWireUrl,
+  photoRefsToWireUrls,
+} from '../../src/lib/photo-ref'
+
+// A real R2 object key shape: `vehicles/<vehicleId>/<uuid>.<ext>` (see
+// r2-photo-storage.ts). Keys contain slashes, so the codec must not split on them.
+const R2_KEY = 'vehicles/veh_123/8f3a-9c.jpg'
+const BASE = 'https://photos.kuruma.app'
+const EXTERNAL = 'https://images.unsplash.com/photo-1734857039653?w=800&q=80'
+
+describe('R2_REF_PREFIX', () => {
+  it('is the literal sentinel `r2:`', () => {
+    expect(R2_REF_PREFIX).toBe('r2:')
+  })
+})
+
+describe('encodeR2Ref', () => {
+  it('prefixes a raw R2 key with the sentinel', () => {
+    expect(encodeR2Ref(R2_KEY)).toBe(`r2:${R2_KEY}`)
+  })
+})
+
+describe('parsePhotoRef', () => {
+  it('classifies a sentinel-prefixed entry as an r2 ref, stripping the prefix', () => {
+    expect(parsePhotoRef(`r2:${R2_KEY}`)).toEqual({ source: 'r2', key: R2_KEY })
+  })
+
+  it('classifies a plain URL as an external ref, preserving the url verbatim', () => {
+    expect(parsePhotoRef(EXTERNAL)).toEqual({ source: 'external', url: EXTERNAL })
+  })
+
+  it('does not mistake an https URL containing a colon for an r2 ref', () => {
+    expect(parsePhotoRef(BASE).source).toBe('external')
+  })
+
+  it('round-trips a key through encode → parse without loss', () => {
+    const ref = parsePhotoRef(encodeR2Ref(R2_KEY))
+    expect(ref).toEqual({ source: 'r2', key: R2_KEY })
+  })
+})
+
+describe('photoRefToWireUrl', () => {
+  it('expands an r2 ref to `${base}/${key}` (slashes in the key preserved)', () => {
+    expect(photoRefToWireUrl(`r2:${R2_KEY}`, BASE)).toBe(`${BASE}/${R2_KEY}`)
+  })
+
+  it('passes an external URL through unchanged regardless of base', () => {
+    expect(photoRefToWireUrl(EXTERNAL, BASE)).toBe(EXTERNAL)
+  })
+})
+
+describe('photoRefsToWireUrls', () => {
+  it('maps a mixed array, expanding r2 refs and passing externals through', () => {
+    expect(photoRefsToWireUrls([`r2:${R2_KEY}`, EXTERNAL], BASE)).toEqual([
+      `${BASE}/${R2_KEY}`,
+      EXTERNAL,
+    ])
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(photoRefsToWireUrls([], BASE)).toEqual([])
+  })
+})

--- a/packages/shared/tests/lib/photo-ref.test.ts
+++ b/packages/shared/tests/lib/photo-ref.test.ts
@@ -5,6 +5,9 @@ import {
   parsePhotoRef,
   photoRefToWireUrl,
   photoRefsToWireUrls,
+  toObjectKey,
+  wireUrlToStoredRef,
+  wireUrlsToStoredRefs,
 } from '../../src/lib/photo-ref'
 
 // A real R2 object key shape: `vehicles/<vehicleId>/<uuid>.<ext>` (see
@@ -64,5 +67,60 @@ describe('photoRefsToWireUrls', () => {
 
   it('returns an empty array unchanged', () => {
     expect(photoRefsToWireUrls([], BASE)).toEqual([])
+  })
+})
+
+describe('toObjectKey', () => {
+  it('recovers the object key from one of our public URLs (slashes preserved)', () => {
+    expect(toObjectKey(`${BASE}/${R2_KEY}`, BASE)).toBe(R2_KEY)
+  })
+
+  it('returns a bare relative value unchanged — it is already a key', () => {
+    expect(toObjectKey(R2_KEY, BASE)).toBe(R2_KEY)
+  })
+
+  it('ignores a trailing slash on the base instead of slicing into the key', () => {
+    expect(toObjectKey(`${BASE}/${R2_KEY}`, `${BASE}/`)).toBe(R2_KEY)
+  })
+
+  it('does not strip a look-alike host that merely shares a string prefix', () => {
+    const lookalike = `${BASE}.evil.com/vehicles/veh_123/x.jpg`
+    expect(toObjectKey(lookalike, BASE)).toBe(lookalike)
+  })
+
+  it('returns a foreign-origin URL untouched', () => {
+    expect(toObjectKey(EXTERNAL, BASE)).toBe(EXTERNAL)
+  })
+
+  it('returns the input when the base is not a URL (e.g. empty in dev)', () => {
+    expect(toObjectKey(`${BASE}/${R2_KEY}`, '')).toBe(`${BASE}/${R2_KEY}`)
+  })
+})
+
+describe('wireUrlToStoredRef', () => {
+  it('encodes one of our public URLs to its r2 stored form', () => {
+    expect(wireUrlToStoredRef(`${BASE}/${R2_KEY}`, BASE)).toBe(`r2:${R2_KEY}`)
+  })
+
+  it('passes an external URL through — clients can never mint an r2 ref', () => {
+    expect(wireUrlToStoredRef(EXTERNAL, BASE)).toBe(EXTERNAL)
+  })
+
+  it('round-trips an r2 ref: decode to a wire URL then re-encode losslessly', () => {
+    const wire = photoRefToWireUrl(`r2:${R2_KEY}`, BASE)
+    expect(wireUrlToStoredRef(wire, BASE)).toBe(`r2:${R2_KEY}`)
+  })
+})
+
+describe('wireUrlsToStoredRefs', () => {
+  it('encodes a mixed array, r2-refing our URLs and passing externals through', () => {
+    expect(wireUrlsToStoredRefs([`${BASE}/${R2_KEY}`, EXTERNAL], BASE)).toEqual([
+      `r2:${R2_KEY}`,
+      EXTERNAL,
+    ])
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(wireUrlsToStoredRefs([], BASE)).toEqual([])
   })
 })

--- a/scripts/backfill-photo-refs.ts
+++ b/scripts/backfill-photo-refs.ts
@@ -1,0 +1,28 @@
+import { getDb } from '../packages/shared/src/db'
+import { backfillPhotoRefs } from '../packages/shared/src/db/backfill-photo-refs'
+
+// CLI entry for `bun run db:backfill-photo-refs` — rewrite legacy resolved photo
+// URLs (`${VEHICLE_PHOTOS_PUBLIC_URL}/<key>`) into canonical r2:<key> stored refs
+// against the Neon DATABASE_URL (#879 Slice 4). Idempotent: externals and rows
+// already in r2: form pass through. The migration logic is the pure, injectable
+// backfillPhotoRefs in @kuruma/shared.
+const publicBaseUrl = process.env.VEHICLE_PHOTOS_PUBLIC_URL
+if (!publicBaseUrl) {
+  console.error(
+    'VEHICLE_PHOTOS_PUBLIC_URL is required — it is the base whose URLs collapse to r2: refs.',
+  )
+  process.exit(1)
+}
+
+backfillPhotoRefs(getDb(), publicBaseUrl)
+  .then((report) => {
+    console.log(
+      `Photo-ref backfill complete: ${report.vehiclesRewritten} vehicle(s) and ` +
+        `${report.vehicleClassesRewritten} class(es) rewritten to r2: refs.`,
+    )
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.error('Photo-ref backfill failed:', err)
+    process.exit(1)
+  })


### PR DESCRIPTION
Closes #879.

Models `vehicles.photos` / `vehicle_classes.photos` (both `text[]`) as a source sum-type encoded **cheaply** into the existing array — R2-managed objects as `r2:<key>`, external images as the full URL. **No jsonb migration** (owner-approved). The **repository is the single serialization boundary**: decode `r2:`→wire-URL on read, encode wire-URL→`r2:` on write. So `r2:` never escapes a repo, the domain `Vehicle.photos` stays wire-URLs exactly as today, and **the web + validators are untouched** (validators stay `.url()`; only the server mints `r2:`, so a client can't inject a key).

### Slices
| # | What |
|---|------|
| 1 | Pure codec `@kuruma/shared/lib/photo-ref` — `encodeR2Ref`/`parsePhotoRef`/`photoRefToWireUrl`/`photoRefsToWireUrls` |
| 2 | Read decode — `decodePhotos` injected into 5 Drizzle repos; `toVehicle`/`toVehicleClass` require it (18 call sites) |
| 3 | **Write encode** — inverse codec (`wireUrlToStoredRef`, `wireUrlsToStoredRefs`; `toObjectKey` hoisted into the codec). `encodePhotos` injected into vehicle + vehicle-class repos, applied in `create`/`update`/`appendPhotos`/`removePhotoByUrl`, wired from `VEHICLE_PHOTOS_PUBLIC_URL` |
| 4 | Idempotent backfill `db/backfill-photo-refs.ts` + CLI `bun run db:backfill-photo-refs` |

### Design note — deviation from the original plan (accepted, code-reviewed)
The plan first proposed "storage-adapter-owns-ref" (grow `PhotoStorage.put` to return a stored ref). Implemented instead as **the repository being the single encode boundary for all four write paths**, symmetric with the Slice-2 read decode. Behaviour-identical (in-memory storage URLs never pair with a real encoder, so "in-memory ⇒ url" still holds), but the storage interface + its tests are untouched, fewer files change, and `r2:` is minted in exactly one layer. The code-reviewer agent judged this the better call (Functional Core / Imperative Shell: `photo-ref.ts` pure core, repos/backfill thin shells).

### Correctness highlights
- `toObjectKey` uses origin + base-path URL matching (not string `startsWith`) — trailing-slash base and look-alike host are both handled (#678 review carried forward).
- External URLs are never minted as `r2:`; the `key === wireUrl` "is-ours" signal is sound (a matched URL is always strictly longer than its sliced key).
- Backfill is idempotent: already-`r2:` rows and external URLs pass through; a second run is a true no-op (proven by test).
- `removePhotoByUrl` re-encodes the incoming wire URL so `array_remove`/`ANY` match the stored `r2:` row.

### Tests / gates (all green locally)
- shared **604** · api unit **1627** · integration **274** (incl. new real-PG `vehicle-photos-ref` + `backfill-photo-refs`, asserting the RAW column holds `r2:<key>` and decodes back to a URL) · db:verify 5/5 · tsc (api+web) · lint:boundaries · export-drift.
- code-reviewer: **SHIP** — 0 CRITICAL/HIGH; one MEDIUM (cap-guard hardening) applied.

> Note: pushed from `feat/879-photo-source-model` (the original `feat/879-photo-ref` remote held the pre-rebase Slice 1-2 commits; rebasing rewrote them and the pre-push hook blocks non-ff, so this is a fresh branch — the old one dangles, no PR).