### PR TITLE
chore(#1015): authority-provenance headers linking each linter to its rule SSoT

### DIFF
--- a/scripts/db-drift-warn.ts
+++ b/scripts/db-drift-warn.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: non-blocking predev warning when the dev DB is behind this worktree's migrations
+// SSOT: CLAUDE.md § Monorepo (#740 predev drift check)
 /**
  * db:drift-warn — a fast, NON-BLOCKING heads-up that the dev DB is behind this
  * worktree's migrations. Wired as `predev` / `predev:api` so `bun run dev[:api]`

--- a/scripts/db-verify.ts
+++ b/scripts/db-verify.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: drizzle migration drift detection (schema<->snapshot, journal<->disk, journal monotonic, journal<->DB, critical DB objects)
+// SSOT: CLAUDE.md § Database Migrations (drizzle)
 /**
  * db:verify — detects drizzle migration drift BEFORE it causes a 500 in prod.
  *

--- a/scripts/lint-dist-size.ts
+++ b/scripts/lint-dist-size.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // ENFORCES: the Vite/CF Pages SPA bundle stays under the 2 MiB gzipped budget
-// SSOT: docs/plans/2026-06-09-378-pages-cutover.md § dist-size 2 MiB gzip budget
+// SSOT: docs/plans/2026-06-09-378-pages-cutover.md § 1. Context
 import { readFileSync } from 'node:fs'
 import { gzipSync } from 'node:zlib'
 import { Glob } from 'bun'

--- a/scripts/lint-dist-size.ts
+++ b/scripts/lint-dist-size.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: the Vite/CF Pages SPA bundle stays under the 2 MiB gzipped budget
+// SSOT: docs/plans/2026-06-09-378-pages-cutover.md § dist-size 2 MiB gzip budget
 import { readFileSync } from 'node:fs'
 import { gzipSync } from 'node:zlib'
 import { Glob } from 'bun'

--- a/scripts/lint-export-drift.ts
+++ b/scripts/lint-export-drift.ts
@@ -1,3 +1,5 @@
+// ENFORCES: @kuruma/shared/* import paths must match packages/shared/package.json "exports"
+// SSOT: code-only — rule undocumented, see #1015
 /**
  * Detects import paths into @kuruma/shared that have no matching entry
  * in packages/shared/package.json "exports". Bun workspace mode resolves

--- a/scripts/lint-fetch-binding.ts
+++ b/scripts/lint-fetch-binding.ts
@@ -1,3 +1,5 @@
+// ENFORCES: deployed runtime code uses boundFetch (this===globalThis) — never a detached global `fetch` default (#887)
+// SSOT: code-only — rule undocumented, see #1015
 /**
  * Ban detached defaults to the global `fetch` in deployed runtime code (#887).
  *

--- a/scripts/lint-file-size.ts
+++ b/scripts/lint-file-size.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: source files <= 800 lines (hard) / soft-warn 400, with route & page sub-caps
+// SSOT: docs/architecture/modules.md § File-size rules (everywhere)
 import { readFileSync } from 'node:fs'
 import { Glob } from 'bun'
 

--- a/scripts/lint-file-size.ts
+++ b/scripts/lint-file-size.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-// ENFORCES: source files <= 800 lines (hard) / soft-warn 400, with route & page sub-caps
-// SSOT: docs/architecture/modules.md § File-size rules (everywhere)
+// ENFORCES: source files <= 800 lines (hard) / soft-warn 400; route (150) & page (80) sub-caps code-only
+// SSOT: docs/architecture/modules.md § File-size rules (everywhere) — sub-caps undocumented, see #1015
 import { readFileSync } from 'node:fs'
 import { Glob } from 'bun'
 

--- a/scripts/lint-fk-indexes.ts
+++ b/scripts/lint-fk-indexes.ts
@@ -1,3 +1,5 @@
+// ENFORCES: every FK column in the drizzle schema has a covering index (unindexed FK = seq scan, outage-grade at scale)
+// SSOT: code-only — rule undocumented, see #1015
 /**
  * Enforce: every FK column in the drizzle schema must have a covering index.
  *

--- a/scripts/lint-i18n-parity.ts
+++ b/scripts/lint-i18n-parity.ts
@@ -1,3 +1,5 @@
+// ENFORCES: every locale's messages/<locale>.json declares the same key set (missing key = MISSING_MESSAGE at runtime)
+// SSOT: CLAUDE.md § i18n (use-intl v4)
 /**
  * Enforce: every configured locale's `messages/<locale>.json` declares the same
  * set of translation keys. Missing keys render a `MISSING_MESSAGE` error at

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: web feature code imports only via the `@/modules/<feature>` barrel (no cross-module internals); web has no direct DB access
+// SSOT: docs/architecture/modules.md § Enforcement
 import { readFileSync, writeFileSync } from 'node:fs'
 import { Glob } from 'bun'
 

--- a/scripts/lint-no-next-app.ts
+++ b/scripts/lint-no-next-app.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+// ENFORCES: the deleted Next.js App Router tree (packages/web/src/app/) must not regrow
+// SSOT: AGENTS.md § Web is Vite + TanStack Router (NOT Next.js)
 import { Glob } from 'bun'
 
 /**

--- a/scripts/lint-provenance.test.ts
+++ b/scripts/lint-provenance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { Glob } from 'bun'
+
+/**
+ * Authority-provenance guard (#1015): every deterministic governance linter must
+ * declare, in a machine-readable header, the rule it ENFORCES and the SSOT where
+ * that rule is written down. This makes "which check backs which rule" traceable,
+ * and makes the annotation itself enforced rather than prose that rots — the
+ * "written != effective" principle applied to our own judicial layer.
+ *
+ * SSOT must either cite a doc (`*.md § ...`) or honestly mark `code-only` for a
+ * rule that has no written home yet (an authority-provenance gap to close).
+ */
+
+const EXPLICIT_NON_LINT = ['scripts/db-verify.ts', 'scripts/db-drift-warn.ts']
+
+function governanceLinters(): string[] {
+  const found = [...new Glob('scripts/lint-*.ts').scanSync('.')].filter(
+    (f) => !f.endsWith('.test.ts'),
+  )
+  return [...new Set([...found, ...EXPLICIT_NON_LINT])].sort()
+}
+
+const ENFORCES = /^\/\/ ENFORCES: \S.+/m
+const SSOT = /^\/\/ SSOT: (?:.*\.md\b|code-only\b).+/m
+
+describe('linter authority-provenance headers', () => {
+  const linters = governanceLinters()
+
+  test('discovers the governance linter set', () => {
+    expect(linters).toContain('scripts/lint-module-boundaries.ts')
+    expect(linters).toContain('scripts/db-verify.ts')
+    expect(linters.length).toBeGreaterThanOrEqual(11)
+  })
+
+  for (const file of linters) {
+    test(`${file} declares ENFORCES + a resolvable SSOT`, () => {
+      const head = readFileSync(file, 'utf8').split('\n').slice(0, 15).join('\n')
+      expect(head).toMatch(ENFORCES)
+      expect(head).toMatch(SSOT)
+    })
+  }
+})

--- a/scripts/lint-unwrap-schema.ts
+++ b/scripts/lint-unwrap-schema.ts
@@ -1,5 +1,5 @@
 // ENFORCES: web API clients pass a Zod schema to unwrap() so the network seam is runtime-validated (#711)
-// SSOT: docs/architecture/modules.md § Validate API responses at the seam
+// SSOT: docs/architecture/modules.md § packages/web — feature folders + barrel imports
 /**
  * Ratcheting lint: web API clients must pass a Zod `schema` to `unwrap()` so the
  * network seam is runtime-validated, not a phantom `T` cast (#711). Schemaless

--- a/scripts/lint-unwrap-schema.ts
+++ b/scripts/lint-unwrap-schema.ts
@@ -1,3 +1,5 @@
+// ENFORCES: web API clients pass a Zod schema to unwrap() so the network seam is runtime-validated (#711)
+// SSOT: docs/architecture/modules.md § Validate API responses at the seam
 /**
  * Ratcheting lint: web API clients must pass a Zod `schema` to `unwrap()` so the
  * network seam is runtime-validated, not a phantom `T` cast (#711). Schemaless


### PR DESCRIPTION
Closes #1015.

## What

Adds a 2-line machine-readable header to every deterministic governance linter
(`scripts/lint-*.ts` + `db-verify` / `db-drift-warn`) declaring the rule it
**ENFORCES** and the **SSOT** doc where that rule is written — plus a
self-enforcing test that *requires* both lines, so the link can't rot.

```
// ENFORCES: web feature code imports only via the `@/modules/<feature>` barrel ...
// SSOT: docs/architecture/modules.md § Enforcement
```

This closes the *Authority Provenance* gap: previously a check carried no
traceable link back to the rule it enforces, so "which check backs which rule"
was invisible to tooling. Framing from a BizReach AI-governance talk
(legislative=rules / judicial=checks / executive=agents; "written != effective").

## Authority-provenance gaps surfaced

Three checks enforce real invariants that live only in code comments — marked
`code-only` in-header, follow-up doc PR to give them a home:
- `lint-fetch-binding.ts` — bound `fetch` (this===globalThis) on CF Workers (#887)
- `lint-fk-indexes.ts` — every FK column needs a covering index
- `lint-export-drift.ts` — `@kuruma/shared/*` imports must match package exports

## Scope / safety

- **No check logic changed** — comment-only edits + one new test.
- The provenance test runs in CI via the existing `bun test scripts/` step.

## Test plan

- [x] `bun test scripts/` — 124 pass / 0 fail (incl. 12 new provenance assertions)
- [x] RED→GREEN proven (test failed for all 11 linters before headers)
- [x] `bunx biome check scripts/` clean
- [x] `lint:modules` + `lint:no-next-app` still run unchanged