### PR TITLE
refactor(#1108): move booking-actor resolution into a service policy (audit M4)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -9,7 +9,6 @@ import {
 import { Hono } from 'hono'
 import {
   MANAGEMENT_READ_ROLES,
-  STAFF_ROLES,
   isOperatorRole,
   requireUser,
   toCallerContext,
@@ -149,19 +148,11 @@ export function createBookingRoutes(service: BookingService, consentGate: Consen
       const parsed = await parseBody(c, createBookingSchema)
       if (!parsed.ok) return parsed.response
 
-      // #589: STAFF and OPERATOR_* are "manual bookers" — they may book on behalf
-      // of a renter (renterId) and set source=MANUAL. An operator's renterId is
-      // authorized in the service against its OWN customer scope (renters with a
-      // prior booking with it), scope-first so it never probes the user table for
-      // an arbitrary id — preserving the #396/#475 enumeration defense
-      // (operator-user-isolation.test.ts). Everyone else books as themselves with
-      // source forced to DIRECT (no advance-booking-hours bypass via MANUAL).
-      const isManualBooker = STAFF_ROLES.has(ctx.role) || isOperatorRole(ctx.role)
-      // #589 1c: only manual bookers may register a walk-in customer inline; a
-      // renter's walkInCustomer is ignored (they book as themselves).
-      const walkInCustomer = isManualBooker ? parsed.data.walkInCustomer : undefined
-      const renterId = isManualBooker && parsed.data.renterId ? parsed.data.renterId : ctx.userId
-      const source = isManualBooker ? parsed.data.source : 'DIRECT'
+      // #1108 (audit M4): actor resolution — who may book on behalf of whom and
+      // force source=MANUAL — is domain authz and now lives in the service
+      // (resolveBookingActor, called by BookingCreationService.create). The route
+      // forwards parsed.data untouched. It may still REJECT on role below (the
+      // disclaimer + consent gates); it no longer REWRITES the payload by role.
 
       // #613: a renter self-serve booking must accept the liability disclaimer
       // (免责声明) at checkout — the IDP/license must be valid at pickup or the
@@ -199,13 +190,14 @@ export function createBookingRoutes(service: BookingService, consentGate: Consen
         dropoffLocationId: parsed.data.dropoffLocationId,
         insuranceOptionId: parsed.data.insuranceOptionId ?? null,
         addOnIds: parsed.data.addOnIds,
-        renterId,
-        // #589 1c: include walkInCustomer only when present, never as explicit
-        // undefined (exactOptionalPropertyTypes); the service prefers it over renterId.
-        ...(walkInCustomer ? { walkInCustomer } : {}),
+        // #1108: forward identity fields RAW — resolveBookingActor (service-side)
+        // derives the concrete renterId / source / walk-in from the caller role.
+        // Omit absent optionals (exactOptionalPropertyTypes).
+        ...(parsed.data.renterId ? { renterId: parsed.data.renterId } : {}),
+        ...(parsed.data.walkInCustomer ? { walkInCustomer: parsed.data.walkInCustomer } : {}),
         startAt: new Date(parsed.data.startAt),
         endAt: new Date(parsed.data.endAt),
-        source,
+        source: parsed.data.source,
         externalId: parsed.data.externalId ?? null,
         notes: parsed.data.notes ?? null,
         idempotencyKey: parsed.data.idempotencyKey ?? null,

--- a/packages/api/src/services/booking-actor.test.ts
+++ b/packages/api/src/services/booking-actor.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../middleware/auth'
+import { resolveBookingActor } from './booking-actor'
+
+// #1108 (audit M4): actor resolution — "who books, with what source, and is it a
+// walk-in" — is domain authz, not a route concern. These tests pin it as a pure
+// function callable with a plain ctx + request, no Hono Context. They assert the
+// EXACT prior route behavior (bookings.ts:159-164) so the extraction is a no-op
+// end-to-end.
+
+const ctx = (role: CallerContext['role'], userId: string): CallerContext => ({
+  userId,
+  role,
+  bypassScope: false,
+})
+
+const WALK_IN = { name: 'Aiko Tanaka', phone: '+81-90-0000-0000' }
+
+describe('resolveBookingActor — renter (self-serve)', () => {
+  it('books as the caller, forces source=DIRECT, ignores a supplied renterId', () => {
+    const actor = resolveBookingActor(ctx('RENTER', 'renter-1'), {
+      renterId: 'someone-else',
+      source: 'MANUAL',
+    })
+    expect(actor).toEqual({ renterId: 'renter-1', source: 'DIRECT' })
+  })
+
+  it('drops a walk-in customer a renter is not allowed to register', () => {
+    const actor = resolveBookingActor(ctx('RENTER', 'renter-1'), {
+      source: 'DIRECT',
+      walkInCustomer: WALK_IN,
+    })
+    expect(actor).toEqual({ renterId: 'renter-1', source: 'DIRECT' })
+    expect(actor.walkInCustomer).toBeUndefined()
+  })
+
+  it('forces source=DIRECT for a PARTNER (api-key) caller too — only manual bookers keep source', () => {
+    const actor = resolveBookingActor(ctx('PARTNER', 'partner-key'), {
+      source: 'TRIP_COM',
+      renterId: 'whoever',
+    })
+    expect(actor).toEqual({ renterId: 'partner-key', source: 'DIRECT' })
+  })
+})
+
+describe('resolveBookingActor — manual booker (operator / platform-admin)', () => {
+  it('an operator books on behalf of a target renterId with source=MANUAL', () => {
+    const actor = resolveBookingActor(ctx('OPERATOR_OWNER', 'op-staff'), {
+      renterId: 'customer-7',
+      source: 'MANUAL',
+    })
+    expect(actor).toEqual({ renterId: 'customer-7', source: 'MANUAL' })
+  })
+
+  it('a platform-admin is a manual booker (STAFF_ROLES) and keeps source + renterId', () => {
+    const actor = resolveBookingActor(ctx('PLATFORM_ADMIN', 'admin-1'), {
+      renterId: 'customer-7',
+      source: 'MANUAL',
+    })
+    expect(actor).toEqual({ renterId: 'customer-7', source: 'MANUAL' })
+  })
+
+  it('passes a walk-in customer through and falls back to the caller id when no renterId given', () => {
+    const actor = resolveBookingActor(ctx('OPERATOR_STAFF', 'op-staff'), {
+      source: 'MANUAL',
+      walkInCustomer: WALK_IN,
+    })
+    expect(actor).toEqual({ renterId: 'op-staff', source: 'MANUAL', walkInCustomer: WALK_IN })
+  })
+
+  it('falls back to the caller id when a manual booker omits renterId and has no walk-in', () => {
+    const actor = resolveBookingActor(ctx('OPERATOR_OWNER', 'op-staff'), { source: 'MANUAL' })
+    expect(actor).toEqual({ renterId: 'op-staff', source: 'MANUAL' })
+  })
+})

--- a/packages/api/src/services/booking-actor.ts
+++ b/packages/api/src/services/booking-actor.ts
@@ -1,0 +1,51 @@
+import { STAFF_ROLES, isOperatorRole } from '../auth/roles'
+import type { CallerContext } from '../middleware/auth'
+import type { Booking } from '../stores'
+
+// Raw request fields the actor policy reads. A subset of CreateBookingInput —
+// kept local so the policy is a pure function with no dependency on the full
+// (discriminated-union) command shape.
+export interface BookingActorRequest {
+  // The renter a manual booker is booking for; absent for self-serve.
+  renterId?: string
+  // The source the caller asked for; only honored for manual bookers.
+  source: Booking['source']
+  // An inline walk-in customer; only honored for manual bookers (#589 1c).
+  walkInCustomer?: { name: string; phone: string }
+}
+
+// The booking command's resolved actor: who the booking is for, its source, and
+// (when applicable) the walk-in to create. renterId is always concrete here.
+export interface ResolvedBookingActor {
+  renterId: string
+  source: Booking['source']
+  walkInCustomer?: { name: string; phone: string }
+}
+
+/**
+ * #1108 (audit M4): "who may book on behalf of whom, and force source=MANUAL" is
+ * domain authz, not a route concern (SRP — a route may *reject* on role, but the
+ * moment it *rewrites the payload* on role, that belongs to the service). Pure
+ * and Hono-free so it is unit-testable in isolation; `BookingCreationService.create`
+ * calls it and trusts the result.
+ *
+ * #589: STAFF and OPERATOR_* are "manual bookers" — they may book on behalf of a
+ * renter (renterId) and set source=MANUAL. An operator's renterId is authorized
+ * downstream against its OWN customer scope (scope-first, no user-table probe —
+ * preserving the #396/#475 enumeration defense). Everyone else (renters,
+ * api-key PARTNER callers) books as themselves with source forced to DIRECT, so
+ * a non-manual caller can't bypass advance-booking-hours via MANUAL nor register
+ * a walk-in (#589 1c).
+ */
+export function resolveBookingActor(
+  ctx: Pick<CallerContext, 'userId' | 'role'>,
+  request: BookingActorRequest,
+): ResolvedBookingActor {
+  const isManualBooker = STAFF_ROLES.has(ctx.role) || isOperatorRole(ctx.role)
+  const renterId = isManualBooker && request.renterId ? request.renterId : ctx.userId
+  const source = isManualBooker ? request.source : 'DIRECT'
+  const walkInCustomer = isManualBooker ? request.walkInCustomer : undefined
+  // Omit walkInCustomer entirely when absent (exactOptionalPropertyTypes forbids
+  // an explicit `walkInCustomer: undefined`).
+  return walkInCustomer ? { renterId, source, walkInCustomer } : { renterId, source }
+}

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -13,11 +13,13 @@ import type {
   UserRepository,
 } from '../repositories/types'
 import type { Location, Vehicle } from '../stores'
+import { resolveBookingActor } from './booking-actor'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
 import { MS_PER_MINUTE, composeBookingTotal, rentalDays } from './booking-pricing-helpers'
 import type {
   BookingVerificationGate,
   CreateBookingInput,
+  CreateBookingRequest,
   CreateBookingResult,
 } from './booking-types'
 
@@ -58,9 +60,26 @@ export class BookingCreationService {
 
   async create(
     ctx: CallerContext,
-    input: CreateBookingInput,
+    rawInput: CreateBookingRequest,
     now: Date = new Date(),
   ): Promise<CreateBookingResult> {
+    // #1108 (audit M4): resolve the actor (renter / source / walk-in) from the
+    // caller's role HERE — the route forwards raw input and no longer rewrites it.
+    // The normalized command carries the resolved trio; every read past this
+    // point (renter scope authz, verification gate, submitInTx) sees it. A renter
+    // who supplied a walkInCustomer has it dropped (only manual bookers may
+    // register one), so strip it before re-attaching the resolved value.
+    const actor = resolveBookingActor(ctx, rawInput)
+    const { walkInCustomer: _rawWalkIn, ...rawRest } = rawInput
+    const input: CreateBookingInput = actor.walkInCustomer
+      ? {
+          ...rawRest,
+          renterId: actor.renterId,
+          source: actor.source,
+          walkInCustomer: actor.walkInCustomer,
+        }
+      : { ...rawRest, renterId: actor.renterId, source: actor.source }
+
     // Resolve the booking's renter (#314, #589). Three cases:
     //  - WALK-IN (1c): the operator registers a brand-new customer inline.
     //    createWalkInRenter ALWAYS makes a fresh renter (never deduped by phone),

--- a/packages/api/src/services/booking-types.ts
+++ b/packages/api/src/services/booking-types.ts
@@ -13,10 +13,10 @@ interface CreateBookingCommon {
   // Selected paid add-on ids (#460). Required at the service boundary (the
   // validator defaults it to []); the route forwards parsed.data.addOnIds.
   addOnIds: string[]
-  // The booking's renter — the route always fills it: the authenticated caller for
-  // a self-serve booking, or a target renter for a staff/operator manual booking.
-  // For a walk-in (#589 1c) it is ignored: walkInCustomer takes over and the
-  // service creates + uses a fresh renter instead.
+  // The booking's RESOLVED renter — resolveBookingActor (#1108) has already
+  // derived it: the authenticated caller for self-serve, or a target renter for a
+  // staff/operator manual booking. For a walk-in (#589 1c) it is ignored:
+  // walkInCustomer takes over and the service mints a fresh renter.
   renterId: string
   // #589 1c: operator walk-in — create a fresh renter (name + phone, no email)
   // and book for them. The service resolves this to the concrete renterId it uses.
@@ -42,6 +42,22 @@ interface CreateBookingCommon {
 export type CreateBookingInput =
   | (CreateBookingCommon & { fulfillmentMode: 'SPECIFIC'; requestedVehicleId: string })
   | (CreateBookingCommon & { fulfillmentMode: 'CLASS_COMBO'; classId: string })
+
+// The RAW request from the route (#1108 audit M4). Identical to CreateBookingInput
+// except renterId is optional: the route forwards parsed.data untouched (a
+// self-serve caller omits renterId) and BookingCreationService.create resolves the
+// actor via resolveBookingActor before building the concrete CreateBookingInput.
+export type CreateBookingRequest =
+  | (Omit<CreateBookingCommon, 'renterId'> & {
+      renterId?: string
+      fulfillmentMode: 'SPECIFIC'
+      requestedVehicleId: string
+    })
+  | (Omit<CreateBookingCommon, 'renterId'> & {
+      renterId?: string
+      fulfillmentMode: 'CLASS_COMBO'
+      classId: string
+    })
 
 export type CreateBookingResult =
   | { ok: true; booking: Booking; status?: 200 }

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -19,7 +19,7 @@ import { BookingQueryService, type BookingWithOperator } from './booking-query'
 import type {
   BookingVerificationGate,
   CancelResult,
-  CreateBookingInput,
+  CreateBookingRequest,
   CreateBookingResult,
   StatusTransitionResult,
   SubstituteResult,
@@ -33,6 +33,7 @@ export type {
   BookingVerificationGate,
   CancelResult,
   CreateBookingInput,
+  CreateBookingRequest,
   CreateBookingResult,
   StatusTransitionResult,
   SubstituteResult,
@@ -158,7 +159,7 @@ export class BookingService {
 
   create(
     ctx: CallerContext,
-    input: CreateBookingInput,
+    input: CreateBookingRequest,
     now: Date = new Date(),
   ): Promise<CreateBookingResult> {
     return this.creation.create(ctx, input, now)


### PR DESCRIPTION
## Problem
`POST /bookings` reshaped the create command by role **inside the handler** — computing `isManualBooker`, then overriding `renterId`/`source`/`walkInCustomer`. Audit finding **M4** (SRP — Business Logic in Route Handler): "who may book on behalf of whom and force `source=MANUAL`" is domain authz, not reusable and not unit-testable outside Hono.

## Change
- **New pure policy** `services/booking-actor.ts` → `resolveBookingActor(ctx, request)` derives `{ renterId, source, walkInCustomer }` from caller role + raw request, **verbatim** from the old route logic. Callable with a plain `ctx` (no Hono `Context`).
- **Boundary type split**: `CreateBookingRequest` (raw — `renterId` optional) is what the route forwards; `CreateBookingInput` (resolved — `renterId: string`) stays the service command, so the verification gate / `submitInTx` / booking row are **untouched**. `BookingCreationService.create` resolves the actor first, then builds the normalized command every downstream read already consumes.
- **Route shrinks** to: parse → `service.create(ctx, rawInput)` → map. It still **rejects** on role (disclaimer + consent gates) but no longer **rewrites** the payload. `STAFF_ROLES` import dropped from the route.

## Tests (TDD, RED-first)
`booking-actor.test.ts` unit-tests the policy with exact field assertions: renter (forces DIRECT, ignores supplied renterId, drops walk-in), PARTNER (forces DIRECT), operator + platform-admin (keep source/renterId), walk-in passthrough + caller-id fallback.

## Verification
- Behavior unchanged end-to-end: 222 booking/route/manual-booking/operator-isolation tests green.
- Aggregate `bun run test`: shared 778 / api 2084 / web 1330.
- tsc ×3 + biome + `lint:boundaries` clean. **No migration.**

⚠️ Sibling **#1109** also refactors `booking-creation.ts` (submit snapshot+insert tail) — coordinate to avoid a conflict.

Closes #1108