### PR TITLE
refactor(#1107): dedupe write-side scoped-create into parseScopedCreate (audit L4)

### DIFF
--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -1,4 +1,3 @@
-import type { CreateAddOnInput } from '@kuruma/shared/validators/add-on'
 import {
   createAddOnSchema,
   platformAdminCreateAddOnSchema,
@@ -15,8 +14,8 @@ import {
 import type { AddOnService } from '../services/add-on'
 import type { AddOnFilters } from '../services/filters'
 import type { AddOn } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createAddOnRoutes(
   service: AddOnService,
@@ -70,24 +69,15 @@ export function createAddOnRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateAddOnInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operatorSchema: createAddOnSchema, adminSchema: platformAdminCreateAddOnSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const d = parsed.data
+      const operatorId = parsed.operatorId
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -1,4 +1,3 @@
-import type { CreateFeeScheduleInput } from '@kuruma/shared/validators/fee-schedule'
 import {
   createFeeScheduleSchema,
   platformAdminCreateFeeScheduleSchema,
@@ -15,8 +14,8 @@ import {
 import type { FeeScheduleService } from '../services/fee-schedule'
 import type { FeeScheduleFilters } from '../services/filters'
 import type { FeeSchedule } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createFeeScheduleRoutes(
   service: FeeScheduleService,
@@ -77,23 +76,18 @@ export function createFeeScheduleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateFeeScheduleInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createFeeScheduleSchema,
+          adminSchema: platformAdminCreateFeeScheduleSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const d = parsed.data
+      const operatorId = parsed.operatorId
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -1,5 +1,7 @@
 import type { Context } from 'hono'
 import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
+import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
 
 // --- Response helpers ---
 
@@ -203,6 +205,44 @@ export async function parseBody<T>(
   }
 
   return { ok: true, data: result.data }
+}
+
+// --- Scoped create (write-route operator resolution) ---
+
+type ScopedCreateSuccess<T> = { ok: true; data: T; operatorId: string }
+
+/**
+ * The write-route twin of the cross-operator read-scope guard (#1107 / audit L4).
+ * Centralizes the "resolve operatorId from the caller, never trust body.operatorId
+ * for an operator role" branch that was copy-pasted across the 4 fleet-config
+ * create handlers (add-ons, fee-schedules, insurance-options, locations).
+ *
+ * A bypass (`all`-scope) caller names the target tenant in the body, validated by
+ * `adminSchema`; an operator caller never sends one — its own tenant is stamped
+ * server-side via `operatorSchema` + `resolveWriteOperatorId(ctx)`. Selecting the
+ * schema by scope keeps each parsed body's type concrete for the call site.
+ */
+export async function parseScopedCreate<O extends object>(
+  c: Context,
+  ctx: CallerContext,
+  schemas: {
+    operatorSchema: z.ZodType<O>
+    adminSchema: z.ZodType<O & { operatorId?: string }>
+  },
+  resolveWriteOperatorId: ResolveWriteOperatorId,
+): Promise<ScopedCreateSuccess<O> | ParseBodyFailure> {
+  if (operatorReadScope(ctx).kind === 'all') {
+    const parsed = await parseBody(c, schemas.adminSchema)
+    if (!parsed.ok) return parsed
+    return {
+      ok: true,
+      data: parsed.data,
+      operatorId: await resolveWriteOperatorId(ctx, parsed.data.operatorId),
+    }
+  }
+  const parsed = await parseBody(c, schemas.operatorSchema)
+  if (!parsed.ok) return parsed
+  return { ok: true, data: parsed.data, operatorId: await resolveWriteOperatorId(ctx) }
 }
 
 type DateRangeRequired = { ok: true; from: Date; to: Date }

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -1,4 +1,3 @@
-import type { CreateInsuranceOptionInput } from '@kuruma/shared/validators/insurance-option'
 import {
   createInsuranceOptionSchema,
   platformAdminCreateInsuranceOptionSchema,
@@ -15,8 +14,8 @@ import {
 import type { InsuranceOptionFilters } from '../services/filters'
 import type { InsuranceOptionService } from '../services/insurance-option'
 import type { InsuranceOption } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createInsuranceOptionRoutes(
   service: InsuranceOptionService,
@@ -70,24 +69,18 @@ export function createInsuranceOptionRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateInsuranceOptionInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        {
+          operatorSchema: createInsuranceOptionSchema,
+          adminSchema: platformAdminCreateInsuranceOptionSchema,
+        },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const d = parsed.data
+      const operatorId = parsed.operatorId
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -1,4 +1,3 @@
-import type { CreateLocationInput } from '@kuruma/shared/validators/location'
 import {
   createLocationSchema,
   platformAdminCreateLocationSchema,
@@ -9,8 +8,8 @@ import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '..
 import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { LocationFilters } from '../services/filters'
 import type { LocationService, LocationUpdateData } from '../services/location'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createLocationRoutes(
   service: LocationService,
@@ -61,24 +60,15 @@ export function createLocationRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateLocationInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operatorSchema: createLocationSchema, adminSchema: platformAdminCreateLocationSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const d = parsed.data
+      const operatorId = parsed.operatorId
 
       try {
         const result = await service.create(ctx, {

--- a/packages/api/src/routes/scoped-create.test.ts
+++ b/packages/api/src/routes/scoped-create.test.ts
@@ -1,0 +1,64 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
+import { resolveOperatorIdForWrite } from '../tenancy'
+import { parseScopedCreate } from './helpers'
+
+// #1107 (audit L4): the write-route schema-selection + operatorId-resolution
+// branch, deduplicated. A bypass caller names the target operator in the body;
+// an operator caller is stamped with its own tenant and a body operatorId is
+// ignored. We drive the real helper through a real Hono app + the real
+// `resolveOperatorIdForWrite` so the wiring (not a mock) is what's asserted.
+
+const operatorSchema = z.object({ name: z.string() })
+const adminSchema = z.object({ name: z.string(), operatorId: z.string() })
+
+const app = (ctx: CallerContext) => {
+  const a = new Hono()
+  a.post('/x', async (c) => {
+    const r = await parseScopedCreate(
+      c,
+      ctx,
+      { operatorSchema, adminSchema },
+      resolveOperatorIdForWrite,
+    )
+    if (!r.ok) return r.response
+    return c.json({ name: r.data.name, operatorId: r.operatorId })
+  })
+  return a
+}
+
+const post = (ctx: CallerContext, body: unknown) =>
+  app(ctx).request('/x', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+const OPERATOR: CallerContext = { userId: 'o1', role: 'OPERATOR_OWNER', operatorId: 'op1' }
+const ADMIN: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+describe('parseScopedCreate (#1107)', () => {
+  it('operator caller is stamped with its own tenant, ignoring a body operatorId', async () => {
+    const res = await post(OPERATOR, { name: 'a', operatorId: 'op-evil' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ name: 'a', operatorId: 'op1' })
+  })
+
+  it('bypass caller resolves the target operator from the body', async () => {
+    const res = await post(ADMIN, { name: 'a', operatorId: 'op2' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ name: 'a', operatorId: 'op2' })
+  })
+
+  it('bypass caller without a body operatorId is a 400 (admin schema requires it)', async () => {
+    const res = await post(ADMIN, { name: 'a' })
+    expect(res.status).toBe(400)
+  })
+
+  it('operator caller with an invalid body is a 400 (operator schema)', async () => {
+    const res = await post(OPERATOR, { notName: 'a' })
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## What
Re-files the **L4 write-side dedup** from #1134 cleanly atop `develop`.

#1134 mixed L4 (write) with M3 (read-side scope), but **#1128 already shipped M3** in the service layer (`tenancy.ts`). So #1134's M3 changes are now redundant + conflicting, and that PR is a stale DRAFT. This PR carries only L4 — the unique value #1128 explicitly deferred — and builds on #1128's `tenancy` module.

## How
`parseScopedCreate` in `routes/helpers.ts` centralizes the create-route branch (bypass caller parses the admin schema naming a target `operatorId`; operator caller parses the plain schema and is stamped its own tenant server-side — `body.operatorId` is never trusted for an operator role). The 4 create routes (add-ons, fee-schedules, insurance-options, locations) drop the copy-pasted boilerplate. Pure refactor — behavior identical.

## Verification
- `tsc --noEmit` clean, `biome check` clean
- new `scoped-create.test.ts` 4 passed; the 4 route suites 69 passed (73 total green)

Closes #1107. Supersedes the L4 portion of #1134 (that draft to be closed).