### PR TITLE
fix(#1056): correlate refund webhook against our receipt before confirming REFUNDED

### DIFF
--- a/packages/api/src/services/payment/payment-gateway.ts
+++ b/packages/api/src/services/payment/payment-gateway.ts
@@ -55,6 +55,10 @@ export interface VerifiedPaymentEvent {
    *  `requires_action`) when this is a refund event (`refund.updated`), else null.
    *  The webhook confirms a booking REFUNDED only on `succeeded` (#851). */
   refundStatus: string | null
+  /** Stripe Refund id (`re_…`) on a `refund.updated` event, else null. The webhook
+   *  confirms a booking REFUNDED only when this equals the receipt we recorded — a
+   *  valid signature proves the event is Stripe's, not that the refund is ours (#1056). */
+  refundId: string | null
   /** Metadata we set at session creation. operatorId is ignored on the webhook.
    *  `| undefined` (not just `?`) because a tampered/legacy session may omit a key
    *  under exactOptionalPropertyTypes. */

--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -95,6 +95,7 @@ function completedEvent(overrides: Partial<VerifiedPaymentEvent> = {}): Verified
     currency: 'jpy',
     paymentStatus: 'paid',
     refundStatus: null,
+    refundId: null,
     metadata: { bookingId: 'bk-1', operatorId: 'spoofed-operator' },
     ...overrides,
   }
@@ -113,6 +114,7 @@ function refundEvent(overrides: Partial<VerifiedPaymentEvent> = {}): VerifiedPay
     currency: 'jpy',
     paymentStatus: null,
     refundStatus: 'succeeded',
+    refundId: 're_1',
     metadata: { bookingId: 'bk-1' },
     ...overrides,
   }
@@ -485,6 +487,37 @@ describe('PaymentService.handleWebhook — refund confirmation (#851)', () => {
     expect(second).toEqual({ status: 200, outcome: 'refund_confirmed' })
     expect((await refundRepo.findByBookingId('bk-1'))?.status).toBe('SUCCEEDED')
     expect(await settlement()).toBe('REFUNDED')
+  })
+
+  it('ignores a succeeded refund whose id does not match our receipt — a foreign/partial refund cannot flip the booking (#1056)', async () => {
+    // An operator issues a manual/partial Stripe refund tagged with our bookingId; it
+    // carries a DIFFERENT re_ than the one we recorded. A valid signature proves the
+    // event is Stripe's — not that this refund is the one we owe.
+    gateway.nextEvent = refundEvent({ refundId: 're_foreign', checkoutSessionId: 're_foreign' })
+    expect(await service.handleWebhook('raw', 'sig')).toEqual({ status: 200, outcome: 'ignored' })
+    expect((await refundRepo.findByBookingId('bk-1'))?.status).toBe('PENDING')
+    expect(await settlement()).toBe('REFUND_DUE')
+  })
+
+  it('ignores a succeeded refund when no receipt has been claimed yet — the eager/reconciler path owns confirmation (#1056)', async () => {
+    // Webhook beats the eager claim: there is no receipt to correlate against, so the
+    // booking must NOT be flipped here; the path that creates the receipt confirms it.
+    const fresh = new InMemoryPaymentRefundRepository()
+    const noReceiptService = new PaymentService(
+      new InMemoryPaymentEventRepository(),
+      fresh,
+      bookingRepo,
+      gateway,
+      new InMemoryPaymentAnomalyRepository(),
+      { webBaseUrl: WEB_BASE },
+    )
+    gateway.nextEvent = refundEvent()
+    expect(await noReceiptService.handleWebhook('raw', 'sig')).toEqual({
+      status: 200,
+      outcome: 'ignored',
+    })
+    expect(await fresh.findByBookingId('bk-1')).toBeNull()
+    expect(await settlement()).toBe('REFUND_DUE')
   })
 })
 

--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -519,6 +519,38 @@ describe('PaymentService.handleWebhook — refund confirmation (#851)', () => {
     expect(await fresh.findByBookingId('bk-1')).toBeNull()
     expect(await settlement()).toBe('REFUND_DUE')
   })
+
+  it('ignores a succeeded refund when both ids are null — null !== null is false, the reconciler owns confirmation (#1059 review HIGH)', async () => {
+    // A receipt claimed BEFORE the re_ was attached (pre-PR row, or a webhook race) has
+    // `stripeRefundId: null`. A `refund.updated` body lacking `obj.id` (Stripe API drift,
+    // replay tooling) parses to `event.refundId: null`. Without the explicit null guard,
+    // `receipt.stripeRefundId !== event.refundId` is `null !== null` → false → the
+    // booking would silently flip REFUNDED on an unverifiable refund — exactly the
+    // surface this PR was opened to close.
+    const fresh = new InMemoryPaymentRefundRepository()
+    const noAttachService = new PaymentService(
+      new InMemoryPaymentEventRepository(),
+      fresh,
+      bookingRepo,
+      gateway,
+      new InMemoryPaymentAnomalyRepository(),
+      { webBaseUrl: WEB_BASE },
+    )
+    // Claim WITHOUT attachStripeRefund → receipt.stripeRefundId stays null.
+    await fresh.claim({
+      bookingId: 'bk-1',
+      operatorId: 'op-1',
+      stripePaymentIntentId: 'pi_1',
+      amountJpy: 70_000,
+    })
+    gateway.nextEvent = refundEvent({ refundId: null })
+    expect(await noAttachService.handleWebhook('raw', 'sig')).toEqual({
+      status: 200,
+      outcome: 'ignored',
+    })
+    expect((await fresh.findByBookingId('bk-1'))?.status).toBe('PENDING')
+    expect(await settlement()).toBe('REFUND_DUE')
+  })
 })
 
 describe('PaymentService.getBookingPaymentStatus', () => {

--- a/packages/api/src/services/payment/payment.ts
+++ b/packages/api/src/services/payment/payment.ts
@@ -249,6 +249,16 @@ export class PaymentService {
     if (!bookingId) return { status: 200, outcome: 'ignored' }
     const booking = await this.bookings.findById(SYSTEM_CONTEXT, bookingId)
     if (!booking) return { status: 200, outcome: 'ignored' }
+    // Confirm ONLY the refund we recorded (#1056). A valid signature proves the event
+    // is Stripe's, not that this refund is the one we owe: a partial/foreign refund
+    // tagged with our bookingId carries a different re_ and must not flip the booking
+    // REFUNDED. Correlate against the receipt the eager/reconciler path wrote — which
+    // also owns receipt creation, so a webhook that raced ahead of the claim (no
+    // receipt, or one without our re_ yet) is a safe no-op the pull path finishes.
+    const receipt = await this.paymentRefunds.findByBookingId(bookingId)
+    if (!receipt || receipt.stripeRefundId !== event.refundId) {
+      return { status: 200, outcome: 'ignored' }
+    }
     await this.confirmRefundSucceeded(bookingId)
     return { status: 200, outcome: 'refund_confirmed' }
   }

--- a/packages/api/src/services/payment/payment.ts
+++ b/packages/api/src/services/payment/payment.ts
@@ -255,8 +255,16 @@ export class PaymentService {
     // REFUNDED. Correlate against the receipt the eager/reconciler path wrote — which
     // also owns receipt creation, so a webhook that raced ahead of the claim (no
     // receipt, or one without our re_ yet) is a safe no-op the pull path finishes.
+    // Both sides are nullable, so explicitly reject either being null BEFORE `!==` —
+    // otherwise `null !== null` is false and a legacy receipt + id-less event would
+    // silently pass the guard, defeating the whole correlation (#1059 review HIGH).
     const receipt = await this.paymentRefunds.findByBookingId(bookingId)
-    if (!receipt || receipt.stripeRefundId !== event.refundId) {
+    if (
+      !receipt ||
+      !receipt.stripeRefundId ||
+      !event.refundId ||
+      receipt.stripeRefundId !== event.refundId
+    ) {
       return { status: 200, outcome: 'ignored' }
     }
     await this.confirmRefundSucceeded(bookingId)

--- a/packages/api/src/services/payment/stripe-payment-gateway.ts
+++ b/packages/api/src/services/payment/stripe-payment-gateway.ts
@@ -117,6 +117,7 @@ export class StripePaymentGateway implements PaymentGateway {
       currency: obj.currency ?? null,
       paymentStatus: obj.payment_status ?? null,
       refundStatus: obj.status ?? null,
+      refundId: event.type === 'refund.updated' ? (obj.id ?? null) : null,
       metadata: {
         bookingId: obj.metadata?.bookingId,
         operatorId: obj.metadata?.operatorId,

--- a/packages/api/tests/integration/payment-refund-confirm.test.ts
+++ b/packages/api/tests/integration/payment-refund-confirm.test.ts
@@ -85,6 +85,10 @@ function refundEvent(bookingId: string, status: string): VerifiedPaymentEvent {
     currency: 'jpy',
     paymentStatus: null,
     refundStatus: status,
+    // The gateway surfaces the Refund id (`re_…`) on refund.updated; the webhook
+    // confirms only when it equals the receipt's recorded re_ (#1056). arm() attaches
+    // this same re_, so a legit event correlates and a foreign re_ would not.
+    refundId: `re_${bookingId}`,
     metadata: { bookingId },
   }
 }


### PR DESCRIPTION
## What
`handleRefundWebhook` flipped a booking `REFUND_DUE → REFUNDED` on `metadata.bookingId` + `refundStatus === 'succeeded'` **alone**, never checking the event's refund matched the `re_` we recorded. Found in a post-merge review of #1040 (auto-refund), before the develop→beta promotion. **Closes #1056.**

## Why it matters
A valid signature proves the event is from Stripe, not that the refund is the one we owe. A partial/foreign refund tagged with our `bookingId` (e.g. an operator's manual Stripe refund) could mark a booking **fully REFUNDED while less was returned** — and the reconciler excludes the now-terminal receipt, so it never self-corrects. The pull/adopt path already correlates (amount + bookingId + PI); only the webhook **push** path skipped it.

## Fix
- Surface the Refund id on `VerifiedPaymentEvent` (`refundId`, from `obj.id` on `refund.updated`) — previously the refund amount was dropped (`amount_total` is null for a Refund) and the id only rode implicitly in `checkoutSessionId`.
- Gate confirmation: `if (!receipt || receipt.stripeRefundId !== event.refundId) return ignored`. The `re_` is a unique, immutable-amount key, so id-correlation is conclusive (no redundant amount check — YAGNI). A webhook that raced ahead of the eager claim (no receipt / re_ not attached yet) is a **safe no-op** the eager/reconciler pull path finishes.

## Test plan
- [x] +2 mutation-resistant unit tests: mismatched `re_` → `ignored`, receipt stays `PENDING`, booking stays `REFUND_DUE`; no-receipt → `ignored`.
- [x] api unit suite: **1849 pass**; `tsc` + biome + boundary/size lints green (pre-commit).
- [ ] **CI `e2e-real-db`**: confirm `payment-refund-confirm.test.ts` still passes — its happy-path event must carry the same `re_` the setup attaches (it does: `re_1`), but verify.

## Scope note
Fixes the **HIGH** from the #1056 review. The MEDIUM (DB `CHECK amountJpy >= 0`) and LOWs (doc wording, eager-path comment) are left as follow-ups in #1056.

Refs #851 #1040