### PR TITLE
fix(search): runtime sink on SearchResultKind exhaustive switches

### DIFF
--- a/packages/web/src/vite/search/MapPopupCarousel.tsx
+++ b/packages/web/src/vite/search/MapPopupCarousel.tsx
@@ -60,7 +60,21 @@ export function MapPopupCarousel({
   const title = resultTitle(current)
   // A combo's badge marks the deal — the class label is already the title, so
   // repeating it as a badge would read twice. SPECIFIC keeps its class badge.
-  const badge = current.kind === 'CLASS_COMBO' ? t('classDeal') : current.classLabel
+  // Switched (vs ternary) so a future `kind` is a tsc error here — the web ships
+  // independently of the API, so a stale bundle can't silently render the wrong
+  // branch.
+  const badge = ((): string => {
+    switch (current.kind) {
+      case 'SPECIFIC':
+        return current.classLabel
+      case 'CLASS_COMBO':
+        return t('classDeal')
+      default: {
+        const _exhaustive: never = current
+        return ''
+      }
+    }
+  })()
 
   return (
     <div

--- a/packages/web/src/vite/search/SearchResultRow.tsx
+++ b/packages/web/src/vite/search/SearchResultRow.tsx
@@ -39,6 +39,14 @@ export function SearchResultRow({ item, ...ctx }: SearchResultRowProps) {
       return <SpecificRow item={item} {...ctx} />
     case 'CLASS_COMBO':
       return <ComboRow item={item} {...ctx} />
+    default: {
+      // Runtime sink: web (CF Pages) and API (CF Workers) deploy independently,
+      // so a future `kind` reaching a stale web bundle wouldn't be caught by the
+      // (compile-time-only) exhaustive narrowing alone. Forces a tsc error here
+      // the moment the union grows; renders nothing instead of silently dropping.
+      const _exhaustive: never = item
+      return null
+    }
   }
 }
 


### PR DESCRIPTION
## What

Follow-up to #1077 (slice 3b of #464). Adds a `default: { const _exhaustive: never = item; … }` sink to the two `SearchResultItem.kind` switch/ternary sites in the cross-operator search UI.

## Why

The discriminated union (`SPECIFIC | CLASS_COMBO`) is checked at **compile time** by `tsc`'s exhaustive narrowing — that's enough as long as the version of `@kuruma/shared` that built the API also built the web bundle on the same deploy. But the web (CF Pages) and API (CF Workers) deploy independently, so the practical failure mode is:

> a future `kind` ships in the API + shared while a stale web bundle is still live → unknown `kind` reaches the renderer.

In that window:

- `SearchResultRow` — exhaustive switch returns `undefined` → React renders nothing → the row silently vanishes from the result list.
- `MapPopupCarousel` — the badge ternary `current.kind === 'CLASS_COMBO' ? t('classDeal') : current.classLabel` silently falls into the `SPECIFIC` branch and tries to read `.classLabel` off whatever the unknown kind is.

Both fail to error visibly. The renter sees fewer (or wrong) cards; we get no signal that the bundle is stale.

Adding the `never` sink **does not change runtime** on known kinds — it's purely a tripwire: the moment the union grows in `@kuruma/shared`, `tsc` errors on these two files and we can't ship a web bundle that's blind to the new variant.

## Scope

Narrow. Only the two sites flagged in the [PR #1077 review](https://github.com/jackli921/kuruma-rental/pull/1077#pullrequestreview):

- `packages/web/src/vite/search/SearchResultRow.tsx` — switch sink.
- `packages/web/src/vite/search/MapPopupCarousel.tsx` — badge becomes an IIFE switch with the same sink.

The analogous ternaries in `packages/web/src/vite/search/result.ts` (`searchResultKey`, `resultTitle`) would throw at runtime when accessing the unknown branch's field rather than silently degrade, so they're out of scope here; happy to harden them as a follow-up if the pattern is wanted.

## Test

- web `tsc --noEmit` — clean.
- web unit run of the two changed test files — 22/22 green (no behavior change on known kinds).
- biome, file-size, module-boundaries (pre-commit hooks) — clean.

Refs #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)