### PR TITLE
fix(#464): namespace CLASS_COMBO list key by location

### DIFF
--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -7,10 +7,12 @@ import {
 import type { RegionNode } from '@kuruma/shared/types/region'
 import type { ResultLocation, SearchResultItem } from '@kuruma/shared/types/search-result'
 
-/** Stable list key — the renter-safe per-car id for SPECIFIC, the class id for a
- *  future CLASS_COMBO row (#464). Shared by the flat list and the map+list view. */
+/** Stable list key — the renter-safe per-car id for SPECIFIC, a location-namespaced
+ *  class id for a CLASS_COMBO row (#464) so the same class offered at two storefronts
+ *  never collides into one React key. Mirrors the API cursor `itemKey` (`c:<loc>:<class>`),
+ *  minus the kind prefix the list doesn't need. Shared by the flat list and map+list view. */
 export function searchResultKey(item: SearchResultItem): string {
-  return item.kind === 'SPECIFIC' ? item.vehicleId : item.classId
+  return item.kind === 'SPECIFIC' ? item.vehicleId : `${item.location.locationId}:${item.classId}`
 }
 
 type Translate = (key: string, values?: Record<string, string | number>) => string

--- a/packages/web/tests/vite/search/result.test.ts
+++ b/packages/web/tests/vite/search/result.test.ts
@@ -5,6 +5,7 @@ import {
   resolveGeoContext,
   resultPriceLabel,
   resultTitle,
+  searchResultKey,
 } from '@/vite/search/result'
 import { haversineKm } from '@kuruma/shared/lib/region-distance'
 import type { RegionNode } from '@kuruma/shared/types/region'
@@ -60,6 +61,23 @@ describe('resultTitle', () => {
   })
   it('uses the class label for a CLASS_COMBO result', () => {
     expect(resultTitle(combo)).toBe('SUV')
+  })
+})
+
+describe('searchResultKey', () => {
+  it('uses the renter-safe per-car vehicleId for a SPECIFIC result', () => {
+    expect(searchResultKey(base)).toBe('v1')
+  })
+
+  it('namespaces a CLASS_COMBO by location so the same class at two stores stays distinct', () => {
+    const here = searchResultKey(combo)
+    const elsewhere = searchResultKey({
+      ...combo,
+      location: { ...combo.location, locationId: 'l2' },
+    })
+    expect(here).toBe('l:cls_suv')
+    expect(elsewhere).toBe('l2:cls_suv')
+    expect(here).not.toBe(elsewhere)
   })
 })
 


### PR DESCRIPTION
## What

`searchResultKey()` (`packages/web/src/vite/search/result.ts`) returned a **bare `classId`** for `CLASS_COMBO` results. The same class offered at two storefronts therefore collapses into one React `<li key>` (`SearchMapList.tsx:167`), so React's reconciler treats two distinct cards as one. This namespaces the combo key by location:

```
v:<vehicleId>                  (SPECIFIC, unchanged)
${locationId}:${classId}       (CLASS_COMBO, was bare classId)
```

Mirrors the API cursor `itemKey` (`flat-search.ts`, `c:<loc>:<class>`), minus the kind prefix the React list doesn't need.

## Why now

The API already emits combos (slice 3a, `b666a1a1`) and the slice-3b card PR (#1077) makes them **render**, so this latent dup-key collision goes live the moment combos appear in a multi-store result. Split out as a focused, conflict-free fix (touches only `result.ts`, which #1077 doesn't) so it can land independently of the card work.

## Test plan

- `result.test.ts` — `searchResultKey` returns the per-car `vehicleId` for SPECIFIC, and `${locationId}:${classId}` for CLASS_COMBO; asserts the same class at two stores yields **distinct** keys.
- ✅ 26 web result tests green, `tsc` clean.

`Refs #464` (slice 3b card UI tracked by #1077; remaining slices keep the issue open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)