### PR TITLE
feat(#500): pin CSP script-src by sha256, drop script-src 'unsafe-inline'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Check web dist size budget
         run: bun run lint:dist-size
 
+      # Hash the inline bootstrap script in the BUILT shell and assert the CSP in
+      # _headers pins it (no 'unsafe-inline'). Runs post-build so it checks the
+      # bytes the browser actually receives, catching any Vite-emission drift the
+      # source-level unit test can't see (#500).
+      - name: Check CSP script-src hash matches the built shell
+        run: bun run lint:csp-hash
+
   # Non-bypassable drift gate. See scripts/db-verify.ts and the "Database
   # Migrations" section of CLAUDE.md for why this exists. Two production
   # incidents (see issue #27) traced to schema changes that shipped without

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -213,6 +213,16 @@ The web and API deploy to the Cloudflare Workers/Pages runtime, where the global
   `boundFetch` from `@kuruma/shared/lib/bound-fetch` instead. Guarded by
   `scripts/lint-fetch-binding.ts` (#887).
 
+- **The CSP `script-src` in `packages/web/public/_headers` must pin the inline
+  bootstrap script by its `sha256-…` hash and carry no `'unsafe-inline'`.** The
+  pin must match the script as actually emitted into `dist/index.html` by
+  `vite build` — not just the source shell. Guarded at two altitudes:
+  `tests/deploy/csp-script-hash.test.ts` hashes the source for fast pre-build
+  feedback; `scripts/lint-csp-hash.ts` (run `bun run lint:csp-hash` post-build in
+  CI) hashes the built artifact the browser receives. A Vite upgrade that changed
+  inline-script emission would diverge the served hash from the pin and silently
+  block the bootstrap once the policy flips to enforcing (#500).
+
 ---
 
 ## Grandfather / migrate-before-you-modify policy

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:unwrap-schema": "bun run scripts/lint-unwrap-schema.ts",
     "lint:fetch-binding": "bun run scripts/lint-fetch-binding.ts",
     "lint:dist-size": "bun run scripts/lint-dist-size.ts",
+    "lint:csp-hash": "bun run scripts/lint-csp-hash.ts",
     "lint:no-next-app": "bun run scripts/lint-no-next-app.ts",
     "lint:deps": "KNIP=1 bun node_modules/.bin/knip",
     "format": "bunx biome format --write .",

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -19,9 +19,12 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: SAMEORIGIN
   Cross-Origin-Opener-Policy: same-origin-allow-popups
-  # CSP ships Report-Only until the live preview (CF #304) lets us verify it
-  # against the Google OAuth redirect, Unsplash imagery, and the inline locale
-  # bootstrap in index.html. The follow-up hashes that inline script and flips
-  # this to an enforcing `Content-Security-Policy`. COEP is intentionally omitted
-  # — `require-corp` would block the cross-origin Unsplash images.
-  Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self' data: https://images.unsplash.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  # CSP ships Report-Only until a live preview (#1009) lets us verify it against
+  # the Google OAuth redirect and Unsplash imagery before flipping the header
+  # name to an enforcing `Content-Security-Policy`. The inline locale bootstrap
+  # in index.html is now pinned by its sha256 hash (#500) instead of
+  # 'unsafe-inline'; a CI guard (tests/deploy/csp-script-hash.test.ts) recomputes
+  # that hash so it can't silently drift and block the script when enforced.
+  # style-src keeps 'unsafe-inline' — inline style attributes can't be hashed.
+  # COEP is intentionally omitted — `require-corp` would block Unsplash images.
+  Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self' data: https://images.unsplash.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -27,4 +27,4 @@
   # that hash so it can't silently drift and block the script when enforced.
   # style-src keeps 'unsafe-inline' — inline style attributes can't be hashed.
   # COEP is intentionally omitted — `require-corp` would block Unsplash images.
-  Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self' data: https://images.unsplash.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self' data: https://images.unsplash.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'

--- a/packages/web/tests/deploy/csp-script-hash.test.ts
+++ b/packages/web/tests/deploy/csp-script-hash.test.ts
@@ -25,8 +25,11 @@ const inlineSource = inlineScripts[0]?.[1] ?? ''
 const expectedHash = `sha256-${createHash('sha256').update(inlineSource, 'utf8').digest('base64')}`
 
 // Pull the script-src directive out of the CSP line (enforcing OR Report-Only,
-// so this keeps guarding after #1009 flips the header name).
-const cspLine = headers.split('\n').find((l) => /Content-Security-Policy(-Report-Only)?:/.test(l))
+// so this keeps guarding after #1009 flips the header name). Anchored on `^\s+`
+// so a `#` comment mentioning the directive name can't be parsed instead.
+const cspLine = headers
+  .split('\n')
+  .find((l) => /^\s+Content-Security-Policy(-Report-Only)?:/.test(l))
 const scriptSrc = cspLine?.match(/script-src ([^;]*)/)?.[1]?.trim() ?? ''
 
 describe('CSP script-src hash (#500)', () => {

--- a/packages/web/tests/deploy/csp-script-hash.test.ts
+++ b/packages/web/tests/deploy/csp-script-hash.test.ts
@@ -1,0 +1,50 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+// Drift guard for the CSP script-src hash (#500). The CSP in public/_headers
+// pins the one inline bootstrap script in index.html by its sha256 hash instead
+// of allowing 'unsafe-inline'. The hash is a literal in _headers, so if anyone
+// edits the inline script without regenerating it, the browser would silently
+// block the script the moment the policy flips from Report-Only to enforcing.
+// This recomputes the hash from index.html and fails CI on any mismatch.
+//
+// Vite emits this non-module inline script byte-identically into dist/index.html
+// (verified: source and built hashes match), so hashing the source is correct.
+
+const WEB_ROOT = process.cwd() // vitest runs with cwd = packages/web
+const indexHtml = readFileSync(path.join(WEB_ROOT, 'index.html'), 'utf8')
+const headers = readFileSync(path.join(WEB_ROOT, 'public', '_headers'), 'utf8')
+
+// The inline <script> is the one WITHOUT a src attribute. There must be exactly
+// one, or the pinned hash would be ambiguous.
+const inlineScripts = [...indexHtml.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)]
+const inlineSource = inlineScripts[0]?.[1] ?? ''
+const expectedHash = `sha256-${createHash('sha256').update(inlineSource, 'utf8').digest('base64')}`
+
+// Pull the script-src directive out of the CSP line (enforcing OR Report-Only,
+// so this keeps guarding after #1009 flips the header name).
+const cspLine = headers.split('\n').find((l) => /Content-Security-Policy(-Report-Only)?:/.test(l))
+const scriptSrc = cspLine?.match(/script-src ([^;]*)/)?.[1]?.trim() ?? ''
+
+describe('CSP script-src hash (#500)', () => {
+  test('index.html has exactly one inline (src-less) script', () => {
+    expect(inlineScripts).toHaveLength(1)
+  })
+
+  test('_headers pins that inline script by its current sha256', () => {
+    expect(scriptSrc).toContain(`'${expectedHash}'`)
+  })
+
+  test("script-src drops 'unsafe-inline' (a hash and 'unsafe-inline' cannot coexist)", () => {
+    // When a hash is present the browser ignores 'unsafe-inline', so leaving it
+    // in is dead config that masks the real policy. Drop it from script-src.
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+  })
+
+  test("style-src keeps 'unsafe-inline' (inline style attrs can't be hashed) — #500 note 2", () => {
+    const styleSrc = cspLine?.match(/style-src ([^;]*)/)?.[1]?.trim() ?? ''
+    expect(styleSrc).toContain("'unsafe-inline'")
+  })
+})

--- a/packages/web/tests/deploy/csp-script-hash.test.ts
+++ b/packages/web/tests/deploy/csp-script-hash.test.ts
@@ -8,10 +8,11 @@ import { describe, expect, test } from 'vitest'
 // of allowing 'unsafe-inline'. The hash is a literal in _headers, so if anyone
 // edits the inline script without regenerating it, the browser would silently
 // block the script the moment the policy flips from Report-Only to enforcing.
-// This recomputes the hash from index.html and fails CI on any mismatch.
-//
-// Vite emits this non-module inline script byte-identically into dist/index.html
-// (verified: source and built hashes match), so hashing the source is correct.
+// This recomputes the hash from the SOURCE index.html for fast pre-build
+// feedback (this lane runs before `vite build` in CI). The authoritative check
+// against the BUILT dist/index.html — the bytes the browser receives — is the
+// post-build CI guard scripts/lint-csp-hash.ts, which catches any Vite-emission
+// drift this source-level test cannot see.
 
 const WEB_ROOT = process.cwd() // vitest runs with cwd = packages/web
 const indexHtml = readFileSync(path.join(WEB_ROOT, 'index.html'), 'utf8')

--- a/scripts/lint-csp-hash.test.ts
+++ b/scripts/lint-csp-hash.test.ts
@@ -41,6 +41,15 @@ describe('extractScriptSrc', () => {
   test('reads script-src from a Report-Only line, stopping at the next directive', () => {
     expect(extractScriptSrc(headersWith(`'self' '${HASH}'`))).toBe(`'self' '${HASH}'`)
   })
+
+  test('binds to the real directive, not a # comment that names it (anti-mask)', () => {
+    const withComment = [
+      '/*',
+      "  # don't put Content-Security-Policy-Report-Only: script-src 'unsafe-inline' in a comment",
+      `  Content-Security-Policy-Report-Only: script-src 'self' '${HASH}'; base-uri 'self'`,
+    ].join('\n')
+    expect(extractScriptSrc(withComment)).toBe(`'self' '${HASH}'`)
+  })
 })
 
 describe('checkCspHash', () => {

--- a/scripts/lint-csp-hash.test.ts
+++ b/scripts/lint-csp-hash.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+import { checkCspHash, cspHash, extractInlineScript, extractScriptSrc } from './lint-csp-hash'
+
+const SCRIPT = "\n      document.documentElement.lang = 'en';\n    "
+const HASH = cspHash(SCRIPT)
+
+function distHtml(inline: string): string {
+  return `<!doctype html><html><head><script>${inline}</script><script type="module" src="/assets/x.js"></script></head><body></body></html>`
+}
+
+function headersWith(scriptSrc: string): string {
+  return [
+    '/*',
+    '  X-Content-Type-Options: nosniff',
+    `  Content-Security-Policy-Report-Only: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src ${scriptSrc}; base-uri 'self'`,
+  ].join('\n')
+}
+
+describe('extractInlineScript', () => {
+  test('returns the src-less script and ignores the module script', () => {
+    expect(extractInlineScript(distHtml(SCRIPT))).toBe(SCRIPT)
+  })
+
+  test('returns null when there is no inline script', () => {
+    expect(extractInlineScript('<html><script src="/a.js"></script></html>')).toBeNull()
+  })
+
+  test('returns null when there is more than one inline script (ambiguous pin)', () => {
+    expect(extractInlineScript('<script>a()</script><script>b()</script>')).toBeNull()
+  })
+})
+
+describe('cspHash', () => {
+  test('is the sha256 base64 CSP source-expression of the exact bytes', () => {
+    expect(HASH).toMatch(/^sha256-[A-Za-z0-9+/]+=*$/)
+    expect(cspHash('x')).not.toBe(cspHash('y'))
+  })
+})
+
+describe('extractScriptSrc', () => {
+  test('reads script-src from a Report-Only line, stopping at the next directive', () => {
+    expect(extractScriptSrc(headersWith(`'self' '${HASH}'`))).toBe(`'self' '${HASH}'`)
+  })
+})
+
+describe('checkCspHash', () => {
+  test('passes when the served hash is pinned and unsafe-inline is absent', () => {
+    const report = checkCspHash(distHtml(SCRIPT), headersWith(`'self' '${HASH}'`))
+    expect(report).toEqual({ ok: true, problems: [], servedHash: HASH })
+  })
+
+  test('fails on a stale pin (inline script changed but hash did not)', () => {
+    const report = checkCspHash(
+      distHtml('document.documentElement.lang = "ja";'),
+      headersWith(`'self' '${HASH}'`),
+    )
+    expect(report.ok).toBe(false)
+    expect(report.problems.join(' ')).toContain('stale pin')
+  })
+
+  test("fails when script-src still allows 'unsafe-inline'", () => {
+    const report = checkCspHash(distHtml(SCRIPT), headersWith(`'self' '${HASH}' 'unsafe-inline'`))
+    expect(report.ok).toBe(false)
+    expect(report.problems.join(' ')).toContain('unsafe-inline')
+  })
+
+  test('fails when the built shell has no single inline script', () => {
+    const report = checkCspHash('<html><body></body></html>', headersWith(`'self' '${HASH}'`))
+    expect(report).toEqual({
+      ok: false,
+      problems: ['dist/index.html must have exactly one inline (src-less) <script>'],
+      servedHash: null,
+    })
+  })
+})

--- a/scripts/lint-csp-hash.ts
+++ b/scripts/lint-csp-hash.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+// ENFORCES: the CSP script-src hash in packages/web/public/_headers matches the
+//   inline bootstrap script as ACTUALLY EMITTED into packages/web/dist/index.html,
+//   and that script-src carries no 'unsafe-inline'.
+// SSOT: packages/web/public/_headers (the shipped CSP) — issue #500.
+//
+// Why this exists alongside the source-level unit test (tests/deploy/
+// csp-script-hash.test.ts): that test hashes the SOURCE index.html for fast
+// pre-build feedback. This one runs in CI AFTER `vite build` and hashes the
+// BUILT shell — the bytes the browser actually receives. If a Vite upgrade ever
+// changed inline-script emission, the served hash would diverge from the pin
+// while the source test stayed green, silently blocking the script the moment
+// the policy flips to enforcing (#1009). This closes that gap at the real artifact.
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+const DIST_INDEX = 'packages/web/dist/index.html'
+const HEADERS = 'packages/web/public/_headers'
+
+/** The inline <script> is the one WITHOUT a src attribute. Null unless exactly one exists. */
+export function extractInlineScript(html: string): string | null {
+  const matches = [...html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)]
+  return matches.length === 1 ? (matches[0]?.[1] ?? null) : null
+}
+
+/** CSP source-expression hash over the exact script bytes (content between the tags). */
+export function cspHash(scriptContent: string): string {
+  return `sha256-${createHash('sha256').update(scriptContent, 'utf8').digest('base64')}`
+}
+
+/** The script-src directive value from the CSP line (enforcing OR Report-Only). */
+export function extractScriptSrc(headers: string): string {
+  const line = headers.split('\n').find((l) => /Content-Security-Policy(-Report-Only)?:/.test(l))
+  return line?.match(/script-src ([^;]*)/)?.[1]?.trim() ?? ''
+}
+
+export interface CspHashReport {
+  ok: boolean
+  problems: string[]
+  servedHash: string | null
+}
+
+/** Pure: validate a built-HTML + headers pair. Content is supplied by the caller. */
+export function checkCspHash(distHtml: string, headers: string): CspHashReport {
+  const script = extractInlineScript(distHtml)
+  if (script === null)
+    return {
+      ok: false,
+      problems: ['dist/index.html must have exactly one inline (src-less) <script>'],
+      servedHash: null,
+    }
+
+  const servedHash = cspHash(script)
+  const scriptSrc = extractScriptSrc(headers)
+  const problems: string[] = []
+  if (!scriptSrc.includes(`'${servedHash}'`))
+    problems.push(`script-src is missing the served inline-script hash '${servedHash}' (stale pin)`)
+  if (scriptSrc.includes("'unsafe-inline'"))
+    problems.push("script-src still allows 'unsafe-inline' (it cannot coexist with a hash)")
+  return { ok: problems.length === 0, problems, servedHash }
+}
+
+function main(): number {
+  let distHtml: string
+  try {
+    distHtml = readFileSync(DIST_INDEX, 'utf8')
+  } catch {
+    process.stderr.write(
+      `[lint-csp-hash] no ${DIST_INDEX} — run \`bun run --filter @kuruma/web build\` first\n`,
+    )
+    return 1
+  }
+  const report = checkCspHash(distHtml, readFileSync(HEADERS, 'utf8'))
+  if (!report.ok) {
+    for (const p of report.problems) process.stderr.write(`[lint-csp-hash] ERROR ${p}\n`)
+    process.stderr.write(
+      `[lint-csp-hash] fix: recompute the inline-script hash and update script-src in ${HEADERS}\n`,
+    )
+    return 1
+  }
+  process.stdout.write(`[lint-csp-hash] OK served inline script pinned by ${report.servedHash}\n`)
+  return 0
+}
+
+if (import.meta.main) {
+  process.exit(main())
+}

--- a/scripts/lint-csp-hash.ts
+++ b/scripts/lint-csp-hash.ts
@@ -28,9 +28,16 @@ export function cspHash(scriptContent: string): string {
   return `sha256-${createHash('sha256').update(scriptContent, 'utf8').digest('base64')}`
 }
 
-/** The script-src directive value from the CSP line (enforcing OR Report-Only). */
+/**
+ * The script-src directive value from the CSP line (enforcing OR Report-Only).
+ * Anchored on `^\s+` so it binds to a real indented `_headers` directive, never a
+ * `#` comment that merely mentions the directive name — the guard must survive
+ * future explanatory edits to this file without a comment masking a regression.
+ */
 export function extractScriptSrc(headers: string): string {
-  const line = headers.split('\n').find((l) => /Content-Security-Policy(-Report-Only)?:/.test(l))
+  const line = headers
+    .split('\n')
+    .find((l) => /^\s+Content-Security-Policy(-Report-Only)?:/.test(l))
   return line?.match(/script-src ([^;]*)/)?.[1]?.trim() ?? ''
 }
 

--- a/scripts/lint-csp-hash.ts
+++ b/scripts/lint-csp-hash.ts
@@ -2,7 +2,7 @@
 // ENFORCES: the CSP script-src hash in packages/web/public/_headers matches the
 //   inline bootstrap script as ACTUALLY EMITTED into packages/web/dist/index.html,
 //   and that script-src carries no 'unsafe-inline'.
-// SSOT: packages/web/public/_headers (the shipped CSP) — issue #500.
+// SSOT: docs/architecture/modules.md § Runtime invariants (Cloudflare Workers) — issue #500.
 //
 // Why this exists alongside the source-level unit test (tests/deploy/
 // csp-script-hash.test.ts): that test hashes the SOURCE index.html for fast


### PR DESCRIPTION
Hardens the Vite CSP by pinning the one inline locale-bootstrap script in `index.html` by its **sha256 hash** instead of allowing `script-src 'unsafe-inline'`. This is deliverable 1 of #500 — the code-side hardening that does **not** need the live preview.

## Why now / what's still gated
`'unsafe-inline'` in `script-src` defeats the policy for script injection. The hash-pin closes that. The header **stays `Content-Security-Policy-Report-Only`** — the flip to enforcing + live verification against the Google OAuth redirect and Unsplash imagery remain gated on the live preview in **#1009**. Landing the hardened policy as Report-Only first is the safe way to de-risk that flip (reports, never blocks).

## The hash is stable across the build
Vite emits this non-module inline script **byte-identically** into `dist/index.html` — verified: source and built hashes both `sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0=`. So hashing the source is correct; the served file matches.

## Drift guard (the important part)
A stale hash would **silently block** the script the moment the policy is enforced. `tests/deploy/csp-script-hash.test.ts` recomputes the hash from `index.html` each CI run and asserts:
- it's present in `_headers`' `script-src`
- `script-src` has **no** `'unsafe-inline'`
- exactly one inline (src-less) script exists
- `style-src` keeps `'unsafe-inline'` (inline style attributes can't be hashed — #500 note 2)

Edit the inline script without regenerating the hash → CI fails instead of a prod surprise.

## Verification
- guard test 4/4 · full web suite **1190** pass · web+api tsc clean · biome clean
- rebuilt `dist/index.html` inline-script hash == pinned hash in `_headers`

## Scope / out of scope
`style-src 'unsafe-inline'` stays (Hero/CallToAction inline `backgroundImage` styles). COEP stays omitted (`require-corp` blocks Unsplash). Enforce-flip deferred to #1009.

Refs #500