### PR TITLE
feat(#959): upload API Worker source maps to Sentry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,31 @@ jobs:
       # the presence check in step 3 fails the deploy loudly if one is gone.
       - name: Deploy API Worker
         working-directory: packages/api
-        run: npx wrangler deploy
+        # `bun run deploy` is the SINGLE source of the deploy command (package.json):
+        # `wrangler deploy --outdir dist --var SENTRY_RELEASE:$(git rev-parse HEAD)`.
+        # CI, rotate-secrets.yml, and manual `bun run deploy` all go through it, so
+        # the release var + source-map outdir can't drift between them (#959).
+        run: bun run deploy
+
+      # 2b. Upload the API Worker source maps to Sentry (#959) so stack frames
+      # resolve to src/ not bundled worker.js. Gated as a shell no-op: GitHub
+      # Actions forbids secrets in `if:`, so we map the creds to env and skip
+      # cleanly when any is absent (mirrors the web's no-op-without-creds gate).
+      # Release is keyed to the SAME `git rev-parse HEAD` the deploy used, so the
+      # uploaded maps match the runtime release Sentry reports. Non-fatal: the API
+      # is already deployed by here, so a Sentry flake must not strand the deploy.
+      - name: Upload API source maps to Sentry
+        working-directory: packages/api
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT_API: ${{ vars.SENTRY_PROJECT_API }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT_API" ]; then
+            echo "Sentry creds absent — skipping API source-map upload"; exit 0
+          fi
+          SENTRY_RELEASE="$(git rev-parse HEAD)" bun run sentry:sourcemaps \
+            || echo "::warning::API source-map upload to Sentry failed (non-fatal)"
 
       # 3. Verify required secrets exist on the API Worker. Read-only drift
       # detector — catches "secret got deleted or never rotated" but NOT

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -79,7 +79,27 @@ jobs:
           # Stripe above, deploy.yml's presence check intentionally does NOT require
           # SENTRY_DSN yet — add it there once Sentry is live (HITL prereq).
           echo "${{ secrets.SENTRY_DSN }}" | npx wrangler secret put SENTRY_DSN
-          npx wrangler deploy
+          # `bun run deploy` (not bare `npx wrangler deploy`) so a rotation ships the
+          # same SENTRY_RELEASE (commit SHA) + --outdir as deploy.yml — otherwise the
+          # promoted version would fall back to CF_VERSION_METADATA.id while Sentry
+          # maps stay SHA-keyed, breaking symbolication for the live version (#959).
+          bun run deploy
+
+      # Upload the API source maps to Sentry for the version this rotation just
+      # promoted (#959) — same gated, non-fatal step as deploy.yml. Separate step,
+      # so it carries its own working-directory (steps don't inherit it).
+      - name: Upload API source maps to Sentry
+        working-directory: packages/api
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT_API: ${{ vars.SENTRY_PROJECT_API }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT_API" ]; then
+            echo "Sentry creds absent — skipping API source-map upload"; exit 0
+          fi
+          SENTRY_RELEASE="$(git rev-parse HEAD)" bun run sentry:sourcemaps \
+            || echo "::warning::API source-map upload to Sentry failed (non-fatal)"
 
       # No web rotation step. The web app is moving to CF Pages (#378 §7.5),
       # which serves a static SPA and holds NO rotatable app secrets — auth +

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260410.1",
         "@neondatabase/serverless": "^1.0.2",
+        "@sentry/cli": "2.58.6",
         "@types/ws": "^8.5.12",
         "postgres": "^3.4.8",
         "vitest": "^2",
@@ -1243,7 +1244,7 @@
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1293,7 +1294,7 @@
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
-    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1391,7 +1392,11 @@
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
+    "data-urls/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
     "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "knip/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -1406,8 +1411,6 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-auth/@auth/core": ["@auth/core@0.41.0", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^6.0.6", "oauth4webapi": "^3.3.0", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ=="],
-
-    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1438,6 +1441,8 @@
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1533,11 +1538,11 @@
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "data-urls/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -80,8 +80,11 @@ until a DSN is present. Plan: `docs/plans/2026-06-17-issue-361-monitoring-activa
 
 - **API** (`@sentry/cloudflare`, `packages/api/src/observability/`): captures
   unhandled exceptions (with stack), raw `>=500` responses, and slow requests
-  (`>2s`), tagged with the deploy's version id (`CF_VERSION_METADATA`) as the
-  **release**. Gated on the `SENTRY_DSN` Worker secret.
+  (`>2s`), tagged with the deploy commit SHA (`SENTRY_RELEASE` `--var`, falling
+  back to `CF_VERSION_METADATA.id`) as the **release**. Gated on the `SENTRY_DSN`
+  Worker secret. Source maps upload to Sentry (#959, gated on `SENTRY_AUTH_TOKEN`/
+  `SENTRY_ORG`/`SENTRY_PROJECT_API`) so API stack frames resolve to `src/` not
+  bundled `worker.js`.
 - **Web** (`@sentry/react`, `packages/web/src/lib/observability/`, #765): captures
   React render crashes + TanStack route errors, tagged with the deploy commit SHA
   (`VITE_SENTRY_RELEASE`) as the release. Gated on the public `VITE_SENTRY_DSN`.
@@ -97,13 +100,15 @@ To activate (HITL, one-time):
 1. Create **two** Sentry projects: platform **Cloudflare Workers** (API) and
    **React** (web). Copy each DSN. Note your Sentry **org** + **project** slugs.
 2. Add GitHub secrets: `SENTRY_DSN` (API), `VITE_SENTRY_DSN` (web — public key,
-   safe to bake into the SPA), `SENTRY_AUTH_TOKEN` (web source-map upload — a real
-   secret). Add repo **variables** `SENTRY_ORG`, `SENTRY_PROJECT`, and
-   `SENTRY_ENVIRONMENT` (set to `beta`; the API Worker also reads it from
-   `wrangler.toml` `[vars]`). Unset env defaults to `production` and would
-   mis-tag beta errors — don't skip it.
-3. Run the **Rotate Worker Secrets** workflow (sets the API `SENTRY_DSN`); the next
-   web deploy bakes the web DSN + release and uploads source maps.
+   safe to bake into the SPA), `SENTRY_AUTH_TOKEN` (source-map upload — a real
+   secret, shared by web *and* API). Add repo **variables** `SENTRY_ORG`,
+   `SENTRY_PROJECT` (web), **`SENTRY_PROJECT_API`** (#959 — the API project slug;
+   the API map upload no-ops until it is set), and `SENTRY_ENVIRONMENT` (set to
+   `beta`; the API Worker also reads it from `wrangler.toml` `[vars]`). Unset env
+   defaults to `production` and would mis-tag beta errors — don't skip it.
+3. Run the **Rotate Worker Secrets** workflow (sets the API `SENTRY_DSN` + uploads
+   the API source maps for the promoted version); the next web deploy bakes the web
+   DSN + release and uploads web source maps. API maps also upload on every deploy.
 4. In Sentry: add an **alert rule** — *error* events spike 5× baseline for 10 min →
    Slack/email (page on errors only; the `>2s` slow-request warnings are
    dashboard-only — Neon cold starts trip 2s, so paging on them is alert fatigue).

--- a/docs/plans/2026-06-17-issue-361-monitoring-activation.md
+++ b/docs/plans/2026-06-17-issue-361-monitoring-activation.md
@@ -13,7 +13,7 @@ deliver value is a small CI/doc finishing slice plus a HITL activation runbook.
 
 | Surface | Code | Gate | Release tag |
 |---|---|---|---|
-| API (Workers) | `packages/api/src/observability/` (`worker.ts` `Sentry.withSentry`, `middleware.ts`, pure `report-policy.ts` + `sentry-options.ts`, all tested) | `enabled:false` until `SENTRY_DSN` | ✅ `CF_VERSION_METADATA.id` (wrangler.toml `[version_metadata]`) |
+| API (Workers) | `packages/api/src/observability/` (`worker.ts` `Sentry.withSentry`, `middleware.ts`, pure `report-policy.ts` + `sentry-options.ts`, all tested) | `enabled:false` until `SENTRY_DSN` | ✅ `SENTRY_RELEASE` (commit SHA, `--var` at deploy), falling back to `CF_VERSION_METADATA.id`. Source maps upload to Sentry (#959) — see below. |
 | Web (Pages SPA, #765) | `packages/web/src/lib/observability/` (`sentry.tsx` boundary + `captureRouteError`, pure `sentry-options.ts`, tested) + `main.tsx` wiring | `enabled:false` until `VITE_SENTRY_DSN` | ⚠️ reads `VITE_SENTRY_RELEASE` but **CI never injects it** |
 
 Captured today (once a DSN is live): unhandled exceptions w/ stack
@@ -93,12 +93,17 @@ uptime monitor as a healthy stack.
 1. Create two Sentry projects: platform **Cloudflare Workers** (API) and
    **React** (web). Copy each DSN.
 2. GitHub secrets: `SENTRY_DSN` (API), `VITE_SENTRY_DSN` (web),
-   `SENTRY_AUTH_TOKEN` (web source-map upload), and **`SENTRY_ENVIRONMENT=beta`
-   + `VITE_SENTRY_ENVIRONMENT=beta` (required, not optional)** — both
-   `sentry-options.ts` files default unset → `'production'`, which would
-   mis-tag beta errors as prod and pollute the env filter at real launch.
-3. Run `rotate-secrets.yml` (sets the API Worker secret); next web deploy bakes
-   the web DSN + release + uploads source maps.
+   `SENTRY_AUTH_TOKEN` (source-map upload — shared by web *and* API), and
+   **`SENTRY_ENVIRONMENT=beta` + `VITE_SENTRY_ENVIRONMENT=beta` (required, not
+   optional)** — both `sentry-options.ts` files default unset → `'production'`,
+   which would mis-tag beta errors as prod and pollute the env filter at real
+   launch. GitHub **variables**: `SENTRY_ORG`, `SENTRY_PROJECT` (web), and
+   **`SENTRY_PROJECT_API`** (#959 — the API's own Sentry project slug; the API
+   source-map upload no-ops until it is set).
+3. Run `rotate-secrets.yml` (sets the API Worker secret + uploads the API source
+   maps for the promoted version); next web deploy bakes the web DSN + release +
+   uploads web source maps. The API source maps also upload on every `deploy.yml`
+   run (gated on `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT_API`).
 4. In Sentry: add the alert rule (Part C) and the uptime monitor on `/health`
    (Part B).
 5. Verify: trigger a test error on each surface; confirm it lands grouped under

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "build": "wrangler deploy --dry-run",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --outdir dist --var SENTRY_RELEASE:$(git rev-parse HEAD)",
+    "sentry:sourcemaps": "sentry-cli sourcemaps upload --org \"$SENTRY_ORG\" --project \"$SENTRY_PROJECT_API\" --release \"$SENTRY_RELEASE\" dist",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260410.1",
+    "@sentry/cli": "2.58.6",
     "@neondatabase/serverless": "^1.0.2",
     "@types/ws": "^8.5.12",
     "postgres": "^3.4.8",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260410.1",
-    "@sentry/cli": "2.58.6",
     "@neondatabase/serverless": "^1.0.2",
+    "@sentry/cli": "2.58.6",
     "@types/ws": "^8.5.12",
     "postgres": "^3.4.8",
     "vitest": "^2",

--- a/packages/api/src/observability/sentry-options.test.ts
+++ b/packages/api/src/observability/sentry-options.test.ts
@@ -30,6 +30,24 @@ describe('resolveSentryOptions', () => {
     expect(opts.release).toBe('deadbeef-version-id')
   })
 
+  it('prefers an explicit SENTRY_RELEASE over the CF version metadata id', () => {
+    const opts = resolveSentryOptions({
+      SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+      SENTRY_RELEASE: 'a1b2c3d-commit-sha',
+      CF_VERSION_METADATA: { id: 'deadbeef-version-id', tag: 'v3' },
+    })
+    expect(opts.release).toBe('a1b2c3d-commit-sha')
+  })
+
+  it('falls back to the CF version id when SENTRY_RELEASE is blank/whitespace', () => {
+    const opts = resolveSentryOptions({
+      SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',
+      SENTRY_RELEASE: '   ',
+      CF_VERSION_METADATA: { id: 'deadbeef-version-id' },
+    })
+    expect(opts.release).toBe('deadbeef-version-id')
+  })
+
   it('honours an explicit SENTRY_ENVIRONMENT override', () => {
     const opts = resolveSentryOptions({
       SENTRY_DSN: 'https://abc@o1.ingest.sentry.io/42',

--- a/packages/api/src/observability/sentry-options.ts
+++ b/packages/api/src/observability/sentry-options.ts
@@ -11,8 +11,15 @@ export interface SentryRuntimeEnv {
   SENTRY_DSN?: string
   SENTRY_ENVIRONMENT?: string
   /**
-   * CF `[version_metadata]` binding — the deployed version id becomes the
-   * Sentry release tag so errors group per deploy (#361 AC).
+   * Explicit release tag, injected as a Worker `--var` at deploy time = the
+   * commit SHA (#959). Preferred over `CF_VERSION_METADATA.id` because the SHA
+   * is known *before* deploy, so the uploaded source maps can be keyed to the
+   * same release the runtime reports (Sentry requires the two to match).
+   */
+  SENTRY_RELEASE?: string
+  /**
+   * CF `[version_metadata]` binding — the deployed version id. Fallback release
+   * tag when `SENTRY_RELEASE` is absent (e.g. a deploy that didn't set the var).
    */
   CF_VERSION_METADATA?: { id?: string; tag?: string }
 }
@@ -28,7 +35,7 @@ export interface ResolvedSentryOptions {
 
 export function resolveSentryOptions(env: SentryRuntimeEnv | undefined): ResolvedSentryOptions {
   const dsn = env?.SENTRY_DSN?.trim() || undefined
-  const release = env?.CF_VERSION_METADATA?.id?.trim() || undefined
+  const release = env?.SENTRY_RELEASE?.trim() || env?.CF_VERSION_METADATA?.id?.trim() || undefined
   return {
     dsn,
     enabled: Boolean(dsn),

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -3,6 +3,13 @@ main = "src/worker.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Source maps (#959). Makes `wrangler deploy` upload Worker source maps to
+# Cloudflare so the CF dashboard de-minifies traces. The Sentry side is separate:
+# the `deploy` script's `--outdir dist` is what writes the local dist/worker.js.map
+# that the gated `sentry:sourcemaps` CI step uploads, keyed to the SENTRY_RELEASE
+# (commit SHA) the runtime reports — see package.json + deploy.yml.
+upload_source_maps = true
+
 # #916 §5.4: daily fleet-compliance digest. 23:00 UTC = 08:00 JST. Fires the
 # worker.ts `scheduled` handler, which runs ComplianceDigestService once.
 [triggers]


### PR DESCRIPTION
Closes #959. Follow-up to #361 (PR #951 did the web half).

## Problem
The API Worker's Sentry stack frames point at bundled `worker.js` line numbers, not `src/`, because nothing uploads its source maps. The web already de-minifies via `@sentry/vite-plugin`.

## Approach
Sentry's Cloudflare-Workers flow requires the **runtime SDK release == the uploaded-maps release** (no debug-ID escape hatch post-deploy). Our runtime keyed release to `CF_VERSION_METADATA.id`, which is only known *after* deploy — unusable for keying an upload. Fix: inject `SENTRY_RELEASE` (the commit SHA) as a Worker `--var` at deploy time, so the release is known *before* deploy and is identical on both sides.

**Single source of the deploy command.** `packages/api/package.json`'s `deploy` script is now the one definition: `wrangler deploy --outdir dist --var SENTRY_RELEASE:$(git rev-parse HEAD)`. `deploy.yml`, `rotate-secrets.yml`, and manual runs all call `bun run deploy`, so the release var + `--outdir` can't drift between the three paths (the rotate path was a real latent gap — it redeploys to promote rotated secrets).

A creds-gated, **non-fatal** `sentry:sourcemaps` step then uploads the maps keyed to the same SHA. Gated as a shell no-op (GitHub forbids `secrets.*` in `if:`); no-ops cleanly until `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT_API` are set — mirroring the web's gate.

## Changes
- `sentry-options.ts`: release prefers `SENTRY_RELEASE`, falls back to `CF_VERSION_METADATA.id` (free fallback). +2 mutation-resistant unit tests.
- `wrangler.toml`: `upload_source_maps = true` (CF-side de-minify bonus).
- `package.json`: canonical `deploy` script + `sentry:sourcemaps` script + `@sentry/cli` devDep (knip sees the bin via the script).
- `deploy.yml` / `rotate-secrets.yml`: `bun run deploy` + gated upload step.
- Docs: new `SENTRY_PROJECT_API` GitHub var recorded in the activation doc + RUNBOOK.

## Verification
- `bun run --filter @kuruma/api test` → **1764/1764 pass** (incl. new release-precedence cases).
- Local dry-run (no CF creds): `wrangler deploy --dry-run --outdir dist` emits both `worker.js` **and** `worker.js.map`.
- `tsc`, biome, `lint:boundaries` green; knip clean for `@sentry/cli`.
- code-reviewer: **ship**, no CRITICAL/HIGH.

## Deliberate decision (noted in review)
Unlike the web (which deletes its maps post-upload because they'd ship to browsers), the API keeps `dist/worker.js.map` — it's a server-side Worker, the map is never served to clients, and `upload_source_maps=true` storing it CF-side is what enables CF-dashboard de-minification. CF stores Worker source maps separately, so no Worker-size impact.

## HITL (out of scope — needs live Sentry creds)
AC#2 (a thrown API error resolves to a `src/` frame in Sentry) can only be verified once `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT_API` exist. Until then every build is a true no-op. This PR ships the wiring + the testable release-precedence change + the local dry-run proof.