### PR TITLE
fix(#982): compliance-digest hardening — group-by, substitute code parity, DRY config

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -380,8 +380,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     locationRepo,
     emailSender,
     {
-      emailFrom: process.env.EMAIL_FROM ?? '',
-      emailReplyTo: process.env.EMAIL_REPLY_TO,
+      ...resolveEmailConfig(),
       fallbackOperatorEmail:
         process.env.OPERATOR_ALERT_FALLBACK_EMAIL ??
         process.env.EMAIL_REPLY_TO ??
@@ -596,6 +595,17 @@ function resolveEmailSender(overrides?: AppOverrides): EmailSender {
 }
 
 /**
+ * The shared envelope fields (from/reply-to) read from one env in two places —
+ * createApp's notification dispatcher and buildComplianceDigestService (#982 DRY).
+ */
+function resolveEmailConfig(): { emailFrom: string; emailReplyTo: string | undefined } {
+  return {
+    emailFrom: process.env.EMAIL_FROM ?? '',
+    emailReplyTo: process.env.EMAIL_REPLY_TO,
+  }
+}
+
+/**
  * Composition seam for the #916 §5.4 daily compliance digest, resolved by the
  * Workers `scheduled` cron the same way routes resolve `createApp`. Wires the
  * fleet scan, the idempotency ledger, the active-member recipient resolver
@@ -615,10 +625,7 @@ export function buildComplianceDigestService(
     }),
     emailSender: resolveEmailSender(overrides),
     today: () => jstDateString(new Date()),
-    config: {
-      emailFrom: process.env.EMAIL_FROM ?? '',
-      emailReplyTo: process.env.EMAIL_REPLY_TO,
-    },
+    config: resolveEmailConfig(),
   })
 }
 

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -274,7 +274,9 @@ export function createBookingRoutes(service: BookingService) {
         parsed.data.reason ?? null,
       )
       if (!result.ok) {
-        return fail(c, result.error, result.status)
+        return fail(c, result.error, result.status, {
+          ...(result.code ? { code: result.code } : {}),
+        })
       }
 
       return ok(c, result.booking)

--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -105,6 +105,9 @@ export class BookingLifecycleService {
             ok: false,
             status: 400,
             error: "Replacement vehicle's shaken or insurance expires before the booking ends",
+            // Same code the create path emits (booking-creation.ts) so callers
+            // branch on it instead of string-matching the message (#982 parity).
+            code: 'VEHICLE_DOCS_EXPIRE_BEFORE_RETURN',
           }
         }
 

--- a/packages/api/src/services/booking-types.ts
+++ b/packages/api/src/services/booking-types.ts
@@ -59,7 +59,7 @@ export type BookingVerificationGate = (
 
 export type SubstituteResult =
   | { ok: true; booking: Booking }
-  | { ok: false; status: 400 | 404 | 409; error: string }
+  | { ok: false; status: 400 | 404 | 409; error: string; code?: ErrorCode }
 
 export type StatusTransitionResult =
   | { ok: true; booking: Booking }

--- a/packages/api/src/services/compliance-digest.ts
+++ b/packages/api/src/services/compliance-digest.ts
@@ -1,8 +1,7 @@
 import {
-  COMPLIANCE_DOCUMENT_TYPES,
   type ComplianceAlertBand,
   type ComplianceDocumentType,
-  complianceThresholdBand,
+  vehicleAlertCandidates,
 } from '@kuruma/shared/lib/compliance'
 import { SYSTEM_CONTEXT } from '../middleware/auth'
 import {
@@ -70,21 +69,16 @@ export class ComplianceDigestService {
     })
 
     const candidates = vehicles.flatMap((v) =>
-      COMPLIANCE_DOCUMENT_TYPES.flatMap((documentType): AlertCandidate[] => {
-        const expiryDate = documentType === 'SHAKEN' ? v.shakenExpiryDate : v.insuranceExpiryDate
-        const band = complianceThresholdBand(expiryDate, today)
-        if (band == null) return []
-        return [
-          {
-            operatorId: v.operatorId,
-            vehicleId: v.id,
-            vehicleName: v.name,
-            licensePlate: v.licensePlate,
-            documentType,
-            band,
-          },
-        ]
-      }),
+      vehicleAlertCandidates(v, today).map(
+        ({ documentType, band }): AlertCandidate => ({
+          operatorId: v.operatorId,
+          vehicleId: v.id,
+          vehicleName: v.name,
+          licensePlate: v.licensePlate,
+          documentType,
+          band,
+        }),
+      ),
     )
     if (candidates.length === 0) return EMPTY_SUMMARY
 

--- a/packages/api/src/services/compliance-digest.ts
+++ b/packages/api/src/services/compliance-digest.ts
@@ -92,8 +92,15 @@ export class ComplianceDigestService {
     let operatorsSkippedNoRecipients = 0
     let operatorsFailed = 0
 
-    for (const operatorId of [...new Set(fresh.map((c) => c.operatorId))]) {
-      const items = fresh.filter((c) => c.operatorId === operatorId)
+    // Group fresh alerts by operator in one pass (mirrors groupByLocation in
+    // storefront-search) instead of re-scanning `fresh` once per operator.
+    const itemsByOperator = new Map<string, AlertCandidate[]>()
+    for (const c of fresh) {
+      const list = itemsByOperator.get(c.operatorId) ?? []
+      itemsByOperator.set(c.operatorId, [...list, c])
+    }
+
+    for (const [operatorId, items] of itemsByOperator) {
       const recipients = await this.deps.resolveRecipients(operatorId)
       // No recipients → don't send and don't record, so the alert retries once a
       // member exists (record-after-send applies to the empty-audience case too).

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -35,6 +35,8 @@ const handler = {
     _env?: unknown,
     _ctx?: ExecutionContext,
   ): Promise<void> {
+    // No cross-run lock: a daily cron can't overlap itself, and run() is
+    // idempotent regardless (record-after-send + the alert ledger dedupe bands).
     const summary = await buildComplianceDigestService().run()
     console.info('[cron:compliance-digest]', JSON.stringify(summary))
   },

--- a/packages/api/tests/integration/booking-substitution.test.ts
+++ b/packages/api/tests/integration/booking-substitution.test.ts
@@ -373,6 +373,7 @@ describe('substitution compliance gate — expired replacement (real pg, §5.3b 
     if (res.ok) throw new Error('expected the expired replacement to be rejected')
     expect(res.status).toBe(400)
     expect(res.error).toMatch(/expires before the booking ends/i)
+    expect(res.code).toBe('VEHICLE_DOCS_EXPIRE_BEFORE_RETURN') // #982 parity with create
 
     // The booking stays on its original vehicle — the rejected swap never landed.
     const fromDb = await bookingRepo.findById(SYSTEM_CONTEXT, bookingId)

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -1083,6 +1083,20 @@ describe('BookingService.substitute — operator vehicle swap (#392 §5.5)', () 
     expect(result.status).toBe(400)
   })
 
+  it('rejects a replacement whose shaken expires before the booking ends (400 + VEHICLE_DOCS_EXPIRE_BEFORE_RETURN)', async () => {
+    const h = await setupSub()
+    // Booking ends 2026-07-04; a shaken lapsing 2026-07-03 is not road-legal for
+    // the return (§5.3b #916). The reject must carry the SAME `code` the create
+    // path emits, so the web branches on it without string-matching (#982 parity).
+    const expired = await addVehicle(h, { shakenExpiryDate: '2026-07-03' })
+    const result = await h.service.substitute(opCtxA, h.bookingId, expired.id, null)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(400)
+    expect(result.error).toMatch(/expires before the booking ends/i)
+    expect(result.code).toBe('VEHICLE_DOCS_EXPIRE_BEFORE_RETURN')
+  })
+
   it('swaps the vehicle: updates assignedVehicleId, keeps requestedVehicleId, re-snapshots totalPrice, appends VEHICLE_SUBSTITUTED', async () => {
     const h = await setupSub()
     const replacement = await addVehicle(h, { dailyRateJpy: 15000 })

--- a/packages/shared/src/lib/compliance.test.ts
+++ b/packages/shared/src/lib/compliance.test.ts
@@ -6,6 +6,7 @@ import {
   isNonCompliant,
   isRoadLegal,
   jstDateString,
+  vehicleAlertCandidates,
 } from './compliance'
 import { EXPIRY_SOON_DAYS, computeExpiryStatus } from './expiry'
 
@@ -193,5 +194,53 @@ describe('compliance horizon is a single source of truth', () => {
 
     expect(computeExpiryStatus(pastHorizon, today)).toBe('OK')
     expect(complianceThresholdBand(pastHorizon, today)).toBeNull()
+  })
+})
+
+/**
+ * #982. The digest's per-vehicle alert derivation (which of shaken/insurance is
+ * in an alert band) as a pure function, so the cron and any other consumer share
+ * one mapping instead of re-deriving the flatMap. SHAKEN is yielded before
+ * INSURANCE (COMPLIANCE_DOCUMENT_TYPES order), and a document with no band (more
+ * than 30 days out) is omitted. MISSING and EXPIRED are bands, so they ARE
+ * yielded — the digest alerts on them.
+ */
+describe('vehicleAlertCandidates', () => {
+  const today = '2026-06-17'
+
+  test('omits a document that is more than 30 days out', () => {
+    expect(
+      vehicleAlertCandidates(
+        { shakenExpiryDate: '2027-01-01', insuranceExpiryDate: '2027-01-01' },
+        today,
+      ),
+    ).toEqual([])
+  })
+
+  test('yields only the document in a band, SHAKEN first', () => {
+    expect(
+      vehicleAlertCandidates(
+        { shakenExpiryDate: '2026-06-24', insuranceExpiryDate: '2027-01-01' },
+        today,
+      ),
+    ).toEqual([{ documentType: 'SHAKEN', band: 'D7' }])
+  })
+
+  test('yields both documents in their own bands, SHAKEN before INSURANCE', () => {
+    expect(
+      vehicleAlertCandidates(
+        { shakenExpiryDate: '2026-06-16', insuranceExpiryDate: '2026-06-24' },
+        today,
+      ),
+    ).toEqual([
+      { documentType: 'SHAKEN', band: 'EXPIRED' },
+      { documentType: 'INSURANCE', band: 'D7' },
+    ])
+  })
+
+  test('a missing date is a MISSING band (the digest alerts on it)', () => {
+    expect(
+      vehicleAlertCandidates({ shakenExpiryDate: null, insuranceExpiryDate: '2027-01-01' }, today),
+    ).toEqual([{ documentType: 'SHAKEN', band: 'MISSING' }])
   })
 })

--- a/packages/shared/src/lib/compliance.ts
+++ b/packages/shared/src/lib/compliance.ts
@@ -114,3 +114,28 @@ export function complianceThresholdBand(
   }
   return null
 }
+
+/** One of a vehicle's documents that has fallen into an alert band. */
+export interface VehicleAlertCandidate {
+  documentType: ComplianceDocumentType
+  band: ComplianceAlertBand
+}
+
+/**
+ * The alert-band derivation for a single vehicle (§5.4 digest, #982): for each of
+ * shaken/insurance, the band its expiry falls into as of `todayIso`, omitting any
+ * document with no band (more than 30 days out). SHAKEN is yielded before
+ * INSURANCE (`COMPLIANCE_DOCUMENT_TYPES` order). Extracted as a pure function so
+ * the cron and any other consumer share one mapping rather than re-deriving it.
+ */
+export function vehicleAlertCandidates(
+  vehicle: { shakenExpiryDate: string | null; insuranceExpiryDate: string | null },
+  todayIso: string,
+): VehicleAlertCandidate[] {
+  return COMPLIANCE_DOCUMENT_TYPES.flatMap((documentType) => {
+    const expiryDate =
+      documentType === 'SHAKEN' ? vehicle.shakenExpiryDate : vehicle.insuranceExpiryDate
+    const band = complianceThresholdBand(expiryDate, todayIso)
+    return band == null ? [] : [{ documentType, band }]
+  })
+}


### PR DESCRIPTION
Closes #982.

Low-risk hardening pass on the compliance digest (#916 §5.4). The batch-query scale fix is deliberately **deferred to #1010** — this PR is safe, behavior-preserving changes only.

## Slices
1. **Pure `vehicleAlertCandidates`** (`shared/lib/compliance.ts`) — extracted the digest's per-vehicle alert-band derivation into a pure function so the cron and any future consumer share one mapping instead of re-deriving the `flatMap`. Reuses `complianceThresholdBand`, so it picks up #998's unified `EXPIRY_SOON_DAYS` horizon automatically. + unit tests.
2. **Map group-by** (`compliance-digest.ts`) — replaced `[...new Set(...)] + per-operator .filter()` (O(operators × candidates)) with a single `Map<operatorId, items[]>` pass. Behavior identical (operator order, items per operator, skip/fail paths). Mirrors `groupByLocation` in `storefront-search.ts`.
3. **Substitute `code` parity** — the substitute road-legal reject returned the same message as create but no `code`, forcing callers to string-match. Added `code?: ErrorCode` to `SubstituteResult`, emit `VEHICLE_DOCS_EXPIRE_BEFORE_RETURN` (the exact create-path code) from the lifecycle reject, and threaded it through the substitute route with the same `...(result.code ? { code } : {})` pattern the create route uses. + unit + integration assertions.
4. **DRY email config + cron note** — extracted a shared `resolveEmailConfig()` reader used by both the notification dispatcher and the digest (`index.ts`); documented why the daily cron needs no overlap lock (idempotent via record-after-send + the band ledger).

## Tests
- `bun run --filter @kuruma/shared test` → 659 pass
- api unit suites (`booking.test.ts`, `compliance-digest*`) → green; new substitute-reject test (RED→GREEN proven)
- `tsc --noEmit` (api) clean · `lint:boundaries` OK
- code-reviewer: **SHIP** (0 findings; behavior identity verified, not just asserted)

## Notes
- Deferred scale fix tracked in #1010 (batch `findActiveByOperators` to drop the per-operator recipient N+1).
- Rebased onto develop after #998 (PR #1005) merged — shared `compliance.ts`/`compliance.test.ts` conflict resolved by keeping both the horizon-SSoT and `vehicleAlertCandidates` describe blocks.