### PR TITLE
fix(auth): require exp claim on Google id_token verification

### DIFF
--- a/packages/api/src/auth/google.ts
+++ b/packages/api/src/auth/google.ts
@@ -80,6 +80,10 @@ export async function verifyGoogleIdToken(
     algorithms: ['RS256'],
     issuer: [...GOOGLE_ISSUERS],
     audience: opts.clientId,
+    // Require `exp` to be PRESENT, not just valid: jose only enforces exp when the
+    // claim exists, so without this a token that simply omits exp would never expire.
+    // Google always emits it; this makes the lifetime bound independent of that.
+    requiredClaims: ['exp'],
     // Absorb small CF Worker ↔ Google clock drift so a valid login isn't spuriously
     // rejected at the exp/iat boundary; 30s is well under any useful replay window.
     clockTolerance: 30,

--- a/packages/api/tests/auth/verify-google-id-token.test.ts
+++ b/packages/api/tests/auth/verify-google-id-token.test.ts
@@ -33,15 +33,17 @@ interface IdClaims {
 
 function mintIdToken(
   claims: IdClaims,
-  opts: { issuer?: string; audience?: string; expiresIn?: string } = {},
+  opts: { issuer?: string; audience?: string; expiresIn?: string; noExp?: boolean } = {},
 ): Promise<string> {
-  return new SignJWT({ ...claims })
+  const builder = new SignJWT({ ...claims })
     .setProtectedHeader({ alg: 'RS256' })
     .setIssuer(opts.issuer ?? 'https://accounts.google.com')
     .setAudience(opts.audience ?? CLIENT_ID)
     .setIssuedAt()
-    .setExpirationTime(opts.expiresIn ?? '5m')
-    .sign(privateKey)
+  // noExp mints a token with NO exp claim — Google always emits one, but jose only
+  // checks exp when present, so we assert our verifier requires its presence (#1055).
+  if (!opts.noExp) builder.setExpirationTime(opts.expiresIn ?? '5m')
+  return builder.sign(privateKey)
 }
 
 const validClaims: IdClaims = {
@@ -102,6 +104,16 @@ describe('verifyGoogleIdToken (#1055)', () => {
 
   it('rejects an expired token', async () => {
     const token = await mintIdToken(validClaims, { expiresIn: '-1m' })
+    await expect(
+      verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects a token with no exp claim (presence required, not just validity)', async () => {
+    // jose only enforces exp when it is present; without requiredClaims a token that
+    // simply omits exp would never expire. Google always emits exp, so this guards a
+    // hypothetical malformed/forged token rather than any real Google response.
+    const token = await mintIdToken(validClaims, { noExp: true })
     await expect(
       verifyGoogleIdToken(token, publicKey, { clientId: CLIENT_ID, nonce: NONCE }),
     ).rejects.toThrow()


### PR DESCRIPTION
## What

Pin `requiredClaims: ['exp']` on `verifyGoogleIdToken` (`packages/api/src/auth/google.ts`).

## Why

jose only enforces `exp` **when the claim is present** — without `requiredClaims`, an id_token that simply omits `exp` would never expire and still pass every other check. Verified empirically: before this change a validly-signed, nonce-bound token with no `exp` was silently accepted.

Severity is LOW (defense-in-depth): reaching this still requires a token signed by Google's key carrying our per-flow nonce, and Google always emits `exp`. But pinning the claim makes the lifetime bound independent of Google's behaviour rather than relying on it.

This closes the lone LOW surfaced by the **2026-06-25 adversarial re-review of the #1055 id_token fix** (PR #1063) — both my pass and an independent code-reviewer agent flagged it as the only (sub-HIGH) item; everything else verified SHIP.

## Test

- RED→GREEN: new mutation-resistant test asserts a no-`exp` token is rejected (extends the `mintIdToken` helper with `noExp`).
- Full api unit suite: **1903 passed**; `tsc --noEmit` clean.

Refs the auth security review; follows up #1055 / #1063.