### PR TITLE
refactor(email): DRY up template renderers — shared table/list/CTA fragments

### DIFF
--- a/packages/api/src/services/email/templates/layout.ts
+++ b/packages/api/src/services/email/templates/layout.ts
@@ -1,6 +1,7 @@
-// Shared layout for the simple lifecycle emails (#664): a heading followed by a
-// labeled-rows table. Keeps the substitution / cancellation / status-update
-// renderers to just their row data — the html/text boilerplate lives here once.
+// Shared layout primitives for the #664 lifecycle emails. The simple templates
+// (substitution / cancellation / status-update) use the whole-body `renderRowsEmail`;
+// the richer ones (renter-confirmation / operator-alert) compose the smaller
+// fragments below. Either way the html/text markup lives here once, not per template.
 import { escapeHtml } from './format'
 
 export interface RenderedBody {
@@ -18,12 +19,46 @@ export function vehicleLabel(v: { name: string; licensePlate: string | null }): 
   return v.licensePlate ? `${v.name} (${v.licensePlate})` : v.name
 }
 
-/** A heading paragraph + a two-column table of [label, value] rows. */
-export function renderRowsEmail(heading: string, rows: Array<[string, string]>): RenderedBody {
+/** Bare two-column table of [label, value] rows — no heading. The shared row
+ *  markup, so the rich templates never re-spell `<tr><td><strong>…`. */
+export function renderRowsTable(rows: Array<[string, string]>): RenderedBody {
   const htmlRows = rows
     .map(([l, v]) => `<tr><td><strong>${escapeHtml(l)}</strong></td><td>${escapeHtml(v)}</td></tr>`)
     .join('')
-  const html = `<p>${escapeHtml(heading)}</p><table>${htmlRows}</table>`
-  const text = `${heading}\n\n${rows.map(([l, v]) => `${l}: ${v}`).join('\n')}`
-  return { html, text }
+  return {
+    html: `<table>${htmlRows}</table>`,
+    text: rows.map(([l, v]) => `${l}: ${v}`).join('\n'),
+  }
+}
+
+/** A heading paragraph + a two-column table of [label, value] rows. */
+export function renderRowsEmail(heading: string, rows: Array<[string, string]>): RenderedBody {
+  const table = renderRowsTable(rows)
+  return {
+    html: `<p>${escapeHtml(heading)}</p>${table.html}`,
+    text: `${heading}\n\n${table.text}`,
+  }
+}
+
+/** An optional `<h3>` + bullet-list section (e.g. fees, add-ons). Renders to
+ *  empty html/text when there are no lines, so callers append it unconditionally. */
+export function renderListSection(title: string, lines: string[]): RenderedBody {
+  if (lines.length === 0) return { html: '', text: '' }
+  const html = `<h3>${escapeHtml(title)}</h3><ul>${lines.map((l) => `<li>${escapeHtml(l)}</li>`).join('')}</ul>`
+  return { html, text: `\n\n${title}\n${lines.join('\n')}` }
+}
+
+/** An `<h3>` + optional explanatory paragraph + a linked call-to-action button
+ *  (e.g. pre-auth handoff, manage-booking deep link). The URL is escaped for the
+ *  `href` attribute; callers gate on URL presence before calling. */
+export function renderCtaSection(
+  title: string,
+  url: string,
+  cta: string,
+  explain?: string,
+): RenderedBody {
+  const explainHtml = explain ? `<p>${escapeHtml(explain)}</p>` : ''
+  const html = `<h3>${escapeHtml(title)}</h3>${explainHtml}<p><a href="${escapeHtml(url)}">${escapeHtml(cta)}</a></p>`
+  const explainText = explain ? `\n${explain}` : ''
+  return { html, text: `\n\n${title}${explainText}\n${cta}: ${url}` }
 }

--- a/packages/api/src/services/email/templates/operator-alert.ts
+++ b/packages/api/src/services/email/templates/operator-alert.ts
@@ -1,6 +1,12 @@
 import type { AddOnSnapshot, BookingSource } from '@kuruma/shared/db/schema'
 import { escapeHtml, formatDateTime, formatDuration, formatJpy } from './format'
-import { type RenderedEmail, vehicleLabel } from './layout'
+import {
+  type RenderedEmail,
+  renderCtaSection,
+  renderListSection,
+  renderRowsTable,
+  vehicleLabel,
+} from './layout'
 import { emailStrings } from './messages'
 
 export interface OperatorAlertData {
@@ -56,23 +62,15 @@ export function renderOperatorAlert(data: OperatorAlertData, locale: string): Re
 
   const subject = `${m.operatorSubject} ${data.bookingCode}`
 
-  const htmlRows = rows
-    .map(([l, v]) => `<tr><td><strong>${escapeHtml(l)}</strong></td><td>${escapeHtml(v)}</td></tr>`)
-    .join('')
-  const htmlAddOns = addOnLines.length
-    ? `<h3>${escapeHtml(m.addOnsLabel)}</h3><ul>${addOnLines.map((a) => `<li>${escapeHtml(a)}</li>`).join('')}</ul>`
-    : ''
-  const htmlCta = data.manageBookingUrl
-    ? `<h3>${escapeHtml(m.manageBookingTitle)}</h3><p><a href="${escapeHtml(data.manageBookingUrl)}">${escapeHtml(m.manageBookingCta)}</a></p>`
-    : ''
-  const html = `<p>${escapeHtml(m.operatorHeading)}</p><table>${htmlRows}</table>${htmlAddOns}${htmlCta}`
+  // Order: heading, details table, add-on list, manage-booking CTA.
+  const table = renderRowsTable(rows)
+  const addOns = renderListSection(m.addOnsLabel, addOnLines)
+  const cta = data.manageBookingUrl
+    ? renderCtaSection(m.manageBookingTitle, data.manageBookingUrl, m.manageBookingCta)
+    : { html: '', text: '' }
 
-  const textRows = rows.map(([l, v]) => `${l}: ${v}`).join('\n')
-  const textAddOns = addOnLines.length ? `\n\n${m.addOnsLabel}\n${addOnLines.join('\n')}` : ''
-  const textCta = data.manageBookingUrl
-    ? `\n\n${m.manageBookingTitle}\n${m.manageBookingCta}: ${data.manageBookingUrl}`
-    : ''
-  const text = `${m.operatorHeading}\n\n${textRows}${textAddOns}${textCta}`
+  const html = `<p>${escapeHtml(m.operatorHeading)}</p>${table.html}${addOns.html}${cta.html}`
+  const text = `${m.operatorHeading}\n\n${table.text}${addOns.text}${cta.text}`
 
   return { subject, html, text }
 }

--- a/packages/api/src/services/email/templates/renter-confirmation.ts
+++ b/packages/api/src/services/email/templates/renter-confirmation.ts
@@ -1,6 +1,12 @@
 import type { FeeSnapshotItem } from '@kuruma/shared/db/schema'
 import { escapeHtml, formatDateTime, formatJpy } from './format'
-import { type RenderedEmail, vehicleLabel } from './layout'
+import {
+  type RenderedEmail,
+  renderCtaSection,
+  renderListSection,
+  renderRowsTable,
+  vehicleLabel,
+} from './layout'
 import { emailStrings } from './messages'
 
 export interface RenterConfirmationData {
@@ -48,23 +54,15 @@ export function renderRenterConfirmation(
 
   const subject = `${m.renterSubject} ${data.bookingCode}`
 
-  const htmlRows = rows
-    .map(([l, v]) => `<tr><td><strong>${escapeHtml(l)}</strong></td><td>${escapeHtml(v)}</td></tr>`)
-    .join('')
-  const htmlFees = feeLines.length
-    ? `<h3>${escapeHtml(m.potentialChargesTitle)}</h3><ul>${feeLines.map((f) => `<li>${escapeHtml(f)}</li>`).join('')}</ul>`
-    : ''
-  const htmlPreAuth = data.preAuthHandoffUrl
-    ? `<h3>${escapeHtml(m.preAuthTitle)}</h3><p>${escapeHtml(m.preAuthExplain)}</p><p><a href="${escapeHtml(data.preAuthHandoffUrl)}">${escapeHtml(m.preAuthCta)}</a></p>`
-    : ''
-  const html = `<p>${escapeHtml(m.renterGreeting)}</p><table>${htmlRows}</table>${htmlPreAuth}${htmlFees}<p>${escapeHtml(m.cancellationContact)}</p>`
+  // Order: greeting, details table, pre-auth CTA, fee list, cancellation footer.
+  const table = renderRowsTable(rows)
+  const preAuth = data.preAuthHandoffUrl
+    ? renderCtaSection(m.preAuthTitle, data.preAuthHandoffUrl, m.preAuthCta, m.preAuthExplain)
+    : { html: '', text: '' }
+  const fees = renderListSection(m.potentialChargesTitle, feeLines)
 
-  const textRows = rows.map(([l, v]) => `${l}: ${v}`).join('\n')
-  const textFees = feeLines.length ? `\n\n${m.potentialChargesTitle}\n${feeLines.join('\n')}` : ''
-  const textPreAuth = data.preAuthHandoffUrl
-    ? `\n\n${m.preAuthTitle}\n${m.preAuthExplain}\n${m.preAuthCta}: ${data.preAuthHandoffUrl}`
-    : ''
-  const text = `${m.renterGreeting}\n\n${textRows}${textPreAuth}${textFees}\n\n${m.cancellationContact}`
+  const html = `<p>${escapeHtml(m.renterGreeting)}</p>${table.html}${preAuth.html}${fees.html}<p>${escapeHtml(m.cancellationContact)}</p>`
+  const text = `${m.renterGreeting}\n\n${table.text}${preAuth.text}${fees.text}\n\n${m.cancellationContact}`
 
   return { subject, html, text }
 }


### PR DESCRIPTION
Closes #1060

## What

`renter-confirmation.ts` and `operator-alert.ts` each hand-rolled the rows-table markup that `layout.ts:renderRowsEmail` already owned, plus near-identical list-section (fees / add-ons) and CTA-section (pre-auth / manage-booking) HTML+text. A change to email row/section markup needed editing in 3 places.

Extract three pure fragment helpers into `layout.ts`:

- `renderRowsTable(rows)` — bare table fragment; `renderRowsEmail` now composes it
- `renderListSection(title, lines)` — optional `<h3>` + bullet list (empty html/text when no lines)
- `renderCtaSection(title, url, cta, explain?)` — `<h3>` + optional explain paragraph + linked button

The two rich renderers now compose these instead of re-spelling the markup.

## Safety

- **Byte-identical output** — verified by rendering 9 section-branches × 4 locales (en/ja/zh/fr) before and after the change and diffing: no diff. Escaping is unchanged (every interpolated value still passes through `escapeHtml`, including the CTA `href`).
- Pure FC/IS core; no behaviour, API, or DB change.
- Scope: only `templates/{layout,renter-confirmation,operator-alert}.ts`.

## Verification

- `bun run --filter @kuruma/api test` → 1850 passed (incl. `templates.test.ts`)
- `tsc --noEmit` clean · `lint:boundaries` OK · biome clean · file-size OK
- code-reviewer agent: clean ship, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)