### PR TITLE
feat(#1022): one-way pure core — locationAt + assessPickupFeasibility + findStrandedSuccessors

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,6 +47,7 @@
     "./lib/return-path": "./src/lib/return-path.ts",
     "./lib/region-distance": "./src/lib/region-distance.ts",
     "./lib/photo-ref": "./src/lib/photo-ref.ts",
+    "./lib/one-way": "./src/lib/one-way.ts",
     "./validators/booking": "./src/validators/booking.ts",
     "./validators/vehicle": "./src/validators/vehicle.ts",
     "./validators/vehicle-class": "./src/validators/vehicle-class.ts",

--- a/packages/shared/src/lib/one-way.ts
+++ b/packages/shared/src/lib/one-way.ts
@@ -1,0 +1,119 @@
+/**
+ * One-way rentals — the pure Functional Core (#882, design §3 & §5.2).
+ *
+ * A vehicle's location is NOT a stored, mutable field; it is a pure FOLD over the
+ * booking chain. This module owns that derivation and the feasibility rules that
+ * depend on it. It performs NO I/O: callers (the booking + search shells, #1024/
+ * #1025) load the legs, resolve the policy, and translate `reason` codes into
+ * typed API errors. Keeping it pure makes every timeline exhaustively unit-testable
+ * with plain arrays — no DB.
+ *
+ * Two status sets are deliberately distinct (design §3): R1 / double-booking uses
+ * OCCUPANCY `{CONFIRMED, ACTIVE}` and is enforced by the Postgres exclusion
+ * constraint — NOT here. Location uses MOVEMENT HISTORY `{CONFIRMED, ACTIVE,
+ * COMPLETED}` = everything except CANCELLED, because a COMPLETED A→B trip is
+ * precisely why the car is at B. The caller pre-filters `legs` to that set.
+ */
+
+/** A booking that actually moved the car. `effectiveEndAt` already folds in turnaround. */
+export type Leg = {
+  pickupLocationId: string
+  dropoffLocationId: string
+  startAt: Date
+  effectiveEndAt: Date
+}
+
+/** The scope dial (design §4). v1 ships tail-only; FULL_CHAIN is the same code, more rules on. */
+export type OneWayPolicy = 'TAIL_ONLY' | 'FULL_CHAIN'
+
+/**
+ * The ONE resolved policy value — search and creation must share it, never
+ * re-derive per caller (maintainability F6). Flip here to change the product
+ * behavior in lockstep across every surface.
+ */
+export const DEFAULT_POLICY: OneWayPolicy = 'TAIL_ONLY'
+
+export type Feasibility =
+  | { ok: true }
+  | { ok: false; reason: 'PICKUP_NOT_AT_LOCATION' | 'ONEWAY_NOT_TAIL' | 'DROPOFF_DISCONTINUITY' }
+
+/**
+ * Where the vehicle is at instant `t`: the dropoff of the latest movement leg
+ * that has settled (`effectiveEndAt <= t`), else its home. A pure step-function
+ * over the booking timeline (design §3).
+ */
+export function locationAt(legs: Leg[], homeLocationId: string | null, t: Date): string | null {
+  let settled: Leg | undefined
+  for (const leg of legs) {
+    if (leg.effectiveEndAt.getTime() <= t.getTime()) {
+      if (!settled || leg.effectiveEndAt.getTime() > settled.effectiveEndAt.getTime()) {
+        settled = leg
+      }
+    }
+  }
+  return settled ? settled.dropoffLocationId : homeLocationId
+}
+
+/**
+ * Can a new booking pick up where the renter chose? Enforces R2 (pickup
+ * continuity) always, plus the policy-dialed one-way rule (design §3.1, §4).
+ * R1 (overlap) is the exclusion constraint's job and is assumed to hold — so
+ * every other leg is wholly before or wholly after this window, never straddling.
+ */
+export function assessPickupFeasibility(args: {
+  legs: Leg[]
+  homeLocationId: string | null
+  pickup: string
+  dropoff: string
+  startAt: Date
+  effectiveEndAt: Date
+  policy: OneWayPolicy
+}): Feasibility {
+  const { legs, homeLocationId, pickup, dropoff, startAt, effectiveEndAt, policy } = args
+
+  // R2 — the car must actually be at the chosen pickup.
+  if (locationAt(legs, homeLocationId, startAt) !== pickup) {
+    return { ok: false, reason: 'PICKUP_NOT_AT_LOCATION' }
+  }
+
+  // Round trips (dropoff === pickup) leave the car where it was; R2 suffices.
+  if (dropoff === pickup) return { ok: true }
+
+  // One-way: the successor is the earliest leg starting at/after this window's end
+  // ([closed, open) ⇒ a leg starting exactly at effectiveEndAt is a successor).
+  const successors = legs.filter((l) => l.startAt.getTime() >= effectiveEndAt.getTime())
+  if (successors.length === 0) return { ok: true } // tail → the car rests at the dropoff
+
+  // TAIL_ONLY (v1): a non-tail one-way is rejected; R3 stays vacuous.
+  if (policy === 'TAIL_ONLY') return { ok: false, reason: 'ONEWAY_NOT_TAIL' }
+
+  // FULL_CHAIN: R3 — the immediate successor must hand off FROM this dropoff.
+  const earliestSuccessor = successors.reduce((earliest, l) =>
+    l.startAt.getTime() < earliest.startAt.getTime() ? l : earliest,
+  )
+  if (earliestSuccessor.pickupLocationId !== dropoff) {
+    return { ok: false, reason: 'DROPOFF_DISCONTINUITY' }
+  }
+  return { ok: true }
+}
+
+/**
+ * Cancelling a leg can STRAND a later booking that relied on the cancelled leg
+ * having relocated the car (design §6). A successor is stranded if, once
+ * `cancelledLeg` is removed, the car is no longer at that successor's pickup.
+ * Only legs starting after the cancelled leg can be affected — R1 guarantees
+ * earlier legs' locations are independent of it. `cancelledLeg` must be an
+ * element of `legs` (matched by reference).
+ */
+export function findStrandedSuccessors(
+  legs: Leg[],
+  homeLocationId: string | null,
+  cancelledLeg: Leg,
+): Leg[] {
+  const remaining = legs.filter((l) => l !== cancelledLeg)
+  return remaining.filter(
+    (l) =>
+      l.startAt.getTime() >= cancelledLeg.effectiveEndAt.getTime() &&
+      locationAt(remaining, homeLocationId, l.startAt) !== l.pickupLocationId,
+  )
+}

--- a/packages/shared/tests/lib/one-way.test.ts
+++ b/packages/shared/tests/lib/one-way.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_POLICY,
+  type Leg,
+  assessPickupFeasibility,
+  findStrandedSuccessors,
+  locationAt,
+} from '../../src/lib/one-way'
+
+// All times are plain UTC instants; turnaround is already folded into
+// `effectiveEndAt` (the car is "settled" at the dropoff from then on).
+const at = (iso: string): Date => new Date(`2026-06-${iso}:00:00Z`)
+const A = 'loc-a'
+const B = 'loc-b'
+const C = 'loc-c'
+
+// A movement leg: car picked up at `pickup` at `startAt`, settled at `dropoff`
+// from `effectiveEndAt` onward. Helper keeps the timelines readable.
+const leg = (pickup: string, dropoff: string, start: string, effEnd: string): Leg => ({
+  pickupLocationId: pickup,
+  dropoffLocationId: dropoff,
+  startAt: at(start),
+  effectiveEndAt: at(effEnd),
+})
+
+describe('locationAt', () => {
+  it('empty history → the home location', () => {
+    expect(locationAt([], A, at('15T10'))).toBe(A)
+  })
+
+  it('home may be null (no home, no movement) → null', () => {
+    expect(locationAt([], null, at('15T10'))).toBeNull()
+  })
+
+  it('a COMPLETED A→B leg puts the car at B AFTER its effectiveEnd (regression: completed trip does not snap home)', () => {
+    // The caller pre-filters to movement history, which INCLUDES COMPLETED.
+    const legs = [leg(A, B, '20T10', '22T10')]
+    expect(locationAt(legs, A, at('23T10'))).toBe(B) // after effEnd → at B
+  })
+
+  it('before the leg settles, the car is still home', () => {
+    const legs = [leg(A, B, '20T10', '22T10')]
+    expect(locationAt(legs, A, at('21T10'))).toBe(A) // effEnd 22 > 21 → not yet moved
+  })
+
+  it('exactly at effectiveEnd the car has settled at the dropoff ([..eff] inclusive)', () => {
+    const legs = [leg(A, B, '20T10', '22T10')]
+    expect(locationAt(legs, A, at('22T10'))).toBe(B) // effEnd <= t
+  })
+
+  it('the leg with the GREATEST effectiveEnd ≤ t wins', () => {
+    const legs = [leg(A, B, '20T10', '22T10'), leg(B, C, '23T10', '24T10')]
+    expect(locationAt(legs, A, at('25T10'))).toBe(C) // C is the latest settle
+    expect(locationAt(legs, A, at('22T20'))).toBe(B) // only the A→B leg has settled by then
+  })
+
+  it('CANCELLED legs are the caller’s job to exclude — a leg present in the array is counted', () => {
+    // This module trusts the caller filtered out CANCELLED; included legs move the car.
+    const legs = [leg(A, B, '20T10', '22T10')]
+    expect(locationAt(legs, A, at('23T10'))).toBe(B)
+  })
+})
+
+describe('assessPickupFeasibility', () => {
+  const base = {
+    homeLocationId: A as string | null,
+    policy: DEFAULT_POLICY,
+  }
+
+  it('round trip at the car’s current location → ok', () => {
+    const res = assessPickupFeasibility({
+      ...base,
+      legs: [],
+      pickup: A,
+      dropoff: A,
+      startAt: at('15T10'),
+      effectiveEndAt: at('16T10'),
+    })
+    expect(res).toEqual({ ok: true })
+  })
+
+  it('pickup ≠ where the car actually is → PICKUP_NOT_AT_LOCATION', () => {
+    // Car moved A→B and settled; a new pickup at A is impossible.
+    const legs = [leg(A, B, '20T10', '22T10')]
+    const res = assessPickupFeasibility({
+      ...base,
+      legs,
+      pickup: A,
+      dropoff: A,
+      startAt: at('25T10'),
+      effectiveEndAt: at('26T10'),
+    })
+    expect(res).toEqual({ ok: false, reason: 'PICKUP_NOT_AT_LOCATION' })
+  })
+
+  it('one-way as the tail (no later booking) → ok', () => {
+    const res = assessPickupFeasibility({
+      ...base,
+      legs: [],
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+    })
+    expect(res).toEqual({ ok: true })
+  })
+
+  it('one-way with a later booking → ONEWAY_NOT_TAIL (TAIL_ONLY)', () => {
+    // A later leg starts after the new booking ends → the one-way is not the tail.
+    const legs = [leg(A, A, '25T10', '26T10')]
+    const res = assessPickupFeasibility({
+      ...base,
+      legs,
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+    })
+    expect(res).toEqual({ ok: false, reason: 'ONEWAY_NOT_TAIL' })
+  })
+
+  it('boundary: a successor starting exactly at effectiveEnd still counts as a successor → ONEWAY_NOT_TAIL', () => {
+    const legs = [leg(A, A, '22T10', '23T10')] // starts at the new booking's effEnd
+    const res = assessPickupFeasibility({
+      ...base,
+      legs,
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+    })
+    expect(res).toEqual({ ok: false, reason: 'ONEWAY_NOT_TAIL' })
+  })
+
+  it('FULL_CHAIN: a successor that picks up at the dropoff → ok (handoff continuous)', () => {
+    const legs = [leg(B, C, '25T10', '26T10')] // successor picks up at B = our dropoff
+    const res = assessPickupFeasibility({
+      legs,
+      homeLocationId: A,
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+      policy: 'FULL_CHAIN',
+    })
+    expect(res).toEqual({ ok: true })
+  })
+
+  it('FULL_CHAIN: a successor that picks up elsewhere → DROPOFF_DISCONTINUITY', () => {
+    const legs = [leg(C, A, '25T10', '26T10')] // successor picks up at C ≠ our dropoff B
+    const res = assessPickupFeasibility({
+      legs,
+      homeLocationId: A,
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+      policy: 'FULL_CHAIN',
+    })
+    expect(res).toEqual({ ok: false, reason: 'DROPOFF_DISCONTINUITY' })
+  })
+
+  it('TAIL_ONLY short-circuits before R3: a discontinuous successor still yields ONEWAY_NOT_TAIL', () => {
+    // Successor picks up at C (≠ our dropoff B). Under FULL_CHAIN this is
+    // DROPOFF_DISCONTINUITY; under tail-only the tail guard fires first, so the
+    // reason must be ONEWAY_NOT_TAIL — locks the check ordering against a refactor.
+    const legs = [leg(C, A, '25T10', '26T10')]
+    const res = assessPickupFeasibility({
+      ...base, // policy = DEFAULT_POLICY = TAIL_ONLY
+      legs,
+      pickup: A,
+      dropoff: B,
+      startAt: at('20T10'),
+      effectiveEndAt: at('22T10'),
+    })
+    expect(res).toEqual({ ok: false, reason: 'ONEWAY_NOT_TAIL' })
+  })
+
+  it('DEFAULT_POLICY is tail-only', () => {
+    expect(DEFAULT_POLICY).toBe('TAIL_ONLY')
+  })
+})
+
+describe('findStrandedSuccessors', () => {
+  it('a successor that picked up at the cancelled leg’s dropoff is stranded', () => {
+    // A→B (cancelled) left the car at B; B→C relied on that. Remove A→B and the
+    // car is back home at A, so B→C can no longer pick up at B.
+    const cancelled = leg(A, B, '20T10', '22T10')
+    const dependent = leg(B, C, '25T10', '26T10')
+    expect(findStrandedSuccessors([cancelled, dependent], A, cancelled)).toEqual([dependent])
+  })
+
+  it('strands every successor that relied on the cancelled relocation', () => {
+    // A→B (cancelled) put the car at B; both B→A and B→C picked up at B. Remove
+    // A→B and neither finds the car at B — both are stranded. (Single-removal
+    // semantics: each remaining leg still folds in, but neither re-establishes B.)
+    const cancelled = leg(A, B, '20T10', '22T10')
+    const dep1 = leg(B, A, '24T10', '25T10')
+    const dep2 = leg(B, C, '26T10', '27T10')
+    expect(findStrandedSuccessors([cancelled, dep1, dep2], A, cancelled)).toEqual([dep1, dep2])
+  })
+
+  it('an independent successor (picks up where the car still is) is not stranded', () => {
+    // A→A round trip cancelled; a later A→C still finds the car at home A.
+    const cancelled = leg(A, A, '20T10', '22T10')
+    const independent = leg(A, C, '25T10', '26T10')
+    expect(findStrandedSuccessors([cancelled, independent], A, cancelled)).toEqual([])
+  })
+
+  it('legs before the cancelled leg are never stranded', () => {
+    const earlier = leg(A, A, '10T10', '11T10')
+    const cancelled = leg(A, B, '20T10', '22T10')
+    expect(findStrandedSuccessors([earlier, cancelled], A, cancelled)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #1022. First slice of the one-way rentals epic #882 — the **pure Functional Core** the rest of the feature builds on. Design: `docs/plans/2026-06-21-one-way-rentals-design.md` §3 (the model) & §5.2 (the pure core). **No deps; lands first.**

## What
A pure, I/O-free module `packages/shared/src/lib/one-way.ts` (+ one `./lib/one-way` export entry). A vehicle's location is **not** a stored mutable field — it's a pure **fold over the booking chain**.

- **`locationAt(legs, home, t)`** → where the car is at instant `t`: the dropoff of the latest leg settled by `t` (`effectiveEndAt <= t`), else `home`. Movement history **includes COMPLETED** (a completed A→B trip is *why* the car is at B — dropping it would snap every future search back home); the caller pre-filters out CANCELLED.
- **`assessPickupFeasibility({...policy})`** → `{ok:true} | {ok:false, reason}`. R2 (pickup continuity) always; round trips pass on R2 alone; a one-way is allowed only as the **tail** under `TAIL_ONLY` (the v1 `DEFAULT_POLICY`), with `FULL_CHAIN` additively turning on R3. `reason ∈ PICKUP_NOT_AT_LOCATION | ONEWAY_NOT_TAIL | DROPOFF_DISCONTINUITY`.
- **`findStrandedSuccessors(legs, home, cancelledLeg)`** → successors whose pickup no longer matches `locationAt` once the cancelled leg is removed (the cancel-path continuity detector, §6).
- `OneWayPolicy` + `DEFAULT_POLICY='TAIL_ONLY'` — one resolved policy value, never re-derived per caller (maintainability **F6**).

## Boundary semantics
`[closed, open)` intervals throughout: `locationAt` settles at `effectiveEndAt <= t` (inclusive); a successor is `startAt >= effectiveEndAt` (a leg starting exactly at the window's end **is** a successor). The two halves are consistent — no off-by-one.

## Tests (TDD, 20 cases, no DB)
Every acceptance criterion plus hardening from review: empty→home, **COMPLETED-snaps-home regression**, CANCELLED-ignored-by-caller, greatest-effEnd wins, round-trip ok, one-way tail ok, `ONEWAY_NOT_TAIL`, `PICKUP_NOT_AT_LOCATION`, `[closed,open)` boundary successor, FULL_CHAIN ok + `DROPOFF_DISCONTINUITY`, **TAIL_ONLY short-circuits R3**, single + **multi-successor** stranding.

## Verification
shared suite **677/677** (incl. the 20 new) · tsc 0 · biome clean · api+web tsc green (pre-commit) · code-reviewer **SHIP** (0 CRIT/HIGH/MED; both LOW hardening tests added).

## Scope
No wiring, SQL, locks, or repo/service imports — the booking-creation shell (#1024) and search parity (#1025) consume this module. `reason`→`ErrorCode` (#941) mapping lands with the route in #1024.

## Note for #1024
The API already accepts same-operator one-way bookings today (per the #882 guardrail), but the slices that make them fully correct (this core's wiring + search parity) are still landing — decide there whether to gate one-way creation until #1025 ships.