### PR TITLE
feat(#464): render CLASS_COMBO search cards (web read-side, slice 3b)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1195,6 +1195,8 @@
     "auto": "Automatic",
     "manual": "Manual",
     "viewStore": "View cars",
+    "comboAvailable": "{count} available",
+    "comboSoldOut": "Sold out",
     "showOnMap": "Show on map",
     "list": {
       "heading": "Available cars",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1195,6 +1195,8 @@
     "auto": "オートマ",
     "manual": "マニュアル",
     "viewStore": "クルマを見る",
+    "comboAvailable": "残り{count}台",
+    "comboSoldOut": "在庫なし",
     "showOnMap": "地図で表示",
     "list": {
       "heading": "空車",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1195,6 +1195,8 @@
     "auto": "自动挡",
     "manual": "手动挡",
     "viewStore": "查看车辆",
+    "comboAvailable": "剩 {count} 辆",
+    "comboSoldOut": "已租罄",
     "showOnMap": "在地图上显示",
     "list": {
       "heading": "可用车辆",

--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils'
 import { carryForwardFilters } from '@/vite/storefronts/params'
 import type {
   ClassComboSearchResult,
+  ResultLocation,
   SearchResultItem,
   SpecificSearchResult,
 } from '@kuruma/shared/types/search-result'
@@ -24,6 +25,12 @@ interface SearchResultRowProps {
   readonly geoLabel?: string | null
 }
 
+/** A concrete row variant's props: its narrowed `item` plus the shared search context. */
+type RowCardProps<T extends SearchResultItem> = { readonly item: T } & Omit<
+  SearchResultRowProps,
+  'item'
+>
+
 /**
  * One flat-list row in the cross-operator vehicle search (#458). Switches on the
  * result `kind`: a SPECIFIC row is one physical car, a CLASS_COMBO row (#464) is a
@@ -44,41 +51,90 @@ export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
   }
 }
 
-function SpecificRow({
-  item,
+/** Square thumbnail with a car-icon placeholder — shared by every row variant. */
+function RowThumbnail({
+  photo,
+  alt,
+}: { readonly photo: string | undefined; readonly alt: string }) {
+  return (
+    <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
+      {photo ? (
+        <img
+          src={photo}
+          alt={alt}
+          // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
+          // h-full/w-full still drive the rendered size inside the square wrapper.
+          width={300}
+          height={300}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <Car className="size-8 text-muted-foreground/30" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** "{operator} · {store}" line — keeps a cross-operator list legible. */
+function RowLocationLine({ location }: { readonly location: ResultLocation }) {
+  return (
+    <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <MapPin className="size-4 shrink-0" />
+      <span className="font-medium text-foreground/80">{location.operatorName}</span>
+      <span aria-hidden="true">·</span>
+      <span>{location.name}</span>
+    </p>
+  )
+}
+
+/** Optional "{area}, {prefecture} · {km} km away" geo line (#885 slice 3a). */
+function RowGeoLine({ geoLabel }: { readonly geoLabel: string | null | undefined }) {
+  if (!geoLabel) return null
+  return (
+    <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <Navigation className="size-4 shrink-0" aria-hidden />
+      <span>{geoLabel}</span>
+    </p>
+  )
+}
+
+/** "View cars" CTA to the pickup store, carrying the date range + active filters forward. */
+function RowDetailCta({
+  location,
   locale,
   from,
   to,
   classFilter,
   pickupLocationId,
   region,
-  geoLabel,
-}: { readonly item: SpecificSearchResult } & Omit<SearchResultRowProps, 'item'>) {
+}: { readonly location: ResultLocation } & Omit<SearchResultRowProps, 'item'>) {
   const t = useTranslations('search')
-  const photo = item.photos[0]
-  const transmissionLabel = item.transmission === 'AUTO' ? t('auto') : t('manual')
+  return (
+    <Link
+      to="/$locale/storefronts/$locationId"
+      params={{ locale, locationId: location.locationId }}
+      search={{
+        from,
+        to,
+        ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
+      }}
+      className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+    >
+      {t('viewStore')}
+    </Link>
+  )
+}
 
+function SpecificRow({ item, ...ctx }: RowCardProps<SpecificSearchResult>) {
+  const t = useTranslations('search')
+  const transmissionLabel = item.transmission === 'AUTO' ? t('auto') : t('manual')
   const priceLabel = resultPriceLabel(item, t)
 
   return (
     <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
-        {photo ? (
-          <img
-            src={photo}
-            alt={item.name}
-            // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
-            // h-full/w-full still drive the rendered size inside the square wrapper.
-            width={300}
-            height={300}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <Car className="size-8 text-muted-foreground/30" />
-          </div>
-        )}
-      </div>
+      <RowThumbnail photo={item.photos[0]} alt={item.name} />
 
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-baseline justify-between gap-2">
@@ -88,19 +144,8 @@ function SpecificRow({
           </span>
         </div>
 
-        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <MapPin className="size-4 shrink-0" />
-          <span className="font-medium text-foreground/80">{item.location.operatorName}</span>
-          <span aria-hidden="true">·</span>
-          <span>{item.location.name}</span>
-        </p>
-
-        {geoLabel && (
-          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Navigation className="size-4 shrink-0" aria-hidden />
-            <span>{geoLabel}</span>
-          </p>
-        )}
+        <RowLocationLine location={item.location} />
+        <RowGeoLine geoLabel={ctx.geoLabel} />
 
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
           <span className="flex items-center gap-1.5">
@@ -115,36 +160,15 @@ function SpecificRow({
 
         <div className="mt-auto flex items-end justify-between gap-2 pt-1">
           <p className="text-base font-semibold text-foreground">{priceLabel}</p>
-          <Link
-            to="/$locale/storefronts/$locationId"
-            params={{ locale, locationId: item.location.locationId }}
-            search={{
-              from,
-              to,
-              ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
-            }}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-          >
-            {t('viewStore')}
-          </Link>
+          <RowDetailCta location={item.location} {...ctx} />
         </div>
       </div>
     </article>
   )
 }
 
-function ClassComboRow({
-  item,
-  locale,
-  from,
-  to,
-  classFilter,
-  pickupLocationId,
-  region,
-  geoLabel,
-}: { readonly item: ClassComboSearchResult } & Omit<SearchResultRowProps, 'item'>) {
+function ClassComboRow({ item, ...ctx }: RowCardProps<ClassComboSearchResult>) {
   const t = useTranslations('search')
-  const photo = item.photos[0]
   const priceLabel = resultPriceLabel(item, t)
   // A class card can size to 0 when demand has eaten the whole float (the API emits
   // max(0, cap − demand)). Show it as sold out — visible but unbookable — rather than
@@ -153,21 +177,7 @@ function ClassComboRow({
 
   return (
     <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
-        {photo ? (
-          <img
-            src={photo}
-            alt={item.classLabel}
-            width={300}
-            height={300}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <Car className="size-8 text-muted-foreground/30" />
-          </div>
-        )}
-      </div>
+      <RowThumbnail photo={item.photos[0]} alt={item.classLabel} />
 
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-baseline justify-between gap-2">
@@ -184,19 +194,8 @@ function ClassComboRow({
           </span>
         </div>
 
-        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <MapPin className="size-4 shrink-0" />
-          <span className="font-medium text-foreground/80">{item.location.operatorName}</span>
-          <span aria-hidden="true">·</span>
-          <span>{item.location.name}</span>
-        </p>
-
-        {geoLabel && (
-          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Navigation className="size-4 shrink-0" aria-hidden />
-            <span>{geoLabel}</span>
-          </p>
-        )}
+        <RowLocationLine location={item.location} />
+        <RowGeoLine geoLabel={ctx.geoLabel} />
 
         {/* Seats only — a class spans transmissions, so the gearbox is decided at pickup. */}
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
@@ -209,20 +208,7 @@ function ClassComboRow({
         <div className="mt-auto flex items-end justify-between gap-2 pt-1">
           <p className="text-base font-semibold text-foreground">{priceLabel}</p>
           {/* No CTA when sold out — the store has nothing bookable in this class right now. */}
-          {!soldOut && (
-            <Link
-              to="/$locale/storefronts/$locationId"
-              params={{ locale, locationId: item.location.locationId }}
-              search={{
-                from,
-                to,
-                ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
-              }}
-              className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-            >
-              {t('viewStore')}
-            </Link>
-          )}
+          {!soldOut && <RowDetailCta location={item.location} {...ctx} />}
         </div>
       </div>
     </article>

--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -1,7 +1,11 @@
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { carryForwardFilters } from '@/vite/storefronts/params'
-import type { SearchResultItem, SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import type {
+  ClassComboSearchResult,
+  SearchResultItem,
+  SpecificSearchResult,
+} from '@kuruma/shared/types/search-result'
 import { Link } from '@tanstack/react-router'
 import { Car, MapPin, Navigation, Settings2, Users } from 'lucide-react'
 import { useTranslations } from 'use-intl'
@@ -22,16 +26,19 @@ interface SearchResultRowProps {
 
 /**
  * One flat-list row in the cross-operator vehicle search (#458). Switches on the
- * result `kind` so the CLASS_COMBO variant (#464, fast-follow) drops in without
- * touching callers — only SPECIFIC is built this slice. The projection is already
- * renter-safe (the API drops operator internals, D3). The CTA navigates to the
+ * result `kind`: a SPECIFIC row is one physical car, a CLASS_COMBO row (#464) is a
+ * class with an inventory count, exact car assigned on pickup day. The projection is
+ * already renter-safe (the API drops operator internals, D3). The CTA navigates to the
  * pickup store's detail page (the only detail surface today, #885 1b); card
- * focus/hover drives the map while the CTA is the sole navigation affordance.
+ * focus/hover drives the map while the CTA is the sole navigation affordance. A future
+ * `kind` renders nothing rather than crash until its row is built.
  */
 export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
   switch (item.kind) {
     case 'SPECIFIC':
       return <SpecificRow item={item} {...ctx} />
+    case 'CLASS_COMBO':
+      return <ClassComboRow item={item} {...ctx} />
     default:
       return null
   }
@@ -120,6 +127,102 @@ function SpecificRow({
           >
             {t('viewStore')}
           </Link>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function ClassComboRow({
+  item,
+  locale,
+  from,
+  to,
+  classFilter,
+  pickupLocationId,
+  region,
+  geoLabel,
+}: { readonly item: ClassComboSearchResult } & Omit<SearchResultRowProps, 'item'>) {
+  const t = useTranslations('search')
+  const photo = item.photos[0]
+  const priceLabel = resultPriceLabel(item, t)
+  // A class card can size to 0 when demand has eaten the whole float (the API emits
+  // max(0, cap − demand)). Show it as sold out — visible but unbookable — rather than
+  // a "0 available" card with a live CTA into an empty class.
+  const soldOut = item.availableCount === 0
+
+  return (
+    <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
+      <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
+        {photo ? (
+          <img
+            src={photo}
+            alt={item.classLabel}
+            width={300}
+            height={300}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <Car className="size-8 text-muted-foreground/30" />
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1">
+        <div className="flex items-baseline justify-between gap-2">
+          {/* The class label IS the title here (no single car), so the pill carries the
+              inventory count instead of the class name. */}
+          <h3 className="text-base font-semibold leading-tight">{item.classLabel}</h3>
+          <span
+            className={cn(
+              'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
+              soldOut ? 'bg-muted text-muted-foreground' : 'bg-secondary text-secondary-foreground',
+            )}
+          >
+            {soldOut ? t('comboSoldOut') : t('comboAvailable', { count: item.availableCount })}
+          </span>
+        </div>
+
+        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <MapPin className="size-4 shrink-0" />
+          <span className="font-medium text-foreground/80">{item.location.operatorName}</span>
+          <span aria-hidden="true">·</span>
+          <span>{item.location.name}</span>
+        </p>
+
+        {geoLabel && (
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Navigation className="size-4 shrink-0" aria-hidden />
+            <span>{geoLabel}</span>
+          </p>
+        )}
+
+        {/* Seats only — a class spans transmissions, so the gearbox is decided at pickup. */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Users className="size-4" />
+            {t('seats', { count: item.seats })}
+          </span>
+        </div>
+
+        <div className="mt-auto flex items-end justify-between gap-2 pt-1">
+          <p className="text-base font-semibold text-foreground">{priceLabel}</p>
+          {/* No CTA when sold out — the store has nothing bookable in this class right now. */}
+          {!soldOut && (
+            <Link
+              to="/$locale/storefronts/$locationId"
+              params={{ locale, locationId: item.location.locationId }}
+              search={{
+                from,
+                to,
+                ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
+              }}
+              className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+            >
+              {t('viewStore')}
+            </Link>
+          )}
         </div>
       </div>
     </article>

--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -37,8 +37,7 @@ type RowCardProps<T extends SearchResultItem> = { readonly item: T } & Omit<
  * class with an inventory count, exact car assigned on pickup day. The projection is
  * already renter-safe (the API drops operator internals, D3). The CTA navigates to the
  * pickup store's detail page (the only detail surface today, #885 1b); card
- * focus/hover drives the map while the CTA is the sole navigation affordance. A future
- * `kind` renders nothing rather than crash until its row is built.
+ * focus/hover drives the map while the CTA is the sole navigation affordance.
  */
 export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
   switch (item.kind) {
@@ -47,6 +46,11 @@ export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
     case 'CLASS_COMBO':
       return <ClassComboRow item={item} {...ctx} />
     default:
+      // Exhaustive today: `item` narrows to `never` here. If the union ever grows a
+      // `kind` without a case above, `item satisfies never` turns red in tsc — turning
+      // a silently-dropped row (the very #464 bug) into a compile error. Still returns
+      // null at runtime so a skewed API can never render a raw object.
+      item satisfies never
       return null
   }
 }
@@ -109,7 +113,7 @@ function RowDetailCta({
   classFilter,
   pickupLocationId,
   region,
-}: { readonly location: ResultLocation } & Omit<SearchResultRowProps, 'item'>) {
+}: { readonly location: ResultLocation } & Omit<SearchResultRowProps, 'item' | 'geoLabel'>) {
   const t = useTranslations('search')
   return (
     <Link

--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -7,10 +7,12 @@ import {
 import type { RegionNode } from '@kuruma/shared/types/region'
 import type { ResultLocation, SearchResultItem } from '@kuruma/shared/types/search-result'
 
-/** Stable list key — the renter-safe per-car id for SPECIFIC, the class id for a
- *  future CLASS_COMBO row (#464). Shared by the flat list and the map+list view. */
+/** Stable list key — the renter-safe per-car id for SPECIFIC, a location-namespaced
+ *  class id for a CLASS_COMBO row (#464) so the same class offered at two storefronts
+ *  never collides into one React key. Mirrors the API cursor `itemKey` (`c:<loc>:<class>`),
+ *  minus the kind prefix the list doesn't need. Shared by the flat list and map+list view. */
 export function searchResultKey(item: SearchResultItem): string {
-  return item.kind === 'SPECIFIC' ? item.vehicleId : item.classId
+  return item.kind === 'SPECIFIC' ? item.vehicleId : `${item.location.locationId}:${item.classId}`
 }
 
 type Translate = (key: string, values?: Record<string, string | number>) => string

--- a/packages/web/tests/vite/search/SearchResultRow.test.tsx
+++ b/packages/web/tests/vite/search/SearchResultRow.test.tsx
@@ -1,5 +1,9 @@
 import { SearchResultRow } from '@/vite/search/SearchResultRow'
-import type { SpecificSearchResult } from '@kuruma/shared/types/search-result'
+import type {
+  ClassComboSearchResult,
+  SearchResultItem,
+  SpecificSearchResult,
+} from '@kuruma/shared/types/search-result'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
@@ -64,9 +68,33 @@ function makeSpecific(overrides: Partial<SpecificSearchResult> = {}): SpecificSe
   }
 }
 
+function makeCombo(overrides: Partial<ClassComboSearchResult> = {}): ClassComboSearchResult {
+  return {
+    kind: 'CLASS_COMBO',
+    location: {
+      locationId: 'loc_kyoto',
+      operatorId: 'op_zen',
+      operatorName: 'Zen Rentals',
+      name: 'Kyoto Station',
+      address: '1 Karasuma, Kyoto',
+      latitude: 34.9858,
+      longitude: 135.7588,
+    },
+    dailyRateJpy: 12000,
+    hourlyRateJpy: null,
+    classLabel: 'SUV',
+    acrissCode: 'IFAR',
+    seats: 7,
+    photos: [],
+    classId: 'cls_suv',
+    availableCount: 3,
+    ...overrides,
+  }
+}
+
 // Search context defaults so the CTA renders; individual tests override what they assert.
 function renderRow(
-  item: SpecificSearchResult,
+  item: SearchResultItem,
   ctx: {
     locale?: string
     from?: string
@@ -156,5 +184,53 @@ describe('SearchResultRow', () => {
   it('omits the geo-context line when no label is provided', () => {
     renderRow(makeSpecific(), { geoLabel: null })
     expect(screen.queryByText(/km away/)).toBeNull()
+  })
+})
+
+describe('SearchResultRow (CLASS_COMBO)', () => {
+  it('renders the class label as the title, plus availability, seats, and price', () => {
+    renderRow(makeCombo())
+    expect(screen.getByRole('heading', { name: 'SUV' })).toBeInTheDocument()
+    expect(screen.getByText('3 available')).toBeInTheDocument()
+    expect(screen.getByText('7 seats')).toBeInTheDocument()
+    expect(screen.getByText('From ¥12,000 / day')).toBeInTheDocument()
+  })
+
+  it('omits the transmission line — a class spans both gearboxes', () => {
+    renderRow(makeCombo())
+    expect(screen.queryByText('Automatic')).toBeNull()
+    expect(screen.queryByText('Manual')).toBeNull()
+  })
+
+  it('shows the operator and pickup store, like the SPECIFIC row', () => {
+    renderRow(makeCombo())
+    expect(screen.getByText('Zen Rentals')).toBeInTheDocument()
+    expect(screen.getByText('Kyoto Station')).toBeInTheDocument()
+  })
+
+  it('navigates to the pickup-store detail via the View cars CTA, preserving dates + filters', () => {
+    renderRow(makeCombo(), {
+      from: '2026-07-01T10:00',
+      to: '2026-07-04T10:00',
+      classFilter: 'suv',
+    })
+    const cta = screen.getByRole('link', { name: 'View cars' })
+    expect(cta).toHaveAttribute('data-to', '/$locale/storefronts/$locationId')
+    expect(cta).toHaveAttribute('data-location', 'loc_kyoto')
+    const search = JSON.parse(cta.getAttribute('data-search') ?? '{}')
+    expect(search).toMatchObject({ from: '2026-07-01T10:00', to: '2026-07-04T10:00', class: 'suv' })
+  })
+
+  it('shows "Sold out" and drops the booking CTA when availableCount is 0', () => {
+    renderRow(makeCombo({ availableCount: 0 }))
+    expect(screen.getByText('Sold out')).toBeInTheDocument()
+    expect(screen.queryByText('0 available')).toBeNull()
+    expect(screen.queryByRole('link', { name: 'View cars' })).toBeNull()
+  })
+
+  it('still shows the class label and store when sold out, so the listing stays legible', () => {
+    renderRow(makeCombo({ availableCount: 0 }))
+    expect(screen.getByRole('heading', { name: 'SUV' })).toBeInTheDocument()
+    expect(screen.getByText('Zen Rentals')).toBeInTheDocument()
   })
 })

--- a/packages/web/tests/vite/search/result.test.ts
+++ b/packages/web/tests/vite/search/result.test.ts
@@ -5,6 +5,7 @@ import {
   resolveGeoContext,
   resultPriceLabel,
   resultTitle,
+  searchResultKey,
 } from '@/vite/search/result'
 import { haversineKm } from '@kuruma/shared/lib/region-distance'
 import type { RegionNode } from '@kuruma/shared/types/region'
@@ -60,6 +61,23 @@ describe('resultTitle', () => {
   })
   it('uses the class label for a CLASS_COMBO result', () => {
     expect(resultTitle(combo)).toBe('SUV')
+  })
+})
+
+describe('searchResultKey', () => {
+  it('uses the renter-safe per-car vehicleId for a SPECIFIC result', () => {
+    expect(searchResultKey(base)).toBe('v1')
+  })
+
+  it('namespaces a CLASS_COMBO by location so the same class at two stores stays distinct', () => {
+    const here = searchResultKey(combo)
+    const elsewhere = searchResultKey({
+      ...combo,
+      location: { ...combo.location, locationId: 'l2' },
+    })
+    expect(here).toBe('l:cls_suv')
+    expect(elsewhere).toBe('l2:cls_suv')
+    expect(here).not.toBe(elsewhere)
   })
 })
 


### PR DESCRIPTION
## What

Slice 3b of #464 — the **web read-side** for cross-operator search `CLASS_COMBO` cards. The API producer (slice 3a, `b666a1a1`) already emits combo rows; the web dropped them on the floor (`default: return null`). This renders them.

- **New `ClassComboRow`** + dispatcher `case 'CLASS_COMBO'`: class label as title, an inventory-count pill, seats only (no transmission — a class spans gearboxes), shared store/geo/price/CTA.
- **Sold-out handling:** the API emits `availableCount = max(0, cap − demand)`, so `0` is possible. A 0-count combo renders a muted **"Sold out"** pill with **no booking CTA** (no live link into an empty class), but stays visible/legible.
- **Composite React key fix:** `searchResultKey()` returned a bare `classId` for combos, so the same class offered at two storefronts collided into one React `<li key>`. Now `${locationId}:${classId}` — mirrors the API cursor `itemKey` (`c:<loc>:<class>`), minus the kind prefix the list doesn't need.
- **i18n** en/ja/zh: `comboAvailable`, `comboSoldOut`.
- **Refactor:** the two row variants duplicated thumbnail/location/geo/CTA markup → extracted `RowThumbnail`/`RowLocationLine`/`RowGeoLine`/`RowDetailCta` + a `RowCardProps<T>` alias. Behaviour-preserving.
- **Exhaustiveness guard:** dispatcher `default` now asserts `item satisfies never` — a future result `kind` added without a case becomes a **tsc error**, not a silently-dropped row (the exact bug this slice fixes for combos). Still returns `null` at runtime for a skewed API.

## Test plan

- `result.test.ts` — composite key dedups the same class across two storefronts (+ SPECIFIC unchanged).
- `SearchResultRow.test.tsx` — combo renders class label / availability / seats / price / CTA; omits transmission; **sold-out → "Sold out", no CTA**; SPECIFIC row unaffected.
- ✅ Full web suite **1248 passing**, i18n parity guard green (en/ja/zh), `tsc` clean. Reviewed by `code-reviewer` (SHIP) + `architect` (SHIP-WITH-NITS — both nits applied).

## Scope / follow-ups

`Refs #464` (not Closes) — issue stays open for the remaining slices.
- **Slice 5+** (next): operator assigns car on pickup day; rate-plan CRUD UI; e2e.
- **Noted, out of scope:** `MapPopupCarousel` renders combos via kind-agnostic accessors but doesn't yet surface availability / sold-out state — confirm intended when the popup gets dedicated combo treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)