### PR TITLE
feat(#1091): platform consent-acceptance governance browser

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ import { requestId } from './middleware/request-id'
 import { observability } from './observability/middleware'
 import { createAddOnRoutes } from './routes/add-ons'
 import { createAdminRoutes } from './routes/admin'
+import { createAdminConsentRoutes } from './routes/admin-consent'
 import { createAdminRevenueRoutes } from './routes/admin-revenue'
 import { createAuthRoutes } from './routes/auth'
 import { createAvailabilityRoutes } from './routes/availability'
@@ -57,6 +58,7 @@ import { ComplianceDigestService } from './services/compliance-digest'
 import { ConsentService } from './services/consent'
 import { ConsentEvidenceService } from './services/consent-evidence'
 import { ConsentGateService } from './services/consent-gate'
+import { ConsentGovernanceService } from './services/consent-governance'
 import { resolveSigningKey } from './services/consent-signing'
 import { CustomerService } from './services/customer'
 import { documentVerificationGate } from './services/document-verification-gate'
@@ -402,6 +404,8 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     const k = resolveSigningKey()
     return k && k.keyId === keyId ? k : undefined
   })
+  // #1091: platform-admin read-only governance browse over the same ledger.
+  const consentGovernanceService = new ConsentGovernanceService(consentRepo)
   const userDirectoryService = new UserDirectoryService(userRepo, threadRepo)
   const maintenanceService = new MaintenanceService(
     vehicleRepo,
@@ -498,6 +502,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createPaymentAnomalyRoutes(paymentAnomalyService))
     .route('/', createMessageRoutes(messageService))
     .route('/', createConsentRoutes(consentService))
+    .route('/', createAdminConsentRoutes(consentGovernanceService))
     .route(
       '/',
       createTranslateRoutes(new MessageTranslationService(messageRepo, translationProvider)),

--- a/packages/api/src/repositories/drizzle/consent.ts
+++ b/packages/api/src/repositories/drizzle/consent.ts
@@ -1,8 +1,14 @@
 import type { ConsentType } from '@kuruma/shared/enums'
 import { consentAcceptances, consentDocuments } from '@kuruma/shared/db/schema'
-import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { type SQL, and, desc, eq, gte, inArray, isNull, lte } from 'drizzle-orm'
 import type { ConsentAcceptance, ConsentDocument } from '../../stores'
-import type { ConsentRepository, NewConsentAcceptance } from '../types'
+import type {
+  ConsentAcceptanceListRow,
+  ConsentAcceptanceQuery,
+  ConsentRepository,
+  NewConsentAcceptance,
+} from '../types'
+import { CONSENT_ACCEPTANCE_LIST_LIMIT } from '../types-consent'
 import type { Db } from './shared'
 
 type DocRow = typeof consentDocuments.$inferSelect
@@ -186,6 +192,32 @@ export class DrizzleConsentRepository implements ConsentRepository {
       .from(consentAcceptances)
       .where(eq(consentAcceptances.bookingId, bookingId))
     return rows.map(toAcceptance)
+  }
+
+  // Governance ledger browse (#1091): one inner join to documents pins the accepted
+  // version (documentId is a single-locale PK, so no fan-out), filtered + newest-first.
+  async findAcceptances(q: ConsentAcceptanceQuery): Promise<ConsentAcceptanceListRow[]> {
+    const conds: SQL[] = []
+    if (q.userId !== undefined) conds.push(eq(consentAcceptances.userId, q.userId))
+    if (q.consentType !== undefined) conds.push(eq(consentAcceptances.consentType, q.consentType))
+    if (q.version !== undefined) conds.push(eq(consentDocuments.version, q.version))
+    if (q.acceptedFrom !== undefined) conds.push(gte(consentAcceptances.acceptedAt, q.acceptedFrom))
+    if (q.acceptedTo !== undefined) conds.push(lte(consentAcceptances.acceptedAt, q.acceptedTo))
+    return this.db
+      .select({
+        id: consentAcceptances.id,
+        userId: consentAcceptances.userId,
+        consentType: consentAcceptances.consentType,
+        version: consentDocuments.version,
+        operatorId: consentAcceptances.operatorId,
+        bookingId: consentAcceptances.bookingId,
+        acceptedAt: consentAcceptances.acceptedAt,
+      })
+      .from(consentAcceptances)
+      .innerJoin(consentDocuments, eq(consentAcceptances.documentId, consentDocuments.id))
+      .where(conds.length > 0 ? and(...conds) : undefined)
+      .orderBy(desc(consentAcceptances.acceptedAt))
+      .limit(CONSENT_ACCEPTANCE_LIST_LIMIT)
   }
 
   async createAcceptance(data: NewConsentAcceptance): Promise<ConsentAcceptance> {

--- a/packages/api/src/repositories/in-memory/consent.test.ts
+++ b/packages/api/src/repositories/in-memory/consent.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { ConsentDocument } from '../../stores'
 import type { NewConsentAcceptance } from '../types'
+import { CONSENT_ACCEPTANCE_LIST_LIMIT } from '../types-consent'
 import { InMemoryConsentRepository } from './consent'
 
 const DOC: ConsentDocument = {
@@ -53,6 +54,37 @@ describe('InMemoryConsentRepository', () => {
     await repo.createAcceptance(baseAcceptance)
     expect(await repo.hasAcceptedVersion('user_1', 'RENTER_TOS', '1.0')).toBe(true)
     expect(await repo.hasAcceptedVersion('user_2', 'RENTER_TOS', '1.0')).toBe(false)
+  })
+
+  it('findAcceptances joins the document version and drops rows whose doc is absent', async () => {
+    await repo.createAcceptance(baseAcceptance)
+    // An acceptance pointing at a document not in the repo (mirrors an inner join
+    // miss) must NOT surface with an empty version — it is dropped entirely.
+    await repo.createAcceptance({ ...baseAcceptance, userId: 'user_2', documentId: 'doc_missing' })
+
+    const rows = await repo.findAcceptances({})
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ userId: 'user_1', consentType: 'RENTER_TOS', version: '1.0' })
+  })
+
+  it('caps the ledger browse at CONSENT_ACCEPTANCE_LIST_LIMIT, keeping the newest', async () => {
+    // Seed more than the cap, each a distinct user (the composite-unique key) with a
+    // strictly increasing acceptedAt, so newest-first ordering is unambiguous.
+    const overflow = CONSENT_ACCEPTANCE_LIST_LIMIT + 5
+    for (let i = 0; i < overflow; i++) {
+      await repo.createAcceptance({
+        ...baseAcceptance,
+        userId: `user_${String(i).padStart(4, '0')}`,
+        acceptedAt: new Date(Date.UTC(2026, 0, 1) + i * 1000),
+      })
+    }
+
+    const rows = await repo.findAcceptances({})
+
+    expect(rows).toHaveLength(CONSENT_ACCEPTANCE_LIST_LIMIT)
+    // Newest row survives; the 5 oldest (user_0000..user_0004) are dropped by the cap.
+    expect(rows[0]?.userId).toBe(`user_${String(overflow - 1).padStart(4, '0')}`)
+    expect(rows.map((r) => r.userId)).not.toContain('user_0000')
   })
 
   it('seals once-per-user idempotency with constraint_name consent_unique_user_document', async () => {

--- a/packages/api/src/repositories/in-memory/consent.ts
+++ b/packages/api/src/repositories/in-memory/consent.ts
@@ -1,7 +1,13 @@
 import type { ConsentType } from '@kuruma/shared/enums'
 import { PG_ERROR } from '../../pg-errors'
 import type { ConsentAcceptance, ConsentDocument } from '../../stores'
-import type { ConsentRepository, NewConsentAcceptance } from '../types'
+import type {
+  ConsentAcceptanceListRow,
+  ConsentAcceptanceQuery,
+  ConsentRepository,
+  NewConsentAcceptance,
+} from '../types'
+import { CONSENT_ACCEPTANCE_LIST_LIMIT } from '../types-consent'
 
 // Mirror postgres-js's PostgresError shape (top-level `code` + `constraint_name`) so the
 // service's 23505 catch-path behaves identically against the in-memory and Drizzle repos.
@@ -89,6 +95,35 @@ export class InMemoryConsentRepository implements ConsentRepository {
 
   async findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]> {
     return this.acceptances.filter((a) => a.bookingId === bookingId)
+  }
+
+  // Mirrors the Drizzle inner join (documentId -> document): an acceptance whose
+  // document is absent is dropped, never surfaced with an empty version.
+  async findAcceptances(q: ConsentAcceptanceQuery): Promise<ConsentAcceptanceListRow[]> {
+    return this.acceptances
+      .flatMap((a) => {
+        const version = this.docs.get(a.documentId)?.version
+        return version === undefined ? [] : [{ a, version }]
+      })
+      .filter(
+        ({ a, version }) =>
+          (q.userId === undefined || a.userId === q.userId) &&
+          (q.consentType === undefined || a.consentType === q.consentType) &&
+          (q.version === undefined || version === q.version) &&
+          (q.acceptedFrom === undefined || a.acceptedAt >= q.acceptedFrom) &&
+          (q.acceptedTo === undefined || a.acceptedAt <= q.acceptedTo),
+      )
+      .map(({ a, version }) => ({
+        id: a.id,
+        userId: a.userId,
+        consentType: a.consentType,
+        version,
+        operatorId: a.operatorId,
+        bookingId: a.bookingId,
+        acceptedAt: a.acceptedAt,
+      }))
+      .sort((x, y) => y.acceptedAt.getTime() - x.acceptedAt.getTime())
+      .slice(0, CONSENT_ACCEPTANCE_LIST_LIMIT)
   }
 
   async createAcceptance(data: NewConsentAcceptance): Promise<ConsentAcceptance> {

--- a/packages/api/src/repositories/types-consent.ts
+++ b/packages/api/src/repositories/types-consent.ts
@@ -23,6 +23,38 @@ export interface NewConsentAcceptance {
   documentSnapshot: DocumentSnapshot | null
 }
 
+/** Filters for the platform-admin governance ledger browse (#1091). All optional;
+ *  an empty query returns the whole ledger. `acceptedFrom`/`acceptedTo` inclusively
+ *  bound `acceptedAt`. */
+export interface ConsentAcceptanceQuery {
+  userId?: string
+  consentType?: ConsentType
+  version?: string
+  acceptedFrom?: Date
+  acceptedTo?: Date
+}
+
+/**
+ * Defensive hard cap on a single ledger browse (#1091). v1 ships no cursor
+ * pagination, and `consent_acceptances` grows per-booking (every booking seals a
+ * RENTER_LIABILITY acceptance), so an uncapped default browse balloons into a
+ * multi-MB response at 2000+ users. Both repo impls slice newest-first to this;
+ * real cursor pagination on `(acceptedAt, id)` is a later slice.
+ */
+export const CONSENT_ACCEPTANCE_LIST_LIMIT = 200
+
+/** A ledger row joined to its document for the accepted `version` label (#1091).
+ *  Read-only projection — carries no computed compliance status. */
+export interface ConsentAcceptanceListRow {
+  id: string
+  userId: string
+  consentType: ConsentType
+  version: string
+  operatorId: string | null
+  bookingId: string | null
+  acceptedAt: Date
+}
+
 export interface ConsentRepository {
   findDocumentById(id: string): Promise<ConsentDocument | undefined>
   /** Latest PUBLISHED+effective version string for a type, independent of locale (§7 cohort). */
@@ -49,4 +81,7 @@ export interface ConsentRepository {
   findAcceptanceById(id: string): Promise<ConsentAcceptance | undefined>
   findAcceptancesByUser(userId: string): Promise<ConsentAcceptance[]>
   findAcceptancesByBooking(bookingId: string): Promise<ConsentAcceptance[]>
+  /** Cross-user governance browse (#1091): one batch read of the ledger, joined to
+   *  documents for the accepted version, filtered + newest-first. Constant queries. */
+  findAcceptances(query: ConsentAcceptanceQuery): Promise<ConsentAcceptanceListRow[]>
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -769,7 +769,12 @@ export type CreateRenterDocumentData = Pick<RenterDocument, 'renterId' | 'type' 
 
 // Consent data-access interfaces (#613) live in their own module to keep this
 // barrel under the file-size cap; re-exported for callers.
-export type { ConsentRepository, NewConsentAcceptance } from './types-consent'
+export type {
+  ConsentAcceptanceListRow,
+  ConsentAcceptanceQuery,
+  ConsentRepository,
+  NewConsentAcceptance,
+} from './types-consent'
 
 // Reviews bounded-context data access (#1067 slice 1) lives in its own module;
 // re-exported for callers (mirrors the payment/consent split above).

--- a/packages/api/src/routes/admin-consent.ts
+++ b/packages/api/src/routes/admin-consent.ts
@@ -1,0 +1,35 @@
+import { consentGovernanceFiltersSchema } from '@kuruma/shared/types/consent-governance'
+import { Hono } from 'hono'
+import { requireAuth, requirePlatformAdmin, requireUser, toCallerContext } from '../middleware/auth'
+import type { ConsentGovernanceService } from '../services/consent-governance'
+import { fail, ok } from './helpers'
+
+/**
+ * Platform-admin consent-acceptance governance browse (#1091, epic #1075 slice 5).
+ * A NEW admin list endpoint — the existing `GET /consent/status` is self-scoped to
+ * the caller and is NOT widened. `requireAuth` gates the path (401 unauth) and
+ * `requirePlatformAdmin` narrows it to PLATFORM_ADMIN (403 otherwise); the service
+ * re-asserts the same gate as defence-in-depth. Read-only: filter the append-only
+ * ledger, never mutate it.
+ */
+export function createAdminConsentRoutes(service: ConsentGovernanceService) {
+  const app = new Hono()
+  app.use('/admin/consent/acceptances', requireAuth())
+
+  return app.get('/admin/consent/acceptances', async (c) => {
+    const ctx = toCallerContext(requireUser(c))
+    requirePlatformAdmin(ctx)
+
+    const parsed = consentGovernanceFiltersSchema.safeParse({
+      userId: c.req.query('userId'),
+      consentType: c.req.query('consentType'),
+      version: c.req.query('version'),
+      acceptedFrom: c.req.query('acceptedFrom'),
+      acceptedTo: c.req.query('acceptedTo'),
+    })
+    if (!parsed.success) return fail(c, 'Invalid filters', 400)
+
+    const data = await service.list(ctx, parsed.data)
+    return ok(c, data)
+  })
+}

--- a/packages/api/src/services/consent-governance.test.ts
+++ b/packages/api/src/services/consent-governance.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { type CallerContext, ForbiddenError } from '../middleware/auth'
+import { InMemoryConsentRepository } from '../repositories/in-memory/consent'
+import type { ConsentDocument } from '../stores'
+import { ConsentGovernanceService } from './consent-governance'
+
+const ADMIN: CallerContext = { userId: 'admin-user', role: 'PLATFORM_ADMIN' }
+
+function doc(id: string, version: string, type: ConsentDocument['type']): ConsentDocument {
+  return {
+    id,
+    type,
+    version,
+    locale: 'en',
+    title: 'Terms',
+    body: 'body',
+    acceptanceLabel: 'I accept',
+    contentHash: 'a'.repeat(64),
+    status: 'PUBLISHED',
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    publishedAt: new Date('2026-01-01T00:00:00Z'),
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }
+}
+
+const TOS_V1 = doc('doc_tos_v1_en', '1.0', 'RENTER_TOS')
+const TOS_V2 = doc('doc_tos_v2_en', '2.0', 'RENTER_TOS')
+const PRIVACY_V1 = doc('doc_privacy_v1_en', '1.0', 'PRIVACY_POLICY')
+
+async function seededService(): Promise<ConsentGovernanceService> {
+  const repo = new InMemoryConsentRepository([TOS_V1, TOS_V2, PRIVACY_V1])
+  // user_a accepted TOS v1 (oldest), then privacy v1; user_b accepted TOS v2 (newest).
+  await repo.createAcceptance({
+    documentId: TOS_V1.id,
+    consentType: 'RENTER_TOS',
+    userId: 'user_a',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-03-01T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP',
+    recordSignature: null,
+    signingKeyId: null,
+    signatureCanonicalVersion: null,
+    documentSnapshot: null,
+  })
+  await repo.createAcceptance({
+    documentId: PRIVACY_V1.id,
+    consentType: 'PRIVACY_POLICY',
+    userId: 'user_a',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-04-01T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP',
+    recordSignature: null,
+    signingKeyId: null,
+    signatureCanonicalVersion: null,
+    documentSnapshot: null,
+  })
+  await repo.createAcceptance({
+    documentId: TOS_V2.id,
+    consentType: 'RENTER_TOS',
+    userId: 'user_b',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-05-01T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP',
+    recordSignature: null,
+    signingKeyId: null,
+    signatureCanonicalVersion: null,
+    documentSnapshot: null,
+  })
+  return new ConsentGovernanceService(repo)
+}
+
+describe('ConsentGovernanceService — defence-in-depth authz', () => {
+  it.each(['OPERATOR_OWNER', 'OPERATOR_STAFF', 'RENTER', 'PARTNER'] as const)(
+    'rejects %s with ForbiddenError even if the route gate were bypassed',
+    async (role) => {
+      const service = await seededService()
+      await expect(service.list({ userId: `${role}-user`, role }, {})).rejects.toThrow(
+        ForbiddenError,
+      )
+    },
+  )
+})
+
+describe('ConsentGovernanceService — ledger browse', () => {
+  it('returns all acceptances across users, newest accepted first', async () => {
+    const service = await seededService()
+    const { acceptances } = await service.list(ADMIN, {})
+
+    expect(acceptances.map((a) => a.userId)).toEqual(['user_b', 'user_a', 'user_a'])
+    expect(acceptances[0]).toMatchObject({
+      userId: 'user_b',
+      consentType: 'RENTER_TOS',
+      version: '2.0',
+      acceptedAt: '2026-05-01T00:00:00.000Z',
+      operatorId: null,
+      bookingId: null,
+    })
+    // The acceptanceId is the evidence-export link target — must be the real PK.
+    expect(acceptances[0]?.acceptanceId).toMatch(/[0-9a-f-]{36}/)
+    // No computed status leaks onto the wire (deferred to a later slice).
+    expect(acceptances[0]).not.toHaveProperty('status')
+  })
+
+  it('filters by userId', async () => {
+    const service = await seededService()
+    const { acceptances } = await service.list(ADMIN, { userId: 'user_a' })
+    expect(acceptances.map((a) => a.consentType)).toEqual(['PRIVACY_POLICY', 'RENTER_TOS'])
+    expect(acceptances.every((a) => a.userId === 'user_a')).toBe(true)
+  })
+
+  it('filters by consentType', async () => {
+    const service = await seededService()
+    const { acceptances } = await service.list(ADMIN, { consentType: 'RENTER_TOS' })
+    expect(acceptances.map((a) => a.version)).toEqual(['2.0', '1.0'])
+  })
+
+  it('filters by version (resolved via the joined document)', async () => {
+    const service = await seededService()
+    const { acceptances } = await service.list(ADMIN, { version: '2.0' })
+    expect(acceptances).toHaveLength(1)
+    expect(acceptances[0]).toMatchObject({ userId: 'user_b', version: '2.0' })
+  })
+
+  it('inclusively bounds acceptedAt by acceptedFrom/acceptedTo', async () => {
+    const service = await seededService()
+    const { acceptances } = await service.list(ADMIN, {
+      acceptedFrom: '2026-04-01T00:00:00.000Z',
+      acceptedTo: '2026-04-30T00:00:00.000Z',
+    })
+    expect(acceptances).toHaveLength(1)
+    expect(acceptances[0]).toMatchObject({ consentType: 'PRIVACY_POLICY', version: '1.0' })
+  })
+})

--- a/packages/api/src/services/consent-governance.ts
+++ b/packages/api/src/services/consent-governance.ts
@@ -1,0 +1,54 @@
+import type {
+  ConsentGovernanceFilters,
+  ConsentGovernanceResponse,
+} from '@kuruma/shared/types/consent-governance'
+import { type CallerContext, requirePlatformAdmin } from '../middleware/auth'
+import type { ConsentAcceptanceQuery, ConsentRepository } from '../repositories/types'
+
+/**
+ * Platform-admin consent-acceptance governance browser (#1091, epic #1075 slice 5).
+ *
+ * Imperative shell over the append-only `consent_acceptances` ledger: it re-asserts
+ * `requirePlatformAdmin` (defence-in-depth — the gate travels with the business
+ * logic, since the consent repo's reads are unscoped), converts the validated
+ * string filters into a typed repo query, and projects the rows onto the wire DTO.
+ *
+ * v1 is READ-ONLY: no computed `current | outdated | missing` status (that needs a
+ * subject cohort + current-document baseline and is a later slice) and no re-consent
+ * action. Each row carries the `acceptanceId` linking to the existing evidence
+ * export (#877) — this service never re-implements proof logic.
+ */
+export class ConsentGovernanceService {
+  constructor(private readonly consent: ConsentRepository) {}
+
+  async list(
+    ctx: CallerContext,
+    filters: ConsentGovernanceFilters,
+  ): Promise<ConsentGovernanceResponse> {
+    requirePlatformAdmin(ctx)
+    const rows = await this.consent.findAcceptances(toQuery(filters))
+    return {
+      acceptances: rows.map((r) => ({
+        acceptanceId: r.id,
+        userId: r.userId,
+        consentType: r.consentType,
+        version: r.version,
+        acceptedAt: r.acceptedAt.toISOString(),
+        operatorId: r.operatorId,
+        bookingId: r.bookingId,
+      })),
+    }
+  }
+}
+
+/** Validated wire filters (strings) -> typed repo query. Only present keys are set
+ *  so `exactOptionalPropertyTypes` never sees an explicit `undefined`. */
+function toQuery(f: ConsentGovernanceFilters): ConsentAcceptanceQuery {
+  const q: ConsentAcceptanceQuery = {}
+  if (f.userId !== undefined) q.userId = f.userId
+  if (f.consentType !== undefined) q.consentType = f.consentType
+  if (f.version !== undefined) q.version = f.version
+  if (f.acceptedFrom !== undefined) q.acceptedFrom = new Date(f.acceptedFrom)
+  if (f.acceptedTo !== undefined) q.acceptedTo = new Date(f.acceptedTo)
+  return q
+}

--- a/packages/api/src/services/consent.test.ts
+++ b/packages/api/src/services/consent.test.ts
@@ -209,6 +209,7 @@ describe('ConsentService.recordAcceptance — concurrent-race catch path', () =>
       findAcceptanceById: (...args) => realRepo.findAcceptanceById(...args),
       findAcceptancesByUser: (...args) => realRepo.findAcceptancesByUser(...args),
       findAcceptancesByBooking: (...args) => realRepo.findAcceptancesByBooking(...args),
+      findAcceptances: (...args) => realRepo.findAcceptances(...args),
     }
 
     const svc = new ConsentService(wrappedRepo, () => KEY)

--- a/packages/api/tests/routes/admin-consent.test.ts
+++ b/packages/api/tests/routes/admin-consent.test.ts
@@ -1,0 +1,137 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import type { UserRole } from '../../src/middleware/auth'
+import { InMemoryConsentRepository } from '../../src/repositories/in-memory/consent'
+import { createAdminConsentRoutes } from '../../src/routes/admin-consent'
+import { ConsentGovernanceService } from '../../src/services/consent-governance'
+import type { ConsentDocument } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+
+function doc(id: string, version: string, type: ConsentDocument['type']): ConsentDocument {
+  return {
+    id,
+    type,
+    version,
+    locale: 'en',
+    title: 'Terms',
+    body: 'body',
+    acceptanceLabel: 'I accept',
+    contentHash: 'a'.repeat(64),
+    status: 'PUBLISHED',
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    publishedAt: new Date('2026-01-01T00:00:00Z'),
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }
+}
+
+const TOS_V1 = doc('doc_tos_v1_en', '1.0', 'RENTER_TOS')
+const TOS_V2 = doc('doc_tos_v2_en', '2.0', 'RENTER_TOS')
+
+async function seededRepo(): Promise<InMemoryConsentRepository> {
+  const repo = new InMemoryConsentRepository([TOS_V1, TOS_V2])
+  await repo.createAcceptance({
+    documentId: TOS_V1.id,
+    consentType: 'RENTER_TOS',
+    userId: 'user_a',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-03-01T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP',
+    recordSignature: null,
+    signingKeyId: null,
+    signatureCanonicalVersion: null,
+    documentSnapshot: null,
+  })
+  await repo.createAcceptance({
+    documentId: TOS_V2.id,
+    consentType: 'RENTER_TOS',
+    userId: 'user_b',
+    operatorId: null,
+    operatorMembershipId: null,
+    actorRole: 'RENTER',
+    bookingId: null,
+    acceptedAt: new Date('2026-05-01T00:00:00Z'),
+    context: null,
+    ipAddress: null,
+    userAgent: null,
+    method: 'CLICKWRAP',
+    recordSignature: null,
+    signingKeyId: null,
+    signatureCanonicalVersion: null,
+    documentSnapshot: null,
+  })
+  return repo
+}
+
+async function mount(role: UserRole, operatorId?: string) {
+  const repo = await seededRepo()
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createAdminConsentRoutes(new ConsentGovernanceService(repo)))
+  return app
+}
+
+describe('GET /admin/consent/acceptances — auth', () => {
+  it('401 when unauthenticated', async () => {
+    const repo = await seededRepo()
+    const app = new Hono()
+    app.route('/', createAdminConsentRoutes(new ConsentGovernanceService(repo)))
+    expect((await app.request('/admin/consent/acceptances')).status).toBe(401)
+  })
+
+  it.each(['RENTER', 'PARTNER', 'STAFF', 'ADMIN', 'OPERATOR_STAFF'] as const)(
+    '403 for %s (not a platform admin)',
+    async (role) => {
+      const app = await mount(role)
+      expect((await app.request('/admin/consent/acceptances')).status).toBe(403)
+    },
+  )
+
+  it('403 for an OPERATOR_OWNER (must never browse the cross-tenant ledger)', async () => {
+    const app = await mount('OPERATOR_OWNER', 'operator-aaaa')
+    expect((await app.request('/admin/consent/acceptances')).status).toBe(403)
+  })
+
+  it('200 for PLATFORM_ADMIN', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    expect((await app.request('/admin/consent/acceptances')).status).toBe(200)
+  })
+})
+
+describe('GET /admin/consent/acceptances — browse + filter', () => {
+  it('returns acceptances across users, newest first, with no status field', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    const res = await app.request('/admin/consent/acceptances')
+    const { data } = await res.json()
+    expect(data.acceptances.map((a: { userId: string }) => a.userId)).toEqual(['user_b', 'user_a'])
+    expect(data.acceptances[0]).toMatchObject({
+      userId: 'user_b',
+      consentType: 'RENTER_TOS',
+      version: '2.0',
+      acceptedAt: '2026-05-01T00:00:00.000Z',
+    })
+    expect(data.acceptances[0]).not.toHaveProperty('status')
+  })
+
+  it('narrows by ?consentType + ?version query params (not the self-scoped narrowing)', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    const res = await app.request('/admin/consent/acceptances?consentType=RENTER_TOS&version=1.0')
+    const { data } = await res.json()
+    expect(data.acceptances).toHaveLength(1)
+    expect(data.acceptances[0]).toMatchObject({ userId: 'user_a', version: '1.0' })
+  })
+
+  it('400 for an out-of-domain consentType', async () => {
+    const app = await mount('PLATFORM_ADMIN')
+    const res = await app.request('/admin/consent/acceptances?consentType=NONSENSE')
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,6 +34,7 @@
     "./types/insurance-option": "./src/types/insurance-option.ts",
     "./types/storefront": "./src/types/storefront.ts",
     "./types/operator-team": "./src/types/operator-team.ts",
+    "./types/consent-governance": "./src/types/consent-governance.ts",
     "./lib/bound-fetch": "./src/lib/bound-fetch.ts",
     "./lib/cancellation-policy": "./src/lib/cancellation-policy.ts",
     "./lib/error-codes": "./src/lib/error-codes.ts",

--- a/packages/shared/src/types/consent-governance.ts
+++ b/packages/shared/src/types/consent-governance.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+import { CONSENT_TYPES, type ConsentType } from '../enums'
+
+/**
+ * Platform-admin consent-acceptance governance browser (#1091, epic #1075 slice 5).
+ *
+ * v1 is a READ-ONLY ledger browse + filter. `consent_acceptances` is append-only
+ * with no status column, so the computed `current | outdated | missing` compliance
+ * projection (which needs a defined subject cohort + current-document baseline) is
+ * deliberately DEFERRED to a later slice — there is no status field on this wire.
+ * Each row carries the `acceptanceId` that links to the existing evidence export
+ * (`GET /admin/consent/acceptances/:id/evidence`, #877); the list never
+ * re-implements proof logic.
+ */
+
+/** One acceptance-ledger row, joined to its document for the version label. */
+export interface ConsentAcceptanceListItem {
+  /** PK of the `consent_acceptances` row — the evidence-export link target. */
+  acceptanceId: string
+  /** Subject who accepted (the user the acceptance was sealed for). */
+  userId: string
+  consentType: ConsentType
+  /** Version of the document the subject accepted (the join target). */
+  version: string
+  /** ISO-8601 UTC instant the acceptance was sealed. */
+  acceptedAt: string
+  /** Tenant the agreement binds — set only for `OPERATOR_AGREEMENT` rows. */
+  operatorId: string | null
+  /** Booking the liability waiver covers — set only for `RENTER_LIABILITY` rows. */
+  bookingId: string | null
+}
+
+/** The list response. No pagination/status in v1 — a flat, newest-first ledger. */
+export interface ConsentGovernanceResponse {
+  /** Matching acceptances, newest accepted first. */
+  acceptances: ConsentAcceptanceListItem[]
+}
+
+/**
+ * Query filters for the ledger browse. Every field is optional (an empty filter
+ * returns the whole ledger). `acceptedFrom`/`acceptedTo` are ISO-8601 instants;
+ * the server inclusively bounds `acceptedAt` by them. Anchors `consentType` to the
+ * enum SSoT so the parse can't drift from the DB pgEnum.
+ */
+export const consentGovernanceFiltersSchema = z.object({
+  userId: z.string().min(1).optional(),
+  consentType: z.enum(CONSENT_TYPES).optional(),
+  version: z.string().min(1).optional(),
+  acceptedFrom: z.string().datetime().optional(),
+  acceptedTo: z.string().datetime().optional(),
+})
+
+export type ConsentGovernanceFilters = z.infer<typeof consentGovernanceFiltersSchema>

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "Overview",
       "revenue": "Partner Revenue",
-      "documents": "Documents"
+      "documents": "Documents",
+      "governance": "Consent governance"
     },
     "home": {
       "title": "Platform Admin",
@@ -1287,6 +1288,26 @@
       "reject": "Reject",
       "error": "Couldn't record the verdict. Try again.",
       "loadError": "Couldn't load the review queue.",
+      "retry": "Retry"
+    },
+    "governance": {
+      "title": "Consent governance",
+      "subtitle": "Browse the consent-acceptance ledger across all users.",
+      "empty": "No consent acceptances match these filters.",
+      "colUser": "User",
+      "colType": "Consent type",
+      "colVersion": "Version",
+      "colAccepted": "Accepted",
+      "colEvidence": "Evidence",
+      "viewEvidence": "View evidence",
+      "evidenceLinkLabel": "View consent evidence for {user}",
+      "filterType": "Consent type",
+      "filterUser": "User ID",
+      "filterVersion": "Version",
+      "allTypes": "All types",
+      "apply": "Apply",
+      "clear": "Clear",
+      "loadError": "Couldn't load the consent ledger.",
       "retry": "Retry"
     }
   },

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "概要",
       "revenue": "パートナー収益",
-      "documents": "書類"
+      "documents": "書類",
+      "governance": "同意ガバナンス"
     },
     "home": {
       "title": "プラットフォーム管理",
@@ -1287,6 +1288,26 @@
       "reject": "却下",
       "error": "判定を記録できませんでした。もう一度お試しください。",
       "loadError": "審査キューを読み込めませんでした。",
+      "retry": "再試行"
+    },
+    "governance": {
+      "title": "同意ガバナンス",
+      "subtitle": "全ユーザーの同意受諾履歴を閲覧します。",
+      "empty": "条件に一致する同意受諾はありません。",
+      "colUser": "ユーザー",
+      "colType": "同意種別",
+      "colVersion": "バージョン",
+      "colAccepted": "受諾日時",
+      "colEvidence": "証跡",
+      "viewEvidence": "証跡を表示",
+      "evidenceLinkLabel": "{user} の同意証跡を表示",
+      "filterType": "同意種別",
+      "filterUser": "ユーザーID",
+      "filterVersion": "バージョン",
+      "allTypes": "すべての種別",
+      "apply": "適用",
+      "clear": "クリア",
+      "loadError": "同意履歴を読み込めませんでした。",
       "retry": "再試行"
     }
   },

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1233,7 +1233,8 @@
     "nav": {
       "overview": "概览",
       "revenue": "合作伙伴收益",
-      "documents": "证件"
+      "documents": "证件",
+      "governance": "同意治理"
     },
     "home": {
       "title": "平台管理",
@@ -1287,6 +1288,26 @@
       "reject": "拒绝",
       "error": "无法记录审核结果，请重试。",
       "loadError": "无法加载审核队列。",
+      "retry": "重试"
+    },
+    "governance": {
+      "title": "同意治理",
+      "subtitle": "浏览所有用户的同意接受记录。",
+      "empty": "没有符合条件的同意接受记录。",
+      "colUser": "用户",
+      "colType": "同意类型",
+      "colVersion": "版本",
+      "colAccepted": "接受时间",
+      "colEvidence": "证据",
+      "viewEvidence": "查看证据",
+      "evidenceLinkLabel": "查看 {user} 的同意证据",
+      "filterType": "同意类型",
+      "filterUser": "用户 ID",
+      "filterVersion": "版本",
+      "allTypes": "所有类型",
+      "apply": "应用",
+      "clear": "清除",
+      "loadError": "无法加载同意记录。",
       "retry": "重试"
     }
   },

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -41,6 +41,7 @@ import { Route as LocaleBusinessManageFeesRouteImport } from './routes/$locale/_
 import { Route as LocaleBusinessManageClassesRouteImport } from './routes/$locale/_business/manage/classes'
 import { Route as LocaleBusinessManageAddOnsRouteImport } from './routes/$locale/_business/manage/add-ons'
 import { Route as LocaleAdminAdminRevenueRouteImport } from './routes/$locale/_admin/admin/revenue'
+import { Route as LocaleAdminAdminGovernanceRouteImport } from './routes/$locale/_admin/admin/governance'
 import { Route as LocaleAdminAdminDocumentsRouteImport } from './routes/$locale/_admin/admin/documents'
 import { Route as LocaleBusinessManageFleetIndexRouteImport } from './routes/$locale/_business/manage/fleet/index'
 import { Route as LocaleBusinessManageBookingsIndexRouteImport } from './routes/$locale/_business/manage/bookings/index'
@@ -218,6 +219,12 @@ const LocaleAdminAdminRevenueRoute = LocaleAdminAdminRevenueRouteImport.update({
   path: '/admin/revenue',
   getParentRoute: () => LocaleAdminRoute,
 } as any)
+const LocaleAdminAdminGovernanceRoute =
+  LocaleAdminAdminGovernanceRouteImport.update({
+    id: '/admin/governance',
+    path: '/admin/governance',
+    getParentRoute: () => LocaleAdminRoute,
+  } as any)
 const LocaleAdminAdminDocumentsRoute =
   LocaleAdminAdminDocumentsRouteImport.update({
     id: '/admin/documents',
@@ -264,6 +271,7 @@ export interface FileRoutesByFullPath {
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
+  '/$locale/admin/governance': typeof LocaleAdminAdminGovernanceRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
   '/$locale/manage/classes': typeof LocaleBusinessManageClassesRoute
@@ -297,6 +305,7 @@ export interface FileRoutesByTo {
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles': typeof LocaleVehiclesIndexRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
+  '/$locale/admin/governance': typeof LocaleAdminAdminGovernanceRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
   '/$locale/manage/classes': typeof LocaleBusinessManageClassesRoute
@@ -337,6 +346,7 @@ export interface FileRoutesById {
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
   '/$locale/_admin/admin/documents': typeof LocaleAdminAdminDocumentsRoute
+  '/$locale/_admin/admin/governance': typeof LocaleAdminAdminGovernanceRoute
   '/$locale/_admin/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/_business/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
   '/$locale/_business/manage/classes': typeof LocaleBusinessManageClassesRoute
@@ -375,6 +385,7 @@ export interface FileRouteTypes {
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
     | '/$locale/admin/documents'
+    | '/$locale/admin/governance'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
     | '/$locale/manage/classes'
@@ -408,6 +419,7 @@ export interface FileRouteTypes {
     | '/provider/invite/$token'
     | '/$locale/vehicles'
     | '/$locale/admin/documents'
+    | '/$locale/admin/governance'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
     | '/$locale/manage/classes'
@@ -447,6 +459,7 @@ export interface FileRouteTypes {
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
     | '/$locale/_admin/admin/documents'
+    | '/$locale/_admin/admin/governance'
     | '/$locale/_admin/admin/revenue'
     | '/$locale/_business/manage/add-ons'
     | '/$locale/_business/manage/classes'
@@ -701,6 +714,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleAdminAdminRevenueRouteImport
       parentRoute: typeof LocaleAdminRoute
     }
+    '/$locale/_admin/admin/governance': {
+      id: '/$locale/_admin/admin/governance'
+      path: '/admin/governance'
+      fullPath: '/$locale/admin/governance'
+      preLoaderRoute: typeof LocaleAdminAdminGovernanceRouteImport
+      parentRoute: typeof LocaleAdminRoute
+    }
     '/$locale/_admin/admin/documents': {
       id: '/$locale/_admin/admin/documents'
       path: '/admin/documents'
@@ -741,12 +761,14 @@ declare module '@tanstack/react-router' {
 
 interface LocaleAdminRouteChildren {
   LocaleAdminAdminDocumentsRoute: typeof LocaleAdminAdminDocumentsRoute
+  LocaleAdminAdminGovernanceRoute: typeof LocaleAdminAdminGovernanceRoute
   LocaleAdminAdminRevenueRoute: typeof LocaleAdminAdminRevenueRoute
   LocaleAdminAdminIndexRoute: typeof LocaleAdminAdminIndexRoute
 }
 
 const LocaleAdminRouteChildren: LocaleAdminRouteChildren = {
   LocaleAdminAdminDocumentsRoute: LocaleAdminAdminDocumentsRoute,
+  LocaleAdminAdminGovernanceRoute: LocaleAdminAdminGovernanceRoute,
   LocaleAdminAdminRevenueRoute: LocaleAdminAdminRevenueRoute,
   LocaleAdminAdminIndexRoute: LocaleAdminAdminIndexRoute,
 }

--- a/packages/web/src/routes/$locale/_admin/admin/governance.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/governance.tsx
@@ -1,0 +1,62 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { ConsentGovernanceView } from '@/vite/admin/governance/ConsentGovernanceView'
+import { consentAcceptancesQueryOptions } from '@/vite/admin/governance/api'
+import {
+  type ConsentGovernanceFilters,
+  consentGovernanceFiltersSchema,
+} from '@kuruma/shared/types/consent-governance'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useTranslations } from 'use-intl'
+
+// A drifted/invalid search (e.g. a hand-typed bad consentType) drops back to the
+// unfiltered ledger rather than erroring; the server validates again anyway.
+function validateSearch(search: Record<string, unknown>): ConsentGovernanceFilters {
+  const parsed = consentGovernanceFiltersSchema.safeParse(search)
+  return parsed.success ? parsed.data : {}
+}
+
+// Platform-admin consent-acceptance governance browse (#1091, epic #1075 slice 5).
+// The `_admin` parent layout already gates on platform-admin membership, so this
+// only owns the data: read the filter search params, prefetch in the loader, render
+// the pure view and turn its filter callback into a URL navigation.
+export const Route = createFileRoute('/$locale/_admin/admin/governance')({
+  validateSearch,
+  loaderDeps: ({ search }) => search,
+  loader: ({ context, deps }) =>
+    context.queryClient.ensureQueryData(consentAcceptancesQueryOptions(deps)),
+  pendingComponent: PageSkeleton,
+  errorComponent: GovernanceError,
+  component: GovernanceRoute,
+})
+
+function GovernanceRoute() {
+  const filters = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const { data } = useSuspenseQuery(consentAcceptancesQueryOptions(filters))
+
+  return (
+    <ConsentGovernanceView
+      acceptances={data.acceptances}
+      filters={filters}
+      onApplyFilters={(next) => navigate({ search: () => next })}
+    />
+  )
+}
+
+function GovernanceError(_props: ErrorComponentProps) {
+  const t = useTranslations('admin.governance')
+  const router = useRouter()
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-20 text-center sm:px-6 lg:px-8">
+      <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+      <button
+        type="button"
+        onClick={() => router.invalidate()}
+        className="mt-4 inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-muted/50"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/governance/ConsentGovernanceView.test.tsx
+++ b/packages/web/src/vite/admin/governance/ConsentGovernanceView.test.tsx
@@ -1,0 +1,81 @@
+import type { ConsentAcceptanceListItem } from '@kuruma/shared/types/consent-governance'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../../messages/en.json'
+import { ConsentGovernanceView } from './ConsentGovernanceView'
+
+function row(over: Partial<ConsentAcceptanceListItem> = {}): ConsentAcceptanceListItem {
+  return {
+    acceptanceId: 'acc_1',
+    userId: 'user_a',
+    consentType: 'RENTER_TOS',
+    version: '1.0',
+    acceptedAt: '2026-03-01T00:00:00.000Z',
+    operatorId: null,
+    bookingId: null,
+    ...over,
+  }
+}
+
+function renderView(
+  acceptances: ConsentAcceptanceListItem[],
+  onApplyFilters = vi.fn(),
+  filters = {},
+) {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <ConsentGovernanceView
+        acceptances={acceptances}
+        filters={filters}
+        onApplyFilters={onApplyFilters}
+      />
+    </IntlProvider>,
+  )
+  return { onApplyFilters }
+}
+
+describe('ConsentGovernanceView', () => {
+  it('shows the empty state when nothing matches', () => {
+    renderView([])
+    expect(screen.queryByText(en.admin.governance.empty)).not.toBeNull()
+    expect(screen.queryByRole('table')).toBeNull()
+  })
+
+  it('renders one row per acceptance with type, version, and a working evidence link', () => {
+    renderView([row(), row({ acceptanceId: 'acc_2', userId: 'user_b', version: '2.0' })])
+
+    const rows = screen.getAllByRole('row')
+    // 1 header + 2 data rows.
+    expect(rows).toHaveLength(3)
+
+    const firstData = rows[1]
+    expect(firstData).toBeDefined()
+    if (!firstData) return
+    const cells = within(firstData)
+    expect(cells.queryByText('user_a')).not.toBeNull()
+    expect(cells.queryByText('RENTER_TOS')).not.toBeNull()
+    expect(cells.queryByText('1.0')).not.toBeNull()
+
+    const link = cells.getByRole('link', { name: /user_a/ })
+    expect(link.getAttribute('href')).toMatch(/\/admin\/consent\/acceptances\/acc_1\/evidence$/)
+    expect(link.getAttribute('target')).toBe('_blank')
+  })
+
+  it('applies the consent-type filter immediately on select', () => {
+    const { onApplyFilters } = renderView([row()])
+    fireEvent.change(screen.getByLabelText(en.admin.governance.filterType), {
+      target: { value: 'PRIVACY_POLICY' },
+    })
+    expect(onApplyFilters).toHaveBeenCalledWith({ consentType: 'PRIVACY_POLICY' })
+  })
+
+  it('commits the user-id filter on submit, dropping blank fields', () => {
+    const { onApplyFilters } = renderView([row()])
+    fireEvent.change(screen.getByLabelText(en.admin.governance.filterUser), {
+      target: { value: 'user_z' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: en.admin.governance.apply }))
+    expect(onApplyFilters).toHaveBeenCalledWith({ userId: 'user_z' })
+  })
+})

--- a/packages/web/src/vite/admin/governance/ConsentGovernanceView.tsx
+++ b/packages/web/src/vite/admin/governance/ConsentGovernanceView.tsx
@@ -1,0 +1,197 @@
+import { NativeSelect } from '@/components/ui/native-select'
+import { formatDateTime } from '@/lib/format'
+import { CONSENT_TYPES, type ConsentType } from '@kuruma/shared/enums'
+import type {
+  ConsentAcceptanceListItem,
+  ConsentGovernanceFilters,
+} from '@kuruma/shared/types/consent-governance'
+import { useState } from 'react'
+import { useLocale, useTranslations } from 'use-intl'
+import { consentEvidenceUrl } from './api'
+
+// Narrow the native-select value to the enum instead of asserting: the empty
+// "all types" option and any drift map to `undefined` (no filter) rather than a
+// lying cast. The server re-validates against the same enum and 400s on drift.
+const isConsentType = (value: string): value is ConsentType =>
+  (CONSENT_TYPES as readonly string[]).includes(value)
+
+interface ConsentGovernanceViewProps {
+  readonly acceptances: ConsentAcceptanceListItem[]
+  readonly filters: ConsentGovernanceFilters
+  /** Apply a new filter set — the route turns this into a URL navigation. */
+  readonly onApplyFilters: (filters: ConsentGovernanceFilters) => void
+}
+
+// Presentational platform-admin consent-acceptance ledger (#1091). Pure function of
+// props (FC/IS — the route owns the loader / useSuspenseQuery and turns the filter
+// callback into a URL nav); this only renders the filter bar + table and links each
+// row to the existing evidence export. Read-only: no status, no re-consent action.
+export function ConsentGovernanceView({
+  acceptances,
+  filters,
+  onApplyFilters,
+}: ConsentGovernanceViewProps) {
+  const t = useTranslations('admin.governance')
+  const locale = useLocale()
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <FilterBar filters={filters} onApply={onApplyFilters} />
+
+      {acceptances.length === 0 ? (
+        <p className="mt-8 rounded-lg border border-dashed border-border py-12 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <div className="mt-6 overflow-x-auto rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="px-4 py-3 font-medium">{t('colUser')}</th>
+                <th className="px-4 py-3 font-medium">{t('colType')}</th>
+                <th className="px-4 py-3 font-medium">{t('colVersion')}</th>
+                <th className="px-4 py-3 font-medium">{t('colAccepted')}</th>
+                <th className="px-4 py-3 font-medium">{t('colEvidence')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {acceptances.map((row) => (
+                <tr key={row.acceptanceId} className="border-b border-border last:border-b-0">
+                  <td className="px-4 py-3 font-mono text-xs">{row.userId}</td>
+                  <td className="px-4 py-3">{row.consentType}</td>
+                  <td className="px-4 py-3 tabular-nums">{row.version}</td>
+                  <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                    {formatDateTime(row.acceptedAt, locale)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <a
+                      href={consentEvidenceUrl(row.acceptanceId)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary underline-offset-2 hover:underline"
+                      aria-label={t('evidenceLinkLabel', { user: row.userId })}
+                    >
+                      {t('viewEvidence')}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface FilterBarProps {
+  readonly filters: ConsentGovernanceFilters
+  readonly onApply: (filters: ConsentGovernanceFilters) => void
+}
+
+// Local draft state so typing doesn't navigate on every keystroke; the form
+// commits on submit. The consentType select commits immediately (a small,
+// closed domain) for a snappier narrow.
+function FilterBar({ filters, onApply }: FilterBarProps) {
+  const t = useTranslations('admin.governance')
+  const [userId, setUserId] = useState(filters.userId ?? '')
+  const [version, setVersion] = useState(filters.version ?? '')
+
+  function apply(next: ConsentGovernanceFilters) {
+    onApply(stripEmpty(next))
+  }
+
+  return (
+    <form
+      className="mt-5 flex flex-wrap items-end gap-3"
+      onSubmit={(e) => {
+        e.preventDefault()
+        apply({ ...filters, userId, version })
+      }}
+    >
+      <div className="flex flex-col gap-1">
+        <label htmlFor="consent-type" className="text-xs text-muted-foreground">
+          {t('filterType')}
+        </label>
+        <NativeSelect
+          id="consent-type"
+          className="w-48"
+          value={filters.consentType ?? ''}
+          onChange={(e) =>
+            apply({
+              ...filters,
+              consentType: isConsentType(e.target.value) ? e.target.value : undefined,
+            })
+          }
+        >
+          <option value="">{t('allTypes')}</option>
+          {CONSENT_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="consent-user" className="text-xs text-muted-foreground">
+          {t('filterUser')}
+        </label>
+        <input
+          id="consent-user"
+          type="text"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          className="h-9 w-56 rounded-md border border-border bg-background px-3 text-sm"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="consent-version" className="text-xs text-muted-foreground">
+          {t('filterVersion')}
+        </label>
+        <input
+          id="consent-version"
+          type="text"
+          value={version}
+          onChange={(e) => setVersion(e.target.value)}
+          className="h-9 w-32 rounded-md border border-border bg-background px-3 text-sm"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        {t('apply')}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setUserId('')
+          setVersion('')
+          onApply({})
+        }}
+        className="h-9 rounded-md border border-border px-4 text-sm font-medium hover:bg-muted/50"
+      >
+        {t('clear')}
+      </button>
+    </form>
+  )
+}
+
+/** Drop blank string fields so an empty control doesn't send `?userId=` to the API. */
+function stripEmpty(filters: ConsentGovernanceFilters): ConsentGovernanceFilters {
+  const next: ConsentGovernanceFilters = {}
+  if (filters.userId) next.userId = filters.userId
+  if (filters.consentType) next.consentType = filters.consentType
+  if (filters.version) next.version = filters.version
+  if (filters.acceptedFrom) next.acceptedFrom = filters.acceptedFrom
+  if (filters.acceptedTo) next.acceptedTo = filters.acceptedTo
+  return next
+}

--- a/packages/web/src/vite/admin/governance/api.test.ts
+++ b/packages/web/src/vite/admin/governance/api.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { consentEvidenceUrl, consentGovernanceResponseSchema } from './api'
+
+const validRow = {
+  acceptanceId: 'acc_1',
+  userId: 'user_a',
+  consentType: 'RENTER_TOS',
+  version: '1.0',
+  acceptedAt: '2026-03-01T00:00:00.000Z',
+  operatorId: null,
+  bookingId: null,
+}
+
+describe('consentGovernanceResponseSchema (network seam)', () => {
+  it('accepts a well-formed ledger body', () => {
+    const parsed = consentGovernanceResponseSchema.safeParse({ acceptances: [validRow] })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects a drifted body where version arrived as a number', () => {
+    const parsed = consentGovernanceResponseSchema.safeParse({
+      acceptances: [{ ...validRow, version: 1 }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects an out-of-domain consentType (anchored to the enum SSoT)', () => {
+    const parsed = consentGovernanceResponseSchema.safeParse({
+      acceptances: [{ ...validRow, consentType: 'NONSENSE' }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+})
+
+describe('consentEvidenceUrl', () => {
+  it('links to the existing per-acceptance evidence export, id percent-encoded', () => {
+    expect(consentEvidenceUrl('acc 1/x')).toMatch(
+      /\/admin\/consent\/acceptances\/acc%201%2Fx\/evidence$/,
+    )
+  })
+})

--- a/packages/web/src/vite/admin/governance/api.ts
+++ b/packages/web/src/vite/admin/governance/api.ts
@@ -1,0 +1,68 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import { CONSENT_TYPES } from '@kuruma/shared/enums'
+import type {
+  ConsentAcceptanceListItem,
+  ConsentGovernanceFilters,
+  ConsentGovernanceResponse,
+} from '@kuruma/shared/types/consent-governance'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// Platform-admin consent-acceptance governance browse (#1091, epic #1075 slice 5).
+// Cookie-based (credentials: 'include') so the API gates on the session role
+// server-side (requirePlatformAdmin); v1 is a read-only ledger browse + filter.
+
+// Network-seam validators (#711). Pinned to the shared wire DTO with `satisfies`
+// so a renamed/added field fails typecheck here; a drifted runtime body (e.g. a
+// version arriving as a number) then surfaces as a ParseError at the seam instead
+// of a wrong/blank cell on the table. Enum domain anchors to the shared SSoT.
+const consentAcceptanceSchema = z.object({
+  acceptanceId: z.string(),
+  userId: z.string(),
+  consentType: z.enum(CONSENT_TYPES),
+  version: z.string(),
+  acceptedAt: z.string(),
+  operatorId: z.string().nullable(),
+  bookingId: z.string().nullable(),
+}) satisfies z.ZodType<ConsentAcceptanceListItem>
+
+// Exported for the network-seam drift test (#711) — the parse is the contract.
+export const consentGovernanceResponseSchema = z.object({
+  acceptances: z.array(consentAcceptanceSchema),
+}) satisfies z.ZodType<ConsentGovernanceResponse>
+
+export const ADMIN_CONSENT_QUERY_KEY = ['admin-consent', 'acceptances'] as const
+
+function toQueryString(filters: ConsentGovernanceFilters): string {
+  const params = new URLSearchParams()
+  if (filters.userId) params.set('userId', filters.userId)
+  if (filters.consentType) params.set('consentType', filters.consentType)
+  if (filters.version) params.set('version', filters.version)
+  if (filters.acceptedFrom) params.set('acceptedFrom', filters.acceptedFrom)
+  if (filters.acceptedTo) params.set('acceptedTo', filters.acceptedTo)
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export async function fetchConsentAcceptances(
+  filters: ConsentGovernanceFilters = {},
+): Promise<ConsentGovernanceResponse> {
+  const res = await fetch(`${getApiBaseUrl()}/admin/consent/acceptances${toQueryString(filters)}`, {
+    credentials: 'include',
+  })
+  return unwrap(res, consentGovernanceResponseSchema)
+}
+
+export function consentAcceptancesQueryOptions(filters: ConsentGovernanceFilters = {}) {
+  return queryOptions({
+    queryKey: [...ADMIN_CONSENT_QUERY_KEY, filters],
+    queryFn: () => fetchConsentAcceptances(filters),
+  })
+}
+
+/** Same-origin-aware link to the existing platform-admin evidence export (#877).
+ *  Carries the /api base so it hits the Hono API, not the SPA origin; cookie-authed. */
+export function consentEvidenceUrl(acceptanceId: string): string {
+  return `${getApiBaseUrl()}/admin/consent/acceptances/${encodeURIComponent(acceptanceId)}/evidence`
+}

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -1,11 +1,12 @@
 import { Link } from '@tanstack/react-router'
-import { Banknote, FileCheck, LayoutDashboard } from 'lucide-react'
+import { Banknote, FileCheck, LayoutDashboard, ShieldCheck } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 const SIDEBAR_ITEMS = [
   { to: '/$locale/admin', icon: LayoutDashboard, labelKey: 'nav.overview' },
   { to: '/$locale/admin/revenue', icon: Banknote, labelKey: 'nav.revenue' },
   { to: '/$locale/admin/documents', icon: FileCheck, labelKey: 'nav.documents' },
+  { to: '/$locale/admin/governance', icon: ShieldCheck, labelKey: 'nav.governance' },
 ] as const
 
 // Single static className; active state is the `aria-current="page"` attribute


### PR DESCRIPTION
## What

Slice #1091 of the platform-owner dashboard epic (#1075): a **read-only consent-acceptance ledger browser** for platform admins.

Per the locked v1 scope, this is browse + filter only — **no computed `current/outdated/missing` status** (the `consent_acceptances` table is append-only with no status column; the cohort/baseline comparison is deferred to a later slice), and **no re-consent/invalidate action**.

- **API:** new `GET /admin/consent/acceptances` (`requireAuth` 401 + `requirePlatformAdmin` 403, service re-asserts). Cross-user ledger read filtered by user / consentType / version / date. Each row carries the `acceptanceId` linking to the **existing** evidence export (`GET /admin/consent/acceptances/:id/evidence`, #877) — proof logic is reused, never re-implemented. The self-scoped `GET /consent/status` is untouched.
- **Web:** `/admin/governance` page + `ConsentGovernanceView`, network-seam Zod validator pinned to the shared DTO (#711), sidebar nav entry.

## Review fixes folded in (code-reviewed: SHIP-WITH-FIXES, both MEDIUMs addressed)

- **Unbounded response → hard cap.** `findAcceptances` now caps at `CONSENT_ACCEPTANCE_LIST_LIMIT = 200` (single constant applied in both Drizzle `.limit()` and InMemory `.slice()` so the two impls stay in conformance). The ledger grows per-booking, so an uncapped default browse would balloon at scale. New mutation-resistant repo test seeds `LIMIT + 5` and asserts the cap drops the oldest.
- **`as ConsentType` → type guard.** The native-select onChange now narrows via `isConsentType()` instead of asserting; "all types" and any drift map to `undefined` (no filter), and the server re-validates against the same enum.

Deferred (noted in review, not blocking): date-filter UI control (backend + URL already support `acceptedFrom`/`acceptedTo`); flattened 400 body.

## Test plan

- [x] Authz: 401 unauth; 403 for RENTER / PARTNER / STAFF / ADMIN / OPERATOR_STAFF / OPERATOR_OWNER; 200 PLATFORM_ADMIN.
- [x] Returns rows across users filtered by params; asserts **no status field** (`not.toHaveProperty('status')`). InMemory mirrors the Drizzle inner-join (drops acceptances whose doc is absent).
- [x] Cap test (new); web ParseError-on-drift. api consent suite 79 tests green; web governance 8 green.
- [x] api + web typecheck, `lint:boundaries` green; i18n parity en/ja/zh.

Refs #1075
Closes #1091