### PR TITLE
feat(#1050): version-tag consent canonical form + i18n drift guard

### DIFF
--- a/packages/shared/src/db/seed-data/consent-documents.test.ts
+++ b/packages/shared/src/db/seed-data/consent-documents.test.ts
@@ -1,6 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { computeContentHash } from '../../lib/consent-canonical'
 import { DEMO_CONSENT_DOCUMENTS } from './consent-documents'
+
+const MESSAGES_DIR = fileURLToPath(new URL('../../../../web/messages/', import.meta.url))
+
+function loadDisclaimer(locale: 'en' | 'ja' | 'zh'): { label: string; terms: string } {
+  const raw = JSON.parse(readFileSync(`${MESSAGES_DIR}${locale}.json`, 'utf8'))
+  return raw.reservation.disclaimer
+}
 
 describe('DEMO_CONSENT_DOCUMENTS', () => {
   it('has 4 types × 3 locales = 12 PUBLISHED rows', () => {
@@ -33,6 +42,19 @@ describe('DEMO_CONSENT_DOCUMENTS', () => {
     expect(en?.version).toBe('2026-06-13')
     expect(en?.body).toContain('verification is completed in person at pickup')
   })
+
+  it.each(['en', 'ja', 'zh'] as const)(
+    'RENTER_LIABILITY %s body/label byte-equal packages/web/messages/$.reservation.disclaimer (#1050 drift guard)',
+    (locale) => {
+      const seed = DEMO_CONSENT_DOCUMENTS.find(
+        (d) => d.type === 'RENTER_LIABILITY' && d.locale === locale,
+      )
+      const i18n = loadDisclaimer(locale)
+      expect(seed).toBeDefined()
+      expect(seed?.body).toBe(i18n.terms)
+      expect(seed?.acceptanceLabel).toBe(i18n.label)
+    },
+  )
 
   it('seeds documents that are PUBLISHED and effective as of the seed date (service-acceptable)', () => {
     const asOf = new Date('2026-06-15T00:00:00Z')

--- a/packages/shared/src/lib/consent-canonical.test.ts
+++ b/packages/shared/src/lib/consent-canonical.test.ts
@@ -23,6 +23,15 @@ describe('canonicalizeFields', () => {
     ).toBe(true)
   })
 
+  it('accepts an explicit version override (forward seam for a v2 verifier)', () => {
+    expect(canonicalizeFields([], 'v2')).toBe('_canon\x1f2:v2\x1e')
+    expect(canonicalizeFields([['k', 'v']], 'v2').startsWith('_canon\x1f2:v2\x1e')).toBe(true)
+    // omitting the arg must keep producing the current default — no behavior shift
+    expect(canonicalizeFields([['k', 'v']])).toBe(
+      canonicalizeFields([['k', 'v']], CANONICAL_VERSION),
+    )
+  })
+
   it('throws if a caller supplies "_canon" — reserved-key guard prevents hash collision', () => {
     expect(() => canonicalizeFields([['_canon', 'spoofed']])).toThrow(/reserved key/)
     expect(() =>

--- a/packages/shared/src/lib/consent-canonical.test.ts
+++ b/packages/shared/src/lib/consent-canonical.test.ts
@@ -22,6 +22,16 @@ describe('canonicalizeFields', () => {
       canonicalizeFields([['k', 'v']]).startsWith(`_canon\x1f2:${CANONICAL_VERSION}\x1e`),
     ).toBe(true)
   })
+
+  it('throws if a caller supplies "_canon" — reserved-key guard prevents hash collision', () => {
+    expect(() => canonicalizeFields([['_canon', 'spoofed']])).toThrow(/reserved key/)
+    expect(() =>
+      canonicalizeFields([
+        ['safe', 'v'],
+        ['_canon', 'v1'],
+      ]),
+    ).toThrow(/reserved key/)
+  })
 })
 
 describe('computeContentHash', () => {

--- a/packages/shared/src/lib/consent-canonical.test.ts
+++ b/packages/shared/src/lib/consent-canonical.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { canonicalizeFields, computeContentHash } from './consent-canonical'
+import { CANONICAL_VERSION, canonicalizeFields, computeContentHash } from './consent-canonical'
 
 describe('canonicalizeFields', () => {
-  it('is order-stable and unambiguous (length-prefixed)', () => {
+  it('is order-stable and unambiguous (length-prefixed) with the version tag bound in', () => {
     expect(
       canonicalizeFields([
         ['a', 'x'],
         ['b', null],
       ]),
-    ).toBe('a\x1f1:x\x1eb\x1fN:\x1e')
+    ).toBe('_canon\x1f2:v1\x1ea\x1f1:x\x1eb\x1fN:\x1e')
   })
 
   it('distinguishes null from the empty string', () => {
     expect(canonicalizeFields([['x', null]])).not.toBe(canonicalizeFields([['x', '']]))
+  })
+
+  it('binds CANONICAL_VERSION into every output — no caller can opt out', () => {
+    expect(CANONICAL_VERSION).toBe('v1')
+    expect(canonicalizeFields([])).toBe(`_canon\x1f2:${CANONICAL_VERSION}\x1e`)
+    expect(
+      canonicalizeFields([['k', 'v']]).startsWith(`_canon\x1f2:${CANONICAL_VERSION}\x1e`),
+    ).toBe(true)
   })
 })
 

--- a/packages/shared/src/lib/consent-canonical.ts
+++ b/packages/shared/src/lib/consent-canonical.ts
@@ -4,15 +4,26 @@ const FIELD_SEP = '\x1e'
 const KV_SEP = '\x1f'
 
 /**
+ * Version tag bound INTO every canonical serialization. Any future field
+ * reordering, addition, or semantics change MUST bump this so verifiers can
+ * dispatch by version (#1050). Without the tag, a v1 row would silently fail
+ * verification under a v2 codec, with no way to tell which side was wrong.
+ * The tag rides as the first KV pair so it's literally in the signed bytes.
+ */
+export const CANONICAL_VERSION = 'v1'
+
+/**
  * Deterministic, injection-proof serialization of an ordered field list.
  * Length-prefixing each value removes any delimiter ambiguity (spec §5).
+ * `_canon:v1` is prepended internally so every caller (signing + content
+ * hashing) is automatically version-tagged — there is no way to opt out.
  */
 export function canonicalizeFields(
   fields: ReadonlyArray<readonly [string, string | null]>,
 ): string {
   // `N:` marks null distinctly from the empty string (`0:`); a real value always
   // starts with a digit, so the null marker can never collide with one.
-  return fields
+  return [['_canon', CANONICAL_VERSION] as const, ...fields]
     .map(([k, v]) => `${k}${KV_SEP}${v === null ? 'N:' : `${byteLen(v)}:${v}`}${FIELD_SEP}`)
     .join('')
 }

--- a/packages/shared/src/lib/consent-canonical.ts
+++ b/packages/shared/src/lib/consent-canonical.ts
@@ -21,6 +21,13 @@ export const CANONICAL_VERSION = 'v1'
 export function canonicalizeFields(
   fields: ReadonlyArray<readonly [string, string | null]>,
 ): string {
+  // `_canon` is reserved for the version tag; a caller-supplied field with
+  // the same key would emit two `_canon` pairs and yield two valid pre-images
+  // for the same hash. Today's call sites use static literals — this guard
+  // protects future generic callers from a silent crypto regression.
+  for (const [k] of fields) {
+    if (k === '_canon') throw new Error('canonicalizeFields: "_canon" is a reserved key')
+  }
   // `N:` marks null distinctly from the empty string (`0:`); a real value always
   // starts with a digit, so the null marker can never collide with one.
   return [['_canon', CANONICAL_VERSION] as const, ...fields]

--- a/packages/shared/src/lib/consent-canonical.ts
+++ b/packages/shared/src/lib/consent-canonical.ts
@@ -15,11 +15,15 @@ export const CANONICAL_VERSION = 'v1'
 /**
  * Deterministic, injection-proof serialization of an ordered field list.
  * Length-prefixing each value removes any delimiter ambiguity (spec §5).
- * `_canon:v1` is prepended internally so every caller (signing + content
- * hashing) is automatically version-tagged — there is no way to opt out.
+ * `_canon:<version>` is prepended internally so every caller (signing +
+ * content hashing) is automatically version-tagged — there is no way to opt
+ * out. The optional `version` argument exists so a future v2 verifier can
+ * re-canonicalize old rows under their original tag for byte-identical
+ * comparison; production call sites must omit it and ride the default.
  */
 export function canonicalizeFields(
   fields: ReadonlyArray<readonly [string, string | null]>,
+  version: string = CANONICAL_VERSION,
 ): string {
   // `_canon` is reserved for the version tag; a caller-supplied field with
   // the same key would emit two `_canon` pairs and yield two valid pre-images
@@ -30,7 +34,7 @@ export function canonicalizeFields(
   }
   // `N:` marks null distinctly from the empty string (`0:`); a real value always
   // starts with a digit, so the null marker can never collide with one.
-  return [['_canon', CANONICAL_VERSION] as const, ...fields]
+  return [['_canon', version] as const, ...fields]
     .map(([k, v]) => `${k}${KV_SEP}${v === null ? 'N:' : `${byteLen(v)}:${v}`}${FIELD_SEP}`)
     .join('')
 }


### PR DESCRIPTION
## Summary

Tier-3 follow-up from the #1031 consent Phase-1 maintainability review (siblings: #1048 → PR #1052 merged; #1049 → PR #1053 awaiting merge). Two surgical changes inside `packages/shared/src/lib/consent-canonical.ts` and its tests:

- **Version-tag the canonical serialization.** `canonicalizeFields` now prepends `_canon\x1f2:v1\x1e` as the first KV pair, binding `CANONICAL_VERSION = 'v1'` *into the signed bytes* for every consent signature and every `DisclosureArtifact` contentHash. No caller can opt out; the tag is applied internally. A future canonical-rules change (field order, separators, null encoding, normalization) MUST bump the tag so a verifier can dispatch by version — without it, a v1 row would silently fail under a v2 codec with no way to tell which side is wrong.
- **i18n drift guard.** New parametric test in `consent-documents.test.ts` reads `packages/web/messages/{en,ja,zh}.json` and asserts the `RENTER_LIABILITY` seed `body`/`acceptanceLabel` byte-equals `reservation.disclaimer.{terms,label}` per locale. A translator-led edit to the live UI text that doesn't re-touch the seed now fails CI instead of silently breaking the §5.1 "what was shown is what was hashed" promise.

## Invalidation note (HITL)

**Any pre-existing `consent_records` signature OR `consent_documents` contentHash written before this commit verifies against the un-tagged bytes and will fail verification under v1.** Consent Phase 1 (#1031) and Phase 2 (#877 Flow A, PR #1044) both shipped *today*, so the live row count is ~0; if any exist they must be re-signed/re-hashed before this lands. A future v2 codec swap MUST ship with a backfill plan and a verifier that dispatches by tag.

## Test plan

- [x] `bun run --filter '@kuruma/shared' test` — 710 passed (added: `CANONICAL_VERSION` binding test + parametric i18n parity test × 3 locales)
- [x] `env -u DATABASE_URL bun run --filter '@kuruma/api' test` — 1847 passed (consent + booking + booking-consent-gate suites unchanged, signatures/hashes recompute through the function so they self-correct)
- [x] `bun run --filter '@kuruma/shared' typecheck` + `bun run --filter '@kuruma/api' typecheck` — both clean
- [x] `bun run lint` (biome + lint:size + lint:modules) — clean

Closes #1050
Refs #877 #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)