### PR TITLE
feat(web): mobile Map toggle for search results (#885 slice 4)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1193,7 +1193,9 @@
       "geoContextAreaOnly": "{area} · {km} km away",
       "geoContextAreaOnlyNoDistance": "{area}",
       "hideMap": "Hide map",
-      "showMap": "Show map"
+      "showMap": "Show map",
+      "openMobileMap": "Map",
+      "mobileMapTitle": "Cars on the map"
     },
     "detail": {
       "backToSearch": "Back to search",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1193,7 +1193,9 @@
       "geoContextAreaOnly": "{area}・{km} km",
       "geoContextAreaOnlyNoDistance": "{area}",
       "hideMap": "地図を隠す",
-      "showMap": "地図を表示"
+      "showMap": "地図を表示",
+      "openMobileMap": "地図",
+      "mobileMapTitle": "地図で見る"
     },
     "detail": {
       "backToSearch": "検索に戻る",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1193,7 +1193,9 @@
       "geoContextAreaOnly": "{area}・{km} km",
       "geoContextAreaOnlyNoDistance": "{area}",
       "hideMap": "隐藏地图",
-      "showMap": "显示地图"
+      "showMap": "显示地图",
+      "openMobileMap": "地图",
+      "mobileMapTitle": "在地图上查看"
     },
     "detail": {
       "backToSearch": "返回搜索",

--- a/packages/web/src/vite/search/MobileMapSheet.tsx
+++ b/packages/web/src/vite/search/MobileMapSheet.tsx
@@ -1,0 +1,90 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import type { SearchResultItem } from '@kuruma/shared/types/search-result'
+import { Map as MapIcon } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
+import { useTranslations } from 'use-intl'
+import type { MapAdapter } from './MapAdapter'
+
+interface MobileMapSheetProps {
+  /** Geocoded, deduped-by-location rows (the map's plottable set). Empty ⇒ no map. */
+  readonly items: SearchResultItem[]
+  /** The concrete map component, injected (#458 D1) — same one the desktop pane uses. */
+  readonly adapter: MapAdapter
+  /** Selection is owned by the parent and shared with the desktop pane (#885 slice 4). */
+  readonly selectedId: string | null
+  readonly onSelect: (selectedId: string) => void
+  readonly anchor?: [number, number] | null
+  /** The interactive price-pill pin, supplied by the view (identical to desktop). */
+  readonly renderPin: (item: SearchResultItem, state: { selected: boolean }) => ReactNode
+  /** The co-location carousel for a selected location — rendered as a bottom sheet
+   *  over the full-screen map instead of an in-map pin overlay (the mobile standard). */
+  readonly renderCarousel: (item: SearchResultItem) => ReactNode
+}
+
+/**
+ * Mobile Map toggle (#885 slice 4). On phones the list is the default; this is the
+ * Airbnb/Turo mobile pattern layered on top: a sticky "Map" pill opens a full-screen
+ * map (`Sheet side="bottom"`), and tapping a pin slides a card carousel up from the
+ * bottom. Desktop keeps the two-pane sticky map+list (slice 3b); this whole control
+ * is `lg:hidden`. Selection is the parent's state, so opening the map already shows
+ * whatever pin the list last focused, and tapping a pin here drives the same `selectedId`.
+ */
+export function MobileMapSheet({
+  items,
+  adapter: Adapter,
+  selectedId,
+  onSelect,
+  anchor = null,
+  renderPin,
+  renderCarousel,
+}: MobileMapSheetProps) {
+  const t = useTranslations('search')
+  const [open, setOpen] = useState(false)
+
+  // No geocoded results ⇒ nothing to map; don't offer a dead Map button (the list
+  // still shows every row, same as the desktop pane's empty state).
+  if (items.length === 0) return null
+
+  const selected = items.find((item) => item.location.locationId === selectedId) ?? null
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      {/* Sticky pill, mobile only — desktop has the inline two-pane map instead. */}
+      <div className="sticky bottom-6 z-10 mt-4 flex justify-center lg:hidden">
+        <SheetTrigger
+          render={
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-lg transition hover:opacity-90"
+            >
+              <MapIcon className="size-4" aria-hidden />
+              {t('map.openMobileMap')}
+            </button>
+          }
+        />
+      </div>
+
+      <SheetContent side="bottom" className="flex h-[90dvh] flex-col gap-0 p-0">
+        <SheetHeader className="shrink-0 border-b">
+          <SheetTitle>{t('map.mobileMapTitle')}</SheetTitle>
+        </SheetHeader>
+        <div className="relative min-h-0 flex-1">
+          <Adapter
+            items={items}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            anchor={anchor}
+            renderPin={renderPin}
+          />
+          {selected && (
+            // The carousel sits over the bottom of the full-screen map; the wrapper
+            // is click-through so the map stays pannable around the card.
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-3">
+              <div className="pointer-events-auto">{renderCarousel(selected)}</div>
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/web/src/vite/search/SearchMapList.tsx
+++ b/packages/web/src/vite/search/SearchMapList.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
 import type { MapAdapter } from './MapAdapter'
 import { MapPopupCarousel } from './MapPopupCarousel'
+import { MobileMapSheet } from './MobileMapSheet'
 import { SearchResultRow } from './SearchResultRow'
 import {
   formatGeoContext,
@@ -88,9 +89,55 @@ export function SearchMapList({
     return byId
   }, [items, regions, geoAnchor, locale, t])
 
+  // The price-pill pin (#885 slice 2) and the co-location carousel are shared by the
+  // desktop two-pane map and the mobile full-screen sheet (slice 4) — lifted to
+  // consts so both map hosts render an identical pin and popup from one definition.
+  const renderPricePin = (item: SearchResultItem, { selected }: { selected: boolean }) => {
+    // The view owns the whole interactive control — group min-price, idempotent
+    // select, and a store+price accessible name (P2) so visually identical prices
+    // stay distinguishable for screen readers. The adapter only positions it at the pin.
+    const group = groupItemsById.get(item.location.locationId) ?? [item]
+    const price = pinPriceLabel(group, t)
+    const store = `${item.location.operatorName} · ${item.location.name}`
+    return (
+      <button
+        type="button"
+        aria-current={selected ? 'true' : undefined}
+        aria-label={t('map.pinSelect', { store, price })}
+        onClick={() => setSelectedId(item.location.locationId)}
+        className={cn(
+          '-translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border px-2.5 py-1 text-xs font-semibold shadow-md transition-colors',
+          selected
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-card text-foreground hover:bg-muted',
+        )}
+      >
+        {price}
+      </button>
+    )
+  }
+  // Walks the full co-located group (#885 slice 2 task 4), not just the representative
+  // pin item — the closure holds every car. Key on the location so selecting a different
+  // pin remounts the carousel at its first car instead of leaking the previous slide.
+  const renderCarousel = (item: SearchResultItem) => (
+    <MapPopupCarousel
+      key={item.location.locationId}
+      items={groupItemsById.get(item.location.locationId) ?? [item]}
+      locale={locale}
+      from={from}
+      to={to}
+      classFilter={classFilter}
+      pickupLocationId={pickupLocationId}
+      region={region}
+      geoLabel={geoLabelById.get(item.location.locationId) ?? null}
+    />
+  )
+
   return (
     <div>
-      <div className="mb-4 flex justify-end">
+      {/* Desktop-only (#885 slice 4): the toggle governs the inline two-pane map,
+          which mobile replaces with the full-screen Map sheet below. */}
+      <div className="mb-4 hidden justify-end lg:flex">
         {/* Quiet presentation toggle (#885 slice 3b) — a single button with
             aria-pressed is the right primitive for a binary show/hide (matches the
             FleetViewToggle precedent), not a two-link data-mode segmented control. */}
@@ -142,13 +189,14 @@ export function SearchMapList({
                   region={region}
                   geoLabel={geoLabelById.get(locationId) ?? null}
                 />
-                {/* The "show on map" affordance only makes sense while the map pane
-                  is visible (#885 3b) — flying to a pin you can't see is a dead end. */}
+                {/* The "show on map" affordance only makes sense while the inline map
+                  pane is visible (#885 3b) — flying to a pin you can't see is a dead
+                  end. Desktop-only (slice 4): mobile uses the Map sheet's pins instead. */}
                 {showMap && geocoded && (
                   <button
                     type="button"
                     onClick={() => setSelectedId(locationId)}
-                    className="mt-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    className="mt-2 hidden items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:inline-flex"
                   >
                     <MapPin className="size-4" />
                     {t('showOnMap')}
@@ -160,7 +208,7 @@ export function SearchMapList({
         </ul>
 
         {showMap && (
-          <div className="sticky top-4 h-[60vh] overflow-hidden rounded-xl border border-border bg-muted lg:h-[70vh]">
+          <div className="sticky top-4 hidden h-[60vh] overflow-hidden rounded-xl border border-border bg-muted lg:block lg:h-[70vh]">
             {mapItems.length === 0 ? (
               <p className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
                 {t('map.noCoordinates')}
@@ -171,53 +219,27 @@ export function SearchMapList({
                 selectedId={selectedId}
                 onSelect={setSelectedId}
                 anchor={anchor}
-                // Price-pill pin (#885 slice 2): the view owns the whole interactive
-                // control — group min-price, idempotent select, and a store+price
-                // accessible name (P2) so visually identical prices stay distinguishable
-                // for screen readers. The adapter only positions it at the pin.
-                renderPin={(item, { selected }) => {
-                  const group = groupItemsById.get(item.location.locationId) ?? [item]
-                  const price = pinPriceLabel(group, t)
-                  const store = `${item.location.operatorName} · ${item.location.name}`
-                  return (
-                    <button
-                      type="button"
-                      aria-current={selected ? 'true' : undefined}
-                      aria-label={t('map.pinSelect', { store, price })}
-                      onClick={() => setSelectedId(item.location.locationId)}
-                      className={cn(
-                        '-translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border px-2.5 py-1 text-xs font-semibold shadow-md transition-colors',
-                        selected
-                          ? 'border-primary bg-primary text-primary-foreground'
-                          : 'border-border bg-card text-foreground hover:bg-muted',
-                      )}
-                    >
-                      {price}
-                    </button>
-                  )
-                }}
-                // The popup walks the full co-located group (#885 slice 2 task 4), not
-                // just the representative pin item — the view's closure holds every car.
-                // Key on the location so selecting a different pin remounts the carousel
-                // at its first car instead of leaking the previous slide index.
-                renderSelected={(item) => (
-                  <MapPopupCarousel
-                    key={item.location.locationId}
-                    items={groupItemsById.get(item.location.locationId) ?? [item]}
-                    locale={locale}
-                    from={from}
-                    to={to}
-                    classFilter={classFilter}
-                    pickupLocationId={pickupLocationId}
-                    region={region}
-                    geoLabel={geoLabelById.get(item.location.locationId) ?? null}
-                  />
-                )}
+                renderPin={renderPricePin}
+                renderSelected={renderCarousel}
               />
             )}
           </div>
         )}
       </div>
+
+      {/* Mobile Map toggle (#885 slice 4): list-default + a sticky "Map" pill that
+          opens a full-screen map with a bottom-sheet carousel on pin tap. Self-gates
+          to `lg:hidden`; shares this view's selection so it opens on the last-focused
+          pin and feeds taps back to the same `selectedId`. */}
+      <MobileMapSheet
+        items={mapItems}
+        adapter={Adapter}
+        selectedId={selectedId}
+        onSelect={setSelectedId}
+        anchor={anchor}
+        renderPin={renderPricePin}
+        renderCarousel={renderCarousel}
+      />
     </div>
   )
 }

--- a/packages/web/tests/vite/search/MobileMapSheet.test.tsx
+++ b/packages/web/tests/vite/search/MobileMapSheet.test.tsx
@@ -1,0 +1,137 @@
+import type { MapAdapter } from '@/vite/search/MapAdapter'
+import { MobileMapSheet } from '@/vite/search/MobileMapSheet'
+import type { SearchResultItem, SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactElement, ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// The base-ui Sheet is portal-backed and flaky to *open* in happy-dom (see
+// MobileMenu.test). Passthrough it so the content renders inline and these tests
+// assert the map/carousel wiring, not base-ui's portal open state. SheetContent
+// stands in as the dialog so queries can scope to "what's inside the sheet".
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTrigger: ({ render }: { render: ReactElement }) => render,
+  SheetContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="sheet-content">{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+// Stand-in for any map library: one `pin-<id>` slot per item, filled by the
+// view's `renderPin`. Asserts the MapAdapterProps seam — no real tiles.
+const FakeMapAdapter: MapAdapter = ({ items, selectedId, renderPin }) => (
+  <div data-testid="fake-map" data-selected={selectedId ?? ''}>
+    {items.map((item) => (
+      <div key={item.location.locationId} data-testid={`pin-${item.location.locationId}`}>
+        {renderPin?.(item, { selected: item.location.locationId === selectedId })}
+      </div>
+    ))}
+  </div>
+)
+
+function carAt(vehicleId: string, name: string, locationId: string): SpecificSearchResult {
+  return {
+    kind: 'SPECIFIC',
+    location: {
+      locationId,
+      operatorId: 'op_best',
+      operatorName: 'Best Car Rental',
+      name: locationId === 'loc_namba' ? 'Namba' : 'Umeda',
+      address: 'Osaka',
+      latitude: 34.66,
+      longitude: 135.5,
+    },
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    classLabel: 'Compact',
+    acrissCode: 'CCAR',
+    seats: 5,
+    photos: [],
+    vehicleId,
+    name,
+    make: 'Toyota',
+    model: 'Yaris',
+    year: 2023,
+    transmission: 'AUTO',
+  }
+}
+
+function renderSheet(opts: {
+  items: SearchResultItem[]
+  selectedId?: string | null
+  onSelect?: (id: string) => void
+}) {
+  const onSelect = opts.onSelect ?? (() => {})
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <MobileMapSheet
+        items={opts.items}
+        adapter={FakeMapAdapter}
+        selectedId={opts.selectedId ?? null}
+        onSelect={onSelect}
+        anchor={null}
+        renderPin={(item) => (
+          <button type="button" onClick={() => onSelect(item.location.locationId)}>
+            {item.name}
+          </button>
+        )}
+        renderCarousel={(item) => <div data-testid="carousel">{item.name}</div>}
+      />
+    </IntlProvider>,
+  )
+}
+
+describe('MobileMapSheet (#885 slice 4 — mobile Map toggle)', () => {
+  it('renders no Map affordance at all when nothing is geocoded', () => {
+    const { container } = renderSheet({ items: [] })
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole('button', { name: /^map$/i })).toBeNull()
+  })
+
+  it('offers a "Map" button that hosts the full-screen map with a pin per location', () => {
+    renderSheet({ items: [carAt('v1', 'Toyota Yaris', 'loc_namba')] })
+
+    expect(screen.getByRole('button', { name: /^map$/i })).toBeInTheDocument()
+    const dialog = screen.getByTestId('sheet-content')
+    expect(within(dialog).getByTestId('fake-map')).toBeInTheDocument()
+    expect(within(dialog).getByTestId('pin-loc_namba')).toBeInTheDocument()
+  })
+
+  it('reports the tapped pin back through onSelect (pin → selection sync)', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    renderSheet({ items: [carAt('v1', 'Toyota Yaris', 'loc_namba')], onSelect })
+
+    const dialog = screen.getByTestId('sheet-content')
+    await user.click(within(within(dialog).getByTestId('pin-loc_namba')).getByRole('button'))
+
+    expect(onSelect).toHaveBeenCalledWith('loc_namba')
+  })
+
+  it('shows no bottom carousel until a location is selected', () => {
+    renderSheet({ items: [carAt('v1', 'Toyota Yaris', 'loc_namba')], selectedId: null })
+    expect(screen.queryByTestId('carousel')).toBeNull()
+  })
+
+  it('renders the bottom carousel for the selected location', () => {
+    renderSheet({
+      items: [carAt('v1', 'Toyota Yaris', 'loc_namba')],
+      selectedId: 'loc_namba',
+    })
+    const carousel = within(screen.getByTestId('sheet-content')).getByTestId('carousel')
+    expect(carousel).toHaveTextContent('Toyota Yaris')
+  })
+
+  it('ignores a selection that is not a geocoded pin (no stray carousel)', () => {
+    renderSheet({
+      items: [carAt('v1', 'Toyota Yaris', 'loc_namba')],
+      selectedId: 'loc_ghost',
+    })
+    expect(screen.queryByTestId('carousel')).toBeNull()
+  })
+})

--- a/packages/web/tests/vite/search/SearchMapList.test.tsx
+++ b/packages/web/tests/vite/search/SearchMapList.test.tsx
@@ -495,3 +495,18 @@ describe('SearchMapList — map show/hide toggle (#885 slice 3b)', () => {
     expect(screen.getByRole('button', { name: 'Hide map' })).toHaveAttribute('aria-pressed', 'true')
   })
 })
+
+describe('SearchMapList — mobile Map toggle (#885 slice 4)', () => {
+  // The mobile sheet itself is unit-tested in MobileMapSheet.test.tsx (Sheet mocked).
+  // Here we only assert SearchMapList WIRES it: a "Map" trigger renders alongside the
+  // desktop pane when there is something to plot, and is absent when nothing is geocoded.
+  it('offers a mobile "Map" trigger when at least one location is geocoded', () => {
+    renderMapList([carAt('v1', 'Toyota Yaris', 'loc_namba', GEOCODED)])
+    expect(screen.getByRole('button', { name: /^map$/i })).toBeInTheDocument()
+  })
+
+  it('offers no mobile "Map" trigger when every result is list-only (null-coord)', () => {
+    renderMapList([carAt('v2', 'Honda Fit', 'loc_umeda', NO_COORDS)])
+    expect(screen.queryByRole('button', { name: /^map$/i })).toBeNull()
+  })
+})


### PR DESCRIPTION
Final slice of the search-results redesign (§5/§7) — #1003 (slice 3b, desktop unify) is merged, so this targets `develop` directly. `Closes #885`.

## What
On mobile the results list is the default; a sticky **"Map" pill** opens a full-screen map (`Sheet side="bottom"`) with a **card carousel** that slides up on pin tap — the Airbnb/Turo mobile pattern. Desktop (slice 3b two-pane sticky map+list) is unchanged.

- **New `MobileMapSheet.tsx`** (`lg:hidden`) — reuses the injected map adapter, the price-pill `renderPin`, and `MapPopupCarousel`; shares the parent's `selectedId`.
- **`SearchMapList.tsx`** — lifted `renderPin`/`renderCarousel` to one shared definition; the presentation toggle, inline map pane, and per-row "show on map" are now `lg:`-only.
- **No `useMediaQuery`** — pure Tailwind breakpoints. i18n `map.openMobileMap`/`map.mobileMapTitle` (en/ja/zh).

## Tests / gates
- `MobileMapSheet.test.tsx` 6 unit (Sheet mocked passthrough per MobileMenu) + 2 wiring tests in `SearchMapList.test.tsx` (real closed Sheet); 27 existing unchanged.
- Search suite **125/125**; web+api `tsc` ✅, biome ✅, i18n-parity ✅, file-size ✅. Rebased onto `develop` and re-verified.

## Test plan
- [ ] Phone width: list default, no inline map, "Map" pill visible.
- [ ] Tap "Map" → full-screen map; tap pin → carousel slides up; swipe co-located cars; CTA carries dates/filters.
- [ ] Desktop `lg+` unchanged: two-pane sticky map+list + Hide/Show-map toggle.