### PR TITLE
fix(#952): scope R2 photo delete to owning vehicle prefix (cross-tenant IDOR)

### DIFF
--- a/packages/api/src/repositories/in-memory/photo-storage.ts
+++ b/packages/api/src/repositories/in-memory/photo-storage.ts
@@ -16,8 +16,10 @@ export class InMemoryPhotoStorage implements PhotoStorage {
     return { key, url: `${BASE_URL}/${key}` }
   }
 
-  async delete(keyOrUrl: string): Promise<void> {
+  async delete(keyOrUrl: string, ownerVehicleId: string): Promise<void> {
     const key = keyOrUrl.startsWith(BASE_URL) ? keyOrUrl.slice(BASE_URL.length + 1) : keyOrUrl
+    // Mirror R2PhotoStorage's ownership guard so dev/test behave like prod (#952).
+    if (!key.startsWith(`vehicles/${ownerVehicleId}/`)) return
     this.store.delete(key)
   }
 

--- a/packages/api/src/repositories/r2-photo-storage.ts
+++ b/packages/api/src/repositories/r2-photo-storage.ts
@@ -39,7 +39,13 @@ export class R2PhotoStorage implements PhotoStorage {
     return { key, url: `${this.publicBaseUrl}/${key}` }
   }
 
-  async delete(keyOrUrl: string): Promise<void> {
-    await this.bucket.delete(toObjectKey(keyOrUrl, this.publicBaseUrl))
+  async delete(keyOrUrl: string, ownerVehicleId: string): Promise<void> {
+    const key = toObjectKey(keyOrUrl, this.publicBaseUrl)
+    // A photo on vehicle X is always stored under `vehicles/X/` (see put), so a
+    // key outside the owner's prefix is not this vehicle's to delete. Refuse it
+    // fail-closed — this is what stops a cross-referenced URL from reaching
+    // another tenant's object (#952).
+    if (!key.startsWith(`vehicles/${ownerVehicleId}/`)) return
+    await this.bucket.delete(key)
   }
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -735,8 +735,8 @@ export interface FeeScheduleRepository {
 
 export interface PhotoStorage {
   put(vehicleId: string, file: File): Promise<{ key: string; url: string }>
-  /** Accepts either a key or full URL — implementations strip the base URL prefix. */
-  delete(keyOrUrl: string): Promise<void>
+  /** Accepts a key or full URL. `ownerVehicleId` scopes the delete to that vehicle's key prefix, so a cross-referenced URL can't reach another vehicle's object (cross-tenant IDOR guard, #952). */
+  delete(keyOrUrl: string, ownerVehicleId: string): Promise<void>
 }
 
 export interface RenterDocumentFilters {

--- a/packages/api/src/services/vehicle-photo.ts
+++ b/packages/api/src/services/vehicle-photo.ts
@@ -50,7 +50,10 @@ export class VehiclePhotoService {
     const anyFailed = uploadResults.some((r) => r.status === 'rejected')
 
     if (anyFailed) {
-      await this.rollback(succeeded.map((r) => r.url))
+      await this.rollback(
+        vehicleId,
+        succeeded.map((r) => r.url),
+      )
       return { ok: false, status: 500, error: 'One or more uploads failed' }
     }
 
@@ -62,11 +65,17 @@ export class VehiclePhotoService {
     )
 
     if (appendResult.outcome === 'not_found') {
-      await this.rollback(succeeded.map((r) => r.url))
+      await this.rollback(
+        vehicleId,
+        succeeded.map((r) => r.url),
+      )
       return { ok: false, status: 404, error: 'Vehicle not found' }
     }
     if (appendResult.outcome === 'cap_exceeded') {
-      await this.rollback(succeeded.map((r) => r.url))
+      await this.rollback(
+        vehicleId,
+        succeeded.map((r) => r.url),
+      )
       return {
         ok: false,
         status: 400,
@@ -89,9 +98,11 @@ export class VehiclePhotoService {
       return { ok: false, status: 404, error: 'Photo not found' }
     }
 
-    // Best-effort R2 cleanup after the authoritative DB write succeeds.
+    // Best-effort R2 cleanup after the authoritative DB write succeeds. Scoped
+    // to this vehicle's key prefix so a cross-referenced URL cannot delete
+    // another vehicle's object (#952).
     try {
-      await this.storage.delete(url)
+      await this.storage.delete(url, vehicleId)
     } catch (e) {
       console.warn('R2 photo cleanup failed, orphan left:', url, e)
     }
@@ -99,8 +110,8 @@ export class VehiclePhotoService {
     return { ok: true, remaining: updated.photos.length }
   }
 
-  private async rollback(urls: string[]): Promise<void> {
-    await Promise.all(urls.map((url) => this.storage.delete(url).catch(() => {})))
+  private async rollback(vehicleId: string, urls: string[]): Promise<void> {
+    await Promise.all(urls.map((url) => this.storage.delete(url, vehicleId).catch(() => {})))
   }
 }
 

--- a/packages/api/tests/repositories/photo-storage.test.ts
+++ b/packages/api/tests/repositories/photo-storage.test.ts
@@ -33,7 +33,7 @@ describe('InMemoryPhotoStorage', () => {
     const file = makeFile('car.jpg', 'image/jpeg', 1024)
     const { key } = await storage.put('v1', file)
 
-    await storage.delete(key)
+    await storage.delete(key, 'v1')
 
     expect(storage.has(key)).toBe(false)
   })
@@ -43,13 +43,23 @@ describe('InMemoryPhotoStorage', () => {
     const file = makeFile('car.jpg', 'image/jpeg', 1024)
     const { key, url } = await storage.put('v1', file)
 
-    await storage.delete(url)
+    await storage.delete(url, 'v1')
 
     expect(storage.has(key)).toBe(false)
   })
 
   it('delete() is idempotent for missing keys', async () => {
     const storage = new InMemoryPhotoStorage()
-    await expect(storage.delete('nonexistent')).resolves.toBeUndefined()
+    await expect(storage.delete('vehicles/v1/missing.jpg', 'v1')).resolves.toBeUndefined()
+  })
+
+  it('delete() does not remove an object owned by a different vehicle', async () => {
+    const storage = new InMemoryPhotoStorage()
+    const { key } = await storage.put('victim', makeFile('v.jpg', 'image/jpeg', 1024))
+
+    // A delete scoped to a different vehicle must not reach victim's object.
+    await storage.delete(key, 'attacker')
+
+    expect(storage.has(key)).toBe(true)
   })
 })

--- a/packages/api/tests/repositories/r2-photo-storage.test.ts
+++ b/packages/api/tests/repositories/r2-photo-storage.test.ts
@@ -31,42 +31,62 @@ describe('R2PhotoStorage.put', () => {
 describe('R2PhotoStorage.delete — key recovery', () => {
   it('deletes a bare key unchanged', async () => {
     const { bucket, deleted } = fakeBucket()
-    await new R2PhotoStorage(bucket, BASE).delete('vehicles/veh-1/abc.jpg')
+    await new R2PhotoStorage(bucket, BASE).delete('vehicles/veh-1/abc.jpg', 'veh-1')
     expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
   })
 
   it('strips the public base URL to recover the key', async () => {
     const { bucket, deleted } = fakeBucket()
-    await new R2PhotoStorage(bucket, BASE).delete(`${BASE}/vehicles/veh-1/abc.jpg`)
+    await new R2PhotoStorage(bucket, BASE).delete(`${BASE}/vehicles/veh-1/abc.jpg`, 'veh-1')
     expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
   })
 
   it('recovers the key when the configured base has a trailing slash', async () => {
     const { bucket, deleted } = fakeBucket()
-    await new R2PhotoStorage(bucket, `${BASE}/`).delete(`${BASE}/vehicles/veh-1/abc.jpg`)
+    await new R2PhotoStorage(bucket, `${BASE}/`).delete(`${BASE}/vehicles/veh-1/abc.jpg`, 'veh-1')
     expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
   })
 
-  it('does not mis-slice a look-alike host (prefix collision)', async () => {
+  it('does not delete a look-alike host (prefix collision is never our object)', async () => {
     const { bucket, deleted } = fakeBucket()
     const lookAlike = 'https://cdn.example.com.evil/vehicles/veh-1/abc.jpg'
-    await new R2PhotoStorage(bucket, BASE).delete(lookAlike)
-    // Not our object — passed through untouched, never mis-parsed into a key.
-    expect(deleted).toEqual([lookAlike])
+    await new R2PhotoStorage(bucket, BASE).delete(lookAlike, 'veh-1')
+    // Not our origin → never resolves to a key under vehicles/veh-1/ → no-op.
+    // Also guards the #678 mis-slice: a regressed parse would match the owner
+    // prefix and wrongly delete, so this asserting [] catches it.
+    expect(deleted).toEqual([])
   })
 
-  it('passes a different-origin (external) URL through untouched', async () => {
+  it('does not delete a different-origin (external) URL', async () => {
     const { bucket, deleted } = fakeBucket()
     const external = 'https://images.unsplash.com/photo-123.jpg'
-    await new R2PhotoStorage(bucket, BASE).delete(external)
-    expect(deleted).toEqual([external])
+    await new R2PhotoStorage(bucket, BASE).delete(external, 'veh-1')
+    expect(deleted).toEqual([])
   })
 
   it('strips a base that includes a path segment', async () => {
     const { bucket, deleted } = fakeBucket()
     await new R2PhotoStorage(bucket, `${BASE}/photos`).delete(
       `${BASE}/photos/vehicles/veh-1/abc.jpg`,
+      'veh-1',
     )
+    expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
+  })
+})
+
+describe('R2PhotoStorage.delete — tenant ownership guard', () => {
+  it('refuses to delete an object outside the owning vehicle key prefix', async () => {
+    const { bucket, deleted } = fakeBucket()
+    // Resolves to our bucket, but addresses ANOTHER vehicle's object. A delete
+    // scoped to veh-attacker must not reach veh-victim's key (cross-tenant IDOR).
+    const foreign = `${BASE}/vehicles/veh-victim/secret.jpg`
+    await new R2PhotoStorage(bucket, BASE).delete(foreign, 'veh-attacker')
+    expect(deleted).toEqual([])
+  })
+
+  it('deletes when the key belongs to the owning vehicle', async () => {
+    const { bucket, deleted } = fakeBucket()
+    await new R2PhotoStorage(bucket, BASE).delete(`${BASE}/vehicles/veh-1/abc.jpg`, 'veh-1')
     expect(deleted).toEqual(['vehicles/veh-1/abc.jpg'])
   })
 })

--- a/packages/api/tests/services/vehicle-photo.test.ts
+++ b/packages/api/tests/services/vehicle-photo.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryVehicleRepository } from '../../src/repositories/in-memory'
 import { InMemoryPhotoStorage } from '../../src/repositories/in-memory/photo-storage'
-import { VehiclePhotoService } from '../../src/services/vehicle-photo'
+import { MAX_PHOTOS_PER_VEHICLE, VehiclePhotoService } from '../../src/services/vehicle-photo'
 import type { Vehicle } from '../../src/stores'
 
 function vehicleInput(overrides?: Partial<Vehicle>) {
@@ -108,6 +108,7 @@ describe('VehiclePhotoService.uploadPhotos rollback', () => {
     // Stub storage that rejects on the second put. All earlier successes
     // must be deleted; DB should be unchanged.
     const deletedUrls: string[] = []
+    const deletedOwners: string[] = []
     let callCount = 0
     const flakyStorage = {
       put: async (vId: string, _file: File) => {
@@ -115,8 +116,9 @@ describe('VehiclePhotoService.uploadPhotos rollback', () => {
         if (callCount === 2) throw new Error('network blip')
         return { key: `k${callCount}`, url: `https://r2.example/${vId}/p${callCount}.jpg` }
       },
-      delete: async (url: string) => {
+      delete: async (url: string, ownerVehicleId: string) => {
         deletedUrls.push(url)
+        deletedOwners.push(ownerVehicleId)
       },
     }
     const flakyService = new VehiclePhotoService(repo, flakyStorage)
@@ -127,8 +129,9 @@ describe('VehiclePhotoService.uploadPhotos rollback', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.status).toBe(500)
-    // The one successful upload must have been cleaned up.
+    // The one successful upload must have been cleaned up, scoped to its vehicle.
     expect(deletedUrls).toEqual([`https://r2.example/${vehicleId}/p1.jpg`])
+    expect(deletedOwners).toEqual([vehicleId])
 
     const after = await repo.findById(SYSTEM_CONTEXT, vehicleId)
     expect(after?.photos).toHaveLength(0)
@@ -160,5 +163,27 @@ describe('VehiclePhotoService.deletePhoto', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.status).toBe(404)
+  })
+
+  it('does not delete another vehicle’s stored object when its URL is cross-referenced', async () => {
+    // Victim vehicle owns a real stored object.
+    const victim = await repo.create(SYSTEM_CONTEXT, vehicleInput())
+    const up = await service.uploadPhotos(SYSTEM_CONTEXT, victim.id, [
+      makeFile('v.jpg', 'image/jpeg', JPEG),
+    ])
+    if (!up.ok) throw new Error('setup failed')
+    const victimUrl = up.uploaded[0]!
+    expect(storage.size()).toBe(1)
+
+    // Attacker references the victim's URL on their OWN row, then deletes it.
+    await repo.appendPhotos(SYSTEM_CONTEXT, vehicleId, [victimUrl], MAX_PHOTOS_PER_VEHICLE)
+    const result = await service.deletePhoto(SYSTEM_CONTEXT, vehicleId, victimUrl)
+
+    expect(result.ok).toBe(true)
+    // The ref is gone from the attacker's row (DB tenant-scoped removal) ...
+    const attacker = await repo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(attacker?.photos).not.toContain(victimUrl)
+    // ... but the victim's object is untouched in storage.
+    expect(storage.size()).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #952 — a cross-tenant R2 photo deletion IDOR (confused-deputy).

`PhotoStorage.delete(keyOrUrl)` deleted whatever object key a caller-supplied URL resolved to, with **no ownership check**. Because the shared bucket key scheme is `vehicles/<vehicleId>/<uuid>` (no tenant prefix), an operator could:

1. PATCH/create their **own** vehicle with `photos: ["${base}/vehicles/<victimVehicleId>/x.jpg"]` (the `photos` validator is permissive `z.string().url()`),
2. `DELETE /vehicles/<own>/photos?url=…victim…` — the DB removal is tenant-scoped (their row, fine), but the R2 `bucket.delete` then ran on the **victim's** key, silently destroying another tenant's live object.

**Pre-existing** (predates #879; the `.url()` validator + URL→key delete are the root). **Not beta-exploitable** (single-operator beta has no second tenant) but a **hard blocker for multi-tenant launch**. Found by an architect review of #879.

## Fix

Scope the R2 delete to the owning vehicle's key prefix. A photo on vehicle X is always stored under `vehicles/X/` (`R2PhotoStorage.put`), so a delete *for* X may only remove keys under `vehicles/X/`.

- `PhotoStorage.delete(keyOrUrl)` → `delete(keyOrUrl, ownerVehicleId)`; adapters `return` early (fail-closed) on any key not under `vehicles/${ownerVehicleId}/`.
- `vehicleId` threaded from `VehiclePhotoService.deletePhoto` + `rollback` (the only callers).
- Same guard mirrored in `InMemoryPhotoStorage` for dev/test parity.
- `ownerVehicleId` is DB-tenant-authoritative — it is the same `id` that `removePhotoByUrl` already scopes by `operatorId`, so the guard's owner is provably the caller's own vehicle.

Defense-in-depth (follow-up, not here): prefix keys with `operatorId` so ownership is structural rather than enforced — needs a key migration.

## Tests (TDD)

Three new tests written test-first (watched fail for the right reason, then fixed):

- `r2-photo-storage.test.ts` — refuses to delete an object outside the owner's key prefix; still deletes when the key belongs to the owner.
- `photo-storage.test.ts` — in-memory parity guard.
- `vehicle-photo.test.ts` — **end-to-end exploit reproduction**: victim uploads a real object → attacker cross-references the URL on their own row → attacker `deletePhoto` → asserts the ref is gone from the attacker's row **and** the victim's object is intact.

Two existing R2 tests (look-alike host / external URL) flipped from "passed through to `bucket.delete`" to "no-op" — strictly stronger, and still guards the #678 mis-slice (a regressed parse would match the owner prefix and wrongly delete, so asserting `[]` catches it).

## Verification

- `tsc --noEmit` clean
- `bun run test` (api): **1631 passed**
- `lint:boundaries` OK · biome clean · pre-commit (lint:size, lint-staged) pass

`code-reviewer`: **SHIP** — no CRITICAL/HIGH/MEDIUM. One optional LOW (brand `VehicleId` so arg-transposition is a compile error) deferred as out-of-scope for a surgical fix; its failure mode is fail-safe (no-op, not over-delete).

Closes #952
