### PR TITLE
fix(auth): record Google email_verified on OAuth user creation

### DIFF
--- a/packages/api/src/auth/drizzle-oauth-account-store.ts
+++ b/packages/api/src/auth/drizzle-oauth-account-store.ts
@@ -10,6 +10,7 @@ import type { getDb } from '@kuruma/shared/db'
 import { accounts, users } from '@kuruma/shared/db/schema'
 import { eq } from 'drizzle-orm'
 import type { UserRole } from '../middleware/auth'
+import { emailVerifiedAt } from './email-verification'
 import type { GoogleProfile, OAuthAccountStore } from './google'
 
 // Derived from the canonical connection factory (same as repositories/drizzle's
@@ -53,11 +54,13 @@ export class DrizzleOAuthAccountStore implements OAuthAccountStore {
       userId = existing.id
     } else {
       // createUser writes role=RENTER + operatorId=NULL via the schema defaults.
-      // emailVerified=null: Google's email_verified isn't consumed here.
+      // Record Google's email_verified claim (was hard-coded null) so the stored
+      // row reflects whether the email was actually verified — a signal the
+      // provider-grant path already trusts on the live claim (#auth-review).
       const created = await createUser({
         id: crypto.randomUUID(),
         email: profile.email ?? '',
-        emailVerified: null,
+        emailVerified: emailVerifiedAt(profile.email_verified, new Date()),
         name: profile.name ?? null,
         image: profile.picture ?? null,
       })

--- a/packages/api/src/auth/email-verification.test.ts
+++ b/packages/api/src/auth/email-verification.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { emailVerifiedAt } from './email-verification'
+
+describe('emailVerifiedAt', () => {
+  const now = new Date('2026-06-25T00:00:00.000Z')
+
+  it('records the verification instant when Google asserts email_verified: true', () => {
+    expect(emailVerifiedAt(true, now)).toBe(now)
+  })
+
+  it('records null when the claim is false (Google says unverified)', () => {
+    expect(emailVerifiedAt(false, now)).toBeNull()
+  })
+
+  it('records null when the claim is absent (older/partial profiles)', () => {
+    expect(emailVerifiedAt(undefined, now)).toBeNull()
+  })
+})

--- a/packages/api/src/auth/email-verification.ts
+++ b/packages/api/src/auth/email-verification.ts
@@ -1,0 +1,15 @@
+/**
+ * When a Google OIDC sign-in first creates a `users` row, record WHETHER Google
+ * asserted the email as verified — instead of hard-coding `emailVerified: null`
+ * for everyone (the old behaviour, which threw away a security-relevant signal).
+ *
+ * Returns the verification instant (`now`) only when Google's `email_verified`
+ * claim is strictly `true`; an absent or `false` claim records `null`. Matching
+ * the strict `=== true` check the provider-grant path already uses
+ * (services/operator-grant.ts) keeps "is this email trustworthy?" answered the
+ * same way everywhere. Pure (the clock is passed in) so the decision is testable
+ * without a DB or a real wall clock — the I/O write stays in the account store.
+ */
+export function emailVerifiedAt(verified: boolean | undefined, now: Date): Date | null {
+  return verified === true ? now : null
+}


### PR DESCRIPTION
## What

The Drizzle OAuth account store hard-coded `emailVerified: null` for every new renter (`drizzle-oauth-account-store.ts:60`), throwing away Google's OIDC `email_verified` claim — even though `GoogleProfile.email_verified` carries it and the provider-grant path already trusts it on the live claim (`operator-grant.ts:68`).

So the stored `users` row always read 'unverified' for genuinely-verified accounts. Any current or future trust decision on `users.emailVerified` would be wrong.

## Fix

Extract `emailVerifiedAt` (pure: `verified === true ? now : null`, matching the provider-grant strict check) and write it on `createUser`.

**Zero behaviour change today** — nothing reads `users.emailVerified` from the DB, so this only stops discarding the signal and records the truth for future correctness/auditability.

## Scope

Found in a **security review of the auth layer** (read-only, no exploitable bypass found — JWT alg-pinning, iss/aud, CSRF double-submit, open-redirect, operator-revocation wiring, cookie flags all verified sound). The one larger item — validate Google's signed `id_token` + a per-flow `nonce` instead of trusting `access_token` via `/userinfo` — is filed as a separate tracked issue (it's a substantial OAuth change, currently safe because the access token is bound to our client).

## Test plan
- [x] `emailVerifiedAt` unit test (true → instant, false/undefined → null)
- [x] api 1850 unit green · typecheck · boundaries · biome clean
- [x] No DB read of `users.emailVerified` exists → no behaviour change for existing flows