### PR TITLE
refactor(#464): extract shared search-row fragments + enforce dispatch exhaustiveness

### DIFF
--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -24,6 +24,9 @@ interface SearchResultRowProps {
   readonly geoLabel?: string | null
 }
 
+/** A concrete result `item` plus the shared search context every row carries. */
+type RowCardProps<T> = { readonly item: T } & Omit<SearchResultRowProps, 'item'>
+
 /**
  * One flat-list row in the cross-operator vehicle search (#458). Switches on the
  * result `kind`: SPECIFIC renders one physical car; CLASS_COMBO (#464) renders a
@@ -39,7 +42,94 @@ export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
       return <SpecificRow item={item} {...ctx} />
     case 'CLASS_COMBO':
       return <ComboRow item={item} {...ctx} />
+    default:
+      // A future result `kind` added to the union without a case here becomes a tsc
+      // error (item is no longer `never`) instead of a silently-dropped row — the exact
+      // failure class this slice fixed for CLASS_COMBO. Runtime no-ops for a skewed API.
+      item satisfies never
+      return null
   }
+}
+
+/** Square thumbnail with a 1:1 intrinsic-size hint and a car-icon fallback when photo-less. */
+function RowThumbnail({
+  photo,
+  alt,
+}: { readonly photo: string | undefined; readonly alt: string }) {
+  return (
+    <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
+      {photo ? (
+        <img
+          src={photo}
+          alt={alt}
+          // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
+          // h-full/w-full still drive the rendered size inside the square wrapper.
+          width={300}
+          height={300}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <Car className="size-8 text-muted-foreground/30" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** "{operatorName} · {storefront}" line shared by every row kind. */
+function RowLocationLine({
+  location,
+}: { readonly location: { readonly operatorName: string; readonly name: string } }) {
+  return (
+    <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <MapPin className="size-4 shrink-0" />
+      <span className="font-medium text-foreground/80">{location.operatorName}</span>
+      <span aria-hidden="true">·</span>
+      <span>{location.name}</span>
+    </p>
+  )
+}
+
+/** Optional "{area}, {prefecture} · {km} km away" geo line (#885 3a); renders nothing without a label. */
+function RowGeoLine({ geoLabel }: { readonly geoLabel?: string | null | undefined }) {
+  if (!geoLabel) return null
+  return (
+    <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <Navigation className="size-4 shrink-0" aria-hidden />
+      <span>{geoLabel}</span>
+    </p>
+  )
+}
+
+/** The sole navigation affordance: a button-styled Link to the pickup store, dates + filters preserved. */
+function RowDetailCta({
+  locale,
+  locationId,
+  from,
+  to,
+  classFilter,
+  pickupLocationId,
+  region,
+  label,
+}: Pick<
+  SearchResultRowProps,
+  'locale' | 'from' | 'to' | 'classFilter' | 'pickupLocationId' | 'region'
+> & { readonly locationId: string; readonly label: string }) {
+  return (
+    <Link
+      to="/$locale/storefronts/$locationId"
+      params={{ locale, locationId }}
+      search={{
+        from,
+        to,
+        ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
+      }}
+      className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+    >
+      {label}
+    </Link>
+  )
 }
 
 function SpecificRow({
@@ -51,32 +141,14 @@ function SpecificRow({
   pickupLocationId,
   region,
   geoLabel,
-}: { readonly item: SpecificSearchResult } & Omit<SearchResultRowProps, 'item'>) {
+}: RowCardProps<SpecificSearchResult>) {
   const t = useTranslations('search')
-  const photo = item.photos[0]
   const transmissionLabel = item.transmission === 'AUTO' ? t('auto') : t('manual')
-
   const priceLabel = resultPriceLabel(item, t)
 
   return (
     <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
-        {photo ? (
-          <img
-            src={photo}
-            alt={item.name}
-            // 1:1 intrinsic hint lets the browser reserve the box before load (#846);
-            // h-full/w-full still drive the rendered size inside the square wrapper.
-            width={300}
-            height={300}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <Car className="size-8 text-muted-foreground/30" />
-          </div>
-        )}
-      </div>
+      <RowThumbnail photo={item.photos[0]} alt={item.name} />
 
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-baseline justify-between gap-2">
@@ -86,19 +158,8 @@ function SpecificRow({
           </span>
         </div>
 
-        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <MapPin className="size-4 shrink-0" />
-          <span className="font-medium text-foreground/80">{item.location.operatorName}</span>
-          <span aria-hidden="true">·</span>
-          <span>{item.location.name}</span>
-        </p>
-
-        {geoLabel && (
-          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Navigation className="size-4 shrink-0" aria-hidden />
-            <span>{geoLabel}</span>
-          </p>
-        )}
+        <RowLocationLine location={item.location} />
+        <RowGeoLine geoLabel={geoLabel} />
 
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
           <span className="flex items-center gap-1.5">
@@ -113,18 +174,16 @@ function SpecificRow({
 
         <div className="mt-auto flex items-end justify-between gap-2 pt-1">
           <p className="text-base font-semibold text-foreground">{priceLabel}</p>
-          <Link
-            to="/$locale/storefronts/$locationId"
-            params={{ locale, locationId: item.location.locationId }}
-            search={{
-              from,
-              to,
-              ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
-            }}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-          >
-            {t('viewStore')}
-          </Link>
+          <RowDetailCta
+            locale={locale}
+            locationId={item.location.locationId}
+            from={from}
+            to={to}
+            classFilter={classFilter}
+            pickupLocationId={pickupLocationId}
+            region={region}
+            label={t('viewStore')}
+          />
         </div>
       </div>
     </article>
@@ -148,28 +207,13 @@ function ComboRow({
   pickupLocationId,
   region,
   geoLabel,
-}: { readonly item: ClassComboSearchResult } & Omit<SearchResultRowProps, 'item'>) {
+}: RowCardProps<ClassComboSearchResult>) {
   const t = useTranslations('search')
-  const photo = item.photos[0]
   const priceLabel = resultPriceLabel(item, t)
 
   return (
     <article className="flex gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      <div className="size-24 shrink-0 overflow-hidden rounded-lg bg-muted sm:size-28">
-        {photo ? (
-          <img
-            src={photo}
-            alt={item.classLabel}
-            width={300}
-            height={300}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <Car className="size-8 text-muted-foreground/30" />
-          </div>
-        )}
-      </div>
+      <RowThumbnail photo={item.photos[0]} alt={item.classLabel} />
 
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-baseline justify-between gap-2">
@@ -179,19 +223,8 @@ function ComboRow({
           </span>
         </div>
 
-        <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <MapPin className="size-4 shrink-0" />
-          <span className="font-medium text-foreground/80">{item.location.operatorName}</span>
-          <span aria-hidden="true">·</span>
-          <span>{item.location.name}</span>
-        </p>
-
-        {geoLabel && (
-          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Navigation className="size-4 shrink-0" aria-hidden />
-            <span>{geoLabel}</span>
-          </p>
-        )}
+        <RowLocationLine location={item.location} />
+        <RowGeoLine geoLabel={geoLabel} />
 
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
           <span className="flex items-center gap-1.5">
@@ -208,18 +241,16 @@ function ComboRow({
 
         <div className="mt-auto flex items-end justify-between gap-2 pt-1">
           <p className="text-base font-semibold text-foreground">{priceLabel}</p>
-          <Link
-            to="/$locale/storefronts/$locationId"
-            params={{ locale, locationId: item.location.locationId }}
-            search={{
-              from,
-              to,
-              ...carryForwardFilters({ class: classFilter, pickupLocationId, region }),
-            }}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-          >
-            {t('viewStore')}
-          </Link>
+          <RowDetailCta
+            locale={locale}
+            locationId={item.location.locationId}
+            from={from}
+            to={to}
+            classFilter={classFilter}
+            pickupLocationId={pickupLocationId}
+            region={region}
+            label={t('viewStore')}
+          />
         </div>
       </div>
     </article>


### PR DESCRIPTION
## What

Follow-up cleanup on the just-merged combo-cards slice 3b (#1077). `SpecificRow` and `ComboRow` in `SearchResultRow.tsx` duplicated the thumbnail, location line, geo line, and **the entire drill-down CTA `<Link>`** verbatim — a change to the shared navigation had to be made in two places.

- Extracted `RowThumbnail` / `RowLocationLine` / `RowGeoLine` / `RowDetailCta` presentational helpers + a `RowCardProps<T>` alias for the shared per-row prop shape.
- The dispatcher `default` now asserts `item satisfies never`, so a future result `kind` added without a case is a **tsc error** rather than a silently-dropped row — the exact failure class this slice fixed for `CLASS_COMBO`. Runtime still no-ops for a skewed API response.
- `RowDetailCta` omits `geoLabel` from its prop bag (ISP) — it never read it.

## Why

The duplication is concrete, not speculative: today the `<Link to="/$locale/storefronts/$locationId">` block is byte-identical across both rows. Single source of truth for the only navigation affordance.

This re-applies the salvaged value from the closed duplicate PR #1078, hand-adapted onto #1077's `ComboRow` (the original commits conflicted with #1077's rewrite).

## Test plan

- [x] `bun run --filter @kuruma/web test src/vite/search tests/vite/search` — **134 pass**, no behaviour change
- [x] `bun run --filter @kuruma/web typecheck` — clean (the `satisfies never` guard proves the union is exhaustively handled)
- [x] `bunx biome check` — clean
- [x] `lint:modules` / `lint:size` — no new violations

Refs #464