### PR TITLE
refactor(web): validate admin revenue + anomaly responses with Zod in unwrap (#711)

### DIFF
--- a/packages/web/src/vite/admin/anomalies/api.ts
+++ b/packages/web/src/vite/admin/anomalies/api.ts
@@ -1,7 +1,12 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { PaymentAnomaliesResponse } from '@kuruma/shared/types/payment-anomaly'
+import {
+  PAYMENT_ANOMALY_KINDS,
+  type PaymentAnomaliesResponse,
+  type PaymentAnomalyView,
+} from '@kuruma/shared/types/payment-anomaly'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // Platform-admin unresolved payment anomalies (#744), surfaced on the revenue tab
 // (#462). Cookie-based (credentials: 'include') so the API gates on the session
@@ -9,11 +14,32 @@ import { queryOptions } from '@tanstack/react-query'
 // Mirrors admin/revenue/api.ts.
 export const PAYMENT_ANOMALIES_QUERY_KEY = ['admin-payment-anomalies'] as const
 
+// Network-seam validator for the anomaly response (#711). Pinned to the shared
+// wire DTO with `satisfies` so a renamed/added field — or a new anomaly `kind`
+// the web can't render — fails typecheck here and surfaces as a ParseError at the
+// seam instead of an `undefined`/unrenderable row deep in the admin revenue tab.
+const paymentAnomalyViewSchema = z.object({
+  id: z.string(),
+  kind: z.enum(PAYMENT_ANOMALY_KINDS),
+  operatorId: z.string(),
+  bookingId: z.string(),
+  receivedAmountJpy: z.number().nullable(),
+  expectedAmountJpy: z.number().nullable(),
+  currency: z.string().nullable(),
+  stripeEventId: z.string(),
+  stripePaymentIntentId: z.string().nullable(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<PaymentAnomalyView>
+
+const paymentAnomaliesResponseSchema = z.object({
+  anomalies: z.array(paymentAnomalyViewSchema),
+}) satisfies z.ZodType<PaymentAnomaliesResponse>
+
 export async function fetchPaymentAnomalies(): Promise<PaymentAnomaliesResponse> {
   const res = await fetch(`${getApiBaseUrl()}/admin/payment-anomalies`, {
     credentials: 'include',
   })
-  return unwrap<PaymentAnomaliesResponse>(res)
+  return unwrap(res, paymentAnomaliesResponseSchema)
 }
 
 export function paymentAnomaliesQueryOptions() {

--- a/packages/web/src/vite/admin/revenue/api.ts
+++ b/packages/web/src/vite/admin/revenue/api.ts
@@ -1,7 +1,13 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import type { AdminRevenueResponse } from '@kuruma/shared/types/admin-revenue'
+import type {
+  AdminRevenueMonth,
+  AdminRevenuePartner,
+  AdminRevenueResponse,
+  AdminRevenueTotals,
+} from '@kuruma/shared/types/admin-revenue'
 import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
 
 // Platform-admin partner revenue (#462, month filter #628). Cookie-based
 // (credentials: 'include') so the API gates on the session role server-side
@@ -9,13 +15,50 @@ import { queryOptions } from '@tanstack/react-query'
 // optional JST `?month=YYYY-MM` payout-month filter. Mirrors operator-dashboard/api.ts.
 export const ADMIN_REVENUE_QUERY_KEY = ['admin-revenue'] as const
 
+// Network-seam validators for the revenue report (#711). Each level is pinned to
+// its shared wire DTO with `satisfies` so a renamed/added figure fails typecheck
+// here; a drifted runtime body (e.g. a yen total arriving as a string) then
+// surfaces as a ParseError at the seam instead of a wrong/blank figure on the tab.
+const adminRevenueMonthSchema = z.object({
+  month: z.string(),
+  grossJpy: z.number(),
+  platformFeeJpy: z.number(),
+  netToPartnerJpy: z.number(),
+  paymentCount: z.number(),
+}) satisfies z.ZodType<AdminRevenueMonth>
+
+const adminRevenueTotalsSchema = z.object({
+  grossJpy: z.number(),
+  platformFeeJpy: z.number(),
+  netToPartnerJpy: z.number(),
+  paymentCount: z.number(),
+}) satisfies z.ZodType<AdminRevenueTotals>
+
+const adminRevenuePartnerSchema = z.object({
+  operatorId: z.string(),
+  operatorName: z.string(),
+  operatorSlug: z.string(),
+  grossJpy: z.number(),
+  platformFeeJpy: z.number(),
+  netToPartnerJpy: z.number(),
+  paymentCount: z.number(),
+  months: z.array(adminRevenueMonthSchema),
+}) satisfies z.ZodType<AdminRevenuePartner>
+
+const adminRevenueResponseSchema = z.object({
+  partners: z.array(adminRevenuePartnerSchema),
+  totals: adminRevenueTotalsSchema,
+  availableMonths: z.array(z.string()),
+  selectedMonth: z.string().nullable(),
+}) satisfies z.ZodType<AdminRevenueResponse>
+
 export async function fetchAdminRevenue(month?: string): Promise<AdminRevenueResponse> {
   // Omit the param entirely for "all months" so the server returns the full matrix.
   const query = month ? `?month=${encodeURIComponent(month)}` : ''
   const res = await fetch(`${getApiBaseUrl()}/admin/revenue${query}`, {
     credentials: 'include',
   })
-  return unwrap<AdminRevenueResponse>(res)
+  return unwrap(res, adminRevenueResponseSchema)
 }
 
 export function adminRevenueQueryOptions(month?: string) {

--- a/packages/web/tests/vite/admin/anomalies/api.test.ts
+++ b/packages/web/tests/vite/admin/anomalies/api.test.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/lib/api-error'
+import { ApiError, ParseError } from '@/lib/api-error'
 import {
   PAYMENT_ANOMALIES_QUERY_KEY,
   fetchPaymentAnomalies,
@@ -52,6 +52,16 @@ describe('fetchPaymentAnomalies', () => {
     expect(err).toBeInstanceOf(ApiError)
     expect((err as ApiError).status).toBe(403)
     expect((err as ApiError).message).toBe('Forbidden')
+  })
+
+  it('throws a ParseError when the API adds an anomaly kind the web cannot render (#711)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: { anomalies: [{ ...anomaly, kind: 'REFUND_PENDING' }] },
+      }),
+    )
+    await expect(fetchPaymentAnomalies()).rejects.toBeInstanceOf(ParseError)
   })
 })
 

--- a/packages/web/tests/vite/admin/revenue-api.test.ts
+++ b/packages/web/tests/vite/admin/revenue-api.test.ts
@@ -1,3 +1,4 @@
+import { ParseError } from '@/lib/api-error'
 import { adminRevenueQueryOptions, fetchAdminRevenue } from '@/vite/admin/revenue/api'
 import type { AdminRevenueResponse } from '@kuruma/shared/types/admin-revenue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -6,6 +7,32 @@ const EMPTY: AdminRevenueResponse = {
   partners: [],
   totals: { grossJpy: 0, platformFeeJpy: 0, netToPartnerJpy: 0, paymentCount: 0 },
   availableMonths: [],
+  selectedMonth: null,
+}
+
+const POPULATED: AdminRevenueResponse = {
+  partners: [
+    {
+      operatorId: 'op_1',
+      operatorName: 'Best Car Rental',
+      operatorSlug: 'best-car-rental',
+      grossJpy: 120_000,
+      platformFeeJpy: 4_800,
+      netToPartnerJpy: 115_200,
+      paymentCount: 3,
+      months: [
+        {
+          month: '2026-04',
+          grossJpy: 120_000,
+          platformFeeJpy: 4_800,
+          netToPartnerJpy: 115_200,
+          paymentCount: 3,
+        },
+      ],
+    },
+  ],
+  totals: { grossJpy: 120_000, platformFeeJpy: 4_800, netToPartnerJpy: 115_200, paymentCount: 3 },
+  availableMonths: ['2026-04'],
   selectedMonth: null,
 }
 
@@ -44,6 +71,28 @@ describe('fetchAdminRevenue (#628 month filter)', () => {
     const url = new URL(fetchMock.mock.calls[0]![0] as string, 'http://x')
     expect(url.searchParams.get('month')).toBe('2026-04')
     expect(report.selectedMonth).toBe('2026-04')
+  })
+
+  it('validates and returns a populated report (nested partners/months) (#711)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: POPULATED }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const report = await fetchAdminRevenue()
+
+    expect(report.partners[0]?.months[0]?.grossJpy).toBe(120_000)
+    expect(report.totals.netToPartnerJpy).toBe(115_200)
+  })
+
+  it('throws a ParseError when a revenue figure drifts to a non-number (#711)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: { ...EMPTY, totals: { ...EMPTY.totals, grossJpy: '0' } },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchAdminRevenue()).rejects.toBeInstanceOf(ParseError)
   })
 })
 

--- a/scripts/lint-unwrap-schema.ts
+++ b/scripts/lint-unwrap-schema.ts
@@ -9,9 +9,11 @@
  *  - an allow-listed file drops below its recorded count -> migrated, the list
  *    must shrink (the ratchet only goes down).
  *
- * The allow-list is seeded with today's sanctioned deferrals: the admin revenue
- * (#744) and payment-anomalies clients, whose API responses aren't schema-modelled
- * yet. Migrate one and you MUST decrement/remove its entry here, or CI fails.
+ * The allow-list is now EMPTY: every web client passes a schema (#711 complete),
+ * so `reconcile` flags any schemaless call as not-allow-listed — i.e. the rule
+ * enforces the flat "no schemaless unwrap anywhere" invariant it was ratcheting
+ * toward. Re-add an entry only as an explicit, temporary deferral, then migrate
+ * it out.
  *
  * Limitation: the source scanner is lexical (it strips comments/strings, then
  * balances brackets). It does not handle `unwrap` inside `${}` template
@@ -24,13 +26,12 @@ const VITE_DIR = 'packages/web/src/vite'
 
 /**
  * Files permitted to contain schemaless `unwrap()` calls, with their exact count.
- * When this empties, delete the count machinery and collapse the rule to a flat
- * "no schemaless unwrap anywhere" check — the invariant it's ratcheting toward.
+ * Empty since #711 finished migrating every client: with no entries, `reconcile`
+ * fails any schemaless call as not-allow-listed, which is exactly the flat
+ * "no schemaless unwrap anywhere" invariant. Keep it empty; an entry is only ever
+ * a temporary, sanctioned deferral while a new client is being validated.
  */
-const ALLOW: Record<string, number> = {
-  'admin/revenue/api.ts': 1,
-  'admin/anomalies/api.ts': 1,
-}
+const ALLOW: Record<string, number> = {}
 
 /**
  * Blanks line/block comments and string/template literals so an `unwrap(` token
@@ -213,6 +214,6 @@ if (import.meta.main) {
   }
   const total = Object.values(actual).reduce((a, b) => a + b, 0)
   console.log(
-    `unwrap-schema ratchet passed (${total} allow-listed schemaless call(s) across ${Object.keys(actual).length} file(s))`,
+    `unwrap-schema ratchet passed: ${total} schemaless unwrap() call(s) across ${sourceFiles.length} file(s) scanned`,
   )
 }


### PR DESCRIPTION
Closes #711.

## What
Finishing slice for #711. Slices 1-2 (#786/#797) shipped the schema-accepting `unwrap(res, schema?)` helper (throws `ParseError` on contract drift) and migrated all high-value clients. This slice migrates the **last two schema-less live clients** — the platform-admin **revenue** and **payment-anomaly** views — so no live web client passes a phantom `T` anymore.

These two matter disproportionately: they render **money** (whole-JPY revenue figures, payment-anomaly amounts). A silently drifted API body previously surfaced as a wrong/blank figure on the admin revenue tab instead of a clean failure at the seam.

## How
Local network-seam Zod schemas pinned to the shared wire DTOs (`@kuruma/shared/types/admin-revenue`, `@kuruma/shared/types/payment-anomaly`) via `satisfies z.ZodType<…>`, passed to `unwrap` — the established convention (mirrors `vite/operator-dashboard/api.ts`). The shared interface stays the type SSoT; the schema is its compiler-checked shadow. **No `shared`/`api`/DB files touched** — web-only.

- Money figures use plain `z.number()` (no `.coerce`) → a stringified yen total is rejected, not silently coerced.
- `kind` reuses the shared `PAYMENT_ANOMALY_KINDS` SSoT → a new DB anomaly kind the web can't render fails closed at the seam.

Left as-is: `vite/operator-locations/api.ts:138` archive cast — a documented exception (`unwrap` discards the `activeBookingsCount` discriminator `LocationArchiveBlockedError` needs). See follow-up note below.

## Acceptance criteria (#711) — all now met
- [x] `unwrap` takes a schema, returns a typed `ParseError` on mismatch (Slice 1)
- [x] booking/class/customer/vehicle (+ all operator/storefront) clients validate (Slices 1-2)
- [x] a drifted response produces a `ParseError` at the seam, not `undefined` deep in render — tested per client here
- [x] no schema-less / raw-cast phantom-`T` remains in live clients (the operator-locations cast is a distinct envelope-extras contract, not a migrated `unwrap` client)

## Test plan
- New per-client drift tests: anomaly `kind: 'REFUND_PENDING'` → `ParseError`; revenue `grossJpy: '0'` (string) → `ParseError`.
- New populated-report test exercises the nested `partners[].months[]` schemas with specific value assertions (the prior tests only covered the empty fixture).
- `tsc --noEmit` (web), biome, full web suite (1167 passed), lint:size/modules — all green.

## Reviews
code-reviewer **SHIP** (verified `satisfies` catches over-permissive/wrong-type/missing-field drift on zod 4.4.3; drift tests confirmed mutation-resistant). architect **SHIP** (contract is a "true triangle" — API producer `admin-revenue.ts:29` + `payment-anomalies.ts toView` both type-pin to the same shared interface).

## Follow-up (out of scope)
Optional 1-line nicety raised by architect review: `archiveLocation`'s success path could `locationSchema.parse(body.data)` instead of the raw cast (reuses the existing schema, no `unwrap` change). Non-blocking — that path is a different (envelope-extras) contract, not part of #711's "thread schemas through `unwrap`" mandate.