### PR TITLE
test(#1106): cross-impl booking-repo conformance suite (+ IDEMPOTENCY_CONSTRAINT drift fix)

### DIFF
--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -50,7 +50,13 @@ export const LOCATIONS_REGION_FK = 'locations_regionId_regions_id_fk'
  * Matching by name (not just the 23505 code) keeps the two paths apart.
  */
 export const BOOKING_CODE_CONSTRAINT = 'bookings_bookingCode_unique'
-export const IDEMPOTENCY_CONSTRAINT = 'bookings_idempotencyKey_unique'
+// Real PG index name from migration 0012_idempotency-unique-index.sql
+// (`CREATE UNIQUE INDEX "bookings_idempotency_key"`) — NOT the Drizzle-auto
+// camelCase suffix the schema's `.unique()` would have produced. Surfaced by
+// the #1106 conformance suite: the InMemory uniqueViolation interpolates this
+// constant, so it must match the real PG index name byte-for-byte or services
+// that disambiguate by constraint name drift between impls.
+export const IDEMPOTENCY_CONSTRAINT = 'bookings_idempotency_key'
 
 /**
  * payment_events unique constraints the PaymentService distinguishes on (#461).

--- a/packages/api/src/repositories/booking-overlap-conformance.ts
+++ b/packages/api/src/repositories/booking-overlap-conformance.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../middleware/auth'
+import {
+  BOOKING_CODE_CONSTRAINT,
+  IDEMPOTENCY_CONSTRAINT,
+  PG_ERROR,
+  pgConstraintName,
+  pgErrorCode,
+} from '../pg-errors'
+import type { Booking } from '../stores'
+import type { BookingRepository } from './types'
+
+// #1106: cross-impl behavioural conformance for the seals that BookingService
+// branches on by Postgres error code + constraint name. The existing
+// composition/repositories.test.ts only pins the *key set* of the repo bundles;
+// it never asserts the two impls *behave* identically on a clash. This file is
+// the shared body — InMemory and Drizzle callers each wire their own setup +
+// cleanup and run the same scenarios. The float scenario is the H1 regression
+// guard: with the bug reintroduced, the InMemory arm fails on the first `it`
+// while the Drizzle arm passes — proving the suite catches the divergence.
+
+export type ConformanceIds = {
+  operatorId: string
+  classId: string
+  locationId: string
+  // A SPECIFIC vehicle to key the non-null exclusion on. Both inserts in the
+  // non-null overlap scenario share this id so Postgres's gist `&&` overlap
+  // fires (and the InMemory mirror takes the same branch).
+  vehicleId: string
+  renterId: string
+}
+
+export type ConformanceContext = {
+  repo: BookingRepository
+  ids: ConformanceIds
+  cleanup: () => Promise<void>
+}
+
+export type ConformanceOptions = {
+  adapterName: string
+  setup: () => Promise<ConformanceContext>
+}
+
+// Far-future window that can never collide with any seeded demo bookings.
+const WINDOW_START = new Date('2027-10-01T09:00:00Z')
+const WINDOW_END = new Date('2027-10-01T17:00:00Z')
+
+type CreateInput = Omit<Booking, 'id' | 'createdAt' | 'updatedAt' | 'cancellationFeeSettlement'>
+
+function baseInput(ids: ConformanceIds, overrides: Partial<CreateInput>): CreateInput {
+  return {
+    operatorId: ids.operatorId,
+    renterId: ids.renterId,
+    classId: ids.classId,
+    // The default below is SPECIFIC, which the DB seals with the
+    // `bookings_specific_requires_requested` CHECK — both ids must be set.
+    // The CLASS_COMBO scenarios override `fulfillmentMode` + both vehicle ids
+    // to null in their `baseInput(..., { ... })` calls.
+    requestedVehicleId: ids.vehicleId,
+    assignedVehicleId: ids.vehicleId,
+    pickupLocationId: ids.locationId,
+    dropoffLocationId: ids.locationId,
+    startAt: WINDOW_START,
+    endAt: WINDOW_END,
+    effectiveEndAt: WINDOW_END,
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: 'CFM-BASE',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 30_000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+    ...overrides,
+  }
+}
+
+export function describeBookingOverlapConformance(opts: ConformanceOptions): void {
+  describe(`BookingRepository conformance — ${opts.adapterName}`, () => {
+    let ctx: ConformanceContext
+
+    beforeEach(async () => {
+      ctx = await opts.setup()
+    })
+
+    afterEach(async () => {
+      await ctx.cleanup()
+    })
+
+    // #1105: the H1 regression. Postgres's `EXCLUDE USING gist
+    // ("assignedVehicleId" WITH =, tstzrange &&)` never conflicts on a NULL
+    // key — two overlapping CLASS_COMBO floats both insert. The InMemory mirror
+    // used `!== continue` which inverts NULL-exclusion (null !== null is false →
+    // falls through, then overlaps → spurious EXCLUSION_VIOLATION).
+    it('two overlapping CLASS_COMBO floats (assignedVehicleId=null) both insert', async () => {
+      await ctx.repo.create(
+        SYSTEM_CONTEXT,
+        baseInput(ctx.ids, {
+          bookingCode: 'CFM-FLOAT-1',
+          assignedVehicleId: null,
+          requestedVehicleId: null,
+          fulfillmentMode: 'CLASS_COMBO',
+        }),
+      )
+      await ctx.repo.create(
+        SYSTEM_CONTEXT,
+        baseInput(ctx.ids, {
+          bookingCode: 'CFM-FLOAT-2',
+          assignedVehicleId: null,
+          requestedVehicleId: null,
+          fulfillmentMode: 'CLASS_COMBO',
+        }),
+      )
+    })
+
+    // Preserves the real double-booking guard: two SPECIFIC bookings on the
+    // same vehicle with overlapping ranges must still raise EXCLUSION_VIOLATION
+    // (constraint name `bookings_no_overlap`).
+    it('two overlapping SPECIFIC bookings on the same vehicle raise EXCLUSION_VIOLATION', async () => {
+      await ctx.repo.create(SYSTEM_CONTEXT, baseInput(ctx.ids, { bookingCode: 'CFM-SPEC-1' }))
+
+      let caught: unknown
+      try {
+        await ctx.repo.create(SYSTEM_CONTEXT, baseInput(ctx.ids, { bookingCode: 'CFM-SPEC-2' }))
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeDefined()
+      expect(pgErrorCode(caught)).toBe(PG_ERROR.EXCLUSION_VIOLATION)
+      expect(pgConstraintName(caught)).toBe('bookings_no_overlap')
+    })
+
+    it('duplicate bookingCode raises UNIQUE_VIOLATION with BOOKING_CODE_CONSTRAINT name', async () => {
+      await ctx.repo.create(SYSTEM_CONTEXT, baseInput(ctx.ids, { bookingCode: 'CFM-DUP-CODE' }))
+
+      let caught: unknown
+      try {
+        await ctx.repo.create(
+          SYSTEM_CONTEXT,
+          baseInput(ctx.ids, {
+            bookingCode: 'CFM-DUP-CODE',
+            // Distinct window so the exclusion seal cannot win the race for
+            // the error name — we want the bookingCode unique to fire.
+            startAt: new Date('2027-11-01T09:00:00Z'),
+            endAt: new Date('2027-11-01T17:00:00Z'),
+            effectiveEndAt: new Date('2027-11-01T17:00:00Z'),
+          }),
+        )
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeDefined()
+      expect(pgErrorCode(caught)).toBe(PG_ERROR.UNIQUE_VIOLATION)
+      expect(pgConstraintName(caught)).toBe(BOOKING_CODE_CONSTRAINT)
+    })
+
+    it('duplicate idempotencyKey raises UNIQUE_VIOLATION with IDEMPOTENCY_CONSTRAINT name', async () => {
+      await ctx.repo.create(
+        SYSTEM_CONTEXT,
+        baseInput(ctx.ids, {
+          bookingCode: 'CFM-IDK-1',
+          idempotencyKey: 'idk-conformance',
+        }),
+      )
+
+      let caught: unknown
+      try {
+        await ctx.repo.create(
+          SYSTEM_CONTEXT,
+          baseInput(ctx.ids, {
+            bookingCode: 'CFM-IDK-2',
+            idempotencyKey: 'idk-conformance',
+            startAt: new Date('2027-12-01T09:00:00Z'),
+            endAt: new Date('2027-12-01T17:00:00Z'),
+            effectiveEndAt: new Date('2027-12-01T17:00:00Z'),
+          }),
+        )
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeDefined()
+      expect(pgErrorCode(caught)).toBe(PG_ERROR.UNIQUE_VIOLATION)
+      expect(pgConstraintName(caught)).toBe(IDEMPOTENCY_CONSTRAINT)
+    })
+  })
+}

--- a/packages/api/src/repositories/in-memory/booking-overlap.conformance.test.ts
+++ b/packages/api/src/repositories/in-memory/booking-overlap.conformance.test.ts
@@ -1,0 +1,23 @@
+import { describeBookingOverlapConformance } from '../booking-overlap-conformance'
+import { InMemoryBookingRepository } from './booking'
+
+// InMemory arm of the cross-impl conformance suite (#1106). Stub IDs are fine
+// because the InMemory repo never validates FK references — only the Drizzle
+// arm (tests/integration/booking-overlap.conformance.test.ts) seeds the real
+// operator/class/location/vehicle rows the FK seal requires.
+describeBookingOverlapConformance({
+  adapterName: 'InMemory',
+  setup: async () => ({
+    repo: new InMemoryBookingRepository(),
+    ids: {
+      operatorId: 'op-conformance',
+      classId: 'class-conformance',
+      locationId: 'loc-conformance',
+      vehicleId: 'veh-conformance',
+      renterId: 'renter-conformance',
+    },
+    cleanup: async () => {
+      // Each test gets a fresh repo above; no shared state to tear down.
+    },
+  }),
+})

--- a/packages/api/src/repositories/in-memory/booking.test.ts
+++ b/packages/api/src/repositories/in-memory/booking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../middleware/auth'
+import { PG_ERROR, pgConstraintName, pgErrorCode } from '../../pg-errors'
 import type { Booking } from '../../stores'
 import { InMemoryBookingRepository } from './booking'
 
@@ -97,12 +98,22 @@ describe('InMemoryBookingRepository — CLASS_COMBO float exclusion parity (#111
   })
 
   // The fix must stay surgical: a real assigned vehicle still excludes on overlap.
+  // Assert by (code, constraint_name) rather than message — matches the
+  // conformance-suite contract (#1106) and stays mutation-resistant if the
+  // postgres-js message format evolves.
   it('still rejects two overlapping bookings on the SAME assigned vehicle', async () => {
     const repo = new InMemoryBookingRepository()
     await repo.create(SYSTEM_CONTEXT, confirmedInput({ ...window, bookingCode: 'BK-SPEC-1' }))
 
-    await expect(
-      repo.create(SYSTEM_CONTEXT, confirmedInput({ ...window, bookingCode: 'BK-SPEC-2' })),
-    ).rejects.toThrow('bookings_no_overlap violation')
+    let caught: unknown
+    try {
+      await repo.create(SYSTEM_CONTEXT, confirmedInput({ ...window, bookingCode: 'BK-SPEC-2' }))
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeDefined()
+    expect(pgErrorCode(caught)).toBe(PG_ERROR.EXCLUSION_VIOLATION)
+    expect(pgConstraintName(caught)).toBe('bookings_no_overlap')
   })
 })

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -19,6 +19,23 @@ function uniqueViolation(
   })
 }
 
+// Same faithful-mirroring policy as uniqueViolation: postgres-js exposes the
+// violated EXCLUDE constraint as `constraint_name`, so a service that disambiguates
+// 23P01 by name behaves identically against either repo (#1106).
+const BOOKINGS_NO_OVERLAP_CONSTRAINT = 'bookings_no_overlap'
+
+function exclusionViolation(): Error & { code: string; constraint_name: string } {
+  return Object.assign(
+    new Error(
+      `conflicting key value violates exclusion constraint "${BOOKINGS_NO_OVERLAP_CONSTRAINT}"`,
+    ),
+    {
+      code: PG_ERROR.EXCLUSION_VIOLATION,
+      constraint_name: BOOKINGS_NO_OVERLAP_CONSTRAINT,
+    },
+  )
+}
+
 export function getConflictingBookings(
   bookings: Booking[],
   vehicleId: string,
@@ -172,7 +189,7 @@ export class InMemoryBookingRepository implements BookingRepository {
     // never conflicts NULL keys, so a CLASS_COMBO float (null vehicle, #464)
     // occupies no specific car and is invisible to the exclusion. Guard on a
     // non-null vehicle first — `null !== null` is false, so without this an
-    // overlapping pair of floats would falsely clash (audit H1 / #1117).
+    // overlapping pair of floats would falsely clash (#1105 / #1117).
     if (data.assignedVehicleId !== null && BLOCKING_STATUSES.has(data.status)) {
       for (const existing of this.store.values()) {
         if (existing.assignedVehicleId !== data.assignedVehicleId) continue
@@ -180,9 +197,7 @@ export class InMemoryBookingRepository implements BookingRepository {
         const overlaps =
           data.startAt < existing.effectiveEndAt && existing.startAt < data.effectiveEndAt
         if (overlaps) {
-          throw Object.assign(new Error('bookings_no_overlap violation'), {
-            code: PG_ERROR.EXCLUSION_VIOLATION,
-          })
+          throw exclusionViolation()
         }
       }
     }
@@ -291,9 +306,7 @@ export class InMemoryBookingRepository implements BookingRepository {
         const overlaps =
           existing.startAt < other.effectiveEndAt && other.startAt < data.effectiveEndAt
         if (overlaps) {
-          throw Object.assign(new Error('bookings_no_overlap violation'), {
-            code: PG_ERROR.EXCLUSION_VIOLATION,
-          })
+          throw exclusionViolation()
         }
       }
     }

--- a/packages/api/tests/integration/booking-overlap.conformance.test.ts
+++ b/packages/api/tests/integration/booking-overlap.conformance.test.ts
@@ -1,0 +1,73 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { bookings } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll } from 'vitest'
+import { describeBookingOverlapConformance } from '../../src/repositories/booking-overlap-conformance'
+import { DrizzleBookingRepository } from '../../src/repositories/drizzle'
+import { seedRenter, seedVehicle } from './booking-factory'
+import {
+  cleanupLocations,
+  cleanupUsers,
+  cleanupVehicleClasses,
+  cleanupVehicles,
+  db,
+  seedLocation,
+  seedVehicleClass,
+} from './setup'
+
+// Drizzle arm of the cross-impl conformance suite (#1106). Seeds the FK chain
+// once (operator is pre-seeded by global-setup; class + location + vehicle +
+// renter here), and clears every test's bookings via the renter id between
+// scenarios so each `it` starts from the same baseline against real Postgres.
+// The InMemory arm lives at src/repositories/in-memory/booking-overlap.conformance.test.ts
+// and runs in the unit lane — both bodies come from the same describe-emitter.
+
+const repo = new DrizzleBookingRepository(db)
+
+let classId: string
+let locationId: string
+let vehicleId: string
+let renterId: string
+
+beforeAll(async () => {
+  const klass = await seedVehicleClass('conformance')
+  classId = klass.id
+  const location = await seedLocation('conformance')
+  locationId = location.id
+  vehicleId = await seedVehicle({
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    classId,
+    pickupLocationId: locationId,
+    name: 'Conformance Vehicle',
+    dailyRateJpy: 5000,
+  })
+  renterId = await seedRenter('conformance')
+})
+
+afterAll(async () => {
+  await cleanupVehicles([vehicleId])
+  await cleanupVehicleClasses([classId])
+  await cleanupLocations([locationId])
+  await cleanupUsers([renterId])
+})
+
+describeBookingOverlapConformance({
+  adapterName: 'Drizzle (real pg)',
+  setup: async () => ({
+    repo,
+    ids: {
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+      classId,
+      locationId,
+      vehicleId,
+      renterId,
+    },
+    cleanup: async () => {
+      // Each `it` may leave 1-2 booking rows the next test would collide with
+      // on bookingCode or idempotencyKey. Delete by renter so the next scenario
+      // starts from an empty fixture-bookings baseline. The renter row itself
+      // is torn down in afterAll.
+      await db.delete(bookings).where(eq(bookings.renterId, renterId))
+    },
+  }),
+})


### PR DESCRIPTION
## Summary
- **#1106 (P1 test infra)** — adds a cross-impl behavioural conformance suite for `BookingRepository`. The existing `composition/repositories.test.ts` only pins the *key set* of the repo bundles; it never asserts the two impls *behave* identically on a clash. The new shared describe body runs against both InMemory (unit lane) and Drizzle (integration lane) and asserts every clash by specific `(code, constraint_name)` — exactly the shape `BookingService` branches on.
- **Drift fix** the suite caught on its first run: `IDEMPOTENCY_CONSTRAINT = 'bookings_idempotencyKey_unique'` (Drizzle-auto naming convention) does NOT match the migration's hand-rolled `'bookings_idempotency_key'`. The InMemory `uniqueViolation` interpolates this constant, so the two impls drifted on the idempotency-replay branch's discriminator.
- **InMemory `exclusionViolation()` mirror** — extracted next to `uniqueViolation()`; the throw now carries `constraint_name: 'bookings_no_overlap'` so 23P01 surfaces identically on either repo. Same faithful-mirroring policy that `uniqueViolation` already follows.

**Note:** #1105 (the H1 NULL-exclusion bug) was independently fixed by #1122 while this branch was in flight. This PR rebased onto #1122; the InMemory short-circuit lives there. What lands here is the conformance suite (which would have caught H1 too, by design) plus the secondary drift fix.

## What landed
1. `packages/api/src/repositories/booking-overlap-conformance.ts` — shared describe body covering 4 scenarios:
   - two overlapping CLASS_COMBO floats both insert (H1 regression guard)
   - two overlapping SPECIFIC bookings on the same vehicle raise `23P01 / bookings_no_overlap`
   - duplicate `bookingCode` raises `23505 / bookings_bookingCode_unique`
   - duplicate `idempotencyKey` raises `23505 / bookings_idempotency_key`
2. `packages/api/src/repositories/in-memory/booking-overlap.conformance.test.ts` — InMemory caller (unit lane, fresh repo per test).
3. `packages/api/tests/integration/booking-overlap.conformance.test.ts` — Drizzle caller (real-pg lane, FK chain seeded once, bookings cleared between tests).
4. `packages/api/src/pg-errors.ts` — `IDEMPOTENCY_CONSTRAINT` updated to `'bookings_idempotency_key'` (matches migration 0012 byte-for-byte).
5. `packages/api/src/repositories/in-memory/booking.ts` — `exclusionViolation()` helper next to `uniqueViolation()`; both create/reassignVehicle paths now throw with `constraint_name`.
6. `packages/api/src/repositories/in-memory/booking.test.ts` — #1117's overlap-still-rejects assertion now uses `pgErrorCode` + `pgConstraintName` instead of a message substring (more mutation-resistant, matches the conformance contract; needed because the new error message is the postgres-js format).

## Why the IDEMPOTENCY_CONSTRAINT fix is independently worth shipping
`booking-creation.ts:156` today only branches on `code === UNIQUE_VIOLATION && input.idempotencyKey` — so the drift is currently latent. But anyone adding `pgConstraintName(err) === IDEMPOTENCY_CONSTRAINT` tomorrow would have shipped a silent prod-only failure (matches against InMemory, never matches against real PG). Constant + InMemory throw now agree with the migration.

## Test plan
- [x] InMemory conformance — 4/4 (RED before H1 fix, GREEN after; this branch builds on #1122's H1 fix so all 4 pass on the merge base)
- [x] Drizzle conformance — 4/4 against `postgres:16` (`bun run --filter @kuruma/api test:integration tests/integration/booking-overlap.conformance.test.ts`)
- [x] Full api unit suite — 169 files, **1912/1912** pass
- [x] Full integration suite — 48 files, **330/330** pass
- [x] `tsc --noEmit` — 0 errors
- [x] `bun run lint` — clean (only pre-existing warnings)
- [x] `bun run lint:boundaries` (api) — OK
- [x] `bun run db:verify` — 5/5 green

## Pattern
**Backing Service Coupling (leaky infra abstraction)** — if services distinguish errors by constraint name, you owe a behavioural conformance suite. A key-set test proves wiring, not equivalence. This suite is the harness that prevents the next H1.

Closes #1106
Refs #1104, #1105, #1122