### PR TITLE
fix(payment): record async_payment_succeeded; lock seal precedence

### DIFF
--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -318,6 +318,33 @@ describe('PaymentService.handleWebhook', () => {
     expect(second).toMatchObject({ status: 200, outcome: 'duplicate' })
   })
 
+  it('records a payment from async_payment_succeeded (konbini/bank transfer)', async () => {
+    // Delayed JP methods complete the Checkout Session `unpaid`, then settle later via
+    // a SEPARATE checkout.session.async_payment_succeeded event whose session is `paid`.
+    // It must record the payment exactly like a card `completed` — else captured funds
+    // never mark the booking paid (#payment-review LOW-1).
+    gateway.nextEvent = completedEvent({
+      type: 'checkout.session.async_payment_succeeded',
+      eventId: 'evt_async',
+      checkoutSessionId: 'cs_async',
+    })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result.outcome).toBe('recorded')
+    const paid = await paymentRepo.findSucceededByBookingId('bk-1')
+    expect(paid?.stripeEventId).toBe('evt_async')
+    expect(paid?.grossJpy).toBe(100_000)
+  })
+
+  it('ignores async_payment_failed (delayed payment never settled, no row)', async () => {
+    gateway.nextEvent = completedEvent({
+      type: 'checkout.session.async_payment_failed',
+      paymentStatus: 'unpaid',
+      eventId: 'evt_async_fail',
+    })
+    expect((await service.handleWebhook('raw', 'sig')).outcome).toBe('ignored')
+    expect(await paymentRepo.findSucceededByBookingId('bk-1')).toBeNull()
+  })
+
   it('flags a SECOND distinct session as double-payment, carrying the paymentIntent to refund', async () => {
     gateway.nextEvent = completedEvent()
     await service.handleWebhook('raw', 'sig')

--- a/packages/api/src/services/payment/payment.ts
+++ b/packages/api/src/services/payment/payment.ts
@@ -18,6 +18,17 @@ import type { PaymentGateway, StripeRefund, VerifiedPaymentEvent } from './payme
 
 const CURRENCY = 'jpy'
 const COMPLETED_EVENT = 'checkout.session.completed'
+// A delayed payment method (JP konbini / bank transfer) completes the Checkout
+// Session as `unpaid`, then settles later via a SEPARATE async_payment_succeeded
+// event whose session is `paid`. Both carry the session's amount + metadata, so
+// either is a valid "this booking was paid" signal; the session-id unique seal keeps
+// a card `completed` and a (never co-occurring) async settle idempotent. Without
+// this, konbini/bank funds are captured but the booking never records paid (#payment-review LOW-1).
+const ASYNC_PAYMENT_SUCCEEDED_EVENT = 'checkout.session.async_payment_succeeded'
+const PAID_SESSION_EVENTS: ReadonlySet<string> = new Set([
+  COMPLETED_EVENT,
+  ASYNC_PAYMENT_SUCCEEDED_EVENT,
+])
 const PAID = 'paid'
 // Stripe fires `refund.updated` as a refund moves through its lifecycle. Our refund
 // carries `metadata.bookingId` (set at refundPayment), so this event — unlike
@@ -166,7 +177,7 @@ export class PaymentService {
       return this.handleRefundWebhook(event)
     }
 
-    if (event.type !== COMPLETED_EVENT || event.paymentStatus !== PAID) {
+    if (!PAID_SESSION_EVENTS.has(event.type) || event.paymentStatus !== PAID) {
       return { status: 200, outcome: 'ignored' }
     }
     const bookingId = event.metadata.bookingId

--- a/packages/api/tests/integration/payment-events.test.ts
+++ b/packages/api/tests/integration/payment-events.test.ts
@@ -181,6 +181,20 @@ describe('DrizzlePaymentEventRepository (real Postgres)', () => {
     expect(pgConstraintName(err)).toBe(PAYMENT_EVENT_ONE_SUCCESS_CONSTRAINT)
   })
 
+  // PRECEDENCE: a redelivered checkout.session.completed for an ALREADY-paid booking
+  // violates BOTH stripeEventId_unique AND one_success_per_booking at once. The webhook
+  // classifies a one-success violation as a DOUBLE_PAYMENT anomaly and everything else
+  // as a benign duplicate, so Postgres MUST surface the event-id seal here (created
+  // before one_success) — otherwise a plain redelivery would be mis-flagged as a double
+  // charge. Append-only migrations fix that creation order; this locks it against drift.
+  it('surfaces the event-id seal (not one-success) on a redelivery of a paid booking', async () => {
+    await paymentRepo.insert(event(bookingA))
+    // Faithful Stripe redelivery: identical event id + session, booking already SUCCEEDED.
+    const err = await paymentRepo.insert(event(bookingA)).catch((e) => e)
+    expect(pgErrorCode(err)).toBe(PG_ERROR.UNIQUE_VIOLATION)
+    expect(pgConstraintName(err)).toBe(PAYMENT_EVENT_STRIPE_EVENT_CONSTRAINT)
+  })
+
   // #717: the month filter + available-months are pushed into SQL. The one thing
   // in-memory cannot prove is that the SQL JST boundary (`AT TIME ZONE
   // 'Asia/Tokyo'`) matches the pure jstYearMonth: a payment at 15:30 UTC on Jul


### PR DESCRIPTION
Addresses both LOWs from the **2026-06-25 Stripe payment-path security review** (my pass + an independent code-reviewer agent; the path was otherwise SHIP, no HIGH+).

## LOW-1 — async payment methods recorded (runtime fix)

The webhook only recorded `checkout.session.completed` with `payment_status: 'paid'`. A delayed JP method (**konbini / bank transfer**) completes the Checkout Session as `unpaid`, then settles later via a **separate** `checkout.session.async_payment_succeeded` event whose session is `paid`. That event was unhandled → captured funds, but the booking never marked paid.

Fix: treat both event types as a paid-session signal (`PAID_SESSION_EVENTS`). The `stripeCheckoutSessionId` unique seal keeps a card `completed` and a (never co-occurring) async settle idempotent.

- `+` test: an `async_payment_succeeded` event records the payment.
- `+` test: `async_payment_failed` is ignored (no row).

## LOW-2 — seal precedence locked (proof, no runtime change)

A redelivered `completed` event on an **already-paid** booking violates *both* `stripeEventId_unique` and `one_success_per_booking`. The webhook flags a `DOUBLE_PAYMENT` anomaly only when `one_success` is the surfaced constraint, so Postgres must report the **event-id** seal first (created before `one_success`) — else a plain redelivery would be mis-flagged a double charge. Existing integration tests proved each seal in isolation but not this overlap.

- `+` real-pg test: a faithful redelivery of a paid booking surfaces `payment_events_stripeEventId_unique`, guarding the append-only index creation order against drift.

The behavior was already correct (in-memory repo mirrors this precedence; append-only migrations fix index order); this just makes the DB-level guarantee explicit and regression-proof — no runtime change.

## Test
- api unit: **1905 passed**; `tsc --noEmit` clean.
- payment integration (real Postgres `postgres:16`): payment-events **9/9** (incl. new precedence test), refund constraints/confirm **7/7**.

Refs the payment-path security review; follows up #461.