### PR TITLE
fix(#464): SPECIFIC bookings must respect class capacity + combo past-start floor

### DIFF
--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -12,6 +12,7 @@ import type {
   TransactionRepos,
   UserRepository,
 } from '../repositories/types'
+import type { Vehicle } from '../stores'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
 import { MS_PER_MINUTE, composeBookingTotal, rentalDays } from './booking-pricing-helpers'
 import type {
@@ -258,6 +259,73 @@ export class BookingCreationService {
     const turnaroundMinutes = dropoff.defaultTurnaroundMinutes ?? DEFAULT_TURNAROUND_MINUTES
     const effectiveEndAt = new Date(input.endAt.getTime() + turnaroundMinutes * MS_PER_MINUTE)
 
+    // #464: a SPECIFIC booking also consumes a class unit. A CLASS_COMBO float
+    // (null assignedVehicleId) is invisible to the per-vehicle exclusion
+    // constraint (booking.ts), so without this gate a SPECIFIC create could grab
+    // the last car a float already reserved. Same advisory lock + demand/capacity
+    // gate as the combo path; the exclusion constraint stays the per-car backstop.
+    const releaseLock = await repos.availabilityRepo.lockComboCapacity(
+      operatorId,
+      classId,
+      input.pickupLocationId,
+    )
+    try {
+      return await this.submitSpecificInTxLocked(
+        ctx,
+        input,
+        renterId,
+        now,
+        repos,
+        vehicle,
+        operatorId,
+        classId,
+        assignedVehicleId,
+        effectiveEndAt,
+      )
+    } finally {
+      releaseLock()
+    }
+  }
+
+  private async submitSpecificInTxLocked(
+    ctx: CallerContext,
+    input: CreateBookingInput & { fulfillmentMode: 'SPECIFIC' },
+    renterId: string | null,
+    now: Date,
+    repos: TransactionRepos,
+    vehicle: Vehicle,
+    operatorId: string,
+    classId: string,
+    assignedVehicleId: string,
+    effectiveEndAt: Date,
+  ): Promise<CreateBookingResult> {
+    // Demand counts SPECIFIC occupancy + floats on the (op, class, loc) triple;
+    // capacity is the road-legal supply at the requested return. demand >= capacity
+    // means every unit is already claimed → reject before insert. (The exclusion
+    // constraint below still rejects a double-booked specific car while capacity
+    // remains — e.g. a multi-car class where only this car is taken.)
+    const demand = await repos.availabilityRepo.countClassDemand(
+      operatorId,
+      classId,
+      input.pickupLocationId,
+      input.startAt,
+      effectiveEndAt,
+    )
+    const capacity = await repos.availabilityRepo.countClassCapacity(
+      operatorId,
+      classId,
+      input.pickupLocationId,
+      input.endAt,
+    )
+    if (demand >= capacity) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'No cars left in this class at this location for the requested window',
+        code: 'CLASS_COMBO_SOLD_OUT',
+      }
+    }
+
     // Price off the ASSIGNED vehicle's rates — never class-level (#406), never
     // client-supplied (#74), non-null on every submit (#429 backfill guard).
     const pricing = calculateBookingPrice(
@@ -434,6 +502,26 @@ export class BookingCreationService {
     const klass = await repos.vehicleClassRepo.findById(SYSTEM_CONTEXT, classId)
     if (!klass || klass.operatorId !== operatorId) {
       return { ok: false, status: 400, error: 'Vehicle class is not available' }
+    }
+
+    // #464: a combo has no per-vehicle rules (no car at book time), but the
+    // universal past-start floor (#954) still applies. checkRentalRules with all
+    // class rules null fires only RENTAL_RULE_START_IN_PAST — ignoring min/max/
+    // advance — so a start already gone is rejected on this path too.
+    const ruleCheck = checkRentalRules(
+      { minRentalHours: null, maxRentalHours: null, advanceBookingHours: null },
+      input.startAt,
+      input.endAt,
+      now,
+    )
+    if (!ruleCheck.ok) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Booking violates a rental rule',
+        code: ruleCheck.code,
+        details: { required: ruleCheck.required, actual: ruleCheck.actual },
+      }
     }
 
     if (input.dropoffLocationId !== input.pickupLocationId) {

--- a/packages/api/tests/integration/booking-class-combo.test.ts
+++ b/packages/api/tests/integration/booking-class-combo.test.ts
@@ -208,4 +208,62 @@ describe('CLASS_COMBO submit serialization (real pg, #464 slice 2d.5)', () => {
     expect(persisted[0]?.fulfillmentMode).toBe('CLASS_COMBO')
     expect(persisted[0]?.totalPrice).toBe(DAY_RATE_JPY) // 1 day × dayRateJpy
   })
+
+  // #464 (fix(#464) follow-up): the SPECIFIC path is class-capacity guarded too —
+  // a CLASS_COMBO float carries null assignedVehicleId, invisible to the per-car
+  // exclusion constraint, so without the SPECIFIC-path advisory lock + demand/
+  // capacity gate a float and a SPECIFIC booking would both read demand=0 and
+  // oversell the single car. A distinct window (Oct) keeps the first test's Sept
+  // booking out of this demand count.
+  it('serializes a CLASS_COMBO float against a concurrent SPECIFIC booking — exactly one wins the last unit', async () => {
+    const raceStart = new Date('2027-10-01T09:00:00Z')
+    const raceEnd = new Date('2027-10-02T09:00:00Z')
+    const post = (body: object) =>
+      app.request('/bookings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+    const [combo, specific] = await Promise.all([
+      post({
+        fulfillmentMode: 'CLASS_COMBO',
+        classId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        startAt: raceStart.toISOString(),
+        endAt: raceEnd.toISOString(),
+        source: 'DIRECT',
+      }),
+      post({
+        fulfillmentMode: 'SPECIFIC',
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        startAt: raceStart.toISOString(),
+        endAt: raceEnd.toISOString(),
+        source: 'DIRECT',
+      }),
+    ])
+
+    // Exactly one wins the single class unit; the loser is sold out (without the
+    // SPECIFIC-path guard both would 201 → overbook).
+    expect([combo.status, specific.status].sort()).toEqual([201, 409])
+    const loser = combo.status === 409 ? combo : specific
+    expect(((await loser.json()) as { code?: string }).code).toBe('CLASS_COMBO_SOLD_OUT')
+
+    // Exactly one booking landed in the race window (no oversell).
+    const persisted = await db
+      .select({ id: bookings.id })
+      .from(bookings)
+      .where(
+        and(
+          eq(bookings.operatorId, BEST_CAR_RENTAL_OPERATOR_ID),
+          eq(bookings.classId, classId),
+          eq(bookings.pickupLocationId, locationId),
+          eq(bookings.startAt, raceStart),
+        ),
+      )
+    expect(persisted).toHaveLength(1)
+  })
 })

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -583,7 +583,13 @@ describe('POST /bookings via HTTP (real Postgres)', () => {
     expect(second.status).toBe(409)
     const secondBody = await second.json()
     expect(secondBody.success).toBe(false)
-    expect(secondBody.error).toMatch(/already booked/i)
+    // #464: a SPECIFIC booking is now class-capacity guarded too (a CLASS_COMBO
+    // float is invisible to the per-car exclusion constraint). On a single-car
+    // class+location the capacity guard (demand >= supply) fires before the
+    // exclusion constraint, so an overlapping re-book of the only car reports the
+    // class as sold out rather than "already booked" — both are a 409 double-book
+    // rejection. Accept either so this stays robust to the class car-count.
+    expect(secondBody.error).toMatch(/already booked|No cars left/i)
   })
 
   it('rejects a cross-operator dropoff with 400 (#882 same-operator one-way guardrail)', async () => {

--- a/packages/api/tests/services/booking-thread.test.ts
+++ b/packages/api/tests/services/booking-thread.test.ts
@@ -7,8 +7,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryAddOnRepository,
+  InMemoryAvailabilityRepository,
   InMemoryBookingEventRepository,
   InMemoryBookingRepository,
+  InMemoryClassRatePlanRepository,
   InMemoryFeeScheduleRepository,
   InMemoryInsuranceOptionRepository,
   InMemoryLocationRepository,
@@ -115,6 +117,10 @@ async function makeService(threadRepo?: ThreadRepository, staffUserId?: string) 
   const addOnRepo = new InMemoryAddOnRepository()
   const feeScheduleRepo = new InMemoryFeeScheduleRepository()
   const maintenanceLogRepo = new InMemoryMaintenanceLogRepository()
+  // #464: the SPECIFIC submit now reads demand/capacity + takes the class
+  // advisory lock through availabilityRepo, so this harness must wire it too.
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  const classRatePlanRepo = new InMemoryClassRatePlanRepository()
 
   const location = await locationRepo.create({
     operatorId: OP,
@@ -168,6 +174,9 @@ async function makeService(threadRepo?: ThreadRepository, staffUserId?: string) 
     addOnRepo,
     feeScheduleRepo,
     userRepo,
+    availabilityRepo,
+    classRatePlanRepo,
+    vehicleClassRepo,
   }
   const runInTransaction: RunInTransaction = async (fn) => fn(repos)
 

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -826,9 +826,11 @@ describe('BookingService.create — single-transaction submit (#392 §4)', () =>
       assignedVehicleId: 'other-veh',
       pickupLocationId: locationId,
       dropoffLocationId: locationId,
-      startAt: START,
-      endAt: END,
-      effectiveEndAt: new Date(END.getTime() + TURNAROUND_MS),
+      // #464: far-future window so this row owns the booking_code without
+      // consuming the class unit the new (overlapping) booking needs.
+      startAt: new Date(START.getTime() + 60 * 24 * 60 * 60 * 1000),
+      endAt: new Date(END.getTime() + 60 * 24 * 60 * 60 * 1000),
+      effectiveEndAt: new Date(END.getTime() + 60 * 24 * 60 * 60 * 1000 + TURNAROUND_MS),
       status: 'CONFIRMED',
       source: 'DIRECT',
       bookingCode: 'COLLIDE1',
@@ -870,9 +872,11 @@ describe('BookingService.create — single-transaction submit (#392 §4)', () =>
       assignedVehicleId: 'other-veh',
       pickupLocationId: locationId,
       dropoffLocationId: locationId,
-      startAt: START,
-      endAt: END,
-      effectiveEndAt: new Date(END.getTime() + TURNAROUND_MS),
+      // #464: far-future window so this row owns the booking_code without
+      // consuming the class unit the new (overlapping) booking needs.
+      startAt: new Date(START.getTime() + 60 * 24 * 60 * 60 * 1000),
+      endAt: new Date(END.getTime() + 60 * 24 * 60 * 60 * 1000),
+      effectiveEndAt: new Date(END.getTime() + 60 * 24 * 60 * 60 * 1000 + TURNAROUND_MS),
       status: 'CONFIRMED',
       source: 'DIRECT',
       bookingCode: 'DUP00001',
@@ -1114,6 +1118,62 @@ describe('BookingService.create — CLASS_COMBO (#464 2d.3)', () => {
     if (result.ok) return
     expect(result.status).toBe(409)
     expect(result.code).toBe('CLASS_COMBO_SOLD_OUT')
+  })
+
+  // #464: mirror of the test above. The per-vehicle exclusion constraint skips
+  // NULL assignedVehicleId, so a CLASS_COMBO float is invisible to it. Without
+  // lifting the class-capacity gate onto the SPECIFIC path too, a SPECIFIC create
+  // can grab the very car a float already reserved → overbook.
+  it('rejects a SPECIFIC create when a CLASS_COMBO float holds the last class unit → 409', async () => {
+    const h = await setup()
+    const { classId, locationId, vehicleId } = await seedComboReady(h)
+    await h.repos.bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingRow({
+        classId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        requestedVehicleId: null,
+        assignedVehicleId: null,
+        fulfillmentMode: 'CLASS_COMBO',
+        bookingCode: 'FLOAT001',
+      }),
+    )
+    const result = await h.service.create(
+      renterCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+      }),
+      NOW,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(409)
+    expect(result.code).toBe('CLASS_COMBO_SOLD_OUT')
+  })
+
+  // #464 / #954: combos have no per-vehicle rules, but the universal past-start
+  // floor must still fire (checkRentalRules with all class rules null).
+  it('rejects a CLASS_COMBO whose start is in the past → 400 RENTAL_RULE_START_IN_PAST', async () => {
+    const h = await setup()
+    const { classId, locationId } = await seedComboReady(h)
+    const result = await h.service.create(
+      renterCtx,
+      comboInput({
+        classId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        startAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1000), // 2h before now
+        endAt: END,
+      }),
+      NOW,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(400)
+    expect(result.code).toBe('RENTAL_RULE_START_IN_PAST')
   })
 })
 


### PR DESCRIPTION
## What

Fixes two latent bugs in the class-combo booking-creation path that shipped in **slice 2d (#1035)** — flagged in the slice-2d code review ([#464 comment](https://github.com/jackli921/kuruma-rental/issues/464#issuecomment-4794038801)) but merged as-is.

### 🔴 SPECIFIC bookings could overbook a class unit a float reserved
The advisory lock + `countClassDemand >= countClassCapacity → 409` guard ran **only** on the `CLASS_COMBO` branch. The per-vehicle exclusion constraint skips `NULL assignedVehicleId` (`booking.ts`), so a `CLASS_COMBO` float is invisible to it — a SPECIFIC booking could grab the last physical car a float already reserved. Fix: lift the same lock + capacity gate onto the SPECIFIC path (extracted `submitSpecificInTxLocked`); the exclusion constraint stays the precise per-car backstop.

### 🟠 CLASS_COMBO bypassed the universal past-start floor
`submitComboInTx` never called `checkRentalRules`; the validator only enforces `endAt > startAt`. A combo with a past `startAt` was created. Fix: call `checkRentalRules` with all class rules `null` so the `RENTAL_RULE_START_IN_PAST` floor (#954) still fires on the combo path.

## Tests
- **SPECIFIC-vs-float** (in-mem): 1-car class + 1 active float → a SPECIFIC create for that car → `409 CLASS_COMBO_SOLD_OUT` (RED before the fix — proves the overbook).
- **combo past-start** (in-mem): past `startAt` → `400 RENTAL_RULE_START_IN_PAST`.
- Wired `availabilityRepo` into the `booking-thread.test.ts` harness (the SPECIFIC path now reads it at runtime).
- `booking_code` collision seeds made non-overlapping so they don't consume the class unit.
- Integration double-book assertion accepts the capacity-409 on a single-car class (`/already booked|No cars left/i`) — both are a 409 double-book rejection.

## Verify
`env -u DATABASE_URL bun run --filter @kuruma/api test` → **1797 green**; tsc + lint:boundaries clean; pre-commit hook passed.

## Ripple (intentional)
The capacity guard fires before the exclusion constraint, so on a **single-car** class a same-car double-book now returns `CLASS_COMBO_SOLD_OUT` instead of "already booked" — both 409. Documented in the integration test.

Refs #464 (stays open for slices 3–7). Follow-up: a float-vs-SPECIFIC **real-pg** race test (the 2d.5 real-pg test only covers combo-vs-combo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
