### PR TITLE
feat(#1090): platform-admin customer directory page

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "Overview",
       "revenue": "Partner Revenue",
-      "documents": "Documents"
+      "documents": "Documents",
+      "customers": "Customers"
     },
     "home": {
       "title": "Platform Admin",
@@ -1287,6 +1288,44 @@
       "reject": "Reject",
       "error": "Couldn't record the verdict. Try again.",
       "loadError": "Couldn't load the review queue.",
+      "retry": "Retry"
+    },
+    "customers": {
+      "title": "Customers",
+      "subtitle": "Search and review every renter across the platform.",
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search by name or email",
+      "sortLabel": "Sort by",
+      "sort": {
+        "lastBookingAt": "Recent booking",
+        "bookingCount": "Most bookings",
+        "name": "Name"
+      },
+      "colName": "Name",
+      "colEmail": "Email",
+      "colBookings": "Bookings",
+      "colTotalSpent": "Total spent",
+      "colLastBooking": "Last booking",
+      "colCountry": "Country",
+      "colLanguage": "Language",
+      "empty": "No customers match your search.",
+      "unnamed": "Unnamed customer",
+      "noEmail": "No email",
+      "noVehicle": "No vehicle assigned",
+      "pagination": "Customer pages",
+      "prev": "Previous",
+      "next": "Next",
+      "bookingsTitle": "Booking history",
+      "bookingsEmpty": "No bookings yet.",
+      "detailLoading": "Loading customer…",
+      "detailEmpty": "This customer is no longer available.",
+      "status": {
+        "CONFIRMED": "Confirmed",
+        "ACTIVE": "Active",
+        "COMPLETED": "Completed",
+        "CANCELLED": "Cancelled"
+      },
+      "loadError": "Couldn't load customers.",
       "retry": "Retry"
     }
   },

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "概要",
       "revenue": "パートナー収益",
-      "documents": "書類"
+      "documents": "書類",
+      "customers": "顧客"
     },
     "home": {
       "title": "プラットフォーム管理",
@@ -1287,6 +1288,44 @@
       "reject": "却下",
       "error": "判定を記録できませんでした。もう一度お試しください。",
       "loadError": "審査キューを読み込めませんでした。",
+      "retry": "再試行"
+    },
+    "customers": {
+      "title": "顧客",
+      "subtitle": "プラットフォーム全体のレンターを検索・確認します。",
+      "searchLabel": "検索",
+      "searchPlaceholder": "名前またはメールで検索",
+      "sortLabel": "並び替え",
+      "sort": {
+        "lastBookingAt": "最近の予約",
+        "bookingCount": "予約数が多い順",
+        "name": "名前"
+      },
+      "colName": "名前",
+      "colEmail": "メール",
+      "colBookings": "予約数",
+      "colTotalSpent": "利用総額",
+      "colLastBooking": "最終予約",
+      "colCountry": "国",
+      "colLanguage": "言語",
+      "empty": "条件に一致する顧客がいません。",
+      "unnamed": "名前なしの顧客",
+      "noEmail": "メールなし",
+      "noVehicle": "車両未割り当て",
+      "pagination": "顧客ページ",
+      "prev": "前へ",
+      "next": "次へ",
+      "bookingsTitle": "予約履歴",
+      "bookingsEmpty": "予約はまだありません。",
+      "detailLoading": "顧客を読み込み中…",
+      "detailEmpty": "この顧客は利用できなくなりました。",
+      "status": {
+        "CONFIRMED": "確定",
+        "ACTIVE": "利用中",
+        "COMPLETED": "完了",
+        "CANCELLED": "キャンセル"
+      },
+      "loadError": "顧客を読み込めませんでした。",
       "retry": "再試行"
     }
   },

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "概览",
       "revenue": "合作伙伴收益",
-      "documents": "证件"
+      "documents": "证件",
+      "customers": "客户"
     },
     "home": {
       "title": "平台管理",
@@ -1287,6 +1288,44 @@
       "reject": "拒绝",
       "error": "无法记录审核结果，请重试。",
       "loadError": "无法加载审核队列。",
+      "retry": "重试"
+    },
+    "customers": {
+      "title": "客户",
+      "subtitle": "搜索并查看平台上的所有租客。",
+      "searchLabel": "搜索",
+      "searchPlaceholder": "按姓名或邮箱搜索",
+      "sortLabel": "排序方式",
+      "sort": {
+        "lastBookingAt": "最近预订",
+        "bookingCount": "预订最多",
+        "name": "姓名"
+      },
+      "colName": "姓名",
+      "colEmail": "邮箱",
+      "colBookings": "预订数",
+      "colTotalSpent": "消费总额",
+      "colLastBooking": "最近预订",
+      "colCountry": "国家",
+      "colLanguage": "语言",
+      "empty": "没有符合条件的客户。",
+      "unnamed": "未命名客户",
+      "noEmail": "无邮箱",
+      "noVehicle": "未分配车辆",
+      "pagination": "客户分页",
+      "prev": "上一页",
+      "next": "下一页",
+      "bookingsTitle": "预订记录",
+      "bookingsEmpty": "暂无预订。",
+      "detailLoading": "正在加载客户…",
+      "detailEmpty": "该客户已不可用。",
+      "status": {
+        "CONFIRMED": "已确认",
+        "ACTIVE": "进行中",
+        "COMPLETED": "已完成",
+        "CANCELLED": "已取消"
+      },
+      "loadError": "无法加载客户。",
       "retry": "重试"
     }
   },

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as LocaleBusinessManageClassesRouteImport } from './routes/$local
 import { Route as LocaleBusinessManageAddOnsRouteImport } from './routes/$locale/_business/manage/add-ons'
 import { Route as LocaleAdminAdminRevenueRouteImport } from './routes/$locale/_admin/admin/revenue'
 import { Route as LocaleAdminAdminDocumentsRouteImport } from './routes/$locale/_admin/admin/documents'
+import { Route as LocaleAdminAdminCustomersRouteImport } from './routes/$locale/_admin/admin/customers'
 import { Route as LocaleBusinessManageFleetIndexRouteImport } from './routes/$locale/_business/manage/fleet/index'
 import { Route as LocaleBusinessManageBookingsIndexRouteImport } from './routes/$locale/_business/manage/bookings/index'
 import { Route as LocaleBusinessManageFleetVehicleIdRouteImport } from './routes/$locale/_business/manage/fleet/$vehicleId'
@@ -224,6 +225,12 @@ const LocaleAdminAdminDocumentsRoute =
     path: '/admin/documents',
     getParentRoute: () => LocaleAdminRoute,
   } as any)
+const LocaleAdminAdminCustomersRoute =
+  LocaleAdminAdminCustomersRouteImport.update({
+    id: '/admin/customers',
+    path: '/admin/customers',
+    getParentRoute: () => LocaleAdminRoute,
+  } as any)
 const LocaleBusinessManageFleetIndexRoute =
   LocaleBusinessManageFleetIndexRouteImport.update({
     id: '/manage/fleet/',
@@ -263,6 +270,7 @@ export interface FileRoutesByFullPath {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/customers': typeof LocaleAdminAdminCustomersRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -296,6 +304,7 @@ export interface FileRoutesByTo {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/customers': typeof LocaleAdminAdminCustomersRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -336,6 +345,7 @@ export interface FileRoutesById {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/_admin/admin/customers': typeof LocaleAdminAdminCustomersRoute
   '/$locale/_admin/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/_admin/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/_business/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -374,6 +384,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/admin/customers'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -407,6 +418,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles'
+    | '/$locale/admin/customers'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -446,6 +458,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/_admin/admin/customers'
     | '/$locale/_admin/admin/documents'
     | '/$locale/_admin/admin/revenue'
     | '/$locale/_business/manage/add-ons'
@@ -708,6 +721,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleAdminAdminDocumentsRouteImport
       parentRoute: typeof LocaleAdminRoute
     }
+    '/$locale/_admin/admin/customers': {
+      id: '/$locale/_admin/admin/customers'
+      path: '/admin/customers'
+      fullPath: '/$locale/admin/customers'
+      preLoaderRoute: typeof LocaleAdminAdminCustomersRouteImport
+      parentRoute: typeof LocaleAdminRoute
+    }
     '/$locale/_business/manage/fleet/': {
       id: '/$locale/_business/manage/fleet/'
       path: '/manage/fleet'
@@ -740,12 +760,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface LocaleAdminRouteChildren {
+  LocaleAdminAdminCustomersRoute: typeof LocaleAdminAdminCustomersRoute
   LocaleAdminAdminDocumentsRoute: typeof LocaleAdminAdminDocumentsRoute
   LocaleAdminAdminRevenueRoute: typeof LocaleAdminAdminRevenueRoute
   LocaleAdminAdminIndexRoute: typeof LocaleAdminAdminIndexRoute
 }
 
 const LocaleAdminRouteChildren: LocaleAdminRouteChildren = {
+  LocaleAdminAdminCustomersRoute: LocaleAdminAdminCustomersRoute,
   LocaleAdminAdminDocumentsRoute: LocaleAdminAdminDocumentsRoute,
   LocaleAdminAdminRevenueRoute: LocaleAdminAdminRevenueRoute,
   LocaleAdminAdminIndexRoute: LocaleAdminAdminIndexRoute,

--- a/packages/web/src/routes/$locale/_admin/admin/customers.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/customers.tsx
@@ -1,0 +1,100 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { CustomersView } from '@/vite/admin/customers/CustomersView'
+import { customerByIdQueryOptions, customersQueryOptions } from '@/vite/admin/customers/api'
+import type { CustomerSort } from '@kuruma/shared/types/customer'
+import { useQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+// Must match the API's default sort (routes/customers.ts ALLOWED_SORTS) so the
+// loader's prefetch key equals the component's first-page key — a cache hit, no
+// refetch flash on mount.
+const DEFAULT_SORT: CustomerSort = 'lastBookingAt'
+const SEARCH_DEBOUNCE_MS = 300
+
+// Platform-admin customer directory (#1090, epic #1075). The `_admin` parent
+// layout already gates on platform-admin membership, so this only owns the data:
+// prefetch the first page in the loader, then drive search / cursor pagination /
+// detail selection from local state over the existing customers API. The view is
+// pure (FC/IS) — all I/O (queries) and cursor/selection state live here.
+export const Route = createFileRoute('/$locale/_admin/admin/customers')({
+  loader: ({ context }) =>
+    context.queryClient.ensureQueryData(customersQueryOptions({ sort: DEFAULT_SORT })),
+  pendingComponent: PageSkeleton,
+  errorComponent: CustomersError,
+  component: CustomersRoute,
+})
+
+function CustomersRoute() {
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [sort, setSort] = useState<CustomerSort>(DEFAULT_SORT)
+  // Stack of cursors for the pages visited; the last element is the current
+  // page's cursor (null = first page). Push on Next, pop on Previous.
+  const [cursorStack, setCursorStack] = useState<(string | null)[]>([null])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  // Debounce keystrokes so each one doesn't fire a request, and reset to page 1
+  // whenever the query changes (a stale cursor is meaningless for a new search).
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchInput)
+      setCursorStack([null])
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  const currentCursor = cursorStack.at(-1) ?? null
+  const listQuery = useQuery(
+    customersQueryOptions({
+      search: debouncedSearch.trim() || undefined,
+      sort,
+      cursor: currentCursor || undefined,
+    }),
+  )
+  const detailQuery = useQuery(customerByIdQueryOptions(selectedId))
+
+  const nextCursor = listQuery.data?.nextCursor ?? null
+
+  return (
+    <CustomersView
+      customers={listQuery.data?.data ?? []}
+      search={searchInput}
+      onSearchChange={setSearchInput}
+      sort={sort}
+      onSortChange={(next) => {
+        setSort(next)
+        setCursorStack([null])
+      }}
+      onSelectCustomer={setSelectedId}
+      selectedCustomer={detailQuery.data ?? null}
+      isDetailOpen={selectedId !== null}
+      isDetailLoading={detailQuery.isLoading}
+      onCloseDetail={() => setSelectedId(null)}
+      canPrev={cursorStack.length > 1}
+      canNext={nextCursor !== null}
+      onPrevPage={() => setCursorStack((stack) => stack.slice(0, -1))}
+      onNextPage={() => {
+        if (nextCursor) setCursorStack((stack) => [...stack, nextCursor])
+      }}
+    />
+  )
+}
+
+function CustomersError(_props: ErrorComponentProps) {
+  const t = useTranslations('admin.customers')
+  const router = useRouter()
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-20 text-center sm:px-6 lg:px-8">
+      <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+      <button
+        type="button"
+        onClick={() => router.invalidate()}
+        className="mt-4 inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted/50"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/customers/CustomerDetailDrawer.test.tsx
+++ b/packages/web/src/vite/admin/customers/CustomerDetailDrawer.test.tsx
@@ -1,0 +1,66 @@
+import { formatJpy } from '@/lib/format'
+import type { CustomerWithBookings } from '@kuruma/shared/types/customer'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../../messages/en.json'
+import { CustomerDetailDrawer } from './CustomerDetailDrawer'
+
+const detail: CustomerWithBookings = {
+  id: 'usr_1',
+  name: 'Aiko Tanaka',
+  email: 'aiko@example.com',
+  language: 'ja',
+  country: 'JP',
+  bookingCount: 1,
+  lastBookingAt: '2026-06-01T09:00:00.000Z',
+  totalSpent: 16000,
+  bookings: [
+    {
+      id: 'bk_1',
+      vehicleId: 'veh_1',
+      vehicleName: 'Toyota Aqua',
+      startAt: '2026-06-01T09:00:00.000Z',
+      endAt: '2026-06-03T09:00:00.000Z',
+      status: 'COMPLETED',
+      totalPrice: 12000,
+    },
+  ],
+}
+
+function renderDrawer(props: Partial<Parameters<typeof CustomerDetailDrawer>[0]> = {}) {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <CustomerDetailDrawer
+        customer={detail}
+        open
+        isLoading={false}
+        onOpenChange={vi.fn()}
+        {...props}
+      />
+    </IntlProvider>,
+  )
+}
+
+describe('CustomerDetailDrawer', () => {
+  it('renders the booking history with vehicle, status and price when open', () => {
+    renderDrawer()
+    expect(screen.queryByText('Toyota Aqua')).not.toBeNull()
+    expect(screen.queryByText(en.admin.customers.status.COMPLETED)).not.toBeNull()
+    // Booking line price (distinct from the lifetime "total spent" stat).
+    expect(screen.queryByText(formatJpy(12000))).not.toBeNull()
+    // Lifetime total in the profile stats.
+    expect(screen.queryByText(formatJpy(16000))).not.toBeNull()
+  })
+
+  it('shows the loading line while the detail read is in flight', () => {
+    renderDrawer({ customer: null, isLoading: true })
+    expect(screen.queryByText(en.admin.customers.detailLoading)).not.toBeNull()
+    expect(screen.queryByText('Toyota Aqua')).toBeNull()
+  })
+
+  it('shows the empty state when the lookup resolved to a deleted customer', () => {
+    renderDrawer({ customer: null, isLoading: false })
+    expect(screen.queryByText(en.admin.customers.detailEmpty)).not.toBeNull()
+  })
+})

--- a/packages/web/src/vite/admin/customers/CustomerDetailDrawer.tsx
+++ b/packages/web/src/vite/admin/customers/CustomerDetailDrawer.tsx
@@ -1,0 +1,92 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { CustomerWithBookings } from '@kuruma/shared/types/customer'
+import { useLocale, useTranslations } from 'use-intl'
+
+interface CustomerDetailDrawerProps {
+  readonly customer: CustomerWithBookings | null
+  readonly open: boolean
+  readonly isLoading: boolean
+  readonly onOpenChange: (open: boolean) => void
+}
+
+// Right-side drawer showing one customer's profile + cross-operator booking
+// history. Pure presentation: the route owns the `customerByIdQueryOptions` read
+// and the open/selected state. Renders a loading line while the detail is in
+// flight and an empty-state when the lookup resolved to null (deleted user).
+export function CustomerDetailDrawer({
+  customer,
+  open,
+  isLoading,
+  onOpenChange,
+}: CustomerDetailDrawerProps) {
+  const t = useTranslations('admin.customers')
+  const locale = useLocale()
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full gap-0 overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{customer?.name ?? t('unnamed')}</SheetTitle>
+          <SheetDescription>{customer?.email ?? t('noEmail')}</SheetDescription>
+        </SheetHeader>
+
+        {isLoading ? (
+          <p className="px-4 py-6 text-muted-foreground">{t('detailLoading')}</p>
+        ) : customer === null ? (
+          <p className="px-4 py-6 text-muted-foreground">{t('detailEmpty')}</p>
+        ) : (
+          <div className="space-y-6 px-4 pb-6">
+            <dl className="grid grid-cols-2 gap-4">
+              <Stat label={t('colBookings')} value={customer.bookingCount.toLocaleString()} />
+              <Stat label={t('colTotalSpent')} value={formatJpy(customer.totalSpent)} />
+              <Stat label={t('colCountry')} value={customer.country ?? '—'} />
+              <Stat label={t('colLanguage')} value={customer.language} />
+            </dl>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground">{t('bookingsTitle')}</h3>
+              {customer.bookings.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t('bookingsEmpty')}</p>
+              ) : (
+                <ul className="space-y-2">
+                  {customer.bookings.map((booking) => (
+                    <li key={booking.id} className="rounded-lg border border-border p-3 text-sm">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium">{booking.vehicleName ?? t('noVehicle')}</span>
+                        <span className="text-muted-foreground">
+                          {t(`status.${booking.status}`)}
+                        </span>
+                      </div>
+                      <div className="mt-1 flex items-center justify-between gap-2 text-muted-foreground">
+                        <span>{formatDateTime(booking.startAt, locale)}</span>
+                        <span className="tabular-nums">
+                          {booking.totalPrice === null ? '—' : formatJpy(booking.totalPrice)}
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function Stat({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-semibold tabular-nums">{value}</dd>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/customers/CustomerSearchBar.tsx
+++ b/packages/web/src/vite/admin/customers/CustomerSearchBar.tsx
@@ -1,0 +1,60 @@
+import { Input } from '@/components/ui/input'
+import { NativeSelect } from '@/components/ui/native-select'
+import type { CustomerSort } from '@kuruma/shared/types/customer'
+import { useTranslations } from 'use-intl'
+
+const SORTS: readonly CustomerSort[] = ['lastBookingAt', 'bookingCount', 'name']
+
+interface CustomerSearchBarProps {
+  readonly search: string
+  readonly onSearchChange: (value: string) => void
+  readonly sort: CustomerSort
+  readonly onSortChange: (sort: CustomerSort) => void
+}
+
+// Search + sort controls for the customer directory. Pure (FC/IS): the route
+// owns the debounced query state and turns these callbacks into refetches. Search
+// is a controlled `type="search"` input with a real `<label>`; sort mirrors the
+// API's `ALLOWED_SORTS` so a value can't drift from what the server accepts.
+export function CustomerSearchBar({
+  search,
+  onSearchChange,
+  sort,
+  onSortChange,
+}: CustomerSearchBarProps) {
+  const t = useTranslations('admin.customers')
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+      <div className="flex-1 space-y-1">
+        <label htmlFor="customer-search" className="text-sm text-muted-foreground">
+          {t('searchLabel')}
+        </label>
+        <Input
+          id="customer-search"
+          type="search"
+          value={search}
+          placeholder={t('searchPlaceholder')}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="customer-sort" className="text-sm text-muted-foreground">
+          {t('sortLabel')}
+        </label>
+        <NativeSelect
+          id="customer-sort"
+          className="w-auto"
+          value={sort}
+          onChange={(e) => onSortChange(e.target.value as CustomerSort)}
+        >
+          {SORTS.map((option) => (
+            <option key={option} value={option}>
+              {t(`sort.${option}`)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/customers/CustomersView.test.tsx
+++ b/packages/web/src/vite/admin/customers/CustomersView.test.tsx
@@ -1,0 +1,141 @@
+import { formatJpy } from '@/lib/format'
+import type { Customer } from '@kuruma/shared/types/customer'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../../messages/en.json'
+import { CustomersView } from './CustomersView'
+
+const customer = (over: Partial<Customer> = {}): Customer => ({
+  id: 'usr_1',
+  name: 'Aiko Tanaka',
+  email: 'aiko@example.com',
+  language: 'ja',
+  country: 'JP',
+  bookingCount: 3,
+  lastBookingAt: '2026-06-01T09:00:00.000Z',
+  totalSpent: 48000,
+  ...over,
+})
+
+type ViewProps = Parameters<typeof CustomersView>[0]
+
+function renderView(over: Partial<ViewProps> = {}) {
+  const props: ViewProps = {
+    customers: [customer()],
+    search: '',
+    onSearchChange: vi.fn(),
+    sort: 'lastBookingAt',
+    onSortChange: vi.fn(),
+    onSelectCustomer: vi.fn(),
+    selectedCustomer: null,
+    isDetailOpen: false,
+    isDetailLoading: false,
+    onCloseDetail: vi.fn(),
+    canPrev: false,
+    canNext: false,
+    onPrevPage: vi.fn(),
+    onNextPage: vi.fn(),
+    ...over,
+  }
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <CustomersView {...props} />
+    </IntlProvider>,
+  )
+  return props
+}
+
+describe('CustomersView', () => {
+  it('shows the empty state and no data rows when no customers match', () => {
+    renderView({ customers: [] })
+    expect(screen.queryByText(en.admin.customers.empty)).not.toBeNull()
+    // header row only — no <td> body cells
+    expect(screen.queryByRole('cell')).toBeNull()
+  })
+
+  it('renders a row per customer with the mapped name, bookings and formatted spend', () => {
+    renderView({
+      customers: [
+        customer(),
+        customer({
+          id: 'usr_2',
+          name: 'Ben Ito',
+          email: 'ben@example.com',
+          bookingCount: 7,
+          totalSpent: 120000,
+        }),
+      ],
+    })
+
+    // 1 header + 2 data rows
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+
+    const aikoRow = screen.getByRole('button', { name: 'Aiko Tanaka' }).closest('tr')!
+    expect(within(aikoRow).queryByText('aiko@example.com')).not.toBeNull()
+    expect(within(aikoRow).queryByText('3')).not.toBeNull()
+    expect(within(aikoRow).queryByText(formatJpy(48000))).not.toBeNull()
+
+    const benRow = screen.getByRole('button', { name: 'Ben Ito' }).closest('tr')!
+    expect(within(benRow).queryByText('7')).not.toBeNull()
+    expect(within(benRow).queryByText(formatJpy(120000))).not.toBeNull()
+  })
+
+  it('falls back to placeholder copy for a nameless / email-less walk-in', () => {
+    renderView({ customers: [customer({ name: null, email: null })] })
+    expect(screen.queryByRole('button', { name: en.admin.customers.unnamed })).not.toBeNull()
+    expect(screen.queryByText(en.admin.customers.noEmail)).not.toBeNull()
+  })
+
+  it('selects a customer by its id when the name button is clicked', () => {
+    const { onSelectCustomer } = renderView({
+      customers: [customer({ id: 'usr_9', name: 'Cho Lin' })],
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cho Lin' }))
+    expect(onSelectCustomer).toHaveBeenCalledWith('usr_9')
+  })
+
+  it('forwards the typed query to onSearchChange', () => {
+    const { onSearchChange } = renderView()
+    fireEvent.change(screen.getByLabelText(en.admin.customers.searchLabel), {
+      target: { value: 'tan' },
+    })
+    expect(onSearchChange).toHaveBeenCalledWith('tan')
+  })
+
+  it('forwards the chosen sort key to onSortChange', () => {
+    const { onSortChange } = renderView()
+    fireEvent.change(screen.getByLabelText(en.admin.customers.sortLabel), {
+      target: { value: 'bookingCount' },
+    })
+    expect(onSortChange).toHaveBeenCalledWith('bookingCount')
+  })
+
+  it('disables Next on the last page and never advances the cursor', () => {
+    const { onNextPage } = renderView({ canNext: false })
+    const next = screen.getByRole('button', { name: en.admin.customers.next }) as HTMLButtonElement
+    expect(next.disabled).toBe(true)
+    fireEvent.click(next)
+    expect(onNextPage).not.toHaveBeenCalled()
+  })
+
+  it('advances the cursor via onNextPage when a next page exists', () => {
+    const { onNextPage } = renderView({ canNext: true })
+    const next = screen.getByRole('button', { name: en.admin.customers.next }) as HTMLButtonElement
+    expect(next.disabled).toBe(false)
+    fireEvent.click(next)
+    expect(onNextPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Previous on the first page', () => {
+    renderView({ canPrev: false })
+    const prev = screen.getByRole('button', { name: en.admin.customers.prev }) as HTMLButtonElement
+    expect(prev.disabled).toBe(true)
+  })
+
+  it('pages back via onPrevPage from a later page', () => {
+    const { onPrevPage } = renderView({ canPrev: true })
+    fireEvent.click(screen.getByRole('button', { name: en.admin.customers.prev }))
+    expect(onPrevPage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web/src/vite/admin/customers/CustomersView.tsx
+++ b/packages/web/src/vite/admin/customers/CustomersView.tsx
@@ -1,0 +1,137 @@
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
+import { useLocale, useTranslations } from 'use-intl'
+import { CustomerDetailDrawer } from './CustomerDetailDrawer'
+import { CustomerSearchBar } from './CustomerSearchBar'
+
+interface CustomersViewProps {
+  readonly customers: Customer[]
+  readonly search: string
+  readonly onSearchChange: (value: string) => void
+  readonly sort: CustomerSort
+  readonly onSortChange: (sort: CustomerSort) => void
+  readonly onSelectCustomer: (id: string) => void
+  readonly selectedCustomer: CustomerWithBookings | null
+  readonly isDetailOpen: boolean
+  readonly isDetailLoading: boolean
+  readonly onCloseDetail: () => void
+  readonly canPrev: boolean
+  readonly canNext: boolean
+  readonly onPrevPage: () => void
+  readonly onNextPage: () => void
+}
+
+// Pure presentation of the platform-admin customer directory (#1090): search +
+// sort controls, the paginated table, prev/next cursor controls, and the detail
+// drawer. All data + query/cursor/selection state live in the route; this stays
+// render-only so the table, pagination, and selection are unit-testable without a
+// router or query client (mirrors RevenueView / DocumentsReviewView).
+export function CustomersView({
+  customers,
+  search,
+  onSearchChange,
+  sort,
+  onSortChange,
+  onSelectCustomer,
+  selectedCustomer,
+  isDetailOpen,
+  isDetailLoading,
+  onCloseDetail,
+  canPrev,
+  canNext,
+  onPrevPage,
+  onNextPage,
+}: CustomersViewProps) {
+  const t = useTranslations('admin.customers')
+  const locale = useLocale()
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">{t('title')}</h1>
+        <p className="text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <CustomerSearchBar
+        search={search}
+        onSearchChange={onSearchChange}
+        sort={sort}
+        onSortChange={onSortChange}
+      />
+
+      {customers.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border py-12 text-center text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('colName')}</TableHead>
+                <TableHead>{t('colEmail')}</TableHead>
+                <TableHead className="text-right">{t('colBookings')}</TableHead>
+                <TableHead className="text-right">{t('colTotalSpent')}</TableHead>
+                <TableHead>{t('colLastBooking')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {customers.map((customer) => (
+                <TableRow key={customer.id}>
+                  <TableCell>
+                    <button
+                      type="button"
+                      className="font-medium text-foreground underline-offset-4 hover:underline"
+                      onClick={() => onSelectCustomer(customer.id)}
+                    >
+                      {customer.name ?? t('unnamed')}
+                    </button>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {customer.email ?? t('noEmail')}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {customer.bookingCount.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {formatJpy(customer.totalSpent)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatDateTime(customer.lastBookingAt, locale)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <nav className="flex items-center justify-end gap-2" aria-label={t('pagination')}>
+        <Button variant="outline" size="sm" disabled={!canPrev} onClick={onPrevPage}>
+          {t('prev')}
+        </Button>
+        <Button variant="outline" size="sm" disabled={!canNext} onClick={onNextPage}>
+          {t('next')}
+        </Button>
+      </nav>
+
+      <CustomerDetailDrawer
+        customer={selectedCustomer}
+        open={isDetailOpen}
+        isLoading={isDetailLoading}
+        onOpenChange={(open) => {
+          if (!open) onCloseDetail()
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/customers/api.test.ts
+++ b/packages/web/src/vite/admin/customers/api.test.ts
@@ -1,0 +1,176 @@
+import { ParseError } from '@/lib/api-error'
+import type { Customer, CustomerWithBookings } from '@kuruma/shared/types/customer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ADMIN_CUSTOMERS_QUERY_KEY,
+  customerByIdQueryOptions,
+  customersQueryOptions,
+  fetchCustomerById,
+  fetchCustomers,
+} from './api'
+
+// Mock Response that models single-consumption like a real `fetch` body: each
+// Response's `json()` succeeds once then throws, and `clone()` yields a fresh
+// INDEPENDENT body. This locks in the load-bearing `res.clone()` in
+// fetchCustomers — peeking the envelope sibling `nextCursor` off a clone before
+// unwrap consumes the original. Drop the clone and the second read throws, so a
+// re-read regression fails here instead of passing against an infinitely
+// re-readable stub.
+function jsonResponse(body: unknown, status = 200): Response {
+  const make = (): Response => {
+    let consumed = false
+    const res = {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => {
+        if (consumed) throw new TypeError('Body has already been consumed.')
+        consumed = true
+        return body
+      },
+      clone: () => make(),
+    } as unknown as Response
+    return res
+  }
+  return make()
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+afterEach(() => fetchMock.mockReset())
+
+const customer: Customer = {
+  id: 'usr_1',
+  name: 'Aiko Tanaka',
+  email: 'aiko@example.com',
+  language: 'ja',
+  country: 'JP',
+  bookingCount: 3,
+  lastBookingAt: '2026-06-01T09:00:00.000Z',
+  totalSpent: 48000,
+}
+
+const customerWithBookings: CustomerWithBookings = {
+  ...customer,
+  bookings: [
+    {
+      id: 'bk_1',
+      vehicleId: 'veh_1',
+      vehicleName: 'Toyota Aqua',
+      startAt: '2026-06-01T09:00:00.000Z',
+      endAt: '2026-06-03T09:00:00.000Z',
+      status: 'COMPLETED',
+      totalPrice: 16000,
+    },
+  ],
+}
+
+describe('fetchCustomers', () => {
+  it('GETs /customers with credentials and the search/sort/cursor/limit params', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: [customer], nextCursor: null }))
+
+    await fetchCustomers({ search: 'aiko', sort: 'bookingCount', cursor: 'c_42', limit: 20 })
+
+    const [url, opts] = fetchMock.mock.calls[0]!
+    expect(opts).toEqual({ credentials: 'include' })
+    expect(url).toMatch(/\/customers\?/)
+    const query = new URLSearchParams(String(url).split('?')[1])
+    expect(query.get('search')).toBe('aiko')
+    expect(query.get('sort')).toBe('bookingCount')
+    expect(query.get('cursor')).toBe('c_42')
+    expect(query.get('limit')).toBe('20')
+  })
+
+  it('omits empty search/sort/cursor but always sends a default limit', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: [], nextCursor: null }))
+
+    await fetchCustomers()
+
+    const query = new URLSearchParams(String(fetchMock.mock.calls[0]![0]).split('?')[1])
+    expect(query.has('search')).toBe(false)
+    expect(query.has('sort')).toBe(false)
+    expect(query.has('cursor')).toBe(false)
+    expect(query.get('limit')).toBe('20')
+  })
+
+  it('returns the validated rows and lifts nextCursor from the envelope sibling', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: [customer], nextCursor: 'cursor_next' }),
+    )
+
+    const page = await fetchCustomers()
+
+    expect(page.data).toEqual([customer])
+    expect(page.nextCursor).toBe('cursor_next')
+  })
+
+  it('treats a missing envelope nextCursor as the last page (null)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: [customer] }))
+
+    const page = await fetchCustomers()
+
+    expect(page.nextCursor).toBeNull()
+  })
+
+  it('rejects with a ParseError when a row drifts (bookingCount as a string)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: [{ ...customer, bookingCount: '3' }],
+        nextCursor: null,
+      }),
+    )
+
+    await expect(fetchCustomers()).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('fetchCustomerById', () => {
+  it('GETs /customers/:id and returns the validated booking history', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: customerWithBookings }))
+
+    const result = await fetchCustomerById('usr_1')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/customers/usr_1', { credentials: 'include' })
+    expect(result).toEqual(customerWithBookings)
+  })
+
+  it('maps a 404 to null rather than throwing', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: false, error: 'Customer not found' }, 404))
+
+    expect(await fetchCustomerById('missing')).toBeNull()
+  })
+
+  it('rejects with a ParseError when a booking carries an out-of-domain status', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: {
+          ...customerWithBookings,
+          bookings: [{ ...customerWithBookings.bookings[0], status: 'WAT' }],
+        },
+      }),
+    )
+
+    await expect(fetchCustomerById('usr_1')).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('query options', () => {
+  it('keys the list query by search, sort and cursor so each page caches separately', () => {
+    expect(customersQueryOptions({ search: 'aiko', sort: 'name', cursor: 'c_1' }).queryKey).toEqual(
+      [...ADMIN_CUSTOMERS_QUERY_KEY, 'list', 'aiko', 'name', 'c_1'],
+    )
+    expect(customersQueryOptions().queryKey).toEqual([
+      ...ADMIN_CUSTOMERS_QUERY_KEY,
+      'list',
+      null,
+      null,
+      null,
+    ])
+  })
+
+  it('disables the detail query until a customer is selected', () => {
+    expect(customerByIdQueryOptions(null).enabled).toBe(false)
+    expect(customerByIdQueryOptions('usr_1').enabled).toBe(true)
+  })
+})

--- a/packages/web/src/vite/admin/customers/api.ts
+++ b/packages/web/src/vite/admin/customers/api.ts
@@ -1,0 +1,129 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
+import type {
+  Customer,
+  CustomerBookingSummary,
+  CustomerSort,
+  CustomerWithBookings,
+} from '@kuruma/shared/types/customer'
+import { keepPreviousData, queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// Platform-admin customer directory (#1090, epic #1075). Wires the existing
+// PLATFORM_ADMIN-only customers API (`routes/customers.ts`): GET /customers
+// (cursor-paginated, search + sort) and GET /customers/:id (cross-operator
+// booking history). Cookie-based (`credentials: 'include'`) so the API gates on
+// the session role server-side — the page layer's `adminGuard` is UX only.
+
+export type { CustomerSort } from '@kuruma/shared/types/customer'
+
+export const ADMIN_CUSTOMERS_QUERY_KEY = ['admin-customers'] as const
+
+// Default page size — small enough to demo cursor pagination on the seed data.
+const DEFAULT_LIMIT = 20
+
+// Network-seam validators (#711) pinned to the shared customer DTOs via
+// `satisfies z.ZodType<...>`: the shared interface stays the single source of the
+// shape, while a renamed/dropped field fails typecheck HERE and a drifted runtime
+// body (e.g. `bookingCount` arriving as a string) surfaces as a ParseError at the
+// seam instead of a wrong/blank cell on the directory. The booking-status domain
+// anchors to the `@kuruma/shared/enums` SSoT so it can't drift from the DB pgEnum.
+const customerSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  language: z.string(),
+  country: z.string().nullable(),
+  bookingCount: z.number(),
+  lastBookingAt: z.string(),
+  totalSpent: z.number(),
+}) satisfies z.ZodType<Customer>
+
+const customerBookingSummarySchema = z.object({
+  id: z.string(),
+  vehicleId: z.string().nullable(),
+  vehicleName: z.string().nullable(),
+  startAt: z.string(),
+  endAt: z.string(),
+  status: z.enum(BOOKING_STATUSES),
+  totalPrice: z.number().nullable(),
+}) satisfies z.ZodType<CustomerBookingSummary>
+
+const customerWithBookingsSchema = customerSchema.extend({
+  bookings: z.array(customerBookingSummarySchema),
+}) satisfies z.ZodType<CustomerWithBookings>
+
+// `nextCursor` rides in the success envelope as a SIBLING of `data` (the API's
+// `ok(c, data, 200, { nextCursor })`), not inside it. `.catch(null)` degrades a
+// missing/garbage cursor to "no more pages" rather than throwing mid-pagination.
+const nextCursorSchema = z.string().nullable().catch(null)
+
+export interface CustomerListParams {
+  search?: string | undefined
+  sort?: CustomerSort | undefined
+  cursor?: string | undefined
+  limit?: number | undefined
+}
+
+export interface CustomerPage {
+  readonly data: Customer[]
+  readonly nextCursor: string | null
+}
+
+// One page of the directory. `unwrap()` returns only `data`, so we peek the
+// sibling `nextCursor` off a `clone()` BEFORE unwrap consumes the body, then
+// unwrap+validate the rows so the #711 seam still guards every cell. A failure
+// envelope (401/403) still throws an ApiError from `unwrap` carrying the status.
+export async function fetchCustomers(params: CustomerListParams = {}): Promise<CustomerPage> {
+  const sp = new URLSearchParams()
+  if (params.search) sp.set('search', params.search)
+  if (params.sort) sp.set('sort', params.sort)
+  if (params.cursor) sp.set('cursor', params.cursor)
+  sp.set('limit', String(params.limit ?? DEFAULT_LIMIT))
+
+  const res = await fetch(`${getApiBaseUrl()}/customers?${sp.toString()}`, {
+    credentials: 'include',
+  })
+  const envelope = (await res
+    .clone()
+    .json()
+    .catch(() => null)) as { nextCursor?: unknown } | null
+  const data = await unwrap(res, customerSchema.array())
+  return { data, nextCursor: nextCursorSchema.parse(envelope?.nextCursor ?? null) }
+}
+
+export function customersQueryOptions(params: CustomerListParams = {}) {
+  return queryOptions({
+    queryKey: [
+      ...ADMIN_CUSTOMERS_QUERY_KEY,
+      'list',
+      params.search ?? null,
+      params.sort ?? null,
+      params.cursor ?? null,
+    ],
+    queryFn: () => fetchCustomers(params),
+    // Hold the current page on screen while the next/searched page loads so the
+    // table doesn't flash empty between cursor steps.
+    placeholderData: keepPreviousData,
+  })
+}
+
+// Cross-operator booking history for one customer. IDOR is a non-issue here (the
+// route is PLATFORM_ADMIN-only), but a missing id still maps 404 -> null so a
+// stale drawer open shows the empty state rather than faulting the page.
+export async function fetchCustomerById(id: string): Promise<CustomerWithBookings | null> {
+  const res = await fetch(`${getApiBaseUrl()}/customers/${encodeURIComponent(id)}`, {
+    credentials: 'include',
+  })
+  if (res.status === 404) return null
+  return unwrap(res, customerWithBookingsSchema)
+}
+
+export function customerByIdQueryOptions(id: string | null) {
+  return queryOptions({
+    queryKey: [...ADMIN_CUSTOMERS_QUERY_KEY, 'detail', id],
+    queryFn: () => (id ? fetchCustomerById(id) : Promise.resolve(null)),
+    enabled: id != null,
+  })
+}

--- a/packages/web/src/vite/guards.test.ts
+++ b/packages/web/src/vite/guards.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { adminGuard } from './guards'
+import type { Session } from './session'
+
+function session(role: string, over: Partial<Session['user']> = {}): Session {
+  return { user: { id: 'usr_1', role, ...over }, csrfToken: 'csrf_1' }
+}
+
+describe('adminGuard', () => {
+  it('sends a signed-out caller to login', () => {
+    expect(adminGuard(null)).toEqual({ type: 'login' })
+  })
+
+  it('admits a PLATFORM_ADMIN', () => {
+    expect(adminGuard(session('PLATFORM_ADMIN'))).toEqual({ type: 'allow' })
+  })
+
+  it('forbids a tenant-scoped operator owner from the cross-tenant admin portal', () => {
+    // An OPERATOR_OWNER clears the business gate but must NOT reach /admin (#462 §2.3):
+    // the customers list is cross-operator PLATFORM_ADMIN-only data.
+    expect(adminGuard(session('OPERATOR_OWNER', { operatorId: 'op_1' }))).toEqual({
+      type: 'forbidden',
+    })
+  })
+
+  it('forbids operator staff', () => {
+    expect(adminGuard(session('OPERATOR_STAFF', { operatorId: 'op_1' }))).toEqual({
+      type: 'forbidden',
+    })
+  })
+})

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -1,11 +1,12 @@
 import { Link } from '@tanstack/react-router'
-import { Banknote, FileCheck, LayoutDashboard } from 'lucide-react'
+import { Banknote, FileCheck, LayoutDashboard, Users } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 const SIDEBAR_ITEMS = [
   { to: '/$locale/admin', icon: LayoutDashboard, labelKey: 'nav.overview' },
   { to: '/$locale/admin/revenue', icon: Banknote, labelKey: 'nav.revenue' },
   { to: '/$locale/admin/documents', icon: FileCheck, labelKey: 'nav.documents' },
+  { to: '/$locale/admin/customers', icon: Users, labelKey: 'nav.customers' },
 ] as const
 
 // Single static className; active state is the `aria-current="page"` attribute


### PR DESCRIPTION
## What

Slice #1090 of the platform-owner dashboard epic (#1075): a **PLATFORM_ADMIN-only customer directory** page. Web-only — it wires the existing `GET /customers` (cursor-paginated, search + sort) and `GET /customers/:id` (cross-operator booking history) routes already gated to `PLATFORM_ADMIN`. No API or schema changes.

- Directory table with search, sort, and cursor pagination (`keepPreviousData` holds the page on screen between cursor steps).
- Customer detail drawer with cross-operator booking history.
- Sidebar nav entry; route `/$locale/_admin/admin/customers` behind `adminGuard` (UX gate; the API gates server-side on the session role).

## Network seam (#711)

`api.ts` validators `satisfies z.ZodType<Customer | CustomerWithBookings>` so a renamed/dropped field fails typecheck and a drifted runtime body surfaces as a `ParseError` at the seam instead of a blank cell. `nextCursor` is lifted off the success envelope sibling via `res.clone()` before `unwrap()` consumes the body.

## Test plan

- [x] `api.test.ts` — 10 tests: params, default limit, nextCursor lift, ParseError on row/status drift, 404→null, query-key cache separation.
- [x] `CustomersView.test.tsx`, `CustomerDetailDrawer.test.tsx`, `guards.test.ts` — 27 tests total green.
- [x] Web typecheck green.
- [x] **Mutation-resistance fix (was the open MEDIUM):** the `jsonResponse` mock now models single-body-consumption with an independent `clone()`, so dropping the load-bearing `res.clone()` now fails 5 tests (verified). Previously the infinitely-re-readable stub let that regression pass.
- [x] i18n parity en/ja/zh.

Refs #1075
Closes #1090