### PR TITLE
fix(web): tolerate legacy/lapsed docs in VehicleForm edit mode (#986)

### DIFF
--- a/packages/web/src/vite/operator-fleet/VehicleForm.tsx
+++ b/packages/web/src/vite/operator-fleet/VehicleForm.tsx
@@ -13,9 +13,13 @@ import {
 } from '@/vite/operator-fleet/api'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { LUGGAGE_SIZES } from '@kuruma/shared/lib/luggage'
-import { type CreateVehicleInput, createVehicleSchema } from '@kuruma/shared/validators/vehicle'
+import {
+  type CreateVehicleInput,
+  createVehicleSchema,
+  updateVehicleSchema,
+} from '@kuruma/shared/validators/vehicle'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useForm } from 'react-hook-form'
+import { type Resolver, useForm } from 'react-hook-form'
 import { useTranslations } from 'use-intl'
 import type { z } from 'zod'
 
@@ -34,9 +38,11 @@ import type { z } from 'zod'
 // silently clearing classId. We only consume the prop here.
 
 // The form binds to the create schema's INPUT shape (pre-transform) for both
-// modes; edit submits a partial of the same fields, so the wider create schema
-// validates a superset safely. react-hook-form emits string values that the
-// schema/setValueAs coerce to the parsed CreateVehicleInput on submit.
+// modes; react-hook-form emits string values that the schema/setValueAs coerce
+// to the parsed CreateVehicleInput on submit. The *resolver*, however, is chosen
+// by mode (see below): edit must use updateVehicleSchema, because #916 made
+// shaken/insurance required + future-dated on createVehicleSchema — a create-only
+// rule that would otherwise block any edit to a legacy/lapsed-doc car (#986).
 type VehicleFormValues = z.input<typeof createVehicleSchema>
 
 interface VehicleFormProps {
@@ -103,10 +109,10 @@ function defaultsFromVehicle(vehicle: OperatorFleetVehicle | null): Partial<Vehi
     minRentalHours: vehicle.minRentalHours,
     maxRentalHours: vehicle.maxRentalHours,
     advanceBookingHours: vehicle.advanceBookingHours,
-    // §5.0 / #916: docs are required strings on the form. A legacy vehicle with
-    // null docs renders blank inputs; the resolver then forces the operator to
-    // enter valid, future-dated dates before the edit can save (emptyToNull
-    // maps a still-blank field back to null → a clear validation error).
+    // A legacy/lapsed vehicle with null docs renders blank inputs. In edit mode
+    // updateVehicleSchema tolerates that (emptyToNull → null → accepted), so the
+    // operator can still save other fields (#986); a doc value they *do* enter
+    // must be future-dated. Create mode requires both via createVehicleSchema.
     shakenExpiryDate: vehicle.shakenExpiryDate ?? '',
     insuranceExpiryDate: vehicle.insuranceExpiryDate ?? '',
   }
@@ -132,7 +138,16 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
     handleSubmit,
     formState: { errors },
   } = useForm<VehicleFormValues, unknown, CreateVehicleInput>({
-    resolver: zodResolver(createVehicleSchema),
+    // Edit tolerates legacy/lapsed (or omitted) docs via updateVehicleSchema's
+    // .partial()/.nullish() shape; the cast bridges only that narrowing — the
+    // partial output is sent to updateVehicle, which accepts it (#986).
+    resolver: isEditMode
+      ? (zodResolver(updateVehicleSchema) as Resolver<
+          VehicleFormValues,
+          unknown,
+          CreateVehicleInput
+        >)
+      : zodResolver(createVehicleSchema),
     defaultValues: defaultsFromVehicle(vehicle),
   })
 

--- a/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
@@ -158,6 +158,26 @@ describe('VehicleForm', () => {
     expect(mockedCreate).not.toHaveBeenCalled()
   })
 
+  it('edit mode: saves a legacy vehicle with null shaken/insurance docs (#986)', async () => {
+    const user = userEvent.setup()
+    mockedUpdate.mockResolvedValue(existingVehicle())
+    // A legacy/lapsed car has null docs. Edit must tolerate them: the create-only
+    // required-docs rule (#916) must not leak into the edit resolver, or the
+    // operator can't change *any* field until they back-fill both documents.
+    renderForm({ vehicle: existingVehicle({ shakenExpiryDate: null, insuranceExpiryDate: null }) })
+
+    const nameInput = screen.getByLabelText(en.name) as HTMLInputElement
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Toyota Aqua Legacy')
+    await user.click(screen.getByRole('button', { name: en.save }))
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1))
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      'veh_1',
+      expect.objectContaining({ name: 'Toyota Aqua Legacy' }),
+    )
+  })
+
   it('blocks submit and shows a field error when required input is invalid', async () => {
     const user = userEvent.setup()
     // Create mode: name is blank and no rate is set -> two validation failures.


### PR DESCRIPTION
Closes #986.

## Problem

#916 Slice 1 made `shakenExpiryDate` + `insuranceExpiryDate` **required and future-dated** on `createVehicleSchema` (correct for create). But `VehicleForm` used that one schema as its resolver for **both** create and edit, so edit inherited the create-only requirement: an operator could not save **any** change (name, pricing, class, …) to a vehicle whose shaken/insurance is null or lapsed.

This is live on beta — some vehicles have null insurance, and editing them through the fleet form is blocked until both docs are back-filled.

It contradicts:
- **Design** (`docs/plans/2026-06-16-shaken-compliance-enforcement.md` §5.0/D5): edit tolerates legacy/lapsed rows; the runtime road-legal gate (D1), not the editor, hides non-compliant cars.
- **API**: `updateVehicleSchema` is `.partial()` with `.nullish()` docs, so the endpoint already accepts a PATCH that omits them — the form was stricter than the route it calls.

## Fix

Select the resolver by mode: `updateVehicleSchema` for edit, `createVehicleSchema` for create. The edit resolver's partial output is sent to `updateVehicle`, which accepts it; a single cast bridges that narrowing. A doc value the operator *does* enter must still be future-dated (the base `expiryDate` refine).

## Tests

- **Regression (RED→GREEN):** edit a vehicle with `shakenExpiryDate: null, insuranceExpiryDate: null`, change the name, assert `updateVehicle` fires. Fails on the old resolver (submit blocked); passes now. This restores the legacy-car coverage that #981's CI fixture fix (`null → '2099-01-01'`) had removed — the gap that masked this bug.
- Full web suite: 1155/1155. `tsc` + `biome` clean. `lint:size`/`lint:modules` exit 0 (pre-existing warnings only).

Refs #916, #981.