### PR TITLE
fix(#851): reconciler heals REFUND_DUE bookings stuck on a SUCCEEDED receipt

### DIFF
--- a/packages/api/src/repositories/drizzle/refund-reconciler.ts
+++ b/packages/api/src/repositories/drizzle/refund-reconciler.ts
@@ -1,5 +1,5 @@
 import { bookings, paymentRefunds } from '@kuruma/shared/db/schema'
-import { and, eq, isNull, or } from 'drizzle-orm'
+import { and, eq, isNull, ne, or } from 'drizzle-orm'
 import type { Booking } from '../../stores'
 import type { RefundReconcilerRepository } from '../types'
 import { type Db, bookingColumns, toBooking } from './shared'
@@ -7,7 +7,7 @@ import { type Db, bookingColumns, toBooking } from './shared'
 /**
  * Drizzle reconciler scan (#851 S4). A booking-driven LEFT JOIN so a REFUND_DUE
  * booking whose eager-fire never claimed a receipt (the primary self-heal case)
- * still surfaces. The terminal-receipt exclusion lives in the WHERE — applied
+ * still surfaces. The FAILED-receipt exclusion lives in the WHERE — applied
  * before LIMIT — so a backlog of human-stuck FAILED rows can't starve retryable
  * work. System-scoped (a cron has no caller): intentionally no tenant filter.
  */
@@ -22,9 +22,14 @@ export class DrizzleRefundReconcilerRepository implements RefundReconcilerReposi
       .where(
         and(
           eq(bookings.cancellationFeeSettlement, 'REFUND_DUE'),
-          // No receipt yet, or a non-terminal PENDING one. payment_refunds is
-          // UNIQUE(bookingId), so the join fans out at most 1:1 — no dedupe needed.
-          or(isNull(paymentRefunds.id), eq(paymentRefunds.status, 'PENDING')),
+          // Drive anything not terminally FAILED: no receipt (lost eager-fire), a
+          // PENDING one, OR a SUCCEEDED receipt whose booking is still REFUND_DUE —
+          // the crash between confirmRefundSucceeded's two writes (a healthy refund
+          // leaves the booking REFUNDED, filtered above, so SUCCEEDED here is ONLY
+          // that orphan; its drive is a no-Stripe booking-side confirm). NULL status
+          // (no receipt) fails `ne`, so the isNull branch admits it. payment_refunds
+          // is UNIQUE(bookingId), so the join fans out at most 1:1 — no dedupe needed.
+          or(isNull(paymentRefunds.id), ne(paymentRefunds.status, 'FAILED')),
         ),
       )
       .orderBy(bookings.cancelledAt)

--- a/packages/api/src/repositories/in-memory/refund-reconciler.test.ts
+++ b/packages/api/src/repositories/in-memory/refund-reconciler.test.ts
@@ -73,13 +73,21 @@ describe('InMemoryRefundReconcilerRepository.listRefundDueNeedingDrive', () => {
     expect(due.map((b) => b.id)).toEqual(['bk-1'])
   })
 
-  it('excludes a booking whose receipt is terminal (SUCCEEDED or FAILED)', async () => {
-    const r = repo(
-      [booking('done'), booking('stuck')],
-      [receipt('done', 'SUCCEEDED'), receipt('stuck', 'FAILED')],
-    )
+  it('returns the orphan: a REFUND_DUE booking whose receipt is already SUCCEEDED', async () => {
+    // The crash/transient-error window: confirmRefundSucceeded marks the receipt
+    // SUCCEEDED, then the booking-side REFUND_DUE→REFUNDED write fails. A *healthy*
+    // refunded booking sits at REFUNDED (filtered out above), so REFUND_DUE + a
+    // SUCCEEDED receipt is ONLY this orphan — and the backstop must finish it (the
+    // SUCCEEDED branch of initiateCancellationRefund is a no-Stripe booking-side
+    // confirm), never depend on a Stripe webhook redelivery to heal.
+    const r = repo([booking('orphan')], [receipt('orphan', 'SUCCEEDED')])
     const due = await r.listRefundDueNeedingDrive({ limit: 10 })
-    expect(due).toEqual([])
+    expect(due.map((b) => b.id)).toEqual(['orphan'])
+  })
+
+  it('excludes a booking whose receipt is terminal FAILED (needs a human)', async () => {
+    const r = repo([booking('stuck')], [receipt('stuck', 'FAILED')])
+    expect(await r.listRefundDueNeedingDrive({ limit: 10 })).toEqual([])
   })
 
   it('excludes bookings not in REFUND_DUE (ADVISORY/CAPTURED/REFUNDED)', async () => {

--- a/packages/api/src/repositories/in-memory/refund-reconciler.ts
+++ b/packages/api/src/repositories/in-memory/refund-reconciler.ts
@@ -4,7 +4,7 @@ import type { RefundReconcilerRepository } from '../types'
 /**
  * In-memory reconciler scan (#851 S4), the Drizzle LEFT JOIN's twin. Reads the
  * SAME booking + refund maps the concrete repos write, so a REFUND_DUE booking's
- * receipt state is visible here exactly as a SQL join would see it. The terminal
+ * receipt state is visible here exactly as a SQL join would see it. The FAILED
  * filter runs BEFORE the limit (parity with the WHERE-before-LIMIT) so a backlog
  * of human-stuck FAILED rows can never crowd out retryable work.
  */
@@ -18,9 +18,13 @@ export class InMemoryRefundReconcilerRepository implements RefundReconcilerRepos
     const needsDrive = [...this.bookings.values()].filter((b) => {
       if (b.cancellationFeeSettlement !== 'REFUND_DUE') return false
       const receipt = this.refunds.get(b.id)
-      // No receipt (lost eager-fire) or a still-PENDING one is retryable; a terminal
-      // SUCCEEDED/FAILED is not — and is dropped here, before the limit applies.
-      return !receipt || receipt.status === 'PENDING'
+      // Drive anything not terminally FAILED: no receipt (lost eager-fire), a PENDING
+      // one, OR a SUCCEEDED receipt whose booking is still REFUND_DUE — the crash
+      // between confirmRefundSucceeded's two writes. A healthy refund leaves the
+      // booking REFUNDED (filtered above), so SUCCEEDED here is ONLY that orphan, and
+      // the SUCCEEDED branch of initiateCancellationRefund finishes it (no Stripe call).
+      // FAILED is the lone exclusion — it needs a human — and is dropped before the limit.
+      return !receipt || receipt.status !== 'FAILED'
     })
     return needsDrive
       .sort((a, b) => (a.cancelledAt?.getTime() ?? 0) - (b.cancelledAt?.getTime() ?? 0))

--- a/packages/api/tests/integration/refund-reconciler.test.ts
+++ b/packages/api/tests/integration/refund-reconciler.test.ts
@@ -181,7 +181,7 @@ const ours = (rows: { id: string }[], ids: string[]): string[] =>
   rows.map((r) => r.id).filter((id) => ids.includes(id))
 
 describe('DrizzleRefundReconcilerRepository.listRefundDueNeedingDrive (#851 Slice 4, real pg)', () => {
-  it('LEFT JOIN keeps no-receipt + PENDING REFUND_DUE rows; excludes terminal receipts and non-REFUND_DUE', async () => {
+  it('LEFT JOIN keeps no-receipt + PENDING + SUCCEEDED-orphan REFUND_DUE rows; excludes terminal-FAILED and non-REFUND_DUE', async () => {
     const noReceipt = await seedConfirmed()
     const pending = await seedConfirmed()
     const succeeded = await seedConfirmed()
@@ -192,6 +192,9 @@ describe('DrizzleRefundReconcilerRepository.listRefundDueNeedingDrive (#851 Slic
 
     await setSettlement(noReceipt, 'REFUND_DUE', D2000(3))
     await setSettlement(pending, 'REFUND_DUE', D2000(2))
+    // REFUND_DUE + a SUCCEEDED receipt is the crash-between-confirm-writes orphan: a
+    // healthy refund leaves the booking REFUNDED, so this state is ONLY the orphan and
+    // the scan MUST surface it for the booking-side finish (it is NOT excluded).
     await setSettlement(succeeded, 'REFUND_DUE', D2000(4))
     await setSettlement(failed, 'REFUND_DUE', D2000(1))
     await setSettlement(advisory, 'ADVISORY', D2000(5))
@@ -202,8 +205,9 @@ describe('DrizzleRefundReconcilerRepository.listRefundDueNeedingDrive (#851 Slic
 
     const rows = await reconcilerRepo.listRefundDueNeedingDrive({ limit: 1000 })
 
-    // Exactly the two retryable rows, oldest cancellation first (pending D2 < noReceipt D3).
-    expect(ours(rows, seeded)).toEqual([pending, noReceipt])
+    // The three non-FAILED REFUND_DUE rows, oldest cancellation first (D2 < D3 < D4);
+    // FAILED (needs a human) and the non-REFUND_DUE rows are excluded.
+    expect(ours(rows, seeded)).toEqual([pending, noReceipt, succeeded])
   })
 
   it('excludes terminal-FAILED BEFORE the limit so it cannot starve retryable work', async () => {
@@ -251,6 +255,59 @@ class WebhookLostGateway implements PaymentGateway {
     ]
   }
 }
+
+// A gateway that throws on EVERY call: the SUCCEEDED-receipt orphan must finish with
+// zero Stripe traffic — initiateCancellationRefund short-circuits on the SUCCEEDED
+// receipt BEFORE resolveRefund, so any gateway touch here is a regression.
+class NoStripeGateway implements PaymentGateway {
+  async createCheckoutSession(): Promise<never> {
+    throw new Error('no Stripe expected for a SUCCEEDED-receipt orphan')
+  }
+  async parseWebhookEvent(): Promise<never> {
+    throw new Error('no Stripe expected for a SUCCEEDED-receipt orphan')
+  }
+  async refundPayment(): Promise<never> {
+    throw new Error('no Stripe expected for a SUCCEEDED-receipt orphan')
+  }
+  async retrieveRefund(): Promise<never> {
+    throw new Error('no Stripe expected for a SUCCEEDED-receipt orphan')
+  }
+  async listRefundsByPaymentIntent(): Promise<never> {
+    throw new Error('no Stripe expected for a SUCCEEDED-receipt orphan')
+  }
+}
+
+describe('CancellationRefundReconciler orphan self-heal (#851 Slice 4, real pg)', () => {
+  it('REFUND_DUE booking with an already-SUCCEEDED receipt → sweep finishes it REFUNDED with zero Stripe calls', async () => {
+    const service = new PaymentService(
+      eventRepo,
+      refundRepo,
+      bookingRepo,
+      new NoStripeGateway(),
+      new DrizzlePaymentAnomalyRepository(db),
+      { webBaseUrl: 'https://app.example.com' },
+    )
+    const reconciler = new CancellationRefundReconciler({
+      scanRepo: reconcilerRepo,
+      driver: service,
+      refundRepo,
+    })
+
+    // The orphan: receipt SUCCEEDED (refund already moved at Stripe) but the booking's
+    // REFUND_DUE→REFUNDED write never landed. Paid, so initiate's PAID gate passes.
+    const orphan = await seedConfirmed()
+    await setSettlement(orphan, 'REFUND_DUE', D2000(2))
+    await markPaid(orphan)
+    await claimReceipt(orphan, 'SUCCEEDED')
+
+    await reconciler.run({ limit: 1000 })
+
+    expect((await bookingRepo.findById(SYSTEM_CONTEXT, orphan))?.cancellationFeeSettlement).toBe(
+      'REFUNDED',
+    )
+    expect((await refundRepo.findByBookingId(orphan))?.status).toBe('SUCCEEDED')
+  })
+})
 
 describe('CancellationRefundReconciler end-to-end self-heal (#851 Slice 4, real pg)', () => {
   it('a refund succeeded at Stripe with no webhook → sweep adopts, confirms REFUNDED via runTx, never re-issues', async () => {


### PR DESCRIPTION
## What

A maintainability-review of the refund/cancellation cluster (#851/#1056/#1061/#1068) surfaced a durability gap in the reconciler backstop.

`PaymentService.confirmRefundSucceeded` does **two non-atomic writes** — `paymentRefunds.markStatus(SUCCEEDED)` then the booking-side `REFUND_DUE → REFUNDED` transition. A crash or transient neon-http error on the **second** write (it propagates up to `fireEagerRefund`'s `catch` and is swallowed) leaves:
- receipt = `SUCCEEDED` (money refunded correctly ✅)
- booking = stuck at `REFUND_DUE` (projection permanently wrong ❌)

The reconciler — the stated backstop ("a webhook that never arrived self-heals here") — **couldn't heal it**. Both scans (`drizzle/refund-reconciler.ts`, `in-memory/refund-reconciler.ts`) filtered `receipt IS NULL OR status='PENDING'`, so a `SUCCEEDED` receipt was excluded. Only a later Stripe `refund.updated` webhook would fix it — exactly the dependency the reconciler exists to remove.

## Fix

A *healthy* refund leaves the booking `REFUNDED` (already filtered out by the settlement condition), so **`REFUND_DUE` + `SUCCEEDED` receipt is *only* this orphan**. Widen the scan filter to "non-FAILED" (`receipt IS NULL OR status != 'FAILED'`). Driving such a row is a **no-Stripe booking-side confirm** — `initiateCancellationRefund`'s `SUCCEEDED` branch just runs `confirmBookingRefunded`. `FAILED` stays excluded (needs a human).

3-line core change (filter + import) mirrored across both repos.

## Tests
- **Unit (in-memory):** new orphan case asserts a `REFUND_DUE` + `SUCCEEDED`-receipt booking is now returned; split the old terminal-exclusion test into the orphan (returned) + `FAILED`-only (excluded).
- **Real-pg integration:** updated the Drizzle scan-filter assertion to include the orphan, oldest-first; **added an end-to-end test** proving the orphan heals to `REFUNDED` via `reconciler.run()` with **zero Stripe calls** (gateway throws on every method).

Verified locally against postgres:16: api unit **1906/1906**, reconciler integration **4/4**, payment/refund/cancel integration **10/10**. Biome + boundaries + tsc clean.

Refs #851.