### PR TITLE
feat(#1092): platform-admin booking oversight (gated GET /admin/bookings)

### DIFF
--- a/e2e/admin-portal.spec.ts
+++ b/e2e/admin-portal.spec.ts
@@ -84,7 +84,12 @@ test.describe('admin portal guard (#462 / #541)', () => {
     await page.goto('/en/admin')
 
     await expect(page.getByRole('link', { name: /partner revenue/i })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Bookings' })).toBeHidden()
+    // The renter global-nav's Bookings link must stay suppressed on /admin. Scope
+    // to `[data-global-nav]` so this asserts the global-nav leak only — the
+    // AdminSidebar now carries its own (visible) Bookings link (#1092).
+    await expect(
+      page.locator('[data-global-nav]').getByRole('link', { name: 'Bookings' }),
+    ).toBeHidden()
   })
 })
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ import { requestId } from './middleware/request-id'
 import { observability } from './observability/middleware'
 import { createAddOnRoutes } from './routes/add-ons'
 import { createAdminRoutes } from './routes/admin'
+import { createAdminBookingRoutes } from './routes/admin-bookings'
 import { createAdminRevenueRoutes } from './routes/admin-revenue'
 import { createAuthRoutes } from './routes/auth'
 import { createAvailabilityRoutes } from './routes/availability'
@@ -48,6 +49,7 @@ import { createVehicleDetailRoutes } from './routes/vehicle-detail'
 import { createVehiclePhotoRoutes } from './routes/vehicle-photos'
 import { createVehicleRoutes } from './routes/vehicles'
 import { AddOnService } from './services/add-on'
+import { AdminBookingService } from './services/admin-booking'
 import { AdminRevenueService } from './services/admin-revenue'
 import { type RecordAuditEvent, toAuditRow } from './services/audit'
 import { AvailabilityService } from './services/availability'
@@ -411,6 +413,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const fleetOverviewService = new FleetOverviewService(fleetOverviewRepo)
   const overviewService = new OverviewService(overviewRepo)
   const adminRevenueService = new AdminRevenueService(paymentEventRepo, operatorRepo)
+  const adminBookingService = new AdminBookingService(bookingRepo, operatorRepo, userRepo)
   const paymentAnomalyService = new PaymentAnomalyService(paymentAnomalyRepo)
   const vehicleDetailService = new VehicleDetailService(vehicleDetailRepo)
   const operatorService = new OperatorService(operatorRepo, recordAudit)
@@ -495,6 +498,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createStatsRoutes(statsRepo))
     .route('/', createOverviewRoutes(overviewService))
     .route('/', createAdminRevenueRoutes(adminRevenueService))
+    .route('/', createAdminBookingRoutes(adminBookingService))
     .route('/', createPaymentAnomalyRoutes(paymentAnomalyService))
     .route('/', createMessageRoutes(messageService))
     .route('/', createConsentRoutes(consentService))

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -1,9 +1,9 @@
 import { bookings } from '@kuruma/shared/db/schema'
-import { type SQL, and, count, desc, eq, inArray, lt, or, sql } from 'drizzle-orm'
+import { type SQL, and, count, desc, eq, ilike, inArray, lt, or, sql } from 'drizzle-orm'
 import { type CallerContext, ForbiddenError } from '../../middleware/auth'
 import type { Booking } from '../../stores'
 import { bookingReadScope } from '../../tenancy'
-import type { BookingFilters, BookingRepository } from '../types'
+import type { AdminBookingFilters, BookingFilters, BookingRepository } from '../types'
 import { type Db, bookingColumns, toBooking } from './shared'
 
 export class DrizzleBookingRepository implements BookingRepository {
@@ -78,6 +78,60 @@ export class DrizzleBookingRepository implements BookingRepository {
     }
 
     if (filters?.limit) {
+      query = query.limit(filters.limit) as typeof query
+    }
+
+    const rows = await query
+    return rows.map(toBooking)
+  }
+
+  // #1092: cross-operator oversight read. UNSCOPED — the platform-admin service
+  // gates the caller before this runs (mirrors the in-memory impl). bookingCode
+  // is a case-insensitive substring match; renterIds is a pre-resolved customer
+  // filter; an EMPTY renterIds array matches nothing (inArray over []).
+  async findForAdmin(filters: AdminBookingFilters): Promise<Booking[]> {
+    const conditions: SQL[] = []
+
+    if (filters.operatorId) {
+      conditions.push(eq(bookings.operatorId, filters.operatorId))
+    }
+    if (filters.bookingCode) {
+      conditions.push(ilike(bookings.bookingCode, `%${filters.bookingCode}%`))
+    }
+    if (filters.status) {
+      conditions.push(eq(bookings.status, filters.status as Booking['status']))
+    }
+    if (filters.renterIds) {
+      conditions.push(inArray(bookings.renterId, filters.renterIds))
+    }
+    if (filters.from && filters.to) {
+      const fromIso = filters.from.toISOString()
+      const toIso = filters.to.toISOString()
+      conditions.push(
+        sql`tstzrange("startAt", "effectiveEndAt") && tstzrange(${fromIso}::timestamptz, ${toIso}::timestamptz)`,
+      )
+    }
+    if (filters.cursor) {
+      const sep = filters.cursor.indexOf('_')
+      const cursorTime = filters.cursor.slice(0, sep)
+      const cursorId = filters.cursor.slice(sep + 1)
+      conditions.push(
+        or(
+          lt(bookings.createdAt, sql`${cursorTime}::timestamptz`),
+          and(eq(bookings.createdAt, sql`${cursorTime}::timestamptz`), lt(bookings.id, cursorId)),
+        )!,
+      )
+    }
+
+    let query = this.db
+      .select(bookingColumns)
+      .from(bookings)
+      .orderBy(desc(bookings.createdAt), desc(bookings.id))
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions)) as typeof query
+    }
+    if (filters.limit) {
       query = query.limit(filters.limit) as typeof query
     }
 

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -2,7 +2,7 @@ import { type CallerContext, ForbiddenError } from '../../middleware/auth'
 import { BOOKING_CODE_CONSTRAINT, IDEMPOTENCY_CONSTRAINT, PG_ERROR } from '../../pg-errors'
 import type { Booking } from '../../stores'
 import { bookingReadScope } from '../../tenancy'
-import type { BookingFilters, BookingRepository } from '../types'
+import type { AdminBookingFilters, BookingFilters, BookingRepository } from '../types'
 
 export const BLOCKING_STATUSES: ReadonlySet<Booking['status']> = new Set(['CONFIRMED', 'ACTIVE'])
 
@@ -124,6 +124,56 @@ export class InMemoryBookingRepository implements BookingRepository {
     }
 
     if (filters?.limit) {
+      results = results.slice(0, filters.limit)
+    }
+
+    return results
+  }
+
+  // #1092: cross-operator oversight read. UNSCOPED on purpose — the
+  // platform-admin service gates the caller before this runs. Mirrors the
+  // Drizzle impl's ordering (createdAt DESC, id DESC) and cursor semantics.
+  async findForAdmin(filters: AdminBookingFilters): Promise<Booking[]> {
+    let results = [...this.store.values()]
+
+    if (filters.operatorId) {
+      results = results.filter((b) => b.operatorId === filters.operatorId)
+    }
+    if (filters.bookingCode) {
+      const needle = filters.bookingCode.toLowerCase()
+      results = results.filter((b) => b.bookingCode.toLowerCase().includes(needle))
+    }
+    if (filters.status) {
+      results = results.filter((b) => b.status === filters.status)
+    }
+    if (filters.renterIds) {
+      const ids = new Set(filters.renterIds)
+      results = results.filter((b) => ids.has(b.renterId))
+    }
+    if (filters.from && filters.to) {
+      const from = filters.from
+      const to = filters.to
+      results = results.filter((b) => b.startAt < to && b.effectiveEndAt > from)
+    }
+
+    results.sort((a, b) => {
+      const timeDiff = b.createdAt.getTime() - a.createdAt.getTime()
+      if (timeDiff !== 0) return timeDiff
+      return b.id < a.id ? -1 : 1
+    })
+
+    if (filters.cursor) {
+      const sep = filters.cursor.indexOf('_')
+      const cursorTime = new Date(filters.cursor.slice(0, sep))
+      const cursorId = filters.cursor.slice(sep + 1)
+      results = results.filter((b) => {
+        if (b.createdAt.getTime() < cursorTime.getTime()) return true
+        if (b.createdAt.getTime() === cursorTime.getTime() && b.id < cursorId) return true
+        return false
+      })
+    }
+
+    if (filters.limit) {
       results = results.slice(0, filters.limit)
     }
 

--- a/packages/api/src/repositories/types-admin-booking.ts
+++ b/packages/api/src/repositories/types-admin-booking.ts
@@ -1,0 +1,25 @@
+/**
+ * Cross-operator oversight filters for the platform-admin booking surface
+ * (#1092). Extracted from the `types.ts` barrel to keep it under the file-size
+ * cap (mirrors the consent/payment/review split); re-exported from there.
+ *
+ * UNSCOPED by design — there is no CallerContext here: `findForAdmin` reads
+ * across every tenant, so `AdminBookingService` is the authz chokepoint (it
+ * calls `requirePlatformAdmin` BEFORE this method, mirroring how
+ * `paymentEvents.listSucceeded` backs the platform-only revenue report).
+ *
+ * `renterIds` is a pre-resolved customer filter (the service maps a name/email
+ * search to renter ids via UserRepository, never the repo). `bookingCode` is a
+ * case-insensitive substring match. An empty `renterIds`/`status` is "match
+ * nothing" — the service supplies an absent (not empty) filter to mean "any".
+ */
+export interface AdminBookingFilters {
+  operatorId?: string
+  bookingCode?: string
+  status?: string
+  renterIds?: string[]
+  from?: Date
+  to?: Date
+  limit?: number
+  cursor?: string
+}

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -52,6 +52,7 @@ import type {
   VehicleClass,
 } from '../stores'
 // Imported (not just re-exported) because the RepoBundle below references it locally.
+import type { AdminBookingFilters } from './types-admin-booking'
 import type { BookingEventRepository } from './types-booking-event'
 
 // Payment interfaces (#461 events, #508 anomalies, #851 refunds) live in their own module (size cap); re-exported.
@@ -86,6 +87,7 @@ export type { ComplianceAlertLogRepository, RecordComplianceAlert } from './type
 
 // Audit ledger entity + insert-only persistence (#930), own module per #837 cap.
 export type { AuditLogEntry, AuditLogRepository } from './types-audit'
+export type { AdminBookingFilters }
 export type { BookingEventRepository }
 
 /** Operator (tenant) data access. Admin bootstrap (#386) + slug/id resolution (#387). */
@@ -407,29 +409,6 @@ export interface BookingFilters {
   status?: string
   vehicleId?: string
   renterId?: string
-  from?: Date
-  to?: Date
-  limit?: number
-  cursor?: string
-}
-
-/**
- * Cross-operator oversight filters for the platform-admin booking surface
- * (#1092). UNSCOPED by design — there is no CallerContext here: `findForAdmin`
- * reads across every tenant, so {@link AdminBookingService} is the authz
- * chokepoint (it calls `requirePlatformAdmin` BEFORE this method, mirroring how
- * `paymentEvents.listSucceeded` backs the platform-only revenue report).
- *
- * `renterIds` is a pre-resolved customer filter (the service maps a name/email
- * search to renter ids via UserRepository, never the repo). `bookingCode` is a
- * case-insensitive substring match. An empty `renterIds`/`status` is "match
- * nothing" — the service supplies an absent (not empty) filter to mean "any".
- */
-export interface AdminBookingFilters {
-  operatorId?: string
-  bookingCode?: string
-  status?: string
-  renterIds?: string[]
   from?: Date
   to?: Date
   limit?: number

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -413,10 +413,39 @@ export interface BookingFilters {
   cursor?: string
 }
 
+/**
+ * Cross-operator oversight filters for the platform-admin booking surface
+ * (#1092). UNSCOPED by design — there is no CallerContext here: `findForAdmin`
+ * reads across every tenant, so {@link AdminBookingService} is the authz
+ * chokepoint (it calls `requirePlatformAdmin` BEFORE this method, mirroring how
+ * `paymentEvents.listSucceeded` backs the platform-only revenue report).
+ *
+ * `renterIds` is a pre-resolved customer filter (the service maps a name/email
+ * search to renter ids via UserRepository, never the repo). `bookingCode` is a
+ * case-insensitive substring match. An empty `renterIds`/`status` is "match
+ * nothing" — the service supplies an absent (not empty) filter to mean "any".
+ */
+export interface AdminBookingFilters {
+  operatorId?: string
+  bookingCode?: string
+  status?: string
+  renterIds?: string[]
+  from?: Date
+  to?: Date
+  limit?: number
+  cursor?: string
+}
+
 export type { CallerContext } from '../middleware/auth'
 
 export interface BookingRepository {
   findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]>
+  /**
+   * Cross-operator oversight read (#1092). UNSCOPED — returns bookings across
+   * every tenant in (createdAt DESC, id DESC) order. Gate at the service with
+   * `requirePlatformAdmin`; never expose to a tenant or PARTNER caller.
+   */
+  findForAdmin(filters: AdminBookingFilters): Promise<Booking[]>
   findById(ctx: CallerContext, id: string): Promise<Booking | undefined>
   findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined>
   /** Counts bookings in BLOCKING_STATUSES (CONFIRMED, ACTIVE) for the given

--- a/packages/api/src/routes/admin-bookings.ts
+++ b/packages/api/src/routes/admin-bookings.ts
@@ -1,0 +1,56 @@
+import { BOOKING_STATUSES, type BookingStatus } from '@kuruma/shared/enums'
+import { Hono } from 'hono'
+import { requireAuth, requirePlatformAdmin, requireUser, toCallerContext } from '../middleware/auth'
+import type { AdminBookingListInput, AdminBookingService } from '../services/admin-booking'
+import { fail, ok, parseDateRange, parseLimit } from './helpers'
+
+function isBookingStatus(value: string): value is BookingStatus {
+  return (BOOKING_STATUSES as readonly string[]).includes(value)
+}
+
+/**
+ * Platform-admin cross-operator booking oversight (#1092). Cross-tenant by
+ * nature, so `requireAuth` gates the path and `requirePlatformAdmin` narrows it
+ * to PLATFORM_ADMIN — OPERATOR_* / RENTER / PARTNER are all rejected (PARTNER is
+ * excluded deliberately; the un-gated `GET /bookings` PARTNER exposure is #1119)
+ * — and the service re-asserts the gate as defence-in-depth. Filters: operator,
+ * bookingCode, customer (name/email), status, date range, cursor pagination.
+ */
+export function createAdminBookingRoutes(service: AdminBookingService) {
+  const app = new Hono()
+  app.use('/admin/bookings', requireAuth())
+
+  return app.get('/admin/bookings', async (c) => {
+    const ctx = toCallerContext(requireUser(c))
+    requirePlatformAdmin(ctx)
+
+    const status = c.req.query('status')
+    if (status !== undefined && !isBookingStatus(status)) {
+      return fail(c, `Invalid status — expected one of ${BOOKING_STATUSES.join(', ')}`, 400)
+    }
+
+    const dateRange = parseDateRange(c, false)
+    if (!dateRange.ok) return dateRange.response
+
+    const pg = parseLimit(c, { defaultLimit: 20 })
+    if (!pg.ok) return pg.response
+
+    const input: AdminBookingListInput = { limit: pg.limit }
+    const operatorId = c.req.query('operatorId')
+    const bookingCode = c.req.query('bookingCode')
+    const customer = c.req.query('customer')
+    const cursor = c.req.query('cursor')
+    if (operatorId) input.operatorId = operatorId
+    if (bookingCode) input.bookingCode = bookingCode
+    if (customer) input.customer = customer
+    if (status) input.status = status
+    if (cursor) input.cursor = cursor
+    if (dateRange.from && dateRange.to) {
+      input.from = dateRange.from
+      input.to = dateRange.to
+    }
+
+    const result = await service.list(ctx, input)
+    return ok(c, result)
+  })
+}

--- a/packages/api/src/services/admin-booking.ts
+++ b/packages/api/src/services/admin-booking.ts
@@ -1,0 +1,113 @@
+import type { AdminBookingDto, AdminBookingsResponse } from '@kuruma/shared/types/admin-booking'
+import { type CallerContext, requirePlatformAdmin } from '../middleware/auth'
+import type {
+  AdminBookingFilters,
+  BookingRepository,
+  OperatorRepository,
+  UserRepository,
+} from '../repositories/types'
+import type { Booking, Operator, User } from '../stores'
+
+/** Route-facing oversight filters (#1092). `customer` is a free-text name/email
+ *  search the service resolves to renter ids; everything else maps straight onto
+ *  {@link AdminBookingFilters}. All optional — absent means "any". */
+export interface AdminBookingListInput {
+  operatorId?: string
+  bookingCode?: string
+  customer?: string
+  status?: string
+  from?: Date
+  to?: Date
+  cursor?: string
+  limit?: number
+}
+
+const DEFAULT_LIMIT = 20
+
+/**
+ * Platform-admin cross-operator booking oversight (#1092, epic #1075 slice 6).
+ * Imperative shell: it gates the caller (`requirePlatformAdmin` — PLATFORM_ADMIN
+ * only, PARTNER excluded), resolves a customer search to renter ids, reads the
+ * UNSCOPED `findForAdmin`, then enriches each row with operator + renter identity
+ * the renter DTO lacks. `requirePlatformAdmin` lives here (not only at the route)
+ * so the gate travels with the business logic — `findForAdmin` is cross-operator,
+ * so this service is the authz chokepoint (mirrors #462 revenue / #508 anomalies).
+ */
+export class AdminBookingService {
+  constructor(
+    private readonly bookings: BookingRepository,
+    private readonly operators: OperatorRepository,
+    private readonly users: UserRepository,
+  ) {}
+
+  async list(ctx: CallerContext, input: AdminBookingListInput): Promise<AdminBookingsResponse> {
+    requirePlatformAdmin(ctx)
+
+    const limit = input.limit ?? DEFAULT_LIMIT
+
+    // A customer search resolves to a renter-id set FIRST. No match ⇒ no booking
+    // can match, so we short-circuit before touching the bookings table.
+    let renterIds: string[] | undefined
+    if (input.customer) {
+      const matches = await this.users.search(input.customer)
+      if (matches.length === 0) return { bookings: [], nextCursor: null }
+      renterIds = matches.map((u) => u.id)
+    }
+
+    const filters: AdminBookingFilters = { limit: limit + 1 } // overfetch by 1 to detect more
+    if (input.operatorId) filters.operatorId = input.operatorId
+    if (input.bookingCode) filters.bookingCode = input.bookingCode
+    if (input.status) filters.status = input.status
+    if (renterIds) filters.renterIds = renterIds
+    if (input.from && input.to) {
+      filters.from = input.from
+      filters.to = input.to
+    }
+    if (input.cursor) filters.cursor = input.cursor
+
+    const rows = await this.bookings.findForAdmin(filters)
+    const hasMore = rows.length > limit
+    const page = hasMore ? rows.slice(0, limit) : rows
+    const last = page[page.length - 1]
+    const nextCursor = hasMore && last ? `${last.createdAt.toISOString()}_${last.id}` : null
+
+    const [operators, renters] = await Promise.all([
+      this.operators.list(),
+      this.users.findByIds([...new Set(page.map((b) => b.renterId))]),
+    ])
+    const operatorsById = new Map<string, Operator>(operators.map((o) => [o.id, o]))
+    const rentersById = new Map<string, User>(renters.map((u) => [u.id, u]))
+
+    return {
+      bookings: page.map((b) => toAdminDto(b, operatorsById, rentersById)),
+      nextCursor,
+    }
+  }
+}
+
+function toAdminDto(
+  b: Booking,
+  operatorsById: Map<string, Operator>,
+  rentersById: Map<string, User>,
+): AdminBookingDto {
+  const operator = operatorsById.get(b.operatorId)
+  const renter = rentersById.get(b.renterId)
+  return {
+    id: b.id,
+    bookingCode: b.bookingCode,
+    status: b.status,
+    operatorId: b.operatorId,
+    // A deleted/unknown operator falls back to its id so the row is never blank.
+    operatorName: operator?.name ?? b.operatorId,
+    renterId: b.renterId,
+    renterName: renter?.name ?? null,
+    renterEmail: renter?.email ?? null,
+    pickupLocationId: b.pickupLocationId,
+    dropoffLocationId: b.dropoffLocationId,
+    startAt: b.startAt.toISOString(),
+    endAt: b.endAt.toISOString(),
+    effectiveEndAt: b.effectiveEndAt.toISOString(),
+    totalPrice: b.totalPrice,
+    createdAt: b.createdAt.toISOString(),
+  }
+}

--- a/packages/api/src/services/filters.ts
+++ b/packages/api/src/services/filters.ts
@@ -16,6 +16,7 @@
  */
 export type {
   AddOnFilters,
+  AdminBookingFilters,
   BookingFilters,
   FeeScheduleFilters,
   InsuranceOptionFilters,

--- a/packages/api/tests/routes/admin-bookings-verify.test.ts
+++ b/packages/api/tests/routes/admin-bookings-verify.test.ts
@@ -1,0 +1,95 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import type { UserRole } from '../../src/middleware/auth'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
+import type { RunInTransaction } from '../../src/repositories/types'
+import { createBookingRoutes } from '../../src/routes/bookings'
+import { BookingService } from '../../src/services/booking'
+import type { Booking } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+import { bookingInput } from '../helpers/booking'
+import { makeInertConsentGate } from '../helpers/consent'
+
+// #1092 STEP 1 — VERIFY-FIRST. The slice decision (#1092 "✅ Decisions") is to
+// BUILD a dedicated `GET /admin/bookings`. This test is the recorded evidence for
+// WHY the existing `GET /bookings` cannot carry the platform-owner oversight page.
+// It establishes three code-grounded facts:
+//   1. A PLATFORM_ADMIN's `GET /bookings` DOES already return cross-operator rows
+//      (>=2 distinct operatorId) — cross-operator READ is not the gap.
+//   2. A PARTNER (Trip.com) gets the SAME cross-operator rows — `GET /bookings` is
+//      ungated (requireUser only) and scopes on `bypassScope`, which PARTNER
+//      shares. So it is NOT platform-only (the gap tracked separately as #1119).
+//   3. The raw row carries `operatorId` but NOT operator identity (name) nor any
+//      customer (renter name/email) — an oversight table cannot say WHICH operator
+//      or WHO booked. Plus it offers no operator/bookingCode/customer filters.
+// VERDICT: build `GET /admin/bookings` (platform-gated) with an admin DTO that
+// includes operator + customer identity and the oversight filters.
+
+const OP_A = '00000000-0000-4000-8000-00000000a001'
+const OP_B = '00000000-0000-4000-8000-00000000b001'
+
+const noopTx: RunInTransaction = (async () => {
+  throw new Error('transactions are not exercised by the GET /bookings read path')
+}) as unknown as RunInTransaction
+
+function fullBooking(overrides: Partial<Booking>): Booking {
+  const base = bookingInput(overrides)
+  return {
+    ...base,
+    id: crypto.randomUUID(),
+    cancellationFeeSettlement: 'ADVISORY',
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    updatedAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+function mountBookingsAs(role: UserRole) {
+  const store = new Map<string, Booking>()
+  for (const b of [
+    fullBooking({ operatorId: OP_A, assignedVehicleId: 'veh-a', requestedVehicleId: 'veh-a' }),
+    fullBooking({ operatorId: OP_B, assignedVehicleId: 'veh-b', requestedVehicleId: 'veh-b' }),
+  ]) {
+    store.set(b.id, b)
+  }
+  const bookingRepo = new InMemoryBookingRepository(store)
+  const service = new BookingService(bookingRepo, noopTx)
+  const app = new Hono()
+  app.use('*', testAuthMiddleware(`${role}-user`, role))
+  app.route('/', createBookingRoutes(service, makeInertConsentGate()))
+  return app
+}
+
+describe('#1092 verify-first: GET /bookings cross-operator behaviour', () => {
+  it('PLATFORM_ADMIN sees rows from >=2 distinct operators (cross-operator read already works)', async () => {
+    const res = await mountBookingsAs('PLATFORM_ADMIN').request('/bookings')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    const operatorIds = new Set(data.map((b: { operatorId: string }) => b.operatorId))
+    expect(operatorIds).toEqual(new Set([OP_A, OP_B]))
+  })
+
+  it('PARTNER gets the SAME cross-operator rows — GET /bookings is NOT platform-only (#1119)', async () => {
+    const res = await mountBookingsAs('PARTNER').request('/bookings')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    // PARTNER shares bypassScope (shared/auth/roles.ts SCOPE_BYPASS_ROLES), so it
+    // reaches every tenant's bookings here. This is exactly why platform-owner
+    // oversight cannot ride this endpoint — it needs requirePlatformAdmin.
+    const operatorIds = new Set(data.map((b: { operatorId: string }) => b.operatorId))
+    expect(operatorIds).toEqual(new Set([OP_A, OP_B]))
+  })
+
+  it('the raw row carries operatorId but NO operator name or customer identity (the DTO gap)', async () => {
+    const res = await mountBookingsAs('PLATFORM_ADMIN').request('/bookings')
+    const { data } = await res.json()
+    const [row] = data as Array<Record<string, unknown>>
+    // operatorId is present at the API level (the web bookingDtoSchema strips it)...
+    expect(typeof row.operatorId).toBe('string')
+    // ...but there is no operator display name and no renter identity, so an
+    // oversight table cannot show WHICH operator or WHO booked.
+    expect('operator' in row).toBe(false)
+    expect('operatorName' in row).toBe(false)
+    expect('renter' in row).toBe(false)
+  })
+})

--- a/packages/api/tests/routes/admin-bookings.test.ts
+++ b/packages/api/tests/routes/admin-bookings.test.ts
@@ -1,0 +1,239 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import { ForbiddenError, type UserRole } from '../../src/middleware/auth'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
+import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
+import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
+import { createAdminBookingRoutes } from '../../src/routes/admin-bookings'
+import { AdminBookingService } from '../../src/services/admin-booking'
+import type { Booking, Operator, User } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+import { bookingInput } from '../helpers/booking'
+
+const OP_A = '00000000-0000-4000-8000-00000000a001'
+const OP_B = '00000000-0000-4000-8000-00000000b001'
+const RENTER_1 = '00000000-0000-4000-8000-0000000000r1'
+const RENTER_2 = '00000000-0000-4000-8000-0000000000r2'
+
+function operator(id: string, name: string, slug: string): Operator {
+  return { id, name, slug, preAuthHandoffUrl: null, createdAt: new Date(), updatedAt: new Date() }
+}
+
+function renter(id: string, name: string, email: string): User {
+  return {
+    id,
+    name,
+    email,
+    phone: null,
+    language: 'en',
+    country: null,
+    role: 'RENTER',
+  }
+}
+
+function fullBooking(overrides: Partial<Booking>): Booking {
+  const base = bookingInput(overrides)
+  return {
+    ...base,
+    id: crypto.randomUUID(),
+    cancellationFeeSettlement: 'ADVISORY',
+    createdAt: overrides.createdAt ?? new Date('2026-05-01T00:00:00Z'),
+    updatedAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+function seeded() {
+  const operators = new Map<string, Operator>([
+    [OP_A, operator(OP_A, 'Best Car Rental', 'best-car')],
+    [OP_B, operator(OP_B, 'Aoki Rentals', 'aoki')],
+  ])
+  const users = new Map<string, User>([
+    [RENTER_1, renter(RENTER_1, 'Alice Tan', 'alice@example.com')],
+    [RENTER_2, renter(RENTER_2, 'Bob Lee', 'bob@example.com')],
+  ])
+  const bookings = new Map<string, Booking>()
+  for (const b of [
+    fullBooking({
+      operatorId: OP_A,
+      renterId: RENTER_1,
+      bookingCode: 'ALPHA001',
+      assignedVehicleId: 'veh-a1',
+      requestedVehicleId: 'veh-a1',
+      createdAt: new Date('2026-05-01T00:00:00Z'),
+    }),
+    fullBooking({
+      operatorId: OP_B,
+      renterId: RENTER_2,
+      bookingCode: 'BETA0002',
+      status: 'COMPLETED',
+      assignedVehicleId: 'veh-b1',
+      requestedVehicleId: 'veh-b1',
+      createdAt: new Date('2026-05-02T00:00:00Z'),
+    }),
+    fullBooking({
+      operatorId: OP_A,
+      renterId: RENTER_2,
+      bookingCode: 'ALPHA003',
+      assignedVehicleId: 'veh-a2',
+      requestedVehicleId: 'veh-a2',
+      createdAt: new Date('2026-05-03T00:00:00Z'),
+    }),
+  ]) {
+    bookings.set(b.id, b)
+  }
+  return {
+    bookingRepo: new InMemoryBookingRepository(bookings),
+    operatorRepo: new InMemoryOperatorRepository(operators),
+    userRepo: new InMemoryUserRepository(users),
+  }
+}
+
+function makeService() {
+  const { bookingRepo, operatorRepo, userRepo } = seeded()
+  return new AdminBookingService(bookingRepo, operatorRepo, userRepo)
+}
+
+function mount(role: UserRole, operatorId?: string) {
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createAdminBookingRoutes(makeService()))
+  return app
+}
+
+describe('GET /admin/bookings — auth', () => {
+  it('401 when unauthenticated', async () => {
+    const app = new Hono()
+    app.route('/', createAdminBookingRoutes(makeService()))
+    expect((await app.request('/admin/bookings')).status).toBe(401)
+  })
+
+  it.each(['RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
+    '403 for %s (not a platform admin — PARTNER excluded #1119, legacy STAFF/ADMIN revoked #487)',
+    async (role) => {
+      expect((await mount(role).request('/admin/bookings')).status).toBe(403)
+    },
+  )
+
+  it.each(['OPERATOR_OWNER', 'OPERATOR_STAFF'] as const)(
+    '403 for %s (a tenant must never reach cross-operator oversight)',
+    async (role) => {
+      expect((await mount(role, OP_A).request('/admin/bookings')).status).toBe(403)
+    },
+  )
+
+  it('200 for PLATFORM_ADMIN', async () => {
+    expect((await mount('PLATFORM_ADMIN').request('/admin/bookings')).status).toBe(200)
+  })
+})
+
+describe('AdminBookingService — defence-in-depth seal (service re-asserts the gate)', () => {
+  it.each(['OPERATOR_OWNER', 'OPERATOR_STAFF', 'RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
+    'throws ForbiddenError for %s even if the route gate were bypassed',
+    async (role) => {
+      await expect(makeService().list({ userId: `${role}-user`, role }, {})).rejects.toThrow(
+        ForbiddenError,
+      )
+    },
+  )
+})
+
+describe('GET /admin/bookings — admin DTO carries operator + customer identity', () => {
+  it('every row exposes operatorId, operatorName, and the renter identity', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings')
+    const { data } = await res.json()
+    expect(data.bookings).toHaveLength(3)
+
+    // Newest first (createdAt DESC): ALPHA003, BETA0002, ALPHA001.
+    expect(data.bookings.map((b: { bookingCode: string }) => b.bookingCode)).toEqual([
+      'ALPHA003',
+      'BETA0002',
+      'ALPHA001',
+    ])
+
+    const alpha001 = data.bookings.find(
+      (b: { bookingCode: string }) => b.bookingCode === 'ALPHA001',
+    )
+    expect(alpha001).toMatchObject({
+      operatorId: OP_A,
+      operatorName: 'Best Car Rental',
+      renterId: RENTER_1,
+      renterName: 'Alice Tan',
+      renterEmail: 'alice@example.com',
+      status: 'CONFIRMED',
+    })
+  })
+})
+
+describe('GET /admin/bookings — filters', () => {
+  it('filter by operator returns only that operator rows', async () => {
+    const res = await mount('PLATFORM_ADMIN').request(`/admin/bookings?operatorId=${OP_A}`)
+    const { data } = await res.json()
+    expect(data.bookings.map((b: { bookingCode: string }) => b.bookingCode)).toEqual([
+      'ALPHA003',
+      'ALPHA001',
+    ])
+    expect(data.bookings.every((b: { operatorId: string }) => b.operatorId === OP_A)).toBe(true)
+  })
+
+  it('bookingCode search is a case-insensitive substring match', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings?bookingCode=beta')
+    const { data } = await res.json()
+    expect(data.bookings).toHaveLength(1)
+    expect(data.bookings[0].bookingCode).toBe('BETA0002')
+  })
+
+  it('customer search resolves name/email to renter rows', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings?customer=bob@example.com')
+    const { data } = await res.json()
+    // Bob (RENTER_2) booked BETA0002 and ALPHA003.
+    expect(data.bookings.map((b: { bookingCode: string }) => b.bookingCode).sort()).toEqual([
+      'ALPHA003',
+      'BETA0002',
+    ])
+  })
+
+  it('customer search with no match returns an empty page (never an unfiltered list)', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings?customer=nobody')
+    const { data } = await res.json()
+    expect(data.bookings).toEqual([])
+    expect(data.nextCursor).toBeNull()
+  })
+
+  it('filter by status returns only matching rows', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings?status=COMPLETED')
+    const { data } = await res.json()
+    expect(data.bookings.map((b: { bookingCode: string }) => b.bookingCode)).toEqual(['BETA0002'])
+  })
+
+  it('400 for an unknown status value', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/bookings?status=BOGUS')
+    expect(res.status).toBe(400)
+  })
+
+  it('paginates with limit + cursor (newest first, stable)', async () => {
+    // ONE app instance across both requests so the page-1 cursor (createdAt + id)
+    // resolves against the same rows on page 2 (a fresh mount() would re-seed with
+    // new random ids and the cursor would no longer match).
+    const app = mount('PLATFORM_ADMIN')
+
+    const first = await app.request('/admin/bookings?limit=2')
+    const firstBody = (await first.json()).data
+    expect(firstBody.bookings.map((b: { bookingCode: string }) => b.bookingCode)).toEqual([
+      'ALPHA003',
+      'BETA0002',
+    ])
+    expect(firstBody.nextCursor).not.toBeNull()
+
+    const next = await app.request(
+      `/admin/bookings?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor)}`,
+    )
+    const nextBody = (await next.json()).data
+    expect(nextBody.bookings.map((b: { bookingCode: string }) => b.bookingCode)).toEqual([
+      'ALPHA001',
+    ])
+    expect(nextBody.nextCursor).toBeNull()
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,6 +34,7 @@
     "./types/insurance-option": "./src/types/insurance-option.ts",
     "./types/storefront": "./src/types/storefront.ts",
     "./types/operator-team": "./src/types/operator-team.ts",
+    "./types/admin-booking": "./src/types/admin-booking.ts",
     "./lib/bound-fetch": "./src/lib/bound-fetch.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/error-codes": "./src/lib/error-codes.ts",

--- a/packages/shared/src/types/admin-booking.ts
+++ b/packages/shared/src/types/admin-booking.ts
@@ -1,0 +1,49 @@
+import type { BookingStatus } from '../enums'
+
+/**
+ * Platform-admin cross-operator booking oversight (#1092, epic #1075 slice 6).
+ *
+ * The platform owner searches/inspects ANY booking across every operator. The
+ * renter-facing booking DTO (`web/.../bookings/api.ts`) deliberately omits
+ * `operatorId` and carries no operator/customer identity, so it cannot answer
+ * "which operator owns this row and who booked it" — this admin projection adds
+ * exactly that. Served ONLY by `GET /admin/bookings`, which is gated to
+ * PLATFORM_ADMIN (the service re-asserts the gate); PARTNER is excluded (the
+ * un-gated `GET /bookings` PARTNER exposure is tracked separately as #1119).
+ *
+ * This is the WIRE contract the API returns and the web consumes — web cannot
+ * import the Drizzle schema, so the shape lives here. Dates are ISO 8601 strings
+ * (JSON has no Date); amounts are whole JPY.
+ */
+export interface AdminBookingDto {
+  id: string
+  bookingCode: string
+  status: BookingStatus
+  /** Owning tenant + its display name, joined in for the oversight table. */
+  operatorId: string
+  operatorName: string
+  /** The customer who booked. `renterName`/`renterEmail` may be null (walk-in). */
+  renterId: string
+  renterName: string | null
+  renterEmail: string | null
+  pickupLocationId: string
+  dropoffLocationId: string
+  /** ISO 8601 (UTC). */
+  startAt: string
+  endAt: string
+  effectiveEndAt: string
+  /** Whole JPY; null until priced/snapshotted. */
+  totalPrice: number | null
+  /** ISO 8601 (UTC). When the booking was created — the list sort key. */
+  createdAt: string
+}
+
+/**
+ * Response body of `GET /admin/bookings` (newest first, cursor-paginated).
+ * `nextCursor` is the opaque `<createdAtIso>_<id>` handle for the next page, or
+ * null when the last page has been reached.
+ */
+export interface AdminBookingsResponse {
+  bookings: AdminBookingDto[]
+  nextCursor: string | null
+}

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1232,12 +1232,47 @@
   "admin": {
     "nav": {
       "overview": "Overview",
+      "bookings": "Bookings",
       "revenue": "Partner Revenue",
       "documents": "Documents"
     },
     "home": {
       "title": "Platform Admin",
       "subtitle": "Platform operations"
+    },
+    "bookings": {
+      "title": "Booking oversight",
+      "subtitle": "Search and inspect any booking across every operator.",
+      "empty": "No bookings match these filters.",
+      "search": "Search",
+      "clear": "Clear",
+      "allStatuses": "All statuses",
+      "filterCustomer": "Customer",
+      "filterCustomerPlaceholder": "Name or email",
+      "filterBookingCode": "Booking code",
+      "filterBookingCodePlaceholder": "e.g. ALPHA001",
+      "filterStatus": "Status",
+      "colOperator": "Operator",
+      "colBookingCode": "Code",
+      "colCustomer": "Customer",
+      "colStatus": "Status",
+      "colStart": "Start",
+      "status": {
+        "CONFIRMED": "Confirmed",
+        "ACTIVE": "Active",
+        "COMPLETED": "Completed",
+        "CANCELLED": "Cancelled"
+      },
+      "detailCustomer": "Customer",
+      "detailEmail": "Email",
+      "detailOperatorId": "Operator ID",
+      "detailStart": "Pickup",
+      "detailEnd": "Return",
+      "detailTotal": "Total",
+      "detailPickup": "Pickup location",
+      "detailDropoff": "Dropoff location",
+      "loadError": "Couldn't load bookings.",
+      "retry": "Retry"
     },
     "revenue": {
       "title": "Partner Revenue",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1232,12 +1232,47 @@
   "admin": {
     "nav": {
       "overview": "概要",
+      "bookings": "予約",
       "revenue": "パートナー収益",
       "documents": "書類"
     },
     "home": {
       "title": "プラットフォーム管理",
       "subtitle": "プラットフォーム運営"
+    },
+    "bookings": {
+      "title": "予約管理",
+      "subtitle": "全事業者の予約を検索・確認します。",
+      "empty": "条件に一致する予約はありません。",
+      "search": "検索",
+      "clear": "クリア",
+      "allStatuses": "すべてのステータス",
+      "filterCustomer": "お客様",
+      "filterCustomerPlaceholder": "氏名またはメール",
+      "filterBookingCode": "予約コード",
+      "filterBookingCodePlaceholder": "例: ALPHA001",
+      "filterStatus": "ステータス",
+      "colOperator": "事業者",
+      "colBookingCode": "コード",
+      "colCustomer": "お客様",
+      "colStatus": "ステータス",
+      "colStart": "開始",
+      "status": {
+        "CONFIRMED": "確定",
+        "ACTIVE": "利用中",
+        "COMPLETED": "完了",
+        "CANCELLED": "キャンセル"
+      },
+      "detailCustomer": "お客様",
+      "detailEmail": "メール",
+      "detailOperatorId": "事業者ID",
+      "detailStart": "貸出",
+      "detailEnd": "返却",
+      "detailTotal": "合計",
+      "detailPickup": "貸出場所",
+      "detailDropoff": "返却場所",
+      "loadError": "予約を読み込めませんでした。",
+      "retry": "再試行"
     },
     "revenue": {
       "title": "パートナー収益",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1232,12 +1232,47 @@
   "admin": {
     "nav": {
       "overview": "概览",
+      "bookings": "预订",
       "revenue": "合作伙伴收益",
       "documents": "证件"
     },
     "home": {
       "title": "平台管理",
       "subtitle": "平台运营"
+    },
+    "bookings": {
+      "title": "预订总览",
+      "subtitle": "搜索并查看所有运营商的任意预订。",
+      "empty": "没有符合筛选条件的预订。",
+      "search": "搜索",
+      "clear": "清除",
+      "allStatuses": "全部状态",
+      "filterCustomer": "客户",
+      "filterCustomerPlaceholder": "姓名或邮箱",
+      "filterBookingCode": "预订编号",
+      "filterBookingCodePlaceholder": "例如 ALPHA001",
+      "filterStatus": "状态",
+      "colOperator": "运营商",
+      "colBookingCode": "编号",
+      "colCustomer": "客户",
+      "colStatus": "状态",
+      "colStart": "开始",
+      "status": {
+        "CONFIRMED": "已确认",
+        "ACTIVE": "进行中",
+        "COMPLETED": "已完成",
+        "CANCELLED": "已取消"
+      },
+      "detailCustomer": "客户",
+      "detailEmail": "邮箱",
+      "detailOperatorId": "运营商 ID",
+      "detailStart": "取车",
+      "detailEnd": "还车",
+      "detailTotal": "总计",
+      "detailPickup": "取车地点",
+      "detailDropoff": "还车地点",
+      "loadError": "无法加载预订。",
+      "retry": "重试"
     },
     "revenue": {
       "title": "合作伙伴收益",

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as LocaleBusinessManageClassesRouteImport } from './routes/$local
 import { Route as LocaleBusinessManageAddOnsRouteImport } from './routes/$locale/_business/manage/add-ons'
 import { Route as LocaleAdminAdminRevenueRouteImport } from './routes/$locale/_admin/admin/revenue'
 import { Route as LocaleAdminAdminDocumentsRouteImport } from './routes/$locale/_admin/admin/documents'
+import { Route as LocaleAdminAdminBookingsRouteImport } from './routes/$locale/_admin/admin/bookings'
 import { Route as LocaleBusinessManageFleetIndexRouteImport } from './routes/$locale/_business/manage/fleet/index'
 import { Route as LocaleBusinessManageBookingsIndexRouteImport } from './routes/$locale/_business/manage/bookings/index'
 import { Route as LocaleBusinessManageFleetVehicleIdRouteImport } from './routes/$locale/_business/manage/fleet/$vehicleId'
@@ -224,6 +225,12 @@ const LocaleAdminAdminDocumentsRoute =
     path: '/admin/documents',
     getParentRoute: () => LocaleAdminRoute,
   } as any)
+const LocaleAdminAdminBookingsRoute =
+  LocaleAdminAdminBookingsRouteImport.update({
+    id: '/admin/bookings',
+    path: '/admin/bookings',
+    getParentRoute: () => LocaleAdminRoute,
+  } as any)
 const LocaleBusinessManageFleetIndexRoute =
   LocaleBusinessManageFleetIndexRouteImport.update({
     id: '/manage/fleet/',
@@ -263,6 +270,7 @@ export interface FileRoutesByFullPath {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/bookings': typeof LocaleAdminAdminBookingsRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -296,6 +304,7 @@ export interface FileRoutesByTo {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/bookings': typeof LocaleAdminAdminBookingsRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -336,6 +345,7 @@ export interface FileRoutesById {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/_admin/admin/bookings': typeof LocaleAdminAdminBookingsRoute
   '/$locale/_admin/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/_admin/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/_business/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -374,6 +384,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/admin/bookings'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -407,6 +418,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles'
+    | '/$locale/admin/bookings'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -446,6 +458,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/_admin/admin/bookings'
     | '/$locale/_admin/admin/documents'
     | '/$locale/_admin/admin/revenue'
     | '/$locale/_business/manage/add-ons'
@@ -708,6 +721,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleAdminAdminDocumentsRouteImport
       parentRoute: typeof LocaleAdminRoute
     }
+    '/$locale/_admin/admin/bookings': {
+      id: '/$locale/_admin/admin/bookings'
+      path: '/admin/bookings'
+      fullPath: '/$locale/admin/bookings'
+      preLoaderRoute: typeof LocaleAdminAdminBookingsRouteImport
+      parentRoute: typeof LocaleAdminRoute
+    }
     '/$locale/_business/manage/fleet/': {
       id: '/$locale/_business/manage/fleet/'
       path: '/manage/fleet'
@@ -740,12 +760,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface LocaleAdminRouteChildren {
+  LocaleAdminAdminBookingsRoute: typeof LocaleAdminAdminBookingsRoute
   LocaleAdminAdminDocumentsRoute: typeof LocaleAdminAdminDocumentsRoute
   LocaleAdminAdminRevenueRoute: typeof LocaleAdminAdminRevenueRoute
   LocaleAdminAdminIndexRoute: typeof LocaleAdminAdminIndexRoute
 }
 
 const LocaleAdminRouteChildren: LocaleAdminRouteChildren = {
+  LocaleAdminAdminBookingsRoute: LocaleAdminAdminBookingsRoute,
   LocaleAdminAdminDocumentsRoute: LocaleAdminAdminDocumentsRoute,
   LocaleAdminAdminRevenueRoute: LocaleAdminAdminRevenueRoute,
   LocaleAdminAdminIndexRoute: LocaleAdminAdminIndexRoute,

--- a/packages/web/src/routes/$locale/_admin/admin/bookings.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/bookings.tsx
@@ -1,0 +1,73 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { BookingOversightView } from '@/vite/admin/bookings/BookingOversightView'
+import { type AdminBookingFiltersInput, adminBookingsQueryOptions } from '@/vite/admin/bookings/api'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useTranslations } from 'use-intl'
+
+// Only keep a string search param when it's a non-empty string; status is also
+// constrained to the known enum so a junk value falls back to "all" rather than
+// 400-ing the loader.
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function validateSearch(search: Record<string, unknown>): AdminBookingFiltersInput {
+  const status = str(search.status)
+  const next: AdminBookingFiltersInput = {}
+  const operatorId = str(search.operatorId)
+  const bookingCode = str(search.bookingCode)
+  const customer = str(search.customer)
+  const cursor = str(search.cursor)
+  if (operatorId) next.operatorId = operatorId
+  if (bookingCode) next.bookingCode = bookingCode
+  if (customer) next.customer = customer
+  if (status && (BOOKING_STATUSES as readonly string[]).includes(status)) next.status = status
+  if (cursor) next.cursor = cursor
+  return next
+}
+
+// Platform-admin cross-operator booking oversight (#1092). The `_admin` parent
+// layout already gates on platform-admin membership; this owns the data: read the
+// filter search params, prefetch in the loader, render the pure
+// BookingOversightView and turn its filter changes into URL navigations.
+export const Route = createFileRoute('/$locale/_admin/admin/bookings')({
+  validateSearch,
+  loaderDeps: ({ search }) => search,
+  loader: ({ context, deps }) =>
+    context.queryClient.ensureQueryData(adminBookingsQueryOptions(deps)),
+  pendingComponent: PageSkeleton,
+  errorComponent: BookingsError,
+  component: BookingsRoute,
+})
+
+function BookingsRoute() {
+  const filters = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const { data } = useSuspenseQuery(adminBookingsQueryOptions(filters))
+  return (
+    <BookingOversightView
+      response={data}
+      filters={filters}
+      onApplyFilters={(next) => navigate({ search: () => next })}
+    />
+  )
+}
+
+function BookingsError(_props: ErrorComponentProps) {
+  const t = useTranslations('admin.bookings')
+  const router = useRouter()
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-20 text-center sm:px-6 lg:px-8">
+      <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+      <button
+        type="button"
+        onClick={() => router.invalidate()}
+        className="mt-4 inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted/50"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/bookings/BookingOversightView.tsx
+++ b/packages/web/src/vite/admin/bookings/BookingOversightView.tsx
@@ -1,0 +1,335 @@
+import { Input } from '@/components/ui/input'
+import { NativeSelect } from '@/components/ui/native-select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
+import type { AdminBookingDto, AdminBookingsResponse } from '@kuruma/shared/types/admin-booking'
+import { useState } from 'react'
+import { useLocale, useTranslations } from 'use-intl'
+import type { AdminBookingFiltersInput } from './api'
+
+interface BookingOversightViewProps {
+  readonly response: AdminBookingsResponse
+  readonly filters: AdminBookingFiltersInput
+  /** Apply a new filter set — the route turns this into a URL navigation. */
+  readonly onApplyFilters: (next: AdminBookingFiltersInput) => void
+}
+
+const DASH = '—'
+
+// Build a clean filter object: drop empty values and always reset the cursor
+// (a changed filter restarts paging at page one). Avoids explicit `undefined`
+// keys, which `exactOptionalPropertyTypes` rejects.
+function buildFilters(next: {
+  operatorId?: string
+  bookingCode?: string
+  customer?: string
+  status?: string
+}): AdminBookingFiltersInput {
+  const out: AdminBookingFiltersInput = {}
+  if (next.operatorId) out.operatorId = next.operatorId
+  if (next.bookingCode) out.bookingCode = next.bookingCode
+  if (next.customer) out.customer = next.customer
+  if (next.status) out.status = next.status
+  return out
+}
+
+/**
+ * Platform-admin cross-operator booking oversight (#1092, epic #1075 slice 6).
+ * Pure function of props (FC/IS — the route owns the loader / useSuspenseQuery +
+ * boundaries and turns onApplyFilters into a URL navigation). Renders a filter bar
+ * (operator/bookingCode/customer/status), a result table that shows WHICH operator
+ * owns each booking and WHO booked it, and a detail drawer on row click.
+ */
+export function BookingOversightView({
+  response,
+  filters,
+  onApplyFilters,
+}: BookingOversightViewProps) {
+  const t = useTranslations('admin.bookings')
+  const locale = useLocale()
+  const [selected, setSelected] = useState<AdminBookingDto | null>(null)
+  const { bookings } = response
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
+      <p className="mt-1 text-muted-foreground text-sm">{t('subtitle')}</p>
+
+      <FilterBar t={t} filters={filters} onApplyFilters={onApplyFilters} />
+
+      {bookings.length === 0 ? (
+        <p className="mt-8 text-muted-foreground text-sm">{t('empty')}</p>
+      ) : (
+        <BookingsTable
+          t={t}
+          locale={locale}
+          bookings={bookings}
+          onSelectBooking={setSelected}
+          onFilterOperator={(operatorId) =>
+            onApplyFilters(buildFilters({ ...filters, operatorId }))
+          }
+        />
+      )}
+
+      <BookingDetailDrawer
+        t={t}
+        locale={locale}
+        booking={selected}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  )
+}
+
+type T = ReturnType<typeof useTranslations<'admin.bookings'>>
+
+function FilterBar({
+  t,
+  filters,
+  onApplyFilters,
+}: {
+  readonly t: T
+  readonly filters: AdminBookingFiltersInput
+  readonly onApplyFilters: (next: AdminBookingFiltersInput) => void
+}) {
+  // Text inputs are local until submit; the status select applies immediately. A
+  // new search always drops the cursor so paging restarts from page one.
+  const [bookingCode, setBookingCode] = useState(filters.bookingCode ?? '')
+  const [customer, setCustomer] = useState(filters.customer ?? '')
+
+  return (
+    <form
+      className="mt-6 flex flex-wrap items-end gap-3"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onApplyFilters(buildFilters({ ...filters, bookingCode, customer }))
+      }}
+    >
+      <div className="flex flex-col gap-1">
+        <label htmlFor="filter-customer" className="text-muted-foreground text-xs">
+          {t('filterCustomer')}
+        </label>
+        <Input
+          id="filter-customer"
+          value={customer}
+          onChange={(e) => setCustomer(e.target.value)}
+          placeholder={t('filterCustomerPlaceholder')}
+          className="w-56"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="filter-code" className="text-muted-foreground text-xs">
+          {t('filterBookingCode')}
+        </label>
+        <Input
+          id="filter-code"
+          value={bookingCode}
+          onChange={(e) => setBookingCode(e.target.value)}
+          placeholder={t('filterBookingCodePlaceholder')}
+          className="w-44"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="filter-status" className="text-muted-foreground text-xs">
+          {t('filterStatus')}
+        </label>
+        <NativeSelect
+          id="filter-status"
+          className="w-44"
+          value={filters.status ?? ''}
+          onChange={(e) => onApplyFilters(buildFilters({ ...filters, status: e.target.value }))}
+        >
+          <option value="">{t('allStatuses')}</option>
+          {BOOKING_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {t(`status.${s}`)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+
+      <button
+        type="submit"
+        className="inline-flex h-9 items-center rounded-lg bg-primary px-4 font-medium text-primary-foreground text-sm hover:bg-primary/90"
+      >
+        {t('search')}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setBookingCode('')
+          setCustomer('')
+          onApplyFilters({})
+        }}
+        className="inline-flex h-9 items-center rounded-lg border border-border px-4 font-medium text-sm hover:bg-muted/50"
+      >
+        {t('clear')}
+      </button>
+    </form>
+  )
+}
+
+function BookingsTable({
+  t,
+  locale,
+  bookings,
+  onSelectBooking,
+  onFilterOperator,
+}: {
+  readonly t: T
+  readonly locale: string
+  readonly bookings: AdminBookingDto[]
+  readonly onSelectBooking: (booking: AdminBookingDto) => void
+  readonly onFilterOperator: (operatorId: string) => void
+}) {
+  const head = 'px-3 py-2 text-left font-medium text-muted-foreground'
+
+  return (
+    <div className="mt-6 overflow-x-auto rounded-xl border border-border">
+      <table className="w-full text-sm">
+        <thead className="border-border border-b bg-muted/50">
+          <tr>
+            <th scope="col" className={head}>
+              {t('colOperator')}
+            </th>
+            <th scope="col" className={head}>
+              {t('colBookingCode')}
+            </th>
+            <th scope="col" className={head}>
+              {t('colCustomer')}
+            </th>
+            <th scope="col" className={head}>
+              {t('colStatus')}
+            </th>
+            <th scope="col" className={head}>
+              {t('colStart')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map((b) => (
+            <tr key={b.id} className="border-border border-b last:border-0 hover:bg-muted/30">
+              <td className="px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => onFilterOperator(b.operatorId)}
+                  className="font-medium text-left underline-offset-2 hover:underline"
+                >
+                  {b.operatorName}
+                </button>
+              </td>
+              <td className="px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => onSelectBooking(b)}
+                  className="font-mono text-xs underline-offset-2 hover:underline"
+                >
+                  {b.bookingCode}
+                </button>
+              </td>
+              <td className="px-3 py-2">
+                <span className="block">{b.renterName ?? DASH}</span>
+                <span className="block text-muted-foreground text-xs">{b.renterEmail ?? DASH}</span>
+              </td>
+              <td className="px-3 py-2">
+                <StatusBadge status={b.status} label={t(`status.${b.status}`)} />
+              </td>
+              <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                <time dateTime={b.startAt}>{formatDateTime(b.startAt, locale)}</time>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StatusBadge({
+  status,
+  label,
+}: {
+  readonly status: AdminBookingDto['status']
+  readonly label: string
+}) {
+  const tone =
+    status === 'CANCELLED'
+      ? 'bg-destructive/10 text-destructive'
+      : status === 'COMPLETED'
+        ? 'bg-muted text-muted-foreground'
+        : 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-medium text-xs ${tone}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+function BookingDetailDrawer({
+  t,
+  locale,
+  booking,
+  onClose,
+}: {
+  readonly t: T
+  readonly locale: string
+  readonly booking: AdminBookingDto | null
+  readonly onClose: () => void
+}) {
+  return (
+    <Sheet open={booking !== null} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent className="w-full sm:max-w-md">
+        {booking && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="font-mono">{booking.bookingCode}</SheetTitle>
+              <SheetDescription>{booking.operatorName}</SheetDescription>
+            </SheetHeader>
+            <dl className="space-y-4 px-4 pb-6 text-sm">
+              <Field label={t('colStatus')} value={t(`status.${booking.status}`)} />
+              <Field label={t('detailCustomer')} value={booking.renterName ?? DASH} />
+              <Field label={t('detailEmail')} value={booking.renterEmail ?? DASH} />
+              <Field label={t('detailOperatorId')} value={booking.operatorId} mono />
+              <Field label={t('detailStart')} value={formatDateTime(booking.startAt, locale)} />
+              <Field label={t('detailEnd')} value={formatDateTime(booking.endAt, locale)} />
+              <Field
+                label={t('detailTotal')}
+                value={booking.totalPrice === null ? DASH : formatJpy(booking.totalPrice)}
+              />
+              <Field label={t('detailPickup')} value={booking.pickupLocationId} mono />
+              <Field label={t('detailDropoff')} value={booking.dropoffLocationId} mono />
+            </dl>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  readonly label: string
+  readonly value: string
+  readonly mono?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={mono ? 'font-mono text-xs' : ''}>{value}</dd>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/bookings/api.test.ts
+++ b/packages/web/src/vite/admin/bookings/api.test.ts
@@ -1,0 +1,95 @@
+import { ParseError } from '@/lib/api-error'
+import type { AdminBookingDto } from '@kuruma/shared/types/admin-booking'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ADMIN_BOOKINGS_QUERY_KEY, adminBookingsQueryOptions, fetchAdminBookings } from './api'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+afterEach(() => fetchMock.mockReset())
+
+const row: AdminBookingDto = {
+  id: 'bk_1',
+  bookingCode: 'ALPHA001',
+  status: 'CONFIRMED',
+  operatorId: 'op_a',
+  operatorName: 'Best Car Rental',
+  renterId: 'r_1',
+  renterName: 'Alice Tan',
+  renterEmail: 'alice@example.com',
+  pickupLocationId: 'loc_1',
+  dropoffLocationId: 'loc_1',
+  startAt: '2026-05-10T01:00:00.000Z',
+  endAt: '2026-05-11T01:00:00.000Z',
+  effectiveEndAt: '2026-05-11T01:00:00.000Z',
+  totalPrice: 12000,
+  createdAt: '2026-05-01T00:00:00.000Z',
+}
+
+describe('fetchAdminBookings', () => {
+  it('GETs /admin/bookings with credentials and unwraps the validated body', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { bookings: [row], nextCursor: null } }),
+    )
+
+    const result = await fetchAdminBookings({})
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/bookings', { credentials: 'include' })
+    expect(result).toEqual({ bookings: [row], nextCursor: null })
+  })
+
+  it('encodes the active filters as query params', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { bookings: [], nextCursor: null } }),
+    )
+
+    await fetchAdminBookings({
+      operatorId: 'op_a',
+      bookingCode: 'ALP',
+      customer: 'a@b.com',
+      status: 'ACTIVE',
+    })
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain('operatorId=op_a')
+    expect(url).toContain('bookingCode=ALP')
+    expect(url).toContain('customer=a%40b.com')
+    expect(url).toContain('status=ACTIVE')
+  })
+
+  it('throws a ParseError when a row carries an out-of-domain status (#711)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { bookings: [{ ...row, status: 'BOGUS' }], nextCursor: null },
+      }),
+    )
+    await expect(fetchAdminBookings({})).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('throws a ParseError when operatorName is missing — the admin DTO drifted (#711)', async () => {
+    const { operatorName: _drop, ...withoutOperatorName } = row
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { bookings: [withoutOperatorName], nextCursor: null } }),
+    )
+    await expect(fetchAdminBookings({})).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('adminBookingsQueryOptions', () => {
+  it('keys the cache by the filter set for per-filter caching', () => {
+    const filters = { operatorId: 'op_a' }
+    expect(adminBookingsQueryOptions(filters).queryKey).toEqual([
+      ...ADMIN_BOOKINGS_QUERY_KEY,
+      filters,
+    ])
+  })
+})

--- a/packages/web/src/vite/admin/bookings/api.ts
+++ b/packages/web/src/vite/admin/bookings/api.ts
@@ -1,0 +1,75 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import { BOOKING_STATUSES } from '@kuruma/shared/enums'
+import type { AdminBookingDto, AdminBookingsResponse } from '@kuruma/shared/types/admin-booking'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// Platform-admin cross-operator booking oversight (#1092). Cookie-based
+// (credentials: 'include') so the API gates on the session role server-side
+// (requirePlatformAdmin — PLATFORM_ADMIN only; PARTNER excluded). Filters ride as
+// query params; an absent param means "any". Mirrors admin/revenue/api.ts.
+export const ADMIN_BOOKINGS_QUERY_KEY = ['admin-bookings'] as const
+
+/** The oversight filter shape carried in the URL search params + the API query. */
+export interface AdminBookingFiltersInput {
+  operatorId?: string
+  bookingCode?: string
+  customer?: string
+  status?: string
+  cursor?: string
+}
+
+// Network-seam validator for the admin booking row (#711). Pinned to the shared
+// wire DTO with `satisfies` so a renamed/added/dropped field fails typecheck here
+// and a drifted runtime body (e.g. a missing operatorName) surfaces as a
+// ParseError at the seam instead of a blank cell deep in the oversight table.
+const adminBookingDtoSchema = z.object({
+  id: z.string(),
+  bookingCode: z.string(),
+  status: z.enum(BOOKING_STATUSES),
+  operatorId: z.string(),
+  operatorName: z.string(),
+  renterId: z.string(),
+  renterName: z.string().nullable(),
+  renterEmail: z.string().nullable(),
+  pickupLocationId: z.string(),
+  dropoffLocationId: z.string(),
+  startAt: z.string(),
+  endAt: z.string(),
+  effectiveEndAt: z.string(),
+  totalPrice: z.number().nullable(),
+  createdAt: z.string(),
+}) satisfies z.ZodType<AdminBookingDto>
+
+const adminBookingsResponseSchema = z.object({
+  bookings: z.array(adminBookingDtoSchema),
+  nextCursor: z.string().nullable(),
+}) satisfies z.ZodType<AdminBookingsResponse>
+
+function buildQuery(filters: AdminBookingFiltersInput): string {
+  const params = new URLSearchParams()
+  if (filters.operatorId) params.set('operatorId', filters.operatorId)
+  if (filters.bookingCode) params.set('bookingCode', filters.bookingCode)
+  if (filters.customer) params.set('customer', filters.customer)
+  if (filters.status) params.set('status', filters.status)
+  if (filters.cursor) params.set('cursor', filters.cursor)
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export async function fetchAdminBookings(
+  filters: AdminBookingFiltersInput,
+): Promise<AdminBookingsResponse> {
+  const res = await fetch(`${getApiBaseUrl()}/admin/bookings${buildQuery(filters)}`, {
+    credentials: 'include',
+  })
+  return unwrap(res, adminBookingsResponseSchema)
+}
+
+export function adminBookingsQueryOptions(filters: AdminBookingFiltersInput) {
+  return queryOptions({
+    queryKey: [...ADMIN_BOOKINGS_QUERY_KEY, filters],
+    queryFn: () => fetchAdminBookings(filters),
+  })
+}

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -1,9 +1,10 @@
 import { Link } from '@tanstack/react-router'
-import { Banknote, FileCheck, LayoutDashboard } from 'lucide-react'
+import { Banknote, CalendarCheck, FileCheck, LayoutDashboard } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 const SIDEBAR_ITEMS = [
   { to: '/$locale/admin', icon: LayoutDashboard, labelKey: 'nav.overview' },
+  { to: '/$locale/admin/bookings', icon: CalendarCheck, labelKey: 'nav.bookings' },
   { to: '/$locale/admin/revenue', icon: Banknote, labelKey: 'nav.revenue' },
   { to: '/$locale/admin/documents', icon: FileCheck, labelKey: 'nav.documents' },
 ] as const

--- a/packages/web/tests/vite/admin/BookingOversightView.test.tsx
+++ b/packages/web/tests/vite/admin/BookingOversightView.test.tsx
@@ -1,0 +1,113 @@
+import { BookingOversightView } from '@/vite/admin/bookings/BookingOversightView'
+import type { AdminBookingDto, AdminBookingsResponse } from '@kuruma/shared/types/admin-booking'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// key -> key translations, and a fixed locale, mirroring AnomaliesPanel.test.tsx.
+vi.mock('use-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+afterEach(() => cleanup())
+
+function dto(over: Partial<AdminBookingDto>): AdminBookingDto {
+  return {
+    id: crypto.randomUUID(),
+    bookingCode: 'ALPHA001',
+    status: 'CONFIRMED',
+    operatorId: 'op_a',
+    operatorName: 'Best Car Rental',
+    renterId: 'r_1',
+    renterName: 'Alice Tan',
+    renterEmail: 'alice@example.com',
+    pickupLocationId: 'loc_1',
+    dropoffLocationId: 'loc_1',
+    startAt: '2026-05-10T01:00:00.000Z',
+    endAt: '2026-05-11T01:00:00.000Z',
+    effectiveEndAt: '2026-05-11T01:00:00.000Z',
+    totalPrice: 12000,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+const rowA = dto({
+  bookingCode: 'ALPHA001',
+  operatorName: 'Best Car Rental',
+  renterName: 'Alice Tan',
+})
+const rowB = dto({
+  bookingCode: 'BETA0002',
+  operatorId: 'op_b',
+  operatorName: 'Aoki Rentals',
+  renterId: 'r_2',
+  renterName: 'Bob Lee',
+  renterEmail: 'bob@example.com',
+})
+
+function response(bookings: AdminBookingDto[]): AdminBookingsResponse {
+  return { bookings, nextCursor: null }
+}
+
+describe('BookingOversightView', () => {
+  it('renders the owning operator and customer identity for each row', () => {
+    render(
+      <BookingOversightView
+        response={response([rowA, rowB])}
+        filters={{}}
+        onApplyFilters={() => {}}
+      />,
+    )
+    expect(screen.getByText('Best Car Rental')).toBeInTheDocument()
+    expect(screen.getByText('Aoki Rentals')).toBeInTheDocument()
+    expect(screen.getByText('Alice Tan')).toBeInTheDocument()
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no bookings match', () => {
+    render(<BookingOversightView response={response([])} filters={{}} onApplyFilters={() => {}} />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('clicking an operator name filters by that operatorId', () => {
+    const onApplyFilters = vi.fn()
+    render(
+      <BookingOversightView
+        response={response([rowA, rowB])}
+        filters={{}}
+        onApplyFilters={onApplyFilters}
+      />,
+    )
+    fireEvent.click(screen.getByText('Aoki Rentals'))
+    expect(onApplyFilters).toHaveBeenCalledWith({ operatorId: 'op_b' })
+  })
+
+  it('submitting the filter bar applies the customer search', () => {
+    const onApplyFilters = vi.fn()
+    render(
+      <BookingOversightView
+        response={response([rowA])}
+        filters={{}}
+        onApplyFilters={onApplyFilters}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText('filterCustomer'), { target: { value: 'bob' } })
+    fireEvent.click(screen.getByText('search'))
+    expect(onApplyFilters).toHaveBeenCalledWith({ customer: 'bob' })
+  })
+
+  it('opens the detail drawer with mapped fields on a booking code click', () => {
+    render(
+      <BookingOversightView response={response([rowA])} filters={{}} onApplyFilters={() => {}} />,
+    )
+    // The drawer is closed initially — its field labels are not mounted.
+    expect(screen.queryByText('detailEmail')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('ALPHA001'))
+    // Now the drawer renders the renter email under its detail label.
+    expect(screen.getByText('detailEmail')).toBeInTheDocument()
+    const emails = screen.getAllByText('alice@example.com')
+    expect(emails.length).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
## What

Slice #1092 of the platform-owner dashboard epic (#1075): cross-operator **booking oversight** for platform admins.

A verify-first test proved the existing booking-read path inadequate for this (ungated, and the web `bookingDtoSchema` omits `operatorId`), so this builds a dedicated, gated read:

- **API:** new `GET /admin/bookings` (`requirePlatformAdmin` route + `AdminBookingService`), an unscoped `findForAdmin` repo read (InMemory + Drizzle), and an **admin DTO** carrying `operatorId` + `operatorName`. Filters by operator / code / customer / status / date.
- **Web:** `/admin/bookings` page + `BookingOversightView`, network-seam Zod validator pinned to the shared admin DTO (#711), sidebar nav entry.

The PARTNER `bypassScope` cross-operator read concern is tracked separately in #1119 (not introduced here).

## Layering

routes → services → repositories, DI wired only in `index.ts`. Service re-asserts `requirePlatformAdmin`. `lint:boundaries` green.

## Test plan

- [x] `admin-bookings-verify.test.ts` — verify-first: a PLATFORM_ADMIN read returns ≥2 distinct operatorIds (proves cross-operator + operator identity).
- [x] `admin-bookings.test.ts` — authz 403 for non-admin roles; filters; admin DTO shape. 25 api tests green.
- [x] `api.test.ts` + `BookingOversightView.test.tsx` — 10 web tests green; ParseError on drift.
- [x] api typecheck + `lint:boundaries` green.
- [x] i18n parity en/ja/zh.

Refs #1075
Closes #1092