### PR TITLE
feat(#877): consent evidence export — snapshot + verified, replayable export

### DIFF
--- a/docs/runbooks/2026-06-24-consent-signing-key.md
+++ b/docs/runbooks/2026-06-24-consent-signing-key.md
@@ -61,3 +61,23 @@ fail-closed protection:
 Once a production deploy is gated on this secret, add `CONSENT_SIGNING_KEY` to
 **`deploy.yml`**'s required-secret presence loop so a missing key fails the deploy
 loudly at the presence check instead of waiting for the first accept to 500.
+
+## Producing a consent evidence export (#877)
+
+Each acceptance is a self-contained, replayable evidence record: it snapshots the
+exact disclosed document (`documentSnapshot`) and the signed canonical version, so
+the export reproduces *what the renter actually agreed to*, independent of later
+edits to `consent_documents`.
+
+- **CLI:** `bun run consent:evidence -- <acceptanceId>` (or `--user <id>` / `--booking <id>`)
+  prints a JSON bundle: identity, the frozen document, the signature, and a
+  `verification.status`.
+- **Admin API:** `GET /admin/consent/acceptances/:id/evidence` (platform-admin only).
+- **`verification.status`** is the trust signal. Only `VERIFIED` is proof. Others are
+  honest gaps, surfaced verbatim: `SNAPSHOT_MISSING` (legacy/un-backfilled row),
+  `SNAPSHOT_HASH_MISMATCH` (snapshot text altered), `UNSIGNED`, `KEY_UNAVAILABLE`
+  (signed under a key we no longer hold — see #1050), `SIGNATURE_MISMATCH`.
+- **Backfill legacy rows:** `bun run db:backfill-consent-snapshot` snapshots a null
+  row *only when the current document is provably the signed artifact* (a stale or
+  edited document is skipped and reported, never backfilled with wrong text). Design
+  detail: `docs/superpowers/specs/2026-06-24-consent-evidence-export-design.md`.

--- a/docs/superpowers/plans/2026-06-24-consent-evidence-export.md
+++ b/docs/superpowers/plans/2026-06-24-consent-evidence-export.md
@@ -1,0 +1,720 @@
+# Consent Evidence Export — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every consent acceptance a self-contained, replayable evidence record — snapshot the exact disclosed text + signed canonical version at accept time, expose a verified export, and backfill legacy rows only when the current document is provably the signed artifact.
+
+**Architecture:** Snapshot (`documentSnapshot` jsonb + `signatureCanonicalVersion`) is written by `ConsentService.recordAcceptance`. A pure `verifyAcceptance()` (Functional Core) runs a strict gate chain (hash-self-check before signature). A new `ConsentEvidenceService` assembles bundles; a platform-admin route + CLI export them. A guarded backfill script reconstructs legacy snapshots.
+
+**Tech Stack:** Bun, Hono (CF Workers), Drizzle + Neon Postgres, Vitest, Zod. Spec: `docs/superpowers/specs/2026-06-24-consent-evidence-export-design.md`.
+
+**Conventions:** API unit tests run with `env -u DATABASE_URL bun run --filter @kuruma/api test`. Schema changes are a danger zone: `bun run db:generate --name <n>` → `bun run db:migrate` → `bun run db:verify` (3 green). Drizzle parity tests run under the real-pg (`db-drift` / e2e-real-db) CI lane. Commit after every green step.
+
+---
+
+### Task 1: `DocumentSnapshot` type + schema columns
+
+**Files:**
+- Modify: `packages/shared/src/lib/consent-canonical.ts` (add `DocumentSnapshot`)
+- Modify: `packages/shared/src/db/consent.ts` (two columns on `consentAcceptances`)
+- Test: `packages/shared/tests/db/consent-schema.test.ts` (extend existing schema test if present, else create)
+
+- [ ] **Step 1: Add the snapshot type.** In `consent-canonical.ts`, after `DisclosureArtifact`:
+
+```typescript
+/** The exact disclosure a subject was shown, frozen onto the acceptance (#877 evidence export). */
+export interface DocumentSnapshot extends DisclosureArtifact {
+  version: string
+  locale: string
+  contentHash: string
+}
+```
+
+- [ ] **Step 2: Add the columns.** In `db/consent.ts`, import the type and add to the `consentAcceptances` column object (after `signatureRef`):
+
+```typescript
+import type { DocumentSnapshot } from '../lib/consent-canonical'
+// ...inside consentAcceptances columns, before createdAt:
+    documentSnapshot: jsonb('documentSnapshot').$type<DocumentSnapshot>(),
+    signatureCanonicalVersion: text('signatureCanonicalVersion'),
+```
+
+Ensure `jsonb` is in the `drizzle-orm/pg-core` import list (it already is — used by `context`).
+
+- [ ] **Step 3: Generate + apply + verify the migration.**
+
+Run: `bun run db:generate --name add_consent_evidence_snapshot && bun run db:migrate && bun run db:verify`
+Expected: a new `drizzle/00XX_*.sql` adding both nullable columns; `db:verify` shows 3 green checks.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/shared/src/lib/consent-canonical.ts packages/shared/src/db/consent.ts drizzle/
+git commit -m "feat(#877): add documentSnapshot + signatureCanonicalVersion columns"
+```
+
+---
+
+### Task 2: Domain types carry the new fields
+
+**Files:**
+- Modify: `packages/api/src/stores.ts:480` (`ConsentAcceptance`)
+- Modify: `packages/api/src/repositories/types-consent.ts` (`NewConsentAcceptance`)
+
+- [ ] **Step 1: Extend `ConsentAcceptance`.** In `stores.ts`, add to the interface (after `signingKeyId`):
+
+```typescript
+  signatureCanonicalVersion: string | null
+  documentSnapshot: import('@kuruma/shared/lib/consent-canonical').DocumentSnapshot | null
+```
+
+(If `stores.ts` already imports from that module, use a top-of-file `import type { DocumentSnapshot }` instead of the inline import.)
+
+- [ ] **Step 2: Extend `NewConsentAcceptance`.** In `types-consent.ts`, add after `signingKeyId`:
+
+```typescript
+  signatureCanonicalVersion: string | null
+  documentSnapshot: DocumentSnapshot | null
+```
+
+and add the import: `import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'`.
+
+- [ ] **Step 3: Typecheck (expected to fail loudly where the row is built — that's Task 3/4).**
+
+Run: `bun run --filter @kuruma/api typecheck`
+Expected: errors only in `services/consent.ts` (buildRow) and `repositories/drizzle/consent.ts` (`toAcceptance`) for the missing properties. These are fixed next.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/api/src/stores.ts packages/api/src/repositories/types-consent.ts
+git commit -m "feat(#877): consent acceptance types carry snapshot + canonical version"
+```
+
+---
+
+### Task 3: Capture the snapshot at accept time
+
+**Files:**
+- Modify: `packages/api/src/services/consent.ts` (`buildRow`, ~148-197)
+- Test: `packages/api/src/services/consent.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Add to `consent.test.ts`:
+
+```typescript
+it('records a documentSnapshot and canonical version matching the signed document', async () => {
+  // publishDoc/makeService are the existing helpers in this file; mirror their use.
+  const doc = await publishDoc({ type: 'RENTER_TOS', version: 'v1', locale: 'en' })
+  const svc = makeService({ getSigningKey: () => ({ key: 'k', keyId: 'v1' }) })
+  const res = await svc.recordAcceptance(
+    { documentId: doc.id, userId: 'user_1', operatorMembershipId: null, actorRole: 'RENTER' },
+    { now: new Date('2026-06-24T00:00:00Z'), ipAddress: '1.1.1.1', userAgent: 'UA' },
+  )
+  if (!res.ok) throw new Error('expected ok')
+  expect(res.acceptance.documentSnapshot).toEqual({
+    version: 'v1', locale: 'en', title: doc.title, body: doc.body,
+    acceptanceLabel: doc.acceptanceLabel, contentHash: doc.contentHash,
+  })
+  expect(res.acceptance.signatureCanonicalVersion).toBe('v1') // CANONICAL_VERSION
+})
+```
+
+- [ ] **Step 2: Run it; confirm it fails.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent.test.ts -t documentSnapshot`
+Expected: FAIL (`documentSnapshot` undefined).
+
+- [ ] **Step 3: Implement.** In `consent.ts`: import `CANONICAL_VERSION` (`import { CANONICAL_VERSION } from '@kuruma/shared/lib/consent-canonical'`); widen `buildRow`'s `doc` param type to include `title`, `body`, `acceptanceLabel`; and add the two fields to the returned object:
+
+```typescript
+  private buildRow(
+    doc: { id: string; type: ConsentType; version: string; locale: string; contentHash: string
+           title: string; body: string; acceptanceLabel: string },
+    // ...unchanged params
+  ): NewConsentAcceptance {
+    // ...unchanged through `const signed = key ? signAcceptanceRecord(...) : undefined`
+    return {
+      // ...all existing fields unchanged...
+      recordSignature: signed?.signature ?? null,
+      signingKeyId: signed?.signingKeyId ?? null,
+      signatureCanonicalVersion: signed ? CANONICAL_VERSION : null,
+      documentSnapshot: {
+        version: doc.version, locale: doc.locale, title: doc.title, body: doc.body,
+        acceptanceLabel: doc.acceptanceLabel, contentHash: doc.contentHash,
+      },
+    }
+  }
+```
+
+- [ ] **Step 4: Run it; confirm it passes.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent.test.ts`
+Expected: PASS (all consent service tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/api/src/services/consent.ts packages/api/src/services/consent.test.ts
+git commit -m "feat(#877): snapshot disclosed text + canonical version on accept"
+```
+
+---
+
+### Task 4: Repo plumbing (in-memory spread + Drizzle mapper)
+
+**Files:**
+- Modify: `packages/api/src/repositories/drizzle/consent.ts` (`toAcceptance`, ~32-52)
+- Test: `packages/api/src/repositories/drizzle/consent.test.ts` (real-pg parity; existing file)
+
+The in-memory repo's `createAcceptance` already does `{ ...data }`, so the new fields flow through once the type carries them — no code change there. The Drizzle `.values({ ...data, id })` insert likewise carries them; only the read mapper `toAcceptance` must surface them.
+
+- [ ] **Step 1: Write the failing parity test.** In the Drizzle consent test (runs under real pg):
+
+```typescript
+it('round-trips documentSnapshot + signatureCanonicalVersion', async () => {
+  const snapshot = { version: 'v1', locale: 'en', title: 'T', body: 'B', acceptanceLabel: 'L',
+                     contentHash: 'h' }
+  const created = await repo.createAcceptance({ ...baseAcceptance, // existing fixture in this file
+    signatureCanonicalVersion: 'v1', documentSnapshot: snapshot })
+  const read = await repo.findUserDocumentAcceptance(created.userId, created.documentId)
+  expect(read?.documentSnapshot).toEqual(snapshot)
+  expect(read?.signatureCanonicalVersion).toBe('v1')
+})
+```
+
+- [ ] **Step 2: Run it; confirm it fails.**
+
+Run: `bunx vitest run packages/api/src/repositories/drizzle/consent.test.ts -t documentSnapshot` (requires a real pg `DATABASE_URL`; see CLAUDE.md docker recipe)
+Expected: FAIL (`documentSnapshot` undefined on read — `toAcceptance` drops it).
+
+- [ ] **Step 3: Implement.** In `drizzle/consent.ts` `toAcceptance`, add before `createdAt`:
+
+```typescript
+    signatureCanonicalVersion: r.signatureCanonicalVersion,
+    documentSnapshot: r.documentSnapshot,
+```
+
+- [ ] **Step 4: Run it; confirm it passes.**
+
+Run: same as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/api/src/repositories/drizzle/consent.ts packages/api/src/repositories/drizzle/consent.test.ts
+git commit -m "feat(#877): persist + read snapshot fields in Drizzle consent repo"
+```
+
+---
+
+### Task 5: Repo read methods for export
+
+**Files:**
+- Modify: `packages/api/src/repositories/types-consent.ts` (interface)
+- Modify: `packages/api/src/repositories/in-memory/consent.ts`
+- Modify: `packages/api/src/repositories/drizzle/consent.ts`
+- Test: `packages/api/src/repositories/in-memory/consent.test.ts`
+
+- [ ] **Step 1: Add to the interface.** In `types-consent.ts` `ConsentRepository`:
+
+```typescript
+  findAcceptanceById(id: string): Promise<ConsentAcceptance | undefined>
+  findAcceptancesByUser(userId: string): Promise<ConsentAcceptance[]>
+  findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]>
+```
+
+- [ ] **Step 2: Write the failing in-memory test.**
+
+```typescript
+it('finds acceptances by id, user, and booking', async () => {
+  const a = await repo.createAcceptance({ ...validUserAcceptance }) // existing fixture
+  expect((await repo.findAcceptanceById(a.id))?.id).toBe(a.id)
+  expect(await repo.findAcceptancesByUser(a.userId)).toHaveLength(1)
+  expect(await repo.findAcceptancesByBooking('booking_none')).toEqual([])
+})
+```
+
+- [ ] **Step 3: Run it; confirm it fails.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/repositories/in-memory/consent.test.ts -t "by id, user"`
+Expected: FAIL (method not a function).
+
+- [ ] **Step 4: Implement both repos.** In-memory (`in-memory/consent.ts`):
+
+```typescript
+  async findAcceptanceById(id: string) { return this.acceptances.find((a) => a.id === id) }
+  async findAcceptancesByUser(userId: string) { return this.acceptances.filter((a) => a.userId === userId) }
+  async findAcceptancesByBooking(bookingId: string) { return this.acceptances.filter((a) => a.bookingId === bookingId) }
+```
+
+Drizzle (`drizzle/consent.ts`, mirroring existing query methods + `toAcceptance`):
+
+```typescript
+  async findAcceptanceById(id: string) {
+    const [row] = await this.db.select().from(consentAcceptances).where(eq(consentAcceptances.id, id)).limit(1)
+    return row ? toAcceptance(row) : undefined
+  }
+  async findAcceptancesByUser(userId: string) {
+    const rows = await this.db.select().from(consentAcceptances).where(eq(consentAcceptances.userId, userId))
+    return rows.map(toAcceptance)
+  }
+  async findAcceptancesByBooking(bookingId: string) {
+    const rows = await this.db.select().from(consentAcceptances).where(eq(consentAcceptances.bookingId, bookingId))
+    return rows.map(toAcceptance)
+  }
+```
+
+- [ ] **Step 5: Run it; confirm it passes + typecheck.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/repositories/in-memory/consent.test.ts && bun run --filter @kuruma/api typecheck`
+Expected: PASS; typecheck clean (the `repositories.test.ts` exhaustiveness map may need the new methods — add them if it fails).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/api/src/repositories/
+git commit -m "feat(#877): consent repo read methods for evidence export"
+```
+
+---
+
+### Task 6: Pure verification (gate chain)
+
+**Files:**
+- Create: `packages/api/src/services/consent-evidence-verify.ts`
+- Test: `packages/api/src/services/consent-evidence-verify.test.ts`
+
+- [ ] **Step 1: Write the failing tests (one behavior per `it`).**
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import { verifyAcceptance } from './consent-evidence-verify'
+import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import { signAcceptanceRecord } from './consent-signing'
+
+const KEY = { key: 'secret', keyId: 'v1' }
+function signedAcceptance(over = {}) { /* build a ConsentAcceptance with a valid snapshot + signature */
+  const snap = { version: 'v1', locale: 'en', title: 'T', body: 'B', acceptanceLabel: 'L',
+                 contentHash: computeContentHash({ title: 'T', body: 'B', acceptanceLabel: 'L' }) }
+  const base = { id: 'acc_1', documentId: 'doc_1', consentType: 'RENTER_TOS', userId: 'u1',
+    operatorId: null, operatorMembershipId: null, actorRole: 'RENTER', bookingId: null,
+    acceptedAt: new Date('2026-06-24T00:00:00Z'), context: null, ipAddress: null, userAgent: null,
+    method: 'CLICKWRAP', signatureRef: null, createdAt: new Date(), signatureCanonicalVersion: 'v1',
+    documentSnapshot: snap } as const
+  const sig = signAcceptanceRecord({ documentId: base.documentId, contentHash: snap.contentHash,
+    consentType: base.consentType, version: snap.version, locale: snap.locale, userId: base.userId,
+    operatorId: base.operatorId, operatorMembershipId: base.operatorMembershipId,
+    bookingId: base.bookingId, method: base.method, acceptedAt: base.acceptedAt,
+    ipAddress: base.ipAddress, userAgent: base.userAgent }, KEY)
+  return { ...base, recordSignature: sig.signature, signingKeyId: sig.signingKeyId, ...over }
+}
+
+it('VERIFIED when snapshot hashes correctly and signature matches', () => {
+  expect(verifyAcceptance(signedAcceptance(), () => KEY).status).toBe('VERIFIED')
+})
+it('SNAPSHOT_MISSING when no snapshot', () => {
+  expect(verifyAcceptance(signedAcceptance({ documentSnapshot: null }), () => KEY).status).toBe('SNAPSHOT_MISSING')
+})
+it('SNAPSHOT_HASH_MISMATCH when body altered but hash left intact (the attack)', () => {
+  const a = signedAcceptance()
+  const tampered = { ...a, documentSnapshot: { ...a.documentSnapshot!, body: 'EVIL' } }
+  expect(verifyAcceptance(tampered, () => KEY).status).toBe('SNAPSHOT_HASH_MISMATCH')
+})
+it('UNSIGNED when recordSignature null', () => {
+  expect(verifyAcceptance(signedAcceptance({ recordSignature: null }), () => KEY).status).toBe('UNSIGNED')
+})
+it('KEY_UNAVAILABLE when signingKeyId is not resolvable', () => {
+  // resolver must DISCRIMINATE on keyId, else 'v9' would resolve to a key and the gate is skipped.
+  const onlyV1 = (keyId: string) => (keyId === 'v1' ? KEY : undefined)
+  expect(verifyAcceptance(signedAcceptance({ signingKeyId: 'v9' }), onlyV1).status).toBe('KEY_UNAVAILABLE')
+})
+it('SIGNATURE_MISMATCH when the signature was altered', () => {
+  expect(verifyAcceptance(signedAcceptance({ recordSignature: 'deadbeef' }), () => KEY).status).toBe('SIGNATURE_MISMATCH')
+})
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent-evidence-verify.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the pure function.**
+
+```typescript
+import { type DocumentSnapshot, computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import type { ConsentAcceptance } from '../stores'
+import { type SigningKey, signAcceptanceRecord } from './consent-signing'
+
+export type ConsentVerificationStatus =
+  | 'VERIFIED' | 'SNAPSHOT_MISSING' | 'SNAPSHOT_HASH_MISMATCH'
+  | 'UNSIGNED' | 'KEY_UNAVAILABLE' | 'SIGNATURE_MISMATCH'
+
+export interface ConsentVerification { status: ConsentVerificationStatus; detail?: string }
+
+/** Gate chain (spec §Verification): first failing gate is the status. `getKey` resolves a
+ *  keyId to its SigningKey (undefined when we no longer hold it). Pure — no I/O. */
+export function verifyAcceptance(
+  a: ConsentAcceptance,
+  getKey: (keyId: string) => SigningKey | undefined,
+): ConsentVerification {
+  const snap: DocumentSnapshot | null = a.documentSnapshot
+  if (!snap) return { status: 'SNAPSHOT_MISSING' }
+  if (computeContentHash(snap) !== snap.contentHash) return { status: 'SNAPSHOT_HASH_MISMATCH' }
+  if (!a.recordSignature) return { status: 'UNSIGNED' }
+  const key = a.signingKeyId ? getKey(a.signingKeyId) : undefined
+  if (!key) return { status: 'KEY_UNAVAILABLE', detail: a.signingKeyId ?? undefined }
+  const recomputed = signAcceptanceRecord({
+    documentId: a.documentId, contentHash: snap.contentHash, consentType: a.consentType,
+    version: snap.version, locale: snap.locale, userId: a.userId, operatorId: a.operatorId,
+    operatorMembershipId: a.operatorMembershipId, bookingId: a.bookingId, method: a.method,
+    acceptedAt: a.acceptedAt, ipAddress: a.ipAddress, userAgent: a.userAgent,
+  }, key).signature
+  return recomputed === a.recordSignature ? { status: 'VERIFIED' } : { status: 'SIGNATURE_MISMATCH' }
+}
+```
+
+Note: `computeContentHash(snap)` works because `DocumentSnapshot extends DisclosureArtifact`.
+Note: this verifies under the current canonical version only; rows whose `signatureCanonicalVersion` differs from the live `CANONICAL_VERSION` are a future concern tracked with #1050 — leave a `// TODO(#1050)` above the `signAcceptanceRecord` recompute.
+
+- [ ] **Step 4: Run; confirm pass.**
+
+Run: same as Step 2. Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/api/src/services/consent-evidence-verify.ts packages/api/src/services/consent-evidence-verify.test.ts
+git commit -m "feat(#877): pure consent verification gate chain"
+```
+
+---
+
+### Task 7: `ConsentEvidenceService` + DI
+
+**Files:**
+- Create: `packages/api/src/services/consent-evidence.ts`
+- Modify: `packages/api/src/index.ts` (construct + wire)
+- Test: `packages/api/src/services/consent-evidence.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```typescript
+it('assembles an evidence bundle with verification for an acceptance id', async () => {
+  const repo = new InMemoryConsentRepository() // existing double
+  const acc = await repo.createAcceptance({ /* a fully-signed fixture, snapshot present */ })
+  const svc = new ConsentEvidenceService(repo, (keyId) => keyId === 'v1' ? { key: 'secret', keyId } : undefined)
+  const ev = await svc.getConsentEvidence(acc.id)
+  expect(ev?.acceptance.id).toBe(acc.id)
+  expect(ev?.document).toEqual(acc.documentSnapshot)
+  expect(ev?.verification.status).toBe('VERIFIED')
+})
+it('returns undefined for an unknown acceptance id', async () => {
+  const svc = new ConsentEvidenceService(new InMemoryConsentRepository(), () => undefined)
+  expect(await svc.getConsentEvidence('nope')).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent-evidence.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement.**
+
+```typescript
+import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
+import type { ConsentRepository } from '../repositories/types-consent'
+import type { ConsentAcceptance } from '../stores'
+import type { SigningKey } from './consent-signing'
+import { type ConsentVerification, verifyAcceptance } from './consent-evidence-verify'
+
+export interface ConsentEvidence {
+  acceptance: Pick<ConsentAcceptance,
+    'id' | 'userId' | 'actorRole' | 'documentId' | 'consentType' | 'operatorId'
+    | 'operatorMembershipId' | 'bookingId' | 'acceptedAt' | 'method' | 'ipAddress' | 'userAgent'>
+  document: DocumentSnapshot | null
+  signature: { recordSignature: string | null; signingKeyId: string | null; signatureCanonicalVersion: string | null }
+  verification: ConsentVerification
+}
+
+export class ConsentEvidenceService {
+  constructor(
+    private readonly repo: ConsentRepository,
+    private readonly getKey: (keyId: string) => SigningKey | undefined,
+  ) {}
+
+  private toEvidence(a: ConsentAcceptance): ConsentEvidence {
+    return {
+      acceptance: { id: a.id, userId: a.userId, actorRole: a.actorRole, documentId: a.documentId,
+        consentType: a.consentType, operatorId: a.operatorId, operatorMembershipId: a.operatorMembershipId,
+        bookingId: a.bookingId, acceptedAt: a.acceptedAt, method: a.method, ipAddress: a.ipAddress,
+        userAgent: a.userAgent },
+      document: a.documentSnapshot,
+      signature: { recordSignature: a.recordSignature, signingKeyId: a.signingKeyId,
+        signatureCanonicalVersion: a.signatureCanonicalVersion },
+      verification: verifyAcceptance(a, this.getKey),
+    }
+  }
+
+  async getConsentEvidence(acceptanceId: string): Promise<ConsentEvidence | undefined> {
+    const a = await this.repo.findAcceptanceById(acceptanceId)
+    return a ? this.toEvidence(a) : undefined
+  }
+  async getConsentEvidenceForUser(userId: string): Promise<ConsentEvidence[]> {
+    return (await this.repo.findAcceptancesByUser(userId)).map((a) => this.toEvidence(a))
+  }
+  async getConsentEvidenceForBooking(bookingId: string): Promise<ConsentEvidence[]> {
+    return (await this.repo.findAcceptancesByBooking(bookingId)).map((a) => this.toEvidence(a))
+  }
+}
+```
+
+The `getKey` resolver: today only the current key exists, so wire `(keyId) => { const k = resolveSigningKey(); return k && k.keyId === keyId ? k : undefined }`. (When #1050 lands a registry, swap this lambda.)
+
+- [ ] **Step 4: Wire DI in `index.ts`.** Near the existing `new ConsentService(...)`/`ConsentGateService` construction, add:
+
+```typescript
+import { ConsentEvidenceService } from './services/consent-evidence'
+import { resolveSigningKey } from './services/consent-signing'
+// ...
+const consentEvidenceService = new ConsentEvidenceService(consentRepo, (keyId) => {
+  const k = resolveSigningKey()
+  return k && k.keyId === keyId ? k : undefined
+})
+```
+
+Pass `consentEvidenceService` into the admin routes factory (Task 8).
+
+- [ ] **Step 5: Run + typecheck.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent-evidence.test.ts && bun run --filter @kuruma/api typecheck`
+Expected: PASS; clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/api/src/services/consent-evidence.ts packages/api/src/services/consent-evidence.test.ts packages/api/src/index.ts
+git commit -m "feat(#877): ConsentEvidenceService assembles verified bundles"
+```
+
+---
+
+### Task 8: Platform-admin export route
+
+**Files:**
+- Modify: `packages/api/src/routes/admin.ts` (add the route under `requirePlatformAdmin`)
+- Test: `packages/api/src/routes/admin.test.ts` (or the existing admin route test file)
+
+- [ ] **Step 1: Write the failing test.** Mirror the existing admin-route tests (they build the app with a `PLATFORM_ADMIN` session and assert 403 for other roles):
+
+```typescript
+it('GET /admin/consent/acceptances/:id/evidence returns the bundle for an admin', async () => {
+  const res = await adminApp.request(`/admin/consent/acceptances/${seededAcceptanceId}/evidence`)
+  expect(res.status).toBe(200)
+  const body = await res.json()
+  expect(body.data.acceptance.id).toBe(seededAcceptanceId)
+  expect(body.data.verification.status).toBeDefined()
+})
+it('rejects a renter caller with 403', async () => {
+  const res = await renterApp.request(`/admin/consent/acceptances/x/evidence`)
+  expect(res.status).toBe(403)
+})
+it('returns 404 for an unknown acceptance', async () => {
+  const res = await adminApp.request(`/admin/consent/acceptances/nope/evidence`)
+  expect(res.status).toBe(404)
+})
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/routes/admin.test.ts -t evidence`
+Expected: FAIL (404 route / handler missing).
+
+- [ ] **Step 3: Implement.** In `admin.ts`, the admin sub-app already does `app.use('/admin/*', requirePlatformAdmin)`. Take `ConsentEvidenceService` into the factory and add:
+
+```typescript
+  app.get('/admin/consent/acceptances/:id/evidence', async (c) => {
+    const evidence = await consentEvidenceService.getConsentEvidence(c.req.param('id'))
+    if (!evidence) return fail(c, 404, 'ACCEPTANCE_NOT_FOUND')
+    return ok(c, evidence)
+  })
+```
+
+Use the existing `ok`/`fail` from `routes/helpers.ts` (already imported in this file or import them). Thread `consentEvidenceService` from `index.ts` into this factory's params.
+
+- [ ] **Step 4: Run; confirm pass.**
+
+Run: same as Step 2. Expected: PASS (admin 200, renter 403, unknown 404).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/api/src/routes/admin.ts packages/api/src/routes/admin.test.ts packages/api/src/index.ts
+git commit -m "feat(#877): platform-admin consent evidence export route"
+```
+
+---
+
+### Task 9: CLI export
+
+**Files:**
+- Create: `scripts/consent-evidence.ts`
+- Modify: `package.json` (scripts)
+
+- [ ] **Step 1: Implement the CLI** (mirrors the env/db wiring of `scripts/backfill-vehicle-expiry.ts`):
+
+```typescript
+// Usage: bun run consent:evidence -- <acceptanceId> | --user <id> | --booking <id>
+import { getDb } from '@kuruma/shared/db'
+import { DrizzleConsentRepository } from '../packages/api/src/repositories/drizzle/consent'
+import { ConsentEvidenceService } from '../packages/api/src/services/consent-evidence'
+import { resolveSigningKey } from '../packages/api/src/services/consent-signing'
+
+async function main() {
+  const [a, b] = process.argv.slice(2)
+  const repo = new DrizzleConsentRepository(getDb())
+  const svc = new ConsentEvidenceService(repo, (keyId) => {
+    const k = resolveSigningKey(); return k && k.keyId === keyId ? k : undefined
+  })
+  const out = a === '--user' ? await svc.getConsentEvidenceForUser(b)
+    : a === '--booking' ? await svc.getConsentEvidenceForBooking(b)
+    : await svc.getConsentEvidence(a)
+  if (!out) { console.error('not found'); process.exit(1) }
+  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`)
+}
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+(If importing `packages/api/...` from `scripts/` trips a boundary lint, place the script under `packages/api/scripts/` and add the run-script there instead — follow whatever the existing `db:backfill-*` scripts do.)
+
+- [ ] **Step 2: Add the script.** In `package.json` `scripts`: `"consent:evidence": "bun run scripts/consent-evidence.ts"`.
+
+- [ ] **Step 3: Smoke-test against a seeded local DB.**
+
+Run: `DATABASE_URL=<local> bun run consent:evidence -- <a seeded acceptance id>`
+Expected: a JSON bundle with a `verification.status`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add scripts/consent-evidence.ts package.json
+git commit -m "feat(#877): CLI consent evidence export"
+```
+
+---
+
+### Task 10: Guarded backfill of legacy snapshots
+
+**Files:**
+- Create: `scripts/backfill-consent-snapshot.ts`
+- Modify: `package.json` (scripts)
+- Test: `packages/api/src/services/consent-backfill.test.ts` (unit-test the pure decision; the script is a thin shell)
+
+- [ ] **Step 1: Write the failing test for the pure decision function.**
+
+```typescript
+import { decideBackfill } from '../../../scripts/consent-backfill-decide' // pure helper (Step 3)
+import { computeContentHash, CANONICAL_VERSION } from '@kuruma/shared/lib/consent-canonical'
+import { signAcceptanceRecord } from '../services/consent-signing'
+
+const KEY = { key: 'secret', keyId: 'v1' }
+// helper builds an unsigned-snapshot acceptance + its current doc + a valid signature over that doc
+it('backfills when current doc is self-consistent AND HMAC matches', () => {
+  const r = decideBackfill(/* acceptance, currentDoc, getKey */)
+  expect(r.action).toBe('backfill')
+})
+it('skips current-doc-hash-mismatch when doc text and its own hash disagree', () => {
+  expect(decideBackfill(/* doc with body!=hash */).action).toBe('skipped-current-doc-hash-mismatch')
+})
+it('skips hash-mismatch when the doc drifted from what was signed', () => {
+  expect(decideBackfill(/* doc whose hash != signed hash */).action).toBe('skipped-hash-mismatch')
+})
+it('skips unsigned rows', () => {
+  expect(decideBackfill(/* recordSignature null */).action).toBe('skipped-unsigned')
+})
+it('backfills with timestamp-drift noted when updatedAt>acceptedAt but HMAC matches', () => {
+  const r = decideBackfill(/* updatedAt later, content identical */)
+  expect(r.action).toBe('backfill'); expect(r.timestampDrift).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+Run: `env -u DATABASE_URL bunx vitest run packages/api/src/services/consent-backfill.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the pure decision** (`scripts/consent-backfill-decide.ts`), then the thin script shell:
+
+```typescript
+import { type DocumentSnapshot, computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import type { ConsentAcceptance, ConsentDocument } from '../packages/api/src/stores'
+import { type SigningKey, signAcceptanceRecord } from '../packages/api/src/services/consent-signing'
+
+export type BackfillAction =
+  | 'backfill' | 'skipped-current-doc-hash-mismatch' | 'skipped-hash-mismatch' | 'skipped-unsigned'
+
+export interface BackfillDecision { action: BackfillAction; snapshot?: DocumentSnapshot; timestampDrift?: boolean }
+
+export function decideBackfill(
+  a: ConsentAcceptance, doc: ConsentDocument, getKey: (keyId: string) => SigningKey | undefined,
+): BackfillDecision {
+  // Gate 1: source-doc self-consistency (text -> its own hash) — must precede the HMAC gate.
+  if (computeContentHash(doc) !== doc.contentHash) return { action: 'skipped-current-doc-hash-mismatch' }
+  // Gate 3: no crypto proof for unsigned rows.
+  if (!a.recordSignature) return { action: 'skipped-unsigned' }
+  const key = a.signingKeyId ? getKey(a.signingKeyId) : undefined
+  if (!key) return { action: 'skipped-unsigned' } // can't prove without the key; treat as unprovable
+  // Gate 2: does the CURRENT doc's hash, signed under this row's fields, reproduce recordSignature?
+  const recomputed = signAcceptanceRecord({
+    documentId: a.documentId, contentHash: doc.contentHash, consentType: a.consentType,
+    version: doc.version, locale: doc.locale, userId: a.userId, operatorId: a.operatorId,
+    operatorMembershipId: a.operatorMembershipId, bookingId: a.bookingId, method: a.method,
+    acceptedAt: a.acceptedAt, ipAddress: a.ipAddress, userAgent: a.userAgent,
+  }, key).signature
+  if (recomputed !== a.recordSignature) return { action: 'skipped-hash-mismatch' }
+  const snapshot: DocumentSnapshot = { version: doc.version, locale: doc.locale, title: doc.title,
+    body: doc.body, acceptanceLabel: doc.acceptanceLabel, contentHash: doc.contentHash }
+  return { action: 'backfill', snapshot, timestampDrift: doc.updatedAt > a.acceptedAt }
+}
+```
+
+The script (`scripts/backfill-consent-snapshot.ts`): load all acceptances with `documentSnapshot IS NULL`, join the current doc, call `decideBackfill`; for `backfill` write `{ documentSnapshot, signatureCanonicalVersion: a.signingKeyId ? CANONICAL_VERSION : null }`; tally `{ backfilled, timestampDrift, 'skipped-*' }`; print the report and exit non-zero if any `skipped-*` rows exist so a human reviews them.
+
+- [ ] **Step 4: Run; confirm pass.**
+
+Run: same as Step 2. Expected: PASS (5 decisions).
+
+- [ ] **Step 5: Add the script + commit.** `package.json`: `"db:backfill-consent-snapshot": "bun run scripts/backfill-consent-snapshot.ts"`.
+
+```bash
+git add scripts/consent-backfill-decide.ts scripts/backfill-consent-snapshot.ts packages/api/src/services/consent-backfill.test.ts package.json
+git commit -m "feat(#877): guarded backfill of legacy consent snapshots"
+```
+
+---
+
+### Task 11: Full-suite gate + docs
+
+- [ ] **Step 1: Run the full gates.**
+
+Run: `bun run --filter @kuruma/api typecheck && env -u DATABASE_URL bun run --filter @kuruma/api test && bun run --filter @kuruma/api lint:boundaries && bun run db:verify`
+Expected: all green. (Drizzle parity tests in Task 4 run under the real-pg CI lane; verify locally with a docker pg per CLAUDE.md before pushing.)
+
+- [ ] **Step 2: Update the runbook reference.** Add a short "Producing a consent evidence export" section to `docs/runbooks/2026-06-24-consent-signing-key.md` pointing at `consent:evidence` and the admin route.
+
+- [ ] **Step 3: Commit + open PR.**
+
+```bash
+git add docs/
+git commit -m "docs(#877): consent evidence export runbook note"
+# rebase onto origin/develop, push, open PR base develop, body: Refs #877; tie #1049/#1050.
+```
+
+---
+
+## Notes for the executor
+
+- **Test fixtures already exist** in `consent.test.ts`, `in-memory/consent.test.ts`, `drizzle/consent.test.ts` — reuse their helpers (`publishDoc`, `makeService`, base acceptance fixtures) rather than re-inventing. Read each test file's top before writing new cases.
+- **`signAcceptanceRecord` is the single source of the signed field set.** If you change which fields it covers, the verify recompute (Task 6) and backfill recompute (Task 10) must change identically — they intentionally mirror it.
+- **Architecture boundaries:** routes→services→repositories only. The route (Task 8) must not import a repo; it takes `ConsentEvidenceService`. `index.ts` is the only place concrete repos/services are constructed.
+- **#1050 hook:** the `getKey` resolver lambda is the single seam to swap for a multi-key registry; verification already dispatches on `signingKeyId`.

--- a/docs/superpowers/specs/2026-06-24-consent-evidence-export-design.md
+++ b/docs/superpowers/specs/2026-06-24-consent-evidence-export-design.md
@@ -1,0 +1,219 @@
+# Consent Evidence Export — Design
+
+> Status: DRAFT for review · 2026-06-24 · Refs #877 (consent ledger), follows #1048 (signing key wired)
+
+## Problem
+
+The consent ledger signs each acceptance with an HMAC (`recordSignature` + `signingKeyId`)
+over the document content the user saw. But the acceptance row only references the **live**
+`consent_documents` row by `documentId`; it does **not** store the version or text that was
+shown. `consent_documents` is mutable in place (PK = `id`, `updatedAt`, seed uses
+`onConflictDoUpdate`). So if a document is ever edited:
+
+- old acceptances would render **today's** text, not what the user actually agreed to, and
+- the stored signature (computed over the original content hash) would no longer verify, with
+  the original text already lost.
+
+The owner's goal is **"proof when needed" via a clean export** — on demand, produce a
+complete, faithful, human-readable evidence record for any acceptance. That requires each
+acceptance to reproduce *exactly* what was agreed, independent of later document edits.
+
+## Goals
+
+- Each acceptance is a **self-contained evidence record**: signature + exact version/text +
+  timestamp + actor + request metadata, frozen at accept time.
+- An on-demand **export** that assembles the bundle and **re-verifies** the signature against
+  the frozen snapshot (not the live, mutable document).
+- Drift between the snapshot and the live document is a **detectable, explainable fact**, never
+  silent corruption.
+
+## Non-goals (explicit YAGNI cuts)
+
+- **No asymmetric signatures / Ed25519.** Owner chose export over third-party-verifiable crypto.
+  The existing HMAC (Tier-1) stays; an asymmetric swap remains a future option if an external
+  party ever must verify without trusting us.
+- **No external timestamp authority / transparency log / hash-chaining.** Not defending against
+  the "you fabricated/backdated it" accusation in this iteration.
+- **No PDF rendering.** Structured JSON export is sufficient; a printable view can come later.
+
+## Approach (chosen: A — snapshot full text)
+
+### Data model
+
+Two new columns on `consent_acceptances`:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `documentSnapshot` | `jsonb` (nullable) | `{ version, locale, title, body, acceptanceLabel, contentHash }` captured at accept time. |
+| `signatureCanonicalVersion` | `text` (nullable) | The `_canon` version (`CANONICAL_VERSION`) embedded in the signed bytes at sign time, **stored explicitly** so a future v2 verifier re-canonicalizes byte-identically instead of guessing/trying versions. Null on legacy rows ⇒ assume the sole historical version. (Delivers part of #1050's groundwork.) |
+
+- `documentSnapshot` is one atomic column, not six loose ones — clearly "the snapshot of what was shown."
+- Both are **nullable** because existing rows predate them. A null `documentSnapshot` unambiguously
+  means "legacy, pre-snapshot"; every new acceptance populates both.
+- The snapshot's `contentHash`/`version`/`locale` are in the signed set; the raw `title`/`body`/
+  `acceptanceLabel` bind to the signature only *through* `contentHash` (enforced by verification
+  gate 2) — so snapshot and signature stay **consistent by construction**.
+
+### Capture flow (no new moving parts)
+
+`ConsentService.recordAcceptance` already loads the document (to check `PUBLISHED` and to
+compute the HMAC over its content). At that point it holds `version`/`locale`/`title`/`body`/
+`acceptanceLabel`/`contentHash` — it writes them into `documentSnapshot` on the same insert, and
+records the `CANONICAL_VERSION` used by the signer into `signatureCanonicalVersion`.
+`NewConsentAcceptance` gains both fields; `InMemory` and `Drizzle` consent repos persist them. The
+signer's canonical-form logic is unchanged — we only *capture* the version tag it already embeds.
+
+### Backfill
+
+One-time idempotent script `db:backfill-consent-snapshot`. "Join the current document and write
+the snapshot" is unsafe on its own: the seed uses `onConflictDoUpdate` for `title`/`body`/
+`contentHash` and advances `updatedAt` (`seed.ts`), so if wording ever drifted, naive backfill
+would **manufacture false evidence**. The script therefore writes a snapshot for a null-snapshot
+row **only when it can prove the current document still matches what was accepted**:
+
+1. **Source-doc self-consistency pre-gate (runs first):** verify the current document is internally
+   consistent — `computeContentHash(currentDoc.title, body, acceptanceLabel) === currentDoc.contentHash`.
+   If it fails, the live row's text and its own hash already disagree (e.g. a body edit that left a
+   stale `contentHash`), so the artifact can't be trusted as the source of a snapshot → **skip** as
+   `skipped-current-doc-hash-mismatch`. This must precede the HMAC gate, because the HMAC is computed
+   over the *stored* `contentHash`, not the raw text — without this pre-gate the HMAC could pass
+   while the displayed text is wrong.
+2. **Signed rows (the strong gate):** recompute the HMAC over the current document's `contentHash` +
+   the row's canonical fields, under the row's `signingKeyId`. If it equals `recordSignature`, then —
+   *given the pre-gate passed* — current text → current `contentHash` → signed `contentHash` all
+   chain, so the current document is provably the disclosure artifact that was signed → safe to
+   snapshot. If it does **not** match → the document drifted → **skip** as `skipped-hash-mismatch`.
+3. **Unsigned rows** (`recordSignature` null): no cryptographic proof is available → **skip**,
+   never guess.
+4. **Timestamp drift = audit metadata, not a veto.** Consent seed upserts set `updatedAt = now` on
+   every reseed even when content is byte-identical (`seed.ts`), so `updatedAt` drift does **not**
+   imply tampering. The gate-2 HMAC match is authoritative: when it passes, the row is backfilled
+   even if `updatedAt > acceptedAt`, and the drift is recorded as audit metadata on the report.
+   `updatedAt` is never allowed to override a passing signature — crypto beats heuristics.
+
+The script **aborts with a report** (backfilled [with/without timestamp-drift noted] /
+`skipped-current-doc-hash-mismatch` / `skipped-hash-mismatch` / `skipped-unsigned`) rather than
+silently completing, so the operator sees exactly what was and wasn't reconstructed. Skipped rows
+stay `null` and surface as `SNAPSHOT_MISSING` in the export — an honest gap, not fabricated text.
+
+## Export + verification (Section 2)
+
+### Service
+
+`ConsentService.getConsentEvidence(acceptanceId)` → `ConsentEvidence`:
+
+```
+ConsentEvidence = {
+  acceptance:   { id, userId, actorRole, documentId, consentType,
+                  operatorId?, operatorMembershipId?, bookingId?,
+                  acceptedAt, method, ipAddress?, userAgent? },
+  document:     { version, locale, title, body, acceptanceLabel, contentHash } | null,  // null = no snapshot
+  signature:    { recordSignature, signingKeyId, signatureCanonicalVersion },
+  verification: { status, detail? },
+}
+```
+
+The record exposes **every field in the signed set** — `documentId`, `contentHash`, `consentType`,
+`version`, `locale`, `userId`, `operatorId`, `operatorMembershipId`, `bookingId`, `method`,
+`acceptedAt`, `ipAddress`, `userAgent`, `signingKeyId` — plus `signatureCanonicalVersion`. So
+verification is **replayable from the exported JSON alone** by anyone holding the key:
+re-canonicalize those fields under the stored version, HMAC, compare. (`actorRole` is included as
+metadata but is *not* in the signed set, so it does not affect verification.)
+`operatorMembershipId` in particular records which membership exercised operator authority.
+
+`document` is **nullable**: legacy and intentionally-un-backfilled rows have no snapshot. The
+export NEVER falls back to reading the live `consent_documents` row in the `document` slot — that
+is the exact silent-substitution bug this design exists to prevent. (A live doc MAY be attached
+under a clearly separate `currentDocument` field labelled "current — not what was shown,
+unverifiable" if an operator explicitly asks; never in `document`.)
+
+Bundle variants for legal export: `getConsentEvidenceForUser(userId)` and
+`...ForBooking(bookingId)` return arrays of the same record.
+
+### Verification semantics
+
+The signed HMAC payload covers `contentHash` (plus `version`/`locale`/record fields) — **not** the
+raw `title`/`body`/`acceptanceLabel` (see `consent-signing.ts`). The raw text is bound to the
+signature only *through* `contentHash`. So a valid signature alone does **not** prove the exported
+text is authentic — the text→hash link must be checked first. Verification is therefore a strict
+precedence chain; the **first** failing gate is the reported status:
+
+| order | `status` | Gate |
+|---|----------|------|
+| 1 | `SNAPSHOT_MISSING` | `documentSnapshot` is null. No authentic text exists to export; stop. |
+| 2 | `SNAPSHOT_HASH_MISMATCH` | `computeContentHash(snapshot.title, body, acceptanceLabel) !== snapshot.contentHash`. Snapshot text was altered while the hash was left intact — the displayed text is untrustworthy even if the signature checks out. |
+| 3 | `UNSIGNED` | `recordSignature` is null — legacy/IMPORTED row, or written before the key was configured. |
+| 4 | `KEY_UNAVAILABLE` | `signingKeyId` is not resolvable (rotated key with no registry; ties to #1050). |
+| 5 | `SIGNATURE_MISMATCH` | Recomputed HMAC (re-canonicalized under the row's stored `signatureCanonicalVersion`; null ⇒ sole historical version) `!== recordSignature`. Row altered after signing. |
+| 6 | `VERIFIED` | All gates pass: the snapshot text hashes to its `contentHash`, and that hash is bound into a valid signature. |
+
+Only `VERIFIED` may be presented as proof. Every other status is surfaced verbatim in the export
+(never hidden) so a reviewer sees exactly why a record fell short. Because verification reads the
+snapshot, a `VERIFIED` result is **stable forever** regardless of later edits to
+`consent_documents`; a live-doc edit is informational drift, not a verification failure.
+
+### Open question — resolved: keep the HMAC payload over `contentHash`
+
+The signed payload stays as-is (over `contentHash`, not raw text). Rationale: `contentHash` is a
+SHA-256 commitment to the text, so verifying *text → hash → signature* is cryptographically
+equivalent to signing the text directly, given collision resistance — and it avoids a
+signing-format change, keeps every existing signature valid, and composes with the canonical-form
+version tag (`_canon`, already present for #1050). **The condition the owner named is mandatory:**
+gate 2 (`SNAPSHOT_HASH_MISMATCH`) is first-class and runs before any signature is trusted. If a
+future requirement ever needs the raw text signed directly, bump `_canon` to a new version — each
+row already records its own `signatureCanonicalVersion`, so the verifier dispatches per-row with no
+guessing.
+
+### Surfaces
+
+- **Platform-admin route** `GET /admin/consent/acceptances/:id/evidence` → `ConsentService`.
+  Authz: platform admin only (reuses the existing admin auth used by the #932 documents area).
+  Renter/operator callers → 403.
+- **CLI** `bun run consent:evidence -- <acceptanceId|--user <id>|--booking <id>>` → writes the
+  JSON bundle to stdout/file for legal export.
+
+## Architecture / boundaries
+
+- Schema in `packages/shared/src/db/consent.ts` — **danger zone**: `db:generate` → `db:migrate`
+  → `db:verify` (3 green checks); CI `db-drift`.
+- `ConsentEvidence` type + verification status enum in `@kuruma/shared` (cross-boundary contract).
+- `recordAcceptance` snapshot write + `getConsentEvidence*` read in `services/consent.ts`;
+  repo methods in `repositories/{in-memory,drizzle}/consent.ts`; route in `routes/` → service
+  (no repo import). Follows routes → services → repositories.
+
+## Testing
+
+- **unit** — `recordAcceptance` persists `documentSnapshot` equal to the loaded document; snapshot
+  fields match what the signature was computed over.
+- **unit** — `getConsentEvidence` returns `VERIFIED` for a freshly signed row.
+- **unit (the point)** — after editing the live document, `getConsentEvidence` still returns the
+  **original** snapshot text and `VERIFIED` — proves independence from the live doc.
+- **unit (P1 hash gate)** — alter `snapshot.body` while leaving `snapshot.contentHash` and a valid
+  `recordSignature` intact → `SNAPSHOT_HASH_MISMATCH`, NOT `VERIFIED`. This is the attack the
+  text→hash self-check exists to stop.
+- **unit (precedence)** — null snapshot → `SNAPSHOT_MISSING` and `document: null` (assert the live
+  doc is never substituted into `document`); tampered `recordSignature` → `SIGNATURE_MISMATCH`;
+  null signature → `UNSIGNED`; foreign `signingKeyId` → `KEY_UNAVAILABLE`. Assert first-failing-gate
+  ordering when several would fail.
+- **unit (replayability)** — recompute the HMAC from the exported `ConsentEvidence` fields alone
+  (re-canonicalized under `signatureCanonicalVersion`) and assert it equals `recordSignature` — the
+  export carries everything needed to replay the proof, no DB read required.
+- **integration** — export route authz (platform admin only; renter/operator 403) + bundle shape
+  (asserts `documentId`/`consentType`/`operatorMembershipId`/`signatureCanonicalVersion` present).
+- **script** — backfill snapshots a row only when the source-doc self-consistency pre-gate passes
+  **and** the current-doc HMAC matches `recordSignature`; a content-edited doc → `skipped-hash-mismatch`;
+  unsigned rows skipped; idempotent; emits the backfilled/skipped report.
+- **script (stale-hash pre-gate)** — a doc whose `body` was edited while `contentHash` was left
+  stale (so the HMAC over the stale hash would still pass) → caught by the pre-gate as
+  `skipped-current-doc-hash-mismatch`, **never** snapshotted as "safe."
+- **script (drift-is-not-veto)** — a harmless reseed that bumps only `updatedAt` (content identical)
+  → HMAC still matches → row **is** backfilled, with the timestamp drift noted as audit metadata,
+  NOT skipped.
+
+## Deferred / related
+
+- **#1050** keyId→key registry — needed for `VERIFIED` on rows signed under a rotated key
+  (otherwise `KEY_UNAVAILABLE`). This export design surfaces the need but does not depend on it.
+- **#1049** real-pg constraint test — unrelated but adjacent consent hardening.
+- Asymmetric signing / external timestamp anchoring — out of scope; revisit only if a
+  third-party-verifiable or anti-backdating requirement appears.

--- a/drizzle/0074_add_consent_evidence_snapshot.sql
+++ b/drizzle/0074_add_consent_evidence_snapshot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "consent_acceptances" ADD COLUMN "documentSnapshot" jsonb;--> statement-breakpoint
+ALTER TABLE "consent_acceptances" ADD COLUMN "signatureCanonicalVersion" text;

--- a/drizzle/meta/0074_snapshot.json
+++ b/drizzle/meta/0074_snapshot.json
@@ -1,0 +1,4771 @@
+{
+  "id": "cdd7570c-7bb4-4734-8253-8646e916c999",
+  "prevId": "1110e34f-06b3-451b-b024-1e7195410701",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nameEn": {
+          "name": "nameEn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameJa": {
+          "name": "nameJa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameZh": {
+          "name": "nameZh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignable": {
+          "name": "assignable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "region_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_regions_parentId": {
+          "name": "idx_regions_parentId",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_unique": {
+          "name": "regions_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parentId_regions_id_fk": {
+          "name": "regions_parentId_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.renter_documents": {
+      "name": "renter_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiryDate": {
+          "name": "expiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_renter_documents_renterId": {
+          "name": "idx_renter_documents_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_verifierId": {
+          "name": "idx_renter_documents_verifierId",
+          "columns": [
+            {
+              "expression": "verifierId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_status": {
+          "name": "idx_renter_documents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "renter_documents_renterId_users_id_fk": {
+          "name": "renter_documents_renterId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "renter_documents_verifierId_users_id_fk": {
+          "name": "renter_documents_verifierId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coordinate_source": {
+          "name": "coordinate_source",
+          "type": "coordinate_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatingHours": {
+          "name": "operatingHours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Tokyo'"
+        },
+        "defaultTurnaroundMinutes": {
+          "name": "defaultTurnaroundMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2880
+        },
+        "regionId": {
+          "name": "regionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_operatorId": {
+          "name": "idx_locations_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_regionId": {
+          "name": "idx_locations_regionId",
+          "columns": [
+            {
+              "expression": "regionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_operatorId_active_name_unique": {
+          "name": "locations_operatorId_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"status\" <> 'ARCHIVED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_operatorId_operators_id_fk": {
+          "name": "locations_operatorId_operators_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "locations_regionId_regions_id_fk": {
+          "name": "locations_regionId_regions_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_operatorId_id_unique": {
+          "name": "locations_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "locations_turnaround_min_60": {
+          "name": "locations_turnaround_min_60",
+          "value": "\"locations\".\"defaultTurnaroundMinutes\" >= 60"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acrissCode": {
+          "name": "acrissCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_acriss_code_format": {
+          "name": "vehicle_classes_acriss_code_format",
+          "value": "\"vehicle_classes\".\"acrissCode\" IS NULL OR \"vehicle_classes\".\"acrissCode\" ~ '^[A-Z9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_pickupLocationId": {
+          "name": "idx_vehicles_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_available": {
+          "name": "idx_vehicles_available",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vehicles\".\"status\" = 'AVAILABLE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_pickupLocationId_fk": {
+          "name": "vehicles_operatorId_pickupLocationId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "operatorId",
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        },
+        "vehicles_operatorId_id_unique": {
+          "name": "vehicles_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.class_rate_plans": {
+      "name": "class_rate_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayRateJpy": {
+          "name": "dayRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_class_rate_plans_operator": {
+          "name": "idx_class_rate_plans_operator",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_class": {
+          "name": "idx_class_rate_plans_class",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_pickup_location": {
+          "name": "idx_class_rate_plans_pickup_location",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "class_rate_plans_operatorId_operators_id_fk": {
+          "name": "class_rate_plans_operatorId_operators_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_pickupLocationId_locations_id_fk": {
+          "name": "class_rate_plans_pickupLocationId_locations_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_operator_class_fk": {
+          "name": "class_rate_plans_operator_class_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "class_rate_plans_operator_class_location_unique": {
+          "name": "class_rate_plans_operator_class_location_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "classId",
+            "pickupLocationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "class_rate_plans_day_rate_non_negative": {
+          "name": "class_rate_plans_day_rate_non_negative",
+          "value": "\"class_rate_plans\".\"dayRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleClassId": {
+          "name": "vehicleClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "fee_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fee_schedule_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_schedules_operator_class": {
+          "name": "idx_fee_schedules_operator_class",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_schedules_vehicle_class": {
+          "name": "idx_fee_schedules_vehicle_class",
+          "columns": [
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_class_unique": {
+          "name": "fee_schedules_active_class_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_operatorwide_unique": {
+          "name": "fee_schedules_active_operatorwide_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_schedules_operatorId_operators_id_fk": {
+          "name": "fee_schedules_operatorId_operators_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fee_schedules_operator_class_fk": {
+          "name": "fee_schedules_operator_class_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleClassId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fee_schedules_amount_non_negative": {
+          "name": "fee_schedules_amount_non_negative",
+          "value": "\"fee_schedules\".\"amountJpy\" >= 0"
+        },
+        "fee_schedules_feetype_unit_coherent": {
+          "name": "fee_schedules_feetype_unit_coherent",
+          "value": "(\"fee_schedules\".\"feeType\" = 'OVERTIME_HOURLY' AND \"fee_schedules\".\"unit\" = 'PER_HOUR') OR (\"fee_schedules\".\"feeType\" = 'CLEANING_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT') OR (\"fee_schedules\".\"feeType\" = 'NO_FUEL_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_options": {
+      "name": "insurance_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyPriceJpy": {
+          "name": "dailyPriceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deductibleJpy": {
+          "name": "deductibleJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_insurance_options_operatorId": {
+          "name": "idx_insurance_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_options_active_name_unique": {
+          "name": "insurance_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_options_operatorId_operators_id_fk": {
+          "name": "insurance_options_operatorId_operators_id_fk",
+          "tableFrom": "insurance_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_options_operatorId_id_unique": {
+          "name": "insurance_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "insurance_options_daily_price_non_negative": {
+          "name": "insurance_options_daily_price_non_negative",
+          "value": "\"insurance_options\".\"dailyPriceJpy\" >= 0"
+        },
+        "insurance_options_deductible_non_negative": {
+          "name": "insurance_options_deductible_non_negative",
+          "value": "\"insurance_options\".\"deductibleJpy\" IS NULL OR \"insurance_options\".\"deductibleJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_events": {
+      "name": "booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booking_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_booking_events_bookingId": {
+          "name": "idx_booking_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_events_actorId": {
+          "name": "idx_booking_events_actorId",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_events_bookingId_bookings_id_fk": {
+          "name": "booking_events_bookingId_bookings_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "booking_events_actorId_users_id_fk": {
+          "name": "booking_events_actorId_users_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestedVehicleId": {
+          "name": "requestedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedVehicleId": {
+          "name": "assignedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropoffLocationId": {
+          "name": "dropoffLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "fulfillmentMode": {
+          "name": "fulfillmentMode",
+          "type": "booking_fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPECIFIC'"
+        },
+        "bookingCode": {
+          "name": "bookingCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insuranceOptionId": {
+          "name": "insuranceOptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceSnapshot": {
+          "name": "insuranceSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeSnapshot": {
+          "name": "feeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "addOnSnapshot": {
+          "name": "addOnSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFeeSettlement": {
+          "name": "cancellationFeeSettlement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADVISORY'"
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerAcknowledgedAt": {
+          "name": "disclaimerAcknowledgedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerTermsVersion": {
+          "name": "disclaimerTermsVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_operatorId": {
+          "name": "idx_bookings_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_requestedVehicleId": {
+          "name": "idx_bookings_requestedVehicleId",
+          "columns": [
+            {
+              "expression": "requestedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_assignedVehicleId": {
+          "name": "idx_bookings_assignedVehicleId",
+          "columns": [
+            {
+              "expression": "assignedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_pickupLocationId": {
+          "name": "idx_bookings_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_dropoffLocationId": {
+          "name": "idx_bookings_dropoffLocationId",
+          "columns": [
+            {
+              "expression": "dropoffLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_insuranceOptionId": {
+          "name": "idx_bookings_insuranceOptionId",
+          "columns": [
+            {
+              "expression": "insuranceOptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_operatorId_operators_id_fk": {
+          "name": "bookings_operatorId_operators_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_pickupLocationId_locations_id_fk": {
+          "name": "bookings_pickupLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_dropoffLocationId_locations_id_fk": {
+          "name": "bookings_dropoffLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "dropoffLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_class_fk": {
+          "name": "bookings_operator_class_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_requested_vehicle_fk": {
+          "name": "bookings_operator_requested_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "requestedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_assigned_vehicle_fk": {
+          "name": "bookings_operator_assigned_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "assignedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_insurance_fk": {
+          "name": "bookings_operator_insurance_fk",
+          "tableFrom": "bookings",
+          "tableTo": "insurance_options",
+          "columnsFrom": [
+            "operatorId",
+            "insuranceOptionId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookings_bookingCode_unique": {
+          "name": "bookings_bookingCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bookings_specific_requires_assigned": {
+          "name": "bookings_specific_requires_assigned",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"assignedVehicleId\" IS NOT NULL"
+        },
+        "bookings_specific_requires_requested": {
+          "name": "bookings_specific_requires_requested",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"requestedVehicleId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_anomalies": {
+      "name": "payment_anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAmountJpy": {
+          "name": "receivedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedAmountJpy": {
+          "name": "expectedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_anomalies_operatorId": {
+          "name": "idx_payment_anomalies_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_anomalies_bookingId": {
+          "name": "idx_payment_anomalies_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_anomalies_stripeEventId_unique": {
+          "name": "payment_anomalies_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_anomalies_operatorId_operators_id_fk": {
+          "name": "payment_anomalies_operatorId_operators_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_anomalies_bookingId_bookings_id_fk": {
+          "name": "payment_anomalies_bookingId_bookings_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_events": {
+      "name": "payment_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grossJpy": {
+          "name": "grossJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFeeJpy": {
+          "name": "platformFeeJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "netToPartnerJpy": {
+          "name": "netToPartnerJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'jpy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_events_operatorId": {
+          "name": "idx_payment_events_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_events_bookingId": {
+          "name": "idx_payment_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeEventId_unique": {
+          "name": "payment_events_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeCheckoutSessionId_unique": {
+          "name": "payment_events_stripeCheckoutSessionId_unique",
+          "columns": [
+            {
+              "expression": "stripeCheckoutSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_one_success_per_booking": {
+          "name": "payment_events_one_success_per_booking",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'SUCCEEDED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_events_operatorId_operators_id_fk": {
+          "name": "payment_events_operatorId_operators_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_events_bookingId_bookings_id_fk": {
+          "name": "payment_events_bookingId_bookings_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_refunds": {
+      "name": "payment_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeRefundId": {
+          "name": "stripeRefundId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_refunds_operatorId": {
+          "name": "idx_payment_refunds_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_bookingId_unique": {
+          "name": "payment_refunds_bookingId_unique",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_stripeRefundId_unique": {
+          "name": "payment_refunds_stripeRefundId_unique",
+          "columns": [
+            {
+              "expression": "stripeRefundId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripeRefundId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_refunds_bookingId_bookings_id_fk": {
+          "name": "payment_refunds_bookingId_bookings_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_refunds_operatorId_operators_id_fk": {
+          "name": "payment_refunds_operatorId_operators_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_refunds_amount_non_negative": {
+          "name": "payment_refunds_amount_non_negative",
+          "value": "\"payment_refunds\".\"amountJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "providerMessageId": {
+          "name": "providerMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_bookingId": {
+          "name": "idx_notification_log_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_log_operatorId": {
+          "name": "idx_notification_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_bookingId_bookings_id_fk": {
+          "name": "notification_log_bookingId_bookings_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_log_operatorId_operators_id_fk": {
+          "name": "notification_log_operatorId_operators_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_log_idempotency_unique": {
+          "name": "notification_log_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotencyKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "audit_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_operatorId": {
+          "name": "idx_audit_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_kind": {
+          "name": "idx_audit_log_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compliance_alert_log": {
+      "name": "compliance_alert_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentType": {
+          "name": "documentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thresholdBand": {
+          "name": "thresholdBand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_compliance_alert_log_operatorId": {
+          "name": "idx_compliance_alert_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compliance_alert_log_vehicleId": {
+          "name": "idx_compliance_alert_log_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compliance_alert_log_operatorId_operators_id_fk": {
+          "name": "compliance_alert_log_operatorId_operators_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "compliance_alert_log_vehicleId_vehicles_id_fk": {
+          "name": "compliance_alert_log_vehicleId_vehicles_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compliance_alert_log_band_unique": {
+          "name": "compliance_alert_log_band_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vehicleId",
+            "documentType",
+            "thresholdBand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.add_on_options": {
+      "name": "add_on_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceJpy": {
+          "name": "priceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "add_on_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_add_on_options_operatorId": {
+          "name": "idx_add_on_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "add_on_options_active_name_unique": {
+          "name": "add_on_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "add_on_options_operatorId_operators_id_fk": {
+          "name": "add_on_options_operatorId_operators_id_fk",
+          "tableFrom": "add_on_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "add_on_options_operatorId_id_unique": {
+          "name": "add_on_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "add_on_options_price_non_negative": {
+          "name": "add_on_options_price_non_negative",
+          "value": "\"add_on_options\".\"priceJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operator_memberships": {
+      "name": "operator_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_memberships_active_user_unique": {
+          "name": "operator_memberships_active_user_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operator_memberships_operatorId": {
+          "name": "idx_operator_memberships_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_memberships_userId_users_id_fk": {
+          "name": "operator_memberships_userId_users_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_memberships_operatorId_operators_id_fk": {
+          "name": "operator_memberships_operatorId_operators_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_invites": {
+      "name": "provider_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedByUserId": {
+          "name": "acceptedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_invites_tokenHash_unique": {
+          "name": "provider_invites_tokenHash_unique",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_invites_pending_email_unique": {
+          "name": "provider_invites_pending_email_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'PENDING'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_email": {
+          "name": "idx_provider_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_operatorId": {
+          "name": "idx_provider_invites_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_invitedByUserId": {
+          "name": "idx_provider_invites_invitedByUserId",
+          "columns": [
+            {
+              "expression": "invitedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_acceptedByUserId": {
+          "name": "idx_provider_invites_acceptedByUserId",
+          "columns": [
+            {
+              "expression": "acceptedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_invites_operatorId_operators_id_fk": {
+          "name": "provider_invites_operatorId_operators_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provider_invites_invitedByUserId_users_id_fk": {
+          "name": "provider_invites_invitedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_invites_acceptedByUserId_users_id_fk": {
+          "name": "provider_invites_acceptedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acceptedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_acceptances": {
+      "name": "consent_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentType": {
+          "name": "consentType",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatorMembershipId": {
+          "name": "operatorMembershipId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorRole": {
+          "name": "actorRole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "consent_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLICKWRAP'"
+        },
+        "recordSignature": {
+          "name": "recordSignature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingKeyId": {
+          "name": "signingKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureRef": {
+          "name": "signatureRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentSnapshot": {
+          "name": "documentSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureCanonicalVersion": {
+          "name": "signatureCanonicalVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_unique_booking_liability": {
+          "name": "consent_unique_booking_liability",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_user_document": {
+          "name": "consent_unique_user_document",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NULL AND \"consent_acceptances\".\"operatorId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_operator_document": {
+          "name": "consent_unique_operator_document",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"operatorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_document_type_idx": {
+          "name": "consent_acceptances_document_type_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_membership_idx": {
+          "name": "consent_acceptances_membership_idx",
+          "columns": [
+            {
+              "expression": "operatorMembershipId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_consent_type_idx": {
+          "name": "consent_acceptances_consent_type_idx",
+          "columns": [
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_acceptances_userId_users_id_fk": {
+          "name": "consent_acceptances_userId_users_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorId_operators_id_fk": {
+          "name": "consent_acceptances_operatorId_operators_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorMembershipId_operator_memberships_id_fk": {
+          "name": "consent_acceptances_operatorMembershipId_operator_memberships_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operator_memberships",
+          "columnsFrom": [
+            "operatorMembershipId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_bookingId_bookings_id_fk": {
+          "name": "consent_acceptances_bookingId_bookings_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_document_type_fk": {
+          "name": "consent_acceptances_document_type_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "consent_documents",
+          "columnsFrom": [
+            "documentId",
+            "consentType"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_liability_booking_chk": {
+          "name": "consent_liability_booking_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'RENTER_LIABILITY') = (\"consent_acceptances\".\"bookingId\" IS NOT NULL)"
+        },
+        "consent_operator_agreement_chk": {
+          "name": "consent_operator_agreement_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'OPERATOR_AGREEMENT') = (\"consent_acceptances\".\"operatorId\" IS NOT NULL)"
+        },
+        "consent_membership_implies_operator_chk": {
+          "name": "consent_membership_implies_operator_chk",
+          "value": "\"consent_acceptances\".\"operatorMembershipId\" IS NULL OR \"consent_acceptances\".\"operatorId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_documents": {
+      "name": "consent_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptanceLabel": {
+          "name": "acceptanceLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "consent_doc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "effectiveFrom": {
+          "name": "effectiveFrom",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_documents_type_version_locale_unique": {
+          "name": "consent_documents_type_version_locale_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "version",
+            "locale"
+          ]
+        },
+        "consent_documents_id_type_unique": {
+          "name": "consent_documents_id_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_status": {
+      "name": "document_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "IDP",
+        "PASSPORT"
+      ]
+    },
+    "public.region_status": {
+      "name": "region_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "PREFECTURE",
+        "CITY",
+        "AREA"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.coordinate_source": {
+      "name": "coordinate_source",
+      "schema": "public",
+      "values": [
+        "GEOCODED",
+        "MANUAL",
+        "PENDING"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.luggage_size": {
+      "name": "luggage_size",
+      "schema": "public",
+      "values": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.fee_schedule_status": {
+      "name": "fee_schedule_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "OVERTIME_HOURLY",
+        "CLEANING_FLAT",
+        "NO_FUEL_FLAT"
+      ]
+    },
+    "public.fee_unit": {
+      "name": "fee_unit",
+      "schema": "public",
+      "values": [
+        "PER_HOUR",
+        "PER_DAY",
+        "PER_KM",
+        "FLAT"
+      ]
+    },
+    "public.insurance_status": {
+      "name": "insurance_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.booking_event_type": {
+      "name": "booking_event_type",
+      "schema": "public",
+      "values": [
+        "BOOKING_CREATED",
+        "VEHICLE_SUBSTITUTED",
+        "BOOKING_CANCELLED",
+        "STATUS_CHANGED"
+      ]
+    },
+    "public.booking_fulfillment_mode": {
+      "name": "booking_fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "SPECIFIC",
+        "CLASS_COMBO"
+      ]
+    },
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.payment_anomaly_kind": {
+      "name": "payment_anomaly_kind",
+      "schema": "public",
+      "values": [
+        "DOUBLE_PAYMENT",
+        "AMOUNT_MISMATCH"
+      ]
+    },
+    "public.payment_event_status": {
+      "name": "payment_event_status",
+      "schema": "public",
+      "values": [
+        "SUCCEEDED"
+      ]
+    },
+    "public.payment_refund_status": {
+      "name": "payment_refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.notification_kind": {
+      "name": "notification_kind",
+      "schema": "public",
+      "values": [
+        "OPERATOR_BOOKING_ALERT",
+        "RENTER_BOOKING_CONFIRM",
+        "RENTER_SUBSTITUTION",
+        "RENTER_CANCELLATION",
+        "RENTER_TRIP_STARTED",
+        "RENTER_TRIP_COMPLETED"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "DEAD",
+        "NO_RECIPIENT"
+      ]
+    },
+    "public.audit_event_kind": {
+      "name": "audit_event_kind",
+      "schema": "public",
+      "values": [
+        "PROVIDER_INVITE_CREATED",
+        "OPERATOR_PROFILE_UPDATED",
+        "OPERATOR_MEMBER_DEACTIVATED"
+      ]
+    },
+    "public.add_on_status": {
+      "name": "add_on_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.operator_membership_status": {
+      "name": "operator_membership_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED"
+      ]
+    },
+    "public.operator_role": {
+      "name": "operator_role",
+      "schema": "public",
+      "values": [
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF"
+      ]
+    },
+    "public.provider_invite_status": {
+      "name": "provider_invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED"
+      ]
+    },
+    "public.consent_doc_status": {
+      "name": "consent_doc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PUBLISHED",
+        "ARCHIVED"
+      ]
+    },
+    "public.consent_method": {
+      "name": "consent_method",
+      "schema": "public",
+      "values": [
+        "CLICKWRAP",
+        "ESIGN",
+        "IMPORTED"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "RENTER_TOS",
+        "PRIVACY_POLICY",
+        "RENTER_LIABILITY",
+        "OPERATOR_AGREEMENT"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1782355030474,
       "tag": "0073_payment_refunds_amount_non_negative",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1782396091706,
+      "tag": "0074_add_consent_evidence_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "db:backfill-regions": "bun run scripts/backfill-location-regions.ts",
     "db:backfill-photo-refs": "bun run scripts/backfill-photo-refs.ts",
     "db:backfill-vehicle-expiry": "bun run scripts/backfill-vehicle-expiry.ts",
+    "db:backfill-consent-snapshot": "bun run scripts/backfill-consent-snapshot.ts",
+    "consent:evidence": "bun run scripts/consent-evidence.ts",
     "db:verify": "bun run scripts/db-verify.ts",
     "db:drift-warn": "bun run scripts/db-drift-warn.ts",
     "prepare": "husky"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -416,8 +416,8 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   // #877 2b: pure policy gate over the same re-consent query; renter booking
   // creation consults it (booking-only scope, the legally load-bearing chokepoint).
   const consentGate = new ConsentGateService(consentService)
-  // #877: assembles verified evidence bundles; route wiring deferred to Task 8.
-  const _consentEvidenceService = new ConsentEvidenceService(consentRepo, (keyId) => {
+  // #877: assembles verified evidence bundles; exposed via platform-admin route (Task 8).
+  const consentEvidenceService = new ConsentEvidenceService(consentRepo, (keyId) => {
     const k = resolveSigningKey()
     return k && k.keyId === keyId ? k : undefined
   })
@@ -523,7 +523,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     )
     .route('/', createCustomerRoutes(customerService))
     .route('/', createUserRoutes(userDirectoryService))
-    .route('/', createAdminRoutes(operatorService, providerInviteService))
+    .route('/', createAdminRoutes(operatorService, providerInviteService, consentEvidenceService))
     .route('/', createLocationRoutes(locationService, resolveWriteOperatorId))
     .route('/', createInsuranceOptionRoutes(insuranceOptionService, resolveWriteOperatorId))
     .route('/', createAddOnRoutes(addOnService, resolveWriteOperatorId))

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -55,7 +55,9 @@ import { BookingService } from './services/booking'
 import { BookingPostCommitDispatcher } from './services/booking-post-commit-dispatcher'
 import { ComplianceDigestService } from './services/compliance-digest'
 import { ConsentService } from './services/consent'
+import { ConsentEvidenceService } from './services/consent-evidence'
 import { ConsentGateService } from './services/consent-gate'
+import { resolveSigningKey } from './services/consent-signing'
 import { CustomerService } from './services/customer'
 import { documentVerificationGate } from './services/document-verification-gate'
 import type { EmailSender } from './services/email/email-sender'
@@ -414,6 +416,11 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   // #877 2b: pure policy gate over the same re-consent query; renter booking
   // creation consults it (booking-only scope, the legally load-bearing chokepoint).
   const consentGate = new ConsentGateService(consentService)
+  // #877: assembles verified evidence bundles; route wiring deferred to Task 8.
+  const _consentEvidenceService = new ConsentEvidenceService(consentRepo, (keyId) => {
+    const k = resolveSigningKey()
+    return k && k.keyId === keyId ? k : undefined
+  })
   const userDirectoryService = new UserDirectoryService(userRepo, threadRepo)
   const maintenanceService = new MaintenanceService(
     vehicleRepo,

--- a/packages/api/src/repositories/drizzle/consent.test.ts
+++ b/packages/api/src/repositories/drizzle/consent.test.ts
@@ -1,0 +1,155 @@
+// Real-pg parity test for DrizzleConsentRepository (#877).
+// Run with: DATABASE_URL="postgres://postgres:postgres@localhost:5479/kuruma" bunx vitest run packages/api/src/repositories/drizzle/consent.test.ts
+import * as schema from '@kuruma/shared/db/schema'
+import { consentAcceptances, consentDocuments } from '@kuruma/shared/db/schema'
+import type { ConsentType } from '@kuruma/shared/enums'
+import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { Db } from './shared'
+import { DrizzleConsentRepository } from './consent'
+
+const url = process.env['DATABASE_URL']
+if (!url) throw new Error('DATABASE_URL must be set to run this test')
+
+const client = postgres(url, { max: 1 })
+// Cast to Db (NeonHttp type) — postgres-js is structurally compatible for the
+// query methods DrizzleConsentRepository uses (select/insert/delete).
+const db = drizzle(client, { schema }) as unknown as Db
+const repo = new DrizzleConsentRepository(db)
+
+const createdDocIds: string[] = []
+const createdAcceptanceIds: string[] = []
+const createdUserIds: string[] = []
+
+async function seedUser(): Promise<string> {
+  const id = crypto.randomUUID()
+  await db.insert(schema.users).values({
+    id,
+    email: `consent-drizzle-test-${id.slice(0, 8)}@kuruma.test`,
+    role: 'RENTER',
+    operatorId: null,
+    language: 'en',
+  })
+  createdUserIds.push(id)
+  return id
+}
+
+async function seedDocument(
+  type: ConsentType = 'RENTER_TOS',
+  overrides: Partial<typeof consentDocuments.$inferInsert> = {},
+): Promise<typeof consentDocuments.$inferSelect> {
+  const id = crypto.randomUUID()
+  const [row] = await db
+    .insert(consentDocuments)
+    .values({
+      id,
+      type,
+      version: `v-${id.slice(0, 8)}`,
+      locale: 'en',
+      title: 'Terms of Service',
+      body: 'You agree to the terms.',
+      acceptanceLabel: 'I accept',
+      contentHash: 'c'.repeat(64),
+      status: 'PUBLISHED',
+      effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+      ...overrides,
+    })
+    .returning()
+  if (!row) throw new Error('Failed to seed consent document')
+  createdDocIds.push(id)
+  return row
+}
+
+beforeAll(async () => {
+  // warm up connection
+  await db.select({ one: schema.users.id }).from(schema.users).limit(1)
+})
+
+afterAll(async () => {
+  if (createdAcceptanceIds.length > 0) {
+    await db
+      .delete(consentAcceptances)
+      .where(inArray(consentAcceptances.id, createdAcceptanceIds))
+  }
+  if (createdDocIds.length > 0) {
+    await db.delete(consentDocuments).where(inArray(consentDocuments.id, createdDocIds))
+  }
+  for (const uid of createdUserIds) {
+    await db.delete(schema.users).where(eq(schema.users.id, uid))
+  }
+  await client.end()
+})
+
+describe('DrizzleConsentRepository — documentSnapshot + signatureCanonicalVersion round-trip (#877)', () => {
+  it('persists and reads back documentSnapshot and signatureCanonicalVersion via findUserDocumentAcceptance', async () => {
+    const userId = await seedUser()
+    const docRow = await seedDocument()
+
+    const snapshot: DocumentSnapshot = {
+      version: docRow.version,
+      locale: docRow.locale,
+      title: docRow.title,
+      body: docRow.body,
+      acceptanceLabel: docRow.acceptanceLabel,
+      contentHash: docRow.contentHash,
+    }
+
+    const created = await repo.createAcceptance({
+      documentId: docRow.id,
+      consentType: 'RENTER_TOS',
+      userId,
+      operatorId: null,
+      operatorMembershipId: null,
+      actorRole: 'RENTER',
+      bookingId: null,
+      acceptedAt: new Date('2026-06-24T00:00:00Z'),
+      context: null,
+      ipAddress: null,
+      userAgent: null,
+      method: 'CLICKWRAP',
+      recordSignature: 'sig_abc',
+      signingKeyId: 'key_v1',
+      signatureCanonicalVersion: 'v1',
+      documentSnapshot: snapshot,
+    })
+    createdAcceptanceIds.push(created.id)
+
+    const found = await repo.findUserDocumentAcceptance(userId, docRow.id)
+    expect(found).toBeDefined()
+    expect(found?.documentSnapshot).toEqual(snapshot)
+    expect(found?.signatureCanonicalVersion).toBe('v1')
+  })
+
+  it('reads back null documentSnapshot and null signatureCanonicalVersion when not set', async () => {
+    const userId = await seedUser()
+    const docRow = await seedDocument()
+
+    const created = await repo.createAcceptance({
+      documentId: docRow.id,
+      consentType: 'RENTER_TOS',
+      userId,
+      operatorId: null,
+      operatorMembershipId: null,
+      actorRole: 'RENTER',
+      bookingId: null,
+      acceptedAt: new Date('2026-06-24T00:00:00Z'),
+      context: null,
+      ipAddress: null,
+      userAgent: null,
+      method: 'CLICKWRAP',
+      recordSignature: null,
+      signingKeyId: null,
+      signatureCanonicalVersion: null,
+      documentSnapshot: null,
+    })
+    createdAcceptanceIds.push(created.id)
+
+    const found = await repo.findUserDocumentAcceptance(userId, docRow.id)
+    expect(found).toBeDefined()
+    expect(found?.documentSnapshot).toBeNull()
+    expect(found?.signatureCanonicalVersion).toBeNull()
+  })
+})

--- a/packages/api/src/repositories/drizzle/consent.ts
+++ b/packages/api/src/repositories/drizzle/consent.ts
@@ -46,6 +46,8 @@ function toAcceptance(r: AcceptanceRow): ConsentAcceptance {
     method: r.method,
     recordSignature: r.recordSignature,
     signingKeyId: r.signingKeyId,
+    signatureCanonicalVersion: r.signatureCanonicalVersion,
+    documentSnapshot: r.documentSnapshot,
     signatureRef: r.signatureRef,
     createdAt: r.createdAt,
   }

--- a/packages/api/src/repositories/drizzle/consent.ts
+++ b/packages/api/src/repositories/drizzle/consent.ts
@@ -163,6 +163,31 @@ export class DrizzleConsentRepository implements ConsentRepository {
     return row ? toAcceptance(row) : undefined
   }
 
+  async findAcceptanceById(id: string): Promise<ConsentAcceptance | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(consentAcceptances)
+      .where(eq(consentAcceptances.id, id))
+      .limit(1)
+    return row ? toAcceptance(row) : undefined
+  }
+
+  async findAcceptancesByUser(userId: string): Promise<ConsentAcceptance[]> {
+    const rows = await this.db
+      .select()
+      .from(consentAcceptances)
+      .where(eq(consentAcceptances.userId, userId))
+    return rows.map(toAcceptance)
+  }
+
+  async findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]> {
+    const rows = await this.db
+      .select()
+      .from(consentAcceptances)
+      .where(eq(consentAcceptances.bookingId, bookingId))
+    return rows.map(toAcceptance)
+  }
+
   async createAcceptance(data: NewConsentAcceptance): Promise<ConsentAcceptance> {
     const [row] = await this.db
       .insert(consentAcceptances)

--- a/packages/api/src/repositories/in-memory/consent.test.ts
+++ b/packages/api/src/repositories/in-memory/consent.test.ts
@@ -34,6 +34,8 @@ const baseAcceptance: NewConsentAcceptance = {
   method: 'CLICKWRAP' as const,
   recordSignature: 'sig',
   signingKeyId: 'v1',
+  signatureCanonicalVersion: 'v1',
+  documentSnapshot: null,
 }
 
 describe('InMemoryConsentRepository', () => {

--- a/packages/api/src/repositories/in-memory/consent.test.ts
+++ b/packages/api/src/repositories/in-memory/consent.test.ts
@@ -99,4 +99,16 @@ describe('InMemoryConsentRepository', () => {
     ).resolves.toBeDefined()
     expect((await repo.findOperatorDocumentAcceptance('op_1', DOC.id))?.id).toBe(created.id)
   })
+
+  it('findAcceptanceById returns the acceptance, findAcceptancesByUser scopes by user, findAcceptancesByBooking returns empty for unknown booking', async () => {
+    const created = await repo.createAcceptance(baseAcceptance)
+    const byId = await repo.findAcceptanceById(created.id)
+    expect(byId?.id).toBe(created.id)
+    expect(byId?.userId).toBe('user_1')
+    const byUser = await repo.findAcceptancesByUser('user_1')
+    expect(byUser).toHaveLength(1)
+    expect(byUser[0]?.id).toBe(created.id)
+    const byBooking = await repo.findAcceptancesByBooking('none')
+    expect(byBooking).toEqual([])
+  })
 })

--- a/packages/api/src/repositories/in-memory/consent.ts
+++ b/packages/api/src/repositories/in-memory/consent.ts
@@ -79,6 +79,18 @@ export class InMemoryConsentRepository implements ConsentRepository {
     return this.acceptances.find((a) => a.operatorId === operatorId && a.documentId === documentId)
   }
 
+  async findAcceptanceById(id: string): Promise<ConsentAcceptance | undefined> {
+    return this.acceptances.find((a) => a.id === id)
+  }
+
+  async findAcceptancesByUser(userId: string): Promise<ConsentAcceptance[]> {
+    return this.acceptances.filter((a) => a.userId === userId)
+  }
+
+  async findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]> {
+    return this.acceptances.filter((a) => a.bookingId === bookingId)
+  }
+
   async createAcceptance(data: NewConsentAcceptance): Promise<ConsentAcceptance> {
     this.assertUnique(data)
     const row: ConsentAcceptance = {

--- a/packages/api/src/repositories/types-consent.ts
+++ b/packages/api/src/repositories/types-consent.ts
@@ -1,6 +1,7 @@
 // Consent data-access contract (#877, extends epic #613). Extracted so types.ts stays under
 // the file-size cap; re-exported from that barrel for callers.
 import type { ConsentType } from '@kuruma/shared/enums'
+import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
 import type { ConsentAcceptance, ConsentDocument } from '../stores'
 
 export interface NewConsentAcceptance {
@@ -18,6 +19,8 @@ export interface NewConsentAcceptance {
   method: ConsentAcceptance['method']
   recordSignature: string | null
   signingKeyId: string | null
+  signatureCanonicalVersion: string | null
+  documentSnapshot: DocumentSnapshot | null
 }
 
 export interface ConsentRepository {

--- a/packages/api/src/repositories/types-consent.ts
+++ b/packages/api/src/repositories/types-consent.ts
@@ -46,4 +46,7 @@ export interface ConsentRepository {
     documentId: string,
   ): Promise<ConsentAcceptance | undefined>
   createAcceptance(data: NewConsentAcceptance): Promise<ConsentAcceptance>
+  findAcceptanceById(id: string): Promise<ConsentAcceptance | undefined>
+  findAcceptancesByUser(userId: string): Promise<ConsentAcceptance[]>
+  findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]>
 }

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2,6 +2,7 @@ import { createOperatorSchema } from '@kuruma/shared/validators/operator'
 import { createProviderInviteSchema } from '@kuruma/shared/validators/provider-invite'
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
+import type { ConsentEvidenceService } from '../services/consent-evidence'
 import type { OperatorService } from '../services/operator'
 import { OperatorNotFoundError, type ProviderInviteService } from '../services/provider-invite'
 import { fail, ok, parseBody } from './helpers'
@@ -9,6 +10,7 @@ import { fail, ok, parseBody } from './helpers'
 export function createAdminRoutes(
   operatorService: OperatorService,
   providerInviteService: ProviderInviteService,
+  consentEvidenceService: ConsentEvidenceService,
 ) {
   const app = new Hono()
 
@@ -40,6 +42,12 @@ export function createAdminRoutes(
           if (e instanceof OperatorNotFoundError) return fail(c, 'Operator not found', 404)
           throw e
         }
+      })
+      // #877 Task 8: platform-admin consent evidence export for legal/audit review.
+      .get('/admin/consent/acceptances/:id/evidence', async (c) => {
+        const evidence = await consentEvidenceService.getConsentEvidence(c.req.param('id'))
+        if (!evidence) return fail(c, 'ACCEPTANCE_NOT_FOUND', 404)
+        return ok(c, evidence)
       })
   )
 }

--- a/packages/api/src/services/consent-backfill-decide.test.ts
+++ b/packages/api/src/services/consent-backfill-decide.test.ts
@@ -1,0 +1,123 @@
+import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import { describe, expect, it } from 'vitest'
+import { decideBackfill } from '../../../../scripts/consent-backfill-decide'
+import { signAcceptanceRecord } from './consent-signing'
+
+const KEY = { key: 'secret', keyId: 'v1' }
+
+const acceptedAt = new Date('2026-06-24T00:00:00Z')
+
+// A self-consistent document: contentHash matches its own text fields.
+const doc = (() => {
+  const title = 'Terms of Service'
+  const body = 'You agree to our terms.'
+  const acceptanceLabel = 'I agree'
+  const contentHash = computeContentHash({ title, body, acceptanceLabel })
+  return {
+    id: 'doc_1',
+    type: 'RENTER_TOS' as const,
+    version: '1.0',
+    locale: 'en',
+    title,
+    body,
+    acceptanceLabel,
+    contentHash,
+    status: 'PUBLISHED' as const,
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    publishedAt: new Date('2026-01-01T00:00:00Z'),
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+  }
+})()
+
+// An acceptance whose recordSignature is computed over doc's fields.
+const acc = (() => {
+  const sig = signAcceptanceRecord(
+    {
+      documentId: 'doc_1',
+      contentHash: doc.contentHash,
+      consentType: 'RENTER_TOS' as const,
+      version: doc.version,
+      locale: doc.locale,
+      userId: 'u1',
+      operatorId: null,
+      operatorMembershipId: null,
+      bookingId: null,
+      method: 'CLICKWRAP' as const,
+      acceptedAt,
+      ipAddress: null,
+      userAgent: null,
+    },
+    KEY,
+  )
+  return {
+    id: 'acc_1',
+    documentId: 'doc_1',
+    consentType: 'RENTER_TOS' as const,
+    userId: 'u1',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt,
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP' as const,
+    recordSignature: sig.signature,
+    signingKeyId: sig.signingKeyId,
+    signatureCanonicalVersion: 'v1',
+    documentSnapshot: null,
+    signatureRef: null,
+    createdAt: new Date('2026-06-24T00:00:00Z'),
+  }
+})()
+
+describe('decideBackfill', () => {
+  it('backfill when current doc is self-consistent AND HMAC matches', () => {
+    expect(decideBackfill(acc, doc, () => KEY).action).toBe('backfill')
+  })
+
+  it('skipped-current-doc-hash-mismatch when doc text and its own hash disagree', () => {
+    expect(decideBackfill(acc, { ...doc, body: 'EDITED' }, () => KEY).action).toBe(
+      'skipped-current-doc-hash-mismatch',
+    )
+  })
+
+  it('skipped-hash-mismatch when the doc drifted from what was signed', () => {
+    // A different, self-consistent doc (its hash matches its own text, but differs from what acc was signed over)
+    const differentTitle = 'Different Terms'
+    const differentBody = 'Different body text.'
+    const differentLabel = 'Accept'
+    const driftedSelfConsistentDoc = {
+      ...doc,
+      title: differentTitle,
+      body: differentBody,
+      acceptanceLabel: differentLabel,
+      contentHash: computeContentHash({
+        title: differentTitle,
+        body: differentBody,
+        acceptanceLabel: differentLabel,
+      }),
+    }
+    expect(decideBackfill(acc, driftedSelfConsistentDoc, () => KEY).action).toBe(
+      'skipped-hash-mismatch',
+    )
+  })
+
+  it('skipped-unsigned for an unsigned row', () => {
+    expect(decideBackfill({ ...acc, recordSignature: null }, doc, () => KEY).action).toBe(
+      'skipped-unsigned',
+    )
+  })
+
+  it('backfill with timestampDrift=true when updatedAt>acceptedAt but HMAC matches', () => {
+    const r = decideBackfill(
+      acc,
+      { ...doc, updatedAt: new Date(acceptedAt.getTime() + 1000) },
+      () => KEY,
+    )
+    expect(r.action).toBe('backfill')
+    expect(r.timestampDrift).toBe(true)
+  })
+})

--- a/packages/api/src/services/consent-evidence-verify.test.ts
+++ b/packages/api/src/services/consent-evidence-verify.test.ts
@@ -1,0 +1,95 @@
+import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import { describe, expect, it } from 'vitest'
+import { verifyAcceptance } from './consent-evidence-verify'
+import { signAcceptanceRecord } from './consent-signing'
+
+const KEY = { key: 'secret', keyId: 'v1' }
+
+function signedAcceptance(over: Record<string, unknown> = {}) {
+  const snap = {
+    version: 'v1',
+    locale: 'en',
+    title: 'T',
+    body: 'B',
+    acceptanceLabel: 'L',
+    contentHash: computeContentHash({ title: 'T', body: 'B', acceptanceLabel: 'L' }),
+  }
+  const base = {
+    id: 'acc_1',
+    documentId: 'doc_1',
+    consentType: 'RENTER_TOS' as const,
+    userId: 'u1',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-06-24T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP' as const,
+    signatureRef: null,
+    createdAt: new Date('2026-06-24T00:00:00Z'),
+    signatureCanonicalVersion: 'v1',
+    documentSnapshot: snap,
+  }
+  const sig = signAcceptanceRecord(
+    {
+      documentId: base.documentId,
+      contentHash: snap.contentHash,
+      consentType: base.consentType,
+      version: snap.version,
+      locale: snap.locale,
+      userId: base.userId,
+      operatorId: base.operatorId,
+      operatorMembershipId: base.operatorMembershipId,
+      bookingId: base.bookingId,
+      method: base.method,
+      acceptedAt: base.acceptedAt,
+      ipAddress: base.ipAddress,
+      userAgent: base.userAgent,
+    },
+    KEY,
+  )
+  // `over` allows targeted overrides for tamper tests; cast needed because tests
+  // deliberately supply invalid values (null signature, unknown keyId, etc.).
+  // biome-ignore lint/suspicious/noExplicitAny: test helper for negative-path overrides
+  return { ...base, recordSignature: sig.signature, signingKeyId: sig.signingKeyId, ...over } as any
+}
+
+describe('verifyAcceptance', () => {
+  it('VERIFIED when snapshot hashes correctly and signature matches', () => {
+    expect(verifyAcceptance(signedAcceptance(), () => KEY).status).toBe('VERIFIED')
+  })
+
+  it('SNAPSHOT_MISSING when no snapshot', () => {
+    expect(verifyAcceptance(signedAcceptance({ documentSnapshot: null }), () => KEY).status).toBe(
+      'SNAPSHOT_MISSING',
+    )
+  })
+
+  it('SNAPSHOT_HASH_MISMATCH when body altered but hash left intact (the attack)', () => {
+    const a = signedAcceptance()
+    const tampered = { ...a, documentSnapshot: { ...a.documentSnapshot, body: 'EVIL' } }
+    expect(verifyAcceptance(tampered, () => KEY).status).toBe('SNAPSHOT_HASH_MISMATCH')
+  })
+
+  it('UNSIGNED when recordSignature null', () => {
+    expect(verifyAcceptance(signedAcceptance({ recordSignature: null }), () => KEY).status).toBe(
+      'UNSIGNED',
+    )
+  })
+
+  it('KEY_UNAVAILABLE when signingKeyId is not resolvable', () => {
+    const onlyV1 = (keyId: string) => (keyId === 'v1' ? KEY : undefined)
+    expect(verifyAcceptance(signedAcceptance({ signingKeyId: 'v9' }), onlyV1).status).toBe(
+      'KEY_UNAVAILABLE',
+    )
+  })
+
+  it('SIGNATURE_MISMATCH when the signature was altered', () => {
+    expect(
+      verifyAcceptance(signedAcceptance({ recordSignature: 'deadbeef' }), () => KEY).status,
+    ).toBe('SIGNATURE_MISMATCH')
+  })
+})

--- a/packages/api/src/services/consent-evidence-verify.ts
+++ b/packages/api/src/services/consent-evidence-verify.ts
@@ -1,0 +1,52 @@
+import { type DocumentSnapshot, computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import type { ConsentAcceptance } from '../stores'
+import { type SigningKey, signAcceptanceRecord } from './consent-signing'
+
+export type ConsentVerificationStatus =
+  | 'VERIFIED'
+  | 'SNAPSHOT_MISSING'
+  | 'SNAPSHOT_HASH_MISMATCH'
+  | 'UNSIGNED'
+  | 'KEY_UNAVAILABLE'
+  | 'SIGNATURE_MISMATCH'
+
+export interface ConsentVerification {
+  status: ConsentVerificationStatus
+  detail?: string | undefined
+}
+
+/** Gate chain — first failing gate is the status. `getKey` resolves a keyId to its
+ *  SigningKey (undefined when we no longer hold it). Pure; no I/O. */
+export function verifyAcceptance(
+  a: ConsentAcceptance,
+  getKey: (keyId: string) => SigningKey | undefined,
+): ConsentVerification {
+  const snap: DocumentSnapshot | null = a.documentSnapshot
+  if (!snap) return { status: 'SNAPSHOT_MISSING' }
+  if (computeContentHash(snap) !== snap.contentHash) return { status: 'SNAPSHOT_HASH_MISMATCH' }
+  if (!a.recordSignature) return { status: 'UNSIGNED' }
+  const key = a.signingKeyId ? getKey(a.signingKeyId) : undefined
+  if (!key) return { status: 'KEY_UNAVAILABLE', detail: a.signingKeyId ?? undefined }
+  // TODO(#1050): when multiple canonical versions exist, dispatch on a.signatureCanonicalVersion.
+  const recomputed = signAcceptanceRecord(
+    {
+      documentId: a.documentId,
+      contentHash: snap.contentHash,
+      consentType: a.consentType,
+      version: snap.version,
+      locale: snap.locale,
+      userId: a.userId,
+      operatorId: a.operatorId,
+      operatorMembershipId: a.operatorMembershipId,
+      bookingId: a.bookingId,
+      method: a.method,
+      acceptedAt: a.acceptedAt,
+      ipAddress: a.ipAddress,
+      userAgent: a.userAgent,
+    },
+    key,
+  ).signature
+  return recomputed === a.recordSignature
+    ? { status: 'VERIFIED' }
+    : { status: 'SIGNATURE_MISMATCH' }
+}

--- a/packages/api/src/services/consent-evidence.test.ts
+++ b/packages/api/src/services/consent-evidence.test.ts
@@ -1,0 +1,88 @@
+import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
+import { describe, expect, it } from 'vitest'
+import { InMemoryConsentRepository } from '../repositories/in-memory/consent'
+import { ConsentEvidenceService } from './consent-evidence'
+import { signAcceptanceRecord } from './consent-signing'
+
+const KEY = { key: 'secret', keyId: 'v1' }
+const getKey = (keyId: string) => (keyId === 'v1' ? KEY : undefined)
+
+function makeSignedNewAcceptance() {
+  const snap = {
+    version: 'v1',
+    locale: 'en',
+    title: 'Terms',
+    body: 'Body text',
+    acceptanceLabel: 'I agree',
+    contentHash: computeContentHash({
+      title: 'Terms',
+      body: 'Body text',
+      acceptanceLabel: 'I agree',
+    }),
+  }
+  const base = {
+    documentId: 'doc_1',
+    consentType: 'RENTER_TOS' as const,
+    userId: 'u1',
+    operatorId: 'op_1',
+    operatorMembershipId: 'mem_1',
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-06-24T00:00:00Z'),
+    context: null,
+    ipAddress: '127.0.0.1',
+    userAgent: 'TestAgent/1.0',
+    method: 'CLICKWRAP' as const,
+    signatureCanonicalVersion: 'v1',
+    documentSnapshot: snap,
+  }
+  const sig = signAcceptanceRecord(
+    {
+      documentId: base.documentId,
+      contentHash: snap.contentHash,
+      consentType: base.consentType,
+      version: snap.version,
+      locale: snap.locale,
+      userId: base.userId,
+      operatorId: base.operatorId,
+      operatorMembershipId: base.operatorMembershipId,
+      bookingId: base.bookingId,
+      method: base.method,
+      acceptedAt: base.acceptedAt,
+      ipAddress: base.ipAddress,
+      userAgent: base.userAgent,
+    },
+    KEY,
+  )
+  return { ...base, recordSignature: sig.signature, signingKeyId: sig.signingKeyId }
+}
+
+describe('ConsentEvidenceService', () => {
+  it('assembles an evidence bundle with verification for an acceptance id', async () => {
+    const repo = new InMemoryConsentRepository()
+    const acc = await repo.createAcceptance(makeSignedNewAcceptance())
+    const svc = new ConsentEvidenceService(repo, getKey)
+    const ev = await svc.getConsentEvidence(acc.id)
+    expect(ev?.acceptance.id).toBe(acc.id)
+    expect(ev?.acceptance.documentId).toBe(acc.documentId)
+    expect(ev?.acceptance.operatorMembershipId).toBe(acc.operatorMembershipId)
+    expect(ev?.document).toEqual(acc.documentSnapshot)
+    expect(ev?.signature.signatureCanonicalVersion).toBe('v1')
+    expect(ev?.verification.status).toBe('VERIFIED')
+  })
+
+  it('returns undefined for an unknown acceptance id', async () => {
+    const svc = new ConsentEvidenceService(new InMemoryConsentRepository(), () => undefined)
+    expect(await svc.getConsentEvidence('nope')).toBeUndefined()
+  })
+
+  it('returns all evidence for a user', async () => {
+    const repo = new InMemoryConsentRepository()
+    const acc = await repo.createAcceptance(makeSignedNewAcceptance())
+    const svc = new ConsentEvidenceService(repo, getKey)
+    const evs = await svc.getConsentEvidenceForUser(acc.userId)
+    expect(evs).toHaveLength(1)
+    expect(evs[0]?.acceptance.id).toBe(acc.id)
+    expect(evs[0]?.verification.status).toBe('VERIFIED')
+  })
+})

--- a/packages/api/src/services/consent-evidence.test.ts
+++ b/packages/api/src/services/consent-evidence.test.ts
@@ -85,4 +85,31 @@ describe('ConsentEvidenceService', () => {
     expect(evs[0]?.acceptance.id).toBe(acc.id)
     expect(evs[0]?.verification.status).toBe('VERIFIED')
   })
+
+  it('is replayable from the exported bundle alone (no DB read needed)', async () => {
+    const repo = new InMemoryConsentRepository()
+    const acc = await repo.createAcceptance(makeSignedNewAcceptance())
+    const ev = await new ConsentEvidenceService(repo, getKey).getConsentEvidence(acc.id)
+    if (!ev?.document) throw new Error('expected evidence with snapshot')
+    // Recompute the HMAC using ONLY fields carried by the exported bundle.
+    const replay = signAcceptanceRecord(
+      {
+        documentId: ev.acceptance.documentId,
+        contentHash: ev.document.contentHash,
+        consentType: ev.acceptance.consentType,
+        version: ev.document.version,
+        locale: ev.document.locale,
+        userId: ev.acceptance.userId,
+        operatorId: ev.acceptance.operatorId,
+        operatorMembershipId: ev.acceptance.operatorMembershipId,
+        bookingId: ev.acceptance.bookingId,
+        method: ev.acceptance.method,
+        acceptedAt: ev.acceptance.acceptedAt,
+        ipAddress: ev.acceptance.ipAddress,
+        userAgent: ev.acceptance.userAgent,
+      },
+      KEY,
+    ).signature
+    expect(replay).toBe(ev.signature.recordSignature)
+  })
 })

--- a/packages/api/src/services/consent-evidence.ts
+++ b/packages/api/src/services/consent-evidence.ts
@@ -1,0 +1,76 @@
+import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
+import type { ConsentRepository } from '../repositories/types-consent'
+import type { ConsentAcceptance } from '../stores'
+import { type ConsentVerification, verifyAcceptance } from './consent-evidence-verify'
+import type { SigningKey } from './consent-signing'
+
+export interface ConsentEvidence {
+  acceptance: Pick<
+    ConsentAcceptance,
+    | 'id'
+    | 'userId'
+    | 'actorRole'
+    | 'documentId'
+    | 'consentType'
+    | 'operatorId'
+    | 'operatorMembershipId'
+    | 'bookingId'
+    | 'acceptedAt'
+    | 'method'
+    | 'ipAddress'
+    | 'userAgent'
+  >
+  document: DocumentSnapshot | null
+  signature: {
+    recordSignature: string | null
+    signingKeyId: string | null
+    signatureCanonicalVersion: string | null
+  }
+  verification: ConsentVerification
+}
+
+export class ConsentEvidenceService {
+  constructor(
+    private readonly repo: ConsentRepository,
+    private readonly getKey: (keyId: string) => SigningKey | undefined,
+  ) {}
+
+  private toEvidence(a: ConsentAcceptance): ConsentEvidence {
+    return {
+      acceptance: {
+        id: a.id,
+        userId: a.userId,
+        actorRole: a.actorRole,
+        documentId: a.documentId,
+        consentType: a.consentType,
+        operatorId: a.operatorId,
+        operatorMembershipId: a.operatorMembershipId,
+        bookingId: a.bookingId,
+        acceptedAt: a.acceptedAt,
+        method: a.method,
+        ipAddress: a.ipAddress,
+        userAgent: a.userAgent,
+      },
+      document: a.documentSnapshot,
+      signature: {
+        recordSignature: a.recordSignature,
+        signingKeyId: a.signingKeyId,
+        signatureCanonicalVersion: a.signatureCanonicalVersion,
+      },
+      verification: verifyAcceptance(a, this.getKey),
+    }
+  }
+
+  async getConsentEvidence(acceptanceId: string): Promise<ConsentEvidence | undefined> {
+    const a = await this.repo.findAcceptanceById(acceptanceId)
+    return a ? this.toEvidence(a) : undefined
+  }
+
+  async getConsentEvidenceForUser(userId: string): Promise<ConsentEvidence[]> {
+    return (await this.repo.findAcceptancesByUser(userId)).map((a) => this.toEvidence(a))
+  }
+
+  async getConsentEvidenceForBooking(bookingId: string): Promise<ConsentEvidence[]> {
+    return (await this.repo.findAcceptancesByBooking(bookingId)).map((a) => this.toEvidence(a))
+  }
+}

--- a/packages/api/src/services/consent.test.ts
+++ b/packages/api/src/services/consent.test.ts
@@ -206,6 +206,9 @@ describe('ConsentService.recordAcceptance — concurrent-race catch path', () =>
       findBookingAcceptance: (...args) => realRepo.findBookingAcceptance(...args),
       findOperatorDocumentAcceptance: (...args) => realRepo.findOperatorDocumentAcceptance(...args),
       createAcceptance: (...args) => realRepo.createAcceptance(...args),
+      findAcceptanceById: (...args) => realRepo.findAcceptanceById(...args),
+      findAcceptancesByUser: (...args) => realRepo.findAcceptancesByUser(...args),
+      findAcceptancesByBooking: (...args) => realRepo.findAcceptancesByBooking(...args),
     }
 
     const svc = new ConsentService(wrappedRepo, () => KEY)

--- a/packages/api/src/services/consent.test.ts
+++ b/packages/api/src/services/consent.test.ts
@@ -1,3 +1,4 @@
+import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { InMemoryConsentRepository } from '../repositories/in-memory/consent'
 import type { ConsentRepository } from '../repositories/types'
@@ -73,6 +74,67 @@ describe('ConsentService.recordAcceptance', () => {
   })
 })
 
+describe('ConsentService.recordAcceptance — document snapshot + canonical version (#877)', () => {
+  it('records documentSnapshot with full disclosure fields and signatureCanonicalVersion=v1 when key configured', async () => {
+    const d = doc()
+    const repo = new InMemoryConsentRepository([d])
+    const svc = new ConsentService(repo, () => KEY)
+    const r = await svc.recordAcceptance(
+      { documentId: d.id, userId: 'user_snap', actorRole: 'RENTER' },
+      { now: NOW },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.acceptance.documentSnapshot).toEqual({
+      version: d.version,
+      locale: d.locale,
+      title: d.title,
+      body: d.body,
+      acceptanceLabel: d.acceptanceLabel,
+      contentHash: d.contentHash,
+    })
+    expect(r.acceptance.signatureCanonicalVersion).toBe('v1')
+  })
+
+  it('records documentSnapshot but sets signatureCanonicalVersion=null when no signing key', async () => {
+    const d = doc()
+    const repo = new InMemoryConsentRepository([d])
+    const svc = new ConsentService(repo, () => undefined)
+    const r = await svc.recordAcceptance(
+      { documentId: d.id, userId: 'user_nokey', actorRole: 'RENTER' },
+      { now: NOW },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.acceptance.documentSnapshot).toEqual({
+      version: d.version,
+      locale: d.locale,
+      title: d.title,
+      body: d.body,
+      acceptanceLabel: d.acceptanceLabel,
+      contentHash: d.contentHash,
+    })
+    expect(r.acceptance.signatureCanonicalVersion).toBeNull()
+  })
+
+  it('documentSnapshot.contentHash matches computeContentHash of the disclosed text', async () => {
+    const title = 'My Title'
+    const body = 'My Body'
+    const acceptanceLabel = 'Agree'
+    const expectedHash = computeContentHash({ title, body, acceptanceLabel })
+    const d = doc({ title, body, acceptanceLabel, contentHash: expectedHash })
+    const repo = new InMemoryConsentRepository([d])
+    const svc = new ConsentService(repo, () => KEY)
+    const r = await svc.recordAcceptance(
+      { documentId: d.id, userId: 'user_hash', actorRole: 'RENTER' },
+      { now: NOW },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.acceptance.documentSnapshot?.contentHash).toBe(expectedHash)
+  })
+})
+
 describe('ConsentService.recordAcceptance — subject-shape validation', () => {
   it('rejects RENTER_LIABILITY accepted without a bookingId → SUBJECT_SHAPE_INVALID', async () => {
     const repo = new InMemoryConsentRepository([
@@ -121,6 +183,8 @@ describe('ConsentService.recordAcceptance — concurrent-race catch path', () =>
       method: 'CLICKWRAP',
       recordSignature: null,
       signingKeyId: null,
+      signatureCanonicalVersion: null,
+      documentSnapshot: null,
     })
 
     // Wrap the repo so the FIRST findUserDocumentAcceptance call returns undefined

--- a/packages/api/src/services/consent.ts
+++ b/packages/api/src/services/consent.ts
@@ -1,5 +1,6 @@
 import type { UserRole } from '@kuruma/shared/auth/roles'
 import { CONSENT_CARDINALITY, type ConsentMethod, type ConsentType } from '@kuruma/shared/enums'
+import { CANONICAL_VERSION } from '@kuruma/shared/lib/consent-canonical'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { ConsentRepository, NewConsentAcceptance } from '../repositories/types'
 import type { ConsentAcceptance, ConsentDocument } from '../stores'
@@ -146,7 +147,16 @@ export class ConsentService {
   }
 
   private buildRow(
-    doc: { id: string; type: ConsentType; version: string; locale: string; contentHash: string },
+    doc: {
+      id: string
+      type: ConsentType
+      version: string
+      locale: string
+      contentHash: string
+      title: string
+      body: string
+      acceptanceLabel: string
+    },
     input: RecordAcceptanceInput,
     meta: RecordAcceptanceMeta,
     operatorId: string | null,
@@ -194,6 +204,15 @@ export class ConsentService {
       method,
       recordSignature: signed?.signature ?? null,
       signingKeyId: signed?.signingKeyId ?? null,
+      signatureCanonicalVersion: signed ? CANONICAL_VERSION : null,
+      documentSnapshot: {
+        version: doc.version,
+        locale: doc.locale,
+        title: doc.title,
+        body: doc.body,
+        acceptanceLabel: doc.acceptanceLabel,
+        contentHash: doc.contentHash,
+      },
     }
   }
 

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -34,6 +34,7 @@ import type {
   VehicleClassStatus,
 } from '@kuruma/shared/enums'
 import type { ComplianceAlertBand, ComplianceDocumentType } from '@kuruma/shared/lib/compliance'
+import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
 import type { LuggageSize } from '@kuruma/shared/lib/luggage'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
 
@@ -493,6 +494,8 @@ export interface ConsentAcceptance {
   method: ConsentMethod
   recordSignature: string | null
   signingKeyId: string | null
+  signatureCanonicalVersion: string | null
+  documentSnapshot: DocumentSnapshot | null
   signatureRef: string | null
   createdAt: Date
 }

--- a/packages/api/tests/integration/consent-repo.test.ts
+++ b/packages/api/tests/integration/consent-repo.test.ts
@@ -8,10 +8,10 @@ import { eq, inArray } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import type { Db } from './shared'
-import { DrizzleConsentRepository } from './consent'
+import { DrizzleConsentRepository } from '../../src/repositories/drizzle/consent'
+import type { Db } from '../../src/repositories/drizzle/shared'
 
-const url = process.env['DATABASE_URL']
+const url = process.env.DATABASE_URL
 if (!url) throw new Error('DATABASE_URL must be set to run this test')
 
 const client = postgres(url, { max: 1 })
@@ -70,9 +70,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (createdAcceptanceIds.length > 0) {
-    await db
-      .delete(consentAcceptances)
-      .where(inArray(consentAcceptances.id, createdAcceptanceIds))
+    await db.delete(consentAcceptances).where(inArray(consentAcceptances.id, createdAcceptanceIds))
   }
   if (createdDocIds.length > 0) {
     await db.delete(consentDocuments).where(inArray(consentDocuments.id, createdDocIds))

--- a/packages/api/tests/routes/admin-consent-evidence.test.ts
+++ b/packages/api/tests/routes/admin-consent-evidence.test.ts
@@ -1,0 +1,86 @@
+import { SignJWT } from 'jose'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { InMemoryConsentRepository } from '../../src/repositories/in-memory/consent'
+import { TEST_AUTH_SECRET, setupAuthEnv } from '../helpers/auth'
+
+async function bearer(payload: Record<string, unknown>): Promise<Record<string, string>> {
+  const key = new TextEncoder().encode(TEST_AUTH_SECRET)
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('kuruma-web')
+    .setAudience('kuruma-api')
+    .sign(key)
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+function makeApp() {
+  setupAuthEnv()
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  const consentRepo = new InMemoryConsentRepository()
+  const app = createApp({ vehicleRepo, bookingRepo, availabilityRepo, consentRepo })
+  return { app, consentRepo }
+}
+
+describe('GET /admin/consent/acceptances/:id/evidence', () => {
+  let app: ReturnType<typeof makeApp>['app']
+  let consentRepo: ReturnType<typeof makeApp>['consentRepo']
+
+  beforeEach(() => {
+    const result = makeApp()
+    app = result.app
+    consentRepo = result.consentRepo
+  })
+
+  test('returns the evidence bundle for a PLATFORM_ADMIN (200)', async () => {
+    const acceptance = await consentRepo.createAcceptance({
+      documentId: 'doc_1',
+      consentType: 'RENTER_TOS',
+      userId: 'user_1',
+      operatorId: null,
+      operatorMembershipId: null,
+      actorRole: 'RENTER',
+      bookingId: null,
+      acceptedAt: new Date('2026-01-01T00:00:00Z'),
+      context: null,
+      ipAddress: '1.2.3.4',
+      userAgent: 'test-agent',
+      method: 'EXPLICIT_CHECKBOX',
+      recordSignature: null,
+      signingKeyId: null,
+      signatureCanonicalVersion: null,
+      documentSnapshot: null,
+    })
+
+    const res = await app.request(`/admin/consent/acceptances/${acceptance.id}/evidence`, {
+      headers: await bearer({ sub: 'admin-1', role: 'PLATFORM_ADMIN' }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.acceptance.id).toBe(acceptance.id)
+    expect(body.data.verification.status).toBeDefined()
+  })
+
+  test('rejects a non-admin caller with 403', async () => {
+    const res = await app.request('/admin/consent/acceptances/x/evidence', {
+      headers: await bearer({ sub: 'renter-1', role: 'RENTER' }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test('returns 404 for an unknown acceptance', async () => {
+    const res = await app.request('/admin/consent/acceptances/nope/evidence', {
+      headers: await bearer({ sub: 'admin-1', role: 'PLATFORM_ADMIN' }),
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/api/tests/routes/admin-consent-evidence.test.ts
+++ b/packages/api/tests/routes/admin-consent-evidence.test.ts
@@ -54,7 +54,7 @@ describe('GET /admin/consent/acceptances/:id/evidence', () => {
       context: null,
       ipAddress: '1.2.3.4',
       userAgent: 'test-agent',
-      method: 'EXPLICIT_CHECKBOX',
+      method: 'CLICKWRAP',
       recordSignature: null,
       signingKeyId: null,
       signatureCanonicalVersion: null,

--- a/packages/shared/src/db/consent.ts
+++ b/packages/shared/src/db/consent.ts
@@ -12,6 +12,7 @@ import {
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { CONSENT_DOC_STATUSES, CONSENT_METHODS, CONSENT_TYPES } from '../enums'
+import type { DocumentSnapshot } from '../lib/consent-canonical'
 import { operators, users } from './auth'
 import { bookings } from './booking'
 import { operatorMemberships } from './provider-access'
@@ -70,6 +71,8 @@ export const consentAcceptances = pgTable(
     recordSignature: text('recordSignature'),
     signingKeyId: text('signingKeyId'),
     signatureRef: text('signatureRef'),
+    documentSnapshot: jsonb('documentSnapshot').$type<DocumentSnapshot>(),
+    signatureCanonicalVersion: text('signatureCanonicalVersion'),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/packages/shared/src/lib/consent-canonical.ts
+++ b/packages/shared/src/lib/consent-canonical.ts
@@ -49,6 +49,13 @@ export interface DisclosureArtifact {
   acceptanceLabel: string
 }
 
+/** The exact disclosure a subject was shown, frozen onto the acceptance (#877 evidence export). */
+export interface DocumentSnapshot extends DisclosureArtifact {
+  version: string
+  locale: string
+  contentHash: string
+}
+
 /** §5.1 — sha256 over the full disclosure a subject was shown. */
 export function computeContentHash(d: DisclosureArtifact): string {
   const canonical = canonicalizeFields([

--- a/scripts/backfill-consent-snapshot.ts
+++ b/scripts/backfill-consent-snapshot.ts
@@ -1,0 +1,132 @@
+// CLI: bun run db:backfill-consent-snapshot [--dry-run]
+// Backfills documentSnapshot onto consent_acceptances rows that have none.
+// Safe to re-run (idempotent): only rows with documentSnapshot IS NULL are touched.
+// Exits non-zero if any rows were skipped due to decision-level checks.
+import { eq, isNull } from 'drizzle-orm'
+import { resolveSigningKey } from '../packages/api/src/services/consent-signing'
+import { getDb } from '../packages/shared/src/db'
+import { consentAcceptances, consentDocuments } from '../packages/shared/src/db/schema'
+import { CANONICAL_VERSION } from '../packages/shared/src/lib/consent-canonical'
+import { decideBackfill } from './consent-backfill-decide'
+
+const dryRun = process.argv.includes('--dry-run')
+
+async function main() {
+  const db = getDb()
+  const signingKey = resolveSigningKey()
+  const getKey = (keyId: string) =>
+    signingKey && signingKey.keyId === keyId ? signingKey : undefined
+
+  // Load all acceptances with no snapshot yet.
+  const rows = await db
+    .select()
+    .from(consentAcceptances)
+    .where(isNull(consentAcceptances.documentSnapshot))
+
+  console.log(`Found ${rows.length} acceptance(s) with no documentSnapshot.`)
+
+  const counts: Record<string, number> = {
+    backfill: 0,
+    'skipped-current-doc-hash-mismatch': 0,
+    'skipped-hash-mismatch': 0,
+    'skipped-unsigned': 0,
+    'skipped-doc-not-found': 0,
+    timestampDrift: 0,
+  }
+
+  for (const row of rows) {
+    // Load the current document for this acceptance.
+    const [docRow] = await db
+      .select()
+      .from(consentDocuments)
+      .where(eq(consentDocuments.id, row.documentId))
+      .limit(1)
+
+    if (!docRow) {
+      counts['skipped-doc-not-found']++
+      console.warn(`[SKIP-NO-DOC] acceptance=${row.id} documentId=${row.documentId}`)
+      continue
+    }
+
+    const doc = {
+      id: docRow.id,
+      type: docRow.type,
+      version: docRow.version,
+      locale: docRow.locale,
+      title: docRow.title,
+      body: docRow.body,
+      acceptanceLabel: docRow.acceptanceLabel,
+      contentHash: docRow.contentHash,
+      status: docRow.status,
+      effectiveFrom: docRow.effectiveFrom,
+      publishedAt: docRow.publishedAt,
+      createdAt: docRow.createdAt,
+      updatedAt: docRow.updatedAt,
+    }
+
+    const acceptance = {
+      id: row.id,
+      documentId: row.documentId,
+      consentType: row.consentType,
+      userId: row.userId,
+      operatorId: row.operatorId,
+      operatorMembershipId: row.operatorMembershipId,
+      actorRole: row.actorRole,
+      bookingId: row.bookingId,
+      acceptedAt: row.acceptedAt,
+      context: row.context,
+      ipAddress: row.ipAddress,
+      userAgent: row.userAgent,
+      method: row.method,
+      recordSignature: row.recordSignature,
+      signingKeyId: row.signingKeyId,
+      signatureCanonicalVersion: row.signatureCanonicalVersion,
+      documentSnapshot: row.documentSnapshot,
+      signatureRef: row.signatureRef,
+      createdAt: row.createdAt,
+    }
+
+    const decision = decideBackfill(acceptance, doc, getKey)
+    counts[decision.action]++
+
+    if (decision.action === 'backfill') {
+      if (decision.timestampDrift) counts.timestampDrift++
+      if (!dryRun) {
+        await db
+          .update(consentAcceptances)
+          .set({
+            documentSnapshot: decision.snapshot,
+            signatureCanonicalVersion: row.signingKeyId ? CANONICAL_VERSION : null,
+          })
+          .where(eq(consentAcceptances.id, row.id))
+      }
+    } else {
+      console.warn(`[${decision.action.toUpperCase()}] acceptance=${row.id}`)
+    }
+  }
+
+  const skippedCount =
+    counts['skipped-current-doc-hash-mismatch'] +
+    counts['skipped-hash-mismatch'] +
+    counts['skipped-unsigned'] +
+    counts['skipped-doc-not-found']
+
+  const report = {
+    dryRun,
+    total: rows.length,
+    backfilled: counts.backfill,
+    timestampDrift: counts.timestampDrift,
+    skippedUnsigned: counts['skipped-unsigned'],
+    skippedHashMismatch: counts['skipped-hash-mismatch'],
+    skippedCurrentDocHashMismatch: counts['skipped-current-doc-hash-mismatch'],
+    skippedDocNotFound: counts['skipped-doc-not-found'],
+  }
+
+  console.log(JSON.stringify(report, null, 2))
+  process.exit(skippedCount > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error('Consent-snapshot backfill failed:', e)
+  process.exit(1)
+})

--- a/scripts/consent-backfill-decide.ts
+++ b/scripts/consent-backfill-decide.ts
@@ -1,0 +1,63 @@
+import { type SigningKey, signAcceptanceRecord } from '../packages/api/src/services/consent-signing'
+import type { ConsentAcceptance, ConsentDocument } from '../packages/api/src/stores'
+import {
+  type DocumentSnapshot,
+  computeContentHash,
+} from '../packages/shared/src/lib/consent-canonical'
+
+export type BackfillAction =
+  | 'backfill'
+  | 'skipped-current-doc-hash-mismatch'
+  | 'skipped-hash-mismatch'
+  | 'skipped-unsigned'
+
+export interface BackfillDecision {
+  action: BackfillAction
+  snapshot?: DocumentSnapshot
+  timestampDrift?: boolean
+}
+
+export function decideBackfill(
+  a: ConsentAcceptance,
+  doc: ConsentDocument,
+  getKey: (keyId: string) => SigningKey | undefined,
+): BackfillDecision {
+  // Gate 1 (MUST be first): the current doc's text must hash to its OWN contentHash, else the
+  // artifact is internally inconsistent and the HMAC (computed over the stored hash) could pass
+  // while the displayed text is wrong.
+  if (computeContentHash(doc) !== doc.contentHash)
+    return { action: 'skipped-current-doc-hash-mismatch' }
+  // Gate 3: no crypto proof for unsigned rows (or rows whose key we no longer hold).
+  if (!a.recordSignature) return { action: 'skipped-unsigned' }
+  const key = a.signingKeyId ? getKey(a.signingKeyId) : undefined
+  if (!key) return { action: 'skipped-unsigned' }
+  // Gate 2: does the CURRENT doc's hash, signed under this row's fields, reproduce recordSignature?
+  const recomputed = signAcceptanceRecord(
+    {
+      documentId: a.documentId,
+      contentHash: doc.contentHash,
+      consentType: a.consentType,
+      version: doc.version,
+      locale: doc.locale,
+      userId: a.userId,
+      operatorId: a.operatorId,
+      operatorMembershipId: a.operatorMembershipId,
+      bookingId: a.bookingId,
+      method: a.method,
+      acceptedAt: a.acceptedAt,
+      ipAddress: a.ipAddress,
+      userAgent: a.userAgent,
+    },
+    key,
+  ).signature
+  if (recomputed !== a.recordSignature) return { action: 'skipped-hash-mismatch' }
+  const snapshot: DocumentSnapshot = {
+    version: doc.version,
+    locale: doc.locale,
+    title: doc.title,
+    body: doc.body,
+    acceptanceLabel: doc.acceptanceLabel,
+    contentHash: doc.contentHash,
+  }
+  return { action: 'backfill', snapshot, timestampDrift: doc.updatedAt > a.acceptedAt }
+}

--- a/scripts/consent-evidence.ts
+++ b/scripts/consent-evidence.ts
@@ -1,0 +1,29 @@
+import { DrizzleConsentRepository } from '../packages/api/src/repositories/drizzle/consent'
+import { ConsentEvidenceService } from '../packages/api/src/services/consent-evidence'
+import { resolveSigningKey } from '../packages/api/src/services/consent-signing'
+// Usage: bun run consent:evidence -- <acceptanceId> | --user <id> | --booking <id>
+import { getDb } from '../packages/shared/src/db'
+
+async function main() {
+  const [a, b] = process.argv.slice(2)
+  const repo = new DrizzleConsentRepository(getDb())
+  const svc = new ConsentEvidenceService(repo, (keyId) => {
+    const k = resolveSigningKey()
+    return k && k.keyId === keyId ? k : undefined
+  })
+  const out =
+    a === '--user'
+      ? await svc.getConsentEvidenceForUser(b)
+      : a === '--booking'
+        ? await svc.getConsentEvidenceForBooking(b)
+        : await svc.getConsentEvidence(a)
+  if (!out) {
+    console.error('not found')
+    process.exit(1)
+  }
+  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`)
+}
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## What

Makes every consent acceptance a **self-contained, replayable evidence record**, with a verified on-demand export. Closes the gap where an acceptance only referenced the *live* (mutable) `consent_documents` row — so a later edit would lose what the renter actually agreed to and break signature verification.

`Refs #877` (consent ledger epic; Phase 3 / operator consent remains separate).

## Why

The HMAC signs `contentHash`, **not** the raw text. Without freezing the disclosed text onto the acceptance, the export couldn't faithfully reproduce *what was shown*, and a document edit would silently invalidate old signatures. Owner goal: "proof when needed" via a clean export.

## How (design: `docs/superpowers/specs/2026-06-24-consent-evidence-export-design.md`)

- **Snapshot at accept time** — two nullable columns on `consent_acceptances`: `documentSnapshot` (jsonb `{version,locale,title,body,acceptanceLabel,contentHash}`) + `signatureCanonicalVersion`. Captured in `ConsentService.buildRow`, byte-consistent with what's signed.
- **Pure verification gate chain** (`consent-evidence-verify.ts`) — first failing gate wins: `SNAPSHOT_MISSING → SNAPSHOT_HASH_MISMATCH → UNSIGNED → KEY_UNAVAILABLE → SIGNATURE_MISMATCH → VERIFIED`. The **hash self-check runs before the signature is trusted**, so tampered text can never read as `VERIFIED`.
- **`ConsentEvidenceService`** assembles a bundle exposing every signed field → verification is **replayable from the exported JSON alone**.
- **Surfaces:** platform-admin `GET /admin/consent/acceptances/:id/evidence` + CLI `consent:evidence`.
- **Guarded backfill** (`db:backfill-consent-snapshot`) — snapshots a legacy row **only when the current doc is provably the signed artifact** (source-doc self-consistency pre-gate → HMAC proof); drift is audit metadata, never a veto; nothing is ever fabricated.

## Security invariants (all verified + tested)

1. Hash self-check precedes signature trust (the body-tamper-with-stale-hash attack → `SNAPSHOT_HASH_MISMATCH`, not `VERIFIED`).
2. Backfill pre-gate precedes the HMAC gate; no false evidence.
3. Verify + backfill recompute field sets mirror `signAcceptanceRecord` exactly.
4. The export never substitutes the live doc into `document` (structurally impossible).

## Test plan

- [x] `bun run --filter @kuruma/api typecheck` / shared typecheck — clean
- [x] api unit suite — **1902/1902**
- [x] real-pg parity (`test:integration -- consent-repo`) — 2/2 (CI `db-drift` lane)
- [x] `db:verify` — 5/5 (75 migrations; `0074` after develop's `0073`)
- [x] `lint:boundaries` — OK
- [x] code-review (final) — SHIP; all four crypto invariants confirmed

## Follow-ups (tracked, not blocking)

- **#1050** keyId→key registry — `signatureCanonicalVersion` is stored now so a future verifier dispatches per-row; rows under a rotated key currently surface `KEY_UNAVAILABLE`.
- **#1049** real-pg constraint test (adjacent).
- HITL: the runbook (`docs/runbooks/2026-06-24-consent-signing-key.md`) documents producing an export + the `CONSENT_SIGNING_KEY` prod prerequisite.