### PR TITLE
chore(web): enforce @/vite/<feature> boundary with reach-in ratchet (#1110)

### DIFF
--- a/scripts/__fixtures__/boundaries/packages/web/src/vite/bookings/list.tsx
+++ b/scripts/__fixtures__/boundaries/packages/web/src/vite/bookings/list.tsx
@@ -1,0 +1,6 @@
+// Fixture: same-feature deep import is allowed.
+import { fetchBookings } from '@/vite/bookings/api'
+
+export function BookingList() {
+  return fetchBookings()
+}

--- a/scripts/__fixtures__/boundaries/packages/web/src/vite/reservation/GoodBarrelConsumer.tsx
+++ b/scripts/__fixtures__/boundaries/packages/web/src/vite/reservation/GoodBarrelConsumer.tsx
@@ -1,0 +1,6 @@
+// Fixture: legitimate cross-feature use via the per-feature barrel.
+import { useBookings } from '@/vite/bookings'
+
+export function GoodBarrelConsumer() {
+  return useBookings()
+}

--- a/scripts/__fixtures__/boundaries/packages/web/src/vite/reservation/ReservationWizard.tsx
+++ b/scripts/__fixtures__/boundaries/packages/web/src/vite/reservation/ReservationWizard.tsx
@@ -1,0 +1,6 @@
+// Fixture: reaches into another feature's internals (forbidden).
+import { useBookings } from '@/vite/bookings/api'
+
+export function ReservationWizard() {
+  return useBookings()
+}

--- a/scripts/lint-module-boundaries.test.ts
+++ b/scripts/lint-module-boundaries.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from 'bun:test'
 import {
   checkImports,
   countDeprecatedWebFiles,
+  countViteCrossFeatureReachIns,
   deprecatedTreeStatus,
   formatDeprecationNotice,
+  formatViteRatchetNotice,
   isDeprecatedWebFile,
+  viteRatchetStatus,
 } from './lint-module-boundaries'
 
 const FIX = 'scripts/__fixtures__/boundaries'
@@ -53,6 +56,48 @@ describe('lint-module-boundaries: web no direct DB access (#722)', () => {
 
   test('does not restrict non-web packages (api may import drizzle at runtime)', () => {
     expect(checkImports([`${FIX}/packages/api/src/uses-drizzle.ts`])).toHaveLength(0)
+  })
+})
+
+describe('lint-module-boundaries: web vite cross-feature reach-ins (#1110)', () => {
+  const WIZARD = `${FIX}/packages/web/src/vite/reservation/ReservationWizard.tsx`
+  const BARREL_CONSUMER = `${FIX}/packages/web/src/vite/reservation/GoodBarrelConsumer.tsx`
+  const SAME_FEATURE = `${FIX}/packages/web/src/vite/bookings/list.tsx`
+
+  test('flags a cross-feature reach-in into another vite feature internals', () => {
+    const report = checkImports([WIZARD])
+    expect(report).toHaveLength(1)
+    expect(report[0]!.file).toBe(WIZARD)
+    expect(report[0]!.importPath).toBe('@/vite/bookings/api')
+    expect(report[0]!.reason).toBe('vite-cross-feature')
+  })
+
+  test('allows cross-feature imports via the per-feature barrel (@/vite/<feature>)', () => {
+    expect(checkImports([BARREL_CONSUMER])).toHaveLength(0)
+  })
+
+  test('allows same-feature deep imports (@/vite/<own>/<internal>)', () => {
+    expect(checkImports([SAME_FEATURE])).toHaveLength(0)
+  })
+
+  test('counts only the cross-feature reach-ins, not same-feature deep imports', () => {
+    expect(countViteCrossFeatureReachIns([WIZARD, BARREL_CONSUMER, SAME_FEATURE])).toBe(1)
+  })
+
+  test('ratchet status reports growth, shrinkage, and steady against the baseline', () => {
+    expect(viteRatchetStatus(152, 151).level).toBe('grew')
+    expect(viteRatchetStatus(150, 151).level).toBe('shrank')
+    expect(viteRatchetStatus(151, 151).level).toBe('ok')
+  })
+
+  test('notice is silent when steady and names the new baseline when it changes', () => {
+    expect(formatViteRatchetNotice({ count: 151, baseline: 151, level: 'ok' })).toBeNull()
+    const grew = formatViteRatchetNotice({ count: 152, baseline: 151, level: 'grew' })
+    expect(grew).toContain('@/vite/<feature>/<internal>')
+    expect(grew).toContain('@/vite/<feature>')
+    expect(grew).toContain('VITE_CROSS_FEATURE_REACH_IN_BASELINE=152')
+    const shrank = formatViteRatchetNotice({ count: 150, baseline: 151, level: 'shrank' })
+    expect(shrank).toContain('VITE_CROSS_FEATURE_REACH_IN_BASELINE=150')
   })
 })
 

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -7,7 +7,7 @@ import { Glob } from 'bun'
 export type Violation = {
   file: string
   importPath: string
-  reason: 'cross-module-internal' | 'web-runtime-db'
+  reason: 'cross-module-internal' | 'web-runtime-db' | 'vite-cross-feature'
 }
 
 type ImportRef = { spec: string; typeOnly: boolean }
@@ -26,6 +26,12 @@ const BARE_IMPORT_RE = /import\s+['"]([^'"]+)['"]/g
 // enforces it, so the risk is low. If relative cross-module imports become a
 // real problem, upgrade to an AST-based check or add a relative-path resolver.
 const INTERNAL_ALIAS_RE = /^@\/modules\/([^/]+)\/(.+)$/
+
+// #1110: web feature boundary enforced against the directory we actually use
+// today (`packages/web/src/vite/<feature>/`), not the empty `@/modules/`.
+// Matches `@/vite/<feature>/<sub>` — a deep import. A bare `@/vite/<feature>`
+// (the per-feature barrel) is allowed by intent and not captured here.
+const VITE_FEATURE_DEEP_RE = /^@\/vite\/([^/]+)\/(.+)$/
 
 // #722: packages/web has NO direct DB access — all data flows through the Hono
 // API (CLAUDE.md architecture boundary). A runtime import of the web DB client
@@ -51,6 +57,15 @@ function moduleOfFile(file: string): string | null {
   const p = file.replaceAll('\\', '/')
   const match = p.match(/\/modules\/([^/]+)\//)
   return match ? match[1]! : null
+}
+
+// The web vite feature the file lives in (e.g. 'bookings' for
+// `packages/web/src/vite/bookings/list.tsx`), or null when the file is not
+// inside any `vite/<feature>/` subtree (loose `vite/foo.ts`, routes/, etc.).
+export function viteFeatureOfWebFile(webRel: string | null): string | null {
+  if (webRel === null) return null
+  const m = webRel.match(/^vite\/([^/]+)\//)
+  return m ? m[1]! : null
 }
 
 // The path under packages/web/src (e.g. 'auth.ts', 'vite/bookings/api.ts'), or
@@ -84,6 +99,14 @@ function isForbiddenWebDbSpec(spec: string): boolean {
 //   bun run scripts/lint-module-boundaries.ts --update-baseline
 const DEPRECATED_WEB_TREE_BASELINE = 170
 
+// #1110: cross-feature reach-ins into vite/<feature>/<internal> from outside
+// that feature. Counted globally; the rule is a ratchet (monotonic
+// non-increasing). A new reach-in pushes the count above this baseline and
+// fails CI; draining one shrinks the count and triggers a soft notice to lock
+// in the new baseline. Refresh with --update-baseline (same flag as the tree
+// ratchet above).
+const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 151
+
 export type DeprecatedTreeStatus = {
   count: number
   baseline: number
@@ -109,6 +132,24 @@ export function countDeprecatedWebFiles(files: string[]): number {
 export function deprecatedTreeStatus(count: number, baseline: number): DeprecatedTreeStatus {
   const level = count > baseline ? 'grew' : count < baseline ? 'shrank' : 'ok'
   return { count, baseline, level }
+}
+
+// #1110: vite cross-feature reach-in ratchet — same shape as the tree ratchet,
+// different copy. Re-uses DeprecatedTreeStatus to keep the level enum aligned.
+export const viteRatchetStatus = (count: number, baseline: number): DeprecatedTreeStatus =>
+  deprecatedTreeStatus(count, baseline)
+
+export function countViteCrossFeatureReachIns(files: string[]): number {
+  return checkImports(files).filter((v) => v.reason === 'vite-cross-feature').length
+}
+
+export function formatViteRatchetNotice(status: DeprecatedTreeStatus): string | null {
+  if (status.level === 'ok') return null
+  const refresh = `run \`bun run scripts/lint-module-boundaries.ts --update-baseline\` to set VITE_CROSS_FEATURE_REACH_IN_BASELINE=${status.count}`
+  if (status.level === 'grew') {
+    return `${status.count} cross-feature reach-in(s) into @/vite/<feature>/<internal>, up from baseline ${status.baseline}. Legitimate cross-feature use should go through the @/vite/<feature> barrel — see docs/architecture/modules.md. If intentional, ${refresh}.`
+  }
+  return `cross-feature vite reach-ins shrank to ${status.count} (baseline ${status.baseline}) — lock in the migration: ${refresh}.`
 }
 
 export function formatDeprecationNotice(status: DeprecatedTreeStatus): string | null {
@@ -141,6 +182,18 @@ export function checkImports(files: string[]): Violation[] {
       // Rule 2 (#722): no runtime DB import from the web package.
       if (webRel !== null && !typeOnly && isForbiddenWebDbSpec(spec)) {
         violations.push({ file, importPath: spec, reason: 'web-runtime-db' })
+      }
+      // Rule 3 (#1110): no cross-feature reach into another web vite feature's
+      // internals. `@/vite/<feature>/<sub>` from outside `<feature>` is a deep
+      // import; legitimate cross-feature use goes through the `@/vite/<feature>`
+      // per-feature barrel (which doesn't match the regex). Only enforced for
+      // web files — routes/ and other web roots reaching into vite count too.
+      const vite = spec.match(VITE_FEATURE_DEEP_RE)
+      if (vite && webRel !== null) {
+        const fileFeature = viteFeatureOfWebFile(webRel)
+        if (fileFeature !== vite[1]!) {
+          violations.push({ file, importPath: spec, reason: 'vite-cross-feature' })
+        }
       }
     }
   }
@@ -178,23 +231,55 @@ function describeViolation(v: Violation): string {
   if (v.reason === 'web-runtime-db') {
     return `runtime DB import "${v.importPath}" — packages/web has no direct DB access; route through the Hono API. Use 'import type' for types.`
   }
+  if (v.reason === 'vite-cross-feature') {
+    return `imports "${v.importPath}" — cross-feature reach-in into another web vite feature; use the '@/vite/<feature>' barrel instead.`
+  }
   return `imports "${v.importPath}" — cross-module internal import; use the '@/modules/<name>' barrel instead.`
 }
 
 function main(): number {
   const files = discover()
   const violations = checkImports(files)
-  for (const v of violations) {
+  const hard = violations.filter((v) => v.reason !== 'vite-cross-feature')
+  const viteReachIns = violations.filter((v) => v.reason === 'vite-cross-feature')
+
+  for (const v of hard) {
     process.stderr.write(`[lint-module-boundaries] ERROR ${v.file}: ${describeViolation(v)}\n`)
   }
+
   // Warning only — the deprecation ratchet must NEVER affect the exit code;
   // only real violations below fail the build. Keep this above the return.
-  const notice = formatDeprecationNotice(
+  const deprecationNotice = formatDeprecationNotice(
     deprecatedTreeStatus(countDeprecatedWebFiles(files), DEPRECATED_WEB_TREE_BASELINE),
   )
-  if (notice) process.stderr.write(`[lint-module-boundaries] WARNING ${notice}\n`)
-  if (violations.length > 0) {
-    process.stderr.write(`[lint-module-boundaries] ${violations.length} violation(s).\n`)
+  if (deprecationNotice) {
+    process.stderr.write(`[lint-module-boundaries] WARNING ${deprecationNotice}\n`)
+  }
+
+  // #1110: vite reach-in ratchet — fail only when count grew past the baseline.
+  // When growing, surface every reach-in so the new one is findable; otherwise
+  // keep output quiet (sample of 222 lines per build would be noise).
+  const viteStatus = viteRatchetStatus(viteReachIns.length, VITE_CROSS_FEATURE_REACH_IN_BASELINE)
+  const viteNotice = formatViteRatchetNotice(viteStatus)
+  if (viteStatus.level === 'grew') {
+    for (const v of viteReachIns) {
+      process.stderr.write(`[lint-module-boundaries] ERROR ${v.file}: ${describeViolation(v)}\n`)
+    }
+    if (viteNotice) process.stderr.write(`[lint-module-boundaries] ERROR ${viteNotice}\n`)
+  } else if (viteNotice) {
+    process.stderr.write(`[lint-module-boundaries] WARNING ${viteNotice}\n`)
+  }
+
+  const failed = hard.length > 0 || viteStatus.level === 'grew'
+  if (failed) {
+    const parts: string[] = []
+    if (hard.length > 0) parts.push(`${hard.length} hard violation(s)`)
+    if (viteStatus.level === 'grew') {
+      parts.push(
+        `${viteReachIns.length} vite reach-in(s) (baseline ${VITE_CROSS_FEATURE_REACH_IN_BASELINE})`,
+      )
+    }
+    process.stderr.write(`[lint-module-boundaries] ${parts.join(', ')}.\n`)
     return 1
   }
   return 0
@@ -202,13 +287,16 @@ function main(): number {
 
 if (import.meta.main) {
   if (process.argv.includes('--update-baseline')) {
-    const count = countDeprecatedWebFiles(discover())
-    const updated = readFileSync(import.meta.path, 'utf8').replace(
-      /(const DEPRECATED_WEB_TREE_BASELINE = )\d+/,
-      `$1${count}`,
+    const files = discover()
+    const depCount = countDeprecatedWebFiles(files)
+    const viteCount = countViteCrossFeatureReachIns(files)
+    const src = readFileSync(import.meta.path, 'utf8')
+      .replace(/(const DEPRECATED_WEB_TREE_BASELINE = )\d+/, `$1${depCount}`)
+      .replace(/(const VITE_CROSS_FEATURE_REACH_IN_BASELINE = )\d+/, `$1${viteCount}`)
+    writeFileSync(import.meta.path, src)
+    process.stdout.write(
+      `[lint-module-boundaries] DEPRECATED_WEB_TREE_BASELINE=${depCount}, VITE_CROSS_FEATURE_REACH_IN_BASELINE=${viteCount}.\n`,
     )
-    writeFileSync(import.meta.path, updated)
-    process.stdout.write(`[lint-module-boundaries] DEPRECATED_WEB_TREE_BASELINE set to ${count}.\n`)
     process.exit(0)
   }
   process.exit(main())


### PR DESCRIPTION
## Summary
- Adds a complementary lint rule to `scripts/lint-module-boundaries.ts`: `@/vite/<feature>/<internal>` imports from outside `<feature>` are flagged as `vite-cross-feature` violations. Same-feature deep imports and bare `@/vite/<feature>` barrel imports are allowed.
- Grandfathers the existing **151 reach-ins** (`routes/` → 107, `vite/<feat>/` → 44) at a ratchet baseline (`VITE_CROSS_FEATURE_REACH_IN_BASELINE = 151`). New reach-ins push count above baseline and fail CI; draining reach-ins shrinks the count and triggers a "lock in the migration" notice.
- `--update-baseline` now refreshes both the new vite ratchet and the existing `DEPRECATED_WEB_TREE_BASELINE`.

Closes #1110. Refs #1104 (architecture audit M5).

## Why this scope
The audit finding was that `INTERNAL_ALIAS_RE` matched `@/modules/<feature>/` — a directory that contains *zero* files today — so cross-feature coupling in the real `src/vite/` tree has grown unguarded. This PR points the rule at the directory we actually use.

Per-feature `index.ts` barrels are intentionally **not** added in this PR. Adding empty barrels is noise; real barrels emerge as feature drain PRs migrate reach-ins. The fixture test proves a barrel import path works, so consumers can adopt one as needed.

## Driving test (TDD)
- RED: `scripts/__fixtures__/boundaries/packages/web/src/vite/reservation/ReservationWizard.tsx` importing `@/vite/bookings/api` fails the lint with `reason='vite-cross-feature'` — before the change, the lint did not match the spec.
- GREEN: the same fixture importing the barrel (`@/vite/bookings`) passes. Same-feature deep imports (`vite/bookings/list.tsx` → `@/vite/bookings/api`) pass. Count function returns 1 for the 3-fixture mix.
- Ratchet behavior: `viteRatchetStatus`/`formatViteRatchetNotice` exercised at the boundary (150/151/152).

## Test plan
- [x] `bun test scripts/lint-module-boundaries.test.ts` — 17/17 pass (was 11, +6 new for #1110)
- [x] `bun run lint:modules` — exit 0 at baseline 151
- [x] `bun run lint` (biome + size + modules) — clean (pre-existing 11 size warnings + tree-ratchet drift `170→191` are unrelated to this slice)
- [x] `bun run test` — shared 732, api 1932, web 1249 — all green