### PR TITLE
fix(#957): 401 GET /auth/session for revoked operators so the web logs them out

### DIFF
--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -87,8 +87,10 @@ export function provideOperatorSessionRevocation(
 
 /** Consult the context-supplied revocation check, but only for operator roles —
  *  renter/admin/partner traffic does zero extra work (the common-case latency AC).
- *  Fail-open when no check is registered (e.g. unit apps that don't wire it). */
-async function isOperatorSessionRevoked(
+ *  Fail-open when no check is registered (e.g. unit apps that don't wire it).
+ *  Exported so GET /auth/session reuses the SAME check (#957): the session read
+ *  and the data routes must agree on revocation — one check, never two that drift. */
+export async function isOperatorSessionRevoked(
   c: { get: (key: string) => unknown },
   user: AuthUser,
 ): Promise<boolean> {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -20,6 +20,7 @@ import {
 import {
   SESSION_COOKIE,
   type UserRole,
+  isOperatorSessionRevoked,
   mintSessionToken,
   verifySessionCookie,
 } from '../middleware/auth'
@@ -240,6 +241,13 @@ export function createAuthRoutes(
 
       const session = await verifySessionCookie(token)
       if (!session) return fail(c, 'Unauthorized', 401)
+
+      // #957: verifySessionCookie is pure crypto, so a deactivated operator's
+      // cookie stays valid for its whole TTL. Consult the SAME context-provided
+      // revocation check the data routes use (#939) so a revoked operator's session
+      // read flips to signed-out and the web's _business guard redirects to login —
+      // instead of leaving them on a broken portal where every call 401s.
+      if (await isOperatorSessionRevoked(c, session.user)) return fail(c, 'Unauthorized', 401)
 
       // Spread the display-only profile (name/email/image) the token carries.
       // `profile` holds only the keys actually present, so the user object never

--- a/packages/api/tests/routes/session-revocation-app.test.ts
+++ b/packages/api/tests/routes/session-revocation-app.test.ts
@@ -35,6 +35,20 @@ async function operatorBearer(): Promise<Record<string, string>> {
   return { Authorization: `Bearer ${token}` }
 }
 
+// GET /auth/session reads the kuruma_session COOKIE (not a Bearer header), so the
+// session-read boundary (#957) must be exercised through the cookie path.
+async function sessionCookie(claims: Record<string, unknown>): Promise<Record<string, string>> {
+  const key = new TextEncoder().encode(TEST_AUTH_SECRET)
+  const token = await new SignJWT({ csrf: 'csrf-abc', ...claims })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('kuruma-web')
+    .setAudience('kuruma-api')
+    .sign(key)
+  return { Cookie: `kuruma_session=${token}` }
+}
+
 // The operator's own users row, mirroring the projection a renter-door sign-in mints
 // the token from (role + operatorId set by setOperatorAccess).
 function activeOperatorRow(): User {
@@ -101,5 +115,33 @@ describe('createApp wires operator-session revocation (#939)', () => {
     const res = await app.request('/operators', { headers })
     expect(res.status).toBe(401)
     expect(((await res.json()) as { error: string }).error).toBe('Unauthorized')
+  })
+
+  // #957 follow-up: #939 closed the DATA-route boundary (requireAuth), but
+  // GET /auth/session verified by pure crypto only, so a deactivated operator's
+  // session read kept 200ing for the whole TTL and the web never logged them out.
+  // The endpoint now consults the SAME context-provided check.
+  it('401s the GET /auth/session read once deactivation clears the projection (#957)', async () => {
+    const headers = await sessionCookie({
+      sub: SELF_ID,
+      role: 'OPERATOR_OWNER',
+      operatorId: OPERATOR_ID,
+    })
+    expect((await app.request('/auth/session', { headers })).status).toBe(200)
+
+    // deactivateMember -> users.clearOperatorAccess: role RENTER, operatorId null.
+    await userRepo.clearOperatorAccess(SELF_ID)
+
+    const res = await app.request('/auth/session', { headers })
+    expect(res.status).toBe(401)
+    expect(((await res.json()) as { error: string }).error).toBe('Unauthorized')
+  })
+
+  it('leaves a renter session read untouched — revocation is operator-only (#957)', async () => {
+    const headers = await sessionCookie({ sub: 'renter_1', role: 'RENTER' })
+    expect((await app.request('/auth/session', { headers })).status).toBe(200)
+    // Clearing an operator must never sweep up renter sessions.
+    await userRepo.clearOperatorAccess(SELF_ID)
+    expect((await app.request('/auth/session', { headers })).status).toBe(200)
   })
 })


### PR DESCRIPTION
## Problem

#939 closed the **data-route** boundary (`requireAuth` re-reads the `users` projection and 401s a stale operator token). But `GET /auth/session` verifies by **pure crypto only**, so a deactivated operator's session cookie kept returning **200 for its whole ≤7-day TTL**. The web never saw a signed-out signal — it left the operator parked on the portal where every data call 401s (a secure-but-broken limbo). This was the remaining gap #939's reviewers flagged.

## Fix

Export the existing context-provided `isOperatorSessionRevoked` check (already used by the data routes via #939) and consult it in `GET /auth/session` right after `verifySessionCookie`. A revoked operator's session read now **401s** → the web's `fetchSession` maps 401→`null` → the `_business` route guard redirects to `/login`. **One check shared with the data routes — no second wiring to drift.** Operator-only; renter/admin reads do zero extra work.

No web change is needed — the machinery already exists:
- `vite/session.ts:42` — `if (response.status === 401) return null`
- `routes/$locale/_business.tsx` `beforeLoad` — a null session → `throw redirect({ to: '/$locale/login' })`

The "web 401 handling" AC is met by routing the API to emit the 401 the web already handles.

## Tests

New, `tests/routes/session-revocation-app.test.ts` (RED→GREEN):
- **Revoked operator:** `/auth/session` 200 → `clearOperatorAccess` → **401**.
- **Renter untouched:** a renter session read stays **200** after an operator is cleared — revocation is operator-only and never sweeps up renter/admin traffic.

Gates (api-only change): targeted file **5/5 green** (3 existing #939 + 2 new), `tsc` exit 0, `lint:boundaries` OK.

## Deferred (optional)

The issue lists a web global 401 interceptor (Option 2) as **optional** defense-in-depth. The AC is met without it — the per-route `_business` guard already redirects a null session — so this PR stays a focused server fix.

Closes #957.