### PR TITLE
refactor(#1113): share search paging scaffold across the 3 search services

### DIFF
--- a/packages/api/src/services/flat-search.ts
+++ b/packages/api/src/services/flat-search.ts
@@ -20,9 +20,7 @@ import type {
   VehicleClassRepository,
 } from '../repositories/types'
 import type { ClassRatePlan } from '../stores'
-
-const DEFAULT_LIMIT = 25
-const MAX_LIMIT = 50
+import { clampLimit, decodeCursor, encodeCursor } from './search-paging'
 
 export type FlatSearchResult =
   | { ok: true; data: SearchResultsData }
@@ -146,7 +144,7 @@ export class FlatSearchService {
     }
     const page = items.slice(start, start + limit)
     const last = page.at(-1)
-    const nextCursor = last && start + limit < items.length ? encodeCursor(last) : null
+    const nextCursor = last && start + limit < items.length ? encodeCursor(itemKey(last)) : null
 
     return { ok: true, data: { items: page, nextCursor } }
   }
@@ -225,11 +223,6 @@ export class FlatSearchService {
   }
 }
 
-function clampLimit(limit: number | undefined): number {
-  if (!limit || limit < 1) return DEFAULT_LIMIT
-  return Math.min(limit, MAX_LIMIT)
-}
-
 function toResultLocation(sf: Storefront): ResultLocation {
   return {
     locationId: sf.id,
@@ -299,17 +292,4 @@ function itemKey(item: SearchResultItem): string {
   return item.kind === 'SPECIFIC'
     ? `v:${item.vehicleId}`
     : `c:${item.location.locationId}:${item.classId}`
-}
-
-// Opaque base64 cursor over the itemKey (§3.2 step 6). btoa/atob are Web-standard
-// globals on CF Workers and Bun.
-const encodeCursor = (item: SearchResultItem): string => btoa(itemKey(item))
-// Returns undefined for a malformed (non-base64) cursor so the caller can answer
-// 400 instead of letting atob() throw into a 500 on a public endpoint.
-const decodeCursor = (cursor: string): string | undefined => {
-  try {
-    return atob(cursor)
-  } catch {
-    return undefined
-  }
 }

--- a/packages/api/src/services/search-paging.test.ts
+++ b/packages/api/src/services/search-paging.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_LIMIT, MAX_LIMIT, clampLimit, decodeCursor, encodeCursor } from './search-paging'
 
-// The two public search services (flat + storefront) share this paging scaffold.
-// These tests lock the contract so a cursor/limit change lives in exactly one place
-// and both services react to it. (#1113, audit L1)
+// The public search surfaces (flat, storefront, storefront-detail) share this
+// paging scaffold. These tests lock the contract so a cursor/limit change lives in
+// exactly one place and every consumer reacts to it. (#1113, audit L1)
 
 describe('clampLimit', () => {
   it('falls back to DEFAULT_LIMIT for undefined / zero / negative', () => {

--- a/packages/api/src/services/search-paging.test.ts
+++ b/packages/api/src/services/search-paging.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_LIMIT, MAX_LIMIT, clampLimit, decodeCursor, encodeCursor } from './search-paging'
+
+// The two public search services (flat + storefront) share this paging scaffold.
+// These tests lock the contract so a cursor/limit change lives in exactly one place
+// and both services react to it. (#1113, audit L1)
+
+describe('clampLimit', () => {
+  it('falls back to DEFAULT_LIMIT for undefined / zero / negative', () => {
+    expect(clampLimit(undefined)).toBe(DEFAULT_LIMIT)
+    expect(clampLimit(0)).toBe(DEFAULT_LIMIT)
+    expect(clampLimit(-5)).toBe(DEFAULT_LIMIT)
+  })
+
+  it('passes through an in-range limit unchanged', () => {
+    expect(clampLimit(1)).toBe(1)
+    expect(clampLimit(25)).toBe(25)
+    expect(clampLimit(MAX_LIMIT)).toBe(MAX_LIMIT)
+  })
+
+  it('caps an over-range limit at MAX_LIMIT', () => {
+    expect(clampLimit(MAX_LIMIT + 1)).toBe(MAX_LIMIT)
+    expect(clampLimit(1000)).toBe(MAX_LIMIT)
+  })
+})
+
+describe('cursor codec', () => {
+  it('round-trips any string key (decode ∘ encode = identity)', () => {
+    for (const key of ['v:veh_123', 'c:loc_9:cls_4', 'loc_storefront_77', '']) {
+      expect(decodeCursor(encodeCursor(key))).toBe(key)
+    }
+  })
+
+  it('encodes to an opaque base64 token, not the raw key', () => {
+    const token = encodeCursor('v:veh_123')
+    expect(token).not.toContain('v:veh_123')
+    expect(token).toBe(btoa('v:veh_123'))
+  })
+
+  it('returns undefined for a malformed (non-base64) cursor instead of throwing', () => {
+    expect(decodeCursor('%%% not base64 %%%')).toBeUndefined()
+  })
+})

--- a/packages/api/src/services/search-paging.ts
+++ b/packages/api/src/services/search-paging.ts
@@ -1,0 +1,28 @@
+// Shared paging scaffold for the two public search services (flat per-car and
+// grouped storefront-card). Both gather the same available-inventory slice and
+// page it with an opaque base64 cursor; only the projection differs. Keeping the
+// limit clamp and cursor codec here means a paging/cursor change lives in exactly
+// one place and both search paths react to it. (#1113, audit L1)
+
+export const DEFAULT_LIMIT = 25
+export const MAX_LIMIT = 50
+
+export function clampLimit(limit: number | undefined): number {
+  if (!limit || limit < 1) return DEFAULT_LIMIT
+  return Math.min(limit, MAX_LIMIT)
+}
+
+// Opaque base64 cursor over a caller-derived string key. btoa/atob are Web-standard
+// globals on CF Workers and Bun. The key derivation stays in each service (flat:
+// itemKey(item); storefront: locationId) — only the codec is shared here.
+export const encodeCursor = (key: string): string => btoa(key)
+
+// Returns undefined for a malformed (non-base64) cursor so the caller can answer
+// 400 instead of letting atob() throw into a 500 on a public endpoint.
+export const decodeCursor = (cursor: string): string | undefined => {
+  try {
+    return atob(cursor)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/api/src/services/search-paging.ts
+++ b/packages/api/src/services/search-paging.ts
@@ -1,8 +1,8 @@
-// Shared paging scaffold for the two public search services (flat per-car and
-// grouped storefront-card). Both gather the same available-inventory slice and
-// page it with an opaque base64 cursor; only the projection differs. Keeping the
-// limit clamp and cursor codec here means a paging/cursor change lives in exactly
-// one place and both search paths react to it. (#1113, audit L1)
+// Shared paging scaffold for the public search surfaces (flat per-car search,
+// grouped storefront-card search, and single-storefront detail). Each pages a
+// list with an opaque base64 cursor; only the projection and the per-item key
+// differ. Keeping the limit clamp and cursor codec here means a paging/cursor
+// change lives in exactly one place and every consumer reacts. (#1113, audit L1)
 
 export const DEFAULT_LIMIT = 25
 export const MAX_LIMIT = 50

--- a/packages/api/src/services/storefront-detail.ts
+++ b/packages/api/src/services/storefront-detail.ts
@@ -11,9 +11,7 @@ import type {
   VehicleClass,
   VehicleClassRepository,
 } from '../repositories/types'
-
-const DEFAULT_LIMIT = 25
-const MAX_LIMIT = 50
+import { clampLimit, decodeCursor, encodeCursor } from './search-paging'
 
 export interface StorefrontSummary {
   locationId: string
@@ -220,11 +218,6 @@ export class StorefrontDetailService {
   }
 }
 
-function clampLimit(limit: number | undefined): number {
-  if (!limit || limit < 1) return DEFAULT_LIMIT
-  return Math.min(limit, MAX_LIMIT)
-}
-
 function keepClass(
   vehicle: Vehicle,
   classById: Map<string, VehicleClass>,
@@ -266,15 +259,4 @@ function compareVehicles(a: AvailableVehicle, b: AvailableVehicle): number {
     a.name.localeCompare(b.name) ||
     a.id.localeCompare(b.id)
   )
-}
-
-const encodeCursor = (vehicleId: string): string => btoa(vehicleId)
-// Returns undefined for a malformed (non-base64) cursor so the caller can
-// answer 400 instead of letting atob() throw into a 500 on a public endpoint.
-const decodeCursor = (cursor: string): string | undefined => {
-  try {
-    return atob(cursor)
-  } catch {
-    return undefined
-  }
 }

--- a/packages/api/src/services/storefront-search.ts
+++ b/packages/api/src/services/storefront-search.ts
@@ -12,9 +12,8 @@ import type {
   VehicleClass,
   VehicleClassRepository,
 } from '../repositories/types'
+import { clampLimit, decodeCursor, encodeCursor } from './search-paging'
 
-const DEFAULT_LIMIT = 25
-const MAX_LIMIT = 50
 const REPRESENTATIVE_PHOTO_CAP = 4
 
 export interface ClassSummary {
@@ -152,11 +151,6 @@ export class StorefrontSearchService {
   }
 }
 
-function clampLimit(limit: number | undefined): number {
-  if (!limit || limit < 1) return DEFAULT_LIMIT
-  return Math.min(limit, MAX_LIMIT)
-}
-
 function groupByLocation(vehicles: Vehicle[]): Map<string, Vehicle[]> {
   const byLocation = new Map<string, Vehicle[]>()
   for (const vehicle of vehicles) {
@@ -240,17 +234,4 @@ function compareCards(a: StorefrontCard, b: StorefrontCard): number {
     a.name.localeCompare(b.name) ||
     a.locationId.localeCompare(b.locationId)
   )
-}
-
-// Opaque base64 cursor over locationId (§3.3). btoa/atob are Web-standard
-// globals available on CF Workers and Bun.
-const encodeCursor = (locationId: string): string => btoa(locationId)
-// Returns undefined for a malformed (non-base64) cursor so the caller can
-// answer 400 instead of letting atob() throw into a 500 on a public endpoint.
-const decodeCursor = (cursor: string): string | undefined => {
-  try {
-    return atob(cursor)
-  } catch {
-    return undefined
-  }
 }


### PR DESCRIPTION
## What
Lift the duplicated search paging scaffold into one module so a cursor/limit change lives in exactly one place.

- New \`packages/api/src/services/search-paging.ts\`: \`DEFAULT_LIMIT\`/\`MAX_LIMIT\`, \`clampLimit\`, the base64 cursor codec (\`encodeCursor(key)\` / \`decodeCursor\`).
- \`flat-search\`, \`storefront-search\`, **and** \`storefront-detail\` import from it and drop their local copies.

## Scope note (audit undercounted)
The audit (L1, #1104) named **two** services. Reading at the source surfaced a **third** byte-identical copy in \`storefront-detail.ts\`. Folded it in too — otherwise the "grep returns one definition" acceptance wouldn't actually hold.

## Design
\`encodeCursor\` now takes the already-derived **string key** (\`btoa(key)\`); each service keeps its own key derivation:
- flat → \`itemKey(item)\`
- storefront-search → \`locationId\`
- storefront-detail → \`vehicleId\`

Projectors stay separate (per the issue). **No public API or response-shape change.** No migration.

## Tests
- New \`search-paging.test.ts\`: clampLimit boundaries + cursor round-trip + malformed-cursor → undefined (6 tests).
- Full api unit suite green: **2024 passed** (2018 + 6), 180 files.
- **Mutation proof**: changing the codec to \`btoa(\`X\${key}\`)\` once fails paging tests in **all three** service suites (flat-search, storefront-search, storefront-detail); revert → green. The change now lives in exactly one place.

## Acceptance
- [x] \`clampLimit\`/\`encodeCursor\`/\`decodeCursor\` exist only in \`search-paging.ts\` (grep: one definition each)
- [x] All search services consume the shared helpers; existing tests pass unchanged
- [x] Per-car / grouped-card / detail projectors remain distinct
- [x] One-line codec change reflects in all consumers (mutation-proven)

Closes #1113
Refs #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)