### PR TITLE
docs(#1015): give the 4 code-only linter rules a documented home in modules.md

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -174,6 +174,18 @@ It scans `packages/{api,web,shared}/src` and enforces three rules:
 No feature-folder structure. Schema and validators already live in per-feature
 files (`db/schema.ts`, `validators/<feature>.ts`). Import from `@kuruma/shared/*`.
 
+**Enforced invariants:**
+
+- **Every `@kuruma/shared/*` import path must have a matching entry in
+  `packages/shared/package.json` "exports".** Bun's workspace mode resolves a
+  missing entry via filesystem fallback, masking it — but stricter bundlers and
+  non-workspace consumers fail. Guarded by `scripts/lint-export-drift.ts`.
+- **Every foreign-key column in the drizzle schema must have a covering index**
+  (the FK column as a primary key, or the leading column of a composite index).
+  Postgres does not auto-index FK columns; an unindexed FK turns every JOIN or
+  WHERE-by-fk into a sequential scan — invisible at 50 rows, outage-grade at 50k.
+  Guarded by `scripts/lint-fk-indexes.ts`.
+
 ---
 
 ## File-size rules (everywhere)
@@ -182,6 +194,24 @@ files (`db/schema.ts`, `validators/<feature>.ts`). Import from `@kuruma/shared/*
 `bun run lint` and the pre-commit hook):
 
 - **Soft warn at 400 lines, hard fail at 800 lines** for source files.
+- **`modules/<feature>/routes.ts` hard-caps at 150 lines** (no soft warn) —
+  route files stay thin; orchestration belongs in the service layer.
+- **`app/**/page.tsx` hard-caps at 80 lines** (no soft warn), outside a frozen
+  pre-R7 exempt list — pages compose modules, they don't hold logic. Never add
+  to the exempt list; refactor into `modules/<feature>/` instead.
+
+---
+
+## Runtime invariants (Cloudflare Workers)
+
+The web and API deploy to the Cloudflare Workers/Pages runtime, where the global
+`fetch` is a branded builtin that throws "Illegal invocation" unless called with
+`this === globalThis`.
+
+- **Deployed runtime code must never default a parameter or field to the bare
+  global `fetch`** — `fetchFn: typeof fetch = fetch` captures it detached. Use
+  `boundFetch` from `@kuruma/shared/lib/bound-fetch` instead. Guarded by
+  `scripts/lint-fetch-binding.ts` (#887).
 
 ---
 

--- a/scripts/lint-export-drift.ts
+++ b/scripts/lint-export-drift.ts
@@ -1,5 +1,5 @@
 // ENFORCES: @kuruma/shared/* import paths must match packages/shared/package.json "exports"
-// SSOT: code-only — rule undocumented, see #1015
+// SSOT: docs/architecture/modules.md § packages/shared
 /**
  * Detects import paths into @kuruma/shared that have no matching entry
  * in packages/shared/package.json "exports". Bun workspace mode resolves

--- a/scripts/lint-fetch-binding.ts
+++ b/scripts/lint-fetch-binding.ts
@@ -1,5 +1,5 @@
 // ENFORCES: deployed runtime code uses boundFetch (this===globalThis) — never a detached global `fetch` default (#887)
-// SSOT: code-only — rule undocumented, see #1015
+// SSOT: docs/architecture/modules.md § Runtime invariants (Cloudflare Workers)
 /**
  * Ban detached defaults to the global `fetch` in deployed runtime code (#887).
  *

--- a/scripts/lint-file-size.ts
+++ b/scripts/lint-file-size.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-// ENFORCES: source files <= 800 lines (hard) / soft-warn 400; route (150) & page (80) sub-caps code-only
-// SSOT: docs/architecture/modules.md § File-size rules (everywhere) — sub-caps undocumented, see #1015
+// ENFORCES: source files <= 800 lines (hard) / soft-warn 400; route (150) & page (80) sub-caps
+// SSOT: docs/architecture/modules.md § File-size rules (everywhere)
 import { readFileSync } from 'node:fs'
 import { Glob } from 'bun'
 

--- a/scripts/lint-fk-indexes.ts
+++ b/scripts/lint-fk-indexes.ts
@@ -1,5 +1,5 @@
 // ENFORCES: every FK column in the drizzle schema has a covering index (unindexed FK = seq scan, outage-grade at scale)
-// SSOT: code-only — rule undocumented, see #1015
+// SSOT: docs/architecture/modules.md § packages/shared
 /**
  * Enforce: every FK column in the drizzle schema must have a covering index.
  *


### PR DESCRIPTION
Follow-up to #1016 (Refs #1015, which it closed). #1016 shipped the authority-
provenance headers but left 4 checks marked `// SSOT: code-only` — rules enforced
in code with no written home. This gives them one and removes every hedge.

## What

`docs/architecture/modules.md` (the architecture-rules SSoT) now documents all
four, and the headers cite the real heading instead of `code-only`:

| Rule | New home | Linter |
|------|----------|--------|
| `@kuruma/shared/*` imports must match package.json `exports` | `§ packages/shared` | `lint-export-drift` |
| every FK column needs a covering index | `§ packages/shared` | `lint-fk-indexes` |
| `routes.ts` ≤150 / `page.tsx` ≤80 sub-caps | `§ File-size rules` (extended) | `lint-file-size` |
| deployed code uses `boundFetch` (this===globalThis) | **new `§ Runtime invariants (Cloudflare Workers)`** | `lint-fetch-binding` |

Net: **zero `code-only` markers remain** — every judicial check now points back to
a legislative rule, closing the authority-provenance loop #1015 opened.

## Notes
- This was meant to fold into #1016, but #1016 was owner-merged before the doc
  commit landed (concurrent merge race), so it ships as this clean follow-up.
- All citations verified against real `##` headings (modules.md:172/191/205);
  `boundFetch` path confirmed (`@kuruma/shared/lib/bound-fetch`, exports entry present).

## Test plan
- [x] `bun test scripts/lint-provenance.test.ts` — 12 pass / 0 fail
- [x] no `code-only` left in any linter header
- [x] `bunx biome check` clean
- [x] cited headings exist in modules.md