### PR TITLE
feat(api): enrich operator new-booking alert email (#960)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -357,6 +357,8 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
         process.env.OPERATOR_ALERT_FALLBACK_EMAIL ??
         process.env.EMAIL_REPLY_TO ??
         process.env.EMAIL_FROM,
+      // #960: empty string (WEB_ORIGIN unset) -> the dispatcher omits the deep link.
+      webBaseUrl,
     },
   )
   const ensureThread = staffUserId ? makeEnsureThread({ threadRepo, staffUserId }) : async () => {}

--- a/packages/api/src/services/email/templates/format.ts
+++ b/packages/api/src/services/email/templates/format.ts
@@ -18,6 +18,26 @@ export function formatJpy(amountJpy: number): string {
   return `¥${new Intl.NumberFormat('en-US').format(amountJpy)}`
 }
 
+const MS_PER_HOUR = 3_600_000
+const HOURS_PER_DAY = 24
+
+/** Rental length from start->end as whole days + leftover hours, with caller-
+ *  supplied (localized) unit labels — e.g. "2d 8h", "3d", "9h". A zero component
+ *  is dropped. Bookings are hourly-granular (#960), so hours are the smallest unit. */
+export function formatDuration(
+  start: Date,
+  end: Date,
+  units: { dayUnit: string; hourUnit: string },
+): string {
+  const totalHours = Math.round((end.getTime() - start.getTime()) / MS_PER_HOUR)
+  const days = Math.floor(totalHours / HOURS_PER_DAY)
+  const hours = totalHours % HOURS_PER_DAY
+  const parts: string[] = []
+  if (days > 0) parts.push(`${days}${units.dayUnit}`)
+  if (hours > 0 || days === 0) parts.push(`${hours}${units.hourUnit}`)
+  return parts.join(' ')
+}
+
 // Every operator is Japan-based, so booking datetimes render in Japan Standard Time
 // (Asia/Tokyo — a fixed UTC+9; Japan observes no DST). A pickup/return is a
 // location-anchored event the renter acts on while standing in Japan, and email can't

--- a/packages/api/src/services/email/templates/messages/index.ts
+++ b/packages/api/src/services/email/templates/messages/index.ts
@@ -1,4 +1,4 @@
-import type { FeeType } from '@kuruma/shared/db/schema'
+import type { BookingSource, FeeType } from '@kuruma/shared/db/schema'
 
 // Outbound email i18n. Distinct from the web `next-intl` namespaces (these render
 // in the API), so adding a key here needs no dev-server restart. Keep all three
@@ -27,6 +27,15 @@ export interface EmailStrings {
   operatorSubject: string
   operatorHeading: string
   renterLabel: string
+  // #960 operator-alert enrichment: contact, duration units, source, add-ons, deep link
+  contactLabel: string
+  sourceLabel: string
+  addOnsLabel: string
+  manageBookingTitle: string
+  manageBookingCta: string
+  dayUnit: string
+  hourUnit: string
+  sourceNames: Record<BookingSource, string>
   // #664 renter lifecycle pushes
   substitutionSubject: string // booking code appended
   substitutionHeading: string
@@ -63,6 +72,14 @@ const en: EmailStrings = {
   operatorSubject: 'New booking —',
   operatorHeading: 'A new booking has landed:',
   renterLabel: 'Renter',
+  contactLabel: 'Contact',
+  sourceLabel: 'Source',
+  addOnsLabel: 'Add-ons',
+  manageBookingTitle: 'Manage this booking',
+  manageBookingCta: 'Open booking in your dashboard',
+  dayUnit: 'd',
+  hourUnit: 'h',
+  sourceNames: { DIRECT: 'Direct', TRIP_COM: 'Trip.com', MANUAL: 'Manual', OTHER: 'Other' },
   substitutionSubject: 'Vehicle changed —',
   substitutionHeading: 'The vehicle assigned to your booking has changed. Your new vehicle:',
   newVehicleLabel: 'New vehicle',
@@ -101,6 +118,14 @@ const ja: EmailStrings = {
   operatorSubject: '新規予約 —',
   operatorHeading: '新しい予約が入りました:',
   renterLabel: '利用者',
+  contactLabel: '連絡先',
+  sourceLabel: '予約元',
+  addOnsLabel: 'オプション',
+  manageBookingTitle: '予約の管理',
+  manageBookingCta: 'ダッシュボードで予約を開く',
+  dayUnit: '日',
+  hourUnit: '時間',
+  sourceNames: { DIRECT: '直接', TRIP_COM: 'Trip.com', MANUAL: '手動', OTHER: 'その他' },
   substitutionSubject: '車両変更のお知らせ —',
   substitutionHeading: 'ご予約の車両が変更されました。新しい車両は以下のとおりです:',
   newVehicleLabel: '新しい車両',
@@ -139,6 +164,14 @@ const zh: EmailStrings = {
   operatorSubject: '新预订 —',
   operatorHeading: '收到一笔新预订:',
   renterLabel: '租客',
+  contactLabel: '联系方式',
+  sourceLabel: '预订来源',
+  addOnsLabel: '附加项目',
+  manageBookingTitle: '管理此预订',
+  manageBookingCta: '在仪表板中打开预订',
+  dayUnit: '天',
+  hourUnit: '小时',
+  sourceNames: { DIRECT: '直接', TRIP_COM: 'Trip.com', MANUAL: '手动', OTHER: '其他' },
   substitutionSubject: '车辆变更通知 —',
   substitutionHeading: '您预订的车辆已变更。您的新车辆为:',
   newVehicleLabel: '新车辆',

--- a/packages/api/src/services/email/templates/operator-alert.ts
+++ b/packages/api/src/services/email/templates/operator-alert.ts
@@ -1,5 +1,6 @@
-import { formatDateTime, formatJpy } from './format'
-import { type RenderedEmail, renderRowsEmail, vehicleLabel } from './layout'
+import type { AddOnSnapshot, BookingSource } from '@kuruma/shared/db/schema'
+import { escapeHtml, formatDateTime, formatDuration, formatJpy } from './format'
+import { type RenderedEmail, vehicleLabel } from './layout'
 import { emailStrings } from './messages'
 
 export interface OperatorAlertData {
@@ -10,24 +11,68 @@ export interface OperatorAlertData {
   startAt: Date
   endAt: Date
   renterName: string | null
+  renterEmail: string | null
+  renterPhone: string | null
+  insurance: { name: string; dailyPriceJpy: number } | null
+  addOns: AddOnSnapshot[]
+  source: BookingSource | null
   totalPriceJpy: number | null
+  // Deep link to the booking in the operator dashboard. Null when WEB_ORIGIN is
+  // unset (the imperative shell can't build a URL), in which case the CTA is omitted.
+  manageBookingUrl: string | null
 }
 
 /**
  * Pure renderer (FC/IS core): operator new-booking alert. Defaults to ja (the
- * operator's working language, §12.2) with en available; zh optional.
+ * operator's working language, §12.2) with en available; zh optional. Carries the
+ * operational detail the operator acts on — renter contact, rental length,
+ * insurance, paid add-ons, source — and a deep link straight to the booking (#960).
  */
 export function renderOperatorAlert(data: OperatorAlertData, locale: string): RenderedEmail {
   const m = emailStrings(locale)
+
+  // Whichever contact channels we have, joined; the row is dropped when neither exists.
+  const contact = [data.renterEmail, data.renterPhone].filter(Boolean).join(' · ')
+
   const rows: Array<[string, string]> = [
     [m.bookingCodeLabel, data.bookingCode],
     [m.renterLabel, data.renterName ?? '—'],
+    ...(contact ? [[m.contactLabel, contact] as [string, string]] : []),
     [m.vehicleLabel, vehicleLabel(data.vehicle)],
     [m.pickupLabel, `${data.pickupLocationName} — ${formatDateTime(data.startAt)}`],
     [m.dropoffLabel, `${data.dropoffLocationName} — ${formatDateTime(data.endAt)}`],
+    [m.periodLabel, formatDuration(data.startAt, data.endAt, m)],
+    [
+      m.insuranceLabel,
+      data.insurance
+        ? `${data.insurance.name} (${formatJpy(data.insurance.dailyPriceJpy)})`
+        : m.insuranceDeclined,
+    ],
+    ...(data.source ? [[m.sourceLabel, m.sourceNames[data.source]] as [string, string]] : []),
   ]
   if (data.totalPriceJpy != null) rows.push([m.totalLabel, formatJpy(data.totalPriceJpy)])
 
+  const addOnLines = data.addOns.map((a) => `${a.name}: ${formatJpy(a.priceJpy)}`)
+
   const subject = `${m.operatorSubject} ${data.bookingCode}`
-  return { subject, ...renderRowsEmail(m.operatorHeading, rows) }
+
+  const htmlRows = rows
+    .map(([l, v]) => `<tr><td><strong>${escapeHtml(l)}</strong></td><td>${escapeHtml(v)}</td></tr>`)
+    .join('')
+  const htmlAddOns = addOnLines.length
+    ? `<h3>${escapeHtml(m.addOnsLabel)}</h3><ul>${addOnLines.map((a) => `<li>${escapeHtml(a)}</li>`).join('')}</ul>`
+    : ''
+  const htmlCta = data.manageBookingUrl
+    ? `<h3>${escapeHtml(m.manageBookingTitle)}</h3><p><a href="${escapeHtml(data.manageBookingUrl)}">${escapeHtml(m.manageBookingCta)}</a></p>`
+    : ''
+  const html = `<p>${escapeHtml(m.operatorHeading)}</p><table>${htmlRows}</table>${htmlAddOns}${htmlCta}`
+
+  const textRows = rows.map(([l, v]) => `${l}: ${v}`).join('\n')
+  const textAddOns = addOnLines.length ? `\n\n${m.addOnsLabel}\n${addOnLines.join('\n')}` : ''
+  const textCta = data.manageBookingUrl
+    ? `\n\n${m.manageBookingTitle}\n${m.manageBookingCta}: ${data.manageBookingUrl}`
+    : ''
+  const text = `${m.operatorHeading}\n\n${textRows}${textAddOns}${textCta}`
+
+  return { subject, html, text }
 }

--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -44,6 +44,9 @@ export interface NotificationDispatcherConfig {
   emailReplyTo?: string | undefined
   // Operator-alert recipient of last resort when an operator has no owner user.
   fallbackOperatorEmail?: string | undefined
+  // #960: WEB_ORIGIN, used to build the operator-alert deep link to the booking.
+  // Absent -> no link (the operator email still sends, just without the CTA).
+  webBaseUrl?: string | undefined
 }
 
 interface Resolved {
@@ -301,8 +304,28 @@ export class NotificationDispatcher {
       default: {
         // OPERATOR_BOOKING_ALERT
         const [renter] = await this.userRepo.findByIds([booking.renterId])
+        const manageBookingUrl = this.config.webBaseUrl
+          ? `${this.config.webBaseUrl}/${locale}/manage/bookings/${booking.id}`
+          : null
         return envelope(
-          renderOperatorAlert({ ...common, renterName: renter?.name ?? null }, locale),
+          renderOperatorAlert(
+            {
+              ...common,
+              renterName: renter?.name ?? null,
+              renterEmail: renter?.email ?? null,
+              renterPhone: renter?.phone ?? null,
+              insurance: booking.insuranceSnapshot
+                ? {
+                    name: booking.insuranceSnapshot.name,
+                    dailyPriceJpy: booking.insuranceSnapshot.dailyPriceJpy,
+                  }
+                : null,
+              addOns: booking.addOnSnapshot,
+              source: booking.source,
+              manageBookingUrl,
+            },
+            locale,
+          ),
         )
       }
     }

--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -304,9 +304,10 @@ export class NotificationDispatcher {
       default: {
         // OPERATOR_BOOKING_ALERT
         const [renter] = await this.userRepo.findByIds([booking.renterId])
-        const manageBookingUrl = this.config.webBaseUrl
-          ? `${this.config.webBaseUrl}/${locale}/manage/bookings/${booking.id}`
-          : null
+        // Strip a trailing slash so a misconfigured WEB_ORIGIN can't emit a
+        // `//{locale}` path that fails the SPA's `/$locale/...` route match.
+        const base = this.config.webBaseUrl?.replace(/\/+$/, '')
+        const manageBookingUrl = base ? `${base}/${locale}/manage/bookings/${booking.id}` : null
         return envelope(
           renderOperatorAlert(
             {

--- a/packages/api/tests/services/email/format.test.ts
+++ b/packages/api/tests/services/email/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatDateTime } from '../../../src/services/email/templates/format'
+import { formatDateTime, formatDuration } from '../../../src/services/email/templates/format'
 
 // #680: a pickup/return is a location-anchored event the renter acts on while standing
 // in Japan, and email can't detect the recipient's own timezone — so booking datetimes
@@ -28,5 +28,41 @@ describe('formatDateTime', () => {
     const out = formatDateTime(new Date('2026-07-01T10:00:00Z'))
     expect(out).not.toContain('UTC')
     expect(out).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} JST$/)
+  })
+})
+
+// #960: the operator alert shows the rental LENGTH (not just the start/end range).
+// Hourly granularity -> whole days + leftover hours, with locale unit labels, and
+// a zero component dropped so a clean 3-day rental reads "3d", not "3d 0h".
+const UNITS = { dayUnit: 'd', hourUnit: 'h' }
+
+describe('formatDuration', () => {
+  it('renders days and leftover hours together', () => {
+    // 2026-07-01 10:00Z -> 2026-07-03 18:00Z = 56h = 2 days 8 hours
+    expect(
+      formatDuration(new Date('2026-07-01T10:00:00Z'), new Date('2026-07-03T18:00:00Z'), UNITS),
+    ).toBe('2d 8h')
+  })
+
+  it('drops the hour component for a whole-day span', () => {
+    // exactly 72h
+    expect(
+      formatDuration(new Date('2026-07-01T09:00:00Z'), new Date('2026-07-04T09:00:00Z'), UNITS),
+    ).toBe('3d')
+  })
+
+  it('renders hours only for a sub-day span', () => {
+    expect(
+      formatDuration(new Date('2026-07-01T09:00:00Z'), new Date('2026-07-01T18:00:00Z'), UNITS),
+    ).toBe('9h')
+  })
+
+  it('uses the supplied locale unit labels', () => {
+    expect(
+      formatDuration(new Date('2026-07-01T10:00:00Z'), new Date('2026-07-03T18:00:00Z'), {
+        dayUnit: '日',
+        hourUnit: '時間',
+      }),
+    ).toBe('2日 8時間')
   })
 })

--- a/packages/api/tests/services/email/templates.test.ts
+++ b/packages/api/tests/services/email/templates.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { OperatorAlertData } from '../../../src/services/email/templates/operator-alert'
 import { renderOperatorAlert } from '../../../src/services/email/templates/operator-alert'
 import type { RenterCancellationData } from '../../../src/services/email/templates/renter-cancellation'
 import { renderRenterCancellation } from '../../../src/services/email/templates/renter-cancellation'
@@ -86,15 +87,21 @@ describe('renderRenterConfirmation', () => {
 })
 
 describe('renderOperatorAlert', () => {
-  const baseOp = {
+  const baseOp: OperatorAlertData = {
     bookingCode: 'ABCD2345',
     vehicle: baseRenter.vehicle,
     pickupLocationName: 'Namba Station Lot',
     dropoffLocationName: 'Kansai Airport Lot',
-    startAt: baseRenter.startAt,
-    endAt: baseRenter.endAt,
+    startAt: baseRenter.startAt, // 2026-07-01T10:00Z
+    endAt: baseRenter.endAt, // 2026-07-03T18:00Z -> 56h = 2d 8h
     renterName: 'Jane Tourist',
+    renterEmail: 'jane@example.com',
+    renterPhone: '+81 90-1234-5678',
+    insurance: { name: 'Full Cover', dailyPriceJpy: 1500 },
+    addOns: [{ addOnId: 'ao-1', name: 'Child Seat', priceJpy: 2000 }],
+    source: 'DIRECT',
     totalPriceJpy: 24000,
+    manageBookingUrl: 'https://app.kuruma.jp/ja/manage/bookings/bk-1',
   }
 
   it('includes booking code, vehicle, renter, and location names (ja default)', () => {
@@ -112,6 +119,66 @@ describe('renderOperatorAlert', () => {
 
   it('renders en when requested', () => {
     expect(renderOperatorAlert(baseOp, 'en').subject).toContain('New booking')
+  })
+
+  it('includes the renter contact (email + phone) so the operator can reach them', () => {
+    const { html, text } = renderOperatorAlert(baseOp, 'en')
+    for (const body of [html, text]) {
+      expect(body).toContain('Contact')
+      expect(body).toContain('jane@example.com')
+      expect(body).toContain('+81 90-1234-5678')
+    }
+  })
+
+  it('omits the contact row entirely when the renter has neither email nor phone', () => {
+    const { html, text } = renderOperatorAlert(
+      { ...baseOp, renterEmail: null, renterPhone: null },
+      'en',
+    )
+    for (const body of [html, text]) {
+      expect(body).not.toContain('Contact')
+      expect(body).not.toContain('jane@example.com')
+    }
+  })
+
+  it('shows the rental duration, insurance, and source', () => {
+    const { html, text } = renderOperatorAlert(baseOp, 'en')
+    for (const body of [html, text]) {
+      expect(body).toContain('2d 8h') // 56h
+      expect(body).toContain('Full Cover')
+      expect(body).toContain('Direct') // DIRECT source label
+    }
+  })
+
+  it('maps the Trip.com source to its display name', () => {
+    expect(renderOperatorAlert({ ...baseOp, source: 'TRIP_COM' }, 'en').html).toContain('Trip.com')
+  })
+
+  it('localizes the duration units (ja -> 日/時間)', () => {
+    expect(renderOperatorAlert(baseOp, 'ja').text).toContain('2日 8時間')
+  })
+
+  it('lists paid add-ons with their prices, and omits the section when there are none', () => {
+    const withAddOns = renderOperatorAlert(baseOp, 'en')
+    expect(withAddOns.html).toContain('Child Seat')
+    expect(withAddOns.text).toContain('Child Seat')
+    expect(withAddOns.text).toContain('¥2,000')
+
+    const none = renderOperatorAlert({ ...baseOp, addOns: [] }, 'en')
+    expect(none.html).not.toContain('Child Seat')
+    expect(none.html).not.toContain('Add-ons')
+  })
+
+  it('renders a deep link with the EXACT manage-booking URL when present', () => {
+    const { html, text } = renderOperatorAlert(baseOp, 'en')
+    expect(html).toContain('href="https://app.kuruma.jp/ja/manage/bookings/bk-1"')
+    expect(text).toContain('https://app.kuruma.jp/ja/manage/bookings/bk-1')
+  })
+
+  it('omits the deep link entirely when the URL is null', () => {
+    const { html, text } = renderOperatorAlert({ ...baseOp, manageBookingUrl: null }, 'en')
+    expect(html).not.toContain('manage/bookings')
+    expect(text).not.toContain('manage/bookings')
   })
 })
 

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -339,6 +339,25 @@ describe('NotificationDispatcher', () => {
       expect(alert?.html).toContain('jane@example.com')
     })
 
+    it('normalizes a trailing slash on webBaseUrl so the deep link has no double slash', async () => {
+      const sent: Array<{ bcc?: string[]; html: string }> = []
+      const sender = {
+        send: vi.fn(async (m: (typeof sent)[number]) => {
+          sent.push(m)
+          return { providerMessageId: 'msg-1' }
+        }),
+      }
+      const { dispatcher } = build({
+        webBaseUrl: 'https://app.example.com/',
+        sender: sender as unknown as EmailSender,
+      })
+      await dispatcher.dispatch(booking)
+
+      const alert = sent.find((m) => m.bcc !== undefined)
+      expect(alert?.html).toContain('href="https://app.example.com/ja/manage/bookings/bk-1"')
+      expect(alert?.html).not.toContain('app.example.com//ja')
+    })
+
     it('omits the deep link when webBaseUrl is unset', async () => {
       const sent: Array<{ bcc?: string[]; html: string }> = []
       const sender = {

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -60,6 +60,7 @@ function build(
     owners?: User[]
     fallback?: string
     renterEmail?: string | null
+    webBaseUrl?: string
     logRepo?: InMemoryNotificationLogRepository
   } = {},
 ) {
@@ -144,6 +145,7 @@ function build(
     {
       emailFrom: 'noreply@bcr.jp',
       fallbackOperatorEmail: opts.fallback,
+      webBaseUrl: opts.webBaseUrl,
     },
   )
   return { dispatcher, logRepo, sender }
@@ -311,6 +313,44 @@ describe('NotificationDispatcher', () => {
       expect(opRow?.recipient).toBe('ops@platform.com')
       // Fallback is a single visible recipient — no Bcc list when there are no members.
       expect(rows.find((r) => r.kind === 'OPERATOR_BOOKING_ALERT')?.recipient).not.toContain(',')
+    })
+
+    // #960: the operator alert carries a deep link to the booking (WEB_ORIGIN +
+    // operator locale + booking id) and the renter's contact, so the operator can
+    // open it and reach the renter straight from the email.
+    it('builds the operator-alert deep link from webBaseUrl, locale, and booking id, and threads renter contact', async () => {
+      const sent: Array<{ to: string; bcc?: string[]; html: string; text: string }> = []
+      const sender = {
+        send: vi.fn(async (m: (typeof sent)[number]) => {
+          sent.push(m)
+          return { providerMessageId: 'msg-1' }
+        }),
+      }
+      const { dispatcher } = build({
+        webBaseUrl: 'https://app.example.com',
+        sender: sender as unknown as EmailSender,
+      })
+      await dispatcher.dispatch(booking)
+
+      const alert = sent.find((m) => m.bcc !== undefined)
+      // operator locale is ja (§12.2); the route is /{locale}/manage/bookings/{id}
+      expect(alert?.html).toContain('href="https://app.example.com/ja/manage/bookings/bk-1"')
+      expect(alert?.text).toContain('https://app.example.com/ja/manage/bookings/bk-1')
+      expect(alert?.html).toContain('jane@example.com')
+    })
+
+    it('omits the deep link when webBaseUrl is unset', async () => {
+      const sent: Array<{ bcc?: string[]; html: string }> = []
+      const sender = {
+        send: vi.fn(async (m: (typeof sent)[number]) => {
+          sent.push(m)
+          return { providerMessageId: 'msg-1' }
+        }),
+      }
+      const { dispatcher } = build({ sender: sender as unknown as EmailSender })
+      await dispatcher.dispatch(booking)
+      const alert = sent.find((m) => m.bcc !== undefined)
+      expect(alert?.html).not.toContain('manage/bookings')
     })
 
     it('persists a terminal NO_RECIPIENT row for the operator alert when there are no members and no fallback', async () => {


### PR DESCRIPTION
Closes #960

## Problem
The operator's `OPERATOR_BOOKING_ALERT` email was minimal — booking code, renter name, vehicle, pickup/dropoff, total. No way to reach the renter, no link into the portal.

## What changed
Enriched the alert with the fields the operator actually needs to act on a new booking:
- **Renter contact** — email + phone (degrades cleanly when either is null)
- **Rental duration** — `"2d 8h"` via a new pure `formatDuration(start, end)`
- **Insurance** — selected option + daily price
- **Paid add-ons** — conditional list, omitted when empty
- **Booking source** — `DIRECT` / `TRIP_COM` / `MANUAL` / `OTHER`, localized
- **Deep link** — CTA to `/{locale}/manage/bookings/{id}` (operator-default locale `ja`, §12.2)

## Design notes
- `renderOperatorAlert` stays a pure FC/IS core; the dispatcher (shell) builds the URL and does I/O.
- i18n parity is **type-enforced** — `sourceNames: Record<BookingSource, string>` won't compile if a source or locale is missing across en/ja/zh.
- Empty `WEB_ORIGIN` omits the link; a trailing slash is stripped so the deep link can't emit a `//{locale}` path that fails the SPA route match.
- Every renter-controlled value is HTML-escaped in the html variant.

## Tests
- Unit: `format` (8), `templates` (24), `notification-dispatcher` (26) — 58 green, incl. escaping, link build/omit, trailing-slash normalization, contact/add-on degradation.
- Integration: full suite **274 passing** against a real Postgres container, incl. `booking-created-notifications` fan-out.

## Review
code-reviewer pass: **Ship** — 0 CRITICAL/HIGH/MEDIUM. Escaping discipline, type-enforced i18n parity, FC/IS separation all confirmed. The one actionable LOW (trailing-slash) is fixed in this PR.