### PR TITLE
refactor(api): extract storage ports to types-storage.ts (#978)

### DIFF
--- a/packages/api/src/repositories/types-storage.ts
+++ b/packages/api/src/repositories/types-storage.ts
@@ -1,0 +1,19 @@
+// Object-storage ports (#459 documents, #461/#952 photos) live in their own
+// module to keep the repositories/types.ts barrel under the file-size cap (#978);
+// re-exported for callers from ./types.
+
+export interface PhotoStorage {
+  put(vehicleId: string, file: File): Promise<{ key: string; url: string }>
+  /** Accepts a key or full URL. `ownerVehicleId` scopes the delete to that vehicle's key prefix, so a cross-referenced URL can't reach another vehicle's object (cross-tenant IDOR guard, #952). */
+  delete(keyOrUrl: string, ownerVehicleId: string): Promise<void>
+}
+
+/** Private object storage for renter document scans (#459) — private, not public-URL addressable (cf. `PhotoStorage`). */
+export interface DocumentStorage {
+  put(renterId: string, file: File): Promise<{ key: string }>
+  /** @deprecated Dormant pending #304; superseded by getFile(). Signed URL to view a scan. */
+  getSignedUrl(key: string): Promise<string>
+  /** Stream a stored scan's bytes + content-type for an authenticated viewer (#932). */
+  getFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null>
+  delete(key: string): Promise<void>
+}

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -72,6 +72,11 @@ export type {
   NotificationLogRepository,
   NotificationLogUpsert,
 } from './types-notification'
+
+// Object-storage ports (PhotoStorage #461/#952, DocumentStorage #459) live in
+// their own module to keep this barrel under the file-size cap (#978);
+// re-exported for callers.
+export type { DocumentStorage, PhotoStorage } from './types-storage'
 export { complianceAlertKey } from './types-compliance'
 export type { ComplianceAlertLogRepository, RecordComplianceAlert } from './types-compliance'
 
@@ -738,12 +743,6 @@ export interface FeeScheduleRepository {
   archive(id: string): Promise<FeeSchedule | undefined>
 }
 
-export interface PhotoStorage {
-  put(vehicleId: string, file: File): Promise<{ key: string; url: string }>
-  /** Accepts a key or full URL. `ownerVehicleId` scopes the delete to that vehicle's key prefix, so a cross-referenced URL can't reach another vehicle's object (cross-tenant IDOR guard, #952). */
-  delete(keyOrUrl: string, ownerVehicleId: string): Promise<void>
-}
-
 export interface RenterDocumentFilters {
   limit?: number
   offset?: number
@@ -788,13 +787,3 @@ export interface RenterDocumentRepository {
 }
 
 export type CreateRenterDocumentData = Pick<RenterDocument, 'renterId' | 'type' | 'storageKey'>
-
-/** Private object storage for renter document scans (#459) — private, not public-URL addressable (cf. `PhotoStorage`). */
-export interface DocumentStorage {
-  put(renterId: string, file: File): Promise<{ key: string }>
-  /** @deprecated Dormant pending #304; superseded by getFile(). Signed URL to view a scan. */
-  getSignedUrl(key: string): Promise<string>
-  /** Stream a stored scan's bytes + content-type for an authenticated viewer (#932). */
-  getFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null>
-  delete(key: string): Promise<void>
-}


### PR DESCRIPTION
## What

`packages/api/src/repositories/types.ts` was pinned at the **800-line hard cap** (`lint:size`). The next interface added to this barrel would have tripped the cap and forced a size-driven extraction onto whoever touched it next — unrelated to their change.

This carves the two object-storage ports — `PhotoStorage` (#461/#952) and `DocumentStorage` (#459) — into a new `repositories/types-storage.ts` and re-exports them from the barrel, matching the existing `types-payment.ts` / `types-notification.ts` seam.

## Why this seam

> Learn: God module (interface barrel at the size ceiling) — each new port forces a size-driven extraction onto whoever touches it next, unrelated to their change. Heuristic: when a shared types file sits within ~20 lines of the cap, split it proactively along seams that already exist.

The storage ports are the natural carve-out: they're pure object-storage abstractions with **no type dependencies** (only global `File` / `ReadableStream`), so the new module imports nothing.

## No behavior change

Every consumer imports `PhotoStorage` / `DocumentStorage` from the `./types` barrel — the re-export keeps all of them untouched. `types.ts` drops **800 → 789** (11 lines of headroom).

## Verification
- `tsc --noEmit` (api + web) — green
- `lint:boundaries` — Import boundaries OK
- `lint:size` — exit 0 (types.ts now under cap)
- `biome check` — clean
- API unit suite — **1698 passed**

Closes #978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)