### PR TITLE
perf(#1114): skip 4 unused reads in cancellation email path

### DIFF
--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -203,8 +203,10 @@ export class NotificationDispatcher {
     return { to: fallback, recipient: fallback, locale: DEFAULT_OPERATOR_LOCALE }
   }
 
-  private async buildMessage(booking: Booking, kind: Kind, resolved: Resolved) {
-    const { to, bcc, locale } = resolved
+  // Eager relations used by every kind EXCEPT RENTER_CANCELLATION (which renders
+  // from booking-snapshot fields alone). Pulled into its own method so the
+  // cancellation branch doesn't pay the 4 repo reads it never consumes (#1114).
+  private async loadRelations(booking: Booking) {
     const [operator, vehicle, pickup, dropoff] = await Promise.all([
       this.operatorRepo.findById(booking.operatorId),
       booking.assignedVehicleId
@@ -230,6 +232,11 @@ export class NotificationDispatcher {
       endAt: booking.endAt,
       totalPriceJpy: booking.totalPrice,
     }
+    return { operator, vehicleData, pickupName, dropoffName, common }
+  }
+
+  private async buildMessage(booking: Booking, kind: Kind, resolved: Resolved) {
+    const { to, bcc, locale } = resolved
     const replyTo = this.config.emailReplyTo
     const envelope = (r: { subject: string; html: string; text: string }) => ({
       to,
@@ -240,6 +247,25 @@ export class NotificationDispatcher {
       text: r.text,
       ...(replyTo ? { replyTo } : {}),
     })
+
+    // Branches that render purely from booking-snapshot fields short-circuit
+    // BEFORE the eager relation reads (#1114).
+    if (kind === 'RENTER_CANCELLATION') {
+      return envelope(
+        renderRenterCancellation(
+          {
+            bookingCode: booking.bookingCode,
+            startAt: booking.startAt,
+            endAt: booking.endAt,
+            cancellationFeeJpy: booking.cancellationFee,
+          },
+          locale,
+        ),
+      )
+    }
+
+    const { operator, vehicleData, pickupName, dropoffName, common } =
+      await this.loadRelations(booking)
 
     switch (kind) {
       case 'RENTER_BOOKING_CONFIRM':
@@ -271,18 +297,6 @@ export class NotificationDispatcher {
               dropoffLocationName: dropoffName,
               startAt: booking.startAt,
               endAt: booking.endAt,
-            },
-            locale,
-          ),
-        )
-      case 'RENTER_CANCELLATION':
-        return envelope(
-          renderRenterCancellation(
-            {
-              bookingCode: booking.bookingCode,
-              startAt: booking.startAt,
-              endAt: booking.endAt,
-              cancellationFeeJpy: booking.cancellationFee,
             },
             locale,
           ),

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -515,6 +515,89 @@ describe('NotificationDispatcher', () => {
       expect(sender.send as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2)
     })
 
+    // #1114: `buildMessage` used to eager-fetch operator+vehicle+pickup+dropoff
+    // for every kind, even though RENTER_CANCELLATION uses none of them. Push
+    // the reads down to the consuming branches.
+    it('RENTER_CANCELLATION skips the 4 unused reads (operator + vehicle + pickup + dropoff)', async () => {
+      const operatorFindById = vi.fn(async () => undefined)
+      const vehicleFindById = vi.fn(async () => undefined)
+      const locationFindById = vi.fn(async (_ctx: unknown, id: string) => ({ id, name: id }))
+      const operatorRepo = { findById: operatorFindById } as unknown as InMemoryOperatorRepository
+      const vehicleRepo = { findById: vehicleFindById } as unknown as VehicleRepository
+      const locationRepo = { findById: locationFindById } as unknown as LocationRepository
+
+      // Reuse the build() rig for everything except the 3 instrumented repos.
+      const { dispatcher: base } = build()
+      const dispatcher = new NotificationDispatcher(
+        // biome-ignore lint/suspicious/noExplicitAny: reaching into the rig only to swap the 3 instrumented repos
+        (base as any).notificationLogRepo,
+        operatorRepo,
+        vehicleRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).userRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).resolveOperatorRecipients,
+        locationRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).emailSender,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).config,
+      )
+
+      await dispatcher.processOne(booking, 'RENTER_CANCELLATION')
+
+      expect(operatorFindById).toHaveBeenCalledTimes(0)
+      expect(vehicleFindById).toHaveBeenCalledTimes(0)
+      expect(locationFindById).toHaveBeenCalledTimes(0)
+    })
+
+    // Mutation guard: a consumer branch MUST still issue those reads after the
+    // refactor, otherwise the cancellation savings came at the cost of breaking
+    // confirmation rendering.
+    it('RENTER_BOOKING_CONFIRM still reads operator + vehicle + pickup + dropoff', async () => {
+      const operatorFindById = vi.fn(async () => ({
+        id: OP,
+        slug: 'bcr',
+        name: 'BCR',
+        preAuthHandoffUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+      const vehicleFindById = vi.fn(async () => ({
+        name: 'Toyota Aqua',
+        make: 'Toyota',
+        model: 'Aqua',
+        licensePlate: 'X 12-34',
+      }))
+      const locationFindById = vi.fn(async (_ctx: unknown, id: string) => ({ id, name: id }))
+      const operatorRepo = { findById: operatorFindById } as unknown as InMemoryOperatorRepository
+      const vehicleRepo = { findById: vehicleFindById } as unknown as VehicleRepository
+      const locationRepo = { findById: locationFindById } as unknown as LocationRepository
+
+      const { dispatcher: base } = build()
+      const dispatcher = new NotificationDispatcher(
+        // biome-ignore lint/suspicious/noExplicitAny: rig-only swap of the 3 instrumented repos
+        (base as any).notificationLogRepo,
+        operatorRepo,
+        vehicleRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).userRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).resolveOperatorRecipients,
+        locationRepo,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).emailSender,
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        (base as any).config,
+      )
+
+      await dispatcher.processOne(booking, 'RENTER_BOOKING_CONFIRM')
+
+      expect(operatorFindById).toHaveBeenCalledTimes(1)
+      expect(vehicleFindById).toHaveBeenCalledTimes(1) // assignedVehicleId = 'veh-1'
+      expect(locationFindById).toHaveBeenCalledTimes(2) // pickup + dropoff
+    })
+
     it('substitution email renders the new vehicle and leaks no internal ids', async () => {
       const sent: Array<{ to: string; subject: string; html: string; text: string }> = []
       const sender = {


### PR DESCRIPTION
## Summary

Audit L2 from \`docs/audits/2026-06-25-solid-architecture-audit.md\` (tracker #1104). \`buildMessage\` used to \`Promise.all\` operator + vehicle + pickup + dropoff for every notification kind. \`RENTER_CANCELLATION\` renders from snapshot fields only (\`bookingCode\`, \`startAt\`, \`endAt\`, \`cancellationFeeJpy\`) — those 4 reads were thrown away on every cancellation email.

- Extracted the eager fetch + derived \`vehicleData / pickupName / dropoffName / common\` into a new \`loadRelations(booking)\` helper.
- The switch short-circuits \`RENTER_CANCELLATION\` **before** the helper runs.
- Every consumer branch (confirmation, substitution, status, operator-alert) calls \`loadRelations\` explicitly and gets the same data it always had — byte-identical message output.

## TDD

- **RED** — \`RENTER_CANCELLATION.processOne\` → assert operator/vehicle/location read counts are \`0\`. Fails on the old code (operator was called once via the eager \`Promise.all\`).
- **GREEN** — counts go to \`0/0/0\` after the short-circuit.
- **Mutation guard** — a parallel test asserts \`RENTER_BOOKING_CONFIRM\` still issues \`1\` operator + \`1\` vehicle + \`2\` location reads. Removing the \`loadRelations\` call in any consumer branch would regress this test.

## Test plan

- [x] \`@kuruma/api test\` — 1925/1925 pass
- [x] \`tsc --noEmit -p packages/api\` — clean
- [x] Existing substitution test (renders Toyota Aqua + plate) still passes — proves the consumer branches' output is unchanged

Closes #1114
Refs #1104