### PR TITLE
fix(#1056): gate updateStatus eager refund on the committed settlement

### DIFF
--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -334,8 +334,10 @@ export class BookingLifecycleService {
     // (ACTIVE/COMPLETED). Unlisted transitions map to undefined → no email.
     const trigger = STATUS_TRIGGER[newStatus]
     if (trigger) await this.postCommit?.run(ctx, updated, trigger)
-    // Eager refund (#851), best-effort: operator fault → the full total, fee-free.
-    if (owesRefund) {
+    // Eager refund (#851), best-effort. Gate on the COMMITTED settlement, not the pre-tx
+    // `owesRefund` (#1056): if the in-tx REFUND_DUE write no-op'd, firing would refund a
+    // booking the reconciler can't see. Mirrors cancel()'s settlement === 'REFUND_DUE' gate.
+    if (updated.cancellationFeeSettlement === 'REFUND_DUE') {
       await this.fireEagerRefund(updated, booking.totalPrice ?? 0)
     }
     return { ok: true, booking: updated }

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -2042,4 +2042,32 @@ describe('BookingService cancel/updateStatus — refund settlement + eager fire 
     expect(h.bookingStore.get(booking.id)?.cancellationFeeSettlement).toBe('REFUND_DUE')
     expect(refunds.initiateCalls).toHaveLength(1)
   })
+
+  // #1056 follow-up — the eager fire must key off the COMMITTED settlement, not the
+  // pre-tx `owesRefund`. If the in-tx REFUND_DUE write no-ops (booking wasn't ADVISORY),
+  // the status still flips to CANCELLED but nothing is owed via this path, so Stripe must
+  // NOT be touched (else a refund is issued for a booking the reconciler can't see — it
+  // isn't REFUND_DUE). Pre-seeding a non-ADVISORY settlement exercises the otherwise-
+  // unreachable no-op branch.
+  it('operator cancel does NOT eager-fire when the REFUND_DUE commit no-ops (settlement already non-ADVISORY)', async () => {
+    const refunds = new FakeRefundCoordinator()
+    refunds.paid = true
+    const h = await setup({ codes: ['NOOPGATE'], refundInitiator: refunds })
+    const booking = await lowTier(h)
+    await h.service.updateStatus(opCtxA, booking.id, 'ACTIVE')
+    // Force the guarded REFUND_DUE write to no-op: the booking is no longer ADVISORY.
+    const seeded = h.bookingStore.get(booking.id)
+    if (!seeded) throw new Error('seed missing')
+    h.bookingStore.set(booking.id, { ...seeded, cancellationFeeSettlement: 'CAPTURED' })
+
+    const res = await h.service.updateStatus(opCtxA, booking.id, 'CANCELLED')
+
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    // Status still transitions; settlement stays CAPTURED (the REFUND_DUE write no-op'd).
+    expect(res.booking.status).toBe('CANCELLED')
+    expect(res.booking.cancellationFeeSettlement).toBe('CAPTURED')
+    // The eager refund must NOT fire — nothing was committed REFUND_DUE for this path.
+    expect(refunds.initiateCalls).toEqual([])
+  })
 })


### PR DESCRIPTION
## What
Found during a maintainability sweep of the #851 eager-fire path (the half **not** covered by #1056's webhook-correlation scope).

`BookingLifecycleService.updateStatus` (operator cancel) computed `owesRefund` **before** the tx and keyed the post-commit eager refund off it — **not** the committed projection. Inside the tx, the guarded `markCancellationSettlement(from:'ADVISORY' → 'REFUND_DUE')` can no-op (returns `undefined`) while the status write still commits. Result:

- booking is `CANCELLED` but **not** `REFUND_DUE`, yet `fireEagerRefund` still ran →
- a receipt is claimed + the refund issued, then `confirmBookingRefunded(from:'REFUND_DUE')` no-ops →
- **SUCCEEDED receipt, booking stuck not-REFUNDED, and the reconciler never re-drives it** (it isn't `REFUND_DUE`).

Contrast `cancel()` (renter path): its tx writes settlement unconditionally via `repo.cancel(settlement)`, atomic with its eager trigger. `updateStatus` used a separate guarded write that can independently no-op — that asymmetry was the fragility.

## Severity
**Medium, latent.** Unreachable today (a fresh CONFIRMED/ACTIVE booking is always `ADVISORY`, so the guard always matches). But a future transition-map change that lets a non-ADVISORY booking reach `→ CANCELLED` re-opens it silently.

## Fix
Gate the eager fire on the **committed** projection — `updated.cancellationFeeSettlement === 'REFUND_DUE'` — mirroring `cancel()`. One-line change; removes the dual source of truth. `owesRefund` still drives the in-tx settlement write.

## Test
Regression test forces the otherwise-unreachable no-op branch by pre-seeding a non-ADVISORY settlement, then asserts the eager refund does **not** fire (RED before the fix: issued a spurious ¥20000 refund; GREEN after).

## Verification
- api unit lane: **163 files / 1851 tests pass** (`env -u DATABASE_URL`)
- `#851 Slice 3` settlement block: 7/7 green (6 existing + new)
- tsc code 0 · lint:boundaries OK · biome clean · lint:size pass (pre-existing warn only)

Refs #1056 #851