### PR TITLE
feat(#916): operator dashboard compliance banner (§5.5, Slice 3)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -183,7 +183,12 @@
       "viewBookings": "View bookings",
       "manageFleet": "Manage fleet",
       "loadError": "Couldn't load your dashboard.",
-      "retry": "Retry"
+      "retry": "Retry",
+      "compliance": {
+        "heading": "{count, plural, one {# vehicle needs attention} other {# vehicles need attention}}",
+        "body": "Shaken or insurance is expired or expiring soon.",
+        "action": "Review fleet"
+      }
     },
     "stats": {
       "totalBookings": "Total Bookings",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -183,7 +183,12 @@
       "viewBookings": "予約を見る",
       "manageFleet": "車両を管理",
       "loadError": "ダッシュボードを読み込めませんでした。",
-      "retry": "再試行"
+      "retry": "再試行",
+      "compliance": {
+        "heading": "{count, plural, other {#台の車両に対応が必要です}}",
+        "body": "車検または保険が期限切れ、または間もなく期限切れです。",
+        "action": "車両を確認"
+      }
     },
     "stats": {
       "totalBookings": "予約総数",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -183,7 +183,12 @@
       "viewBookings": "查看预订",
       "manageFleet": "管理车辆",
       "loadError": "无法加载仪表盘。",
-      "retry": "重试"
+      "retry": "重试",
+      "compliance": {
+        "heading": "{count, plural, other {# 辆车需要处理}}",
+        "body": "车检或保险已过期或即将到期。",
+        "action": "查看车队"
+      }
     },
     "stats": {
       "totalBookings": "总预订数",

--- a/packages/web/src/routes/$locale/_business/dashboard.tsx
+++ b/packages/web/src/routes/$locale/_business/dashboard.tsx
@@ -1,6 +1,7 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { OperatorDashboardView } from '@/vite/operator-dashboard/OperatorDashboardView'
 import { operatorOverviewQueryOptions } from '@/vite/operator-dashboard/api'
+import { operatorFleetQueryOptions } from '@/vite/operator-fleet/api'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
@@ -8,8 +9,14 @@ import { useTranslations } from 'use-intl'
 // Operator landing (#524). Provider login (#521) routes here. The `_business`
 // parent layout already gates on operator membership, so this only owns the
 // data: prefetch in the loader, read via useSuspenseQuery, render the pure view.
+// The loader also warms the fleet query so the §5.5 compliance banner (#916) can
+// count expiring shaken/insurance with no second loading state.
 export const Route = createFileRoute('/$locale/_business/dashboard')({
-  loader: ({ context }) => context.queryClient.ensureQueryData(operatorOverviewQueryOptions()),
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(operatorOverviewQueryOptions()),
+      context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
+    ]),
   pendingComponent: PageSkeleton,
   errorComponent: OperatorDashboardError,
   component: OperatorDashboardRoute,
@@ -17,8 +24,9 @@ export const Route = createFileRoute('/$locale/_business/dashboard')({
 
 function OperatorDashboardRoute() {
   const { locale } = Route.useParams()
-  const { data } = useSuspenseQuery(operatorOverviewQueryOptions())
-  return <OperatorDashboardView overview={data} locale={locale} />
+  const { data: overview } = useSuspenseQuery(operatorOverviewQueryOptions())
+  const { data: vehicles } = useSuspenseQuery(operatorFleetQueryOptions())
+  return <OperatorDashboardView overview={overview} vehicles={vehicles} locale={locale} />
 }
 
 function OperatorDashboardError(_props: ErrorComponentProps) {

--- a/packages/web/src/routes/$locale/_business/manage/fleet/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fleet/index.tsx
@@ -1,3 +1,4 @@
+import type { FleetFilterState } from '@/lib/fleet-filters'
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { isOperatorSession } from '@/vite/guards'
 import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
@@ -9,6 +10,20 @@ import { sessionQueryOptions } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
+
+// #916 §5.5: the dashboard compliance banner deep-links here with
+// `?expiringSoon=true` to open the fleet already narrowed to the non-compliant
+// set. Accept the flag as a real boolean (in-app navigation) or the string
+// `'true'` (a shared/reloaded URL); anything else opens unfiltered.
+interface FleetSearch {
+  expiringSoon?: boolean | undefined
+}
+
+function validateSearch(search: Record<string, unknown>): FleetSearch {
+  return {
+    expiringSoon: search.expiringSoon === true || search.expiringSoon === 'true' ? true : undefined,
+  }
+}
 
 // Operator fleet management (#526). URL `/<locale>/manage/fleet` — behind the
 // `_business` guard, so only business roles reach it; tenant scoping is
@@ -23,6 +38,7 @@ import { useTranslations } from 'use-intl'
 // Lives at `fleet/index` (not `fleet.tsx`) so the sibling `fleet/$vehicleId`
 // detail route (#527) can coexist; the URL is unchanged.
 export const Route = createFileRoute('/$locale/_business/manage/fleet/')({
+  validateSearch,
   loader: ({ context }) =>
     Promise.all([
       context.queryClient.ensureQueryData(operatorFleetQueryOptions()),
@@ -39,6 +55,8 @@ export function OperatorFleetRoute() {
   const { data: vehicles } = useSuspenseQuery(operatorFleetQueryOptions())
   const { data: classOptions } = useSuspenseQuery(vehicleClassOptionsQueryOptions())
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  const { expiringSoon } = Route.useSearch()
+  const initialFilters: FleetFilterState = expiringSoon ? { expiringSoon: true } : {}
 
   // Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) read the
   // fleet cross-operator for oversight but cannot write: every create/edit/bulk
@@ -59,6 +77,7 @@ export function OperatorFleetRoute() {
           classOptions={classOptions}
           canWrite={canWrite}
           locale={locale}
+          initialFilters={initialFilters}
         />
       </div>
     </main>

--- a/packages/web/src/vite/operator-dashboard/ComplianceBanner.tsx
+++ b/packages/web/src/vite/operator-dashboard/ComplianceBanner.tsx
@@ -1,0 +1,43 @@
+import { filterVehicles } from '@/lib/fleet-filters'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { Link } from '@tanstack/react-router'
+import { TriangleAlert } from 'lucide-react'
+import { useTranslations } from 'use-intl'
+
+interface ComplianceBannerProps {
+  readonly vehicles: readonly OperatorFleetVehicle[]
+  readonly locale: string
+}
+
+// §5.5 in-app compliance banner (#916). On the operator dashboard, surfaces how
+// many fleet vehicles have shaken/insurance expired or expiring within 30 days
+// and deep-links to the fleet pre-filtered to that same set. The count comes from
+// the shared `filterVehicles({ expiringSoon })` the fleet view uses, so the
+// headline number can never drift from the list the link lands on (FC/IS — pure
+// derivation, no I/O). Renders nothing when the fleet is fully compliant.
+export function ComplianceBanner({ vehicles, locale }: ComplianceBannerProps) {
+  const t = useTranslations('business.dashboard.compliance')
+  const count = filterVehicles([...vehicles], { expiringSoon: true }).length
+  if (count === 0) return null
+
+  return (
+    <div
+      role="alert"
+      className="mt-6 flex flex-wrap items-center gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
+    >
+      <TriangleAlert className="size-5 shrink-0" aria-hidden="true" />
+      <div className="min-w-0">
+        <p className="font-medium">{t('heading', { count })}</p>
+        <p className="text-sm text-amber-800 dark:text-amber-300/90">{t('body')}</p>
+      </div>
+      <Link
+        to="/$locale/manage/fleet"
+        params={{ locale }}
+        search={{ expiringSoon: true }}
+        className="ml-auto inline-flex items-center rounded-lg border border-amber-400 px-3 py-1.5 text-sm font-medium hover:bg-amber-100 dark:hover:bg-amber-500/20"
+      >
+        {t('action')}
+      </Link>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
+++ b/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
@@ -1,3 +1,5 @@
+import { ComplianceBanner } from '@/vite/operator-dashboard/ComplianceBanner'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import { Link } from '@tanstack/react-router'
 import { CalendarDays, CarFront, Clock } from 'lucide-react'
@@ -5,6 +7,10 @@ import { useTranslations } from 'use-intl'
 
 interface OperatorDashboardViewProps {
   readonly overview: OperatorOverview
+  // The operator's fleet, fed to the §5.5 compliance banner (#916). The route
+  // already warms this query for the Manage Fleet link, so reading it here is a
+  // cache hit, not a second round-trip.
+  readonly vehicles: readonly OperatorFleetVehicle[]
   readonly locale: string
 }
 
@@ -12,7 +18,7 @@ interface OperatorDashboardViewProps {
 // useSuspenseQuery and the pending/error boundaries; this stays a pure function
 // of the resolved counts so it is unit-testable (FC/IS — the shell does I/O,
 // this renders). All three figures are already operator-scoped by the API.
-export function OperatorDashboardView({ overview, locale }: OperatorDashboardViewProps) {
+export function OperatorDashboardView({ overview, vehicles, locale }: OperatorDashboardViewProps) {
   const t = useTranslations('business')
 
   const tiles = [
@@ -26,6 +32,8 @@ export function OperatorDashboardView({ overview, locale }: OperatorDashboardVie
       <div className="mx-auto max-w-7xl">
         <h1 className="text-2xl font-semibold">{t('dashboard.title')}</h1>
         <p className="mt-1 text-muted-foreground">{t('dashboard.subtitle')}</p>
+
+        <ComplianceBanner vehicles={vehicles} locale={locale} />
 
         <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {tiles.map(({ label, icon: Icon, value }) => (

--- a/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
+++ b/packages/web/src/vite/operator-fleet/OperatorFleetView.tsx
@@ -23,6 +23,11 @@ interface OperatorFleetViewProps {
   // Passed as a prop (not read from a router hook) to keep the view tree
   // router-free and unit-testable — the bookings locale-as-prop convention.
   readonly locale: string
+  // Seed filter state from the URL (#916 §5.5): the dashboard compliance banner
+  // deep-links here with `?expiringSoon=true` so the page opens already narrowed
+  // to the non-compliant set. The route reads it via validateSearch and passes
+  // it down; absent ⇒ the page opens unfiltered.
+  readonly initialFilters?: FleetFilterState
 }
 
 // Stateful fleet management container. The route owns the loader /
@@ -36,12 +41,13 @@ export function OperatorFleetView({
   classOptions,
   canWrite,
   locale,
+  initialFilters,
 }: OperatorFleetViewProps) {
   const t = useTranslations('business.vehicles.fleet')
   const todayIso = new Date().toISOString().slice(0, 10)
   const [view, setView] = useFleetViewMode()
   const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
-  const [filters, setFilters] = useState<FleetFilterState>({})
+  const [filters, setFilters] = useState<FleetFilterState>(initialFilters ?? {})
   const [sheet, setSheet] = useState<{ vehicle: OperatorFleetVehicle | null } | null>(null)
 
   const visibleVehicles = filterVehicles([...vehicles], filters)

--- a/packages/web/tests/vite/operator-dashboard/ComplianceBanner.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/ComplianceBanner.test.tsx
@@ -1,0 +1,113 @@
+import { ComplianceBanner } from '@/vite/operator-dashboard/ComplianceBanner'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+// Stub TanStack's Link as a plain anchor that also surfaces the search object,
+// so the test can assert the deep-link target plus the expiringSoon filter it
+// carries (the banner must land the operator on the same set it counts).
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    params,
+    search,
+    children,
+    ...rest
+  }: {
+    to: string
+    params?: { locale?: string }
+    search?: Record<string, unknown>
+    children: ReactNode
+  }) => (
+    <a
+      href={to}
+      data-to={to}
+      data-locale={params?.locale}
+      data-search={JSON.stringify(search)}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
+}))
+
+const copy = enMessages.business.dashboard.compliance
+
+function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'v1',
+    operatorId: 'op_1',
+    classId: null,
+    pickupLocationId: null,
+    name: 'Toyota Aqua',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'なにわ 300 あ 12-34',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: 'Toyota',
+    model: 'Aqua',
+    year: 2022,
+    color: null,
+    dailyRateJpy: 6800,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-01-01',
+    insuranceExpiryDate: '2099-01-01',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+function renderBanner(vehicles: OperatorFleetVehicle[]) {
+  return render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <ComplianceBanner vehicles={vehicles} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('ComplianceBanner', () => {
+  it('renders nothing when every vehicle is compliant', () => {
+    const { container } = renderBanner([vehicle()])
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('counts vehicles whose shaken OR insurance is expired or expiring', () => {
+    renderBanner([
+      vehicle({ id: 'a', shakenExpiryDate: '2020-01-01' }),
+      vehicle({ id: 'b', insuranceExpiryDate: '2020-01-01' }),
+      vehicle({ id: 'c' }),
+    ])
+    expect(screen.getByRole('alert')).toHaveTextContent('2 vehicles need attention')
+  })
+
+  it('uses the singular form for exactly one non-compliant vehicle', () => {
+    renderBanner([vehicle({ shakenExpiryDate: '2020-01-01' }), vehicle({ id: 'ok' })])
+    expect(screen.getByRole('alert')).toHaveTextContent('1 vehicle needs attention')
+  })
+
+  it('deep-links to the fleet pre-filtered to the expiring set', () => {
+    renderBanner([vehicle({ shakenExpiryDate: '2020-01-01' })])
+    const link = screen.getByRole('link', { name: copy.action })
+    expect(link).toHaveAttribute('data-to', '/$locale/manage/fleet')
+    expect(link).toHaveAttribute('data-locale', 'en')
+    expect(link).toHaveAttribute('data-search', JSON.stringify({ expiringSoon: true }))
+  })
+})

--- a/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
@@ -1,0 +1,89 @@
+import { OperatorDashboardView } from '@/vite/operator-dashboard/OperatorDashboardView'
+import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { OperatorOverview } from '@kuruma/shared/types/overview'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+// The view mounts the compliance banner (#916 §5.5), which links to the fleet via
+// TanStack's Link; stub it as a plain anchor so the view renders without a router.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, ...rest }: { to: string; children: ReactNode }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+const overview: OperatorOverview = {
+  totalBookings: 12,
+  activeVehicles: 5,
+  upcomingBookings: 3,
+}
+
+function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
+  return {
+    id: 'v1',
+    operatorId: 'op_1',
+    classId: null,
+    pickupLocationId: null,
+    name: 'Toyota Aqua',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'MEDIUM',
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: 'なにわ 300 あ 12-34',
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: 'Toyota',
+    model: 'Aqua',
+    year: 2022,
+    color: null,
+    dailyRateJpy: 6800,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-01-01',
+    insuranceExpiryDate: '2099-01-01',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    utilization: 0,
+    bookingCountLast30Days: 0,
+    currentBooking: null,
+    nextBooking: null,
+    activeMaintenanceReason: null,
+    ...overrides,
+  }
+}
+
+function renderDashboard(vehicles: OperatorFleetVehicle[]) {
+  return render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <OperatorDashboardView overview={overview} vehicles={vehicles} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('OperatorDashboardView', () => {
+  it('renders the three operator stat tiles', () => {
+    renderDashboard([vehicle()])
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('mounts the compliance banner when a fleet vehicle is non-compliant (#916 §5.5)', () => {
+    renderDashboard([vehicle({ shakenExpiryDate: '2020-01-01' }), vehicle({ id: 'ok' })])
+    expect(screen.getByRole('alert')).toHaveTextContent('1 vehicle needs attention')
+  })
+
+  it('omits the compliance banner when the whole fleet is compliant', () => {
+    renderDashboard([vehicle()])
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetRoute.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetRoute.test.tsx
@@ -12,13 +12,17 @@ import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
-// The route component now reads `locale` via Route.useParams and links rows to
-// the detail route (#527). This test renders the component outside a
-// RouterProvider, so stub createFileRoute (Route.useParams -> a fixed locale) and
-// Link (-> an anchor). Keep everything else real.
+// The route component now reads `locale` via Route.useParams, the compliance
+// deep-link filter via Route.useSearch (#916 §5.5), and links rows to the detail
+// route (#527). This test renders the component outside a RouterProvider, so stub
+// createFileRoute (useParams -> a fixed locale, useSearch -> no filter) and Link
+// (-> an anchor). Keep everything else real.
 vi.mock('@tanstack/react-router', async () => ({
   ...(await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')),
-  createFileRoute: () => () => ({ useParams: () => ({ locale: 'en' }) }),
+  createFileRoute: () => () => ({
+    useParams: () => ({ locale: 'en' }),
+    useSearch: () => ({}),
+  }),
   Link: ({
     to,
     params: _params,

--- a/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/OperatorFleetView.test.tsx
@@ -1,3 +1,4 @@
+import type { FleetFilterState } from '@/lib/fleet-filters'
 import { formatVehicleRate } from '@/lib/format'
 import { OperatorFleetView } from '@/vite/operator-fleet/OperatorFleetView'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
@@ -94,6 +95,7 @@ function renderView(
   vehicles: OperatorFleetVehicle[],
   classOptions: ReadonlyArray<{ id: string; name: string }> = [],
   canWrite = true,
+  initialFilters: FleetFilterState = {},
 ) {
   // The route prefetches class options and passes them down as a prop, so the
   // grid groups synchronously with no fetch of its own — the test mirrors that
@@ -108,6 +110,7 @@ function renderView(
           classOptions={classOptions}
           canWrite={canWrite}
           locale="en"
+          initialFilters={initialFilters}
         />
       </IntlProvider>
     </QueryClientProvider>,
@@ -301,6 +304,20 @@ describe('OperatorFleetView', () => {
     expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
     expect(screen.queryAllByRole('button', { name: en.columns.actions })).toHaveLength(0)
     expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+  })
+
+  it('opens pre-filtered when handed an initial filter (compliance deep-link, #916 §5.5)', () => {
+    renderView(
+      [
+        vehicle({ id: 'exp', name: 'Expiring Car', shakenExpiryDate: '2020-01-01' }),
+        vehicle({ id: 'ok', name: 'Compliant Car', shakenExpiryDate: '2099-01-01' }),
+      ],
+      [],
+      true,
+      { expiringSoon: true },
+    )
+    expect(screen.getByText('Expiring Car')).toBeInTheDocument()
+    expect(screen.queryByText('Compliant Car')).not.toBeInTheDocument()
   })
 
   it('renders the fleet summary counts strip', () => {


### PR DESCRIPTION
## Slice 3 — §5.5 in-app compliance banner

Final slice of #916 (shaken/insurance compliance). Slices 1–2 (enforcement gates + scheduled digest) already shipped via #981. This adds the operator-facing **in-app banner** the spec's §5.5 calls for.

### What it does
On the operator dashboard, surfaces how many fleet vehicles have a **shaken or insurance certificate expired or expiring within 30 days**, and deep-links to the fleet pre-filtered to exactly that set. Renders nothing when the fleet is fully compliant.

### How
- **`ComplianceBanner`** (new, pure) derives its count from the *same* shared `filterVehicles({ expiringSoon })` the fleet view uses — so the headline number can never drift from the list the link lands on (FC/IS: pure derivation, no I/O).
- **Fleet route** gains `validateSearch(expiringSoon)` + an `initialFilters` prop on `OperatorFleetView`, so the banner's `?expiringSoon=true` opens the fleet already narrowed. The filter chip is visible and clearable.
- **Dashboard loader** warms `operatorFleetQueryOptions()` — a cache hit (the Manage Fleet link already fetches it), not a second round-trip.
- **i18n** en/ja/zh (`business.dashboard.compliance`), CLDR-correct plural (en `one`/`other`; ja/zh `other`-only).

### Tests (TDD)
- `ComplianceBanner.test.tsx` — null at 0, shaken-OR-insurance counting, singular/plural copy, deep-link target + `expiringSoon` search param.
- `OperatorDashboardView.test.tsx` — banner mounts on the dashboard for a non-compliant fleet; absent when compliant; stat tiles render.
- `OperatorFleetView.test.tsx` — `initialFilters` opens pre-filtered.
- `OperatorFleetRoute.test.tsx` — mock updated for `Route.useSearch`.

### Verification (against develop)
- Web suite: **1172 passed (176 files)** · `tsc` clean · `vite build` clean (no route-tree churn) · biome clean · module-boundary + file-size guards pass.
- Reviewed by code-reviewer: no CRITICAL/HIGH; the one MEDIUM (missing dashboard-view test) was closed before commit.

Closes #916