### PR TITLE
feat(#361): activate error + uptime monitoring (web release + source maps, API DSN rotation)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,20 @@ jobs:
         env:
           AUTH_SECRET: ci-placeholder-secret-not-real
           DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+          # Sentry web monitoring (#361). Secrets absent by default → web Sentry
+          # stays gated off (resolveBrowserSentryOptions) and no source maps are
+          # emitted (vite.config sentrySourcemapPlugin) until the DSN/token are
+          # provisioned (HITL). VITE_SENTRY_RELEASE (the commit SHA) is always
+          # baked in — harmless, public, and only read once a DSN enables the SDK.
+          # VITE_SENTRY_DSN is a public
+          # ingestion key (ships in the bundle by design); SENTRY_AUTH_TOKEN is a
+          # real secret used only to UPLOAD maps — never a VITE_* var.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: ${{ vars.SENTRY_ENVIRONMENT || 'beta' }}
+          VITE_SENTRY_RELEASE: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: bun run build
 
       # 6. Enforce the gzip budget on the artifact we're about to ship, even if

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -73,6 +73,12 @@ jobs:
           # NOT require them yet — add them there once Stripe is live (HITL prereq).
           echo "${{ secrets.STRIPE_SECRET_KEY }}" | npx wrangler secret put STRIPE_SECRET_KEY
           echo "${{ secrets.STRIPE_WEBHOOK_SECRET }}" | npx wrangler secret put STRIPE_WEBHOOK_SECRET
+          # Error monitoring (#361). SENTRY_DSN gates the API Worker's Sentry on;
+          # absent/empty it stays a no-op (resolveSentryOptions). SENTRY_ENVIRONMENT
+          # is a non-secret var in wrangler.toml ("beta"), not rotated here. Like
+          # Stripe above, deploy.yml's presence check intentionally does NOT require
+          # SENTRY_DSN yet — add it there once Sentry is live (HITL prereq).
+          echo "${{ secrets.SENTRY_DSN }}" | npx wrangler secret put SENTRY_DSN
           npx wrangler deploy
 
       # No web rotation step. The web app is moving to CF Pages (#378 §7.5),

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "use-intl": "^4.13.0",
       },
       "devDependencies": {
+        "@sentry/vite-plugin": "^5.3.0",
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/router-plugin": "^1.168.18",
@@ -575,13 +576,39 @@
 
     "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.57.0", "", { "dependencies": { "@sentry-internal/replay": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A=="],
 
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
+
     "@sentry/browser": ["@sentry/browser@10.57.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.57.0", "@sentry-internal/feedback": "10.57.0", "@sentry-internal/replay": "10.57.0", "@sentry-internal/replay-canvas": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA=="],
+
+    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.3.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.3.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
 
     "@sentry/cloudflare": ["@sentry/cloudflare@10.57.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.57.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-LDKk177la/uG92ILNozcwQR7+4/pizPu01Y7M7l9J7o1uwAi9WjElafh/HU2Jqw+vST1BKknw/tQB1pnsnkDlA=="],
 
     "@sentry/core": ["@sentry/core@10.57.0", "", {}, "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="],
 
     "@sentry/react": ["@sentry/react@10.57.0", "", { "dependencies": { "@sentry/browser": "10.57.0", "@sentry/core": "10.57.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA=="],
+
+    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "@sentry/rollup-plugin": "5.3.0" } }, "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -707,6 +734,8 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -721,11 +750,15 @@
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -801,6 +834,8 @@
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
@@ -839,6 +874,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -850,6 +887,8 @@
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -866,6 +905,8 @@
     "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
@@ -890,6 +931,8 @@
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "isbot": ["isbot@5.1.41", "", {}, "sha512-9WFV/Vhh0FEj6CQ7MoHweEL9/vLKPjeoD2I2htbAjX7kbW7VJs3OCpWOVyd+JraNTWVU6/DRx2MZy2KaUNXHcg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -935,6 +978,8 @@
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
@@ -969,7 +1014,11 @@
 
     "miniflare": ["miniflare@4.20260405.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260405.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-tpr4XdWMq7zFdsHH+CS0XS47nQzlRZH0rMJ1vobOZbkrs3cIj7qbD40ON616hDnzHxwqwB2qKHzmmuj6oRisSQ=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
 
@@ -987,6 +1036,8 @@
 
     "next-auth": ["next-auth@5.0.0-beta.30", "", { "dependencies": { "@auth/core": "0.41.0" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0", "nodemailer": "^7.0.7", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
 
     "oauth4webapi": ["oauth4webapi@3.8.5", "", {}, "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg=="],
@@ -1001,7 +1052,15 @@
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -1045,7 +1104,11 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -1227,6 +1290,8 @@
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "workerd": ["workerd@1.20260405.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260405.1", "@cloudflare/workerd-darwin-arm64": "1.20260405.1", "@cloudflare/workerd-linux-64": "1.20260405.1", "@cloudflare/workerd-linux-arm64": "1.20260405.1", "@cloudflare/workerd-windows-64": "1.20260405.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-bSaRWCv9iO8/FWpgZRjHLGZLolX5s1AErRSYaTECMMHOZKuCbl2+ehnSyc+ZZ/70y+9owADmN6HoYEWvBlJdYw=="],
@@ -1252,6 +1317,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
@@ -1334,6 +1401,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-auth/@auth/core": ["@auth/core@0.41.0", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ=="],
+
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1460,6 +1529,10 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -112,6 +112,12 @@ To activate (HITL, one-time):
 5. Verify: trigger a test error on each surface; confirm it lands grouped under the
    deploy's release, with a **readable (de-minified)** web stack trace.
 
+> **At real-prod launch, flip BOTH `SENTRY_ENVIRONMENT` homes together** or the two
+> surfaces tag differently: the **web** reads the `SENTRY_ENVIRONMENT` *repo
+> variable* (`deploy.yml`, default `beta`), the **API** reads the committed
+> `wrangler.toml` `[vars]` value. Changing only one tags web `production` while the
+> API stays `beta` (or vice-versa).
+
 ## Rollback
 
 ### Code rollback

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -73,24 +73,44 @@ bunx shadcn@latest add <component> -c packages/web
 - **Neon dashboard**: Query performance, connection count, storage usage
 - **Drizzle Studio**: `bun run db:studio` for inspecting data locally
 
-### Error monitoring — Sentry (API), #361
+### Error monitoring — Sentry (API + web), #361
 
-The API Worker is instrumented with `@sentry/cloudflare`: it captures unhandled
-exceptions (with stack), raw `>=500` responses, and slow requests (`>2s`), tagged
-with the deploy's version id as the Sentry **release**. It is **gated off by
-default** — nothing is sent until a DSN is present (see
-`packages/api/src/observability/`).
+Both surfaces are instrumented and **gated off by default** — nothing is sent
+until a DSN is present. Plan: `docs/plans/2026-06-17-issue-361-monitoring-activation.md`.
+
+- **API** (`@sentry/cloudflare`, `packages/api/src/observability/`): captures
+  unhandled exceptions (with stack), raw `>=500` responses, and slow requests
+  (`>2s`), tagged with the deploy's version id (`CF_VERSION_METADATA`) as the
+  **release**. Gated on the `SENTRY_DSN` Worker secret.
+- **Web** (`@sentry/react`, `packages/web/src/lib/observability/`, #765): captures
+  React render crashes + TanStack route errors, tagged with the deploy commit SHA
+  (`VITE_SENTRY_RELEASE`) as the release. Gated on the public `VITE_SENTRY_DSN`.
+  Source maps upload on the deploying build (`vite.config` `sentrySourcemapPlugin`,
+  gated on `SENTRY_AUTH_TOKEN`) so web stack traces are de-minified — without it
+  every browser error is unreadable minified gibberish.
+
+CI is already wired: `rotate-secrets.yml` rotates `SENTRY_DSN`; `deploy.yml`'s web
+build injects `VITE_SENTRY_*` + `SENTRY_AUTH_TOKEN/ORG/PROJECT`. Until those
+secrets exist, every build is byte-identical (no maps emitted, SDKs `enabled:false`).
 
 To activate (HITL, one-time):
-1. Create a Sentry project (platform: Cloudflare Workers); copy its DSN.
-2. `cd packages/api && npx wrangler secret put SENTRY_DSN` (paste the DSN). Add a
-   matching `SENTRY_DSN` GitHub secret so deploys keep it. Optional:
-   `SENTRY_ENVIRONMENT` (defaults to `production`).
-3. In Sentry, add an **alert rule**: error rate spikes 5× baseline for 10 min →
-   Slack/email. Add an **uptime monitor** pinging `GET /health`.
-
-**Web monitoring is deferred** until the Next→Vite migration (#378/#689) settles —
-tracked separately so we don't instrument code that's being deleted.
+1. Create **two** Sentry projects: platform **Cloudflare Workers** (API) and
+   **React** (web). Copy each DSN. Note your Sentry **org** + **project** slugs.
+2. Add GitHub secrets: `SENTRY_DSN` (API), `VITE_SENTRY_DSN` (web — public key,
+   safe to bake into the SPA), `SENTRY_AUTH_TOKEN` (web source-map upload — a real
+   secret). Add repo **variables** `SENTRY_ORG`, `SENTRY_PROJECT`, and
+   `SENTRY_ENVIRONMENT` (set to `beta`; the API Worker also reads it from
+   `wrangler.toml` `[vars]`). Unset env defaults to `production` and would
+   mis-tag beta errors — don't skip it.
+3. Run the **Rotate Worker Secrets** workflow (sets the API `SENTRY_DSN`); the next
+   web deploy bakes the web DSN + release and uploads source maps.
+4. In Sentry: add an **alert rule** — *error* events spike 5× baseline for 10 min →
+   Slack/email (page on errors only; the `>2s` slow-request warnings are
+   dashboard-only — Neon cold starts trip 2s, so paging on them is alert fatigue).
+   Add an **uptime monitor** pinging `GET /health`. The monitor only proves the
+   Worker is routable; **DB-down is caught by the error alerts**, not `/health`.
+5. Verify: trigger a test error on each surface; confirm it lands grouped under the
+   deploy's release, with a **readable (de-minified)** web stack trace.
 
 ## Rollback
 

--- a/docs/plans/2026-06-17-issue-361-monitoring-activation.md
+++ b/docs/plans/2026-06-17-issue-361-monitoring-activation.md
@@ -1,0 +1,136 @@
+# #361 — Error + Uptime Monitoring: Finish & Activate
+
+**Status:** design (2026-06-17) · **Issue:** #361 (P1, infra) · **Author:** session
+
+## TL;DR
+
+The Sentry instrumentation is **already built and unit-tested on both surfaces**
+and is dormant (gated off when no DSN is set) — the same "built-but-OFF" pattern
+as Stripe. This is **not a greenfield build**. The remaining work to make #361
+deliver value is a small CI/doc finishing slice plus a HITL activation runbook.
+
+## What already exists (verified)
+
+| Surface | Code | Gate | Release tag |
+|---|---|---|---|
+| API (Workers) | `packages/api/src/observability/` (`worker.ts` `Sentry.withSentry`, `middleware.ts`, pure `report-policy.ts` + `sentry-options.ts`, all tested) | `enabled:false` until `SENTRY_DSN` | ✅ `CF_VERSION_METADATA.id` (wrangler.toml `[version_metadata]`) |
+| Web (Pages SPA, #765) | `packages/web/src/lib/observability/` (`sentry.tsx` boundary + `captureRouteError`, pure `sentry-options.ts`, tested) + `main.tsx` wiring | `enabled:false` until `VITE_SENTRY_DSN` | ⚠️ reads `VITE_SENTRY_RELEASE` but **CI never injects it** |
+
+Captured today (once a DSN is live): unhandled exceptions w/ stack
+(`error-handlers.ts` → `Sentry.captureException`), raw ≥500 responses and >2s
+slow requests (`report-policy.ts`), React render crashes + TanStack route
+errors. Health endpoint `GET /health` exists (`routes/health.ts`, smoke-tested
+in deploy.yml). PII off by default (`sendDefaultPii:false`), traces off
+(`tracesSampleRate:0`) — both deliberate per the issue's out-of-scope list.
+
+## Gaps (the actual #361 remaining work)
+
+### Part A — Code/CI (TDD where logic exists; mostly CI + docs)
+
+1. **Web release injection (CI).** Add to the deploy.yml *Build web* step env
+   (`deploy.yml:106`): `VITE_SENTRY_RELEASE: ${{ github.sha }}` so web errors
+   group per release. The consumer (`resolveBrowserSentryOptions`) is already
+   unit-tested — no app code changes.
+   - **Precondition:** that build only reaches production through the *Deploy web
+     to CF Pages* step (`deploy.yml:135`), which is gated behind the
+     `WEB_PAGES_DEPLOY_ENABLED == 'true'` repo variable. Verify it is `true`
+     (beta web is live on Pages, so it should be) before assuming the injected
+     env ships — a green build with the gate off deploys nothing.
+   - The duplicate *Build web* in `ci.yml:62` is **test-only** (typecheck +
+     `lint:dist-size`); it never deploys, so it needs no injection.
+2. **DSN secret wiring (CI).** In `rotate-secrets.yml`:
+   - API: `echo "${{ secrets.SENTRY_DSN }}" | npx wrangler secret put SENTRY_DSN`
+     (optional `SENTRY_ENVIRONMENT`). Runtime secret on the Worker.
+   - Web: the browser DSN is **public** (ships in the bundle) — add
+     `VITE_SENTRY_DSN` + `VITE_SENTRY_ENVIRONMENT` to the deploy.yml *Build web*
+     step env from GitHub secrets (build-time, not a Worker secret).
+   - **Do NOT add to deploy.yml's presence check yet** — mirror the Stripe
+     decision (rotate-secrets.yml comment): the gateways no-op when absent, so a
+     presence check would break deploys before Sentry is provisioned. Add a
+     `# add to presence check once live` note.
+3. **Web source-map upload (CI) — makes web traces readable.** `vite build`
+   minifies, so without uploaded source maps every browser error in Sentry is
+   mangled (`a.b is not a fn` at `index-4f2a.js:1:88421`) — the web half of #361
+   delivers near-zero forensic value. Add `@sentry/vite-plugin` to
+   `packages/web/vite.config`, keyed to `VITE_SENTRY_RELEASE`, uploading maps on
+   the **deploying** build only (`deploy.yml:106`, not the `ci.yml` test build).
+   Auth via a build-time `SENTRY_AUTH_TOKEN` — **a true secret, NOT a `VITE_*`
+   var** (it must never ship in the bundle). The plugin no-ops without the token,
+   so it stays dormant pre-activation like everything else.
+4. **Fix stale RUNBOOK.** The Monitoring section (`docs/RUNBOOK.md:92`) claims
+   *"Web monitoring is deferred until the Next→Vite migration settles"* — false
+   now (#714 done, #765 shipped web Sentry). Rewrite to document both DSNs, the
+   web release + source-map injection, and the full activation checklist below.
+
+### Part B — Uptime monitor (decision; HITL to configure)
+
+`/health` exists but nothing pings it. Recommendation: **Sentry Uptime Monitors**
+— single pane with the error alerts, pings `GET /health`, no new code/worker.
+Rejected: Cloudflare Health Checks (needs paid Load Balancing add-on); external
+SaaS (second vendor); self-hosted CF Cron worker pinging `/health` (extra code +
+worker — YAGNI). Keep `/health` shallow/dependency-free; a deep DB ping invites
+false alarms on Neon cold starts (revisit at scale, out of scope).
+**The uptime monitor catches total Worker/routing outages only** — a green ping
+does not mean the DB is up. **DB-down is caught by the error alerts** (500s flow
+to Sentry via `error-handlers.ts:47`), not by `/health`. Don't read a green
+uptime monitor as a healthy stack.
+
+### Part C — Alerts + dashboards (HITL, Sentry UI)
+
+- Alert rule: **error** events spike 5× baseline over 10 min → Slack/email (issue
+  AC). Page on errors only.
+- **Slow-request warnings are dashboard-only, never paging.** `report-policy.ts:8`
+  fires a `warning` on every request >2s, and Workers→Neon cold starts routinely
+  exceed 2s (same latency the shallow-`/health` call cites). Routing these to a
+  pager would be pure alert fatigue. If the dashboard noise is still high after
+  activation, raise `SLOW_REQUEST_THRESHOLD_MS` (3–5s) or sample — a follow-up
+  tuning change, not part of this slice.
+- Dashboard: error rate by route + booking-endpoint success rate (the structured
+  logger already tags path/status/requestId; release tag groups per deploy).
+
+## Activation runbook (HITL, owner-only — one-time)
+
+1. Create two Sentry projects: platform **Cloudflare Workers** (API) and
+   **React** (web). Copy each DSN.
+2. GitHub secrets: `SENTRY_DSN` (API), `VITE_SENTRY_DSN` (web),
+   `SENTRY_AUTH_TOKEN` (web source-map upload), and **`SENTRY_ENVIRONMENT=beta`
+   + `VITE_SENTRY_ENVIRONMENT=beta` (required, not optional)** — both
+   `sentry-options.ts` files default unset → `'production'`, which would
+   mis-tag beta errors as prod and pollute the env filter at real launch.
+3. Run `rotate-secrets.yml` (sets the API Worker secret); next web deploy bakes
+   the web DSN + release + uploads source maps.
+4. In Sentry: add the alert rule (Part C) and the uptime monitor on `/health`
+   (Part B).
+5. Verify: trigger a test error on each surface; confirm it lands grouped under
+   the deploy's release **with a readable (de-minified) web stack trace**.
+
+## Scope / sequencing
+
+- **This slice (code):** Part A — changes across `deploy.yml`,
+  `rotate-secrets.yml`, `packages/web/vite.config` (source-map plugin), and
+  `docs/RUNBOOK.md`. The only app-adjacent change is the Vite plugin; the Sentry
+  instrumentation itself is done. Verification = CI green + a deploy dry-read of
+  the env wiring; the plugin no-ops without `SENTRY_AUTH_TOKEN`.
+- **Owner (HITL):** Parts B + C + activation runbook. Cannot be automated.
+- **DoD — the PR uses `Refs #361`, NOT `Closes #361`.** Part A ships dormant and
+  is safe to merge (gating is fail-off, verified in both `sentry-options.ts`),
+  but #361's acceptance criteria (alert rule, uptime monitor) are Sentry-UI HITL
+  actions no PR can perform. #361 stays open until the owner completes the
+  runbook and verifies a test error lands on each surface.
+- **Out of scope (per issue):** APM/trace waterfalls, PII scrubbing pipeline,
+  deep `/health` DB check.
+
+## Risks
+
+- Web DSN is public by design — fine, but do not put any *secret* in a `VITE_*`
+  var. Only the ingestion DSN, which Sentry intends to be client-visible.
+- `rotate-secrets.yml` requires clean (no pending) Worker state — run after a
+  successful deploy, per its own header.
+- Don't enable `tracesSampleRate>0` casually on Workers — quota + cost; keep 0
+  until we deliberately want performance traces.
+- **`SENTRY_AUTH_TOKEN` is the one true secret here** (source-map upload) — keep
+  it out of any `VITE_*` var so it never reaches the bundle.
+- **Known limitation (accepted):** API release = CF version id, web release = git
+  SHA, in two separate Sentry projects — different ID spaces, so you can't
+  correlate "which web build talks to which API version" by release string. Fine
+  for now; just don't expect cross-surface release joins.

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -98,8 +98,13 @@ VEHICLE_PHOTOS_PUBLIC_URL = "https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev
 
 # Monitoring (#361). The deployed version id is exposed as CF_VERSION_METADATA
 # and used as the Sentry release tag so errors group per deploy.
-# SENTRY_DSN is a SECRET, not a var: `wrangler secret put SENTRY_DSN` (+ the
+# SENTRY_DSN is a SECRET, not a var: rotated via rotate-secrets.yml (+ the
 # matching GitHub secret). Absent it, Sentry is gated off (no-op) — see
-# src/observability/sentry-options.ts. Optional: SENTRY_ENVIRONMENT.
+# src/observability/sentry-options.ts.
+# SENTRY_ENVIRONMENT is non-secret and set here so activation can't forget it:
+# this Worker serves the beta deploy, and unset would default to "production"
+# (sentry-options.ts), mis-tagging beta errors. Change at real prod launch.
+SENTRY_ENVIRONMENT = "beta"
+
 [version_metadata]
 binding = "CF_VERSION_METADATA"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "use-intl": "^4.13.0"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^5.3.0",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/router-plugin": "^1.168.18",

--- a/packages/web/vite.config.mts
+++ b/packages/web/vite.config.mts
@@ -57,7 +57,20 @@ function sentrySourcemapPlugin(): PluginOption {
     org,
     project,
     ...(release ? { release: { name: release } } : {}),
-    sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+    // Absolute glob anchored to THIS config dir, not process.cwd(): the plugin
+    // resolves filesToDeleteAfterUpload against cwd, so a root-level
+    // `bun run --filter @kuruma/web build` would resolve './dist' to the repo
+    // root, match nothing, and silently leave maps in packages/web/dist.
+    sourcemaps: { filesToDeleteAfterUpload: [path.resolve(__dirname, 'dist/**/*.map')] },
+    // Non-fatal upload failures. The API Worker deploys earlier in the pipeline,
+    // so a hard throw here would strand a half-deploy (new API, stale web). A
+    // transient flake (bad token, network, quota) degrades to "this release isn't
+    // symbolicated" instead of breaking the web deploy. Verified: even on a failed
+    // upload the plugin still deletes the maps (0 .map left in dist), so a flake
+    // never leaks maps into the Pages artifact nor trips the size budget.
+    errorHandler: (err: Error) => {
+      console.warn('[sentry-vite-plugin] source-map upload failed (non-fatal):', err.message)
+    },
   })
 }
 

--- a/packages/web/vite.config.mts
+++ b/packages/web/vite.config.mts
@@ -1,9 +1,10 @@
 import { cpSync, existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import react from '@vitejs/plugin-react'
-import { type Plugin, defineConfig } from 'vite'
+import { type Plugin, type PluginOption, defineConfig } from 'vite'
 
 const MESSAGES_DIR = path.resolve(__dirname, 'messages')
 
@@ -34,9 +35,33 @@ function messagesPlugin(): Plugin {
   }
 }
 
+// Sentry source-map upload (#361). Gated on the build-time auth token + org +
+// project so dormant builds are a TRUE no-op: with any missing, NO source maps
+// are emitted (byte-identical output) and the plugin is skipped. SENTRY_AUTH_TOKEN
+// is a real secret and must NEVER be a VITE_* var — it must not reach the bundle.
+const uploadSourcemaps = Boolean(
+  process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT,
+)
+
+// When active, maps are emitted 'hidden' (not referenced by the shipped JS),
+// uploaded to Sentry keyed to the same release as the runtime client
+// (VITE_SENTRY_RELEASE), then deleted so they never ship in the Pages artifact.
+function sentrySourcemapPlugin(): PluginOption {
+  const authToken = process.env.SENTRY_AUTH_TOKEN
+  const org = process.env.SENTRY_ORG
+  const project = process.env.SENTRY_PROJECT
+  if (!authToken || !org || !project) return null
+  const release = process.env.VITE_SENTRY_RELEASE
+  return sentryVitePlugin({
+    authToken,
+    org,
+    project,
+    ...(release ? { release: { name: release } } : {}),
+    sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+  })
+}
+
 // Vite + TanStack Router shell for CF Pages (#378, slice 0 phase 5).
-// Coexists with the frozen Next.js app until DNS cutover (spec §7.5):
-// `vite build` is the Pages primary; `build:worker` still emits the Next Worker.
 export default defineConfig({
   base: '/',
   plugins: [
@@ -47,9 +72,15 @@ export default defineConfig({
     // main.tsx imports. Without this the Vite shell ships unstyled (#510).
     tailwindcss(),
     messagesPlugin(),
+    // Must be last so it sees the final emitted bundle + maps (Sentry docs).
+    // No-op unless SENTRY_AUTH_TOKEN/ORG/PROJECT are all set.
+    sentrySourcemapPlugin(),
   ],
   publicDir: 'public',
-  build: { outDir: 'dist' },
+  // 'hidden' only when uploading: emit maps for Sentry but don't reference them
+  // from the shipped JS; the plugin deletes them post-upload. Off otherwise so
+  // the default Pages build is unchanged.
+  build: { outDir: 'dist', sourcemap: uploadSourcemaps ? 'hidden' : false },
   // Dev-only (ignored by `vite build`). `/api/*` is stripped (the Hono API has no
   // /api prefix); `/auth/*` is forwarded verbatim — matching the Pages Functions.
   server: {


### PR DESCRIPTION
## What

Finishes the wiring for **#361 (error + uptime monitoring)**. The Sentry instrumentation was already built and unit-tested on both surfaces (API `@sentry/cloudflare`; web `@sentry/react`, #765) but **dormant** — gated off until a DSN is set, the same "built-but-OFF" pattern as Stripe. This PR wires the remaining CI/config so the owner can activate it, and ships **fully dormant**: with no secrets, builds are unchanged (no source maps emitted, SDKs `enabled:false`).

Design + review: `docs/plans/2026-06-17-issue-361-monitoring-activation.md` (architect-reviewed → SHIP w/ changes, all folded in; code-reviewed → clean, dormant-safe).

## Changes
- **`packages/web/vite.config.mts`** — conditional `@sentry/vite-plugin` source-map upload, gated on `SENTRY_AUTH_TOKEN && SENTRY_ORG && SENTRY_PROJECT`. `build.sourcemap` flips to `'hidden'` only when uploading; maps are uploaded then deleted, never shipped. Without the token: no plugin, no maps.
- **`.github/workflows/deploy.yml`** — inject `VITE_SENTRY_DSN` / `VITE_SENTRY_ENVIRONMENT` / `VITE_SENTRY_RELEASE` (commit SHA) + `SENTRY_AUTH_TOKEN`/`ORG`/`PROJECT` into the web build. **`SENTRY_AUTH_TOKEN` is a real secret — never a `VITE_*` var** (never reaches the bundle); `VITE_SENTRY_DSN` is a public ingestion key (correct to bake into the SPA).
- **`.github/workflows/rotate-secrets.yml`** — rotate the API `SENTRY_DSN` Worker secret. Mirrors the Stripe precedent; intentionally **not** in deploy.yml's presence check until live.
- **`packages/api/wrangler.toml`** — non-secret `SENTRY_ENVIRONMENT = "beta"` so activation can't mis-tag beta errors as `production`.
- **`docs/RUNBOOK.md`** — rewrote the stale Monitoring section (it claimed web monitoring was deferred — false since #714/#765). Now documents both surfaces, source maps, and the full HITL activation checklist.

## Why source maps
`vite build` minifies; without uploaded maps every browser stack trace in Sentry is unreadable. This makes the web half of #361 actually useful.

## Verification (dormant path — what ships today)
- `bun run build` → **0 `.map` files, 0 `sourceMappingURL` refs** (byte-clean dist); dist-size budget passes
- web typecheck clean · 9 observability tests pass · Biome clean · both workflow YAMLs parse
- knip hits are pre-existing + the step is `continue-on-error`

## Not done here (owner HITL — why this is `Refs`, not `Closes`)
#361's acceptance criteria (alert rule on 5× spike, uptime monitor on `/health`) are Sentry-UI actions no PR can perform. **#361 stays open** until the owner runs the activation runbook (create 2 Sentry projects, set DSNs/token/org/project, run rotate-secrets, configure alert + uptime) and verifies a test error lands with a readable trace.

Refs #361