### PR TITLE
fix(operator-fleet): correct retire error feedback + polite compliance banner

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -326,6 +326,7 @@
       "retireVehicle": "Retire vehicle",
       "retireConfirm": "Retire {name}?",
       "retireConfirmMessage": "This will hide the vehicle from renters. You can restore it later.",
+      "retireError": "Could not retire the vehicle. Please try again.",
       "noPhoto": "No photo",
       "expiry": {
         "shaken": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -326,6 +326,7 @@
       "retireVehicle": "車両を廃止",
       "retireConfirm": "{name}を廃止しますか？",
       "retireConfirmMessage": "この車両は利用者に表示されなくなります。後で復元できます。",
+      "retireError": "車両を廃止できませんでした。もう一度お試しください。",
       "noPhoto": "写真なし",
       "expiry": {
         "shaken": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -326,6 +326,7 @@
       "retireVehicle": "停用车辆",
       "retireConfirm": "确定停用{name}？",
       "retireConfirmMessage": "此车辆将对租客隐藏。您可以稍后恢复。",
+      "retireError": "无法停用车辆，请重试。",
       "noPhoto": "无照片",
       "expiry": {
         "shaken": {

--- a/packages/web/src/vite/operator-fleet/ComplianceBanner.tsx
+++ b/packages/web/src/vite/operator-fleet/ComplianceBanner.tsx
@@ -21,8 +21,11 @@ export function ComplianceBanner({ vehicles, locale }: ComplianceBannerProps) {
   if (count === 0) return null
 
   return (
+    // A persistent advisory rendered on dashboard load — role="status" (polite),
+    // not role="alert" (assertive), so screen readers don't interrupt every visit.
+    // biome-ignore lint/a11y/useSemanticElements: <output> is phrasing-only and can't host this banner's heading + body + action-link flow content; role="status" on the container is the correct polite live region.
     <div
-      role="alert"
+      role="status"
       className="mt-6 flex flex-wrap items-center gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
     >
       <TriangleAlert className="size-5 shrink-0" aria-hidden="true" />

--- a/packages/web/src/vite/operator-fleet/FleetRowActions.tsx
+++ b/packages/web/src/vite/operator-fleet/FleetRowActions.tsx
@@ -109,7 +109,9 @@ export function FleetRowActions({ vehicle, onEdit }: FleetRowActionsProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {(statusMutation.isError || retireMutation.isError) && (
+      {/* The AVAILABLE toggle fires without a dialog, so its failure needs an
+          inline slot. Errors raised while a dialog is open surface inside it. */}
+      {statusMutation.isError && openDialog === 'none' && (
         <output className="text-[11px] text-destructive">{t('statusToggle.error')}</output>
       )}
 
@@ -119,6 +121,7 @@ export function FleetRowActions({ vehicle, onEdit }: FleetRowActionsProps) {
           if (!open) {
             setOpenDialog('none')
             setReason('')
+            statusMutation.reset()
           }
         }}
       >
@@ -140,6 +143,9 @@ export function FleetRowActions({ vehicle, onEdit }: FleetRowActionsProps) {
                 placeholder={t('maintenance.reasonPlaceholder')}
               />
             </div>
+            {statusMutation.isError && (
+              <p className="px-1 text-sm text-destructive">{t('statusToggle.error')}</p>
+            )}
             <DialogFooter>
               <DialogClose
                 render={
@@ -159,7 +165,10 @@ export function FleetRowActions({ vehicle, onEdit }: FleetRowActionsProps) {
       <Dialog
         open={openDialog === 'retire'}
         onOpenChange={(open) => {
-          if (!open) setOpenDialog('none')
+          if (!open) {
+            setOpenDialog('none')
+            retireMutation.reset()
+          }
         }}
       >
         <DialogContent>
@@ -167,6 +176,9 @@ export function FleetRowActions({ vehicle, onEdit }: FleetRowActionsProps) {
             <DialogTitle>{t('retireConfirm', { name: vehicle.name })}</DialogTitle>
             <DialogDescription>{t('retireConfirmMessage')}</DialogDescription>
           </DialogHeader>
+          {retireMutation.isError && (
+            <p className="px-1 text-sm text-destructive">{t('retireError')}</p>
+          )}
           <DialogFooter>
             <DialogClose
               render={

--- a/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
@@ -79,11 +79,11 @@ describe('OperatorDashboardView', () => {
 
   it('mounts the compliance banner when a fleet vehicle is non-compliant (#916 §5.5)', () => {
     renderDashboard([vehicle({ shakenExpiryDate: '2020-01-01' }), vehicle({ id: 'ok' })])
-    expect(screen.getByRole('alert')).toHaveTextContent('1 vehicle needs attention')
+    expect(screen.getByRole('status')).toHaveTextContent('1 vehicle needs attention')
   })
 
   it('omits the compliance banner when the whole fleet is compliant', () => {
     renderDashboard([vehicle()])
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/packages/web/tests/vite/operator-fleet/ComplianceBanner.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/ComplianceBanner.test.tsx
@@ -86,6 +86,8 @@ describe('ComplianceBanner', () => {
   it('renders nothing when every vehicle is compliant', () => {
     const { container } = renderBanner([vehicle()])
     expect(container).toBeEmptyDOMElement()
+    // A persistent dashboard advisory is a polite status region, not an assertive alert.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
@@ -95,12 +97,12 @@ describe('ComplianceBanner', () => {
       vehicle({ id: 'b', insuranceExpiryDate: '2020-01-01' }),
       vehicle({ id: 'c' }),
     ])
-    expect(screen.getByRole('alert')).toHaveTextContent('2 vehicles need attention')
+    expect(screen.getByRole('status')).toHaveTextContent('2 vehicles need attention')
   })
 
   it('uses the singular form for exactly one non-compliant vehicle', () => {
     renderBanner([vehicle({ shakenExpiryDate: '2020-01-01' }), vehicle({ id: 'ok' })])
-    expect(screen.getByRole('alert')).toHaveTextContent('1 vehicle needs attention')
+    expect(screen.getByRole('status')).toHaveTextContent('1 vehicle needs attention')
   })
 
   it('deep-links to the fleet pre-filtered to the expiring set', () => {

--- a/packages/web/tests/vite/operator-fleet/FleetRowActions.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/FleetRowActions.test.tsx
@@ -185,4 +185,35 @@ describe('FleetRowActions', () => {
       expect(screen.getByText(en.statusToggle.error)).toBeInTheDocument()
     })
   })
+
+  it('shows the retire-specific error (not the status copy) when retire fails', async () => {
+    retireVehicle.mockRejectedValueOnce(new Error('network boom'))
+    renderActions(vehicle({ id: 'v8' }))
+
+    fireEvent.click(screen.getByText(en.retireVehicle))
+    fireEvent.click(await screen.findByRole('button', { name: en.retireVehicle }))
+
+    await waitFor(() => {
+      expect(screen.getByText(en.retireError)).toBeInTheDocument()
+    })
+    // The wrong "could not update status" copy must NOT be used for a retire failure.
+    expect(screen.queryByText(en.statusToggle.error)).not.toBeInTheDocument()
+  })
+
+  it('shows the status error inside the maintenance dialog when the reason submit fails', async () => {
+    updateVehicleStatus.mockRejectedValueOnce(new Error('network boom'))
+    renderActions(vehicle({ id: 'v9', status: 'AVAILABLE' }))
+
+    fireEvent.click(screen.getByText(en.actions.setMaintenance))
+    const reason = screen.getByPlaceholderText(en.maintenance.reasonPlaceholder)
+    fireEvent.change(reason, { target: { value: 'Brake inspection' } })
+    fireEvent.click(screen.getByRole('button', { name: en.maintenance.submit }))
+
+    // The maintenance dialog stays open on failure and surfaces the error in-context;
+    // the reason field the operator submitted is still on screen.
+    await waitFor(() => {
+      expect(screen.getByText(en.statusToggle.error)).toBeInTheDocument()
+    })
+    expect(screen.getByPlaceholderText(en.maintenance.reasonPlaceholder)).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Closes #1064

Two contained UX/a11y fixes found reviewing the cold `operator-fleet` web module.

## 1. Error feedback on FleetRowActions (LOW)

A single inline `<output>` rendered `statusToggle.error` ("Could not update status") for **both** the status and retire mutations, so:
- a failed **retire** showed the wrong copy, and
- both dialogs stay open on error, yet the message rendered **outside** the dialog the operator was looking at — no in-context feedback.

Now:
- the inline slot shows the status error only for the dialog-less AVAILABLE toggle (`openDialog === 'none'`);
- the maintenance dialog surfaces the status error in-context;
- the retire dialog surfaces a new retire-specific error (`retireError`, en/ja/zh), mirroring `BulkActionBar`'s in-dialog error;
- both mutations `.reset()` on dialog close so a stale error can't linger.

## 2. ComplianceBanner live-region role (LOW, a11y)

`role="alert"` (assertive) → `role="status"` (polite). The banner renders on dashboard load, so an assertive live region made screen readers interrupt on every visit. `<output>` (the semantic equivalent biome suggests) is phrasing-only and can't host the banner's heading + body + action-link flow content, so `role="status"` stays on the container with a justified `biome-ignore`.

## Tests / verification

- TDD: +1 retire-error test (asserts `retireError` shows and `statusToggle.error` does **not**), +1 maintenance-in-dialog-error test; banner + dashboard role assertions updated to `status`.
- Full web suite **1240 passing**, tsc clean, biome clean, `lint:i18n-parity` clean (1088 keys × 3 locales).
- code-reviewer agent: clean ship, no CRITICAL/HIGH/MEDIUM. Edge-case trace confirms no double-display and no missing error across all 5 failure paths.

## Scope

`operator-fleet/{FleetRowActions,ComplianceBanner}.tsx` + their tests + the dashboard integration test + 3 i18n files. No API/DB change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)