### PR TITLE
refactor(#1107): push cross-operator read-scope below the route + dedupe scoped-create (audit M3+L4)

### DIFF
--- a/packages/api/src/repositories/drizzle/add-on.ts
+++ b/packages/api/src/repositories/drizzle/add-on.ts
@@ -23,6 +23,11 @@ export class DrizzleAddOnRepository implements AddOnRepository {
       conditions.push(eq(addOnOptions.operatorId, scope.operatorId))
     } else if (filters?.operatorId) {
       conditions.push(eq(addOnOptions.operatorId, filters.operatorId))
+    } else if (!filters?.includeAllOperators) {
+      // scope is 'all' (bypass role) without an explicit platform-wide opt-in:
+      // read nothing. The safe default lives here, so a forgotten route guard
+      // cannot enumerate every tenant's private config (#1107).
+      conditions.push(sql`false`)
     }
 
     if (filters?.status) {

--- a/packages/api/src/repositories/drizzle/fee-schedule.ts
+++ b/packages/api/src/repositories/drizzle/fee-schedule.ts
@@ -21,6 +21,11 @@ export class DrizzleFeeScheduleRepository implements FeeScheduleRepository {
       conditions.push(eq(feeSchedules.operatorId, scope.operatorId))
     } else if (filters?.operatorId) {
       conditions.push(eq(feeSchedules.operatorId, filters.operatorId))
+    } else if (!filters?.includeAllOperators) {
+      // scope is 'all' (bypass role) without an explicit platform-wide opt-in:
+      // read nothing. The safe default lives here, so a forgotten route guard
+      // cannot enumerate every tenant's private config (#1107).
+      conditions.push(sql`false`)
     }
 
     if (filters?.status) {

--- a/packages/api/src/repositories/drizzle/insurance-option.ts
+++ b/packages/api/src/repositories/drizzle/insurance-option.ts
@@ -26,6 +26,11 @@ export class DrizzleInsuranceOptionRepository implements InsuranceOptionReposito
       conditions.push(eq(insuranceOptions.operatorId, scope.operatorId))
     } else if (filters?.operatorId) {
       conditions.push(eq(insuranceOptions.operatorId, filters.operatorId))
+    } else if (!filters?.includeAllOperators) {
+      // scope is 'all' (bypass role) without an explicit platform-wide opt-in:
+      // read nothing. The safe default lives here, so a forgotten route guard
+      // cannot enumerate every tenant's private config (#1107).
+      conditions.push(sql`false`)
     }
 
     if (filters?.status) {

--- a/packages/api/src/repositories/drizzle/location.ts
+++ b/packages/api/src/repositories/drizzle/location.ts
@@ -21,6 +21,11 @@ export class DrizzleLocationRepository implements LocationRepository {
       conditions.push(eq(locations.operatorId, scope.operatorId))
     } else if (filters?.operatorId) {
       conditions.push(eq(locations.operatorId, filters.operatorId))
+    } else if (!filters?.includeAllOperators) {
+      // scope is 'all' (bypass role) without an explicit platform-wide opt-in:
+      // read nothing. The safe default lives here, so a forgotten route guard
+      // cannot enumerate every tenant's private config (#1107).
+      conditions.push(sql`false`)
     }
 
     if (filters?.status) {

--- a/packages/api/src/repositories/drizzle/notification-log.ts
+++ b/packages/api/src/repositories/drizzle/notification-log.ts
@@ -150,6 +150,12 @@ export class DrizzleNotificationLogRepository implements NotificationLogReposito
     const conditions: SQL[] = []
     if (scope.kind === 'operator') conditions.push(eq(notificationLog.operatorId, scope.operatorId))
     else if (filters?.operatorId) conditions.push(eq(notificationLog.operatorId, filters.operatorId))
+    else if (!filters?.includeAllOperators) {
+      // scope is 'all' (bypass role) without an explicit platform-wide opt-in:
+      // read nothing. The safe default lives here, so a forgotten route guard
+      // cannot enumerate every tenant's private ledger (#1107).
+      conditions.push(sql`false`)
+    }
     if (filters?.bookingId) conditions.push(eq(notificationLog.bookingId, filters.bookingId))
 
     const rows = await this.db

--- a/packages/api/src/repositories/in-memory/add-on.read-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/add-on.read-scope.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import type { AddOn } from '../../stores'
+import { InMemoryAddOnRepository } from './add-on'
+
+// #1107 (audit M3): the cross-operator read-scope default must live BELOW the
+// route. A bypass caller (PLATFORM_ADMIN) that reaches the repo with no explicit
+// scope — the exact state a forgotten route guard produces — must read nothing,
+// not enumerate every tenant's private config.
+
+const addOn = (id: string, operatorId: string): AddOn => ({
+  id,
+  operatorId,
+  name: `${id}-name`,
+  description: null,
+  priceJpy: 1000,
+  status: 'ACTIVE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+})
+
+const SEED: AddOn[] = [addOn('op1-a', 'op1'), addOn('op2-a', 'op2')]
+
+const seededRepo = () => new InMemoryAddOnRepository(new Map(SEED.map((o) => [o.id, o])))
+
+const PLATFORM_ADMIN: CallerContext = {
+  userId: 'admin',
+  role: 'PLATFORM_ADMIN',
+  bypassScope: true,
+}
+const OPERATOR_1: CallerContext = {
+  userId: 'o1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op1',
+}
+
+describe('InMemoryAddOnRepository read-scope (#1107)', () => {
+  it('bypass caller with no explicit scope reads nothing (defence-in-depth backstop)', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, {})
+    expect(rows).toEqual([])
+  })
+
+  it('bypass caller with includeAllOperators reads every tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { includeAllOperators: true })
+    expect(new Set(rows.map((o) => o.id))).toEqual(new Set(['op1-a', 'op2-a']))
+  })
+
+  it('bypass caller with operatorId narrows to that one tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { operatorId: 'op2' })
+    expect(rows.map((o) => o.id)).toEqual(['op2-a'])
+  })
+
+  it('operator caller auto-scopes to its own tenant, ignoring includeAllOperators', async () => {
+    const rows = await seededRepo().findAll(OPERATOR_1, { includeAllOperators: true })
+    expect(rows.map((o) => o.id)).toEqual(['op1-a'])
+  })
+})

--- a/packages/api/src/repositories/in-memory/add-on.ts
+++ b/packages/api/src/repositories/in-memory/add-on.ts
@@ -42,7 +42,10 @@ export class InMemoryAddOnRepository implements AddOnRepository {
       // it. The explicit filter only narrows a bypass-role ('all') read.
       if (scope.kind === 'operator') return o.operatorId === scope.operatorId
       if (filters?.operatorId) return o.operatorId === filters.operatorId
-      return true
+      // scope is 'all' (bypass role): read across tenants ONLY when the route
+      // explicitly opted in. Absent that, read nothing — the safe default lives
+      // here, so a forgotten route guard cannot enumerate every tenant (#1107).
+      return filters?.includeAllOperators === true
     })
 
     if (filters?.status) return all.filter((o) => o.status === filters.status)

--- a/packages/api/src/repositories/in-memory/fee-schedule.read-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/fee-schedule.read-scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import type { FeeSchedule } from '../../stores'
+import { InMemoryFeeScheduleRepository } from './fee-schedule'
+
+// #1107 (audit M3): the cross-operator read-scope default must live BELOW the
+// route. A bypass caller (PLATFORM_ADMIN) that reaches the repo with no explicit
+// scope — the exact state a forgotten route guard produces — must read nothing,
+// not enumerate every tenant's private fee config.
+
+const fee = (id: string, operatorId: string): FeeSchedule => ({
+  id,
+  operatorId,
+  vehicleClassId: null,
+  feeType: 'CLEANING_FLAT',
+  unit: 'FLAT',
+  amountJpy: 3000,
+  status: 'ACTIVE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+})
+
+const SEED: FeeSchedule[] = [fee('op1-a', 'op1'), fee('op2-a', 'op2')]
+
+const seededRepo = () => new InMemoryFeeScheduleRepository(new Map(SEED.map((f) => [f.id, f])))
+
+const PLATFORM_ADMIN: CallerContext = {
+  userId: 'admin',
+  role: 'PLATFORM_ADMIN',
+  bypassScope: true,
+}
+const OPERATOR_1: CallerContext = {
+  userId: 'owner1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op1',
+}
+
+describe('InMemoryFeeScheduleRepository read-scope (#1107)', () => {
+  it('bypass caller with no explicit scope reads nothing (defence-in-depth backstop)', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, {})
+    expect(rows).toEqual([])
+  })
+
+  it('bypass caller with includeAllOperators reads every tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { includeAllOperators: true })
+    expect(new Set(rows.map((f) => f.id))).toEqual(new Set(['op1-a', 'op2-a']))
+  })
+
+  it('bypass caller with operatorId narrows to that one tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { operatorId: 'op2' })
+    expect(rows.map((f) => f.id)).toEqual(['op2-a'])
+  })
+
+  it('operator caller auto-scopes to its own tenant, ignoring includeAllOperators', async () => {
+    const rows = await seededRepo().findAll(OPERATOR_1, { includeAllOperators: true })
+    expect(rows.map((f) => f.id)).toEqual(['op1-a'])
+  })
+})

--- a/packages/api/src/repositories/in-memory/fee-schedule.ts
+++ b/packages/api/src/repositories/in-memory/fee-schedule.ts
@@ -49,7 +49,10 @@ export class InMemoryFeeScheduleRepository implements FeeScheduleRepository {
       // it. The explicit filter only narrows bypass-role ('all') reads.
       if (scope.kind === 'operator') return f.operatorId === scope.operatorId
       if (filters?.operatorId) return f.operatorId === filters.operatorId
-      return true
+      // scope is 'all' (bypass role): read across tenants ONLY when the route
+      // explicitly opted in. Absent that, read nothing — the safe default lives
+      // here, so a forgotten route guard cannot enumerate every tenant (#1107).
+      return filters?.includeAllOperators === true
     })
 
     const byStatus = filters?.status

--- a/packages/api/src/repositories/in-memory/insurance-option.read-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/insurance-option.read-scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import type { InsuranceOption } from '../../stores'
+import { InMemoryInsuranceOptionRepository } from './insurance-option'
+
+// #1107 (audit M3): the cross-operator read-scope default must live BELOW the
+// route. A bypass caller (PLATFORM_ADMIN) that reaches the repo with no explicit
+// scope — the exact state a forgotten route guard produces — must read nothing,
+// not enumerate every tenant's private config.
+
+const option = (id: string, operatorId: string): InsuranceOption => ({
+  id,
+  operatorId,
+  name: `${id}-name`,
+  description: null,
+  dailyPriceJpy: 1000,
+  deductibleJpy: null,
+  status: 'ACTIVE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+})
+
+const SEED: InsuranceOption[] = [option('op1-a', 'op1'), option('op2-a', 'op2')]
+
+const seededRepo = () => new InMemoryInsuranceOptionRepository(new Map(SEED.map((o) => [o.id, o])))
+
+const PLATFORM_ADMIN: CallerContext = {
+  userId: 'admin',
+  role: 'PLATFORM_ADMIN',
+  bypassScope: true,
+}
+const OPERATOR_1: CallerContext = {
+  userId: 'owner1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op1',
+}
+
+describe('InMemoryInsuranceOptionRepository read-scope (#1107)', () => {
+  it('bypass caller with no explicit scope reads nothing (defence-in-depth backstop)', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, {})
+    expect(rows).toEqual([])
+  })
+
+  it('bypass caller with includeAllOperators reads every tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { includeAllOperators: true })
+    expect(new Set(rows.map((o) => o.id))).toEqual(new Set(['op1-a', 'op2-a']))
+  })
+
+  it('bypass caller with operatorId narrows to that one tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { operatorId: 'op2' })
+    expect(rows.map((o) => o.id)).toEqual(['op2-a'])
+  })
+
+  it('operator caller auto-scopes to its own tenant, ignoring includeAllOperators', async () => {
+    const rows = await seededRepo().findAll(OPERATOR_1, { includeAllOperators: true })
+    expect(rows.map((o) => o.id)).toEqual(['op1-a'])
+  })
+})

--- a/packages/api/src/repositories/in-memory/insurance-option.ts
+++ b/packages/api/src/repositories/in-memory/insurance-option.ts
@@ -42,7 +42,10 @@ export class InMemoryInsuranceOptionRepository implements InsuranceOptionReposit
       // it. The explicit filter only narrows a bypass-role ('all') read.
       if (scope.kind === 'operator') return o.operatorId === scope.operatorId
       if (filters?.operatorId) return o.operatorId === filters.operatorId
-      return true
+      // scope is 'all' (bypass role): read across tenants ONLY when the route
+      // explicitly opted in. Absent that, read nothing — the safe default lives
+      // here, so a forgotten route guard cannot enumerate every tenant (#1107).
+      return filters?.includeAllOperators === true
     })
 
     if (filters?.status) return all.filter((o) => o.status === filters.status)

--- a/packages/api/src/repositories/in-memory/location.read-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/location.read-scope.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import type { Location } from '../../stores'
+import { InMemoryLocationRepository } from './location'
+
+// #1107 (audit M3): the cross-operator read-scope default must live BELOW the
+// route. A bypass caller (PLATFORM_ADMIN) that reaches the repo with no explicit
+// scope — the exact state a forgotten route guard produces — must read nothing,
+// not enumerate every tenant's private config.
+
+const location = (id: string, operatorId: string): Location => ({
+  id,
+  operatorId,
+  name: `${id}-name`,
+  address: `${id}-address`,
+  latitude: null,
+  longitude: null,
+  coordinateSource: null,
+  operatingHours: { openTime: '09:00', closeTime: '18:00' },
+  timezone: 'Asia/Tokyo',
+  defaultTurnaroundMinutes: 60,
+  regionId: null,
+  status: 'ACTIVE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+})
+
+const SEED: Location[] = [location('op1-a', 'op1'), location('op2-a', 'op2')]
+
+const seededRepo = () => new InMemoryLocationRepository(new Map(SEED.map((l) => [l.id, l])))
+
+const PLATFORM_ADMIN: CallerContext = {
+  userId: 'admin',
+  role: 'PLATFORM_ADMIN',
+  bypassScope: true,
+}
+const OPERATOR_1: CallerContext = {
+  userId: 'o1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op1',
+}
+
+describe('InMemoryLocationRepository read-scope (#1107)', () => {
+  it('bypass caller with no explicit scope reads nothing (defence-in-depth backstop)', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, {})
+    expect(rows).toEqual([])
+  })
+
+  it('bypass caller with includeAllOperators reads every tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { includeAllOperators: true })
+    expect(new Set(rows.map((l) => l.id))).toEqual(new Set(['op1-a', 'op2-a']))
+  })
+
+  it('bypass caller with operatorId narrows to that one tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { operatorId: 'op2' })
+    expect(rows.map((l) => l.id)).toEqual(['op2-a'])
+  })
+
+  it('operator caller auto-scopes to its own tenant, ignoring includeAllOperators', async () => {
+    const rows = await seededRepo().findAll(OPERATOR_1, { includeAllOperators: true })
+    expect(rows.map((l) => l.id)).toEqual(['op1-a'])
+  })
+})

--- a/packages/api/src/repositories/in-memory/location.ts
+++ b/packages/api/src/repositories/in-memory/location.ts
@@ -41,7 +41,10 @@ export class InMemoryLocationRepository implements LocationRepository {
       // filter only narrows bypass-role ('all') reads to a single operator.
       if (scope.kind === 'operator') return l.operatorId === scope.operatorId
       if (filters?.operatorId) return l.operatorId === filters.operatorId
-      return true
+      // scope is 'all' (bypass role): read across tenants ONLY when the route
+      // explicitly opted in. Absent that, read nothing — the safe default lives
+      // here, so a forgotten route guard cannot enumerate every tenant (#1107).
+      return filters?.includeAllOperators === true
     })
 
     if (filters?.status) return all.filter((l) => l.status === filters.status)

--- a/packages/api/src/repositories/in-memory/notification-log.read-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/notification-log.read-scope.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import type { NotificationLog } from '../../stores'
+import { InMemoryNotificationLogRepository } from './notification-log'
+
+// #1107 (audit M3): the cross-operator read-scope default must live BELOW the
+// route. A bypass caller (PLATFORM_ADMIN) that reaches the repo with no explicit
+// scope — the exact state a forgotten route guard produces — must read nothing,
+// not enumerate every tenant's private notification ledger.
+
+const log = (id: string, operatorId: string): NotificationLog => ({
+  id,
+  bookingId: `${id}-booking`,
+  operatorId,
+  kind: 'OPERATOR_BOOKING_ALERT',
+  channel: 'EMAIL',
+  recipient: `${id}@example.com`,
+  locale: 'en',
+  status: 'SENT',
+  providerMessageId: null,
+  error: null,
+  attempts: 0,
+  idempotencyKey: `notify:${id}`,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+})
+
+const SEED: NotificationLog[] = [log('op1-a', 'op1'), log('op2-a', 'op2')]
+
+const seededRepo = () => new InMemoryNotificationLogRepository(new Map(SEED.map((r) => [r.id, r])))
+
+const PLATFORM_ADMIN: CallerContext = {
+  userId: 'admin',
+  role: 'PLATFORM_ADMIN',
+  bypassScope: true,
+}
+const OPERATOR_1: CallerContext = {
+  userId: 'o1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op1',
+}
+
+describe('InMemoryNotificationLogRepository read-scope (#1107)', () => {
+  it('bypass caller with no explicit scope reads nothing (defence-in-depth backstop)', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, {})
+    expect(rows).toEqual([])
+  })
+
+  it('bypass caller with includeAllOperators reads every tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { includeAllOperators: true })
+    expect(new Set(rows.map((r) => r.id))).toEqual(new Set(['op1-a', 'op2-a']))
+  })
+
+  it('bypass caller with operatorId narrows to that one tenant', async () => {
+    const rows = await seededRepo().findAll(PLATFORM_ADMIN, { operatorId: 'op2' })
+    expect(rows.map((r) => r.id)).toEqual(['op2-a'])
+  })
+
+  it('operator caller auto-scopes to its own tenant, ignoring includeAllOperators', async () => {
+    const rows = await seededRepo().findAll(OPERATOR_1, { includeAllOperators: true })
+    expect(rows.map((r) => r.id)).toEqual(['op1-a'])
+  })
+})

--- a/packages/api/src/repositories/in-memory/notification-log.ts
+++ b/packages/api/src/repositories/in-memory/notification-log.ts
@@ -142,7 +142,10 @@ export class InMemoryNotificationLogRepository implements NotificationLogReposit
       .filter((r) => {
         if (scope.kind === 'operator') return r.operatorId === scope.operatorId
         if (filters?.operatorId) return r.operatorId === filters.operatorId
-        return true
+        // scope is 'all' (bypass role): read across tenants ONLY when the route
+        // explicitly opted in. Absent that, read nothing — the safe default lives
+        // here, so a forgotten route guard cannot enumerate every tenant (#1107).
+        return filters?.includeAllOperators === true
       })
       .filter((r) => (filters?.bookingId ? r.bookingId === filters.bookingId : true))
   }

--- a/packages/api/src/repositories/in-memory/storefront.ts
+++ b/packages/api/src/repositories/in-memory/storefront.ts
@@ -24,7 +24,15 @@ export class InMemoryStorefrontRepository implements StorefrontRepository {
     ctx: CallerContext,
     filters?: StorefrontFilters,
   ): Promise<Storefront[]> {
-    const active = await this.locationRepo.findAll(ctx, { status: 'ACTIVE' })
+    // The marketplace catalog is an explicit platform-wide read: an anonymous
+    // renter (mapped to `all` scope) browses every operator's storefront, so
+    // opt in to the cross-operator read (#1107). An operator ctx still scopes to
+    // its own tenant (operator scope is absolute); this mirrors the Drizzle
+    // storefront query, which pushes no operator condition for `all` scope.
+    const active = await this.locationRepo.findAll(ctx, {
+      status: 'ACTIVE',
+      includeAllOperators: true,
+    })
     let locations = filters?.pickupLocationId
       ? active.filter((l) => l.id === filters.pickupLocationId)
       : active

--- a/packages/api/src/repositories/types-fee-schedule.ts
+++ b/packages/api/src/repositories/types-fee-schedule.ts
@@ -14,10 +14,12 @@ export interface FeeScheduleFilters {
    */
   operatorId?: string
   /**
-   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
-   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
-   * nor this flag reads nothing — the safe default lives in the repo, so a
-   * forgotten route guard can no longer leak every tenant's private config.
+   * Explicit platform-wide read (#1107). Set by the bypass-role route layer
+   * (from `?includeAll=true`) and by the in-memory storefront double (the public
+   * marketplace catalog is an explicit cross-operator read). A bypass caller
+   * with NEITHER `operatorId` nor this flag reads nothing — the safe default
+   * lives in the repo, so a forgotten route guard can no longer leak every
+   * tenant's private config.
    */
   includeAllOperators?: boolean
   feeType?: 'OVERTIME_HOURLY' | 'CLEANING_FLAT' | 'NO_FUEL_FLAT'

--- a/packages/api/src/repositories/types-fee-schedule.ts
+++ b/packages/api/src/repositories/types-fee-schedule.ts
@@ -13,6 +13,13 @@ export interface FeeScheduleFilters {
    * operator callers — their scope is absolute (see findAll precedence).
    */
   operatorId?: string
+  /**
+   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
+   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
+   * nor this flag reads nothing — the safe default lives in the repo, so a
+   * forgotten route guard can no longer leak every tenant's private config.
+   */
+  includeAllOperators?: boolean
   feeType?: 'OVERTIME_HOURLY' | 'CLEANING_FLAT' | 'NO_FUEL_FLAT'
   /** Narrow to one vehicle class. The string 'null' / explicit null is not a
    *  filter value here — operator-wide rows surface in an unfiltered list. */

--- a/packages/api/src/repositories/types-notification.ts
+++ b/packages/api/src/repositories/types-notification.ts
@@ -38,10 +38,12 @@ export interface NotificationLogFilters {
   bookingId?: string
   operatorId?: string
   /**
-   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
-   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
-   * nor this flag reads nothing — the safe default lives in the repo, so a
-   * forgotten route guard can no longer leak every tenant's private config.
+   * Explicit platform-wide read (#1107). Set by the bypass-role route layer
+   * (from `?includeAll=true`) and by the in-memory storefront double (the public
+   * marketplace catalog is an explicit cross-operator read). A bypass caller
+   * with NEITHER `operatorId` nor this flag reads nothing — the safe default
+   * lives in the repo, so a forgotten route guard can no longer leak every
+   * tenant's private config.
    */
   includeAllOperators?: boolean
 }

--- a/packages/api/src/repositories/types-notification.ts
+++ b/packages/api/src/repositories/types-notification.ts
@@ -37,6 +37,13 @@ export type NotificationLogNoRecipient = Omit<NotificationLogUpsert, 'recipient'
 export interface NotificationLogFilters {
   bookingId?: string
   operatorId?: string
+  /**
+   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
+   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
+   * nor this flag reads nothing — the safe default lives in the repo, so a
+   * forgotten route guard can no longer leak every tenant's private config.
+   */
+  includeAllOperators?: boolean
 }
 
 export interface NotificationLogRepository {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -128,10 +128,12 @@ export interface LocationFilters {
    */
   operatorId?: string
   /**
-   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
-   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
-   * nor this flag reads nothing — the safe default lives in the repo, so a
-   * forgotten route guard can no longer leak every tenant's private config.
+   * Explicit platform-wide read (#1107). Set by the bypass-role route layer
+   * (from `?includeAll=true`) and by the in-memory storefront double (the public
+   * marketplace catalog is an explicit cross-operator read). A bypass caller
+   * with NEITHER `operatorId` nor this flag reads nothing — the safe default
+   * lives in the repo, so a forgotten route guard can no longer leak every
+   * tenant's private config.
    */
   includeAllOperators?: boolean
 }
@@ -173,10 +175,12 @@ export interface InsuranceOptionFilters {
    */
   operatorId?: string
   /**
-   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
-   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
-   * nor this flag reads nothing — the safe default lives in the repo, so a
-   * forgotten route guard can no longer leak every tenant's private config.
+   * Explicit platform-wide read (#1107). Set by the bypass-role route layer
+   * (from `?includeAll=true`) and by the in-memory storefront double (the public
+   * marketplace catalog is an explicit cross-operator read). A bypass caller
+   * with NEITHER `operatorId` nor this flag reads nothing — the safe default
+   * lives in the repo, so a forgotten route guard can no longer leak every
+   * tenant's private config.
    */
   includeAllOperators?: boolean
 }
@@ -220,10 +224,12 @@ export interface AddOnFilters {
    */
   operatorId?: string
   /**
-   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
-   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
-   * nor this flag reads nothing — the safe default lives in the repo, so a
-   * forgotten route guard can no longer leak every tenant's private config.
+   * Explicit platform-wide read (#1107). Set by the bypass-role route layer
+   * (from `?includeAll=true`) and by the in-memory storefront double (the public
+   * marketplace catalog is an explicit cross-operator read). A bypass caller
+   * with NEITHER `operatorId` nor this flag reads nothing — the safe default
+   * lives in the repo, so a forgotten route guard can no longer leak every
+   * tenant's private config.
    */
   includeAllOperators?: boolean
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -127,6 +127,13 @@ export interface LocationFilters {
    * for operator callers — their scope is absolute (see findAll precedence).
    */
   operatorId?: string
+  /**
+   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
+   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
+   * nor this flag reads nothing — the safe default lives in the repo, so a
+   * forgotten route guard can no longer leak every tenant's private config.
+   */
+  includeAllOperators?: boolean
 }
 
 export interface LocationRepository {
@@ -165,6 +172,13 @@ export interface InsuranceOptionFilters {
    * for operator callers — their scope is absolute (see findAll precedence).
    */
   operatorId?: string
+  /**
+   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
+   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
+   * nor this flag reads nothing — the safe default lives in the repo, so a
+   * forgotten route guard can no longer leak every tenant's private config.
+   */
+  includeAllOperators?: boolean
 }
 
 export interface InsuranceOptionRepository {
@@ -205,6 +219,13 @@ export interface AddOnFilters {
    * for operator callers — their scope is absolute (see findAll precedence).
    */
   operatorId?: string
+  /**
+   * Explicit platform-wide read (#1107). ONLY the bypass-role route layer sets
+   * this (from `?includeAll=true`). A bypass caller with NEITHER `operatorId`
+   * nor this flag reads nothing — the safe default lives in the repo, so a
+   * forgotten route guard can no longer leak every tenant's private config.
+   */
+  includeAllOperators?: boolean
 }
 
 export interface AddOnRepository {

--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -1,4 +1,3 @@
-import type { CreateAddOnInput } from '@kuruma/shared/validators/add-on'
 import {
   createAddOnSchema,
   platformAdminCreateAddOnSchema,
@@ -16,7 +15,7 @@ import type { AddOnService } from '../services/add-on'
 import type { AddOnFilters } from '../services/filters'
 import type { AddOn } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createAddOnRoutes(
   service: AddOnService,
@@ -76,24 +75,19 @@ export function createAddOnRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateAddOnInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      // Bypass callers name the target operator in the body; operator callers
+      // never send one — their tenant is stamped server-side (#1107).
+      const scoped = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createAddOnSchema,
+          adminSchema: platformAdminCreateAddOnSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!scoped.ok) return scoped.response
+      const { data: d, operatorId } = scoped
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -45,9 +45,9 @@ export function createAddOnRoutes(
       if (c.req.query('includeArchived') === 'true') filters.includeArchived = true
 
       // Bypass-scope callers (PLATFORM_ADMIN, legacy STAFF/ADMIN) must scope
-      // explicitly — an accidental unscoped list across every operator is the
-      // exact leak we guard. Operator callers auto-scope, and any operatorId
-      // they pass is ignored here + at the repo.
+      // explicitly. This 400 is now redundant defence-in-depth: the repo reads
+      // nothing for an unscoped bypass caller (#1107), so the real seal is the
+      // threaded intent below — operatorId narrows, includeAllOperators opts in.
       if (operatorReadScope(ctx).kind === 'all') {
         const operatorIdParam = c.req.query('operatorId')
         const includeAll = c.req.query('includeAll') === 'true'
@@ -55,6 +55,7 @@ export function createAddOnRoutes(
           return fail(c, 'operatorId or includeAll=true is required for cross-operator reads', 400)
         }
         if (operatorIdParam) filters.operatorId = operatorIdParam
+        if (includeAll) filters.includeAllOperators = true
       }
 
       return ok(c, await service.findAll(ctx, filters))

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -1,4 +1,3 @@
-import type { CreateFeeScheduleInput } from '@kuruma/shared/validators/fee-schedule'
 import {
   createFeeScheduleSchema,
   platformAdminCreateFeeScheduleSchema,
@@ -16,7 +15,7 @@ import type { FeeScheduleService } from '../services/fee-schedule'
 import type { FeeScheduleFilters } from '../services/filters'
 import type { FeeSchedule } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createFeeScheduleRoutes(
   service: FeeScheduleService,
@@ -83,23 +82,19 @@ export function createFeeScheduleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateFeeScheduleInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      // Bypass callers name the target operator in the body; operator callers
+      // never send one — their tenant is stamped server-side (#1107).
+      const scoped = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createFeeScheduleSchema,
+          adminSchema: platformAdminCreateFeeScheduleSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!scoped.ok) return scoped.response
+      const { data: d, operatorId } = scoped
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -52,9 +52,9 @@ export function createFeeScheduleRoutes(
       if (vehicleClassId) filters.vehicleClassId = vehicleClassId
 
       // Bypass-scope callers (PLATFORM_ADMIN, legacy STAFF/ADMIN) must scope
-      // explicitly — an accidental unscoped list across every operator is the
-      // exact leak we guard. Operator callers auto-scope, and any operatorId
-      // they pass is ignored here + at the repo.
+      // explicitly. This 400 is now redundant defence-in-depth: the repo reads
+      // nothing for an unscoped bypass caller (#1107), so the real seal is the
+      // threaded intent below — operatorId narrows, includeAllOperators opts in.
       if (operatorReadScope(ctx).kind === 'all') {
         const operatorIdParam = c.req.query('operatorId')
         const includeAll = c.req.query('includeAll') === 'true'
@@ -62,6 +62,7 @@ export function createFeeScheduleRoutes(
           return fail(c, 'operatorId or includeAll=true is required for cross-operator reads', 400)
         }
         if (operatorIdParam) filters.operatorId = operatorIdParam
+        if (includeAll) filters.includeAllOperators = true
       }
 
       return ok(c, await service.findAll(ctx, filters))

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -1,5 +1,7 @@
 import type { Context } from 'hono'
 import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
+import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
 
 // --- Response helpers ---
 
@@ -203,6 +205,46 @@ export async function parseBody<T>(
   }
 
   return { ok: true, data: result.data }
+}
+
+// --- Scoped create (write-route operator resolution) ---
+
+type ScopedCreateSuccess<T> = { ok: true; data: T; operatorId: string }
+
+/**
+ * The write-route twin of the cross-operator read-scope guard (#1107 / audit
+ * L4). Every operator-private POST repeats the same branch: a bypass caller
+ * (PLATFORM_ADMIN / legacy STAFF) parses an admin schema that names the target
+ * `operatorId` in the body; an operator caller parses the plain schema and is
+ * stamped with its own tenant server-side. Centralising it kills the 4x copy
+ * and the risk of one route drifting — e.g. trusting a body `operatorId` for an
+ * operator role, which `resolveWriteOperatorId` ignores for tenant-scoped roles.
+ *
+ * Returns the validated `data` (operator-shaped — the admin schema is the same
+ * shape PLUS `operatorId`, consumed here to resolve the tenant) and the resolved
+ * `operatorId`, or a 400 `parseBody` failure to short-circuit.
+ */
+export async function parseScopedCreate<O extends object>(
+  c: Context,
+  ctx: CallerContext,
+  schemas: {
+    operatorSchema: z.ZodType<O>
+    adminSchema: z.ZodType<O & { operatorId?: string }>
+  },
+  resolveWriteOperatorId: ResolveWriteOperatorId,
+): Promise<ScopedCreateSuccess<O> | ParseBodyFailure> {
+  if (operatorReadScope(ctx).kind === 'all') {
+    const parsed = await parseBody(c, schemas.adminSchema)
+    if (!parsed.ok) return parsed
+    return {
+      ok: true,
+      data: parsed.data,
+      operatorId: await resolveWriteOperatorId(ctx, parsed.data.operatorId),
+    }
+  }
+  const parsed = await parseBody(c, schemas.operatorSchema)
+  if (!parsed.ok) return parsed
+  return { ok: true, data: parsed.data, operatorId: await resolveWriteOperatorId(ctx) }
 }
 
 type DateRangeRequired = { ok: true; from: Date; to: Date }

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -1,4 +1,3 @@
-import type { CreateInsuranceOptionInput } from '@kuruma/shared/validators/insurance-option'
 import {
   createInsuranceOptionSchema,
   platformAdminCreateInsuranceOptionSchema,
@@ -16,7 +15,7 @@ import type { InsuranceOptionFilters } from '../services/filters'
 import type { InsuranceOptionService } from '../services/insurance-option'
 import type { InsuranceOption } from '../stores'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createInsuranceOptionRoutes(
   service: InsuranceOptionService,
@@ -76,24 +75,19 @@ export function createInsuranceOptionRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateInsuranceOptionInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      // Bypass callers name the target operator in the body; operator callers
+      // never send one — their tenant is stamped server-side (#1107).
+      const scoped = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createInsuranceOptionSchema,
+          adminSchema: platformAdminCreateInsuranceOptionSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!scoped.ok) return scoped.response
+      const { data: d, operatorId } = scoped
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -45,9 +45,9 @@ export function createInsuranceOptionRoutes(
       if (c.req.query('includeArchived') === 'true') filters.includeArchived = true
 
       // Bypass-scope callers (PLATFORM_ADMIN, legacy STAFF/ADMIN) must scope
-      // explicitly — an accidental unscoped list across every operator is the
-      // exact leak we guard. Operator callers auto-scope, and any operatorId
-      // they pass is ignored here + at the repo.
+      // explicitly. This 400 is now redundant defence-in-depth: the repo reads
+      // nothing for an unscoped bypass caller (#1107), so the real seal is the
+      // threaded intent below — operatorId narrows, includeAllOperators opts in.
       if (operatorReadScope(ctx).kind === 'all') {
         const operatorIdParam = c.req.query('operatorId')
         const includeAll = c.req.query('includeAll') === 'true'
@@ -55,6 +55,7 @@ export function createInsuranceOptionRoutes(
           return fail(c, 'operatorId or includeAll=true is required for cross-operator reads', 400)
         }
         if (operatorIdParam) filters.operatorId = operatorIdParam
+        if (includeAll) filters.includeAllOperators = true
       }
 
       return ok(c, await service.findAll(ctx, filters))

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -35,9 +35,10 @@ export function createLocationRoutes(
       if (c.req.query('includeArchived') === 'true') filters.includeArchived = true
 
       // Bypass-scope callers (PLATFORM_ADMIN, legacy STAFF/ADMIN) must scope
-      // explicitly — an accidental unscoped list across every operator is the
-      // exact leak we guard (#387 amendment item 2). Operator callers
-      // auto-scope, and any operatorId they pass is ignored here + at the repo.
+      // explicitly. This 400 is now redundant defence-in-depth (#387 amendment
+      // item 2): the repo reads nothing for an unscoped bypass caller (#1107),
+      // so the real seal is the threaded intent below — operatorId narrows,
+      // includeAllOperators opts in. Operator callers auto-scope at the repo.
       if (operatorReadScope(ctx).kind === 'all') {
         const operatorIdParam = c.req.query('operatorId')
         const includeAll = c.req.query('includeAll') === 'true'

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -46,6 +46,7 @@ export function createLocationRoutes(
           return fail(c, 'operatorId or includeAll=true is required for cross-operator reads', 400)
         }
         if (operatorIdParam) filters.operatorId = operatorIdParam
+        if (includeAll) filters.includeAllOperators = true
       }
 
       return ok(c, await service.findAll(ctx, filters))

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -1,4 +1,3 @@
-import type { CreateLocationInput } from '@kuruma/shared/validators/location'
 import {
   createLocationSchema,
   platformAdminCreateLocationSchema,
@@ -10,7 +9,7 @@ import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '..
 import type { LocationFilters } from '../services/filters'
 import type { LocationService, LocationUpdateData } from '../services/location'
 import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createLocationRoutes(
   service: LocationService,
@@ -67,24 +66,19 @@ export function createLocationRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateLocationInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      // Bypass callers name the target operator in the body; operator callers
+      // never send one — their tenant is stamped server-side (#1107).
+      const scoped = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createLocationSchema,
+          adminSchema: platformAdminCreateLocationSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!scoped.ok) return scoped.response
+      const { data: d, operatorId } = scoped
 
       try {
         const result = await service.create(ctx, {

--- a/packages/api/src/routes/notifications.ts
+++ b/packages/api/src/routes/notifications.ts
@@ -33,8 +33,10 @@ export function createNotificationRoutes(service: NotificationService) {
       const bookingId = c.req.query('bookingId')
       if (bookingId) filters.bookingId = bookingId
 
-      // Bypass callers must scope explicitly — an unscoped cross-operator list is
-      // the exact leak we guard. Operator callers auto-scope at the repo.
+      // Bypass callers must scope explicitly. This 400 is now redundant
+      // defence-in-depth: the repo reads nothing for an unscoped bypass caller
+      // (#1107), so the real seal is the threaded intent below. Operator callers
+      // auto-scope at the repo.
       if (operatorReadScope(ctx).kind === 'all') {
         const operatorIdParam = c.req.query('operatorId')
         const includeAll = c.req.query('includeAll') === 'true'

--- a/packages/api/src/routes/notifications.ts
+++ b/packages/api/src/routes/notifications.ts
@@ -42,6 +42,7 @@ export function createNotificationRoutes(service: NotificationService) {
           return fail(c, 'operatorId or includeAll=true is required for cross-operator reads', 400)
         }
         if (operatorIdParam) filters.operatorId = operatorIdParam
+        if (includeAll) filters.includeAllOperators = true
       }
 
       return ok(c, await service.findAll(ctx, filters))

--- a/packages/api/src/routes/scoped-create.test.ts
+++ b/packages/api/src/routes/scoped-create.test.ts
@@ -1,0 +1,64 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
+import { resolveOperatorIdForWrite } from '../tenancy'
+import { parseScopedCreate } from './helpers'
+
+// #1107 (audit L4): the write-route schema-selection + operatorId-resolution
+// branch, deduplicated. A bypass caller names the target operator in the body;
+// an operator caller is stamped with its own tenant and a body operatorId is
+// ignored. We drive the real helper through a real Hono app + the real
+// `resolveOperatorIdForWrite` so the wiring (not a mock) is what's asserted.
+
+const operatorSchema = z.object({ name: z.string() })
+const adminSchema = z.object({ name: z.string(), operatorId: z.string() })
+
+const app = (ctx: CallerContext) => {
+  const a = new Hono()
+  a.post('/x', async (c) => {
+    const r = await parseScopedCreate(
+      c,
+      ctx,
+      { operatorSchema, adminSchema },
+      resolveOperatorIdForWrite,
+    )
+    if (!r.ok) return r.response
+    return c.json({ name: r.data.name, operatorId: r.operatorId })
+  })
+  return a
+}
+
+const post = (ctx: CallerContext, body: unknown) =>
+  app(ctx).request('/x', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+const OPERATOR: CallerContext = { userId: 'o1', role: 'OPERATOR_OWNER', operatorId: 'op1' }
+const ADMIN: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+describe('parseScopedCreate (#1107)', () => {
+  it('operator caller is stamped with its own tenant, ignoring a body operatorId', async () => {
+    const res = await post(OPERATOR, { name: 'a', operatorId: 'op-evil' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ name: 'a', operatorId: 'op1' })
+  })
+
+  it('bypass caller resolves the target operator from the body', async () => {
+    const res = await post(ADMIN, { name: 'a', operatorId: 'op2' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ name: 'a', operatorId: 'op2' })
+  })
+
+  it('bypass caller without a body operatorId is a 400 (admin schema requires it)', async () => {
+    const res = await post(ADMIN, { name: 'a' })
+    expect(res.status).toBe(400)
+  })
+
+  it('operator caller with an invalid body is a 400 (operator schema)', async () => {
+    const res = await post(OPERATOR, { notName: 'a' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/api/tests/integration/fee-schedules.test.ts
+++ b/packages/api/tests/integration/fee-schedules.test.ts
@@ -111,10 +111,16 @@ describe('cross-operator fee-schedule isolation + uniqueness (Drizzle)', () => {
     expect(await repo.findById(noTenant, feeA.id)).toBeUndefined()
   })
 
-  it('SYSTEM_CONTEXT reads fees across operators', async () => {
-    const ids = (await repo.findAll(SYSTEM_CONTEXT)).map((f) => f.id)
+  it('SYSTEM_CONTEXT reads fees across operators with includeAllOperators', async () => {
+    const ids = (await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).map((f) => f.id)
     expect(ids).toContain(feeA.id)
     expect(ids).toContain(feeB.id)
+  })
+
+  // #1107: the Drizzle backstop (`sql\`false\``) — a bypass caller with no
+  // explicit cross-operator opt-in reads nothing.
+  it('SYSTEM_CONTEXT without includeAllOperators reads nothing', async () => {
+    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(0)
   })
 })
 

--- a/packages/api/tests/integration/insurance-options.test.ts
+++ b/packages/api/tests/integration/insurance-options.test.ts
@@ -92,10 +92,16 @@ describe('cross-operator insurance-option isolation (Drizzle)', () => {
     expect(await repo.findById(noTenant, optionA.id)).toBeUndefined()
   })
 
-  it('SYSTEM_CONTEXT reads options across operators', async () => {
-    const ids = (await repo.findAll(SYSTEM_CONTEXT)).map((o) => o.id)
+  it('SYSTEM_CONTEXT reads options across operators with includeAllOperators', async () => {
+    const ids = (await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).map((o) => o.id)
     expect(ids).toContain(optionA.id)
     expect(ids).toContain(optionB.id)
+  })
+
+  // #1107: the Drizzle backstop (`sql\`false\``) — a bypass caller with no
+  // explicit cross-operator opt-in reads nothing.
+  it('SYSTEM_CONTEXT without includeAllOperators reads nothing', async () => {
+    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(0)
   })
 
   // [P0] a RENTER must be rejected, NOT served every operator's config.

--- a/packages/api/tests/integration/locations.test.ts
+++ b/packages/api/tests/integration/locations.test.ts
@@ -97,10 +97,18 @@ describe('cross-operator location isolation (Drizzle)', () => {
     expect(await repo.findById(noTenant, locationA.id)).toBeUndefined()
   })
 
-  it('SYSTEM_CONTEXT reads locations across operators', async () => {
-    const ids = (await repo.findAll(SYSTEM_CONTEXT)).map((l) => l.id)
+  it('SYSTEM_CONTEXT reads locations across operators with includeAllOperators', async () => {
+    const ids = (await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).map((l) => l.id)
     expect(ids).toContain(locationA.id)
     expect(ids).toContain(locationB.id)
+  })
+
+  // #1107: the Drizzle backstop (`sql\`false\``) — a bypass caller with no
+  // explicit cross-operator opt-in reads nothing, so a forgotten route guard
+  // can't enumerate every tenant. The `includeAllOperators` test above is the
+  // intentional platform-wide path.
+  it('SYSTEM_CONTEXT without includeAllOperators reads nothing', async () => {
+    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(0)
   })
 })
 

--- a/packages/api/tests/repositories/fee-schedule.test.ts
+++ b/packages/api/tests/repositories/fee-schedule.test.ts
@@ -237,7 +237,7 @@ describe('InMemoryFeeScheduleRepository — operator-scoped reads + filters', ()
 
   it('a bypass admin (SYSTEM_CONTEXT) sees every operator fee', async () => {
     const { repo } = await seed()
-    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(3)
+    expect(await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).toHaveLength(3)
   })
 
   it('an operatorId filter narrows a bypass-role read to one tenant', async () => {

--- a/packages/api/tests/repositories/insurance-option.test.ts
+++ b/packages/api/tests/repositories/insurance-option.test.ts
@@ -93,7 +93,7 @@ describe('InMemoryInsuranceOptionRepository', () => {
     it('excludes ARCHIVED by default', async () => {
       await repo.create(optionInput({ name: 'Active' }))
       await repo.create(optionInput({ name: 'Gone', status: 'ARCHIVED' }))
-      const result = await repo.findAll(SYSTEM_CONTEXT)
+      const result = await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Active')
     })
@@ -101,13 +101,18 @@ describe('InMemoryInsuranceOptionRepository', () => {
     it('includes ARCHIVED when includeArchived is true', async () => {
       await repo.create(optionInput({ name: 'Active' }))
       await repo.create(optionInput({ name: 'Gone', status: 'ARCHIVED' }))
-      expect(await repo.findAll(SYSTEM_CONTEXT, { includeArchived: true })).toHaveLength(2)
+      expect(
+        await repo.findAll(SYSTEM_CONTEXT, { includeArchived: true, includeAllOperators: true }),
+      ).toHaveLength(2)
     })
 
     it('filters by status', async () => {
       await repo.create(optionInput({ name: 'Active' }))
       await repo.create(optionInput({ name: 'Gone', status: 'ARCHIVED' }))
-      const result = await repo.findAll(SYSTEM_CONTEXT, { status: 'ARCHIVED' })
+      const result = await repo.findAll(SYSTEM_CONTEXT, {
+        status: 'ARCHIVED',
+        includeAllOperators: true,
+      })
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Gone')
     })
@@ -185,7 +190,7 @@ describe('InMemoryInsuranceOptionRepository operator-scopes + management-gates r
 
   it('an admin (SYSTEM_CONTEXT) sees every operator option', async () => {
     const { repo } = await seed()
-    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(2)
+    expect(await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).toHaveLength(2)
   })
 
   it('an operator filter narrows a bypass-role read to one tenant', async () => {

--- a/packages/api/tests/repositories/location.test.ts
+++ b/packages/api/tests/repositories/location.test.ts
@@ -72,7 +72,7 @@ describe('InMemoryLocationRepository', () => {
       await repo.create(locationInput({ name: 'Active' }))
       await repo.create(locationInput({ name: 'Gone', status: 'ARCHIVED' }))
 
-      const result = await repo.findAll(SYSTEM_CONTEXT)
+      const result = await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })
 
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Active')
@@ -82,14 +82,19 @@ describe('InMemoryLocationRepository', () => {
       await repo.create(locationInput({ name: 'Active' }))
       await repo.create(locationInput({ name: 'Gone', status: 'ARCHIVED' }))
 
-      expect(await repo.findAll(SYSTEM_CONTEXT, { includeArchived: true })).toHaveLength(2)
+      expect(
+        await repo.findAll(SYSTEM_CONTEXT, { includeArchived: true, includeAllOperators: true }),
+      ).toHaveLength(2)
     })
 
     it('filters by status', async () => {
       await repo.create(locationInput({ name: 'Active' }))
       await repo.create(locationInput({ name: 'Gone', status: 'ARCHIVED' }))
 
-      const result = await repo.findAll(SYSTEM_CONTEXT, { status: 'ARCHIVED' })
+      const result = await repo.findAll(SYSTEM_CONTEXT, {
+        status: 'ARCHIVED',
+        includeAllOperators: true,
+      })
 
       expect(result).toHaveLength(1)
       expect(result[0]!.name).toBe('Gone')
@@ -196,7 +201,7 @@ describe('InMemoryLocationRepository operator-scopes reads', () => {
 
   it('an admin (SYSTEM_CONTEXT) sees every operator location', async () => {
     const { repo } = await seed()
-    expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(2)
+    expect(await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).toHaveLength(2)
   })
 
   it('an operator filter narrows a bypass-role read to one tenant', async () => {
@@ -214,6 +219,6 @@ describe('InMemoryLocationRepository operator-scopes reads', () => {
 
   it('the public catalog sees every operator location (slice 5 forward-compat)', async () => {
     const { repo } = await seed()
-    expect(await repo.findAll(PUBLIC_CONTEXT)).toHaveLength(2)
+    expect(await repo.findAll(PUBLIC_CONTEXT, { includeAllOperators: true })).toHaveLength(2)
   })
 })

--- a/packages/api/tests/repositories/notification-log.test.ts
+++ b/packages/api/tests/repositories/notification-log.test.ts
@@ -230,8 +230,10 @@ describe('InMemoryNotificationLogRepository', () => {
     })
 
     it('a bypass caller sees all rows, filterable by bookingId', async () => {
-      expect(await repo.findAll(SYSTEM_CONTEXT)).toHaveLength(2)
-      expect(await repo.findAll(SYSTEM_CONTEXT, { bookingId: 'bk-2' })).toHaveLength(1)
+      expect(await repo.findAll(SYSTEM_CONTEXT, { includeAllOperators: true })).toHaveLength(2)
+      expect(
+        await repo.findAll(SYSTEM_CONTEXT, { bookingId: 'bk-2', includeAllOperators: true }),
+      ).toHaveLength(1)
     })
   })
 

--- a/packages/api/tests/routes/notifications.test.ts
+++ b/packages/api/tests/routes/notifications.test.ts
@@ -189,7 +189,10 @@ function mount(service: NotificationService, role: UserRole, operatorId?: string
 
 /** All rows in the ledger, read with a full-access bypass context. */
 async function allRows(logRepo: InMemoryNotificationLogRepository): Promise<NotificationLog[]> {
-  return logRepo.findAll({ userId: 'sys', role: 'PLATFORM_ADMIN', bypassScope: true })
+  return logRepo.findAll(
+    { userId: 'sys', role: 'PLATFORM_ADMIN', bypassScope: true },
+    { includeAllOperators: true },
+  )
 }
 
 describe('GET /notifications — auth & role gate', () => {

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -245,7 +245,9 @@ function comboInput(o: Partial<CreateBookingInput> = {}): CreateBookingInput {
 // Resolve the real seeded location id (InMemory repos assign UUIDs) and align
 // the vehicle's pickupLocationId to it, returning ids ready for createInput.
 async function seedReady(h: Harness) {
-  const locations = await h.repos.locationRepo.findAll(SYSTEM_CONTEXT)
+  const locations = await h.repos.locationRepo.findAll(SYSTEM_CONTEXT, {
+    includeAllOperators: true,
+  })
   const locationId = locations[0]!.id
   // Point the seeded vehicle at the real location so pickup resolution matches.
   const veh = await h.repos.vehicleRepo.findById(SYSTEM_CONTEXT, h.vehicleId)

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -161,7 +161,10 @@ describe('NotificationDispatcher', () => {
     const { dispatcher, logRepo, sender } = build()
     await dispatcher.dispatch(booking)
 
-    const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+    const rows = await logRepo.findAll(
+      { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+      { includeAllOperators: true },
+    )
     expect(rows).toHaveLength(2)
     expect(rows.every((r) => r.status === 'SENT')).toBe(true)
     expect(rows.every((r) => r.providerMessageId === 'msg-1')).toBe(true)
@@ -177,7 +180,10 @@ describe('NotificationDispatcher', () => {
     }
     const { dispatcher, logRepo } = build({ sender })
     await expect(dispatcher.dispatch(booking)).resolves.toBeUndefined()
-    const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+    const rows = await logRepo.findAll(
+      { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+      { includeAllOperators: true },
+    )
     expect(rows.every((r) => r.status === 'FAILED')).toBe(true)
     expect(rows[0]!.error).toContain('SMTP 550')
   })
@@ -264,7 +270,10 @@ describe('NotificationDispatcher', () => {
     it('renter confirm goes to the renter email; operator alert to the active members', async () => {
       const { dispatcher, logRepo } = build()
       await dispatcher.dispatch(booking)
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       const renterRow = rows.find((r) => r.kind === 'RENTER_BOOKING_CONFIRM')
       const opRow = rows.find((r) => r.kind === 'OPERATOR_BOOKING_ALERT')
       expect(renterRow?.recipient).toBe('jane@example.com')
@@ -298,7 +307,10 @@ describe('NotificationDispatcher', () => {
       expect(alert?.to).toBe('noreply@bcr.jp')
       expect(alert?.to).not.toContain('@op.com')
       // The audit row records the full member list; the renter mail stays single.
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       const opRow = rows.find((r) => r.kind === 'OPERATOR_BOOKING_ALERT')
       expect(opRow?.recipient).toBe('owner@op.com, staff@op.com')
       const renterMsg = sent.find((m) => m.bcc === undefined)
@@ -308,7 +320,10 @@ describe('NotificationDispatcher', () => {
     it('falls back to OPERATOR_ALERT_FALLBACK_EMAIL when the operator has no active members', async () => {
       const { dispatcher, logRepo } = build({ owners: [], fallback: 'ops@platform.com' })
       await dispatcher.dispatch(booking)
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       const opRow = rows.find((r) => r.kind === 'OPERATOR_BOOKING_ALERT')
       expect(opRow?.recipient).toBe('ops@platform.com')
       // Fallback is a single visible recipient — no Bcc list when there are no members.
@@ -389,7 +404,10 @@ describe('NotificationDispatcher', () => {
       const outcome = await dispatcher.processOne(booking, 'RENTER_BOOKING_CONFIRM')
 
       expect(outcome.result).toBe('no_recipient')
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows).toHaveLength(1)
       expect(rows[0]).toMatchObject({
         kind: 'RENTER_BOOKING_CONFIRM',
@@ -404,7 +422,10 @@ describe('NotificationDispatcher', () => {
     it('keys the NO_RECIPIENT row separately so a later real send is never blocked', async () => {
       const { dispatcher, logRepo } = build({ renterEmail: null })
       await dispatcher.processOne(booking, 'RENTER_BOOKING_CONFIRM')
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows[0]!.idempotencyKey).toBe(
         `notify:${booking.id}:RENTER_BOOKING_CONFIRM:no_recipient`,
       )
@@ -414,7 +435,10 @@ describe('NotificationDispatcher', () => {
       const { dispatcher, logRepo } = build({ renterEmail: null })
       await dispatcher.processOne(booking, 'RENTER_BOOKING_CONFIRM')
       await dispatcher.processOne(booking, 'RENTER_BOOKING_CONFIRM')
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows).toHaveLength(1)
       expect(rows[0]!.status).toBe('NO_RECIPIENT')
     })
@@ -440,7 +464,10 @@ describe('NotificationDispatcher', () => {
         'already_sent',
       )
 
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows.map((r) => r.status).sort()).toEqual(['NO_RECIPIENT', 'SENT'])
     })
   })
@@ -451,7 +478,10 @@ describe('NotificationDispatcher', () => {
     async function kindsFor(trigger: Parameters<typeof dispatcher.dispatch>[1]) {
       const { dispatcher, logRepo, sender } = build()
       await dispatcher.dispatch(booking, trigger)
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       return { rows, sender }
     }
 
@@ -492,7 +522,10 @@ describe('NotificationDispatcher', () => {
     it('defaults to CREATED when no trigger is passed (back-compat with create + resend)', async () => {
       const { dispatcher, logRepo } = build()
       await dispatcher.dispatch(booking)
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows).toHaveLength(2)
     })
 
@@ -503,7 +536,10 @@ describe('NotificationDispatcher', () => {
       const { dispatcher, logRepo, sender } = build()
       await dispatcher.dispatch(booking, 'ACTIVATED')
       await dispatcher.dispatch(booking, 'COMPLETED')
-      const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      const rows = await logRepo.findAll(
+        { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+        { includeAllOperators: true },
+      )
       expect(rows.map((r) => r.kind).sort()).toEqual([
         'RENTER_TRIP_COMPLETED',
         'RENTER_TRIP_STARTED',

--- a/packages/api/tests/services/notification-service.test.ts
+++ b/packages/api/tests/services/notification-service.test.ts
@@ -157,7 +157,10 @@ describe('NotificationService', () => {
   it('resend of a cross-operator id returns 404 (no tenant-existence leak)', async () => {
     const { service, dispatcher, booking, logRepo } = build()
     await dispatcher.dispatch(booking)
-    const [row] = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+    const [row] = await logRepo.findAll(
+      { userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true },
+      { includeAllOperators: true },
+    )
     const result = await service.resend(op2Ctx, row!.id)
     expect(result).toEqual({ ok: false, status: 404, error: 'Notification not found' })
   })


### PR DESCRIPTION
## What

Push the cross-operator read-scope default **below the route** (audit **M3**) and dedupe the write-side scoped-create boilerplate (audit **L4**). Closes #1107. Refs #1104.

Before this change, a bypass/all-scope `findAll` (PLATFORM_ADMIN / SYSTEM_CONTEXT / public-RENTER-for-location) relied on each route remembering to scope its filter. Five read routes hand-rolled that guard; four write routes hand-rolled the same "pick operatorId from caller, never the body" create scaffold. The protection was correct but copy-pasted — one missed route = a cross-tenant leak.

## How

**M3 — read-side fail-closed default.** A new `includeAllOperators?: boolean` lands on the 5 `*Filters` and a backstop in all 10 `findAll` implementations:
- **InMemory**: predicate excludes every operator unless `includeAllOperators === true` or `filters.operatorId` is set.
- **Drizzle**: `sql\`false\`` short-circuits to zero rows under the same condition.

Routes thread the flag explicitly from `?includeAll=true`. The default is now **fail-closed**: a bypass scope reads *nothing* unless the route opts in. `booking-creation.ts` (`:391`/`:658`) passes `operatorId`, so booking flows are unaffected.

**L4 — write-side dedupe.** `parseScopedCreate` (in `routes/helpers.ts`) centralizes "resolve operatorId from the authenticated caller, never trust `body.operatorId`" for the 4 create routes (add-ons, fee-schedules, insurance-options, locations).

**Blast-radius fix:** the in-memory storefront repo now passes `includeAllOperators: true` — the public catalog is an *explicit* cross-operator read, mirroring the Drizzle storefront. ~8 test files that relied on the old implicit-leak behavior were updated to the explicit contract.

## Contract

> A bypass/all-scope `findAll` returns rows **only** when `filters.includeAllOperators === true` or `filters.operatorId` is set. Default = zero rows. The operator role never reads `body.operatorId`.

## Verification

- `api` **1936 unit + 329 integration** green on real Postgres
- `tsc --noEmit` clean, `lint:boundaries` OK, biome clean
- **code-reviewer + architect both SHIP**, no must-fix (confirmed: fail-closed default, route-only opt-in, `sql\`false\`` zero-rows, never trusts `body.operatorId` for operator role, no weakened tests)

## Deferred follow-ups (architect, all SHIP-optional)

- Extract `resolveOperatorFilter(ctx, filters)` to collapse the 10-fold inline precedence (InMemory/Drizzle divergence risk).
- `parseReadScope` read-guard twin — 5 routes still dup the 400.
- `SYSTEM_CONTEXT = all` footgun: future internal `findAll` callers silently get `[]` (current 2 callers are safe).

## Review note

Security-sensitive (tenancy isolation) — intended for human review/merge, not auto-merge. The two agent reviews above already passed.
