### PR TITLE
feat(#1075 slice 3): payment-anomaly resolution (mark-reviewed, no money)

### DIFF
--- a/drizzle/0078_add_payment_anomaly_resolution.sql
+++ b/drizzle/0078_add_payment_anomaly_resolution.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "public"."payment_anomaly_resolution" AS ENUM('BENIGN', 'INVESTIGATED', 'REFUNDED_EXTERNALLY');--> statement-breakpoint
+ALTER TABLE "payment_anomalies" ADD COLUMN "resolution" "payment_anomaly_resolution";--> statement-breakpoint
+ALTER TABLE "payment_anomalies" ADD COLUMN "resolvedBy" text;--> statement-breakpoint
+ALTER TABLE "payment_anomalies" ADD COLUMN "note" text;

--- a/drizzle/meta/0078_snapshot.json
+++ b/drizzle/meta/0078_snapshot.json
@@ -1,0 +1,5138 @@
+{
+  "id": "6dbf676e-71b4-42e7-84db-82770c9454dd",
+  "prevId": "13ae4b5e-6eb4-4517-afa8-9d157b76a12a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nameEn": {
+          "name": "nameEn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameJa": {
+          "name": "nameJa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameZh": {
+          "name": "nameZh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignable": {
+          "name": "assignable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "region_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_regions_parentId": {
+          "name": "idx_regions_parentId",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_unique": {
+          "name": "regions_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parentId_regions_id_fk": {
+          "name": "regions_parentId_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.renter_documents": {
+      "name": "renter_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiryDate": {
+          "name": "expiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_renter_documents_renterId": {
+          "name": "idx_renter_documents_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_verifierId": {
+          "name": "idx_renter_documents_verifierId",
+          "columns": [
+            {
+              "expression": "verifierId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_status": {
+          "name": "idx_renter_documents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "renter_documents_renterId_users_id_fk": {
+          "name": "renter_documents_renterId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "renter_documents_verifierId_users_id_fk": {
+          "name": "renter_documents_verifierId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coordinate_source": {
+          "name": "coordinate_source",
+          "type": "coordinate_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatingHours": {
+          "name": "operatingHours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Tokyo'"
+        },
+        "defaultTurnaroundMinutes": {
+          "name": "defaultTurnaroundMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2880
+        },
+        "regionId": {
+          "name": "regionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_operatorId": {
+          "name": "idx_locations_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_regionId": {
+          "name": "idx_locations_regionId",
+          "columns": [
+            {
+              "expression": "regionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_operatorId_active_name_unique": {
+          "name": "locations_operatorId_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"status\" <> 'ARCHIVED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_operatorId_operators_id_fk": {
+          "name": "locations_operatorId_operators_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "locations_regionId_regions_id_fk": {
+          "name": "locations_regionId_regions_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_operatorId_id_unique": {
+          "name": "locations_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "locations_turnaround_min_60": {
+          "name": "locations_turnaround_min_60",
+          "value": "\"locations\".\"defaultTurnaroundMinutes\" >= 60"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acrissCode": {
+          "name": "acrissCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_acriss_code_format": {
+          "name": "vehicle_classes_acriss_code_format",
+          "value": "\"vehicle_classes\".\"acrissCode\" IS NULL OR \"vehicle_classes\".\"acrissCode\" ~ '^[A-Z9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_pickupLocationId": {
+          "name": "idx_vehicles_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_available": {
+          "name": "idx_vehicles_available",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vehicles\".\"status\" = 'AVAILABLE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_pickupLocationId_fk": {
+          "name": "vehicles_operatorId_pickupLocationId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "operatorId",
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        },
+        "vehicles_operatorId_id_unique": {
+          "name": "vehicles_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.class_rate_plans": {
+      "name": "class_rate_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayRateJpy": {
+          "name": "dayRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_class_rate_plans_operator": {
+          "name": "idx_class_rate_plans_operator",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_class": {
+          "name": "idx_class_rate_plans_class",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_pickup_location": {
+          "name": "idx_class_rate_plans_pickup_location",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "class_rate_plans_operatorId_operators_id_fk": {
+          "name": "class_rate_plans_operatorId_operators_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_pickupLocationId_locations_id_fk": {
+          "name": "class_rate_plans_pickupLocationId_locations_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_operator_class_fk": {
+          "name": "class_rate_plans_operator_class_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "class_rate_plans_operator_class_location_unique": {
+          "name": "class_rate_plans_operator_class_location_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "classId",
+            "pickupLocationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "class_rate_plans_day_rate_non_negative": {
+          "name": "class_rate_plans_day_rate_non_negative",
+          "value": "\"class_rate_plans\".\"dayRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleClassId": {
+          "name": "vehicleClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "fee_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fee_schedule_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_schedules_operator_class": {
+          "name": "idx_fee_schedules_operator_class",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_schedules_vehicle_class": {
+          "name": "idx_fee_schedules_vehicle_class",
+          "columns": [
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_class_unique": {
+          "name": "fee_schedules_active_class_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_operatorwide_unique": {
+          "name": "fee_schedules_active_operatorwide_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_schedules_operatorId_operators_id_fk": {
+          "name": "fee_schedules_operatorId_operators_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fee_schedules_operator_class_fk": {
+          "name": "fee_schedules_operator_class_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleClassId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fee_schedules_amount_non_negative": {
+          "name": "fee_schedules_amount_non_negative",
+          "value": "\"fee_schedules\".\"amountJpy\" >= 0"
+        },
+        "fee_schedules_feetype_unit_coherent": {
+          "name": "fee_schedules_feetype_unit_coherent",
+          "value": "(\"fee_schedules\".\"feeType\" = 'OVERTIME_HOURLY' AND \"fee_schedules\".\"unit\" = 'PER_HOUR') OR (\"fee_schedules\".\"feeType\" = 'CLEANING_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT') OR (\"fee_schedules\".\"feeType\" = 'NO_FUEL_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_options": {
+      "name": "insurance_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyPriceJpy": {
+          "name": "dailyPriceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deductibleJpy": {
+          "name": "deductibleJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_insurance_options_operatorId": {
+          "name": "idx_insurance_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_options_active_name_unique": {
+          "name": "insurance_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_options_operatorId_operators_id_fk": {
+          "name": "insurance_options_operatorId_operators_id_fk",
+          "tableFrom": "insurance_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_options_operatorId_id_unique": {
+          "name": "insurance_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "insurance_options_daily_price_non_negative": {
+          "name": "insurance_options_daily_price_non_negative",
+          "value": "\"insurance_options\".\"dailyPriceJpy\" >= 0"
+        },
+        "insurance_options_deductible_non_negative": {
+          "name": "insurance_options_deductible_non_negative",
+          "value": "\"insurance_options\".\"deductibleJpy\" IS NULL OR \"insurance_options\".\"deductibleJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_events": {
+      "name": "booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booking_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_booking_events_bookingId": {
+          "name": "idx_booking_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_events_actorId": {
+          "name": "idx_booking_events_actorId",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_events_bookingId_bookings_id_fk": {
+          "name": "booking_events_bookingId_bookings_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "booking_events_actorId_users_id_fk": {
+          "name": "booking_events_actorId_users_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestedVehicleId": {
+          "name": "requestedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedVehicleId": {
+          "name": "assignedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropoffLocationId": {
+          "name": "dropoffLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "fulfillmentMode": {
+          "name": "fulfillmentMode",
+          "type": "booking_fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPECIFIC'"
+        },
+        "bookingCode": {
+          "name": "bookingCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insuranceOptionId": {
+          "name": "insuranceOptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceSnapshot": {
+          "name": "insuranceSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeSnapshot": {
+          "name": "feeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "addOnSnapshot": {
+          "name": "addOnSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFeeSettlement": {
+          "name": "cancellationFeeSettlement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADVISORY'"
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerAcknowledgedAt": {
+          "name": "disclaimerAcknowledgedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerTermsVersion": {
+          "name": "disclaimerTermsVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_operatorId": {
+          "name": "idx_bookings_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_requestedVehicleId": {
+          "name": "idx_bookings_requestedVehicleId",
+          "columns": [
+            {
+              "expression": "requestedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_assignedVehicleId": {
+          "name": "idx_bookings_assignedVehicleId",
+          "columns": [
+            {
+              "expression": "assignedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_pickupLocationId": {
+          "name": "idx_bookings_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_dropoffLocationId": {
+          "name": "idx_bookings_dropoffLocationId",
+          "columns": [
+            {
+              "expression": "dropoffLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_insuranceOptionId": {
+          "name": "idx_bookings_insuranceOptionId",
+          "columns": [
+            {
+              "expression": "insuranceOptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_operatorId_operators_id_fk": {
+          "name": "bookings_operatorId_operators_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_pickupLocationId_locations_id_fk": {
+          "name": "bookings_pickupLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_dropoffLocationId_locations_id_fk": {
+          "name": "bookings_dropoffLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "dropoffLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_class_fk": {
+          "name": "bookings_operator_class_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_requested_vehicle_fk": {
+          "name": "bookings_operator_requested_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "requestedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_assigned_vehicle_fk": {
+          "name": "bookings_operator_assigned_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "assignedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_insurance_fk": {
+          "name": "bookings_operator_insurance_fk",
+          "tableFrom": "bookings",
+          "tableTo": "insurance_options",
+          "columnsFrom": [
+            "operatorId",
+            "insuranceOptionId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookings_bookingCode_unique": {
+          "name": "bookings_bookingCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bookings_specific_requires_assigned": {
+          "name": "bookings_specific_requires_assigned",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"assignedVehicleId\" IS NOT NULL"
+        },
+        "bookings_specific_requires_requested": {
+          "name": "bookings_specific_requires_requested",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"requestedVehicleId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_anomalies": {
+      "name": "payment_anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAmountJpy": {
+          "name": "receivedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedAmountJpy": {
+          "name": "expectedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "payment_anomaly_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_anomalies_operatorId": {
+          "name": "idx_payment_anomalies_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_anomalies_bookingId": {
+          "name": "idx_payment_anomalies_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_anomalies_stripeEventId_unique": {
+          "name": "payment_anomalies_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_anomalies_operatorId_operators_id_fk": {
+          "name": "payment_anomalies_operatorId_operators_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_anomalies_bookingId_bookings_id_fk": {
+          "name": "payment_anomalies_bookingId_bookings_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_events": {
+      "name": "payment_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grossJpy": {
+          "name": "grossJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFeeJpy": {
+          "name": "platformFeeJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "netToPartnerJpy": {
+          "name": "netToPartnerJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'jpy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_events_operatorId": {
+          "name": "idx_payment_events_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_events_bookingId": {
+          "name": "idx_payment_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeEventId_unique": {
+          "name": "payment_events_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeCheckoutSessionId_unique": {
+          "name": "payment_events_stripeCheckoutSessionId_unique",
+          "columns": [
+            {
+              "expression": "stripeCheckoutSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_one_success_per_booking": {
+          "name": "payment_events_one_success_per_booking",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'SUCCEEDED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_events_operatorId_operators_id_fk": {
+          "name": "payment_events_operatorId_operators_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_events_bookingId_bookings_id_fk": {
+          "name": "payment_events_bookingId_bookings_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_refunds": {
+      "name": "payment_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeRefundId": {
+          "name": "stripeRefundId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_refunds_operatorId": {
+          "name": "idx_payment_refunds_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_bookingId_unique": {
+          "name": "payment_refunds_bookingId_unique",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_stripeRefundId_unique": {
+          "name": "payment_refunds_stripeRefundId_unique",
+          "columns": [
+            {
+              "expression": "stripeRefundId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripeRefundId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_refunds_bookingId_bookings_id_fk": {
+          "name": "payment_refunds_bookingId_bookings_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_refunds_operatorId_operators_id_fk": {
+          "name": "payment_refunds_operatorId_operators_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_refunds_amount_non_negative": {
+          "name": "payment_refunds_amount_non_negative",
+          "value": "\"payment_refunds\".\"amountJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "providerMessageId": {
+          "name": "providerMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_bookingId": {
+          "name": "idx_notification_log_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_log_operatorId": {
+          "name": "idx_notification_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_bookingId_bookings_id_fk": {
+          "name": "notification_log_bookingId_bookings_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_log_operatorId_operators_id_fk": {
+          "name": "notification_log_operatorId_operators_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_log_idempotency_unique": {
+          "name": "notification_log_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotencyKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "audit_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_operatorId": {
+          "name": "idx_audit_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_kind": {
+          "name": "idx_audit_log_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compliance_alert_log": {
+      "name": "compliance_alert_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentType": {
+          "name": "documentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thresholdBand": {
+          "name": "thresholdBand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_compliance_alert_log_operatorId": {
+          "name": "idx_compliance_alert_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compliance_alert_log_vehicleId": {
+          "name": "idx_compliance_alert_log_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compliance_alert_log_operatorId_operators_id_fk": {
+          "name": "compliance_alert_log_operatorId_operators_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "compliance_alert_log_vehicleId_vehicles_id_fk": {
+          "name": "compliance_alert_log_vehicleId_vehicles_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compliance_alert_log_band_unique": {
+          "name": "compliance_alert_log_band_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vehicleId",
+            "documentType",
+            "thresholdBand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.add_on_options": {
+      "name": "add_on_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceJpy": {
+          "name": "priceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "add_on_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_add_on_options_operatorId": {
+          "name": "idx_add_on_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "add_on_options_active_name_unique": {
+          "name": "add_on_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "add_on_options_operatorId_operators_id_fk": {
+          "name": "add_on_options_operatorId_operators_id_fk",
+          "tableFrom": "add_on_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "add_on_options_operatorId_id_unique": {
+          "name": "add_on_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "add_on_options_price_non_negative": {
+          "name": "add_on_options_price_non_negative",
+          "value": "\"add_on_options\".\"priceJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operator_memberships": {
+      "name": "operator_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_memberships_active_user_unique": {
+          "name": "operator_memberships_active_user_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operator_memberships_operatorId": {
+          "name": "idx_operator_memberships_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_memberships_userId_users_id_fk": {
+          "name": "operator_memberships_userId_users_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_memberships_operatorId_operators_id_fk": {
+          "name": "operator_memberships_operatorId_operators_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_invites": {
+      "name": "provider_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedByUserId": {
+          "name": "acceptedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_invites_tokenHash_unique": {
+          "name": "provider_invites_tokenHash_unique",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_invites_pending_email_unique": {
+          "name": "provider_invites_pending_email_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'PENDING'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_email": {
+          "name": "idx_provider_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_operatorId": {
+          "name": "idx_provider_invites_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_invitedByUserId": {
+          "name": "idx_provider_invites_invitedByUserId",
+          "columns": [
+            {
+              "expression": "invitedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_acceptedByUserId": {
+          "name": "idx_provider_invites_acceptedByUserId",
+          "columns": [
+            {
+              "expression": "acceptedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_invites_operatorId_operators_id_fk": {
+          "name": "provider_invites_operatorId_operators_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provider_invites_invitedByUserId_users_id_fk": {
+          "name": "provider_invites_invitedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_invites_acceptedByUserId_users_id_fk": {
+          "name": "provider_invites_acceptedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acceptedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_acceptances": {
+      "name": "consent_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentType": {
+          "name": "consentType",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatorMembershipId": {
+          "name": "operatorMembershipId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorRole": {
+          "name": "actorRole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "consent_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLICKWRAP'"
+        },
+        "recordSignature": {
+          "name": "recordSignature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingKeyId": {
+          "name": "signingKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureRef": {
+          "name": "signatureRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentSnapshot": {
+          "name": "documentSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureCanonicalVersion": {
+          "name": "signatureCanonicalVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_unique_booking_liability": {
+          "name": "consent_unique_booking_liability",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_user_document": {
+          "name": "consent_unique_user_document",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NULL AND \"consent_acceptances\".\"operatorId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_operator_document": {
+          "name": "consent_unique_operator_document",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"operatorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_document_type_idx": {
+          "name": "consent_acceptances_document_type_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_membership_idx": {
+          "name": "consent_acceptances_membership_idx",
+          "columns": [
+            {
+              "expression": "operatorMembershipId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_consent_type_idx": {
+          "name": "consent_acceptances_consent_type_idx",
+          "columns": [
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_acceptances_userId_users_id_fk": {
+          "name": "consent_acceptances_userId_users_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorId_operators_id_fk": {
+          "name": "consent_acceptances_operatorId_operators_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorMembershipId_operator_memberships_id_fk": {
+          "name": "consent_acceptances_operatorMembershipId_operator_memberships_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operator_memberships",
+          "columnsFrom": [
+            "operatorMembershipId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_bookingId_bookings_id_fk": {
+          "name": "consent_acceptances_bookingId_bookings_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_document_type_fk": {
+          "name": "consent_acceptances_document_type_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "consent_documents",
+          "columnsFrom": [
+            "documentId",
+            "consentType"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_liability_booking_chk": {
+          "name": "consent_liability_booking_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'RENTER_LIABILITY') = (\"consent_acceptances\".\"bookingId\" IS NOT NULL)"
+        },
+        "consent_operator_agreement_chk": {
+          "name": "consent_operator_agreement_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'OPERATOR_AGREEMENT') = (\"consent_acceptances\".\"operatorId\" IS NOT NULL)"
+        },
+        "consent_membership_implies_operator_chk": {
+          "name": "consent_membership_implies_operator_chk",
+          "value": "\"consent_acceptances\".\"operatorMembershipId\" IS NULL OR \"consent_acceptances\".\"operatorId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_documents": {
+      "name": "consent_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptanceLabel": {
+          "name": "acceptanceLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "consent_doc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "effectiveFrom": {
+          "name": "effectiveFrom",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_documents_type_version_locale_unique": {
+          "name": "consent_documents_type_version_locale_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "version",
+            "locale"
+          ]
+        },
+        "consent_documents_id_type_unique": {
+          "name": "consent_documents_id_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorRole": {
+          "name": "authorRole",
+          "type": "review_author_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "review_subject",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectVehicleId": {
+          "name": "subjectVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectClassId": {
+          "name": "subjectClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall": {
+          "name": "overall",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subRatings": {
+          "name": "subRatings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderationStatus": {
+          "name": "moderationStatus",
+          "type": "review_moderation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VISIBLE'"
+        },
+        "revealDeadlineAt": {
+          "name": "revealDeadlineAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_bookingId": {
+          "name": "idx_reviews_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_authorUserId": {
+          "name": "idx_reviews_authorUserId",
+          "columns": [
+            {
+              "expression": "authorUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_operator_published": {
+          "name": "idx_reviews_operator_published",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_vehicle": {
+          "name": "idx_reviews_subject_vehicle",
+          "columns": [
+            {
+              "expression": "subjectVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_class": {
+          "name": "idx_reviews_subject_class",
+          "columns": [
+            {
+              "expression": "subjectClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_reveal_due": {
+          "name": "idx_reviews_reveal_due",
+          "columns": [
+            {
+              "expression": "revealDeadlineAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"publishedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_bookingId_bookings_id_fk": {
+          "name": "reviews_bookingId_bookings_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_operatorId_operators_id_fk": {
+          "name": "reviews_operatorId_operators_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_authorUserId_users_id_fk": {
+          "name": "reviews_authorUserId_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectVehicleId_vehicles_id_fk": {
+          "name": "reviews_subjectVehicleId_vehicles_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "subjectVehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectClassId_vehicle_classes_id_fk": {
+          "name": "reviews_subjectClassId_vehicle_classes_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "subjectClassId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_author_subject_per_booking_unique": {
+          "name": "reviews_author_subject_per_booking_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingId",
+            "authorUserId",
+            "subject"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_overall_range_chk": {
+          "name": "reviews_overall_range_chk",
+          "value": "\"reviews\".\"overall\" BETWEEN 1 AND 5"
+        },
+        "reviews_subject_pairing_chk": {
+          "name": "reviews_subject_pairing_chk",
+          "value": "(\"reviews\".\"authorRole\" = 'OPERATOR') = (\"reviews\".\"subject\" = 'RENTER')"
+        },
+        "reviews_vehicle_subject_chk": {
+          "name": "reviews_vehicle_subject_chk",
+          "value": "(\"reviews\".\"subject\" = 'VEHICLE') = (\"reviews\".\"subjectVehicleId\" IS NOT NULL)"
+        },
+        "reviews_class_subject_chk": {
+          "name": "reviews_class_subject_chk",
+          "value": "\"reviews\".\"subjectClassId\" IS NULL OR \"reviews\".\"subject\" = 'VEHICLE'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_status": {
+      "name": "document_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "IDP",
+        "PASSPORT"
+      ]
+    },
+    "public.region_status": {
+      "name": "region_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "PREFECTURE",
+        "CITY",
+        "AREA"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.coordinate_source": {
+      "name": "coordinate_source",
+      "schema": "public",
+      "values": [
+        "GEOCODED",
+        "MANUAL",
+        "PENDING"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.luggage_size": {
+      "name": "luggage_size",
+      "schema": "public",
+      "values": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.fee_schedule_status": {
+      "name": "fee_schedule_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "OVERTIME_HOURLY",
+        "CLEANING_FLAT",
+        "NO_FUEL_FLAT"
+      ]
+    },
+    "public.fee_unit": {
+      "name": "fee_unit",
+      "schema": "public",
+      "values": [
+        "PER_HOUR",
+        "PER_DAY",
+        "PER_KM",
+        "FLAT"
+      ]
+    },
+    "public.insurance_status": {
+      "name": "insurance_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.booking_event_type": {
+      "name": "booking_event_type",
+      "schema": "public",
+      "values": [
+        "BOOKING_CREATED",
+        "VEHICLE_SUBSTITUTED",
+        "BOOKING_CANCELLED",
+        "STATUS_CHANGED"
+      ]
+    },
+    "public.booking_fulfillment_mode": {
+      "name": "booking_fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "SPECIFIC",
+        "CLASS_COMBO"
+      ]
+    },
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.payment_anomaly_kind": {
+      "name": "payment_anomaly_kind",
+      "schema": "public",
+      "values": [
+        "DOUBLE_PAYMENT",
+        "AMOUNT_MISMATCH"
+      ]
+    },
+    "public.payment_anomaly_resolution": {
+      "name": "payment_anomaly_resolution",
+      "schema": "public",
+      "values": [
+        "BENIGN",
+        "INVESTIGATED",
+        "REFUNDED_EXTERNALLY"
+      ]
+    },
+    "public.payment_event_status": {
+      "name": "payment_event_status",
+      "schema": "public",
+      "values": [
+        "SUCCEEDED"
+      ]
+    },
+    "public.payment_refund_status": {
+      "name": "payment_refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.notification_kind": {
+      "name": "notification_kind",
+      "schema": "public",
+      "values": [
+        "OPERATOR_BOOKING_ALERT",
+        "RENTER_BOOKING_CONFIRM",
+        "RENTER_SUBSTITUTION",
+        "RENTER_CANCELLATION",
+        "RENTER_TRIP_STARTED",
+        "RENTER_TRIP_COMPLETED"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "DEAD",
+        "NO_RECIPIENT"
+      ]
+    },
+    "public.audit_event_kind": {
+      "name": "audit_event_kind",
+      "schema": "public",
+      "values": [
+        "PROVIDER_INVITE_CREATED",
+        "OPERATOR_PROFILE_UPDATED",
+        "OPERATOR_MEMBER_DEACTIVATED"
+      ]
+    },
+    "public.add_on_status": {
+      "name": "add_on_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.operator_membership_status": {
+      "name": "operator_membership_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED"
+      ]
+    },
+    "public.operator_role": {
+      "name": "operator_role",
+      "schema": "public",
+      "values": [
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF"
+      ]
+    },
+    "public.provider_invite_status": {
+      "name": "provider_invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED"
+      ]
+    },
+    "public.consent_doc_status": {
+      "name": "consent_doc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PUBLISHED",
+        "ARCHIVED"
+      ]
+    },
+    "public.consent_method": {
+      "name": "consent_method",
+      "schema": "public",
+      "values": [
+        "CLICKWRAP",
+        "ESIGN",
+        "IMPORTED"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "RENTER_TOS",
+        "PRIVACY_POLICY",
+        "RENTER_LIABILITY",
+        "OPERATOR_AGREEMENT"
+      ]
+    },
+    "public.review_author_role": {
+      "name": "review_author_role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "OPERATOR"
+      ]
+    },
+    "public.review_moderation_status": {
+      "name": "review_moderation_status",
+      "schema": "public",
+      "values": [
+        "VISIBLE",
+        "HIDDEN"
+      ]
+    },
+    "public.review_subject": {
+      "name": "review_subject",
+      "schema": "public",
+      "values": [
+        "OPERATOR",
+        "VEHICLE",
+        "RENTER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1782432393780,
       "tag": "0077_reviews_class_subject_chk",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1782435185883,
+      "tag": "0078_add_payment_anomaly_resolution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/repositories/drizzle/payment-anomaly.ts
+++ b/packages/api/src/repositories/drizzle/payment-anomaly.ts
@@ -1,7 +1,11 @@
 import { paymentAnomalies } from '@kuruma/shared/db/schema'
-import { isNull } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull } from 'drizzle-orm'
 import type { PaymentAnomaly } from '../../stores'
-import type { NewPaymentAnomaly, PaymentAnomalyRepository } from '../types'
+import type {
+  NewPaymentAnomaly,
+  PaymentAnomalyRepository,
+  ResolvePaymentAnomalyInput,
+} from '../types'
 import { type Db, paymentAnomalyColumns, toPaymentAnomaly } from './shared'
 
 export class DrizzlePaymentAnomalyRepository implements PaymentAnomalyRepository {
@@ -24,5 +28,31 @@ export class DrizzlePaymentAnomalyRepository implements PaymentAnomalyRepository
       .from(paymentAnomalies)
       .where(isNull(paymentAnomalies.resolvedAt))
     return rows.map(toPaymentAnomaly)
+  }
+
+  async listResolved(): Promise<PaymentAnomaly[]> {
+    const rows = await this.db
+      .select(paymentAnomalyColumns)
+      .from(paymentAnomalies)
+      .where(isNotNull(paymentAnomalies.resolvedAt))
+    return rows.map(toPaymentAnomaly)
+  }
+
+  // Write-once close: the `isNull(resolvedAt)` predicate makes the UPDATE match zero
+  // rows for an unknown OR already-resolved id, so `.returning()` is empty and we
+  // return null (=> 404) instead of silently overwriting who first closed it.
+  async resolve(id: string, input: ResolvePaymentAnomalyInput): Promise<PaymentAnomaly | null> {
+    const rows = await this.db
+      .update(paymentAnomalies)
+      .set({
+        resolvedAt: new Date(),
+        resolution: input.resolution,
+        resolvedBy: input.resolvedBy,
+        note: input.note,
+      })
+      .where(and(eq(paymentAnomalies.id, id), isNull(paymentAnomalies.resolvedAt)))
+      .returning(paymentAnomalyColumns)
+    const row = rows[0]
+    return row ? toPaymentAnomaly(row) : null
   }
 }

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -228,6 +228,9 @@ export const paymentAnomalyColumns = {
   expectedAmountJpy: paymentAnomalies.expectedAmountJpy,
   currency: paymentAnomalies.currency,
   resolvedAt: paymentAnomalies.resolvedAt,
+  resolution: paymentAnomalies.resolution,
+  resolvedBy: paymentAnomalies.resolvedBy,
+  note: paymentAnomalies.note,
   createdAt: paymentAnomalies.createdAt,
 }
 
@@ -544,6 +547,9 @@ export function toPaymentAnomaly(r: PaymentAnomalyRow): PaymentAnomaly {
     expectedAmountJpy: r.expectedAmountJpy,
     currency: r.currency,
     resolvedAt: r.resolvedAt,
+    resolution: r.resolution,
+    resolvedBy: r.resolvedBy,
+    note: r.note,
     createdAt: r.createdAt,
   }
 }

--- a/packages/api/src/repositories/in-memory/payment-anomaly.test.ts
+++ b/packages/api/src/repositories/in-memory/payment-anomaly.test.ts
@@ -65,6 +65,9 @@ describe('InMemoryPaymentAnomalyRepository', () => {
       expectedAmountJpy: 50_000,
       currency: 'jpy',
       resolvedAt: new Date('2026-06-10T00:00:00Z'),
+      resolution: 'REFUNDED_EXTERNALLY',
+      resolvedBy: 'admin-1',
+      note: null,
       createdAt: new Date('2026-06-09T00:00:00Z'),
     }
     const repo = new InMemoryPaymentAnomalyRepository(new Map([[resolved.id, resolved]]))

--- a/packages/api/src/repositories/in-memory/payment-anomaly.ts
+++ b/packages/api/src/repositories/in-memory/payment-anomaly.ts
@@ -1,5 +1,9 @@
 import type { PaymentAnomaly } from '../../stores'
-import type { NewPaymentAnomaly, PaymentAnomalyRepository } from '../types'
+import type {
+  NewPaymentAnomaly,
+  PaymentAnomalyRepository,
+  ResolvePaymentAnomalyInput,
+} from '../types'
 
 export class InMemoryPaymentAnomalyRepository implements PaymentAnomalyRepository {
   private readonly store: Map<string, PaymentAnomaly>
@@ -18,6 +22,9 @@ export class InMemoryPaymentAnomalyRepository implements PaymentAnomalyRepositor
       ...data,
       id: crypto.randomUUID(),
       resolvedAt: null,
+      resolution: null,
+      resolvedBy: null,
+      note: null,
       createdAt: new Date(),
     }
     this.store.set(anomaly.id, anomaly)
@@ -25,5 +32,25 @@ export class InMemoryPaymentAnomalyRepository implements PaymentAnomalyRepositor
 
   async listUnresolved(): Promise<PaymentAnomaly[]> {
     return [...this.store.values()].filter((r) => r.resolvedAt === null)
+  }
+
+  async listResolved(): Promise<PaymentAnomaly[]> {
+    return [...this.store.values()].filter((r) => r.resolvedAt !== null)
+  }
+
+  // Guarded, write-once: mirrors the Drizzle `WHERE id AND resolvedAt IS NULL` so an
+  // already-resolved (or unknown) id is a no-op returning null, not a silent overwrite.
+  async resolve(id: string, input: ResolvePaymentAnomalyInput): Promise<PaymentAnomaly | null> {
+    const existing = this.store.get(id)
+    if (!existing || existing.resolvedAt !== null) return null
+    const resolved: PaymentAnomaly = {
+      ...existing,
+      resolvedAt: new Date(),
+      resolution: input.resolution,
+      resolvedBy: input.resolvedBy,
+      note: input.note,
+    }
+    this.store.set(id, resolved)
+    return resolved
   }
 }

--- a/packages/api/src/repositories/types-payment.ts
+++ b/packages/api/src/repositories/types-payment.ts
@@ -1,4 +1,5 @@
 import type { PaymentRefundStatus } from '@kuruma/shared/enums'
+import type { PaymentAnomalyResolution } from '@kuruma/shared/types/payment-anomaly'
 import type { Booking, PaymentAnomaly, PaymentEvent, PaymentRefund } from '../stores'
 
 /** A verified successful payment to persist. id + createdAt are assigned by the
@@ -27,10 +28,25 @@ export interface PaymentEventRepository {
   listSucceededMonths(): Promise<string[]>
 }
 
-/** A payment anomaly to persist. id/createdAt/resolvedAt are store-assigned (#508 P2). */
-export type NewPaymentAnomaly = Omit<PaymentAnomaly, 'id' | 'createdAt' | 'resolvedAt'>
+/** A payment anomaly to persist. id/createdAt are store-assigned; the resolution
+ *  audit fields (resolvedAt/resolution/resolvedBy/note) start NULL and are set only
+ *  by `resolve()` — the webhook writer never supplies them (#508 P2, #1075 slice 3). */
+export type NewPaymentAnomaly = Omit<
+  PaymentAnomaly,
+  'id' | 'createdAt' | 'resolvedAt' | 'resolution' | 'resolvedBy' | 'note'
+>
 
-/** payment_anomalies data access (#508 P2). The webhook is the only writer. */
+/** The audit an admin writes to close an anomaly's review-queue item (#1075 slice 3).
+ *  `resolvedBy` is the actioning admin's id (from the caller ctx, never the body);
+ *  `note` is optional free-text. Carries NO money — v1 only clears the queue. */
+export interface ResolvePaymentAnomalyInput {
+  resolution: PaymentAnomalyResolution
+  resolvedBy: string
+  note: string | null
+}
+
+/** payment_anomalies data access (#508 P2). The webhook is the only writer of new
+ *  rows; an admin resolution (#1075 slice 3) is the only other mutation. */
 export interface PaymentAnomalyRepository {
   // Persist an anomaly for operator review. IDEMPOTENT on stripeEventId: a
   // redelivered webhook (which re-derives the same anomaly) must not stack rows.
@@ -38,6 +54,14 @@ export interface PaymentAnomalyRepository {
   // Unresolved anomalies across all operators for the platform-admin surface.
   // Unscoped by design — authz lives in the service (mirrors listSucceeded).
   listUnresolved(): Promise<PaymentAnomaly[]>
+  // Resolved anomalies across all operators (the "resolved" filter tab). Also
+  // unscoped; the service is the authz chokepoint.
+  listResolved(): Promise<PaymentAnomaly[]>
+  // Close an anomaly: set resolvedAt=now plus the audit fields in ONE guarded
+  // UPDATE (WHERE id AND resolvedAt IS NULL). Returns the updated row, or null when
+  // the id is unknown OR already resolved — the resolution audit is write-once, so a
+  // double-resolve is a no-op (=> 404), never a silent overwrite of who closed it.
+  resolve(id: string, input: ResolvePaymentAnomalyInput): Promise<PaymentAnomaly | null>
 }
 
 /** A refund attempt to claim. id/createdAt/updatedAt are store-assigned; stripeRefundId

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -63,6 +63,7 @@ export type {
   PaymentEventRepository,
   PaymentRefundRepository,
   RefundReconcilerRepository,
+  ResolvePaymentAnomalyInput,
 } from './types-payment'
 
 // Notification persistence: SENDING-lease + delivery-cap consts (#393, #483) and

--- a/packages/api/src/routes/payment-anomalies.ts
+++ b/packages/api/src/routes/payment-anomalies.ts
@@ -1,13 +1,21 @@
 import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
+import { resolvePaymentAnomalySchema } from '@kuruma/shared/validators/payment-anomaly'
 import { Hono } from 'hono'
-import { requireAuth, requirePlatformRead, requireUser, toCallerContext } from '../middleware/auth'
+import {
+  requireAuth,
+  requirePlatformAdmin,
+  requirePlatformRead,
+  requireUser,
+  toCallerContext,
+} from '../middleware/auth'
 import type { PaymentAnomalyService } from '../services/payment-anomaly'
 import type { PaymentAnomaly } from '../stores'
-import { ok } from './helpers'
+import { fail, ok, parseBody } from './helpers'
 
 // Project a persisted anomaly onto the admin wire view (@kuruma/shared): drop the
-// internal resolved flag (this list is unresolved-only) and the checkout-session
-// id (refunds are issued against the paymentIntent), and serialize createdAt as ISO.
+// internal checkout-session id (refunds are issued against the paymentIntent) and
+// `resolvedBy` (no user-join in v1), and serialize the timestamps as ISO. The
+// resolution audit fields are null exactly while the anomaly is unresolved.
 function toView(a: PaymentAnomaly): PaymentAnomalyView {
   return {
     id: a.id,
@@ -20,23 +28,58 @@ function toView(a: PaymentAnomaly): PaymentAnomalyView {
     stripeEventId: a.stripeEventId,
     stripePaymentIntentId: a.stripePaymentIntentId,
     createdAt: a.createdAt.toISOString(),
+    resolvedAt: a.resolvedAt ? a.resolvedAt.toISOString() : null,
+    resolution: a.resolution,
+    note: a.note,
   }
 }
 
 /**
- * Platform-admin payment anomalies needing review (#508 P2). Cross-tenant by
- * nature, so `requireAuth` gates the path and `requirePlatformRead` narrows it to
- * platform-admin roles — OPERATOR_* are rejected (payment oversight is platform
- * only) — and the service re-asserts the gate as defence-in-depth.
+ * Platform-admin payment anomalies (#508 P2; resolution UI #1075 slice 3). Cross-tenant
+ * by nature, so `requireAuth` gates the paths and the per-handler `requirePlatform*`
+ * guards narrow them to platform-admin roles — OPERATOR_* are rejected (payment
+ * oversight is platform only) — and the service re-asserts the gate as defence-in-depth.
+ *
+ * The LIST read uses `requirePlatformRead`; the resolve WRITE uses the stricter
+ * `requirePlatformAdmin`. The split is intentional even though both resolve to
+ * {PLATFORM_ADMIN} today (#487). v1 resolve moves NO money — it only clears the queue.
  */
 export function createPaymentAnomalyRoutes(service: PaymentAnomalyService) {
   const app = new Hono()
   app.use('/admin/payment-anomalies', requireAuth())
+  app.use('/admin/payment-anomalies/*', requireAuth())
 
-  return app.get('/admin/payment-anomalies', async (c) => {
-    const ctx = toCallerContext(requireUser(c))
-    requirePlatformRead(ctx)
-    const anomalies = (await service.listUnresolved(ctx)).map(toView)
-    return ok(c, { anomalies })
-  })
+  return app
+    .get('/admin/payment-anomalies', async (c) => {
+      const ctx = toCallerContext(requireUser(c))
+      requirePlatformRead(ctx)
+
+      // ?status=resolved|unresolved (default unresolved — the review queue). The two
+      // tabs share this one endpoint so the Revenue-tab panel and the dedicated page
+      // stay pointed at the same query.
+      const status = c.req.query('status') ?? 'unresolved'
+      if (status !== 'resolved' && status !== 'unresolved') {
+        return fail(c, 'status must be "resolved" or "unresolved"', 400)
+      }
+
+      const anomalies = (
+        status === 'resolved' ? await service.listResolved(ctx) : await service.listUnresolved(ctx)
+      ).map(toView)
+      return ok(c, { anomalies })
+    })
+    .post('/admin/payment-anomalies/:id/resolve', async (c) => {
+      const ctx = toCallerContext(requireUser(c))
+      requirePlatformAdmin(ctx)
+
+      const parsed = await parseBody(c, resolvePaymentAnomalySchema)
+      if (!parsed.ok) return parsed.response
+
+      const anomaly = await service.resolve(
+        ctx,
+        c.req.param('id'),
+        parsed.data.resolution,
+        parsed.data.note ?? null,
+      )
+      return ok(c, { anomaly: toView(anomaly) })
+    })
 }

--- a/packages/api/src/services/payment-anomaly.ts
+++ b/packages/api/src/services/payment-anomaly.ts
@@ -1,4 +1,10 @@
-import { type CallerContext, requirePlatformRead } from '../middleware/auth'
+import type { PaymentAnomalyResolution } from '@kuruma/shared/types/payment-anomaly'
+import {
+  type CallerContext,
+  NotFoundError,
+  requirePlatformAdmin,
+  requirePlatformRead,
+} from '../middleware/auth'
 import type { PaymentAnomalyRepository } from '../repositories/types'
 import type { PaymentAnomaly } from '../stores'
 
@@ -15,5 +21,35 @@ export class PaymentAnomalyService {
   async listUnresolved(ctx: CallerContext): Promise<PaymentAnomaly[]> {
     requirePlatformRead(ctx)
     return this.anomalies.listUnresolved()
+  }
+
+  async listResolved(ctx: CallerContext): Promise<PaymentAnomaly[]> {
+    requirePlatformRead(ctx)
+    return this.anomalies.listResolved()
+  }
+
+  /**
+   * Close an anomaly's review-queue item (#1075 slice 3). A WRITE, so it gates on
+   * the stricter `requirePlatformAdmin` (only PLATFORM_ADMIN — never legacy
+   * STAFF/ADMIN or any OPERATOR_*), distinct from the `requirePlatformRead` on the
+   * list reads above; the split is intentional even though both resolve to
+   * {PLATFORM_ADMIN} today. `resolvedBy` comes from the verified caller, never the
+   * request body. A null result (unknown or already-resolved id — the guarded
+   * write-once UPDATE matched nothing) surfaces as a 404. NO money moves here.
+   */
+  async resolve(
+    ctx: CallerContext,
+    id: string,
+    resolution: PaymentAnomalyResolution,
+    note: string | null,
+  ): Promise<PaymentAnomaly> {
+    requirePlatformAdmin(ctx)
+    const resolved = await this.anomalies.resolve(id, {
+      resolution,
+      resolvedBy: ctx.userId,
+      note,
+    })
+    if (!resolved) throw new NotFoundError('payment anomaly not found or already resolved')
+    return resolved
   }
 }

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -40,6 +40,7 @@ import type { ComplianceAlertBand, ComplianceDocumentType } from '@kuruma/shared
 import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
 import type { LuggageSize } from '@kuruma/shared/lib/luggage'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
+import type { PaymentAnomalyResolution } from '@kuruma/shared/types/payment-anomaly'
 
 /**
  * The notification kind/status sets have a single source of truth: the
@@ -219,8 +220,13 @@ export interface PaymentAnomaly {
   receivedAmountJpy: number | null
   expectedAmountJpy: number | null
   currency: string | null
-  // NULL until an operator actions it (refunded / dismissed).
+  // Resolution audit (#1075 slice 3): all four are NULL while the anomaly needs
+  // review and written together when an admin closes it. `resolution` = why it was
+  // closed, `resolvedBy` = the actioning admin's id, `note` = optional free-text.
   resolvedAt: Date | null
+  resolution: PaymentAnomalyResolution | null
+  resolvedBy: string | null
+  note: string | null
   createdAt: Date
 }
 

--- a/packages/api/tests/integration/payment-anomaly-resolution.test.ts
+++ b/packages/api/tests/integration/payment-anomaly-resolution.test.ts
@@ -1,0 +1,174 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { bookings, paymentAnomalies, paymentRefunds, users } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleBookingRepository,
+  DrizzlePaymentAnomalyRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { bookingInput } from '../helpers/booking'
+import {
+  DEFAULT_DAILY_RATE_JPY,
+  cleanupBookings,
+  cleanupLocations,
+  cleanupUsers,
+  cleanupVehicleClasses,
+  cleanupVehicles,
+  db,
+  seedLocation,
+  seedVehicleClass,
+} from './setup'
+
+// Real-Postgres proof for the #1075 slice-3 resolve path: the guarded UPDATE sets
+// the audit fields and moves the row between the unresolved/resolved lists, AND
+// (the locked invariant of this slice) it touches NO money — no payment_refunds
+// row is written and the booking's cancellation settlement is left untouched.
+const anomalyRepo = new DrizzlePaymentAnomalyRepository(db)
+const bookingRepo = new DrizzleBookingRepository(db)
+const vehicleRepo = new DrizzleVehicleRepository(db)
+
+let bookingId: string
+let userId: string
+const classIds: string[] = []
+const locationIds: string[] = []
+const vehicleIds: string[] = []
+
+beforeAll(async () => {
+  const [user] = await db
+    .insert(users)
+    .values({
+      id: crypto.randomUUID(),
+      email: `anomaly-${Date.now()}@kuruma-test.com`,
+      role: 'RENTER',
+      language: 'en',
+    })
+    .returning()
+  userId = user.id
+
+  const klass = await seedVehicleClass('anomaly')
+  classIds.push(klass.id)
+  const location = await seedLocation('anomaly')
+  locationIds.push(location.id)
+  const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, {
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+    classId: klass.id,
+    name: 'Anomaly Test Car',
+    description: null,
+    seats: 5,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+  })
+  vehicleIds.push(vehicle.id)
+
+  const booking = await bookingRepo.create(
+    SYSTEM_CONTEXT,
+    bookingInput({
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+      renterId: userId,
+      classId: klass.id,
+      requestedVehicleId: vehicle.id,
+      assignedVehicleId: vehicle.id,
+      pickupLocationId: location.id,
+      dropoffLocationId: location.id,
+      startAt: new Date('2026-09-01T09:00:00Z'),
+      endAt: new Date('2026-09-02T09:00:00Z'),
+    }),
+  )
+  bookingId = booking.id
+})
+
+afterAll(async () => {
+  await db.delete(paymentAnomalies).where(eq(paymentAnomalies.bookingId, bookingId))
+  await cleanupBookings([bookingId])
+  await cleanupVehicles(vehicleIds)
+  await cleanupVehicleClasses(classIds)
+  await cleanupLocations(locationIds)
+  await cleanupUsers([userId])
+})
+
+async function seedAnomaly(): Promise<string> {
+  const [row] = await db
+    .insert(paymentAnomalies)
+    .values({
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+      bookingId,
+      kind: 'DOUBLE_PAYMENT',
+      stripeEventId: `evt_${crypto.randomUUID()}`,
+      stripeCheckoutSessionId: `cs_${crypto.randomUUID()}`,
+      stripePaymentIntentId: 'pi_dupe',
+      receivedAmountJpy: 10_000,
+      expectedAmountJpy: 10_000,
+      currency: 'jpy',
+    })
+    .returning()
+  return row.id
+}
+
+describe('DrizzlePaymentAnomalyRepository.resolve (real Postgres)', () => {
+  it('writes the audit fields and moves the row from unresolved to resolved', async () => {
+    const id = await seedAnomaly()
+
+    const resolved = await anomalyRepo.resolve(id, {
+      resolution: 'REFUNDED_EXTERNALLY',
+      resolvedBy: 'admin-xyz',
+      note: 'refunded the duplicate in the Stripe dashboard',
+    })
+
+    expect(resolved).toMatchObject({
+      id,
+      resolution: 'REFUNDED_EXTERNALLY',
+      resolvedBy: 'admin-xyz',
+      note: 'refunded the duplicate in the Stripe dashboard',
+    })
+    expect(resolved?.resolvedAt).toBeInstanceOf(Date)
+
+    const unresolvedIds = (await anomalyRepo.listUnresolved()).map((a) => a.id)
+    const resolvedIds = (await anomalyRepo.listResolved()).map((a) => a.id)
+    expect(unresolvedIds).not.toContain(id)
+    expect(resolvedIds).toContain(id)
+  })
+
+  it('is write-once at the DB: a second resolve matches no row and returns null', async () => {
+    const id = await seedAnomaly()
+    await anomalyRepo.resolve(id, { resolution: 'BENIGN', resolvedBy: 'admin-1', note: null })
+
+    const second = await anomalyRepo.resolve(id, {
+      resolution: 'INVESTIGATED',
+      resolvedBy: 'admin-2',
+      note: 'should not overwrite',
+    })
+    expect(second).toBeNull()
+
+    // The first resolution is intact — not clobbered by the second attempt.
+    const [row] = await db.select().from(paymentAnomalies).where(eq(paymentAnomalies.id, id))
+    expect(row).toMatchObject({ resolution: 'BENIGN', resolvedBy: 'admin-1' })
+  })
+
+  it('moves NO money: no payment_refunds row and the booking settlement is untouched', async () => {
+    const id = await seedAnomaly()
+    await anomalyRepo.resolve(id, {
+      resolution: 'REFUNDED_EXTERNALLY',
+      resolvedBy: 'admin-1',
+      note: null,
+    })
+
+    const refunds = await db
+      .select()
+      .from(paymentRefunds)
+      .where(eq(paymentRefunds.bookingId, bookingId))
+    expect(refunds).toHaveLength(0)
+
+    const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId))
+    expect(booking.cancellationFeeSettlement).toBe('ADVISORY')
+  })
+})

--- a/packages/api/tests/routes/payment-anomalies-resolve.test.ts
+++ b/packages/api/tests/routes/payment-anomalies-resolve.test.ts
@@ -1,0 +1,144 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import type { UserRole } from '../../src/middleware/auth'
+import { InMemoryPaymentAnomalyRepository } from '../../src/repositories/in-memory/payment-anomaly'
+import { createPaymentAnomalyRoutes } from '../../src/routes/payment-anomalies'
+import { PaymentAnomalyService } from '../../src/services/payment-anomaly'
+import type { PaymentAnomaly } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+
+const OP_A = 'operator-aaaaaaaa'
+const ANOMALY_ID = 'anomaly-11111111'
+
+function anomaly(over: Partial<PaymentAnomaly> = {}): PaymentAnomaly {
+  return {
+    id: ANOMALY_ID,
+    operatorId: OP_A,
+    bookingId: crypto.randomUUID(),
+    kind: 'DOUBLE_PAYMENT',
+    stripeEventId: crypto.randomUUID(),
+    stripeCheckoutSessionId: crypto.randomUUID(),
+    stripePaymentIntentId: 'pi_dupe',
+    receivedAmountJpy: 10_000,
+    expectedAmountJpy: 10_000,
+    currency: 'jpy',
+    resolution: null,
+    resolvedBy: null,
+    note: null,
+    resolvedAt: null,
+    createdAt: new Date('2026-06-20T03:00:00Z'),
+    ...over,
+  }
+}
+
+function seeded() {
+  return new InMemoryPaymentAnomalyRepository(new Map([[ANOMALY_ID, anomaly()]]))
+}
+
+function mount(role: UserRole, operatorId?: string) {
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createPaymentAnomalyRoutes(new PaymentAnomalyService(seeded())))
+  return app
+}
+
+function resolveReq(app: Hono, body: unknown = { resolution: 'BENIGN' }) {
+  return app.request(`/admin/payment-anomalies/${ANOMALY_ID}/resolve`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function listReq(app: Hono, status: 'resolved' | 'unresolved') {
+  return app.request(`/admin/payment-anomalies?status=${status}`)
+}
+
+async function ids(res: Response): Promise<string[]> {
+  const json = (await res.json()) as { data: { anomalies: Array<{ id: string }> } }
+  return json.data.anomalies.map((a) => a.id)
+}
+
+describe('POST /admin/payment-anomalies/:id/resolve — auth', () => {
+  it('401 when unauthenticated', async () => {
+    const app = new Hono()
+    setupGlobalHandlers(app)
+    app.route('/', createPaymentAnomalyRoutes(new PaymentAnomalyService(seeded())))
+    expect((await resolveReq(app)).status).toBe(401)
+  })
+
+  it.each(['RENTER', 'PARTNER', 'STAFF', 'ADMIN'] as const)(
+    '403 for %s (resolving an anomaly is a platform-governance action)',
+    async (role) => {
+      expect((await resolveReq(mount(role))).status).toBe(403)
+    },
+  )
+
+  it('403 for an OPERATOR_OWNER (payment oversight is platform-only)', async () => {
+    expect((await resolveReq(mount('OPERATOR_OWNER', OP_A))).status).toBe(403)
+  })
+})
+
+describe('POST /admin/payment-anomalies/:id/resolve — behaviour', () => {
+  it('writes the full resolution audit and returns the resolved view (no money fields)', async () => {
+    const app = mount('PLATFORM_ADMIN')
+    const res = await resolveReq(app, {
+      resolution: 'REFUNDED_EXTERNALLY',
+      note: 'refunded in Stripe',
+    })
+    expect(res.status).toBe(200)
+
+    const { data } = (await res.json()) as {
+      data: { anomaly: { id: string; resolution: string; note: string; resolvedAt: string } }
+    }
+    expect(data.anomaly).toMatchObject({
+      id: ANOMALY_ID,
+      resolution: 'REFUNDED_EXTERNALLY',
+      note: 'refunded in Stripe',
+    })
+    // resolvedAt is stamped to a real ISO instant by the resolve, not echoed null.
+    expect(Number.isNaN(Date.parse(data.anomaly.resolvedAt))).toBe(false)
+  })
+
+  it('drops the anomaly from the unresolved list and surfaces it under ?status=resolved', async () => {
+    const app = mount('PLATFORM_ADMIN')
+    expect(await ids(await listReq(app, 'unresolved'))).toEqual([ANOMALY_ID])
+
+    expect((await resolveReq(app, { resolution: 'BENIGN' })).status).toBe(200)
+
+    expect(await ids(await listReq(app, 'unresolved'))).toEqual([])
+    expect(await ids(await listReq(app, 'resolved'))).toEqual([ANOMALY_ID])
+  })
+
+  it('is write-once: resolving an already-resolved anomaly is a 404, not a silent overwrite', async () => {
+    const app = mount('PLATFORM_ADMIN')
+    expect((await resolveReq(app, { resolution: 'BENIGN' })).status).toBe(200)
+    expect((await resolveReq(app, { resolution: 'INVESTIGATED' })).status).toBe(404)
+  })
+
+  it('404 when the anomaly id is unknown', async () => {
+    const app = new Hono()
+    setupGlobalHandlers(app)
+    app.use('*', testAuthMiddleware('admin', 'PLATFORM_ADMIN'))
+    app.route('/', createPaymentAnomalyRoutes(new PaymentAnomalyService(seeded())))
+    const res = await app.request('/admin/payment-anomalies/anomaly-99999999/resolve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ resolution: 'BENIGN' }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('400 on a drifted body — an unknown resolution or a foreign field (.strict seam)', async () => {
+    const app = mount('PLATFORM_ADMIN')
+    expect((await resolveReq(app, { resolution: 'WHATEVER' })).status).toBe(400)
+    expect((await resolveReq(app, { resolution: 'BENIGN', amountJpy: 5000 })).status).toBe(400)
+  })
+
+  it('400 when ?status is neither resolved nor unresolved', async () => {
+    const res = await mount('PLATFORM_ADMIN').request('/admin/payment-anomalies?status=bogus')
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/api/tests/routes/payment-anomalies.test.ts
+++ b/packages/api/tests/routes/payment-anomalies.test.ts
@@ -24,6 +24,9 @@ function anomaly(
     expectedAmountJpy: 100_000,
     currency: 'jpy',
     resolvedAt: null,
+    resolution: null,
+    resolvedBy: null,
+    note: null,
     createdAt: new Date('2026-06-10T03:00:00Z'),
     ...over,
   }
@@ -98,9 +101,12 @@ describe('GET /admin/payment-anomalies — listing (PaymentAnomalyView contract)
     })
     // Dates cross the wire as ISO strings (JSON has no Date type).
     expect(view.createdAt).toBe('2026-06-10T03:00:00.000Z')
-    // Lean admin projection: the internal resolved flag and the checkout-session
-    // id are not part of the unresolved-anomaly view.
-    expect('resolvedAt' in view).toBe(false)
+    // An unresolved view carries the resolution audit fields as null (#1075 slice 3);
+    // the internal resolvedBy and checkout-session id stay off the wire.
+    expect(view.resolvedAt).toBeNull()
+    expect(view.resolution).toBeNull()
+    expect(view.note).toBeNull()
+    expect('resolvedBy' in view).toBe(false)
     expect('stripeCheckoutSessionId' in view).toBe(false)
   })
 })

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./db/backfill-vehicle-expiry": "./src/db/backfill-vehicle-expiry.ts",
     "./validators/auth": "./src/validators/auth.ts",
     "./validators/message": "./src/validators/message.ts",
+    "./validators/payment-anomaly": "./src/validators/payment-anomaly.ts",
     "./types/stats": "./src/types/stats.ts",
     "./types/overview": "./src/types/overview.ts",
     "./types/admin-revenue": "./src/types/admin-revenue.ts",

--- a/packages/shared/src/db/payment.ts
+++ b/packages/shared/src/db/payment.ts
@@ -115,6 +115,14 @@ export const paymentAnomalyKindEnum = pgEnum('payment_anomaly_kind', [
   'DOUBLE_PAYMENT',
   'AMOUNT_MISMATCH',
 ])
+// How a platform admin closed a flagged charge (#1075 slice 3). Carries NO money —
+// v1 only clears the review queue; the duplicate's actual refund happens in the
+// Stripe dashboard (REFUNDED_EXTERNALLY) until in-app refund ships as its own slice.
+export const paymentAnomalyResolutionEnum = pgEnum('payment_anomaly_resolution', [
+  'BENIGN',
+  'INVESTIGATED',
+  'REFUNDED_EXTERNALLY',
+])
 export const paymentAnomalies = pgTable(
   'payment_anomalies',
   {
@@ -137,8 +145,13 @@ export const paymentAnomalies = pgTable(
     receivedAmountJpy: integer('receivedAmountJpy'),
     expectedAmountJpy: integer('expectedAmountJpy'),
     currency: text('currency'),
-    // Set once an operator actions it (refunded / dismissed). NULL = still needs review.
+    // Set once an admin closes the review queue item. NULL (with resolution/resolvedBy
+    // /note also NULL) = still needs review; all four are written together (#1075 slice 3).
     resolvedAt: timestamp('resolvedAt', { withTimezone: true }),
+    // Why it was closed; the admin who closed it; their optional note. NULL while unresolved.
+    resolution: paymentAnomalyResolutionEnum('resolution'),
+    resolvedBy: text('resolvedBy'),
+    note: text('note'),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/packages/shared/src/types/payment-anomaly.ts
+++ b/packages/shared/src/types/payment-anomaly.ts
@@ -20,6 +20,20 @@ export const PAYMENT_ANOMALY_KINDS = ['DOUBLE_PAYMENT', 'AMOUNT_MISMATCH'] as co
 
 export type PaymentAnomalyKind = (typeof PAYMENT_ANOMALY_KINDS)[number]
 
+/** The `payment_anomaly_resolution` DB enum, mirrored for the web boundary (#1075
+ *  slice 3). An admin clears the review queue by tagging WHY a flagged charge is
+ *  closed — it carries no money: `BENIGN` (not actually a problem), `INVESTIGATED`
+ *  (looked into, no action), `REFUNDED_EXTERNALLY` (refunded in the Stripe
+ *  dashboard, since in-app refund is deferred to a future slice). Order must match
+ *  the schema enum — pinned by `tests/types/payment-anomaly.test.ts`. */
+export const PAYMENT_ANOMALY_RESOLUTIONS = [
+  'BENIGN',
+  'INVESTIGATED',
+  'REFUNDED_EXTERNALLY',
+] as const
+
+export type PaymentAnomalyResolution = (typeof PAYMENT_ANOMALY_RESOLUTIONS)[number]
+
 /** One unresolved anomaly. Identifiers are carried so an admin can reconcile or
  *  refund: `stripeEventId` is the reconciliation handle, `stripePaymentIntentId`
  *  is what an actual refund is issued against (null on a malformed event). */
@@ -38,6 +52,14 @@ export interface PaymentAnomalyView {
   stripePaymentIntentId: string | null
   /** ISO 8601 (UTC). When the anomaly was recorded. */
   createdAt: string
+  /** ISO 8601 (UTC) once an admin closed the review queue item; null = still open.
+   *  The other resolution fields are null exactly when this is (#1075 slice 3). */
+  resolvedAt: string | null
+  /** Why the anomaly was closed; null while unresolved. `resolvedBy` (the actioning
+   *  admin's id) stays internal — no user join on this surface in v1. */
+  resolution: PaymentAnomalyResolution | null
+  /** Optional free-text the admin left when resolving; null otherwise. */
+  note: string | null
 }
 
 /** Response body of `GET /admin/payment-anomalies` (unresolved only, newest first). */

--- a/packages/shared/src/validators/payment-anomaly.ts
+++ b/packages/shared/src/validators/payment-anomaly.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { PAYMENT_ANOMALY_RESOLUTIONS } from '../types/payment-anomaly'
+
+/** Body of `POST /admin/payment-anomalies/:id/resolve` (#1075 slice 3). The admin
+ *  tags WHY the flagged charge is closed plus an optional note — NO money fields,
+ *  v1 only clears the review queue. `.strict()` rejects any foreign key (a drifted
+ *  or injected field) outright rather than silently dropping it, so the network
+ *  seam can never carry, say, an `amountJpy` into a slice that moves no money. */
+export const resolvePaymentAnomalySchema = z
+  .object({
+    resolution: z.enum(PAYMENT_ANOMALY_RESOLUTIONS),
+    note: z.string().max(1000).optional(),
+  })
+  .strict()
+
+export type ResolvePaymentAnomalyBody = z.infer<typeof resolvePaymentAnomalySchema>

--- a/packages/shared/tests/types/payment-anomaly.test.ts
+++ b/packages/shared/tests/types/payment-anomaly.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { paymentAnomalyKindEnum } from '../../src/db/schema'
-import { PAYMENT_ANOMALY_KINDS, type PaymentAnomalyView } from '../../src/types/payment-anomaly'
+import { paymentAnomalyKindEnum, paymentAnomalyResolutionEnum } from '../../src/db/schema'
+import {
+  PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
+  type PaymentAnomalyView,
+} from '../../src/types/payment-anomaly'
 
 describe('PaymentAnomalyView contract', () => {
   // Drift fence: the web-facing kind union must stay identical to the DB enum
@@ -8,6 +12,10 @@ describe('PaymentAnomalyView contract', () => {
   // place the two are pinned together — mirrors the roleEnum guard in schema.test.ts.
   it('PAYMENT_ANOMALY_KINDS mirrors the payment_anomaly_kind DB enum (order matters)', () => {
     expect([...PAYMENT_ANOMALY_KINDS]).toEqual([...paymentAnomalyKindEnum.enumValues])
+  })
+
+  it('PAYMENT_ANOMALY_RESOLUTIONS mirrors the payment_anomaly_resolution DB enum (order matters)', () => {
+    expect([...PAYMENT_ANOMALY_RESOLUTIONS]).toEqual([...paymentAnomalyResolutionEnum.enumValues])
   })
 
   it('a DOUBLE_PAYMENT view carries the refund/reconcile identifiers', () => {
@@ -22,6 +30,9 @@ describe('PaymentAnomalyView contract', () => {
       stripeEventId: 'evt_1',
       stripePaymentIntentId: 'pi_1',
       createdAt: '2026-06-13T03:00:00.000Z',
+      resolvedAt: null,
+      resolution: null,
+      note: null,
     }
     expect(view.kind).toBe('DOUBLE_PAYMENT')
     expect(view.stripePaymentIntentId).toBe('pi_1')
@@ -39,6 +50,9 @@ describe('PaymentAnomalyView contract', () => {
       stripeEventId: 'evt_2',
       stripePaymentIntentId: null,
       createdAt: '2026-06-13T03:00:00.000Z',
+      resolvedAt: '2026-06-14T05:00:00.000Z',
+      resolution: 'REFUNDED_EXTERNALLY',
+      note: 'duplicate refunded in Stripe dashboard',
     }
     expect(view.receivedAmountJpy).toBeNull()
     expect(view.stripePaymentIntentId).toBeNull()

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1233,6 +1233,7 @@
     "nav": {
       "overview": "Overview",
       "revenue": "Partner Revenue",
+      "anomalies": "Payment Anomalies",
       "documents": "Documents"
     },
     "home": {
@@ -1260,16 +1261,39 @@
     "anomalies": {
       "title": "Payment anomalies",
       "subtitle": "Charges flagged during reconciliation — refund a duplicate or investigate a mismatch.",
-      "empty": "No unresolved payment anomalies.",
+      "empty": "No payment anomalies to show.",
       "colKind": "Type",
       "colBooking": "Booking",
       "colReceived": "Received",
       "colExpected": "Expected",
       "colStripeEvent": "Stripe event",
       "colWhen": "When",
+      "colAction": "Action",
+      "loadError": "Couldn't load payment anomalies.",
+      "retry": "Try again",
       "kind": {
         "DOUBLE_PAYMENT": "Double payment",
         "AMOUNT_MISMATCH": "Amount mismatch"
+      },
+      "tab": {
+        "unresolved": "Needs review",
+        "resolved": "Resolved"
+      },
+      "resolution": {
+        "BENIGN": "Not a problem",
+        "INVESTIGATED": "Investigated — no action",
+        "REFUNDED_EXTERNALLY": "Refunded in Stripe"
+      },
+      "resolve": {
+        "action": "Resolve",
+        "title": "Resolve anomaly",
+        "description": "Mark this flagged charge as reviewed. This records a verdict only — no money is moved here.",
+        "resolutionLabel": "Resolution",
+        "noteLabel": "Note (optional)",
+        "notePlaceholder": "Add context for the audit trail",
+        "cancel": "Cancel",
+        "submit": "Resolve",
+        "submitting": "Resolving…"
       }
     },
     "documents": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1233,6 +1233,7 @@
     "nav": {
       "overview": "概要",
       "revenue": "パートナー収益",
+      "anomalies": "決済の異常",
       "documents": "書類"
     },
     "home": {
@@ -1260,16 +1261,39 @@
     "anomalies": {
       "title": "決済の異常",
       "subtitle": "照合中にフラグが付いた請求 — 二重請求は返金、金額不一致は確認してください。",
-      "empty": "未対応の決済異常はありません。",
+      "empty": "表示する決済異常はありません。",
       "colKind": "種別",
       "colBooking": "予約",
       "colReceived": "受領額",
       "colExpected": "予定額",
       "colStripeEvent": "Stripeイベント",
       "colWhen": "日時",
+      "colAction": "操作",
+      "loadError": "決済異常を読み込めませんでした。",
+      "retry": "再試行",
       "kind": {
         "DOUBLE_PAYMENT": "二重決済",
         "AMOUNT_MISMATCH": "金額不一致"
+      },
+      "tab": {
+        "unresolved": "要確認",
+        "resolved": "対応済み"
+      },
+      "resolution": {
+        "BENIGN": "問題なし",
+        "INVESTIGATED": "確認済み — 対応不要",
+        "REFUNDED_EXTERNALLY": "Stripeで返金済み"
+      },
+      "resolve": {
+        "action": "対応する",
+        "title": "異常を解決",
+        "description": "フラグが付いた請求を確認済みにします。判定を記録するだけで、ここでは返金などの処理は行いません。",
+        "resolutionLabel": "対応区分",
+        "noteLabel": "メモ（任意）",
+        "notePlaceholder": "監査用の補足を入力",
+        "cancel": "キャンセル",
+        "submit": "解決する",
+        "submitting": "処理中…"
       }
     },
     "documents": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1233,6 +1233,7 @@
     "nav": {
       "overview": "概览",
       "revenue": "合作伙伴收益",
+      "anomalies": "支付异常",
       "documents": "证件"
     },
     "home": {
@@ -1260,16 +1261,39 @@
     "anomalies": {
       "title": "支付异常",
       "subtitle": "对账时标记的扣款 — 重复扣款应退款，金额不符需核查。",
-      "empty": "没有待处理的支付异常。",
+      "empty": "暂无可显示的支付异常。",
       "colKind": "类型",
       "colBooking": "订单",
       "colReceived": "实收",
       "colExpected": "应收",
       "colStripeEvent": "Stripe 事件",
       "colWhen": "时间",
+      "colAction": "操作",
+      "loadError": "无法加载支付异常。",
+      "retry": "重试",
       "kind": {
         "DOUBLE_PAYMENT": "重复支付",
         "AMOUNT_MISMATCH": "金额不符"
+      },
+      "tab": {
+        "unresolved": "待核查",
+        "resolved": "已处理"
+      },
+      "resolution": {
+        "BENIGN": "无问题",
+        "INVESTIGATED": "已核查 — 无需处理",
+        "REFUNDED_EXTERNALLY": "已在 Stripe 退款"
+      },
+      "resolve": {
+        "action": "处理",
+        "title": "处理异常",
+        "description": "将此标记的扣款标为已审核。此操作仅记录处理结论，不会在此移动任何资金。",
+        "resolutionLabel": "处理结论",
+        "noteLabel": "备注（可选）",
+        "notePlaceholder": "补充说明以便审计追溯",
+        "cancel": "取消",
+        "submit": "处理",
+        "submitting": "处理中…"
       }
     },
     "documents": {

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as LocaleBusinessManageClassesRouteImport } from './routes/$local
 import { Route as LocaleBusinessManageAddOnsRouteImport } from './routes/$locale/_business/manage/add-ons'
 import { Route as LocaleAdminAdminRevenueRouteImport } from './routes/$locale/_admin/admin/revenue'
 import { Route as LocaleAdminAdminDocumentsRouteImport } from './routes/$locale/_admin/admin/documents'
+import { Route as LocaleAdminAdminAnomaliesRouteImport } from './routes/$locale/_admin/admin/anomalies'
 import { Route as LocaleBusinessManageFleetIndexRouteImport } from './routes/$locale/_business/manage/fleet/index'
 import { Route as LocaleBusinessManageBookingsIndexRouteImport } from './routes/$locale/_business/manage/bookings/index'
 import { Route as LocaleBusinessManageFleetVehicleIdRouteImport } from './routes/$locale/_business/manage/fleet/$vehicleId'
@@ -224,6 +225,12 @@ const LocaleAdminAdminDocumentsRoute =
     path: '/admin/documents',
     getParentRoute: () => LocaleAdminRoute,
   } as any)
+const LocaleAdminAdminAnomaliesRoute =
+  LocaleAdminAdminAnomaliesRouteImport.update({
+    id: '/admin/anomalies',
+    path: '/admin/anomalies',
+    getParentRoute: () => LocaleAdminRoute,
+  } as any)
 const LocaleBusinessManageFleetIndexRoute =
   LocaleBusinessManageFleetIndexRouteImport.update({
     id: '/manage/fleet/',
@@ -263,6 +270,7 @@ export interface FileRoutesByFullPath {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/anomalies': typeof LocaleAdminAdminAnomaliesRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -296,6 +304,7 @@ export interface FileRoutesByTo {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles': typeof LocaleVehiclesIndexRoute
+  '/$locale/admin/anomalies': typeof LocaleAdminAdminAnomaliesRoute
   '/$locale/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -336,6 +345,7 @@ export interface FileRoutesById {
   '/$locale/storefronts/$locationId': typeof LocaleStorefrontsLocationIdRoute
   '/provider/invite/$token': typeof ProviderInviteTokenRoute
   '/$locale/vehicles/': typeof LocaleVehiclesIndexRoute
+  '/$locale/_admin/admin/anomalies': typeof LocaleAdminAdminAnomaliesRoute
   '/$locale/_admin/admin/documents': typeof LocaleAdminAdminDocumentsRoute
   '/$locale/_admin/admin/revenue': typeof LocaleAdminAdminRevenueRoute
   '/$locale/_business/manage/add-ons': typeof LocaleBusinessManageAddOnsRoute
@@ -374,6 +384,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/admin/anomalies'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -407,6 +418,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles'
+    | '/$locale/admin/anomalies'
     | '/$locale/admin/documents'
     | '/$locale/admin/revenue'
     | '/$locale/manage/add-ons'
@@ -446,6 +458,7 @@ export interface FileRouteTypes {
     | '/$locale/storefronts/$locationId'
     | '/provider/invite/$token'
     | '/$locale/vehicles/'
+    | '/$locale/_admin/admin/anomalies'
     | '/$locale/_admin/admin/documents'
     | '/$locale/_admin/admin/revenue'
     | '/$locale/_business/manage/add-ons'
@@ -708,6 +721,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleAdminAdminDocumentsRouteImport
       parentRoute: typeof LocaleAdminRoute
     }
+    '/$locale/_admin/admin/anomalies': {
+      id: '/$locale/_admin/admin/anomalies'
+      path: '/admin/anomalies'
+      fullPath: '/$locale/admin/anomalies'
+      preLoaderRoute: typeof LocaleAdminAdminAnomaliesRouteImport
+      parentRoute: typeof LocaleAdminRoute
+    }
     '/$locale/_business/manage/fleet/': {
       id: '/$locale/_business/manage/fleet/'
       path: '/manage/fleet'
@@ -740,12 +760,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface LocaleAdminRouteChildren {
+  LocaleAdminAdminAnomaliesRoute: typeof LocaleAdminAdminAnomaliesRoute
   LocaleAdminAdminDocumentsRoute: typeof LocaleAdminAdminDocumentsRoute
   LocaleAdminAdminRevenueRoute: typeof LocaleAdminAdminRevenueRoute
   LocaleAdminAdminIndexRoute: typeof LocaleAdminAdminIndexRoute
 }
 
 const LocaleAdminRouteChildren: LocaleAdminRouteChildren = {
+  LocaleAdminAdminAnomaliesRoute: LocaleAdminAdminAnomaliesRoute,
   LocaleAdminAdminDocumentsRoute: LocaleAdminAdminDocumentsRoute,
   LocaleAdminAdminRevenueRoute: LocaleAdminAdminRevenueRoute,
   LocaleAdminAdminIndexRoute: LocaleAdminAdminIndexRoute,

--- a/packages/web/src/routes/$locale/_admin/admin/anomalies.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/anomalies.tsx
@@ -1,0 +1,87 @@
+import { PageSkeleton } from '@/vite/PageSkeleton'
+import { AnomaliesPanel } from '@/vite/admin/AnomaliesPanel'
+import { AnomalyResolveDialog } from '@/vite/admin/anomalies/AnomalyResolveDialog'
+import {
+  type PaymentAnomalyStatusFilter,
+  paymentAnomaliesQueryOptions,
+} from '@/vite/admin/anomalies/api'
+import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
+import { useQuery } from '@tanstack/react-query'
+import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+const STATUSES = ['unresolved', 'resolved'] as const
+
+// Platform-admin payment-anomaly resolution page (#1075 slice 3). The `_admin`
+// parent layout already gates on platform-admin membership, so this owns the data:
+// prefetch the unresolved queue, let the admin toggle to the resolved history, and
+// open the resolve dialog per row. v1 records a verdict only — it moves NO money.
+export const Route = createFileRoute('/$locale/_admin/admin/anomalies')({
+  loader: ({ context }) =>
+    context.queryClient.ensureQueryData(paymentAnomaliesQueryOptions('unresolved')),
+  pendingComponent: PageSkeleton,
+  errorComponent: AnomaliesError,
+  component: AnomaliesRoute,
+})
+
+function AnomaliesRoute() {
+  const { locale } = Route.useParams()
+  const t = useTranslations('admin.anomalies')
+  const [status, setStatus] = useState<PaymentAnomalyStatusFilter>('unresolved')
+  const [selected, setSelected] = useState<PaymentAnomalyView | null>(null)
+  const { data, isPending } = useQuery(paymentAnomaliesQueryOptions(status))
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-8 sm:px-6 lg:px-8">
+      <div className="flex gap-1 rounded-lg border border-border p-1 w-fit">
+        {STATUSES.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setStatus(s)}
+            aria-pressed={status === s}
+            className="rounded-md px-3 py-1.5 font-medium text-sm transition-colors aria-pressed:bg-muted aria-[pressed=false]:text-muted-foreground aria-[pressed=false]:hover:bg-muted/50"
+          >
+            {t(`tab.${s}`)}
+          </button>
+        ))}
+      </div>
+
+      {data ? (
+        <AnomaliesPanel
+          anomalies={data.anomalies}
+          locale={locale}
+          // Action column only on the review queue; the resolved history is read-only.
+          {...(status === 'unresolved' ? { onResolve: setSelected } : {})}
+        />
+      ) : isPending ? (
+        <PageSkeleton />
+      ) : null}
+
+      <AnomalyResolveDialog
+        anomaly={selected}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null)
+        }}
+      />
+    </div>
+  )
+}
+
+function AnomaliesError(_props: ErrorComponentProps) {
+  const t = useTranslations('admin.anomalies')
+  const router = useRouter()
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-20 text-center sm:px-6 lg:px-8">
+      <p className="text-lg text-muted-foreground">{t('loadError')}</p>
+      <button
+        type="button"
+        onClick={() => router.invalidate()}
+        className="mt-4 inline-flex items-center rounded-lg border border-border px-4 py-2 font-medium text-sm hover:bg-muted/50"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/vite/admin/AnomaliesPanel.tsx
+++ b/packages/web/src/vite/admin/AnomaliesPanel.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/ui/button'
 import { formatDateTime, formatJpy } from '@/lib/format'
 import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
 import { useTranslations } from 'use-intl'
@@ -5,6 +6,11 @@ import { useTranslations } from 'use-intl'
 interface AnomaliesPanelProps {
   readonly anomalies: PaymentAnomalyView[]
   readonly locale: string
+  // Opt-in resolve action (#1075 slice 3). Supplied only on the dedicated admin page;
+  // the revenue tab omits it and stays a read-only oversight panel. When present, each
+  // row gains a trailing cell — a "Resolve" button while unresolved, the recorded
+  // resolution once closed.
+  readonly onResolve?: (anomaly: PaymentAnomalyView) => void
 }
 
 const DASH = '—'
@@ -22,7 +28,7 @@ function money(amount: number | null): string {
  * amount/currency differs from the booking snapshot to investigate. `stripeEventId`
  * is the reconciliation handle the admin carries to Stripe.
  */
-export function AnomaliesPanel({ anomalies, locale }: AnomaliesPanelProps) {
+export function AnomaliesPanel({ anomalies, locale, onResolve }: AnomaliesPanelProps) {
   const t = useTranslations('admin.anomalies')
   const head = 'px-3 py-2 text-left font-medium text-muted-foreground'
   const headNum = 'px-3 py-2 text-right font-medium text-muted-foreground'
@@ -64,6 +70,11 @@ export function AnomaliesPanel({ anomalies, locale }: AnomaliesPanelProps) {
                 <th scope="col" className={head}>
                   {t('colWhen')}
                 </th>
+                {onResolve && (
+                  <th scope="col" className={head}>
+                    {t('colAction')}
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -85,6 +96,24 @@ export function AnomaliesPanel({ anomalies, locale }: AnomaliesPanelProps) {
                   <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
                     <time dateTime={a.createdAt}>{formatDateTime(a.createdAt, locale)}</time>
                   </td>
+                  {onResolve && (
+                    <td className="px-3 py-2">
+                      {a.resolvedAt === null ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => onResolve(a)}
+                        >
+                          {t('resolve.action')}
+                        </Button>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">
+                          {a.resolution ? t(`resolution.${a.resolution}`) : DASH}
+                        </span>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/packages/web/src/vite/admin/anomalies/AnomalyResolveDialog.tsx
+++ b/packages/web/src/vite/admin/anomalies/AnomalyResolveDialog.tsx
@@ -1,0 +1,136 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { NativeSelect } from '@/components/ui/native-select'
+import { Textarea } from '@/components/ui/textarea'
+import { PAYMENT_ANOMALIES_QUERY_KEY, resolvePaymentAnomaly } from '@/vite/admin/anomalies/api'
+import { useSession } from '@/vite/session'
+import {
+  PAYMENT_ANOMALY_RESOLUTIONS,
+  type PaymentAnomalyResolution,
+  type PaymentAnomalyView,
+} from '@kuruma/shared/types/payment-anomaly'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface AnomalyResolveDialogProps {
+  readonly anomaly: PaymentAnomalyView | null
+  readonly onOpenChange: (open: boolean) => void
+}
+
+// Resolve an anomaly's review-queue item (#1075 slice 3). Self-contained like the
+// operator dialogs: owns the CSRF token, the mutation, and the cache invalidation.
+// v1 records WHY the charge was closed (+ optional note) — it moves NO money.
+export function AnomalyResolveDialog({ anomaly, onOpenChange }: AnomalyResolveDialogProps) {
+  const t = useTranslations('admin.anomalies')
+  const queryClient = useQueryClient()
+  const csrfToken = useSession().data?.csrfToken ?? ''
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: resolvePaymentAnomaly,
+    onSuccess: () => {
+      // A resolved row leaves the unresolved queue and joins the resolved list, so
+      // invalidate the whole prefix — both status tabs refetch.
+      queryClient.invalidateQueries({ queryKey: PAYMENT_ANOMALIES_QUERY_KEY })
+      onOpenChange(false)
+    },
+  })
+
+  return (
+    <Dialog open={anomaly !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('resolve.title')}</DialogTitle>
+          <DialogDescription>{t('resolve.description')}</DialogDescription>
+        </DialogHeader>
+        {error && (
+          <p className="px-1 text-destructive text-sm">
+            {error instanceof Error ? error.message : String(error)}
+          </p>
+        )}
+        {anomaly && (
+          <ResolveForm
+            key={anomaly.id}
+            t={t}
+            isSubmitting={isPending}
+            onCancel={() => onOpenChange(false)}
+            onSubmit={(resolution, note) =>
+              mutate({ id: anomaly.id, resolution, csrfToken, ...(note ? { note } : {}) })
+            }
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ResolveForm({
+  t,
+  isSubmitting,
+  onCancel,
+  onSubmit,
+}: {
+  readonly t: (key: string) => string
+  readonly isSubmitting: boolean
+  readonly onCancel: () => void
+  readonly onSubmit: (resolution: PaymentAnomalyResolution, note: string) => void
+}) {
+  const [resolution, setResolution] = useState<PaymentAnomalyResolution>(
+    PAYMENT_ANOMALY_RESOLUTIONS[0],
+  )
+  const [note, setNote] = useState('')
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit(resolution, note.trim())
+      }}
+      className="space-y-4"
+    >
+      <div className="space-y-1.5">
+        <label htmlFor="anomaly-resolution" className="font-medium text-sm">
+          {t('resolve.resolutionLabel')}
+        </label>
+        <NativeSelect
+          id="anomaly-resolution"
+          value={resolution}
+          onChange={(e) => setResolution(e.target.value as PaymentAnomalyResolution)}
+        >
+          {PAYMENT_ANOMALY_RESOLUTIONS.map((r) => (
+            <option key={r} value={r}>
+              {t(`resolution.${r}`)}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+      <div className="space-y-1.5">
+        <label htmlFor="anomaly-note" className="font-medium text-sm">
+          {t('resolve.noteLabel')}
+        </label>
+        <Textarea
+          id="anomaly-note"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          maxLength={1000}
+          placeholder={t('resolve.notePlaceholder')}
+        />
+      </div>
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+          {t('resolve.cancel')}
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? t('resolve.submitting') : t('resolve.submit')}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}

--- a/packages/web/src/vite/admin/anomalies/api.ts
+++ b/packages/web/src/vite/admin/anomalies/api.ts
@@ -2,22 +2,26 @@ import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import {
   PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
   type PaymentAnomaliesResponse,
+  type PaymentAnomalyResolution,
   type PaymentAnomalyView,
 } from '@kuruma/shared/types/payment-anomaly'
+import { resolvePaymentAnomalySchema } from '@kuruma/shared/validators/payment-anomaly'
 import { queryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-// Platform-admin unresolved payment anomalies (#744), surfaced on the revenue tab
-// (#462). Cookie-based (credentials: 'include') so the API gates on the session
-// role server-side (requirePlatformRead = STAFF/ADMIN/PLATFORM_ADMIN); no params.
-// Mirrors admin/revenue/api.ts.
+// Platform-admin payment anomalies (#744 list; resolution UI #1075 slice 3). Cookie-
+// based (credentials: 'include') so the API gates on the session role server-side
+// (requirePlatformRead to list, requirePlatformAdmin to resolve). Mirrors admin/documents/api.ts.
 export const PAYMENT_ANOMALIES_QUERY_KEY = ['admin-payment-anomalies'] as const
 
+export type PaymentAnomalyStatusFilter = 'resolved' | 'unresolved'
+
 // Network-seam validator for the anomaly response (#711). Pinned to the shared
-// wire DTO with `satisfies` so a renamed/added field — or a new anomaly `kind`
-// the web can't render — fails typecheck here and surfaces as a ParseError at the
-// seam instead of an `undefined`/unrenderable row deep in the admin revenue tab.
+// wire DTO with `satisfies` so a renamed/added field — or a new anomaly `kind` or
+// `resolution` the web can't render — fails typecheck here and surfaces as a
+// ParseError at the seam instead of an `undefined`/unrenderable row in the admin UI.
 const paymentAnomalyViewSchema = z.object({
   id: z.string(),
   kind: z.enum(PAYMENT_ANOMALY_KINDS),
@@ -29,22 +33,54 @@ const paymentAnomalyViewSchema = z.object({
   stripeEventId: z.string(),
   stripePaymentIntentId: z.string().nullable(),
   createdAt: z.string(),
+  resolvedAt: z.string().nullable(),
+  resolution: z.enum(PAYMENT_ANOMALY_RESOLUTIONS).nullable(),
+  note: z.string().nullable(),
 }) satisfies z.ZodType<PaymentAnomalyView>
 
 const paymentAnomaliesResponseSchema = z.object({
   anomalies: z.array(paymentAnomalyViewSchema),
 }) satisfies z.ZodType<PaymentAnomaliesResponse>
 
-export async function fetchPaymentAnomalies(): Promise<PaymentAnomaliesResponse> {
-  const res = await fetch(`${getApiBaseUrl()}/admin/payment-anomalies`, {
+const resolveResponseSchema = z.object({ anomaly: paymentAnomalyViewSchema })
+
+export async function fetchPaymentAnomalies(
+  status: PaymentAnomalyStatusFilter = 'unresolved',
+): Promise<PaymentAnomaliesResponse> {
+  const res = await fetch(`${getApiBaseUrl()}/admin/payment-anomalies?status=${status}`, {
     credentials: 'include',
   })
   return unwrap(res, paymentAnomaliesResponseSchema)
 }
 
-export function paymentAnomaliesQueryOptions() {
+export function paymentAnomaliesQueryOptions(status: PaymentAnomalyStatusFilter = 'unresolved') {
   return queryOptions({
-    queryKey: PAYMENT_ANOMALIES_QUERY_KEY,
-    queryFn: fetchPaymentAnomalies,
+    queryKey: [...PAYMENT_ANOMALIES_QUERY_KEY, status],
+    queryFn: () => fetchPaymentAnomalies(status),
   })
+}
+
+// Close an anomaly's review-queue item (#1075 slice 3). Cookie-authed + CSRF-gated,
+// so the caller echoes the session CSRF token in the header — NEVER the body. The
+// payload is validated against the shared `.strict()` schema before the network
+// call, so a drifted/invalid form fails fast and offline. v1 moves NO money.
+export async function resolvePaymentAnomaly(params: {
+  id: string
+  resolution: PaymentAnomalyResolution
+  note?: string
+  csrfToken: string
+}): Promise<PaymentAnomalyView> {
+  const { id, csrfToken, ...verdict } = params
+  const body = resolvePaymentAnomalySchema.parse(verdict)
+  const res = await fetch(
+    `${getApiBaseUrl()}/admin/payment-anomalies/${encodeURIComponent(id)}/resolve`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify(body),
+    },
+  )
+  const data = await unwrap(res, resolveResponseSchema)
+  return data.anomaly
 }

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -1,10 +1,11 @@
 import { Link } from '@tanstack/react-router'
-import { Banknote, FileCheck, LayoutDashboard } from 'lucide-react'
+import { AlertTriangle, Banknote, FileCheck, LayoutDashboard } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 const SIDEBAR_ITEMS = [
   { to: '/$locale/admin', icon: LayoutDashboard, labelKey: 'nav.overview' },
   { to: '/$locale/admin/revenue', icon: Banknote, labelKey: 'nav.revenue' },
+  { to: '/$locale/admin/anomalies', icon: AlertTriangle, labelKey: 'nav.anomalies' },
   { to: '/$locale/admin/documents', icon: FileCheck, labelKey: 'nav.documents' },
 ] as const
 

--- a/packages/web/tests/vite/admin/anomalies/api.test.ts
+++ b/packages/web/tests/vite/admin/anomalies/api.test.ts
@@ -3,6 +3,7 @@ import {
   PAYMENT_ANOMALIES_QUERY_KEY,
   fetchPaymentAnomalies,
   paymentAnomaliesQueryOptions,
+  resolvePaymentAnomaly,
 } from '@/vite/admin/anomalies/api'
 import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -20,6 +21,9 @@ const anomaly: PaymentAnomalyView = {
   stripeEventId: 'evt_1',
   stripePaymentIntentId: 'pi_1',
   createdAt: '2026-06-10T03:00:00.000Z',
+  resolvedAt: null,
+  resolution: null,
+  note: null,
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -30,18 +34,26 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('fetchPaymentAnomalies', () => {
-  it('GETs /admin/payment-anomalies with cookie credentials and unwraps the anomalies', async () => {
+  it('GETs the status-scoped endpoint with cookie credentials and unwraps the anomalies', async () => {
     const spy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(jsonResponse({ success: true, data: { anomalies: [anomaly] } }))
 
-    const result = await fetchPaymentAnomalies()
+    const result = await fetchPaymentAnomalies('resolved')
 
     expect(result.anomalies).toHaveLength(1)
     expect(result.anomalies[0]?.stripeEventId).toBe('evt_1')
     const [url, init] = spy.mock.calls[0] ?? []
-    expect(String(url)).toMatch(/\/admin\/payment-anomalies$/)
+    expect(String(url)).toMatch(/\/admin\/payment-anomalies\?status=resolved$/)
     expect(init?.credentials).toBe('include')
+  })
+
+  it('defaults to the unresolved review queue when no status is given', async () => {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: { anomalies: [] } }))
+    await fetchPaymentAnomalies()
+    expect(String(spy.mock.calls[0]?.[0])).toMatch(/\?status=unresolved$/)
   })
 
   it('throws an ApiError carrying the status when the API rejects (e.g. 403)', async () => {
@@ -63,11 +75,81 @@ describe('fetchPaymentAnomalies', () => {
     )
     await expect(fetchPaymentAnomalies()).rejects.toBeInstanceOf(ParseError)
   })
+
+  it('throws a ParseError when a row carries an out-of-domain resolution (#1075 slice 3)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      jsonResponse({ success: true, data: { anomalies: [{ ...anomaly, resolution: 'WAT' }] } }),
+    )
+    await expect(fetchPaymentAnomalies('resolved')).rejects.toBeInstanceOf(ParseError)
+  })
 })
 
 describe('paymentAnomaliesQueryOptions', () => {
-  it('carries the stable query key', () => {
-    expect(paymentAnomaliesQueryOptions().queryKey).toEqual(PAYMENT_ANOMALIES_QUERY_KEY)
+  it('keys the cache by status so the resolved and unresolved tabs cache separately', () => {
     expect(PAYMENT_ANOMALIES_QUERY_KEY).toEqual(['admin-payment-anomalies'])
+    expect(paymentAnomaliesQueryOptions().queryKey).toEqual([
+      ...PAYMENT_ANOMALIES_QUERY_KEY,
+      'unresolved',
+    ])
+    expect(paymentAnomaliesQueryOptions('resolved').queryKey).toEqual([
+      ...PAYMENT_ANOMALIES_QUERY_KEY,
+      'resolved',
+    ])
+  })
+})
+
+describe('resolvePaymentAnomaly', () => {
+  it('POSTs the resolution with the CSRF header and no csrfToken in the body', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: {
+          anomaly: {
+            ...anomaly,
+            resolution: 'REFUNDED_EXTERNALLY',
+            resolvedAt: '2026-06-11T00:00:00.000Z',
+          },
+        },
+      }),
+    )
+
+    await resolvePaymentAnomaly({
+      id: 'pa_1',
+      resolution: 'REFUNDED_EXTERNALLY',
+      note: 'refunded in Stripe',
+      csrfToken: 'csrf-1',
+    })
+
+    const [url, init] = spy.mock.calls[0] ?? []
+    expect(String(url)).toMatch(/\/admin\/payment-anomalies\/pa_1\/resolve$/)
+    expect(init?.method).toBe('POST')
+    expect(init?.credentials).toBe('include')
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': 'csrf-1',
+    })
+    expect(JSON.parse(String(init?.body))).toEqual({
+      resolution: 'REFUNDED_EXTERNALLY',
+      note: 'refunded in Stripe',
+    })
+  })
+
+  it('omits an absent note from the body and never leaks the csrfToken into it', async () => {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: { anomaly } }))
+
+    await resolvePaymentAnomaly({ id: 'pa_1', resolution: 'BENIGN', csrfToken: 'csrf-1' })
+
+    expect(JSON.parse(String(spy.mock.calls[0]?.[1]?.body))).toEqual({ resolution: 'BENIGN' })
+  })
+
+  it('refuses an out-of-domain resolution — never hits the network (.strict seam)', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch')
+    await expect(
+      // @ts-expect-error — a drifted resolution must not typecheck nor reach fetch.
+      resolvePaymentAnomaly({ id: 'pa_1', resolution: 'WHATEVER', csrfToken: 'csrf-1' }),
+    ).rejects.toThrow()
+    expect(spy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #1089 · Refs #1075 (platform-dashboard epic, slice 3 of 6)

## What
A platform-admin **mark-reviewed** action for flagged payment anomalies. **v1 records a verdict only — NO money moves through our code.** Refunding a `DOUBLE_PAYMENT` duplicate stays in the Stripe dashboard (`REFUNDED_EXTERNALLY`) until in-app refund ships as its own slice.

> In-app refund, when built, must be a separate anomaly-keyed workflow reusing **only** `stripe-payment-gateway.ts` — never the booking-keyed cancellation `payment_refunds` outbox (leaky abstraction).

## Changes
- **Schema** — migration `0078` adds `payment_anomaly_resolution` enum `{BENIGN, INVESTIGATED, REFUNDED_EXTERNALLY}` + nullable `resolution`/`resolvedBy`/`note` columns (all four resolution fields written together on resolve).
- **API** — `POST /admin/payment-anomalies/:id/resolve` (`requirePlatformAdmin`; **guarded write-once** UPDATE `WHERE id AND resolvedAt IS NULL` → 404 on unknown/already-resolved, never a silent overwrite). `GET …?status=resolved|unresolved` (`requirePlatformRead`, default unresolved). **No `payment_refunds` write, no booking-settlement mutation.**
- **Web** — dedicated `/admin/anomalies` page (promoted `AnomaliesPanel`) + resolve dialog (CSRF) + unresolved/resolved tabs + sidebar nav; i18n en/ja/zh.

## ⚠️ Migration 0078 — three-way race
PRs **#1135** (messaging-indexes) and **#1142** (vehicle-blocks) also claim `0078`. `0078` is free on develop as of this PR. Whoever merges first keeps it; **I'll renumber + bump the journal `when` if one of those lands ahead of this.** Please sequence accordingly.

## Test plan / evidence (all green locally)
- api unit **1935**; web **1254**; shared enum-pin **4**
- real-pg integration **3** — write-once at the DB + asserts **no `payment_refunds` row** and booking settlement stays `ADVISORY`
- route authz + behaviour **12** (403/401 gates, drops-from-unresolved, `?status`, write-once 404, `.strict` 400); web seam-Zod + CSRF mutation **9**
- tsc (api/web/shared), `lint` (biome), `lint:boundaries`, i18n parity, `db:verify` (79 migrations)
- mutation-checked the write-once guard kills its test

🤖 Generated with [Claude Code](https://claude.com/claude-code)