### PR TITLE
feat(#1087): platform overview KPIs (GET /admin/overview)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ import { requestId } from './middleware/request-id'
 import { observability } from './observability/middleware'
 import { createAddOnRoutes } from './routes/add-ons'
 import { createAdminRoutes } from './routes/admin'
+import { createAdminOverviewRoutes } from './routes/admin-overview'
 import { createAdminRevenueRoutes } from './routes/admin-revenue'
 import { createAuthRoutes } from './routes/auth'
 import { createAvailabilityRoutes } from './routes/availability'
@@ -48,6 +49,7 @@ import { createVehicleDetailRoutes } from './routes/vehicle-detail'
 import { createVehiclePhotoRoutes } from './routes/vehicle-photos'
 import { createVehicleRoutes } from './routes/vehicles'
 import { AddOnService } from './services/add-on'
+import { AdminOverviewService } from './services/admin-overview'
 import { AdminRevenueService } from './services/admin-revenue'
 import { type RecordAuditEvent, toAuditRow } from './services/audit'
 import { AvailabilityService } from './services/availability'
@@ -411,6 +413,14 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const fleetOverviewService = new FleetOverviewService(fleetOverviewRepo)
   const overviewService = new OverviewService(overviewRepo)
   const adminRevenueService = new AdminRevenueService(paymentEventRepo, operatorRepo)
+  const adminOverviewService = new AdminOverviewService(
+    bookingRepo,
+    paymentEventRepo,
+    vehicleRepo,
+    operatorRepo,
+    paymentAnomalyRepo,
+    renterDocumentRepo,
+  )
   const paymentAnomalyService = new PaymentAnomalyService(paymentAnomalyRepo)
   const vehicleDetailService = new VehicleDetailService(vehicleDetailRepo)
   const operatorService = new OperatorService(operatorRepo, recordAudit)
@@ -495,6 +505,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createStatsRoutes(statsRepo))
     .route('/', createOverviewRoutes(overviewService))
     .route('/', createAdminRevenueRoutes(adminRevenueService))
+    .route('/', createAdminOverviewRoutes(adminOverviewService))
     .route('/', createPaymentAnomalyRoutes(paymentAnomalyService))
     .route('/', createMessageRoutes(messageService))
     .route('/', createConsentRoutes(consentService))

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -107,6 +107,12 @@ export class DrizzleBookingRepository implements BookingRepository {
     return row ? toBooking(row) : undefined
   }
 
+  // #1087 platform overview: COUNT(bookings) across all operators (unscoped).
+  async count(): Promise<number> {
+    const [row] = await this.db.select({ value: count() }).from(bookings)
+    return row?.value ?? 0
+  }
+
   async countActiveForVehicles(vehicleIds: string[]): Promise<number> {
     if (vehicleIds.length === 0) return 0
     const [row] = await this.db

--- a/packages/api/src/repositories/drizzle/operator.ts
+++ b/packages/api/src/repositories/drizzle/operator.ts
@@ -1,5 +1,5 @@
 import { operators } from '@kuruma/shared/db/schema'
-import { asc, eq } from 'drizzle-orm'
+import { asc, count, eq } from 'drizzle-orm'
 import type { Operator } from '../../stores'
 import type { OperatorRepository, OperatorUpdatePatch } from '../types'
 import type { Db } from './shared'
@@ -18,6 +18,13 @@ export class DrizzleOperatorRepository implements OperatorRepository {
 
   async list(): Promise<Operator[]> {
     return this.db.select().from(operators).orderBy(asc(operators.name))
+  }
+
+  // #1087 platform overview: COUNT(operators). TODO(#1088): narrow to active
+  // (deactivatedAt IS NULL) once that column lands.
+  async count(): Promise<number> {
+    const [row] = await this.db.select({ value: count() }).from(operators)
+    return row?.value ?? 0
   }
 
   async findById(id: string): Promise<Operator | undefined> {

--- a/packages/api/src/repositories/drizzle/payment-anomaly.ts
+++ b/packages/api/src/repositories/drizzle/payment-anomaly.ts
@@ -1,5 +1,5 @@
 import { paymentAnomalies } from '@kuruma/shared/db/schema'
-import { isNull } from 'drizzle-orm'
+import { count, isNull } from 'drizzle-orm'
 import type { PaymentAnomaly } from '../../stores'
 import type { NewPaymentAnomaly, PaymentAnomalyRepository } from '../types'
 import { type Db, paymentAnomalyColumns, toPaymentAnomaly } from './shared'
@@ -24,5 +24,14 @@ export class DrizzlePaymentAnomalyRepository implements PaymentAnomalyRepository
       .from(paymentAnomalies)
       .where(isNull(paymentAnomalies.resolvedAt))
     return rows.map(toPaymentAnomaly)
+  }
+
+  // #1087 platform overview: open-anomaly count. COUNT at the DB, never load-then-count.
+  async countUnresolved(): Promise<number> {
+    const [row] = await this.db
+      .select({ value: count() })
+      .from(paymentAnomalies)
+      .where(isNull(paymentAnomalies.resolvedAt))
+    return row?.value ?? 0
   }
 }

--- a/packages/api/src/repositories/drizzle/payment-event.ts
+++ b/packages/api/src/repositories/drizzle/payment-event.ts
@@ -55,4 +55,16 @@ export class DrizzlePaymentEventRepository implements PaymentEventRepository {
       .orderBy(sql`${jstMonthExpr} desc`)
     return rows.map((r) => r.month)
   }
+
+  // #1087 platform overview: total GMV over SUCCEEDED payments. COALESCE(SUM,0)
+  // at the DB (mirrors vehicle-detail revenue) so the Worker never materializes
+  // the table. Postgres returns SUM as a string (numeric/bigint); the Number()
+  // coercion below is load-bearing — `sql<...>` is a type assertion, not a cast.
+  async sumSucceededGrossJpy(): Promise<number> {
+    const [row] = await this.db
+      .select({ gross: sql<string | number>`COALESCE(SUM(${paymentEvents.grossJpy}), 0)` })
+      .from(paymentEvents)
+      .where(eq(paymentEvents.status, 'SUCCEEDED'))
+    return Number(row?.gross ?? 0)
+  }
 }

--- a/packages/api/src/repositories/drizzle/renter-document.ts
+++ b/packages/api/src/repositories/drizzle/renter-document.ts
@@ -97,6 +97,17 @@ export class DrizzleRenterDocumentRepository implements RenterDocumentRepository
     return { data: rows.map(toRenterDocument), total: countResult[0]?.value ?? 0 }
   }
 
+  // #1087 platform overview: pending-queue depth (unscoped; authz in the service).
+  // Pure COUNT — never materializes the queue. Uses the idx_renter_documents_status
+  // partial index the listPending count already relies on.
+  async countPending(): Promise<number> {
+    const [row] = await this.db
+      .select({ value: count() })
+      .from(renterDocuments)
+      .where(eq(renterDocuments.status, 'PENDING'))
+    return row?.value ?? 0
+  }
+
   async verify(
     ctx: CallerContext,
     id: string,

--- a/packages/api/src/repositories/drizzle/vehicle.ts
+++ b/packages/api/src/repositories/drizzle/vehicle.ts
@@ -96,6 +96,16 @@ export class DrizzleVehicleRepository implements VehicleRepository {
     return rows.map((r) => toVehicle(r, this.decodePhotos))
   }
 
+  // #1087 platform overview: live fleet across all operators (unscoped).
+  // COUNT at the DB, never materialize-then-count.
+  async countActive(): Promise<number> {
+    const [row] = await this.db
+      .select({ value: count() })
+      .from(vehicles)
+      .where(ne(vehicles.status, 'RETIRED'))
+    return row?.value ?? 0
+  }
+
   async create(
     ctx: CallerContext,
     data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -145,6 +145,11 @@ export class InMemoryBookingRepository implements BookingRepository {
     return undefined
   }
 
+  // #1087: platform-overview total booking count across all operators (unscoped).
+  async count(): Promise<number> {
+    return this.store.size
+  }
+
   async countActiveForVehicles(vehicleIds: string[]): Promise<number> {
     if (vehicleIds.length === 0) return 0
     const ids = new Set(vehicleIds)

--- a/packages/api/src/repositories/in-memory/operator.ts
+++ b/packages/api/src/repositories/in-memory/operator.ts
@@ -19,6 +19,12 @@ export class InMemoryOperatorRepository implements OperatorRepository {
     return [...this.store.values()].sort((a, b) => a.name.localeCompare(b.name))
   }
 
+  // #1087: platform-overview COUNT(operators). TODO(#1088): filter active once
+  // the deactivatedAt column lands.
+  async count(): Promise<number> {
+    return this.store.size
+  }
+
   async findById(id: string): Promise<Operator | undefined> {
     return this.store.get(id)
   }

--- a/packages/api/src/repositories/in-memory/payment-anomaly.ts
+++ b/packages/api/src/repositories/in-memory/payment-anomaly.ts
@@ -26,4 +26,14 @@ export class InMemoryPaymentAnomalyRepository implements PaymentAnomalyRepositor
   async listUnresolved(): Promise<PaymentAnomaly[]> {
     return [...this.store.values()].filter((r) => r.resolvedAt === null)
   }
+
+  // #1087: platform-overview open-anomaly KPI. Mirrors the Drizzle COUNT(* WHERE
+  // resolvedAt IS NULL).
+  async countUnresolved(): Promise<number> {
+    let n = 0
+    for (const r of this.store.values()) {
+      if (r.resolvedAt === null) n++
+    }
+    return n
+  }
 }

--- a/packages/api/src/repositories/in-memory/payment-event.ts
+++ b/packages/api/src/repositories/in-memory/payment-event.ts
@@ -72,4 +72,14 @@ export class InMemoryPaymentEventRepository implements PaymentEventRepository {
   async listSucceededMonths(): Promise<string[]> {
     return availableRevenueMonths([...this.store.values()].filter((r) => r.status === 'SUCCEEDED'))
   }
+
+  // #1087: platform-overview GMV. Mirrors the Drizzle COALESCE(SUM(grossJpy),0)
+  // over SUCCEEDED rows; an empty store yields 0.
+  async sumSucceededGrossJpy(): Promise<number> {
+    let sum = 0
+    for (const r of this.store.values()) {
+      if (r.status === 'SUCCEEDED') sum += r.grossJpy
+    }
+    return sum
+  }
 }

--- a/packages/api/src/repositories/in-memory/renter-document.ts
+++ b/packages/api/src/repositories/in-memory/renter-document.ts
@@ -76,6 +76,16 @@ export class InMemoryRenterDocumentRepository implements RenterDocumentRepositor
     return { data: pending.slice(offset, offset + limit), total: pending.length }
   }
 
+  // #1087: platform-overview pending-document queue depth (unscoped; authz in
+  // AdminOverviewService). Mirrors the Drizzle COUNT — no page materialized.
+  async countPending(): Promise<number> {
+    let n = 0
+    for (const d of this.store.values()) {
+      if (d.status === 'PENDING') n++
+    }
+    return n
+  }
+
   async verify(
     ctx: CallerContext,
     id: string,

--- a/packages/api/src/repositories/in-memory/vehicle.ts
+++ b/packages/api/src/repositories/in-memory/vehicle.ts
@@ -59,6 +59,15 @@ export class InMemoryVehicleRepository implements VehicleRepository {
     })
   }
 
+  // #1087: platform-overview live-fleet count across all operators (unscoped).
+  async countActive(): Promise<number> {
+    let n = 0
+    for (const v of this.store.values()) {
+      if (v.status !== 'RETIRED') n++
+    }
+    return n
+  }
+
   async create(
     ctx: CallerContext,
     data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>,

--- a/packages/api/src/repositories/types-payment.ts
+++ b/packages/api/src/repositories/types-payment.ts
@@ -25,6 +25,10 @@ export interface PaymentEventRepository {
   // payment, newest first. Powers the month picker without materializing every
   // row (#717).
   listSucceededMonths(): Promise<string[]>
+  // #1087 platform overview: total GMV = `COALESCE(SUM(grossJpy), 0)` over
+  // SUCCEEDED payments, in whole JPY. A DB SUM (mirrors vehicle-detail revenue),
+  // never load-then-sum. Unscoped — authz lives in AdminOverviewService.
+  sumSucceededGrossJpy(): Promise<number>
 }
 
 /** A payment anomaly to persist. id/createdAt/resolvedAt are store-assigned (#508 P2). */
@@ -38,6 +42,9 @@ export interface PaymentAnomalyRepository {
   // Unresolved anomalies across all operators for the platform-admin surface.
   // Unscoped by design — authz lives in the service (mirrors listSucceeded).
   listUnresolved(): Promise<PaymentAnomaly[]>
+  // #1087 platform overview: `COUNT(* WHERE resolvedAt IS NULL)` for the
+  // open-anomalies KPI. COUNT at the DB layer, never load-then-count.
+  countUnresolved(): Promise<number>
 }
 
 /** A refund attempt to claim. id/createdAt/updatedAt are store-assigned; stripeRefundId

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -113,6 +113,10 @@ export interface OperatorRepository {
   // #407: list all operators (name-sorted), powering the admin operator picker.
   // Caller scoping (operator sees only its own) is applied in OperatorService.
   list(): Promise<Operator[]>
+  // #1087 platform overview: `COUNT(operators)` for the platform-owner home KPI.
+  // Unscoped (authz lives in AdminOverviewService). Labelled "Operators" today;
+  // TODO(#1088): tighten to active=true once the `deactivatedAt` column lands.
+  count(): Promise<number>
   findBySlug(slug: string): Promise<Operator | undefined>
   // #903: apply a partial profile patch and return the updated row, or undefined
   // if no operator has that id (never inserts).
@@ -301,6 +305,11 @@ export interface VehicleRepository {
   findAll(ctx: CallerContext, filters?: VehicleFilters): Promise<PaginatedResult<Vehicle>>
   findById(ctx: CallerContext, id: string): Promise<Vehicle | undefined>
   findByIds(ctx: CallerContext, ids: string[]): Promise<Vehicle[]>
+  // #1087 platform overview: `COUNT(vehicles WHERE status != 'RETIRED')` — the
+  // live fleet across all operators. Unscoped (no ctx) by design: this is a
+  // platform-wide KPI; authz lives in AdminOverviewService. COUNT at the DB layer,
+  // never materialize-then-count.
+  countActive(): Promise<number>
   create(
     ctx: CallerContext,
     data: Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>,
@@ -419,6 +428,10 @@ export interface BookingRepository {
   findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]>
   findById(ctx: CallerContext, id: string): Promise<Booking | undefined>
   findByIdempotencyKey(ctx: CallerContext, key: string): Promise<Booking | undefined>
+  /** #1087 platform overview: `COUNT(bookings)` across every operator for the
+   *  platform-owner home KPI. Unscoped by design (authz lives in
+   *  AdminOverviewService); COUNT at the DB layer, never load-then-count. */
+  count(): Promise<number>
   /** Counts bookings in BLOCKING_STATUSES (CONFIRMED, ACTIVE) for the given
    *  vehicle set. Used to guard operations that assume no live bookings exist
    *  for those vehicles — e.g. archiving a vehicle class. */
@@ -751,6 +764,11 @@ export interface RenterDocumentRepository {
     ctx: CallerContext,
     filters?: RenterDocumentFilters,
   ): Promise<PaginatedResult<RenterDocument>>
+  /** #1087 platform overview: `COUNT(renter_documents WHERE status = 'PENDING')`
+   *  for the verification-queue-depth KPI. Unscoped (no ctx) by design — a
+   *  platform-wide count whose authz lives in AdminOverviewService — and a pure
+   *  COUNT so the overview never materializes the queue just to size it. */
+  countPending(): Promise<number>
   /** Platform-staff records a terminal verdict. */
   verify(
     ctx: CallerContext,

--- a/packages/api/src/routes/admin-overview.ts
+++ b/packages/api/src/routes/admin-overview.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono'
+import { requireAuth, requirePlatformAdmin, requireUser, toCallerContext } from '../middleware/auth'
+import type { AdminOverviewService } from '../services/admin-overview'
+import { ok } from './helpers'
+
+/**
+ * Platform-owner home overview (#1087, epic #1075 slice 1). Cross-tenant by
+ * nature, so `requireAuth` gates the path and `requirePlatformAdmin` narrows it to
+ * PLATFORM_ADMIN — legacy STAFF/ADMIN, OPERATOR_*, RENTER and PARTNER are all
+ * rejected. `requireAuth` alone is insufficient: `bypassScope` also admits PARTNER
+ * (Trip.com). The service re-asserts the same gate as defence-in-depth.
+ */
+export function createAdminOverviewRoutes(service: AdminOverviewService) {
+  const app = new Hono()
+  app.use('/admin/overview', requireAuth())
+
+  return app.get('/admin/overview', async (c) => {
+    const ctx = toCallerContext(requireUser(c))
+    requirePlatformAdmin(ctx)
+
+    const data = await service.getOverview(ctx)
+    return ok(c, data)
+  })
+}

--- a/packages/api/src/services/admin-overview.test.ts
+++ b/packages/api/src/services/admin-overview.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type CallerContext,
+  ForbiddenError,
+  SYSTEM_CONTEXT,
+  type UserRole,
+} from '../middleware/auth'
+import { InMemoryBookingRepository } from '../repositories/in-memory/booking'
+import { InMemoryOperatorRepository } from '../repositories/in-memory/operator'
+import { InMemoryPaymentAnomalyRepository } from '../repositories/in-memory/payment-anomaly'
+import { InMemoryPaymentEventRepository } from '../repositories/in-memory/payment-event'
+import { InMemoryRenterDocumentRepository } from '../repositories/in-memory/renter-document'
+import { InMemoryVehicleRepository } from '../repositories/in-memory/vehicle'
+import type { Booking, Operator, PaymentAnomaly, PaymentEvent, RenterDocument } from '../stores'
+import { AdminOverviewService } from './admin-overview'
+
+const OP_A = 'operator-aaaaaaaa'
+const OP_B = 'operator-bbbbbbbb'
+
+function operator(id: string, name: string, slug: string): Operator {
+  return { id, name, slug, preAuthHandoffUrl: null, createdAt: new Date(), updatedAt: new Date() }
+}
+
+function payment(grossJpy: number): PaymentEvent {
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    bookingId: crypto.randomUUID(),
+    stripeEventId: crypto.randomUUID(),
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: null,
+    grossJpy,
+    platformFeeJpy: Math.round(grossJpy * 0.04),
+    netToPartnerJpy: grossJpy - Math.round(grossJpy * 0.04),
+    currency: 'jpy',
+    status: 'SUCCEEDED',
+    createdAt: new Date('2026-05-10T03:00:00Z'),
+  }
+}
+
+function anomaly(over: Pick<PaymentAnomaly, 'stripeEventId' | 'resolvedAt'>): PaymentAnomaly {
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    bookingId: crypto.randomUUID(),
+    kind: 'DOUBLE_PAYMENT',
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: 'pi_dup',
+    receivedAmountJpy: 100_000,
+    expectedAmountJpy: 100_000,
+    currency: 'jpy',
+    createdAt: new Date('2026-06-10T03:00:00Z'),
+    ...over,
+  }
+}
+
+function renterDoc(status: RenterDocument['status']): RenterDocument {
+  const now = new Date()
+  return {
+    id: crypto.randomUUID(),
+    renterId: crypto.randomUUID(),
+    type: 'PASSPORT',
+    storageKey: `doc/${crypto.randomUUID()}`,
+    status,
+    expiryDate: null,
+    verifiedAt: null,
+    verifierId: null,
+    rejectionReason: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function booking(): Booking {
+  const now = new Date()
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    renterId: crypto.randomUUID(),
+    classId: 'class-1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: new Date('2026-08-01T09:00:00Z'),
+    endAt: new Date('2026-08-01T17:00:00Z'),
+    effectiveEndAt: new Date('2026-08-01T17:00:00Z'),
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: `BK-${crypto.randomUUID().slice(0, 6)}`,
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 30_000,
+    cancellationFee: null,
+    cancellationFeeSettlement: 'ADVISORY',
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function mapOf<T extends { id: string }>(rows: T[]): Map<string, T> {
+  return new Map(rows.map((r) => [r.id, r]))
+}
+
+/**
+ * Seeds every repo with a known fixture whose six aggregates are all DISTINCT
+ * numbers, so a service that wired one figure to the wrong repo (or swapped two)
+ * is caught — not a uniform "non-zero" smoke test.
+ *
+ * Expected: bookings=3, gmvJpy=35_000 (10k+25k SUCCEEDED), fleet=3 (4 vehicles −
+ * 1 RETIRED), operators=2, unresolvedAnomalies=1 (1 unresolved + 1 actioned),
+ * pendingDocs=2 (2 PENDING + 1 APPROVED).
+ */
+async function seededService() {
+  const vehicleRepo = new InMemoryVehicleRepository()
+  for (const status of ['AVAILABLE', 'AVAILABLE', 'MAINTENANCE', 'RETIRED'] as const) {
+    await vehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId: OP_A,
+      classId: 'class-1',
+      pickupLocationId: 'loc-1',
+      name: 'Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: null,
+      luggageSize: null,
+      transmission: 'AUTO',
+      fuelType: null,
+      licensePlate: null,
+      status,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      make: null,
+      model: null,
+      year: null,
+      color: null,
+      dailyRateJpy: 8_000,
+      hourlyRateJpy: null,
+      shakenExpiryDate: null,
+      insuranceExpiryDate: null,
+    })
+  }
+
+  return new AdminOverviewService(
+    new InMemoryBookingRepository(mapOf([booking(), booking(), booking()])),
+    new InMemoryPaymentEventRepository(mapOf([payment(10_000), payment(25_000)])),
+    vehicleRepo,
+    new InMemoryOperatorRepository(
+      mapOf([operator(OP_A, 'Best Car', 'best-car'), operator(OP_B, 'Aoki', 'aoki')]),
+    ),
+    new InMemoryPaymentAnomalyRepository(
+      mapOf([
+        anomaly({ stripeEventId: 'evt_open', resolvedAt: null }),
+        anomaly({ stripeEventId: 'evt_done', resolvedAt: new Date('2026-06-11T03:00:00Z') }),
+      ]),
+    ),
+    new InMemoryRenterDocumentRepository(
+      mapOf([renterDoc('PENDING'), renterDoc('PENDING'), renterDoc('APPROVED')]),
+    ),
+  )
+}
+
+const ADMIN: CallerContext = { userId: 'admin-user', role: 'PLATFORM_ADMIN' }
+
+describe('AdminOverviewService.getOverview (#1087)', () => {
+  it('composes the six platform KPIs from their own repos with exact counts/sum', async () => {
+    const service = await seededService()
+
+    const overview = await service.getOverview(ADMIN)
+
+    expect(overview).toEqual({
+      bookings: 3,
+      gmvJpy: 35_000,
+      fleet: 3,
+      operators: 2,
+      unresolvedAnomalies: 1,
+      pendingDocs: 2,
+    })
+  })
+
+  it('counts RETIRED vehicles out of the fleet figure', async () => {
+    const service = await seededService()
+    const overview = await service.getOverview(ADMIN)
+    // 4 vehicles seeded, one RETIRED — the live fleet is 3.
+    expect(overview.fleet).toBe(3)
+  })
+
+  it('sums only SUCCEEDED gross, ignoring anomalies/refunds', async () => {
+    const service = await seededService()
+    const overview = await service.getOverview(ADMIN)
+    expect(overview.gmvJpy).toBe(35_000)
+  })
+})
+
+describe('AdminOverviewService — defence-in-depth gate (route bypass)', () => {
+  it.each(['OPERATOR_OWNER', 'OPERATOR_STAFF', 'RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
+    'throws ForbiddenError for %s even if the route gate were bypassed',
+    async (role: UserRole) => {
+      const service = await seededService()
+      await expect(service.getOverview({ userId: `${role}-user`, role })).rejects.toThrow(
+        ForbiddenError,
+      )
+    },
+  )
+})

--- a/packages/api/src/services/admin-overview.ts
+++ b/packages/api/src/services/admin-overview.ts
@@ -1,0 +1,45 @@
+import type { AdminOverview } from '@kuruma/shared/types/admin-overview'
+import { type CallerContext, requirePlatformAdmin } from '../middleware/auth'
+import type {
+  BookingRepository,
+  OperatorRepository,
+  PaymentAnomalyRepository,
+  PaymentEventRepository,
+  RenterDocumentRepository,
+  VehicleRepository,
+} from '../repositories/types'
+
+/**
+ * Platform-owner home overview (#1087, epic #1075 slice 1). Imperative shell: it
+ * gates the caller (PLATFORM_ADMIN only) then fans out six single-table COUNT/SUM
+ * reads — one per existing repo — and composes them into the {@link AdminOverview}
+ * aggregate. `requirePlatformAdmin` lives HERE (not only at the route) so the gate
+ * travels with the business logic: every repo read is cross-tenant and unscoped,
+ * so this service is the authz chokepoint (mirrors #462 revenue / #508 anomalies).
+ * The route's `requireAuth` alone is insufficient — `bypassScope` also admits
+ * PARTNER (Trip.com), who must never read platform-wide health.
+ */
+export class AdminOverviewService {
+  constructor(
+    private readonly bookings: BookingRepository,
+    private readonly paymentEvents: PaymentEventRepository,
+    private readonly vehicles: VehicleRepository,
+    private readonly operators: OperatorRepository,
+    private readonly anomalies: PaymentAnomalyRepository,
+    private readonly renterDocuments: RenterDocumentRepository,
+  ) {}
+
+  async getOverview(ctx: CallerContext): Promise<AdminOverview> {
+    requirePlatformAdmin(ctx)
+    const [bookings, gmvJpy, fleet, operators, unresolvedAnomalies, pendingDocs] =
+      await Promise.all([
+        this.bookings.count(),
+        this.paymentEvents.sumSucceededGrossJpy(),
+        this.vehicles.countActive(),
+        this.operators.count(),
+        this.anomalies.countUnresolved(),
+        this.renterDocuments.countPending(),
+      ])
+    return { bookings, gmvJpy, fleet, operators, unresolvedAnomalies, pendingDocs }
+  }
+}

--- a/packages/api/src/services/admin-revenue.test.ts
+++ b/packages/api/src/services/admin-revenue.test.ts
@@ -88,6 +88,8 @@ class SpyPaymentEventRepository implements PaymentEventRepository {
     this.monthsCallCount += 1
     return this.inner.listSucceededMonths()
   }
+  sumSucceededGrossJpy: PaymentEventRepository['sumSucceededGrossJpy'] = () =>
+    this.inner.sumSucceededGrossJpy()
 }
 
 describe('AdminRevenueService.getReport (#717 — push month filter into the data layer)', () => {

--- a/packages/api/tests/routes/admin-overview.test.ts
+++ b/packages/api/tests/routes/admin-overview.test.ts
@@ -1,0 +1,220 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import { SYSTEM_CONTEXT, type UserRole } from '../../src/middleware/auth'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
+import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
+import { InMemoryPaymentAnomalyRepository } from '../../src/repositories/in-memory/payment-anomaly'
+import { InMemoryPaymentEventRepository } from '../../src/repositories/in-memory/payment-event'
+import { InMemoryRenterDocumentRepository } from '../../src/repositories/in-memory/renter-document'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory/vehicle'
+import { createAdminOverviewRoutes } from '../../src/routes/admin-overview'
+import { AdminOverviewService } from '../../src/services/admin-overview'
+import type {
+  Booking,
+  Operator,
+  PaymentAnomaly,
+  PaymentEvent,
+  RenterDocument,
+} from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+
+const OP_A = 'operator-aaaaaaaa'
+const OP_B = 'operator-bbbbbbbb'
+
+function operator(id: string, name: string, slug: string): Operator {
+  return { id, name, slug, preAuthHandoffUrl: null, createdAt: new Date(), updatedAt: new Date() }
+}
+
+function payment(grossJpy: number): PaymentEvent {
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    bookingId: crypto.randomUUID(),
+    stripeEventId: crypto.randomUUID(),
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: null,
+    grossJpy,
+    platformFeeJpy: Math.round(grossJpy * 0.04),
+    netToPartnerJpy: grossJpy - Math.round(grossJpy * 0.04),
+    currency: 'jpy',
+    status: 'SUCCEEDED',
+    createdAt: new Date('2026-05-10T03:00:00Z'),
+  }
+}
+
+function anomaly(over: Pick<PaymentAnomaly, 'stripeEventId' | 'resolvedAt'>): PaymentAnomaly {
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    bookingId: crypto.randomUUID(),
+    kind: 'DOUBLE_PAYMENT',
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: 'pi_dup',
+    receivedAmountJpy: 100_000,
+    expectedAmountJpy: 100_000,
+    currency: 'jpy',
+    createdAt: new Date('2026-06-10T03:00:00Z'),
+    ...over,
+  }
+}
+
+function renterDoc(status: RenterDocument['status']): RenterDocument {
+  const now = new Date()
+  return {
+    id: crypto.randomUUID(),
+    renterId: crypto.randomUUID(),
+    type: 'PASSPORT',
+    storageKey: `doc/${crypto.randomUUID()}`,
+    status,
+    expiryDate: null,
+    verifiedAt: null,
+    verifierId: null,
+    rejectionReason: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function booking(): Booking {
+  const now = new Date()
+  return {
+    id: crypto.randomUUID(),
+    operatorId: OP_A,
+    renterId: crypto.randomUUID(),
+    classId: 'class-1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: new Date('2026-08-01T09:00:00Z'),
+    endAt: new Date('2026-08-01T17:00:00Z'),
+    effectiveEndAt: new Date('2026-08-01T17:00:00Z'),
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: `BK-${crypto.randomUUID().slice(0, 6)}`,
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 30_000,
+    cancellationFee: null,
+    cancellationFeeSettlement: 'ADVISORY',
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function mapOf<T extends { id: string }>(rows: T[]): Map<string, T> {
+  return new Map(rows.map((r) => [r.id, r]))
+}
+
+// bookings=3, gmvJpy=35_000, fleet=3 (4 − 1 RETIRED), operators=2,
+// unresolvedAnomalies=1, pendingDocs=2 — six distinct figures (catch a swap).
+async function seededService() {
+  const vehicleRepo = new InMemoryVehicleRepository()
+  for (const status of ['AVAILABLE', 'AVAILABLE', 'MAINTENANCE', 'RETIRED'] as const) {
+    await vehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId: OP_A,
+      classId: 'class-1',
+      pickupLocationId: 'loc-1',
+      name: 'Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: null,
+      luggageSize: null,
+      transmission: 'AUTO',
+      fuelType: null,
+      licensePlate: null,
+      status,
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      make: null,
+      model: null,
+      year: null,
+      color: null,
+      dailyRateJpy: 8_000,
+      hourlyRateJpy: null,
+      shakenExpiryDate: null,
+      insuranceExpiryDate: null,
+    })
+  }
+
+  return new AdminOverviewService(
+    new InMemoryBookingRepository(mapOf([booking(), booking(), booking()])),
+    new InMemoryPaymentEventRepository(mapOf([payment(10_000), payment(25_000)])),
+    vehicleRepo,
+    new InMemoryOperatorRepository(
+      mapOf([operator(OP_A, 'Best Car', 'best-car'), operator(OP_B, 'Aoki', 'aoki')]),
+    ),
+    new InMemoryPaymentAnomalyRepository(
+      mapOf([
+        anomaly({ stripeEventId: 'evt_open', resolvedAt: null }),
+        anomaly({ stripeEventId: 'evt_done', resolvedAt: new Date('2026-06-11T03:00:00Z') }),
+      ]),
+    ),
+    new InMemoryRenterDocumentRepository(
+      mapOf([renterDoc('PENDING'), renterDoc('PENDING'), renterDoc('APPROVED')]),
+    ),
+  )
+}
+
+async function mount(role: UserRole, operatorId?: string) {
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createAdminOverviewRoutes(await seededService()))
+  return app
+}
+
+describe('GET /admin/overview — auth', () => {
+  it('401 when unauthenticated', async () => {
+    const app = new Hono()
+    app.route('/', createAdminOverviewRoutes(await seededService()))
+    expect((await app.request('/admin/overview')).status).toBe(401)
+  })
+
+  it.each(['RENTER', 'PARTNER', 'STAFF', 'ADMIN', 'OPERATOR_STAFF'] as const)(
+    '403 for %s (only PLATFORM_ADMIN may read platform health)',
+    async (role) => {
+      expect((await (await mount(role)).request('/admin/overview')).status).toBe(403)
+    },
+  )
+
+  it('403 for an OPERATOR_OWNER (a tenant must never read platform-wide health)', async () => {
+    const app = await mount('OPERATOR_OWNER', OP_A)
+    expect((await app.request('/admin/overview')).status).toBe(403)
+  })
+
+  it('200 for PLATFORM_ADMIN (the only platform-admin role)', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    expect((await app.request('/admin/overview')).status).toBe(200)
+  })
+})
+
+describe('GET /admin/overview — aggregate', () => {
+  it('returns the six platform KPIs computed from the seeded fixture', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    const res = await app.request('/admin/overview')
+    const { success, data } = await res.json()
+
+    expect(success).toBe(true)
+    expect(data).toMatchObject({
+      bookings: 3,
+      gmvJpy: 35_000,
+      fleet: 3,
+      operators: 2,
+      unresolvedAnomalies: 1,
+      pendingDocs: 2,
+    })
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,7 @@
     "./types/stats": "./src/types/stats.ts",
     "./types/overview": "./src/types/overview.ts",
     "./types/admin-revenue": "./src/types/admin-revenue.ts",
+    "./types/admin-overview": "./src/types/admin-overview.ts",
     "./types/payment-anomaly": "./src/types/payment-anomaly.ts",
     "./types/api-response": "./src/types/api-response.ts",
     "./types/fleet": "./src/types/fleet.ts",

--- a/packages/shared/src/types/admin-overview.ts
+++ b/packages/shared/src/types/admin-overview.ts
@@ -1,0 +1,25 @@
+/**
+ * Platform-owner home overview (#1087, epic #1075 slice 1). Six platform-wide
+ * health KPIs for the `_admin` landing screen — distinct from the operator-scoped
+ * {@link OperatorOverview} (one tenant) and the X-API-Key `DashboardStats` (4
+ * fields). Every figure is a single-table COUNT/SUM computed in the repo layer
+ * (never load-then-count); the `AdminOverviewService` is the platform-admin authz
+ * chokepoint. Read-only.
+ */
+export interface AdminOverview {
+  /** `COUNT(bookings)` — every booking ever placed, across all operators. */
+  bookings: number
+  /** `COALESCE(SUM(payment_events.grossJpy), 0)` over SUCCEEDED payments. Whole JPY. */
+  gmvJpy: number
+  /** `COUNT(vehicles WHERE status != 'RETIRED')` — the live fleet across all operators. */
+  fleet: number
+  /**
+   * `COUNT(operators)`. Labelled "Operators" for now; #1088 adds a `deactivatedAt`
+   * column and relabels this to "Active operators" (`deactivatedAt IS NULL`).
+   */
+  operators: number
+  /** `COUNT(payment_anomalies WHERE resolvedAt IS NULL)` — duplicate/mismatch charges awaiting review. */
+  unresolvedAnomalies: number
+  /** `COUNT(renter_documents WHERE status = 'PENDING')` — the verification queue depth. */
+  pendingDocs: number
+}

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1237,7 +1237,17 @@
     },
     "home": {
       "title": "Platform Admin",
-      "subtitle": "Platform operations"
+      "subtitle": "Platform operations",
+      "kpi": {
+        "bookings": "Bookings",
+        "gmv": "GMV",
+        "fleet": "Fleet",
+        "operators": "Operators",
+        "unresolvedAnomalies": "Open anomalies",
+        "pendingDocs": "Pending documents"
+      },
+      "loadError": "Couldn't load the platform overview.",
+      "retry": "Retry"
     },
     "revenue": {
       "title": "Partner Revenue",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1237,7 +1237,17 @@
     },
     "home": {
       "title": "プラットフォーム管理",
-      "subtitle": "プラットフォーム運営"
+      "subtitle": "プラットフォーム運営",
+      "kpi": {
+        "bookings": "予約数",
+        "gmv": "流通総額",
+        "fleet": "車両数",
+        "operators": "事業者数",
+        "unresolvedAnomalies": "未解決の異常",
+        "pendingDocs": "審査待ち書類"
+      },
+      "loadError": "プラットフォーム概要を読み込めませんでした。",
+      "retry": "再試行"
     },
     "revenue": {
       "title": "パートナー収益",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1237,7 +1237,17 @@
     },
     "home": {
       "title": "平台管理",
-      "subtitle": "平台运营"
+      "subtitle": "平台运营",
+      "kpi": {
+        "bookings": "预订量",
+        "gmv": "成交总额",
+        "fleet": "车队规模",
+        "operators": "运营商数量",
+        "unresolvedAnomalies": "未解决异常",
+        "pendingDocs": "待审文件"
+      },
+      "loadError": "无法加载平台概览。",
+      "retry": "重试"
     },
     "revenue": {
       "title": "合作伙伴收益",

--- a/packages/web/src/routes/$locale/_admin/admin/index.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/index.tsx
@@ -1,6 +1,38 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
 import { AdminHomeView } from '@/vite/admin/AdminHomeView'
-import { createFileRoute } from '@tanstack/react-router'
+import { adminOverviewQueryOptions } from '@/vite/admin/overview/api'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useTranslations } from 'use-intl'
 
+// Platform-owner home (#1087, epic #1075 slice 1). The `_admin` parent layout
+// already gates on platform-admin membership, so this only owns the data: prefetch
+// the overview in the loader, then render the pure AdminHomeView KPI grid.
 export const Route = createFileRoute('/$locale/_admin/admin/')({
-  component: AdminHomeView,
+  loader: ({ context }) => context.queryClient.ensureQueryData(adminOverviewQueryOptions()),
+  pendingComponent: PageSkeleton,
+  errorComponent: AdminHomeError,
+  component: AdminHomeRoute,
 })
+
+function AdminHomeRoute() {
+  const { data } = useSuspenseQuery(adminOverviewQueryOptions())
+  return <AdminHomeView overview={data} />
+}
+
+function AdminHomeError(_props: ErrorComponentProps) {
+  const t = useTranslations('admin.home')
+  const router = useRouter()
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 text-center">
+      <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+      <button
+        type="button"
+        onClick={() => router.invalidate()}
+        className="mt-4 inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted/50"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/AdminHomeView.test.tsx
+++ b/packages/web/src/vite/admin/AdminHomeView.test.tsx
@@ -1,0 +1,54 @@
+import { formatJpy } from '@/lib/format'
+import type { AdminOverview } from '@kuruma/shared/types/admin-overview'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+import { AdminHomeView } from './AdminHomeView'
+
+const OVERVIEW: AdminOverview = {
+  bookings: 128,
+  gmvJpy: 4_560_000,
+  fleet: 42,
+  operators: 7,
+  unresolvedAnomalies: 2,
+  pendingDocs: 5,
+}
+
+function renderView(overview: AdminOverview = OVERVIEW) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <AdminHomeView overview={overview} />
+    </IntlProvider>,
+  )
+}
+
+const KPI = en.admin.home.kpi
+
+describe('AdminHomeView', () => {
+  it('renders all six KPI labels', () => {
+    renderView()
+    for (const label of Object.values(KPI)) {
+      expect(screen.getByText(label)).not.toBeNull()
+    }
+  })
+
+  it('renders each KPI value, formatting GMV as yen and counts grouped', () => {
+    renderView()
+    // Counts are locale-grouped (en-US): 128, 42, 7.
+    expect(screen.getByText('128')).not.toBeNull()
+    expect(screen.getByText('42')).not.toBeNull()
+    expect(screen.getByText('7')).not.toBeNull()
+    // GMV is yen-formatted (not the bare 4560000), via the shared formatter so the
+    // assertion tracks the runtime's currency glyph rather than hard-coding it.
+    expect(screen.getByText(formatJpy(OVERVIEW.gmvJpy))).not.toBeNull()
+    expect(screen.queryByText('4560000')).toBeNull()
+  })
+
+  it('pairs the GMV label with the yen value in the same card', () => {
+    renderView()
+    const gmvLabel = screen.getByText(KPI.gmv)
+    const card = gmvLabel.closest('div')
+    expect(card?.textContent).toContain(formatJpy(OVERVIEW.gmvJpy))
+  })
+})

--- a/packages/web/src/vite/admin/AdminHomeView.tsx
+++ b/packages/web/src/vite/admin/AdminHomeView.tsx
@@ -1,12 +1,43 @@
+import { formatJpy } from '@/lib/format'
+import type { AdminOverview } from '@kuruma/shared/types/admin-overview'
 import { useTranslations } from 'use-intl'
 
-export function AdminHomeView() {
-  const t = useTranslations('admin')
+interface AdminHomeViewProps {
+  readonly overview: AdminOverview
+}
+
+// Platform-owner home overview (#1087, epic #1075 slice 1). Presentational: the
+// route owns the loader / useSuspenseQuery + boundaries and passes the aggregate
+// in, so this is a pure function of props. Renders the six platform-health KPIs as
+// a card grid; GMV is formatted as yen, the rest as locale-grouped counts.
+export function AdminHomeView({ overview }: AdminHomeViewProps) {
+  const t = useTranslations('admin.home')
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <h1 className="text-3xl font-semibold tracking-tight">{t('home.title')}</h1>
-      <p className="text-sm text-muted-foreground mt-1">{t('home.subtitle')}</p>
+      <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
+      <p className="text-sm text-muted-foreground mt-1">{t('subtitle')}</p>
+
+      <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <KpiCard label={t('kpi.bookings')} value={overview.bookings.toLocaleString()} />
+        <KpiCard label={t('kpi.gmv')} value={formatJpy(overview.gmvJpy)} />
+        <KpiCard label={t('kpi.fleet')} value={overview.fleet.toLocaleString()} />
+        <KpiCard label={t('kpi.operators')} value={overview.operators.toLocaleString()} />
+        <KpiCard
+          label={t('kpi.unresolvedAnomalies')}
+          value={overview.unresolvedAnomalies.toLocaleString()}
+        />
+        <KpiCard label={t('kpi.pendingDocs')} value={overview.pendingDocs.toLocaleString()} />
+      </dl>
+    </div>
+  )
+}
+
+function KpiCard({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div className="rounded-xl border border-border p-6">
+      <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
+      <dd className="mt-2 font-semibold text-3xl tabular-nums">{value}</dd>
     </div>
   )
 }

--- a/packages/web/src/vite/admin/overview/api.test.ts
+++ b/packages/web/src/vite/admin/overview/api.test.ts
@@ -1,0 +1,58 @@
+import { ParseError } from '@/lib/api-error'
+import type { AdminOverview } from '@kuruma/shared/types/admin-overview'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ADMIN_OVERVIEW_QUERY_KEY, adminOverviewQueryOptions, fetchAdminOverview } from './api'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+afterEach(() => fetchMock.mockReset())
+
+const OVERVIEW: AdminOverview = {
+  bookings: 128,
+  gmvJpy: 4_560_000,
+  fleet: 42,
+  operators: 7,
+  unresolvedAnomalies: 2,
+  pendingDocs: 5,
+}
+
+describe('adminOverviewQueryOptions', () => {
+  it('exposes the stable admin-overview key for cache invalidation', () => {
+    expect(ADMIN_OVERVIEW_QUERY_KEY).toEqual(['admin-overview'])
+    expect(adminOverviewQueryOptions().queryKey).toEqual(['admin-overview'])
+  })
+})
+
+describe('fetchAdminOverview', () => {
+  it('GETs /api/admin/overview with credentials and unwraps the validated aggregate', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: OVERVIEW }))
+
+    const result = await fetchAdminOverview()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/overview', { credentials: 'include' })
+    expect(result).toEqual(OVERVIEW)
+  })
+
+  it('rejects with a ParseError when a KPI arrives as a string (contract drift)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { ...OVERVIEW, gmvJpy: '4560000' } }),
+    )
+    await expect(fetchAdminOverview()).rejects.toBeInstanceOf(ParseError)
+  })
+
+  it('rejects with a ParseError when a KPI is missing entirely', async () => {
+    const { pendingDocs, ...partial } = OVERVIEW
+    void pendingDocs
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: partial }))
+    await expect(fetchAdminOverview()).rejects.toBeInstanceOf(ParseError)
+  })
+})

--- a/packages/web/src/vite/admin/overview/api.ts
+++ b/packages/web/src/vite/admin/overview/api.ts
@@ -1,0 +1,36 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import type { AdminOverview } from '@kuruma/shared/types/admin-overview'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// Platform-owner home KPIs (#1087, epic #1075 slice 1). Cookie-based
+// (credentials: 'include') so the API gates on the session role server-side
+// (requirePlatformAdmin). No query params — the endpoint returns the six
+// platform-wide figures. Mirrors revenue/api.ts.
+export const ADMIN_OVERVIEW_QUERY_KEY = ['admin-overview'] as const
+
+// Network-seam validator (#711 ratchet). `satisfies z.ZodType<AdminOverview>`
+// pins it to the shared wire DTO so a renamed/added KPI fails typecheck HERE; a
+// drifted runtime body (e.g. a yen total arriving as a string) then surfaces as a
+// ParseError at the seam instead of a blank/NaN KPI card.
+const adminOverviewSchema = z.object({
+  bookings: z.number(),
+  gmvJpy: z.number(),
+  fleet: z.number(),
+  operators: z.number(),
+  unresolvedAnomalies: z.number(),
+  pendingDocs: z.number(),
+}) satisfies z.ZodType<AdminOverview>
+
+export async function fetchAdminOverview(): Promise<AdminOverview> {
+  const res = await fetch(`${getApiBaseUrl()}/admin/overview`, { credentials: 'include' })
+  return unwrap(res, adminOverviewSchema)
+}
+
+export function adminOverviewQueryOptions() {
+  return queryOptions({
+    queryKey: ADMIN_OVERVIEW_QUERY_KEY,
+    queryFn: fetchAdminOverview,
+  })
+}

--- a/packages/web/tests/vite/admin/views.test.tsx
+++ b/packages/web/tests/vite/admin/views.test.tsx
@@ -87,7 +87,18 @@ const EMPTY_REPORT: AdminRevenueResponse = {
 
 describe('AdminHomeView', () => {
   it('shows the platform admin title + subtitle', () => {
-    renderView(<AdminHomeView />)
+    renderView(
+      <AdminHomeView
+        overview={{
+          bookings: 0,
+          gmvJpy: 0,
+          fleet: 0,
+          operators: 0,
+          unresolvedAnomalies: 0,
+          pendingDocs: 0,
+        }}
+      />,
+    )
     expect(screen.getByRole('heading', { name: 'Platform Admin' })).toBeInTheDocument()
     expect(screen.getByText('Platform operations')).toBeInTheDocument()
   })


### PR DESCRIPTION
## What

Slice #1087 of the platform-owner dashboard epic (#1075): the admin **overview / KPI tiles** landing page.

- **API:** new session-authed `GET /admin/overview` (`requirePlatformAdmin` route + `AdminOverviewService`, which re-asserts the gate). Returns all 6 KPIs via DB-side aggregates — 6 new repo COUNT/SUM reads (InMemory + Drizzle).
- **Money:** GMV is a DB-side `COALESCE(SUM(grossJpy),0)` over SUCCEEDED payment events — not load-then-sum; whole-yen (zero-decimal).
- **Web:** KPI tiles on the admin home, network-seam Zod validator `satisfies z.ZodType<AdminOverview>` (#711), error boundary with retry.

The `operators` KPI is a plain active-operator count with `TODO(#1088)` — richer per-operator metrics are intentionally deferred to #1088/#1120.

## Layering

routes → services → repositories; concretes wired only in `index.ts`. `getOverview` is a thin imperative shell that fans out six pure single-table reads (FC/IS). `lint:boundaries` green.

## Test plan

- [x] Authz: 403 for PARTNER / OPERATOR_OWNER / OPERATOR_STAFF / RENTER / STAFF / ADMIN, 401 unauth, 200 PLATFORM_ADMIN. (The `bypassScope`-admits-PARTNER hazard is explicitly tested.)
- [x] KPI values: six *distinct* fixture figures so a repo-swap is caught (mutation-resistant, not a non-zero smoke test). 18 api tests green.
- [x] Web: ParseError on string-gmv and on missing key (#711). 7 web tests green.
- [x] api + web typecheck, `lint:boundaries` green; i18n parity en/ja/zh (8 keys).

Code-reviewed: SHIP, no CRITICAL/HIGH/MEDIUM (3 deferrable LOWs: test-fixture DRY, untested error boundary, return-type-by-convention).

Refs #1075
Closes #1087