### PR TITLE
fix(web): store placeholder instead of car photo on storefront cards (#955)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1137,6 +1137,7 @@
     "fromDaily": "From ¥{price} / day",
     "fromHourly": "From ¥{price} / hour",
     "noPrice": "Price on request",
+    "storeImagePlaceholder": "Store location",
     "turnaround": "~{hours}h turnaround between rentals",
     "distance": "~{km} km",
     "emptyTurnaroundHint": "Cars need preparation time between rentals, so they can be unavailable right after another booking. Try a later pickup date.",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1137,6 +1137,7 @@
     "fromDaily": "¥{price}〜／日",
     "fromHourly": "¥{price}〜／時間",
     "noPrice": "料金はお問い合わせください",
+    "storeImagePlaceholder": "店舗の所在地",
     "turnaround": "貸出間隔 約{hours}時間",
     "distance": "約{km} km",
     "emptyTurnaroundHint": "車両は貸出の合間に準備時間が必要なため、直後はご利用いただけない場合があります。受け取り日を遅らせてお試しください。",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1137,6 +1137,7 @@
     "fromDaily": "¥{price}起／天",
     "fromHourly": "¥{price}起／小时",
     "noPrice": "价格请咨询",
+    "storeImagePlaceholder": "门店位置",
     "turnaround": "两次租赁间隔约{hours}小时",
     "distance": "约{km} km",
     "emptyTurnaroundHint": "车辆在两次租赁之间需要准备时间，紧接着可能无法预订。请尝试选择较晚的取车日期。",

--- a/packages/web/src/vite/storefronts/StorefrontCard.tsx
+++ b/packages/web/src/vite/storefronts/StorefrontCard.tsx
@@ -3,7 +3,7 @@ import type { StorefrontCardData } from '@/vite/storefronts/api'
 import { carryForwardFilters } from '@/vite/storefronts/params'
 import { turnaroundHours } from '@/vite/storefronts/turnaround'
 import { Link } from '@tanstack/react-router'
-import { Car, Clock, MapPin } from 'lucide-react'
+import { Clock, MapPin, Store } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 interface StorefrontCardProps {
@@ -37,7 +37,6 @@ export function StorefrontCard({
 }: StorefrontCardProps) {
   const t = useTranslations('search')
   const locale = useLocale()
-  const photo = storefront.representativePhotos[0]
 
   const priceLabel =
     storefront.fromDailyPriceJpy != null
@@ -58,21 +57,19 @@ export function StorefrontCard({
       className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-shadow hover:shadow-md"
     >
       <div className="aspect-[4/3] overflow-hidden bg-muted">
-        {photo ? (
-          <img
-            src={photo}
-            alt={storefront.name}
-            // 4:3 intrinsic hint lets the browser reserve the box before load (#440);
-            // h-full/w-full still drive the rendered size inside the aspect wrapper.
-            width={400}
-            height={300}
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <Car className="size-12 text-muted-foreground/30" />
-          </div>
-        )}
+        {/*
+          A storefront is a rental location, not a car: showing a vehicle photo here
+          read as "this is the store" (#955). Until a real store image field exists,
+          show a location placeholder — a Store glyph, distinct from the PhotoGallery
+          Car fallback so it unambiguously signals "location".
+        */}
+        <div
+          role="img"
+          aria-label={t('storeImagePlaceholder')}
+          className="flex h-full w-full items-center justify-center"
+        >
+          <Store className="size-12 text-muted-foreground/30" aria-hidden="true" />
+        </div>
       </div>
       <div className="flex flex-1 flex-col gap-3 p-5">
         <div>

--- a/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
+++ b/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
@@ -113,10 +113,13 @@ describe('StorefrontCard', () => {
     expect(screen.queryByText(/km$/)).not.toBeInTheDocument()
   })
 
-  it('declares explicit 4:3 width and height on the photo so the browser reserves the box (#440)', () => {
-    renderCard(makeStorefront({ representativePhotos: ['/photos/store.jpg'] }))
-    const img = screen.getByRole('img')
-    expect(img).toHaveAttribute('width', '400')
-    expect(img).toHaveAttribute('height', '300')
+  it('never renders a vehicle photo as the store hero, even when photos exist (#955)', () => {
+    const { container } = renderCard(makeStorefront({ representativePhotos: ['/photos/car.jpg'] }))
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('shows a store/location placeholder with an accessible label instead of a car photo (#955)', () => {
+    renderCard(makeStorefront({ representativePhotos: ['/photos/car.jpg'] }))
+    expect(screen.getByRole('img', { name: 'Store location' })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem

Renter search result cards showed a **car photo as the store's image** — `StorefrontCard.tsx` rendered `representativePhotos[0]` (built from vehicle photos in `storefront-search.ts`) as the card hero, conflating a vehicle with the rental location.

## Fix (no schema / API change)

Stop representing a storefront with a car photo. The card now always renders a **location placeholder** — a Lucide `Store` glyph on `bg-muted`, mirroring the existing fallback convention but distinct from the `PhotoGallery` `Car` fallback so it unambiguously signals "location", not "vehicle". The placeholder is `role="img"` with an i18n `aria-label` for screen readers.

The `representativePhotos` DTO field is left untouched (only its misuse as the store hero is removed). A real storefront image (operator logo / store photo) needs a `locations` migration + projection and stays deferred per `docs/plans/2026-06-17-renter-booking-ux-improvements-design.md` ("operator branding out of scope").

**Decision (issue asked to confirm in PR):** dropped the vehicle-photo hero entirely; did **not** add an "N cars" affordance (YAGNI) — class summary badges already convey availability below the hero.

## Tests

- `StorefrontCard` no longer renders any `<img>` even when `representativePhotos` is populated.
- A store/location placeholder with an accessible label ("Store location") renders in its place.
- Replaced the now-obsolete `#440` vehicle-photo width/height test.

Gates: tsc ✓ · biome ✓ · i18n parity (1034 keys × en/ja/zh) ✓ · full web suite **1087 passed** · module/size lints exit 0.

Closes #955