### PR TITLE
fix(web): muted-link styling for wizard step-1 back affordance

### DIFF
--- a/packages/web/src/vite/reservation/ReservationWizard.tsx
+++ b/packages/web/src/vite/reservation/ReservationWizard.tsx
@@ -1,4 +1,4 @@
-import { Button, buttonVariants } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
 import { formatJstDateTimeLocal } from '@/lib/datetime'
 import type { CreateBookingInput } from '@/vite/bookings/api'
 import type { AvailableVehicleData } from '@/vite/storefronts/api'
@@ -142,14 +142,16 @@ export function ReservationWizard({
             </Button>
           ) : (
             // First step has no in-wizard back; link out to the storefront the
-            // renter came from so they're never stranded (#962). Dates are
-            // reformatted to JST datetime-local — the storefront route redirects
-            // to /search if parseSearchRange can't read a raw ISO instant.
+            // renter came from so they're never stranded (#962). from/to are Date
+            // objects, serialized to JST datetime-local so the storefront route's
+            // parseSearchRange accepts them (a raw Date becomes an ISO instant it
+            // rejects, redirecting to /search). Styled as a muted link mirroring
+            // StorefrontDetailView's back affordance.
             <Link
               to="/$locale/storefronts/$locationId"
               params={{ locale, locationId }}
               search={{ from: formatJstDateTimeLocal(from), to: formatJstDateTimeLocal(to) }}
-              className={buttonVariants({ variant: 'outline' })}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               <ArrowLeft className="size-4" />
               {t('nav.backToListing')}

--- a/packages/web/tests/vite/reservation/ReservationWizard.test.tsx
+++ b/packages/web/tests/vite/reservation/ReservationWizard.test.tsx
@@ -98,8 +98,9 @@ describe('ReservationWizard', () => {
     expect(back).toHaveAttribute('data-to', '/$locale/storefronts/$locationId')
     expect(back).toHaveAttribute('data-locale', 'en')
     expect(back).toHaveAttribute('data-location', 'loc1')
-    // ISO Dates are reformatted to JST datetime-local so the storefront route's
-    // parseSearchRange accepts them (a raw ISO instant would redirect to /search).
+    // from/to are Date objects, serialized to JST datetime-local so the storefront
+    // route's parseSearchRange accepts them (a raw Date becomes an ISO instant that
+    // would redirect to /search).
     const search = JSON.parse(back.getAttribute('data-search') ?? '{}')
     expect(search).toMatchObject({ from: '2026-07-01T10:00', to: '2026-07-03T10:00' })
   })


### PR DESCRIPTION
## What
Polish follow-up to the merged renter booking-flow UX slices — review nits surfaced while reviewing #971/#963/#964:

- **Styling fidelity (Slice A / #962):** the wizard step-1 storefront back-link shipped as an *outline button*; the approved design said to mirror `StorefrontDetailView`'s back affordance — a muted-text link (`ArrowLeft` + `text-muted-foreground`, `hover:text-foreground`). Swapped to that and dropped the now-unused `buttonVariants` import.
- **Comment accuracy:** corrected the `from`/`to` comment in the component and its test — they are `Date` objects serialized to JST `datetime-local`, not pre-formatted "ISO Dates". (The design-doc twin of this was corrected separately.)

## Deliberately not included
- Slice B's "redundant" guard `baseJpy !== null && booking.totalPrice !== null`: the second clause does real TS narrowing for `formatJpy(booking.totalPrice)`. Removing it forces a non-null assertion (worse, and against the repo's `!`-avoidance rule), so the guard is the cleanest correct form.

## Behavior
None — visual styling + comments only.

## Test plan
- [x] `bun run --filter @kuruma/web typecheck` — clean (verifies the import removal)
- [x] `ReservationWizard` tests **6/6** green (back-link asserts data-attributes, unaffected by the class swap)
- [x] Pre-commit: biome, file-size, module-boundaries, web + api `tsc` — all green