### PR TITLE
perf(#1010): batch operator-recipient resolution in the compliance digest

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -76,7 +76,10 @@ import { NotificationService } from './services/notification'
 import { NotificationDispatcher } from './services/notification-dispatcher'
 import { OperatorService } from './services/operator'
 import { createOperatorGrantService } from './services/operator-grant'
-import { makeResolveOperatorRecipients } from './services/operator-recipients'
+import {
+  makeResolveOperatorRecipients,
+  makeResolveOperatorRecipientsBatch,
+} from './services/operator-recipients'
 import { OperatorTeamService } from './services/operator-team'
 import { OverviewService } from './services/overview'
 import { PaymentAnomalyService } from './services/payment-anomaly'
@@ -609,7 +612,8 @@ function resolveEmailConfig(): { emailFrom: string; emailReplyTo: string | undef
  * Composition seam for the #916 §5.4 daily compliance digest, resolved by the
  * Workers `scheduled` cron the same way routes resolve `createApp`. Wires the
  * fleet scan, the idempotency ledger, the active-member recipient resolver
- * (reused from the booking dispatcher), the JST clock, and the email sender.
+ * (the batch sibling of the booking dispatcher's, #1010), the JST clock, and
+ * the email sender.
  */
 export function buildComplianceDigestService(
   overrides?: AppOverrides,
@@ -619,7 +623,7 @@ export function buildComplianceDigestService(
   return new ComplianceDigestService({
     vehicleRepo,
     alertLogRepo: complianceAlertLogRepo,
-    resolveRecipients: makeResolveOperatorRecipients({
+    resolveRecipients: makeResolveOperatorRecipientsBatch({
       membershipRepo: operatorMembershipRepo,
       userRepo,
     }),

--- a/packages/api/src/repositories/drizzle/operator-membership.ts
+++ b/packages/api/src/repositories/drizzle/operator-membership.ts
@@ -1,5 +1,5 @@
 import { operatorMemberships } from '@kuruma/shared/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { OperatorMembership } from '../../stores'
 import type { OperatorMembershipRepository } from '../types'
 import type { Db } from './shared'
@@ -48,6 +48,31 @@ export class DrizzleOperatorMembershipRepository implements OperatorMembershipRe
       // string in notification_log is stable across resends. #878.
       .orderBy(operatorMemberships.createdAt, operatorMemberships.id)
     return rows.map(toOperatorMembership)
+  }
+
+  // #1010: batch sibling for the digest. One scoped read over (operatorId ∈ ids,
+  // status='ACTIVE') with the same (createdAt, id) ORDER BY, grouped in app — a
+  // constant number of queries regardless of operator count. Empty ids → no query.
+  async findActiveByOperators(
+    operatorIds: string[],
+  ): Promise<Map<string, OperatorMembership[]>> {
+    const byOperator = new Map<string, OperatorMembership[]>()
+    if (operatorIds.length === 0) return byOperator
+    const rows = await this.db
+      .select()
+      .from(operatorMemberships)
+      .where(
+        and(
+          inArray(operatorMemberships.operatorId, operatorIds),
+          eq(operatorMemberships.status, 'ACTIVE'),
+        ),
+      )
+      .orderBy(operatorMemberships.createdAt, operatorMemberships.id)
+    for (const r of rows) {
+      const m = toOperatorMembership(r)
+      byOperator.set(m.operatorId, [...(byOperator.get(m.operatorId) ?? []), m])
+    }
+    return byOperator
   }
 
   // A concurrent double-accept that inserts a second ACTIVE row for one user

--- a/packages/api/src/repositories/in-memory/operator-membership.ts
+++ b/packages/api/src/repositories/in-memory/operator-membership.ts
@@ -34,6 +34,21 @@ export class InMemoryOperatorMembershipRepository implements OperatorMembershipR
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id))
   }
 
+  // #1010: the batch read behind the digest's recipient resolution. Filter the
+  // requested operators, sort ONCE by (createdAt, id), then group — so each
+  // operator's list carries the same deterministic order as findActiveByOperator.
+  async findActiveByOperators(operatorIds: string[]): Promise<Map<string, OperatorMembership[]>> {
+    const wanted = new Set(operatorIds)
+    const sorted = [...this.store.values()]
+      .filter((m) => wanted.has(m.operatorId) && m.status === 'ACTIVE')
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id))
+    const byOperator = new Map<string, OperatorMembership[]>()
+    for (const m of sorted) {
+      byOperator.set(m.operatorId, [...(byOperator.get(m.operatorId) ?? []), m])
+    }
+    return byOperator
+  }
+
   async create(
     data: Omit<OperatorMembership, 'id' | 'createdAt' | 'updatedAt'>,
   ): Promise<OperatorMembership> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -256,6 +256,10 @@ export interface OperatorMembershipRepository {
   // recipient set. Ledger-sourced (status='ACTIVE'), so it is revocation-aware and
   // never reads the stale users.role/operatorId projection.
   findActiveByOperator(operatorId: string): Promise<OperatorMembership[]>
+  // #1010: batch sibling for the compliance digest — every ACTIVE member of each
+  // requested operator, grouped by operatorId in the same (createdAt, id) order, in
+  // one query. Operators with no active members are absent from the map.
+  findActiveByOperators(operatorIds: string[]): Promise<Map<string, OperatorMembership[]>>
   create(
     data: Omit<OperatorMembership, 'id' | 'createdAt' | 'updatedAt'>,
   ): Promise<OperatorMembership>

--- a/packages/api/src/services/compliance-digest.test.ts
+++ b/packages/api/src/services/compliance-digest.test.ts
@@ -6,7 +6,7 @@ import { complianceAlertKey } from '../repositories/types'
 import type { Vehicle } from '../stores'
 import { ComplianceDigestService } from './compliance-digest'
 import type { EmailMessage } from './email/email-sender'
-import type { ResolveOperatorRecipients } from './operator-recipients'
+import type { ResolveOperatorRecipientsBatch } from './operator-recipients'
 
 const TODAY = '2026-09-01'
 const EXPIRED = '2026-08-01' // before TODAY
@@ -64,7 +64,10 @@ const RECIPIENTS: Record<string, string[]> = {
   op_a: ['owner-a@op.example', 'staff-a@op.example'],
   op_b: ['owner-b@op.example'],
 }
-const resolveRecipients: ResolveOperatorRecipients = async (id) => RECIPIENTS[id] ?? []
+// #1010: the digest now resolves all operators in one batch call — the fake
+// mirrors that shape (ids → map), so the service test exercises the real seam.
+const resolveRecipients: ResolveOperatorRecipientsBatch = async (ids) =>
+  new Map(ids.map((id) => [id, RECIPIENTS[id] ?? []]))
 
 function setup(opts?: {
   ctrl?: { fail: boolean }

--- a/packages/api/src/services/compliance-digest.ts
+++ b/packages/api/src/services/compliance-digest.ts
@@ -11,7 +11,7 @@ import {
 } from '../repositories/types'
 import type { EmailMessage, EmailSender } from './email/email-sender'
 import { renderComplianceDigest } from './email/templates/compliance-digest'
-import type { ResolveOperatorRecipients } from './operator-recipients'
+import type { ResolveOperatorRecipientsBatch } from './operator-recipients'
 
 // Operators are Japan/JST; the digest is operator-facing (§12.2 working language).
 const DEFAULT_DIGEST_LOCALE = 'ja'
@@ -28,7 +28,7 @@ export interface ComplianceDigestConfig {
 export interface ComplianceDigestDeps {
   vehicleRepo: Pick<VehicleRepository, 'findAll'>
   alertLogRepo: ComplianceAlertLogRepository
-  resolveRecipients: ResolveOperatorRecipients
+  resolveRecipients: ResolveOperatorRecipientsBatch
   emailSender: EmailSender
   /** JST calendar day (YYYY-MM-DD) the bands are computed against — the one clock. */
   today: () => string
@@ -100,8 +100,12 @@ export class ComplianceDigestService {
       itemsByOperator.set(c.operatorId, [...list, c])
     }
 
+    // #1010: resolve every operator's recipients up front in a constant number of
+    // queries (one membership read + one user read), then loop to send — no
+    // per-operator round-trip inside the loop.
+    const recipientsByOperator = await this.deps.resolveRecipients([...itemsByOperator.keys()])
     for (const [operatorId, items] of itemsByOperator) {
-      const recipients = await this.deps.resolveRecipients(operatorId)
+      const recipients = recipientsByOperator.get(operatorId) ?? []
       // No recipients → don't send and don't record, so the alert retries once a
       // member exists (record-after-send applies to the empty-audience case too).
       if (recipients.length === 0) {

--- a/packages/api/src/services/operator-recipients.ts
+++ b/packages/api/src/services/operator-recipients.ts
@@ -35,3 +35,41 @@ export function makeResolveOperatorRecipients(deps: {
     })
   }
 }
+
+/**
+ * Batch shape of the resolver for the compliance digest (#1010). Resolves the
+ * recipient set for MANY operators in a CONSTANT number of queries — one
+ * `findActiveByOperators` over all ids, then one `findByIds` over the union of
+ * member ids — instead of the per-operator N+1 the cron used to fan out. Per
+ * operator the order + null-mask are identical to the single resolver. Every
+ * requested operator is a key in the returned map (no members → []), so the
+ * caller indexes it without a fallback and can never silently skip an operator.
+ */
+export type ResolveOperatorRecipientsBatch = (
+  operatorIds: string[],
+) => Promise<Map<string, string[]>>
+
+export function makeResolveOperatorRecipientsBatch(deps: {
+  membershipRepo: Pick<OperatorMembershipRepository, 'findActiveByOperators'>
+  userRepo: Pick<UserRepository, 'findByIds'>
+}): ResolveOperatorRecipientsBatch {
+  const { membershipRepo, userRepo } = deps
+  return async (operatorIds) => {
+    const membersByOperator = await membershipRepo.findActiveByOperators(operatorIds)
+    const userIds = [
+      ...new Set([...membersByOperator.values()].flatMap((ms) => ms.map((m) => m.userId))),
+    ]
+    const users = userIds.length > 0 ? await userRepo.findByIds(userIds) : []
+    const emailByUserId = new Map(users.map((u) => [u.id, u.email]))
+    return new Map(
+      operatorIds.map((operatorId) => {
+        const members = membersByOperator.get(operatorId) ?? []
+        const emails = members.flatMap((m) => {
+          const email = emailByUserId.get(m.userId)
+          return email ? [email] : []
+        })
+        return [operatorId, emails]
+      }),
+    )
+  }
+}

--- a/packages/api/tests/integration/operator-membership.test.ts
+++ b/packages/api/tests/integration/operator-membership.test.ts
@@ -1,0 +1,115 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID, SECOND_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { operatorMemberships, users } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { DrizzleOperatorMembershipRepository } from '../../src/repositories/drizzle'
+import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
+import type { OperatorMembership } from '../../src/stores'
+import { cleanupUsers, db } from './setup'
+
+// #1010: proves findActiveByOperators against REAL Postgres. The InMemory unit
+// tests cover the contract; only this exercises the `operatorId = ANY(...)`
+// (inArray) read + the (createdAt, id) ORDER BY + app-side grouping — and that the
+// Drizzle SQL returns the SAME grouped shape as the InMemory filter (adapter
+// parity), so swapping adapters can never change who the digest emails.
+
+const SUFFIX = Date.now()
+const uid = (s: string) => `m1010-${s}-${SUFFIX}`
+const EARLY = new Date('2026-01-01T00:00:00Z')
+const LATE = new Date('2026-02-01T00:00:00Z')
+
+// op A (BEST_CAR): two ACTIVE members (early, late) + one REVOKED (must drop out).
+// op B (SECOND): one ACTIVE member. The LATE member is listed first so a missing
+// ORDER BY would surface as reversed output.
+const ROWS: OperatorMembership[] = [
+  {
+    id: uid('a-late'),
+    userId: uid('u-a-late'),
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    role: 'OPERATOR_STAFF',
+    status: 'ACTIVE',
+    createdAt: LATE,
+    updatedAt: LATE,
+  },
+  {
+    id: uid('a-early'),
+    userId: uid('u-a-early'),
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    role: 'OPERATOR_OWNER',
+    status: 'ACTIVE',
+    createdAt: EARLY,
+    updatedAt: EARLY,
+  },
+  {
+    id: uid('a-revoked'),
+    userId: uid('u-a-revoked'),
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    role: 'OPERATOR_STAFF',
+    status: 'REVOKED',
+    createdAt: EARLY,
+    updatedAt: EARLY,
+  },
+  {
+    id: uid('b-solo'),
+    userId: uid('u-b'),
+    operatorId: SECOND_OPERATOR_ID,
+    role: 'OPERATOR_OWNER',
+    status: 'ACTIVE',
+    createdAt: EARLY,
+    updatedAt: EARLY,
+  },
+]
+const USER_IDS = ROWS.map((r) => r.userId)
+const MY = new Set(USER_IDS)
+// Other integration files share these operators, so assert only on the users this
+// test seeded; filtering preserves their relative (createdAt, id) order.
+const mine = (members?: OperatorMembership[]) =>
+  (members ?? []).map((m) => m.userId).filter((id) => MY.has(id))
+
+beforeAll(async () => {
+  await db.insert(users).values(
+    USER_IDS.map((id) => ({
+      id,
+      email: `${id}@kuruma-test.com`,
+      role: 'OPERATOR_STAFF' as const,
+      language: 'ja',
+    })),
+  )
+  await db.insert(operatorMemberships).values(ROWS)
+})
+
+afterAll(async () => {
+  await db.delete(operatorMemberships).where(
+    inArray(
+      operatorMemberships.id,
+      ROWS.map((r) => r.id),
+    ),
+  )
+  await cleanupUsers(USER_IDS) // memberships also cascade on user delete; explicit delete first is belt-and-braces
+})
+
+describe('DrizzleOperatorMembershipRepository.findActiveByOperators (#1010)', () => {
+  const repo = new DrizzleOperatorMembershipRepository(db)
+  const ids = [BEST_CAR_RENTAL_OPERATOR_ID, SECOND_OPERATOR_ID]
+
+  it('groups each operator’s ACTIVE members, ordered by (createdAt, id), excluding REVOKED', async () => {
+    const byOp = await repo.findActiveByOperators(ids)
+    expect(mine(byOp.get(BEST_CAR_RENTAL_OPERATOR_ID))).toEqual([uid('u-a-early'), uid('u-a-late')])
+    expect(mine(byOp.get(SECOND_OPERATOR_ID))).toEqual([uid('u-b')])
+    // the REVOKED member is absent from the ACTIVE-only result
+    expect(mine(byOp.get(BEST_CAR_RENTAL_OPERATOR_ID))).not.toContain(uid('u-a-revoked'))
+  })
+
+  it('matches the InMemory repo for the same rows (adapter parity)', async () => {
+    const inMemory = new InMemoryOperatorMembershipRepository(
+      new Map(ROWS.map((r) => [r.id, { ...r }])),
+    )
+    const fromDrizzle = await repo.findActiveByOperators(ids)
+    const fromMemory = await inMemory.findActiveByOperators(ids)
+    // `mine()` is load-bearing on the Drizzle side (strips concurrently-seeded
+    // foreign members) and a no-op on the InMemory side (built only from ROWS) —
+    // applied to both so the comparison is symmetric.
+    const shape = (m: Map<string, OperatorMembership[]>) => ids.map((id) => [id, mine(m.get(id))])
+    expect(shape(fromDrizzle)).toEqual(shape(fromMemory))
+  })
+})

--- a/packages/api/tests/repositories/operator-membership.test.ts
+++ b/packages/api/tests/repositories/operator-membership.test.ts
@@ -115,6 +115,64 @@ describe('InMemoryOperatorMembershipRepository', () => {
     })
   })
 
+  // #1010: batch sibling of findActiveByOperator. The compliance digest resolves
+  // EVERY alert-band operator's recipients in a constant number of queries, so it
+  // needs the active members of many operators grouped in one call (no per-operator
+  // N+1). Same ledger semantics + (createdAt, id) order as the single-operator read.
+  describe('findActiveByOperators', () => {
+    it('groups each requested operator’s ACTIVE members, keyed by operatorId', async () => {
+      await repo.create(membershipInput({ userId: 'a1', operatorId: 'op_a' }))
+      await repo.create(membershipInput({ userId: 'b1', operatorId: 'op_b' }))
+      const byOp = await repo.findActiveByOperators(['op_a', 'op_b'])
+      expect(byOp.get('op_a')?.map((m) => m.userId)).toEqual(['a1'])
+      expect(byOp.get('op_b')?.map((m) => m.userId)).toEqual(['b1'])
+    })
+
+    it('excludes REVOKED members and operators that were not requested', async () => {
+      await repo.create(membershipInput({ userId: 'live', operatorId: 'op_a' }))
+      await repo.create(membershipInput({ userId: 'gone', operatorId: 'op_a', status: 'REVOKED' }))
+      await repo.create(membershipInput({ userId: 'other', operatorId: 'op_unasked' }))
+      const byOp = await repo.findActiveByOperators(['op_a'])
+      expect(byOp.get('op_a')?.map((m) => m.userId)).toEqual(['live'])
+      expect(byOp.has('op_unasked')).toBe(false)
+    })
+
+    it('omits operators with no active members (absent key, not an empty list)', async () => {
+      await repo.create(membershipInput({ userId: 'x', operatorId: 'op_a' }))
+      const byOp = await repo.findActiveByOperators(['op_a', 'op_empty'])
+      expect(byOp.has('op_empty')).toBe(false)
+    })
+
+    it('returns an empty map for no requested operators', async () => {
+      await repo.create(membershipInput({ userId: 'x', operatorId: 'op_a' }))
+      expect((await repo.findActiveByOperators([])).size).toBe(0)
+    })
+
+    // Same audit-stability guarantee as the single read: each operator’s list is
+    // ordered by (createdAt, id), independent of store insertion order.
+    it('orders each operator’s members by createdAt so the audit string is stable', async () => {
+      const mk = (id: string, userId: string, createdAt: Date): OperatorMembership => ({
+        id,
+        userId,
+        operatorId: 'op_a',
+        role: 'OPERATOR_OWNER',
+        status: 'ACTIVE',
+        createdAt,
+        updatedAt: createdAt,
+      })
+      const early = new Date('2026-01-01T00:00:00Z')
+      const late = new Date('2026-02-01T00:00:00Z')
+      // Newer seeded first, so a missing ORDER BY would surface as reversed output.
+      const store = new Map<string, OperatorMembership>([
+        ['m-newer', mk('m-newer', 'u_newer', late)],
+        ['m-older', mk('m-older', 'u_older', early)],
+      ])
+      const seeded = new InMemoryOperatorMembershipRepository(store)
+      const byOp = await seeded.findActiveByOperators(['op_a'])
+      expect(byOp.get('op_a')?.map((m) => m.userId)).toEqual(['u_older', 'u_newer'])
+    })
+  })
+
   // #904 slice 2: the owner deactivates a member. ACTIVE -> REVOKED, scoped to
   // (id, operatorId) so a tenant can only touch its own rows; a no-match reads as
   // undefined (the service maps that to a 404, never a cross-tenant oracle).

--- a/packages/api/tests/services/operator-recipients.test.ts
+++ b/packages/api/tests/services/operator-recipients.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
 import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
-import { makeResolveOperatorRecipients } from '../../src/services/operator-recipients'
+import {
+  makeResolveOperatorRecipients,
+  makeResolveOperatorRecipientsBatch,
+} from '../../src/services/operator-recipients'
 import type { OperatorMembership, User } from '../../src/stores'
 
 const OP = 'op-1'
@@ -65,5 +68,104 @@ describe('makeResolveOperatorRecipients', () => {
     const resolve = build([], [user('u-real', 'real@op.com')])
 
     expect(await resolve(OP)).toEqual([])
+  })
+})
+
+// #1010: the batch resolver behind the compliance digest. Same per-operator
+// semantics as the single resolver (order + null-mask), but resolves EVERY
+// requested operator in a constant number of queries, not one round-trip each.
+describe('makeResolveOperatorRecipientsBatch', () => {
+  function memberOf(
+    id: string,
+    userId: string,
+    operatorId: string,
+    createdAt: Date,
+  ): OperatorMembership {
+    return {
+      id,
+      userId,
+      operatorId,
+      role: 'OPERATOR_STAFF',
+      status: 'ACTIVE',
+      createdAt,
+      updatedAt: createdAt,
+    }
+  }
+  function buildBatch(members: OperatorMembership[], users: User[]) {
+    const membershipRepo = new InMemoryOperatorMembershipRepository(
+      new Map(members.map((m) => [m.id, m])),
+    )
+    const userRepo = new InMemoryUserRepository(new Map(users.map((u) => [u.id, u])))
+    return {
+      resolve: makeResolveOperatorRecipientsBatch({ membershipRepo, userRepo }),
+      membershipRepo,
+      userRepo,
+    }
+  }
+
+  const d = (iso: string) => new Date(iso)
+
+  it('resolves each operator’s recipients in (createdAt, id) order, keyed by operatorId', async () => {
+    // op-a's later member seeded first — the resolver must defer to repo order, not Map order.
+    const { resolve } = buildBatch(
+      [
+        memberOf('a-late', 'u-a-late', 'op-a', d('2026-01-02T00:00:00Z')),
+        memberOf('a-early', 'u-a-early', 'op-a', d('2026-01-01T00:00:00Z')),
+        memberOf('b-solo', 'u-b', 'op-b', d('2026-01-01T00:00:00Z')),
+      ],
+      [user('u-a-late', 'late@a.com'), user('u-a-early', 'early@a.com'), user('u-b', 'solo@b.com')],
+    )
+    const byOp = await resolve(['op-a', 'op-b'])
+    expect(byOp.get('op-a')).toEqual(['early@a.com', 'late@a.com'])
+    expect(byOp.get('op-b')).toEqual(['solo@b.com'])
+  })
+
+  it('drops a member whose user email is masked to null', async () => {
+    const { resolve } = buildBatch(
+      [
+        memberOf('a-real', 'u-real', 'op-a', d('2026-01-01T00:00:00Z')),
+        memberOf('a-ph', 'u-ph', 'op-a', d('2026-01-02T00:00:00Z')),
+      ],
+      [user('u-real', 'real@a.com'), user('u-ph', null)],
+    )
+    expect((await resolve(['op-a'])).get('op-a')).toEqual(['real@a.com'])
+  })
+
+  it('returns [] for a requested operator with no active members', async () => {
+    const { resolve } = buildBatch(
+      [memberOf('a1', 'u-a', 'op-a', d('2026-01-01T00:00:00Z'))],
+      [user('u-a', 'a@a.com')],
+    )
+    expect((await resolve(['op-a', 'op-empty'])).get('op-empty')).toEqual([])
+  })
+
+  it('issues a CONSTANT number of queries regardless of operator count (no per-operator N+1)', async () => {
+    const real = buildBatch(
+      [
+        memberOf('a1', 'u-a', 'op-a', d('2026-01-01T00:00:00Z')),
+        memberOf('b1', 'u-b', 'op-b', d('2026-01-01T00:00:00Z')),
+        memberOf('c1', 'u-c', 'op-c', d('2026-01-01T00:00:00Z')),
+      ],
+      [user('u-a', 'a@a.com'), user('u-b', 'b@b.com'), user('u-c', 'c@c.com')],
+    )
+    let membershipCalls = 0
+    let userCalls = 0
+    const resolve = makeResolveOperatorRecipientsBatch({
+      membershipRepo: {
+        findActiveByOperators: (ids) => {
+          membershipCalls++
+          return real.membershipRepo.findActiveByOperators(ids)
+        },
+      },
+      userRepo: {
+        findByIds: (ids) => {
+          userCalls++
+          return real.userRepo.findByIds(ids)
+        },
+      },
+    })
+    await resolve(['op-a', 'op-b', 'op-c'])
+    expect(membershipCalls).toBe(1)
+    expect(userCalls).toBe(1)
   })
 })


### PR DESCRIPTION
## What
Replaces the per-operator **N+1** in `ComplianceDigestService.run()` with a batch resolver. The cron used to issue 2 sequential DB queries per alert-band operator (`findActiveByOperator` → `findByIds`) inside the send loop; it now resolves every operator's recipients up front in a **constant number of queries** (1 membership read + 1 user read), regardless of operator count.

Deferred scale fix split out of #982 (which shipped the safe hardening only).

## How
- **`OperatorMembershipRepository.findActiveByOperators(ids)`** → `Map<operatorId, OperatorMembership[]>` — Drizzle does one `operatorId = ANY(...)` read with the same `(createdAt, id)` ORDER BY and groups in app; InMemory filters + sorts + groups. Empty-ids → no query.
- **`makeResolveOperatorRecipientsBatch`** alongside the existing single resolver: one `findActiveByOperators` + one `findByIds` over the deduped union of member ids. The booking-alert `NotificationDispatcher` keeps the per-operator `makeResolveOperatorRecipients` (reactive, one operator per booking) — two call shapes, one repo.
- `buildComplianceDigestService` (composition root) wired to the batch resolver.

Per-operator recipient **order** and the joined audit string (`recipients.join(',')`) are byte-identical to the old path — order derives solely from membership `(createdAt, id)`, never from `findByIds` return order.

## Acceptance (issue)
- [x] Constant query count regardless of operator count — `operator-recipients.test.ts` asserts `membershipCalls === 1 && userCalls === 1` across 3 operators.
- [x] Recipient sets + audit-string order unchanged — order/null-mask tests on both resolvers.
- [x] InMemory ↔ Drizzle parity — `tests/integration/operator-membership.test.ts` (pollution-safe: filters to its own seeded users since integration files share the seeded operators).

## Test plan
- api unit suite: **1741 passing** (`env -u DATABASE_URL`), tsc + boundaries + biome green.
- The Drizzle parity test runs in the CI integration lane (`test:integration`, real Postgres) — excluded from the unit lane by config.
- code-reviewer: **SHIP**, nothing above LOW.

Closes #1010