### PR TITLE
fix(search): runtime sink on result.ts kind-discriminating helpers

### DIFF
--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -10,16 +10,36 @@ import type { ResultLocation, SearchResultItem } from '@kuruma/shared/types/sear
 /** Stable list key — the renter-safe per-car id for SPECIFIC, a location-namespaced
  *  class id for a CLASS_COMBO row (#464) so the same class offered at two storefronts
  *  never collides into one React key. Mirrors the API cursor `itemKey` (`c:<loc>:<class>`),
- *  minus the kind prefix the list doesn't need. Shared by the flat list and map+list view. */
+ *  minus the kind prefix the list doesn't need. Shared by the flat list and map+list view.
+ *  Switched (vs ternary) so a future `kind` is a tsc error here — the web ships
+ *  independently of the API, so a stale bundle can't silently produce a collision-prone
+ *  key for an unknown variant (matches #1094/#1096). */
 export function searchResultKey(item: SearchResultItem): string {
-  return item.kind === 'SPECIFIC' ? item.vehicleId : `${item.location.locationId}:${item.classId}`
+  switch (item.kind) {
+    case 'SPECIFIC':
+      return item.vehicleId
+    case 'CLASS_COMBO':
+      return `${item.location.locationId}:${item.classId}`
+    default:
+      item satisfies never
+      return ''
+  }
 }
 
 type Translate = (key: string, values?: Record<string, string | number>) => string
 
-/** Human title of a result row: the car name (SPECIFIC) or class label (CLASS_COMBO). */
+/** Human title of a result row: the car name (SPECIFIC) or class label (CLASS_COMBO).
+ *  Switched (vs ternary) so a future `kind` is a tsc error here — see searchResultKey. */
 export function resultTitle(item: SearchResultItem): string {
-  return item.kind === 'SPECIFIC' ? item.name : item.classLabel
+  switch (item.kind) {
+    case 'SPECIFIC':
+      return item.name
+    case 'CLASS_COMBO':
+      return item.classLabel
+    default:
+      item satisfies never
+      return ''
+  }
 }
 
 /** "From ¥X / day" (or hourly, or price-on-request) — shared by the list row and


### PR DESCRIPTION
## What

Completes the satisfies-never sweep across the search row family:

- #1094 — `SearchResultRow` dispatcher
- #1096 — `MapPopupCarousel` badge ternary
- **this** — `searchResultKey` + `resultTitle` in `result.ts`

The last two kind-discriminating ternaries in the search rendering pipeline get the same treatment: switch + `item satisfies never` default.

## Why

Same failure class. Web (CF Pages) and API (CF Workers) deploy independently, so a future `SearchResultKind` shipped in `@kuruma/shared` + the API but not yet built into the live web bundle silently falls into the else branch:

- `searchResultKey` — accesses `${item.location.locationId}:${item.classId}` on an unknown kind, producing `"<loc>:undefined"` keys → mass React-key collision (the same trap #1079 just shut for CLASS_COMBO before location-keying).
- `resultTitle` — accesses `item.classLabel` on an unknown kind, rendering an empty/wrong title.

The `never` sink turns each into a tsc error the moment the union grows, instead of a silent runtime degradation under split deploy. Runtime on known kinds (SPECIFIC + CLASS_COMBO) is unchanged.

## Scope

One file, two functions. `resultPriceLabel` discriminates on `dailyRateJpy != null`, not `kind`, so it's safe and out of scope.

## Test

- web `tsc --noEmit` — clean.
- `bunx vitest run tests/vite/search/` — 134/134 green (no behavior change on known kinds).
- biome, file-size, module-boundaries, husky pre-commit — clean.

Refs #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)