### PR TITLE
fix(carousel): runtime sink on MapPopupCarousel badge ternary

### DIFF
--- a/packages/web/src/vite/search/MapPopupCarousel.tsx
+++ b/packages/web/src/vite/search/MapPopupCarousel.tsx
@@ -60,7 +60,20 @@ export function MapPopupCarousel({
   const title = resultTitle(current)
   // A combo's badge marks the deal — the class label is already the title, so
   // repeating it as a badge would read twice. SPECIFIC keeps its class badge.
-  const badge = current.kind === 'CLASS_COMBO' ? t('classDeal') : current.classLabel
+  // Switched (vs ternary) so a future `kind` is a tsc error here — the web ships
+  // independently of the API, so a stale bundle can't silently render the wrong
+  // branch.
+  const badge = ((): string => {
+    switch (current.kind) {
+      case 'SPECIFIC':
+        return current.classLabel
+      case 'CLASS_COMBO':
+        return t('classDeal')
+      default:
+        current satisfies never
+        return ''
+    }
+  })()
 
   return (
     <div


### PR DESCRIPTION
## What

Mirrors the dispatch-exhaustiveness guard that #1094 added to `SearchResultRow` — for the matching `current.kind === 'CLASS_COMBO' ? … : …` ternary in `MapPopupCarousel`.

## Why

The map popup carousel computes its per-slide badge with:

```ts
const badge = current.kind === 'CLASS_COMBO' ? t('classDeal') : current.classLabel
```

For a future `SearchResultKind` shipped in the API + `@kuruma/shared` but not yet picked up by the still-live web bundle (CF Pages and CF Workers deploy independently), this silently falls into the `current.classLabel` branch. On a hypothetical new kind without that field the badge would render empty — no error, no signal. Same class of failure that #1094 closed for the row dispatcher.

Switching the badge to an IIFE switch with `current satisfies never` in the default makes the moment-the-union-grows case a tsc error in this file, matching the row-side pattern. Runtime on known kinds is unchanged.

## Scope

One file, one expression. The Result row already grew its sink in #1094; this is the same idea two doors down.

## Test

- web `tsc --noEmit` — clean.
- `bunx vitest run tests/vite/search/MapPopupCarousel.test.tsx` — 7/7 green.
- biome, file-size, module-boundaries, husky pre-commit — clean.

Background: opened #1095 with both files at first, but #1094 (the row-extraction + exhaustiveness refactor) merged ~3 seconds before #1095 was filed. Reduced to carousel-only and re-opened as this PR to keep the trail clean.

Refs #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)