### PR TITLE
fix(#1043): harden compliance-digest — batch+guard band records, surface fleet-scan cap

### DIFF
--- a/packages/api/src/repositories/drizzle/compliance-alert-log.ts
+++ b/packages/api/src/repositories/drizzle/compliance-alert-log.ts
@@ -8,10 +8,11 @@ import {
 import type { Db } from './shared'
 
 /**
- * Drizzle ComplianceAlertLogRepository (#916 §5.4/§7). `record` is an idempotent
- * insert — `onConflictDoNothing` on the (vehicleId, documentType, thresholdBand)
- * unique seal makes a same-band re-run a no-op, so the digest can record after a
- * successful send without ever double-writing.
+ * Drizzle ComplianceAlertLogRepository (#916 §5.4/§7). `recordMany` is one
+ * idempotent bulk insert — `onConflictDoNothing` on the (vehicleId, documentType,
+ * thresholdBand) unique seal makes any already-sealed band a no-op, so the digest
+ * can record after a successful send without ever double-writing. A single
+ * statement = one operator's bands seal atomically (#1043).
  */
 export class DrizzleComplianceAlertLogRepository implements ComplianceAlertLogRepository {
   constructor(private readonly db: Db) {}
@@ -29,7 +30,8 @@ export class DrizzleComplianceAlertLogRepository implements ComplianceAlertLogRe
     return new Set(rows.map((r) => complianceAlertKey(r.vehicleId, r.documentType, r.thresholdBand)))
   }
 
-  async record(data: RecordComplianceAlert): Promise<void> {
-    await this.db.insert(complianceAlertLog).values(data).onConflictDoNothing()
+  async recordMany(alerts: RecordComplianceAlert[]): Promise<void> {
+    if (alerts.length === 0) return
+    await this.db.insert(complianceAlertLog).values(alerts).onConflictDoNothing()
   }
 }

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -148,6 +148,9 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     requireFleetWriteScope(ctx)
     // operatorId is the tenant anchor — never reassignable via an update, or a
     // caller could move a vehicle to another tenant (#386 F2). Strip it here.
+    // The compliance-alert idempotency seal (db/compliance.ts) leans on this: it
+    // omits operatorId, which is safe ONLY while a vehicle can't change operator.
+    // If you ever allow reassignment, widen that seal too (#1043).
     const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data
     // #879: re-encode an edited photos array (wire URLs -> stored refs) so an
     // edit round-trip never bakes the public host into the stored value. Absent

--- a/packages/api/src/repositories/in-memory/compliance-alert-log.test.ts
+++ b/packages/api/src/repositories/in-memory/compliance-alert-log.test.ts
@@ -34,15 +34,6 @@ describe('InMemoryComplianceAlertLogRepository', () => {
     expect([...store.values()][0].recipient).toBe('a@example.com')
   })
 
-  test('recordMany dedupes a same-band duplicate within a single batch', async () => {
-    const store = new Map()
-    const repo = new InMemoryComplianceAlertLogRepository(store)
-    await repo.recordMany([base, { ...base, recipient: 'changed@example.com' }])
-
-    expect(store.size).toBe(1)
-    expect([...store.values()][0].recipient).toBe('a@example.com')
-  })
-
   test('findAlertedKeys only returns keys for the requested vehicles', async () => {
     const repo = new InMemoryComplianceAlertLogRepository()
     await repo.recordMany([base, { ...base, vehicleId: 'veh-2' }])

--- a/packages/api/src/repositories/in-memory/compliance-alert-log.test.ts
+++ b/packages/api/src/repositories/in-memory/compliance-alert-log.test.ts
@@ -11,10 +11,9 @@ const base = {
 }
 
 describe('InMemoryComplianceAlertLogRepository', () => {
-  test('records distinct bands and exposes their keys', async () => {
+  test('records distinct bands (in one batch) and exposes their keys', async () => {
     const repo = new InMemoryComplianceAlertLogRepository()
-    await repo.record(base)
-    await repo.record({ ...base, documentType: 'INSURANCE', thresholdBand: 'D7' })
+    await repo.recordMany([base, { ...base, documentType: 'INSURANCE', thresholdBand: 'D7' }])
 
     const keys = await repo.findAlertedKeys(['veh-1'])
     expect(keys).toEqual(
@@ -25,11 +24,20 @@ describe('InMemoryComplianceAlertLogRepository', () => {
     )
   })
 
-  test('record is idempotent on (vehicle, document, band) — a same-band re-run is a no-op', async () => {
+  test('recordMany is idempotent on (vehicle, document, band) — a same-band re-run is a no-op', async () => {
     const store = new Map()
     const repo = new InMemoryComplianceAlertLogRepository(store)
-    await repo.record(base)
-    await repo.record({ ...base, recipient: 'changed@example.com' })
+    await repo.recordMany([base])
+    await repo.recordMany([{ ...base, recipient: 'changed@example.com' }])
+
+    expect(store.size).toBe(1)
+    expect([...store.values()][0].recipient).toBe('a@example.com')
+  })
+
+  test('recordMany dedupes a same-band duplicate within a single batch', async () => {
+    const store = new Map()
+    const repo = new InMemoryComplianceAlertLogRepository(store)
+    await repo.recordMany([base, { ...base, recipient: 'changed@example.com' }])
 
     expect(store.size).toBe(1)
     expect([...store.values()][0].recipient).toBe('a@example.com')
@@ -37,8 +45,7 @@ describe('InMemoryComplianceAlertLogRepository', () => {
 
   test('findAlertedKeys only returns keys for the requested vehicles', async () => {
     const repo = new InMemoryComplianceAlertLogRepository()
-    await repo.record(base)
-    await repo.record({ ...base, vehicleId: 'veh-2' })
+    await repo.recordMany([base, { ...base, vehicleId: 'veh-2' }])
 
     const keys = await repo.findAlertedKeys(['veh-1'])
     expect(keys).toEqual(new Set([complianceAlertKey('veh-1', 'SHAKEN', 'D30')]))

--- a/packages/api/src/repositories/in-memory/compliance-alert-log.ts
+++ b/packages/api/src/repositories/in-memory/compliance-alert-log.ts
@@ -6,7 +6,7 @@ import {
 } from '../types'
 
 /**
- * In-memory ComplianceAlertLogRepository (#916 §5.4/§7). `record` is idempotent
+ * In-memory ComplianceAlertLogRepository (#916 §5.4/§7). `recordMany` is idempotent
  * on (vehicleId, documentType, thresholdBand) — a duplicate band is a no-op,
  * mirroring the DB unique seal. The `now` clock is injectable for deterministic
  * `sentAt` in tests.
@@ -36,11 +36,13 @@ export class InMemoryComplianceAlertLogRepository implements ComplianceAlertLogR
     return keys
   }
 
-  async record(data: RecordComplianceAlert): Promise<void> {
-    const key = complianceAlertKey(data.vehicleId, data.documentType, data.thresholdBand)
-    if (this.byKey.has(key)) return // unique seal — same-band re-run is a no-op
-    this.byKey.add(key)
-    const id = crypto.randomUUID()
-    this.store.set(id, { id, ...data, sentAt: this.now() })
+  async recordMany(alerts: RecordComplianceAlert[]): Promise<void> {
+    for (const data of alerts) {
+      const key = complianceAlertKey(data.vehicleId, data.documentType, data.thresholdBand)
+      if (this.byKey.has(key)) continue // unique seal — same-band re-run is a no-op
+      this.byKey.add(key)
+      const id = crypto.randomUUID()
+      this.store.set(id, { id, ...data, sentAt: this.now() })
+    }
   }
 }

--- a/packages/api/src/repositories/types-compliance.ts
+++ b/packages/api/src/repositories/types-compliance.ts
@@ -26,7 +26,10 @@ export interface ComplianceAlertLogRepository {
   // The set of already-sent `complianceAlertKey(...)` values among these vehicles,
   // so the digest knows which bands are new before composing a mail.
   findAlertedKeys(vehicleIds: string[]): Promise<Set<string>>
-  // Idempotent insert — a duplicate (vehicleId, documentType, band) is a no-op
-  // (the unique seal), so a same-band re-run never double-records.
-  record(data: RecordComplianceAlert): Promise<void>
+  // Idempotent BATCH insert — one operator's freshly-sent bands sealed in a single
+  // atomic statement. A duplicate (vehicleId, documentType, band) is a no-op (the
+  // unique seal), so a same-band re-run never double-records. Batched (not one call
+  // per band) so a sent digest is sealed all-or-nothing, and a single write blip
+  // can't cascade past the operator it hit (#1043).
+  recordMany(alerts: RecordComplianceAlert[]): Promise<void>
 }

--- a/packages/api/src/services/compliance-digest.test.ts
+++ b/packages/api/src/services/compliance-digest.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { SYSTEM_CONTEXT } from '../middleware/auth'
 import { InMemoryComplianceAlertLogRepository } from '../repositories/in-memory/compliance-alert-log'
 import { InMemoryVehicleRepository } from '../repositories/in-memory/vehicle'
-import { complianceAlertKey } from '../repositories/types'
+import { type ComplianceAlertLogRepository, complianceAlertKey } from '../repositories/types'
 import type { Vehicle } from '../stores'
-import { ComplianceDigestService } from './compliance-digest'
+import { ComplianceDigestService, SCAN_LIMIT } from './compliance-digest'
 import type { EmailMessage } from './email/email-sender'
 import type { ResolveOperatorRecipientsBatch } from './operator-recipients'
 
@@ -71,7 +71,7 @@ const resolveRecipients: ResolveOperatorRecipientsBatch = async (ids) =>
 
 function setup(opts?: {
   ctrl?: { fail: boolean }
-  alertLogRepo?: InMemoryComplianceAlertLogRepository
+  alertLogRepo?: ComplianceAlertLogRepository
 }) {
   const vehicleRepo = new InMemoryVehicleRepository()
   const alertLogRepo = opts?.alertLogRepo ?? new InMemoryComplianceAlertLogRepository()
@@ -208,5 +208,63 @@ describe('ComplianceDigestService.run (#916 §5.4)', () => {
 
     expect(summary).toMatchObject({ operatorsNotified: 0 })
     expect(sent).toHaveLength(0)
+  })
+
+  it('a ledger-write failure for one operator does not abort the rest of the fleet (#1043)', async () => {
+    // recordMany always rejects: every sent digest fails to seal. The fix guards
+    // the write like the send, so the second operator still gets its mail instead
+    // of the first operator's throw aborting the whole run.
+    const failingLedger: ComplianceAlertLogRepository = {
+      findAlertedKeys: async () => new Set<string>(),
+      recordMany: async () => {
+        throw new Error('ledger down')
+      },
+    }
+    const { vehicleRepo, sent, service } = setup({ alertLogRepo: failingLedger })
+    await makeVehicle(vehicleRepo, { operatorId: 'op_a', shakenExpiryDate: EXPIRED })
+    await makeVehicle(vehicleRepo, { operatorId: 'op_b', shakenExpiryDate: EXPIRED })
+
+    const summary = await service.run() // must not throw
+
+    expect(sent).toHaveLength(2) // both operators emailed despite both seals failing
+    expect(summary).toMatchObject({
+      operatorsNotified: 2,
+      alertsRecorded: 0,
+      operatorsRecordFailed: 2,
+      operatorsFailed: 0,
+    })
+  })
+
+  it('flags fleetScanTruncated and warns when the scan fills the page (silent-cap guard, #1043)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seed = await makeVehicle(new InMemoryVehicleRepository(), {}) // both FAR → no candidates
+    const fullPage = Array.from(
+      { length: SCAN_LIMIT },
+      (_, i): Vehicle => ({ ...seed, id: `veh_${i}` }),
+    )
+    const service = new ComplianceDigestService({
+      vehicleRepo: { findAll: async () => ({ data: fullPage, total: SCAN_LIMIT }) },
+      alertLogRepo: new InMemoryComplianceAlertLogRepository(),
+      resolveRecipients,
+      emailSender: fakeSender().sender,
+      today: () => TODAY,
+      config: { emailFrom: 'fleet@platform.example' },
+    })
+
+    const summary = await service.run()
+    const warnCalls = warnSpy.mock.calls.length // capture before mockRestore clears it
+    warnSpy.mockRestore()
+
+    expect(summary.fleetScanTruncated).toBe(true)
+    expect(warnCalls).toBe(1)
+  })
+
+  it('does not flag fleetScanTruncated for a sub-cap scan', async () => {
+    const { vehicleRepo, service } = setup()
+    await makeVehicle(vehicleRepo, { shakenExpiryDate: EXPIRED })
+
+    const summary = await service.run()
+
+    expect(summary.fleetScanTruncated).toBe(false)
   })
 })

--- a/packages/api/src/services/compliance-digest.test.ts
+++ b/packages/api/src/services/compliance-digest.test.ts
@@ -252,11 +252,11 @@ describe('ComplianceDigestService.run (#916 §5.4)', () => {
     })
 
     const summary = await service.run()
-    const warnCalls = warnSpy.mock.calls.length // capture before mockRestore clears it
+    const warnMsg = warnSpy.mock.calls[0]?.[0] // capture before mockRestore clears it
     warnSpy.mockRestore()
 
     expect(summary.fleetScanTruncated).toBe(true)
-    expect(warnCalls).toBe(1)
+    expect(warnMsg).toContain('page cap') // the cron line names the cause, not just a flag
   })
 
   it('does not flag fleetScanTruncated for a sub-cap scan', async () => {

--- a/packages/api/src/services/compliance-digest.ts
+++ b/packages/api/src/services/compliance-digest.ts
@@ -17,7 +17,11 @@ import type { ResolveOperatorRecipientsBatch } from './operator-recipients'
 const DEFAULT_DIGEST_LOCALE = 'ja'
 // One scan of the whole fleet (40-50 today, low hundreds at scale) — a single
 // bounded page, not paginated: the digest must see every vehicle in one pass.
-const SCAN_LIMIT = 2000
+// Exported so the silent-cap guard test asserts the real boundary (#1043): if a
+// run ever returns exactly this many vehicles, the page is full and the fleet has
+// outgrown one pass — `fleetScanTruncated` flags it instead of under-alerting in
+// silence.
+export const SCAN_LIMIT = 2000
 
 export interface ComplianceDigestConfig {
   emailFrom: string
@@ -41,6 +45,13 @@ export interface ComplianceDigestSummary {
   alertsRecorded: number
   operatorsSkippedNoRecipients: number
   operatorsFailed: number
+  /** Send succeeded but sealing its bands didn't — the digest re-sends next run
+   *  (idempotent). A persistent non-zero here flags a ledger-write problem. */
+  operatorsRecordFailed: number
+  /** The fleet scan filled the page (vehicles.length === SCAN_LIMIT): vehicles
+   *  beyond the cap were NOT scanned, so some compliance alerts may be silently
+   *  missed. False in normal operation; true means paginate before the next run. */
+  fleetScanTruncated: boolean
 }
 
 interface AlertCandidate {
@@ -68,6 +79,20 @@ export class ComplianceDigestService {
       limit: SCAN_LIMIT,
     })
 
+    // No silent cap: a full page means the fleet has outgrown one pass and the
+    // overflow was never scanned (so never alerted). Surface it in the cron line
+    // AND the summary rather than under-alerting in silence (#1043).
+    const fleetScanTruncated = vehicles.length === SCAN_LIMIT
+    if (fleetScanTruncated) {
+      console.warn(
+        '[cron:compliance-digest] fleet scan hit the page cap — vehicles beyond it were not scanned; paginate',
+        {
+          scanned: vehicles.length,
+          cap: SCAN_LIMIT,
+        },
+      )
+    }
+
     const candidates = vehicles.flatMap((v) =>
       vehicleAlertCandidates(v, today).map(
         ({ documentType, band }): AlertCandidate => ({
@@ -80,7 +105,7 @@ export class ComplianceDigestService {
         }),
       ),
     )
-    if (candidates.length === 0) return EMPTY_SUMMARY
+    if (candidates.length === 0) return emptySummary(fleetScanTruncated)
 
     const alerted = await this.deps.alertLogRepo.findAlertedKeys(candidates.map((c) => c.vehicleId))
     const fresh = candidates.filter(
@@ -91,6 +116,7 @@ export class ComplianceDigestService {
     let alertsRecorded = 0
     let operatorsSkippedNoRecipients = 0
     let operatorsFailed = 0
+    let operatorsRecordFailed = 0
 
     // Group fresh alerts by operator in one pass (mirrors groupByLocation in
     // storefront-search) instead of re-scanning `fresh` once per operator.
@@ -126,19 +152,35 @@ export class ComplianceDigestService {
 
       operatorsNotified++
       const recipientAudit = recipients.join(',')
-      for (const c of items) {
-        await this.deps.alertLogRepo.record({
-          operatorId,
-          vehicleId: c.vehicleId,
-          documentType: c.documentType,
-          thresholdBand: c.band,
-          recipient: recipientAudit,
-        })
-        alertsRecorded++
+      try {
+        // Seal all of this operator's bands in one atomic statement. Symmetric with
+        // the send guard above: a record failure leaves the bands unsealed so the
+        // next run re-sends (idempotent) rather than aborting the rest of the fleet,
+        // and the all-or-nothing write means a sent digest is never half-sealed (#1043).
+        await this.deps.alertLogRepo.recordMany(
+          items.map((c) => ({
+            operatorId,
+            vehicleId: c.vehicleId,
+            documentType: c.documentType,
+            thresholdBand: c.band,
+            recipient: recipientAudit,
+          })),
+        )
+        alertsRecorded += items.length
+      } catch (err) {
+        console.error('[cron:compliance-digest] record failed', { operatorId, err })
+        operatorsRecordFailed++
       }
     }
 
-    return { operatorsNotified, alertsRecorded, operatorsSkippedNoRecipients, operatorsFailed }
+    return {
+      operatorsNotified,
+      alertsRecorded,
+      operatorsSkippedNoRecipients,
+      operatorsFailed,
+      operatorsRecordFailed,
+      fleetScanTruncated,
+    }
   }
 
   private buildMessage(items: AlertCandidate[], recipients: string[]): EmailMessage {
@@ -168,9 +210,15 @@ export class ComplianceDigestService {
   }
 }
 
-const EMPTY_SUMMARY: ComplianceDigestSummary = {
-  operatorsNotified: 0,
-  alertsRecorded: 0,
-  operatorsSkippedNoRecipients: 0,
-  operatorsFailed: 0,
+/** A run that sent nothing — all counters zero, carrying through whether the scan
+ *  was truncated so a silently-capped fleet still surfaces on an empty day. */
+function emptySummary(fleetScanTruncated: boolean): ComplianceDigestSummary {
+  return {
+    operatorsNotified: 0,
+    alertsRecorded: 0,
+    operatorsSkippedNoRecipients: 0,
+    operatorsFailed: 0,
+    operatorsRecordFailed: 0,
+    fleetScanTruncated,
+  }
 }

--- a/packages/api/tests/integration/compliance-alert-log.test.ts
+++ b/packages/api/tests/integration/compliance-alert-log.test.ts
@@ -20,7 +20,7 @@ import {
 // #652 S5: the compliance_alert_log idempotency ledger is what stops the digest
 // double-alerting. The InMemory double (compliance-digest.test.ts) covers the
 // contract; ONLY this proves the real `compliance_alert_log_band_unique` seal +
-// record()'s onConflictDoNothing against Postgres. Scoped to freshly-created
+// recordMany()'s onConflictDoNothing against Postgres. Scoped to freshly-created
 // vehicles, so findAlertedKeys([myVehicle]) can never see another file's rows.
 
 const vehicleRepo = new DrizzleVehicleRepository(db)
@@ -81,19 +81,19 @@ const alert = (
 })
 
 describe('DrizzleComplianceAlertLogRepository (#652 S5, real pg)', () => {
-  it('record() then findAlertedKeys round-trips the canonical key', async () => {
-    await repo.record(alert(v1, 'SHAKEN', 'D30'))
+  it('recordMany() then findAlertedKeys round-trips the canonical key', async () => {
+    await repo.recordMany([alert(v1, 'SHAKEN', 'D30')])
     const keys = await repo.findAlertedKeys([v1])
     expect(keys.has(complianceAlertKey(v1, 'SHAKEN', 'D30'))).toBe(true)
   })
 
   it('is idempotent on a duplicate (vehicle, doc, band): no second row, no throw', async () => {
     const dup = alert(v1, 'INSURANCE', 'EXPIRED')
-    await repo.record(dup)
+    await repo.recordMany([dup])
     // A same-band re-run (even with a different recipient) hits the unique seal +
     // onConflictDoNothing — it resolves without throwing and writes nothing new.
     await expect(
-      repo.record({ ...dup, recipient: 'someone-else@op.example' }),
+      repo.recordMany([{ ...dup, recipient: 'someone-else@op.example' }]),
     ).resolves.toBeUndefined()
     const rows = await db
       .select({ id: complianceAlertLog.id, recipient: complianceAlertLog.recipient })
@@ -110,9 +110,12 @@ describe('DrizzleComplianceAlertLogRepository (#652 S5, real pg)', () => {
   })
 
   it('treats each band and document as a distinct alert (a vehicle re-alerts as it counts down)', async () => {
-    await repo.record(alert(v2, 'SHAKEN', 'D30'))
-    await repo.record(alert(v2, 'SHAKEN', 'D14'))
-    await repo.record(alert(v2, 'INSURANCE', 'D30'))
+    // One batch carrying three distinct (doc, band) keys — all seal, none collide.
+    await repo.recordMany([
+      alert(v2, 'SHAKEN', 'D30'),
+      alert(v2, 'SHAKEN', 'D14'),
+      alert(v2, 'INSURANCE', 'D30'),
+    ])
     const keys = await repo.findAlertedKeys([v2])
     expect(keys).toEqual(
       new Set([

--- a/packages/shared/src/db/compliance.ts
+++ b/packages/shared/src/db/compliance.ts
@@ -37,6 +37,12 @@ export const complianceAlertLog = pgTable(
     // with vehicleId but the gate credits only declared indexes / PKs).
     index('idx_compliance_alert_log_vehicleId').on(t.vehicleId),
     // Idempotency seal: one alert per (vehicle, document, band) across daily runs.
+    // operatorId is deliberately NOT part of the seal — safe ONLY because a vehicle
+    // can never change operator (the tenant anchor is stripped on update; see
+    // repositories/drizzle/vehicle.ts `update`). If vehicle→operator reassignment is
+    // ever added, this seal must widen to include operatorId, or onConflictDoNothing
+    // will silently suppress the new operator's first alert for any band the old one
+    // already consumed (#1043).
     unique('compliance_alert_log_band_unique').on(t.vehicleId, t.documentType, t.thresholdBand),
   ],
 )


### PR DESCRIPTION
## What

Maintainability follow-up on the daily compliance-digest cron (found via `/maintainability-review`). Three latent risks, **no happy-path behaviour change**. Closes #1043.

### 1. (Med) Unguarded per-band record writes → cascade + partial-dup
The `record()` loop ran **unguarded** while `send` was guarded to continue-on-failure. One transient ledger write threw out of `run()`, aborting **every operator not yet processed**; a mid-loop death re-sent a **partial-duplicate** digest.
**Fix:** replace `record` with a batch **`recordMany`** — one operator's bands seal in a single atomic `onConflictDoNothing` statement, inside a try/catch symmetric with the send guard. Cascade gone, partial-seal window closed, N writes → 1. New `operatorsRecordFailed` counter.

### 2. (Low) SCAN_LIMIT=2000 silent cap
Past 2000 vehicles the overflow was never scanned (so never alerted), zero signal. Now a full page sets **`fleetScanTruncated`** on the summary and **warns** on the cron line.

### 3. (Low) operatorId absent from the idempotency seal (inert)
Safe only because a vehicle can never change operator (`vehicle.ts` strips it on update). Comments at the seal + the reassignment block tie the two invariants together so a future 'allow transfer' knows to widen the seal.

## Test plan
- [x] New: record-failure-no-cascade (both operators still emailed, run doesn't throw) + fleet-scan-cap (warn + flag) + sub-cap negative + intra-batch dedupe
- [x] Repo unit + real-pg integration updated to `recordMany`
- [x] api **1803** unit green · typecheck · boundaries · biome · size all clean
- [x] Schema change is comment-only → no migration / no drift

_Found and fixed via the maintainability-review skill._