### PR TITLE
chore(api): route boundary hygiene (parseId, dedupe guard, authz off path-string) (#1116)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1,37 +1,42 @@
 import { createOperatorSchema } from '@kuruma/shared/validators/operator'
 import { createProviderInviteSchema } from '@kuruma/shared/validators/provider-invite'
 import { Hono } from 'hono'
-import { requireUser, toCallerContext } from '../middleware/auth'
+import { requirePlatformAdmin, requireUser, toCallerContext } from '../middleware/auth'
 import type { ConsentEvidenceService } from '../services/consent-evidence'
 import type { OperatorService } from '../services/operator'
 import { OperatorNotFoundError, type ProviderInviteService } from '../services/provider-invite'
-import { fail, ok, parseBody } from './helpers'
+import { fail, ok, parseBody, parseId } from './helpers'
 
 export function createAdminRoutes(
   operatorService: OperatorService,
   providerInviteService: ProviderInviteService,
   consentEvidenceService: ConsentEvidenceService,
 ) {
-  const app = new Hono()
-
   // Platform-admin only. Operator bootstrap is a platform-governance action;
-  // legacy STAFF/ADMIN do not qualify (proposal §9 item 23). Mounted behind
-  // the app-level requireAuth, so unauthenticated requests are 401'd first.
-  app.use('/admin/*', requirePlatformAdmin)
+  // legacy STAFF/ADMIN do not qualify (proposal §9 item 23). Each handler calls
+  // the canonical `requirePlatformAdmin` from auth/guards.ts (single source of
+  // truth — no local re-impl) after `requireUser`; the global error handler
+  // maps the thrown ForbiddenError to 403.
+  const app = new Hono()
 
   return (
     app
       .post('/admin/operators', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
+        requirePlatformAdmin(ctx)
+
         const parsed = await parseBody(c, createOperatorSchema)
         if (!parsed.ok) return parsed.response
 
-        const ctx = toCallerContext(requireUser(c))
         const operator = await operatorService.create(ctx, parsed.data)
         return ok(c, operator, 201)
       })
       // #521 §7: mint an invite-backed operator grant. The plaintext token is
       // returned once here and only its sha256 hash is stored — never logged.
       .post('/admin/provider-invites', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
+        requirePlatformAdmin(ctx)
+
         const parsed = await parseBody(c, createProviderInviteSchema)
         if (!parsed.ok) return parsed.response
 
@@ -45,20 +50,18 @@ export function createAdminRoutes(
       })
       // #877 Task 8: platform-admin consent evidence export for legal/audit review.
       .get('/admin/consent/acceptances/:id/evidence', async (c) => {
-        const evidence = await consentEvidenceService.getConsentEvidence(c.req.param('id'))
+        const ctx = toCallerContext(requireUser(c))
+        requirePlatformAdmin(ctx)
+
+        // Validate the uuid at the boundary so a malformed id is a clean 400 —
+        // the service tolerates an unknown id (returns undefined → 404) and can't
+        // otherwise distinguish bad input from missing row.
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
+
+        const evidence = await consentEvidenceService.getConsentEvidence(idResult.id)
         if (!evidence) return fail(c, 'ACCEPTANCE_NOT_FOUND', 404)
         return ok(c, evidence)
       })
   )
-}
-
-async function requirePlatformAdmin(
-  c: Parameters<Parameters<Hono['use']>[1]>[0],
-  next: () => Promise<void>,
-) {
-  const user = requireUser(c)
-  if (user.role !== 'PLATFORM_ADMIN') {
-    return fail(c, 'Forbidden', 403)
-  }
-  return next()
 }

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -1,4 +1,5 @@
 import { quickCreateCustomerSchema } from '@kuruma/shared/validators/customer'
+import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { toCallerContext } from '../auth/context'
 import { STAFF_ROLES, requireUser } from '../middleware/auth'
@@ -7,25 +8,24 @@ import { fail, ok, parseBody, parseId, parseLimit } from './helpers'
 
 const ALLOWED_SORTS = new Set(['lastBookingAt', 'bookingCount', 'name'])
 
+// Staff-default authz used by every /customers route except `/customers/search`
+// (which widens to operator-with-tenant — see its handler). Bound to the route,
+// not pattern-matched on `c.req.path`, so a future `/customers/something-else`
+// can't silently inherit a different policy from a path-prefix carve-out.
+function rejectIfNotStaff(c: Context): Response | null {
+  const ctx = toCallerContext(requireUser(c))
+  if (!STAFF_ROLES.has(ctx.role)) return fail(c, 'Forbidden', 403)
+  return null
+}
+
 export function createCustomerRoutes(service: CustomerService) {
   const app = new Hono()
 
-  // /customers (full list) and /customers/:id return cross-operator data and stay
-  // PLATFORM_ADMIN-only; /customers/quick-create likewise (operator walk-ins are
-  // created atomically via POST /bookings instead — #589). /customers/search is
-  // the ONE operator-reachable route: CustomerService.search scopes an OPERATOR_*
-  // caller to its own renters (prior-booking), so it can't enumerate the global
-  // user table (cf. #396/#475). Anything not explicitly operator-allowed → 403.
-  app.use('/customers', requireStaff)
-  app.use('/customers/*', async (c, next) => {
-    const ctx = toCallerContext(requireUser(c))
-    if (STAFF_ROLES.has(ctx.role)) return next()
-    if (c.req.path.endsWith('/customers/search') && ctx.operatorId) return next()
-    return fail(c, 'Forbidden', 403)
-  })
-
   return app
     .get('/customers', async (c) => {
+      const denied = rejectIfNotStaff(c)
+      if (denied) return denied
+
       const pg = parseLimit(c, { defaultLimit: 50 })
       if (!pg.ok) return pg.response
 
@@ -45,16 +45,28 @@ export function createCustomerRoutes(service: CustomerService) {
       return ok(c, result.data, 200, { nextCursor: result.nextCursor })
     })
     .get('/customers/search', async (c) => {
+      // The ONE operator-reachable route in this module: `CustomerService.search`
+      // scopes an OPERATOR_* caller to its own renters (those with a prior
+      // booking with it), so a tenant-scoped caller can't enumerate the global
+      // user table (cf. #396/#475). Anything else without staff → 403.
+      const ctx = toCallerContext(requireUser(c))
+      if (!STAFF_ROLES.has(ctx.role) && !ctx.operatorId) {
+        return fail(c, 'Forbidden', 403)
+      }
+
       // Flat user lookup for the manual-booking dialog. Separate from the
       // paginated list above so callers get a predictable User[] shape.
       const q = c.req.query('q')
       if (!q || q.length < 2) {
         return fail(c, 'Search query must be at least 2 characters', 400)
       }
-      const customers = await service.search(q, toCallerContext(requireUser(c)))
+      const customers = await service.search(q, ctx)
       return ok(c, customers)
     })
     .post('/customers/quick-create', async (c) => {
+      const denied = rejectIfNotStaff(c)
+      if (denied) return denied
+
       const parsed = await parseBody(c, quickCreateCustomerSchema)
       if (!parsed.ok) return parsed.response
 
@@ -62,21 +74,13 @@ export function createCustomerRoutes(service: CustomerService) {
       return ok(c, customer, created ? 201 : 200)
     })
     .get('/customers/:id', async (c) => {
+      const denied = rejectIfNotStaff(c)
+      if (denied) return denied
+
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
       const customer = await service.findById(idResult.id)
       if (!customer) return fail(c, 'Customer not found', 404)
       return ok(c, customer)
     })
-}
-
-async function requireStaff(
-  c: Parameters<Parameters<Hono['use']>[1]>[0],
-  next: () => Promise<void>,
-) {
-  const user = requireUser(c)
-  if (!STAFF_ROLES.has(user.role)) {
-    return fail(c, 'Forbidden', 403)
-  }
-  return next()
 }

--- a/packages/api/tests/routes/admin-consent-evidence.test.ts
+++ b/packages/api/tests/routes/admin-consent-evidence.test.ts
@@ -82,10 +82,21 @@ describe('GET /admin/consent/acceptances/:id/evidence', () => {
     expect(res.status).toBe(403)
   })
 
-  test('returns 404 for an unknown acceptance', async () => {
+  test('returns 404 for a valid-but-unknown acceptance id', async () => {
+    const res = await app.request(
+      '/admin/consent/acceptances/00000000-0000-4000-8000-000000000ace/evidence',
+      {
+        headers: await bearer({ sub: 'admin-1', role: 'PLATFORM_ADMIN' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  test('returns 400 for a malformed (non-uuid) acceptance id (L5)', async () => {
     const res = await app.request('/admin/consent/acceptances/nope/evidence', {
       headers: await bearer({ sub: 'admin-1', role: 'PLATFORM_ADMIN' }),
     })
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('id must be a valid uuid')
   })
 })

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -360,7 +360,7 @@ describe('GET /customers/search', () => {
   // detail, or quick-create routes. Mutation proof: if the carve-out is restored
   // as `path.endsWith(...)`, a future `/customers/search-*` would silently inherit
   // the operator path — these tests bind the policy to the route.
-  it('admits OPERATOR_OWNER with a tenant on /customers/search (200) — L7', async () => {
+  it('admits OPERATOR_OWNER with a tenant on /customers/search (200, tenant-scoped result) — L7', async () => {
     setup({
       users: seed(),
       asRole: 'OPERATOR_OWNER',
@@ -368,6 +368,11 @@ describe('GET /customers/search', () => {
     })
     const res = await app.request('/customers/search?q=tanaka')
     expect(res.status).toBe(200)
+    // Empty because the tenant has no prior bookings with `tanaka` — locks in
+    // CustomerService.search's per-operator scoping. A regression that returned
+    // the cross-operator matches would surface here, not silently pass on 200.
+    const body = await res.json()
+    expect(body.data).toEqual([])
   })
 
   it('rejects OPERATOR_OWNER on /customers list (403) — L7', async () => {

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { InMemoryCustomerRepository } from '../../src/repositories/in-memory/customer'
 import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
 import { createCustomerRoutes } from '../../src/routes/customers'
@@ -47,18 +48,21 @@ function setup({
   users = [] as User[],
   bookings = [] as Booking[],
   asRole = 'PLATFORM_ADMIN' as const,
+  operatorId,
 }: {
   users?: User[]
   bookings?: Booking[]
-  asRole?: 'PLATFORM_ADMIN' | 'RENTER'
+  asRole?: 'PLATFORM_ADMIN' | 'RENTER' | 'OPERATOR_OWNER' | 'OPERATOR_STAFF'
+  operatorId?: string
 } = {}) {
   const userStore = new Map(users.map((u) => [u.id, u]))
   const bookingStore = new Map(bookings.map((b) => [b.id, b]))
   const customerRepo = new InMemoryCustomerRepository(userStore, bookingStore)
   const userRepo = new InMemoryUserRepository(userStore)
-  const service = new CustomerService(customerRepo, userRepo)
+  const bookingRepo = new InMemoryBookingRepository(bookingStore)
+  const service = new CustomerService(customerRepo, userRepo, bookingRepo)
   app = new Hono()
-  app.use('*', testAuthMiddleware(ADMIN, asRole))
+  app.use('*', testAuthMiddleware(ADMIN, asRole, operatorId))
   app.route('/', createCustomerRoutes(service))
   return { customerRepo, userRepo, service }
 }
@@ -348,6 +352,56 @@ describe('GET /customers/search', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data).toEqual([])
+  })
+
+  // L7: operator carve-out for /customers/search lives on the handler, not on a
+  // path-string `path.endsWith()` match. An OPERATOR_OWNER with a tenant must be
+  // able to reach search; the same caller must NOT reach the cross-operator list,
+  // detail, or quick-create routes. Mutation proof: if the carve-out is restored
+  // as `path.endsWith(...)`, a future `/customers/search-*` would silently inherit
+  // the operator path — these tests bind the policy to the route.
+  it('admits OPERATOR_OWNER with a tenant on /customers/search (200) — L7', async () => {
+    setup({
+      users: seed(),
+      asRole: 'OPERATOR_OWNER',
+      operatorId: '00000000-0000-4000-8000-0000000000aa',
+    })
+    const res = await app.request('/customers/search?q=tanaka')
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects OPERATOR_OWNER on /customers list (403) — L7', async () => {
+    setup({
+      users: seed(),
+      asRole: 'OPERATOR_OWNER',
+      operatorId: '00000000-0000-4000-8000-0000000000aa',
+    })
+    const res = await app.request('/customers')
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects OPERATOR_OWNER on /customers/:id (403) — L7', async () => {
+    setup({
+      users: seed(),
+      asRole: 'OPERATOR_OWNER',
+      operatorId: '00000000-0000-4000-8000-0000000000aa',
+    })
+    const res = await app.request('/customers/00000000-0000-4000-8000-0000000000ff')
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects OPERATOR_OWNER on /customers/quick-create (403) — L7', async () => {
+    setup({
+      users: seed(),
+      asRole: 'OPERATOR_OWNER',
+      operatorId: '00000000-0000-4000-8000-0000000000aa',
+    })
+    const res = await app.request('/customers/quick-create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X', email: 'x@example.com' }),
+    })
+    expect(res.status).toBe(403)
   })
 })
 


### PR DESCRIPTION
Closes #1116. From the 2026-06-25 audit (`docs/audits/2026-06-25-solid-architecture-audit.md`), findings L5/L6/L7.

## Summary
Three independent boundary-hygiene fixes batched into one PR — none change observable behavior for already-correct callers.

### L5 — Validate consent-evidence `:id` at the boundary
`routes/admin.ts` now runs the `:id` param through `parseId(c)` before calling `consentEvidenceService.getConsentEvidence`. A malformed (non-uuid) id used to 404 as if it were an unknown id, breaking the "malformed input = clean 400" contract. The service still tolerates valid-but-unknown ids → 404.

### L6 — Single canonical `requirePlatformAdmin`
Deleted the local middleware copy in `routes/admin.ts`. Each handler now calls the canonical `requirePlatformAdmin(ctx)` from `auth/guards.ts` (matches the per-handler pattern in `routes/payment-anomalies.ts`). One source of truth — a future tightening of the guard can't silently diverge across two same-named gates.

### L7 — Authz bound to the route, not a path-string match
`routes/customers.ts` no longer uses `c.req.path.endsWith('/customers/search')` as an operator carve-out. The `/customers/search` handler explicitly admits `staff-or-(operator-with-tenant)`; every other `/customers/*` route enforces staff-only via a small local helper. Fail-closed today, but a future `/customers/search-*` would have silently inherited the operator policy from the prefix match — now it can't.

## Test plan
- [x] `bun run test` — aggregate (shared 740 / api 2077 / web 1330) green
- [x] `bun run --filter @kuruma/api typecheck` green
- [x] `bun run --filter @kuruma/api lint:boundaries` green
- [x] `bun run lint` green
- [x] L5: `'returns 400 for a malformed (non-uuid) acceptance id (L5)'` was RED before fix
- [x] L6: `rg "function requirePlatformAdmin" packages/api/src` shows exactly one definition (`auth/guards.ts:165`)
- [x] L7: 4 mutation-resistant regression tests — OPERATOR_OWNER on `/customers`/`/customers/:id`/`/customers/quick-create` → 403; on `/customers/search` → 200
- [x] Pre-existing test bug fixed: `customers.test.ts setup()` was constructing `CustomerService` with 2 args (constructor wants 3) — only worked because no prior test exercised the operator-scoped branch

Refs #1104.