### PR TITLE
fix(#1055): verify Google id_token (sig/aud/iss/exp + nonce), drop /userinfo trust

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@kuruma/shared": "workspace:*",
         "@sentry/cloudflare": "^10.57.0",
         "hono": "^4",
+        "jose": "^6.0.6",
         "nanoid": "^5.1.11",
         "stripe": "^22.2.0",
       },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
     "@kuruma/shared": "workspace:*",
     "@sentry/cloudflare": "^10.57.0",
     "hono": "^4",
+    "jose": "^6.0.6",
     "nanoid": "^5.1.11",
     "stripe": "^22.2.0"
   },

--- a/packages/api/src/auth/fetch-google-oauth-provider.ts
+++ b/packages/api/src/auth/fetch-google-oauth-provider.ts
@@ -1,18 +1,26 @@
 // Concrete GoogleOAuthProvider over global fetch (CF Workers + Node). Thin HTTP
 // boundary, deliberately NOT unit-tested — the manual round-trip (#378 Phase 2d)
-// is the real proof; a fetch mock would only restate this file. Constructed in
-// index.ts (composition root); the route depends on the GoogleOAuthProvider port.
+// is the real proof; a fetch mock would only restate this file. The id_token
+// verification LOGIC it delegates to lives in `verifyGoogleIdToken`, which IS unit
+// tested (#1055). Constructed in the composition root; the route depends on the port.
 
+import { createRemoteJWKSet } from 'jose'
 import {
+  GOOGLE_JWKS_ENDPOINT,
   GOOGLE_TOKEN_ENDPOINT,
-  GOOGLE_USERINFO_ENDPOINT,
   type GoogleOAuthConfig,
   type GoogleOAuthProvider,
   type GoogleProfile,
+  verifyGoogleIdToken,
 } from './google'
 
+// Google's JWKS resolver. createRemoteJWKSet caches keys per isolate with a cooldown
+// and only fetches on first verify (no module-scope I/O), so it's safe to build once
+// and reuse — mirroring the lazy-singleton rule for backing services on Workers.
+const googleJwks = createRemoteJWKSet(new URL(GOOGLE_JWKS_ENDPOINT))
+
 export class FetchGoogleOAuthProvider implements GoogleOAuthProvider {
-  async exchangeCode(code: string, config: GoogleOAuthConfig): Promise<{ accessToken: string }> {
+  async exchangeCode(code: string, config: GoogleOAuthConfig): Promise<{ idToken: string }> {
     const res = await fetch(GOOGLE_TOKEN_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -25,31 +33,12 @@ export class FetchGoogleOAuthProvider implements GoogleOAuthProvider {
       }).toString(),
     })
     if (!res.ok) throw new Error(`Google token exchange failed (${res.status})`)
-    const data = (await res.json()) as { access_token?: string }
-    if (!data.access_token) throw new Error('Google token response missing access_token')
-    return { accessToken: data.access_token }
+    const data = (await res.json()) as { id_token?: string }
+    if (!data.id_token) throw new Error('Google token response missing id_token')
+    return { idToken: data.id_token }
   }
 
-  async getUserInfo(accessToken: string): Promise<GoogleProfile> {
-    const res = await fetch(GOOGLE_USERINFO_ENDPOINT, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    })
-    if (!res.ok) throw new Error(`Google userinfo request failed (${res.status})`)
-    const p = (await res.json()) as {
-      sub?: string
-      email?: string
-      email_verified?: boolean
-      name?: string
-      picture?: string
-    }
-    if (!p.sub) throw new Error('Google userinfo response missing sub')
-    // exactOptionalPropertyTypes: omit optional keys rather than set undefined.
-    return {
-      sub: p.sub,
-      ...(p.email !== undefined ? { email: p.email } : {}),
-      ...(p.email_verified !== undefined ? { email_verified: p.email_verified } : {}),
-      ...(p.name !== undefined ? { name: p.name } : {}),
-      ...(p.picture !== undefined ? { picture: p.picture } : {}),
-    }
+  verifyIdToken(idToken: string, config: GoogleOAuthConfig, nonce: string): Promise<GoogleProfile> {
+    return verifyGoogleIdToken(idToken, googleJwks, { clientId: config.clientId, nonce })
   }
 }

--- a/packages/api/src/auth/google.ts
+++ b/packages/api/src/auth/google.ts
@@ -80,6 +80,9 @@ export async function verifyGoogleIdToken(
     algorithms: ['RS256'],
     issuer: [...GOOGLE_ISSUERS],
     audience: opts.clientId,
+    // Absorb small CF Worker ↔ Google clock drift so a valid login isn't spuriously
+    // rejected at the exp/iat boundary; 30s is well under any useful replay window.
+    clockTolerance: 30,
   })
   if (typeof payload.nonce !== 'string' || payload.nonce !== opts.nonce) {
     throw new Error('id_token nonce mismatch')

--- a/packages/api/src/auth/google.ts
+++ b/packages/api/src/auth/google.ts
@@ -3,10 +3,11 @@
 // directly rather than via @auth/core so the result is OUR kuruma_session
 // cookie (Phase 1) — one session system, not Auth.js's parallel one.
 
+import { jwtVerify } from 'jose'
 import type { UserRole } from '../middleware/auth'
 
-/** OpenID Connect profile we read from Google's userinfo endpoint. `sub` is the
- *  stable Google account id used as `accounts.providerAccountId`. */
+/** OpenID Connect profile read from the verified Google `id_token` (#1055). `sub`
+ *  is the stable Google account id used as `accounts.providerAccountId`. */
 export interface GoogleProfile {
   readonly sub: string
   readonly email?: string
@@ -24,10 +25,13 @@ export interface GoogleProfile {
  * TranslationProvider pattern (services/google-translation-provider.ts).
  */
 export interface GoogleOAuthProvider {
-  /** Exchange an authorization code for tokens at Google's token endpoint. */
-  exchangeCode(code: string, config: GoogleOAuthConfig): Promise<{ accessToken: string }>
-  /** Fetch the OIDC profile for an access token. */
-  getUserInfo(accessToken: string): Promise<GoogleProfile>
+  /** Exchange an authorization code for tokens at Google's token endpoint. Returns
+   *  the OIDC `id_token` — the signed identity assertion (#1055) — not the bearer
+   *  access token, which the callback no longer needs. */
+  exchangeCode(code: string, config: GoogleOAuthConfig): Promise<{ idToken: string }>
+  /** Verify the `id_token` (signature/iss/aud/exp + the per-flow `nonce`) and return
+   *  its profile claims. Replaces the unsigned `/userinfo` read (#1055). */
+  verifyIdToken(idToken: string, config: GoogleOAuthConfig, nonce: string): Promise<GoogleProfile>
 }
 
 /**
@@ -48,8 +52,52 @@ export interface GoogleAuthRuntime {
 
 export const GOOGLE_AUTHORIZE_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
 export const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
-export const GOOGLE_USERINFO_ENDPOINT = 'https://openidconnect.googleapis.com/v1/userinfo'
 export const GOOGLE_SCOPE = 'openid email profile'
+/** Google's OIDC JWKS — the signing keys an id_token is verified against (#1055). */
+export const GOOGLE_JWKS_ENDPOINT = 'https://www.googleapis.com/oauth2/v3/certs'
+/** Accepted `iss` values for a Google id_token (both forms Google emits). */
+export const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'] as const
+
+/**
+ * Verify a Google OIDC `id_token` and return its profile claims (#1055). `key`
+ * is jose's verification key — a JWKS resolver (`createRemoteJWKSet`) in prod, a
+ * local key in tests — so this stays I/O-agnostic and fully unit-testable.
+ *
+ * `jwtVerify` enforces the signature, `iss`, `aud === clientId`, and `exp`; we then
+ * bind the token to THIS flow via the `nonce` and require a `sub`. Any failure throws
+ * (the caller fails the sign-in closed), so identity rests on a signed, audience- and
+ * flow-bound token rather than an unsigned `/userinfo` read.
+ */
+export async function verifyGoogleIdToken(
+  idToken: string,
+  key: Parameters<typeof jwtVerify>[1],
+  opts: { clientId: string; nonce: string },
+): Promise<GoogleProfile> {
+  const { payload } = await jwtVerify(idToken, key, {
+    // Pin RS256 (Google's only published id_token alg) so a token can't be slipped in
+    // under a weaker/none alg — jose rejects alg:none and key-type mismatches anyway,
+    // but the explicit allow-list mirrors the session JWT's HS256 pin (defence in depth).
+    algorithms: ['RS256'],
+    issuer: [...GOOGLE_ISSUERS],
+    audience: opts.clientId,
+  })
+  if (typeof payload.nonce !== 'string' || payload.nonce !== opts.nonce) {
+    throw new Error('id_token nonce mismatch')
+  }
+  if (typeof payload.sub !== 'string') throw new Error('id_token missing sub')
+  const email = typeof payload.email === 'string' ? payload.email : undefined
+  const emailVerified =
+    typeof payload.email_verified === 'boolean' ? payload.email_verified : undefined
+  const name = typeof payload.name === 'string' ? payload.name : undefined
+  const picture = typeof payload.picture === 'string' ? payload.picture : undefined
+  return {
+    sub: payload.sub,
+    ...(email !== undefined ? { email } : {}),
+    ...(emailVerified !== undefined ? { email_verified: emailVerified } : {}),
+    ...(name !== undefined ? { name } : {}),
+    ...(picture !== undefined ? { picture } : {}),
+  }
+}
 
 /** Per-flow OAuth round-trip cookie. Each sign-in gets its OWN cookie, named by
  *  its random `state` (`<prefix><state>`), instead of four fixed-name single-slot
@@ -159,14 +207,21 @@ export function randomToken(byteLength = 32): string {
   return Buffer.from(bytes).toString('base64url')
 }
 
-/** Build the Google authorization-code URL. Pure — no I/O, fully assertable. */
-export function buildGoogleAuthorizeUrl(config: GoogleOAuthConfig, state: string): string {
+/** Build the Google authorization-code URL. Pure — no I/O, fully assertable.
+ *  `nonce` is echoed back inside the signed `id_token` (#1055), letting the callback
+ *  bind the token to THIS flow and reject a replay from another sign-in. */
+export function buildGoogleAuthorizeUrl(
+  config: GoogleOAuthConfig,
+  state: string,
+  nonce: string,
+): string {
   const params = new URLSearchParams({
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     response_type: 'code',
     scope: GOOGLE_SCOPE,
     state,
+    nonce,
     access_type: 'offline',
     prompt: 'select_account',
   })
@@ -175,22 +230,34 @@ export function buildGoogleAuthorizeUrl(config: GoogleOAuthConfig, state: string
 
 /** The data a flow carries from /start to its callback, stashed in the per-flow
  *  cookie value. Keys are always present (values may be undefined) so callers can
- *  destructure without exactOptionalPropertyTypes friction. */
+ *  destructure without exactOptionalPropertyTypes friction. `nonce` (#1055) binds
+ *  the OIDC id_token to this flow; it's undefined only for a malformed cookie, which
+ *  fails id_token verification closed. */
 export interface FlowPayload {
   readonly returnTo: string | undefined
   readonly intent: OAuthIntent
   readonly invite: string | undefined
+  readonly nonce: string | undefined
+}
+
+/** The per-flow OIDC nonce if syntactically acceptable, else undefined. Same
+ *  base64url shape as randomToken's output; a re-validated cookie can't smuggle a
+ *  weird value into the id_token nonce comparison. */
+export function safeNonce(raw: string | undefined): string | undefined {
+  return raw && INVITE_TOKEN_RE.test(raw) ? raw : undefined
 }
 
 /** Encode a flow's payload for its cookie value. Only non-default fields are
- *  stored (renter intent + absent returnTo/invite encode to an empty object), so
- *  the cookie stays tiny. base64url(JSON) — opaque + HttpOnly, never script-read. */
+ *  stored (renter intent + absent returnTo/invite encode to just the nonce), so
+ *  the cookie stays tiny. base64url(JSON) — opaque + HttpOnly, never script-read.
+ *  `nonce` is always stored: every flow needs it to verify the returned id_token. */
 export function encodeFlowPayload(payload: {
   returnTo: string | undefined
   intent: OAuthIntent
   invite: string | undefined
+  nonce: string
 }): string {
-  const stored: Record<string, string> = {}
+  const stored: Record<string, string> = { nonce: payload.nonce }
   if (payload.returnTo) stored.returnTo = payload.returnTo
   if (payload.intent === 'provider') stored.intent = 'provider'
   if (payload.invite) stored.invite = payload.invite
@@ -198,17 +265,19 @@ export function encodeFlowPayload(payload: {
 }
 
 /** Decode + re-validate a per-flow cookie value into a FlowPayload. Every field
- *  runs back through its guard (safeReturnPath/parseOAuthIntent/safeInviteToken) —
- *  the cookie was set by us, but defence in depth never trusts a returned cookie.
- *  A malformed value degrades to the safe default (renter, no returnTo/invite):
- *  the state binding already held (the cookie existed), so a garbled value drops
- *  its extras rather than 400-ing a real flow. */
+ *  runs back through its guard (safeReturnPath/parseOAuthIntent/safeInviteToken/
+ *  safeNonce) — the cookie was set by us, but defence in depth never trusts a
+ *  returned cookie. A malformed value degrades to the safe default (renter, no
+ *  returnTo/invite, undefined nonce): the state binding already held (the cookie
+ *  existed); dropping extras beats 400-ing a real flow, and an absent nonce simply
+ *  fails the id_token check closed. */
 export function decodeFlowPayload(raw: string | undefined): FlowPayload {
   const parsed = parseFlowJson(raw)
   return {
     returnTo: safeReturnPath(parsed.returnTo),
     intent: parseOAuthIntent(parsed.intent),
     invite: safeInviteToken(parsed.invite),
+    nonce: safeNonce(parsed.nonce),
   }
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -104,10 +104,14 @@ export function createAuthRoutes(
       // and any syntactically-acceptable invite token; #521 §5) rides in the HttpOnly
       // cookie VALUE, not the `state` param, so returnTo never leaks into the URL.
       const state = randomToken()
+      // A per-flow nonce (#1055): sent in the authorize URL and stashed in this flow's
+      // cookie, so the callback can bind the returned id_token to THIS sign-in.
+      const nonce = randomToken()
       const payload = encodeFlowPayload({
         returnTo: safeReturnPath(c.req.query('returnTo')),
         intent: parseOAuthIntent(c.req.query('intent')),
         invite: safeInviteToken(c.req.query('invite')),
+        nonce,
       })
       // Bound the live flow-cookie count before adding this one (issue #592): an
       // abandoned flow lingers until its 600s TTL, so a rapid abandon — or a
@@ -120,7 +124,7 @@ export function createAuthRoutes(
         deleteCookie(c, name, { path: '/' })
       }
       setCookie(c, flowCookieName(state), payload, OAUTH_FLOW_COOKIE_OPTS)
-      return c.redirect(buildGoogleAuthorizeUrl(googleConfig, state), 302)
+      return c.redirect(buildGoogleAuthorizeUrl(googleConfig, state, nonce), 302)
     })
     .get('/auth/google/callback', async (c) => {
       if (!googleConfig || !googleRuntime) return fail(c, 'Google sign-in is not configured', 503)
@@ -146,15 +150,22 @@ export function createAuthRoutes(
       // below works from these values and never reads it again. decodeFlowPayload
       // re-validates every field (defence in depth — a tampered cookie can't
       // open-redirect); returnTo's locale segment steers server-computed redirects.
-      const { returnTo, intent, invite: inviteToken } = decodeFlowPayload(flowCookie)
+      const { returnTo, intent, invite: inviteToken, nonce } = decodeFlowPayload(flowCookie)
       const locale = localeFromReturnPath(returnTo)
       deleteCookie(c, flowCookieName(state), { path: '/' })
+
+      // A real flow always stashed a nonce; its absence means a malformed/tampered
+      // cookie, so we can't bind the id_token to this flow — fail closed (#1055).
+      if (!nonce) return fail(c, 'Invalid OAuth state', 400)
 
       const secret = process.env.AUTH_SECRET
       if (!secret) return fail(c, 'Server auth is not configured', 500)
 
-      const { accessToken } = await googleRuntime.provider.exchangeCode(code, googleConfig)
-      const profile = await googleRuntime.provider.getUserInfo(accessToken)
+      // Identity from the SIGNED, audience- and nonce-bound id_token (#1055), not an
+      // unsigned /userinfo read. verifyIdToken throws on any failed check, failing
+      // the sign-in closed.
+      const { idToken } = await googleRuntime.provider.exchangeCode(code, googleConfig)
+      const profile = await googleRuntime.provider.verifyIdToken(idToken, googleConfig, nonce)
       const user = await googleRuntime.accountStore.resolveUser(profile)
 
       // Default grant = the user's already-projected identity (a renter, or an

--- a/packages/api/tests/auth/google-helpers.test.ts
+++ b/packages/api/tests/auth/google-helpers.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   FALLBACK_LOCALE,
+  type GoogleOAuthConfig,
+  buildGoogleAuthorizeUrl,
+  decodeFlowPayload,
+  encodeFlowPayload,
   localeFromReturnPath,
   parseOAuthIntent,
+  randomToken,
   safeInviteToken,
 } from '../../src/auth/google'
 
@@ -65,6 +70,65 @@ describe('safeInviteToken', () => {
   it('accepts a token exactly at the 128-char boundary', () => {
     const token = 'a'.repeat(128)
     expect(safeInviteToken(token)).toBe(token)
+  })
+})
+
+describe('buildGoogleAuthorizeUrl', () => {
+  const config: GoogleOAuthConfig = {
+    clientId: 'client-123.apps.googleusercontent.com',
+    clientSecret: 'top-secret',
+    redirectUri: 'https://api.example.com/auth/google/callback',
+    postLoginRedirect: 'https://app.example.com',
+  }
+
+  // #1055: the authorize URL must carry a per-flow `nonce` so the id_token returned
+  // by Google can be bound back to THIS sign-in — without it the callback can't
+  // prove the token isn't a replay from another flow.
+  it('binds the per-flow nonce into the authorize URL', () => {
+    const url = new URL(buildGoogleAuthorizeUrl(config, 'state-abc', 'nonce-xyz'))
+    expect(url.searchParams.get('nonce')).toBe('nonce-xyz')
+  })
+
+  it('keeps state and nonce as distinct params', () => {
+    const url = new URL(buildGoogleAuthorizeUrl(config, 'state-abc', 'nonce-xyz'))
+    expect(url.searchParams.get('state')).toBe('state-abc')
+    expect(url.searchParams.get('nonce')).toBe('nonce-xyz')
+  })
+})
+
+describe('flow payload nonce (#1055)', () => {
+  // The per-flow nonce rides in the same HttpOnly flow cookie as returnTo/intent/invite,
+  // so the callback can recover it to bind the id_token to THIS sign-in.
+  it('encodes and recovers the per-flow nonce', () => {
+    const nonce = randomToken()
+    const encoded = encodeFlowPayload({
+      returnTo: undefined,
+      intent: 'renter',
+      invite: undefined,
+      nonce,
+    })
+    expect(decodeFlowPayload(encoded).nonce).toBe(nonce)
+  })
+
+  it('recovers the nonce alongside the other validated fields', () => {
+    const nonce = randomToken()
+    const encoded = encodeFlowPayload({
+      returnTo: '/ja/manage',
+      intent: 'provider',
+      invite: 'inv-token',
+      nonce,
+    })
+    const decoded = decodeFlowPayload(encoded)
+    expect(decoded).toMatchObject({
+      returnTo: '/ja/manage',
+      intent: 'provider',
+      invite: 'inv-token',
+      nonce,
+    })
+  })
+
+  it('yields an undefined nonce for a malformed cookie (fail-closed on verification)', () => {
+    expect(decodeFlowPayload('not-base64url-json').nonce).toBeUndefined()
   })
 })
 

--- a/packages/api/tests/auth/verify-google-id-token.test.ts
+++ b/packages/api/tests/auth/verify-google-id-token.test.ts
@@ -107,6 +107,15 @@ describe('verifyGoogleIdToken (#1055)', () => {
     ).rejects.toThrow()
   })
 
+  it('accepts a token expired within the clock-tolerance window (CF↔Google drift)', async () => {
+    const token = await mintIdToken(validClaims, { expiresIn: '-10s' })
+    const profile = await verifyGoogleIdToken(token, publicKey, {
+      clientId: CLIENT_ID,
+      nonce: NONCE,
+    })
+    expect(profile.sub).toBe('google-sub-001')
+  })
+
   it('rejects a token signed by a key outside the trusted JWKS (forged signature)', async () => {
     const token = await mintIdToken(validClaims)
     await expect(

--- a/packages/api/tests/auth/verify-google-id-token.test.ts
+++ b/packages/api/tests/auth/verify-google-id-token.test.ts
@@ -1,0 +1,134 @@
+import { type CryptoKey, SignJWT, exportJWK, generateKeyPair } from 'jose'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { verifyGoogleIdToken } from '../../src/auth/google'
+
+// #1055: identity must rest on Google's SIGNED id_token, not an unsigned /userinfo
+// read. This is the verification core — every claim that closes the OIDC chain
+// (signature, aud, iss, exp, and our per-flow nonce) is asserted here against
+// locally-minted tokens, because crypto that isn't tested is crypto you don't trust.
+
+const CLIENT_ID = 'client-123.apps.googleusercontent.com'
+const NONCE = 'flow-nonce-abc'
+
+let privateKey: CryptoKey
+let publicKey: CryptoKey
+let otherPublicKey: CryptoKey
+
+beforeAll(async () => {
+  const kp = await generateKeyPair('RS256') // Google signs id_tokens with RS256
+  privateKey = kp.privateKey
+  publicKey = kp.publicKey
+  otherPublicKey = (await generateKeyPair('RS256')).publicKey
+  void exportJWK // keep import available for future JWKS-shaped tests
+})
+
+interface IdClaims {
+  sub?: string
+  email?: string
+  email_verified?: boolean
+  name?: string
+  picture?: string
+  nonce?: string
+}
+
+function mintIdToken(
+  claims: IdClaims,
+  opts: { issuer?: string; audience?: string; expiresIn?: string } = {},
+): Promise<string> {
+  return new SignJWT({ ...claims })
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(opts.issuer ?? 'https://accounts.google.com')
+    .setAudience(opts.audience ?? CLIENT_ID)
+    .setIssuedAt()
+    .setExpirationTime(opts.expiresIn ?? '5m')
+    .sign(privateKey)
+}
+
+const validClaims: IdClaims = {
+  sub: 'google-sub-001',
+  email: 'renter@example.com',
+  email_verified: true,
+  name: 'Test Renter',
+  picture: 'https://lh3.googleusercontent.com/a/pic',
+  nonce: NONCE,
+}
+
+describe('verifyGoogleIdToken (#1055)', () => {
+  it('returns the verified profile for a well-formed token', async () => {
+    const token = await mintIdToken(validClaims)
+    const profile = await verifyGoogleIdToken(token, publicKey, {
+      clientId: CLIENT_ID,
+      nonce: NONCE,
+    })
+    expect(profile).toEqual({
+      sub: 'google-sub-001',
+      email: 'renter@example.com',
+      email_verified: true,
+      name: 'Test Renter',
+      picture: 'https://lh3.googleusercontent.com/a/pic',
+    })
+  })
+
+  it('rejects a token whose nonce does not match this flow (replay defence)', async () => {
+    const token = await mintIdToken({ ...validClaims, nonce: 'some-other-flow-nonce' })
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow(/nonce/i)
+  })
+
+  it('rejects a token carrying no nonce claim at all', async () => {
+    const { nonce: _omit, ...noNonce } = validClaims
+    const token = await mintIdToken(noNonce)
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow(/nonce/i)
+  })
+
+  it('rejects a token minted for a different client (aud mismatch)', async () => {
+    const token = await mintIdToken(validClaims, {
+      audience: 'attacker.apps.googleusercontent.com',
+    })
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects a token from an unexpected issuer', async () => {
+    const token = await mintIdToken(validClaims, { issuer: 'https://evil.example.com' })
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects an expired token', async () => {
+    const token = await mintIdToken(validClaims, { expiresIn: '-1m' })
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects a token signed by a key outside the trusted JWKS (forged signature)', async () => {
+    const token = await mintIdToken(validClaims)
+    await expect(
+      verifyGoogleIdToken(token, otherPublicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects a token with no sub claim', async () => {
+    const { sub: _omit, ...noSub } = validClaims
+    const token = await mintIdToken(noSub)
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow(/sub/i)
+  })
+
+  it('keeps optional profile fields absent rather than undefined (exactOptionalPropertyTypes)', async () => {
+    const token = await mintIdToken({ sub: 'google-sub-002', nonce: NONCE })
+    const profile = await verifyGoogleIdToken(token, publicKey, {
+      clientId: CLIENT_ID,
+      nonce: NONCE,
+    })
+    expect(profile).toEqual({ sub: 'google-sub-002' })
+    expect('email' in profile).toBe(false)
+  })
+})

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -59,12 +59,15 @@ export async function authHeaders(payload?: { sub: string; role?: string }): Pro
  *  `state` names the cookie; returnTo/intent/invite ride in its value (#519). */
 export function oauthFlowCookie(
   state: string,
-  flow: { returnTo?: string; intent?: OAuthIntent; invite?: string } = {},
+  flow: { returnTo?: string; intent?: OAuthIntent; invite?: string; nonce?: string } = {},
 ): string {
   const value = encodeFlowPayload({
     returnTo: flow.returnTo,
     intent: flow.intent ?? 'renter',
     invite: flow.invite,
+    // #1055: every flow carries a nonce the callback binds the id_token to. Default
+    // to a fixed value so a test can assert it reaches the verifier, override per-test.
+    nonce: flow.nonce ?? 'test-nonce',
   })
   return `${flowCookieName(state)}=${value}`
 }

--- a/packages/api/tests/routes/auth-google-callback.test.ts
+++ b/packages/api/tests/routes/auth-google-callback.test.ts
@@ -94,6 +94,27 @@ describe('GET /auth/google/callback', () => {
     expect(erasesFlowCookie(res, 's1')).toBe(true)
   })
 
+  test('id_token verification failure → fails closed, mints NO session (#1055)', async () => {
+    setupAuthEnv()
+    // A token that fails verification (bad sig / wrong aud / nonce mismatch) makes
+    // verifyIdToken throw; the callback must NOT mint a session on that path.
+    const runtime = {
+      provider: {
+        exchangeCode: async () => ({ idToken: 'id-1' }),
+        verifyIdToken: async () => {
+          throw new Error('id_token nonce mismatch')
+        },
+      },
+      accountStore: { resolveUser: async () => ({ id: 'user_42', role: 'RENTER' as const }) },
+    }
+    const app = createAuthRoutes(config, runtime)
+    const res = await app.request('/auth/google/callback?state=s1&code=c1', {
+      headers: { Cookie: oauthFlowCookie('s1') },
+    })
+    expect(res.status).not.toBe(302)
+    expect(getSetCookie(res, 'kuruma_session')).toBeUndefined()
+  })
+
   test('state query has no matching flow cookie → 400', async () => {
     setupAuthEnv()
     const { runtime } = makeRuntime()

--- a/packages/api/tests/routes/auth-google-callback.test.ts
+++ b/packages/api/tests/routes/auth-google-callback.test.ts
@@ -11,19 +11,21 @@ const config = {
 }
 
 /** Records what the route passed to the injected boundary so we can assert the
- *  code/profile actually flowed through, not just that a 302 came back. */
+ *  code/id_token/nonce/profile actually flowed through, not just that a 302 came back. */
 function makeRuntime() {
-  const calls: { code?: string; accessToken?: string; profile?: unknown } = {}
+  const calls: { code?: string; idToken?: string; nonce?: string; profile?: unknown } = {}
   return {
     calls,
     runtime: {
       provider: {
         exchangeCode: async (code: string) => {
           calls.code = code
-          return { accessToken: 'access-1' }
+          return { idToken: 'id-token-1' }
         },
-        getUserInfo: async (accessToken: string) => {
-          calls.accessToken = accessToken
+        // #1055: identity now comes from the verified id_token, bound to the flow nonce.
+        verifyIdToken: async (idToken: string, _config: unknown, nonce: string) => {
+          calls.idToken = idToken
+          calls.nonce = nonce
           return { sub: 'g-123', email: 'jo@ex.com', name: 'Jo', picture: 'https://pic/jo.png' }
         },
       },
@@ -63,9 +65,11 @@ describe('GET /auth/google/callback', () => {
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('https://web.example.test/en/dashboard')
 
-    // The code/profile actually flowed through the boundary.
+    // The code → id_token → profile chain actually flowed through the boundary, and
+    // the flow's nonce was forwarded to the id_token verifier (#1055).
     expect(calls.code).toBe('c1')
-    expect(calls.accessToken).toBe('access-1')
+    expect(calls.idToken).toBe('id-token-1')
+    expect(calls.nonce).toBe('test-nonce')
     expect(calls.profile).toMatchObject({ sub: 'g-123', email: 'jo@ex.com' })
 
     // Session minted with the resolved user + a fresh csrf claim.
@@ -197,8 +201,8 @@ describe('GET /auth/google/callback', () => {
     const calls: Record<string, unknown> = {}
     const runtime = {
       provider: {
-        exchangeCode: async () => ({ accessToken: 'a' }),
-        getUserInfo: async () => ({
+        exchangeCode: async () => ({ idToken: 'id-1' }),
+        verifyIdToken: async () => ({
           sub: 'g-1',
           email: 'JO@ex.com',
           email_verified: true,
@@ -233,8 +237,8 @@ describe('GET /auth/google/callback', () => {
     setupAuthEnv()
     const runtime = {
       provider: {
-        exchangeCode: async () => ({ accessToken: 'a' }),
-        getUserInfo: async () => ({ sub: 'g-1', email: 'o@ex.com' }),
+        exchangeCode: async () => ({ idToken: 'id-1' }),
+        verifyIdToken: async () => ({ sub: 'g-1', email: 'o@ex.com' }),
       },
       accountStore: {
         resolveUser: async () => ({

--- a/packages/api/tests/routes/auth-google-multitab.test.ts
+++ b/packages/api/tests/routes/auth-google-multitab.test.ts
@@ -13,8 +13,8 @@ const config = {
 function makeRuntime() {
   return {
     provider: {
-      exchangeCode: async () => ({ accessToken: 'a' }),
-      getUserInfo: async () => ({ sub: 'g-1', email: 'jo@ex.com' }),
+      exchangeCode: async () => ({ idToken: 'id-1' }),
+      verifyIdToken: async () => ({ sub: 'g-1', email: 'jo@ex.com' }),
     },
     accountStore: {
       resolveUser: async () => ({ id: 'user_1', role: 'RENTER' as const }),

--- a/packages/api/tests/routes/auth-google-runtime-wiring.test.ts
+++ b/packages/api/tests/routes/auth-google-runtime-wiring.test.ts
@@ -22,9 +22,9 @@ function makeRuntime(): { calls: { code?: string }; runtime: GoogleAuthRuntime }
       provider: {
         exchangeCode: async (code) => {
           calls.code = code
-          return { accessToken: 'access-1' }
+          return { idToken: 'id-token-1' }
         },
-        getUserInfo: async () => ({ sub: 'g-1', email: 'jo@ex.com', name: 'Jo' }),
+        verifyIdToken: async () => ({ sub: 'g-1', email: 'jo@ex.com', name: 'Jo' }),
       },
       accountStore: {
         resolveUser: async () => ({ id: 'user_7', role: 'RENTER' as const }),
@@ -117,8 +117,8 @@ describe('createApp wires a googleAuthRuntime override into /auth/google/callbac
 
     const runtime: GoogleAuthRuntime = {
       provider: {
-        exchangeCode: async () => ({ accessToken: 'a' }),
-        getUserInfo: async () => ({
+        exchangeCode: async () => ({ idToken: 'id-1' }),
+        verifyIdToken: async () => ({
           sub: 'g-op',
           email: 'op@ex.com',
           email_verified: true,

--- a/packages/api/tests/routes/auth-google-start.test.ts
+++ b/packages/api/tests/routes/auth-google-start.test.ts
@@ -43,6 +43,21 @@ describe('POST /auth/google/start', () => {
     expect(readOAuthFlowCookie(res)?.state).toBe(state)
   })
 
+  test('binds a per-flow nonce: same value in the authorize URL and the flow cookie (#1055)', async () => {
+    setupGoogleEnv()
+    const app = createApp()
+    const res = await app.request('/auth/google/start', { method: 'POST' })
+
+    const url = new URL(res.headers.get('location') ?? '')
+    const urlNonce = url.searchParams.get('nonce')
+    // 32 random bytes, base64url — distinct from state, so the id_token can't be
+    // replayed from another flow even if its state leaked.
+    expect(urlNonce).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(urlNonce).not.toBe(url.searchParams.get('state'))
+    // The callback recovers THIS nonce from the cookie to verify the id_token.
+    expect(readOAuthFlowCookie(res)?.payload.nonce).toBe(urlNonce)
+  })
+
   test('503 when Google OAuth is not configured', async () => {
     setupAuthEnv()
     // Empty (falsy) rather than delete: Node coerces env values to strings, so


### PR DESCRIPTION
## What

Closes #1055. Closes the OIDC chain for Google sign-in: the callback now verifies Google's **signed `id_token`** and uses its claims as identity, replacing the unsigned `/userinfo` read. Identity is now cryptographically bound to *our* client and *this* sign-in flow.

Found in the 2026-06-25 auth security review — **not an exploitable bypass today** (the access token was minted by our own `exchangeCode` and spent immediately), but launch-gating hardening: identity should rest on a signed, audience- and nonce-bound token, not an OAuth2 profile call.

## How (5 TDD slices)

1. `buildGoogleAuthorizeUrl(config, state, nonce)` sends a per-flow `nonce`.
2. `FlowPayload` carries the `nonce` in the existing HttpOnly per-flow cookie (re-validated on decode, like every other field).
3. **`verifyGoogleIdToken`** — the verification core: jose `jwtVerify` pins `RS256` + `iss` (both Google forms) + `aud === clientId` + `exp` (signature via JWKS), then binds the `nonce` and requires `sub`. Takes the key as a param so it's I/O-agnostic and **fully unit-tested** with locally-minted tokens (valid, nonce-mismatch, nonce-absent, wrong-aud, wrong-iss, expired, forged-signature, missing-sub, optional-field hygiene).
4. `GoogleOAuthProvider`: `exchangeCode` returns `{ idToken }`; new `verifyIdToken()` wires the remote Google JWKS via `createRemoteJWKSet`. `getUserInfo` + `GOOGLE_USERINFO_ENDPOINT` removed (dead).
5. Route: `/start` mints + stashes the nonce; `/callback` verifies the id_token with the stashed nonce and **fails closed** if a tampered cookie carries none.

`jose` promoted to a direct `@kuruma/api` dependency (was transitive via `@auth/core`; `jwt.ts` already relied on it).

## Security properties
- Signature verified against Google's JWKS; **`alg` pinned to RS256** (jose also rejects `alg:none`/key-type mismatch) — mirrors the session JWT's HS256 pin.
- `aud === clientId` closes confused-deputy/token-substitution.
- Per-flow `nonce` closes id_token replay across flows.
- Any failed check throws → sign-in fails closed; no session minted.

## Test plan
- [x] `verify-google-id-token.test.ts` — 9 crypto cases (locally-minted RS256 tokens)
- [x] `google-helpers.test.ts` — authorize-URL nonce + FlowPayload nonce round-trip
- [x] `auth-google-start/callback/multitab/runtime-wiring` — nonce sent, stashed, and forwarded to the verifier; `/userinfo` gone
- [x] Full API suite **1862 passed**, `tsc` clean, biome clean, module-boundaries OK, file-size OK
- [ ] Manual live Google round-trip (owner, post-merge on a preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)