### PR TITLE
refactor(#1107): extract parseScopedCreate helper across 4 config write routes (audit L4)

### DIFF
--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -1,4 +1,3 @@
-import type { CreateAddOnInput } from '@kuruma/shared/validators/add-on'
 import {
   createAddOnSchema,
   platformAdminCreateAddOnSchema,
@@ -15,8 +14,8 @@ import {
 import type { AddOnService } from '../services/add-on'
 import type { AddOnFilters } from '../services/filters'
 import type { AddOn } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createAddOnRoutes(
   service: AddOnService,
@@ -70,24 +69,14 @@ export function createAddOnRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateAddOnInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createAddOnSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operator: createAddOnSchema, admin: platformAdminCreateAddOnSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const { data: d, operatorId } = parsed
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -1,4 +1,3 @@
-import type { CreateFeeScheduleInput } from '@kuruma/shared/validators/fee-schedule'
 import {
   createFeeScheduleSchema,
   platformAdminCreateFeeScheduleSchema,
@@ -15,8 +14,8 @@ import {
 import type { FeeScheduleService } from '../services/fee-schedule'
 import type { FeeScheduleFilters } from '../services/filters'
 import type { FeeSchedule } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createFeeScheduleRoutes(
   service: FeeScheduleService,
@@ -77,23 +76,14 @@ export function createFeeScheduleRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateFeeScheduleInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createFeeScheduleSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operator: createFeeScheduleSchema, admin: platformAdminCreateFeeScheduleSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const { data: d, operatorId } = parsed
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -1,5 +1,7 @@
 import type { Context } from 'hono'
 import { z } from 'zod'
+import type { CallerContext } from '../middleware/auth'
+import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
 
 // --- Response helpers ---
 
@@ -203,6 +205,43 @@ export async function parseBody<T>(
   }
 
   return { ok: true, data: result.data }
+}
+
+type ScopedCreateSuccess<T> = { ok: true; data: T; operatorId: string }
+type ScopedCreateResult<T> = ScopedCreateSuccess<T> | ParseBodyFailure
+
+/**
+ * Parse + authorize a create on an operator-owned config resource (fee-schedules,
+ * insurance-options, add-ons, locations — audit L4). All four shared an identical
+ * ~10-line branch: a bypass caller (PLATFORM_ADMIN / legacy staff — `all` read
+ * scope) names the target operator in the body and is parsed with the
+ * platform-admin schema; an operator caller never sends one, so its tenant is
+ * stamped server-side via `resolveWriteOperatorId(ctx)`. Collapsing it here keeps
+ * the "who can write to which tenant" policy in one place — a new write route
+ * can't silently drift from it, and a bypass caller can never spoof another
+ * operator (operator callers' body `operatorId`, if any, is ignored).
+ *
+ * Returns the parsed `data` (narrowed to the operator schema's `T`) plus the
+ * resolved `operatorId`, or a 400 `response` to short-circuit on a bad body.
+ */
+export async function parseScopedCreate<T>(
+  c: Context,
+  ctx: CallerContext,
+  schemas: { operator: z.ZodType<T>; admin: z.ZodType<T & { operatorId?: string | undefined }> },
+  resolveWriteOperatorId: ResolveWriteOperatorId,
+): Promise<ScopedCreateResult<T>> {
+  if (operatorReadScope(ctx).kind === 'all') {
+    const parsed = await parseBody(c, schemas.admin)
+    if (!parsed.ok) return parsed
+    return {
+      ok: true,
+      data: parsed.data,
+      operatorId: await resolveWriteOperatorId(ctx, parsed.data.operatorId),
+    }
+  }
+  const parsed = await parseBody(c, schemas.operator)
+  if (!parsed.ok) return parsed
+  return { ok: true, data: parsed.data, operatorId: await resolveWriteOperatorId(ctx) }
 }
 
 type DateRangeRequired = { ok: true; from: Date; to: Date }

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -1,4 +1,3 @@
-import type { CreateInsuranceOptionInput } from '@kuruma/shared/validators/insurance-option'
 import {
   createInsuranceOptionSchema,
   platformAdminCreateInsuranceOptionSchema,
@@ -15,8 +14,8 @@ import {
 import type { InsuranceOptionFilters } from '../services/filters'
 import type { InsuranceOptionService } from '../services/insurance-option'
 import type { InsuranceOption } from '../stores'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createInsuranceOptionRoutes(
   service: InsuranceOptionService,
@@ -70,24 +69,14 @@ export function createInsuranceOptionRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateInsuranceOptionInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createInsuranceOptionSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operator: createInsuranceOptionSchema, admin: platformAdminCreateInsuranceOptionSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const { data: d, operatorId } = parsed
 
       const result = await service.create(ctx, {
         operatorId,

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -1,4 +1,3 @@
-import type { CreateLocationInput } from '@kuruma/shared/validators/location'
 import {
   createLocationSchema,
   platformAdminCreateLocationSchema,
@@ -9,8 +8,8 @@ import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '..
 import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { LocationFilters } from '../services/filters'
 import type { LocationService, LocationUpdateData } from '../services/location'
-import { type ResolveWriteOperatorId, operatorReadScope } from '../tenancy'
-import { fail, ok, parseBody, parseId, stripUndefined } from './helpers'
+import type { ResolveWriteOperatorId } from '../tenancy'
+import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
 
 export function createLocationRoutes(
   service: LocationService,
@@ -61,24 +60,14 @@ export function createLocationRoutes(
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
       const ctx = toCallerContext(user)
-      // Bypass callers must name the target operator in the body; operator
-      // callers never send one — their tenant is stamped server-side. Resolve
-      // operatorId inside each branch where the body type is concrete.
-      const isBypass = operatorReadScope(ctx).kind === 'all'
-
-      let d: CreateLocationInput
-      let operatorId: string
-      if (isBypass) {
-        const parsed = await parseBody(c, platformAdminCreateLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx, parsed.data.operatorId)
-      } else {
-        const parsed = await parseBody(c, createLocationSchema)
-        if (!parsed.ok) return parsed.response
-        d = parsed.data
-        operatorId = await resolveWriteOperatorId(ctx)
-      }
+      const parsed = await parseScopedCreate(
+        c,
+        ctx,
+        { operator: createLocationSchema, admin: platformAdminCreateLocationSchema },
+        resolveWriteOperatorId,
+      )
+      if (!parsed.ok) return parsed.response
+      const { data: d, operatorId } = parsed
 
       try {
         const result = await service.create(ctx, {

--- a/packages/api/tests/routes/scoped-create.test.ts
+++ b/packages/api/tests/routes/scoped-create.test.ts
@@ -1,15 +1,17 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import type { CallerContext } from '../../src/auth/context'
+import type { CallerContext } from '../../src/middleware/auth'
 import { parseScopedCreate } from '../../src/routes/helpers'
 import type { ResolveWriteOperatorId } from '../../src/tenancy'
 
 // The operator schema has NO operatorId; the admin (bypass) schema requires one.
-// This mirrors the real config create/platformAdminCreate pairs: an operator
-// caller can never name a tenant, a bypass caller must.
-const operatorSchema = z.object({ name: z.string() }).strict()
-const adminSchema = z.object({ name: z.string(), operatorId: z.string() }).strict()
+// Both are PLAIN (non-strict) z.object — mirroring the real config
+// create/platformAdminCreate pairs, which strip unknown keys rather than reject.
+// So an operator caller's stray `operatorId` is silently dropped by the schema;
+// the helper — not the schema — is what guarantees the tenant is server-derived.
+const operatorSchema = z.object({ name: z.string() })
+const adminSchema = z.object({ name: z.string(), operatorId: z.string() })
 
 const OPERATOR_CTX: CallerContext = {
   userId: 'u-1',
@@ -62,13 +64,16 @@ describe('parseScopedCreate()', () => {
     expect(calls).toEqual([{ role: 'OPERATOR_OWNER', input: undefined }])
   })
 
-  it('operator caller cannot smuggle a foreign operatorId: the strict operator schema rejects it (400)', async () => {
+  it('operator caller cannot smuggle a foreign operatorId: the body value is neutralized, the tenant wins (200)', async () => {
     const { calls, resolve } = spyResolver()
     const res = await post(appWith(OPERATOR_CTX, resolve), { name: 'Std', operatorId: 'op-victim' })
 
-    expect(res.status).toBe(400)
-    // Rejected before any tenant resolution — no spoof reaches the resolver.
-    expect(calls).toHaveLength(0)
+    // Prod-faithful: the non-strict operator schema strips the stray key, so this
+    // is a 200 — but the resolved operatorId is the server tenant, NEVER the body.
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ operatorId: 'op-self' })
+    // The invariant: the helper handed the resolver NO body operatorId on the operator path.
+    expect(calls).toEqual([{ role: 'OPERATOR_OWNER', input: undefined }])
   })
 
   it('bypass caller: parses with the admin schema and resolves the body-named operatorId', async () => {

--- a/packages/api/tests/routes/scoped-create.test.ts
+++ b/packages/api/tests/routes/scoped-create.test.ts
@@ -1,0 +1,98 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import type { CallerContext } from '../../src/auth/context'
+import { parseScopedCreate } from '../../src/routes/helpers'
+import type { ResolveWriteOperatorId } from '../../src/tenancy'
+
+// The operator schema has NO operatorId; the admin (bypass) schema requires one.
+// This mirrors the real config create/platformAdminCreate pairs: an operator
+// caller can never name a tenant, a bypass caller must.
+const operatorSchema = z.object({ name: z.string() }).strict()
+const adminSchema = z.object({ name: z.string(), operatorId: z.string() }).strict()
+
+const OPERATOR_CTX: CallerContext = {
+  userId: 'u-1',
+  role: 'OPERATOR_OWNER',
+  operatorId: 'op-self',
+  bypassScope: false,
+}
+const ADMIN_CTX: CallerContext = { userId: 'a-1', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+// Records every (role, inputOperatorId) the helper hands the resolver, so a test
+// can prove WHICH operatorId the helper trusted — server tenant vs request body.
+function spyResolver() {
+  const calls: Array<{ role: string; input: string | undefined }> = []
+  const resolve: ResolveWriteOperatorId = async (ctx, input) => {
+    calls.push({ role: ctx.role, input })
+    return ctx.operatorId ?? input ?? 'UNRESOLVED'
+  }
+  return { calls, resolve }
+}
+
+function appWith(ctx: CallerContext, resolve: ResolveWriteOperatorId) {
+  return new Hono().post('/x', async (c) => {
+    const parsed = await parseScopedCreate(
+      c,
+      ctx,
+      { operator: operatorSchema, admin: adminSchema },
+      resolve,
+    )
+    if (!parsed.ok) return parsed.response
+    return c.json({ data: parsed.data, operatorId: parsed.operatorId })
+  })
+}
+
+function post(app: Hono, body: unknown) {
+  return app.request('/x', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('parseScopedCreate()', () => {
+  it('operator caller: parses with the operator schema and derives operatorId from the tenant, never the body', async () => {
+    const { calls, resolve } = spyResolver()
+    const res = await post(appWith(OPERATOR_CTX, resolve), { name: 'Std' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ data: { name: 'Std' }, operatorId: 'op-self' })
+    // The security invariant: the operator path resolved WITHOUT a body operatorId.
+    expect(calls).toEqual([{ role: 'OPERATOR_OWNER', input: undefined }])
+  })
+
+  it('operator caller cannot smuggle a foreign operatorId: the strict operator schema rejects it (400)', async () => {
+    const { calls, resolve } = spyResolver()
+    const res = await post(appWith(OPERATOR_CTX, resolve), { name: 'Std', operatorId: 'op-victim' })
+
+    expect(res.status).toBe(400)
+    // Rejected before any tenant resolution — no spoof reaches the resolver.
+    expect(calls).toHaveLength(0)
+  })
+
+  it('bypass caller: parses with the admin schema and resolves the body-named operatorId', async () => {
+    const { calls, resolve } = spyResolver()
+    const res = await post(appWith(ADMIN_CTX, resolve), { name: 'Adm', operatorId: 'op-target' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ operatorId: 'op-target' })
+    expect(calls).toEqual([{ role: 'PLATFORM_ADMIN', input: 'op-target' }])
+  })
+
+  it('bypass caller must name a target operator: a body without operatorId is a 400', async () => {
+    const { calls, resolve } = spyResolver()
+    const res = await post(appWith(ADMIN_CTX, resolve), { name: 'Adm' })
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('a body that fails the operator schema short-circuits to 400 without resolving', async () => {
+    const { calls, resolve } = spyResolver()
+    const res = await post(appWith(OPERATOR_CTX, resolve), { name: 42 })
+
+    expect(res.status).toBe(400)
+    expect(calls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #1107. Finishes the **L4** half of the audit issue. The **M3** half (cross-operator read-scope pushed below the route) already shipped as **#1128**; this PR supersedes the entangled **#1134** (M3+L4 in one PR), which will be closed.

## What

Four config-resource `POST` routes — `fee-schedules`, `insurance-options`, `add-ons`, `locations` — carried a byte-identical ~10-line block that parsed the body and resolved the target operator, branching on whether the caller is a bypass admin (names the operator in the body) or an operator (tenant stamped server-side). Extracted that into one helper, `parseScopedCreate(c, ctx, { operator, admin }, resolveWriteOperatorId)` in `routes/helpers.ts`; each route's block collapses ~10 lines → 4.

## Why it matters (security)

The "who can write to which tenant" policy now lives in **one** place instead of four copies. A new config write route can't silently drift from it, and a bypass caller can never spoof another operator — an operator caller's `operatorId`, if present in the body, is ignored and the tenant is always server-derived. Pure refactor; no behavior change, migration-free.

Learn: DRY / Single Point of Truth for policy
Four copies of an authz branch means four places a future edit can diverge — and a tenant-isolation bug only needs one to drift.
Heuristic: when the same security branch is copy-pasted across routes, the copies *are* the bug waiting to happen — collapse to one helper.

## Tests

New `tests/routes/scoped-create.test.ts` (5 tests) pins the invariant with a spy resolver that records exactly which `operatorId` the helper trusts (server tenant vs request body): operator path resolves with no body operatorId; bypass path resolves the body-named one; missing/invalid bodies 400 before any resolution.

## Code review applied

A `code-reviewer` pass confirmed the security invariant holds through three layers and the refactor is behavior-exact. One MEDIUM was fixed (commit 2): the operator-smuggle test had built a local `.strict()` schema and asserted a **400** the real routes never produce — production operator schemas are plain `z.object` that **strip** unknown keys (200, foreign id dropped + neutralized). Reworked it to be prod-faithful and assert the real invariant (body operatorId neutralized, server tenant wins, spy proves no body id reached the resolver). Also aligned the test's `CallerContext` import to the `middleware/auth` barrel that `helpers.ts` uses.

## Gates

- `@kuruma/api` typecheck: green
- `lint:boundaries`: Import boundaries OK
- new suite: 5/5 pass
- pre-commit (biome / file-size / module-boundaries / api+web tsc): green