### PR TITLE
feat(#1161): gate post-MVP features behind admin-bypass for beta

### DIFF
--- a/docs/plans/2026-06-26-mvp-feature-gating-design.md
+++ b/docs/plans/2026-06-26-mvp-feature-gating-design.md
@@ -1,0 +1,147 @@
+# MVP Feature Gating — "release only the agreed MVP to beta; owner previews everything"
+
+- **Date:** 2026-06-26
+- **Status:** Proposed (design only — no code yet)
+- **Owner decision captured:** single-beta + admin-bypass; hide **in-app messaging** and **operator scheduled blocks**
+- **Relates to:** Epic #385 (marketplace MVP), `docs/plans/2026-05-25-marketplace-mvp-proposal.md` (scope source of truth), `packages/web/src/vite/config/features.ts` (existing flag system)
+
+---
+
+## 1. Problem
+
+`develop` is **58 commits ahead of beta** and has accumulated features beyond the contracted MVP (in-app messaging, class-deal search, platform-admin console, operator scheduled blocks, payment-anomaly review, …). We want to promote `develop → beta` to ship the MVP, **without exposing beyond-MVP features to renters and operators**, while the **owner can still preview every feature on the live beta site** to evaluate it.
+
+Two needs, one deployment:
+1. **Public beta** shows only the agreed MVP.
+2. **Owner** sees all features — on the same live beta URL, not a separate build.
+
+## 2. Decision
+
+**Single beta deployment + admin bypass.** Each post-MVP feature is hidden behind a build-time flag (OFF in beta), with one exception: a viewer whose role is `PLATFORM_ADMIN` always sees it. The owner logs into beta as a platform admin and sees everything; everyone else sees the MVP.
+
+Rejected alternative — **two builds / preview URL** (beta build strips post-MVP code; owner previews on localhost or a separate preview deploy). Cleaner bundle and no role logic, but the owner would preview on a *different URL* than real beta with different data. The owner explicitly wants to evaluate on live beta, so admin-bypass wins. Trade-off accepted: post-MVP JS still ships in the public bundle (gated, not tree-shaken out) — negligible for a beta demo.
+
+### 2.1 This is a product-visibility gate, NOT a security boundary
+
+The gate hides **UI entry points** (nav links, routes). It does **not** harden the API. The messaging endpoints stay authorized per-participant/role on the server exactly as today; a curious user who calls the API directly is still bound by that authz. We are choosing what to *advertise*, not adding an access-control layer. (Mirrors the existing Navbar invariant: "view state is not authorization state.") If a feature ever needs to be *forbidden* (not just hidden) in beta, that is a separate API-side change and out of scope here.
+
+## 3. The MVP cut line (this revision)
+
+| Recently-merged feature | Beta visibility | Mechanism |
+|---|---|---|
+| In-app renter↔operator **messaging** | **Hidden** (owner-only) | `VITE_FEATURE_MESSAGING` + admin bypass |
+| Operator **scheduled vehicle blocks** | **Hidden** (owner-only) | `VITE_FEATURE_OPERATOR_BLOCKS` + admin bypass — *backend-only today; UI born gated when built* |
+| Class-deal (CLASS_COMBO) **search cards** | **Not visible in default beta** — *not additionally gated here* | Governed by the existing `VITE_SEARCH_MAP_ENABLED` flag, not this design. See §3.1. |
+| Operator **assign vehicle to combo float** | Visible | — (in MVP; operator bookings calendar, not flag-gated) |
+| **Platform-admin console** (`/admin/*`) | Owner-only already | Existing `PLATFORM_ADMIN` role gate (`_admin.tsx`) — no change |
+| Cancellation, operator team/settings, renter documents | Already gated OFF | Existing `VITE_FEATURE_*` flags (`features.ts`) — no change |
+
+The table is the single place to read "what beta shows." Adding/removing a row is the whole change for a future cut-line tweak.
+
+### 3.1 Class-combo cards are governed by the search-map flag, not this design
+
+This design hides exactly **two** features (messaging, scheduled blocks). It does **not** touch class-combo card visibility — but "Visible" would be misleading, because class-combo cards only render inside the unified **map+list** results view, and `isSearchMapEnabled()` (`vite/search/flags.ts`) is the *single source of truth* for which results view mounts: ON → map+list (renders `SearchResultRow` → `ComboRow`), OFF → store grid (no `ComboRow`). Default beta sets no `VITE_SEARCH_MAP_ENABLED`, so it ships the **store grid** and class-combo cards do **not** appear — regardless of this design.
+
+Consequence: the cut line "only messaging + scheduled blocks hidden" is accurate *for the entry points this design owns*. Class-combo's beta visibility is inherited from the search-map flag and is **off by default**. To actually surface class-combo cards in beta, the owner would separately set `VITE_SEARCH_MAP_ENABLED=true` at build — a distinct decision that also turns on the whole premium map+list view (superseding the #885 post-MVP framing). That decision is **out of scope here** and is not assumed.
+
+## 4. Mechanism
+
+Two orthogonal axes, combined by one helper:
+
+- **Build-time flag** — *does this build include the feature?* Existing strict-string pattern in `features.ts` (`value === 'true'`, fail-safe OFF). Beta sets none → all post-MVP flags OFF.
+- **Runtime role** — *can this viewer preview it anyway?* `isPlatformAdmin(role)` from `@/lib/platform-roles` (re-exports `PLATFORM_ROLES` from `@kuruma/shared/auth/roles`; pure data, Edge-safe).
+
+```ts
+// packages/web/src/vite/config/features.ts  — additions (mirror isRenterDocumentsEnabled)
+export function isMessagingEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_MESSAGING)
+}
+export function isOperatorBlocksEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_BLOCKS)
+}
+
+// packages/web/src/vite/config/feature-visibility.ts  — NEW: the admin-bypass rule, one place
+import { isPlatformAdmin } from '@/lib/platform-roles'
+
+/**
+ * A post-MVP feature is hidden in beta (flag OFF) but always visible to the
+ * platform admin so the owner can preview it on the live site. Visibility only —
+ * the API still enforces its own authorization (see design §2.1).
+ */
+export function isVisibleToViewer(flagEnabled: boolean, role: string | undefined): boolean {
+  return flagEnabled || isPlatformAdmin(role)
+}
+```
+
+### 4.1 Application points (messaging — the only post-MVP UI live today)
+
+- **Nav link** — `packages/web/src/vite/nav/Navbar.tsx:40`. Today `renterNavItems` is built **only when `role === 'RENTER'`**, so a naive "wrap the Messages item" would still hide it from a `PLATFORM_ADMIN` owner (the admin isn't a RENTER, so the whole list is empty). The fix is to **split the renter-view items by their real gate**, not lump them under `isRenter`:
+  - `My Bookings` → **stays renter-only** (`isRenter`) — personal "my data"; an admin/operator in renter view must not see it (view state ≠ authorization, per the existing Navbar invariant).
+  - `Messages` → gated by **`isVisibleToViewer(isMessagingEnabled(), role)`**, independent of `isRenter`, so the admin-bypass actually lands. It renders in the **renter-view** nav list, so the owner previews Messages by being in renter view.
+  - `Documents` → unchanged, stays behind `isRenterDocumentsEnabled()` (and renter-only).
+
+  Sketch:
+  ```ts
+  const isRenter = role === 'RENTER'
+  const showMessages = isVisibleToViewer(isMessagingEnabled(), role)
+  const renterNavItems: NavItem[] = [
+    ...(isRenter ? [{ to: '/$locale/bookings', label: t('myBookings') }] : []),
+    ...(showMessages ? [{ to: '/$locale/messages', label: t('messages'), ...badge }] : []),
+    ...(isRenterDocumentsEnabled() && isRenter ? [{ to: '/$locale/documents', label: t('documents') }] : []),
+  ]
+  ```
+  `MobileMenu` renders Navbar's already-filtered `navItems`, so it is covered by this one edit. The `useUnreadBadge` hook stays called unconditionally with `enabled: isRenter` (hooks rule; the admin is not a thread participant, so no count — the link shows without a badge).
+- **Route guard** — `packages/web/src/routes/$locale/_renter/messages.tsx`. Add a `beforeLoad` that reads the session via `ensureQueryData(sessionQueryOptions())` and `throw redirect({ to: '/$locale' })` unless `isVisibleToViewer(isMessagingEnabled(), session?.user.role)`. This blocks direct-URL access, not just the nav entry. Pattern mirrors `routes/$locale/_admin.tsx`.
+
+### 4.2 Scheduled blocks
+
+Backend-only today (#1101 shipped table/repo/availability/routes; no web UI). We reserve `VITE_FEATURE_OPERATOR_BLOCKS` + its env type now so that whatever operator UI lands is *born* behind `isVisibleToViewer(...)`. No entry point to gate yet → no further work this slice.
+
+### 4.3 Env type declaration
+
+`packages/web/src/vite/vite-env.d.ts` — add `readonly VITE_FEATURE_MESSAGING?: string` and `readonly VITE_FEATURE_OPERATOR_BLOCKS?: string` to the `ImportMetaEnv` interface, matching the existing `VITE_FEATURE_*` entries.
+
+## 5. Why beta hides these with zero deploy/CI change
+
+Flags fail-safe to OFF and `deploy.yml`'s "Build web" step bakes **no** `VITE_FEATURE_*` var (only Sentry placeholders). So a build with no env override → `isMessagingEnabled() === false` → hidden for every non-admin. Nothing to change in `deploy.yml`, `ci.yml`, or wrangler config. A future "full/paid" build opts a feature in by baking the matching var to `'true'`, exactly like the existing flags.
+
+## 6. Prerequisite for the owner to preview on beta
+
+Admin-bypass needs the owner's beta session to carry `role === 'PLATFORM_ADMIN'`. The deploy pipeline never seeds, so this is a one-time DB action against the beta database. The bootstrap that promotes the allowlist lives in `packages/shared/src/db/seed.ts:119` (the `db:seed` CLI entry point is `scripts/seed.ts`):
+
+- `PLATFORM_ADMIN_EMAILS=<owner-email> DATABASE_URL=<beta> bun run db:seed` (idempotent upsert), **or**
+- `UPDATE users SET role='PLATFORM_ADMIN', "operatorId"=NULL WHERE email='<owner-email>'`.
+
+Without this, the bypass has no one to bypass for and beta shows MVP-only to everyone, including the owner.
+
+## 7. Extensibility — adding the next post-MVP feature to the gate
+
+1. Add `isFeatureXEnabled()` to `features.ts` (one line).
+2. Add `readonly VITE_FEATURE_X?: string` to `vite-env.d.ts`.
+3. Wrap the feature's nav item / route `beforeLoad` in `isVisibleToViewer(isFeatureXEnabled(), role)`.
+4. Add the row to the §3 table.
+
+No new abstraction per feature — the visibility rule lives in exactly one function.
+
+## 8. Testing (TDD, mutation-resistant)
+
+- **Unit** — `isVisibleToViewer` truth table: `(false, 'RENTER') → false`, `(false, 'PLATFORM_ADMIN') → true`, `(false, 'OPERATOR_OWNER') → false`, `(false, undefined) → false`, `(true, 'RENTER') → true`.
+- **Component** — Navbar: with the flag OFF, a `PLATFORM_ADMIN` session renders the "Messages" link; a `RENTER` session does not. With the flag ON, `RENTER` does. **Set `kuruma-view=renter` in the admin test** — Messages lives in the renter-view nav, so the admin must be in renter view to see it (otherwise the test is asserting the wrong view, and we are *not* adding Messages to the business nav). Also assert `My Bookings` is **absent** for the admin (it stays renter-only — this is what proves we split the items rather than ungating the whole renter list).
+- **Route guard** — `/messages` `beforeLoad` redirects a `RENTER` to `/$locale` when the flag is OFF, and admits a `PLATFORM_ADMIN`.
+
+## 9. Out of scope
+
+- API-side enforcement / forbidding endpoints (§2.1) — visibility only.
+- Tree-shaking post-MVP code out of the public bundle (that is the rejected two-build approach).
+- The `develop → beta` promotion PR itself (separate, owner's call) and the beta admin-seed action (§6, operational).
+- Per-operator or per-renter feature flags (YAGNI — owner-only preview is the requirement).
+
+## 10. Vertical slice / PR
+
+One slice, ~6 files: `features.ts`, new `feature-visibility.ts`, `vite-env.d.ts`, `Navbar.tsx`, `messages.tsx`, tests. Branch `feat/mvp-gate-messaging`, worktree `../kuruma-mvp-gate`, PR body `Refs #385, #1161`. Beta is unaffected until the next promotion.
+
+## 11. Principles
+
+- **Functional Core / Imperative Shell** — `isVisibleToViewer` is a pure decision; the Navbar/route shells just consume it.
+- **Open/Closed** — a new gated feature adds a row + a one-line flag, never edits the rule.
+- **Single source of truth** — the §3 table is the human-readable cut line; `isVisibleToViewer` is the one machine rule. No drift between "what we say beta shows" and "what the code shows."

--- a/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
@@ -1,0 +1,41 @@
+import { isRedirect } from '@tanstack/react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './messages'
+
+// Invoke the route's beforeLoad directly with a minimal stubbed context to prove the
+// wiring (design §4.1 / §8): the guard reads the session, runs the admin-bypass rule,
+// and redirects home when messaging is hidden. The decision itself is unit-tested in
+// feature-visibility.test.ts; this asserts the route is wired to it correctly.
+function runGuard(role: string | undefined): Promise<unknown> {
+  const session = role ? { user: { role } } : null
+  const context = { queryClient: { ensureQueryData: async () => session } }
+  // Minimal stub — the real beforeLoad arg carries more, but the guard only touches these.
+  return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
+    context,
+    params: { locale: 'en' },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('messages route guard (admin bypass)', () => {
+  it('redirects a renter home when messaging is hidden in beta', async () => {
+    try {
+      await runGuard('RENTER')
+      expect.unreachable('guard should have redirected the renter')
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true)
+    }
+  })
+
+  it('admits the platform admin so the owner can preview on beta', async () => {
+    await expect(runGuard('PLATFORM_ADMIN')).resolves.toBeUndefined()
+  })
+
+  it('admits a renter once the messaging flag is on', async () => {
+    vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
+    await expect(runGuard('RENTER')).resolves.toBeUndefined()
+  })
+})

--- a/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
@@ -30,6 +30,15 @@ describe('messages route guard (admin bypass)', () => {
     }
   })
 
+  it('redirects a signed-out viewer (undefined role) home — fails safe, no bypass', async () => {
+    try {
+      await runGuard(undefined)
+      expect.unreachable('guard should have redirected the signed-out viewer')
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true)
+    }
+  })
+
   it('admits the platform admin so the owner can preview on beta', async () => {
     await expect(runGuard('PLATFORM_ADMIN')).resolves.toBeUndefined()
   })

--- a/packages/web/src/routes/$locale/_renter/messages.tsx
+++ b/packages/web/src/routes/$locale/_renter/messages.tsx
@@ -1,8 +1,20 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { isMessagingEnabled, isVisibleToViewer } from '@/vite/config'
+import { sessionQueryOptions } from '@/vite/session'
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
-// Layout for everything under `/<locale>/messages` (#1032). The renter guard
-// lives on the parent `_renter` route; `/messages` renders the inbox index child
-// and `/messages/$threadId` the conversation view.
+// Layout for everything under `/<locale>/messages` (#1032). The renter guard lives on
+// the parent `_renter` route; this adds the post-MVP visibility gate: messaging is
+// hidden in beta, so a viewer who can't see it is redirected home even if they type
+// the URL (the nav entry is already hidden by renter-nav-items). The platform admin
+// passes (owner preview); a renter is sent home while the flag is OFF. Mirrors the
+// redirect pattern in `_admin.tsx`. Visibility only — the messaging API still enforces
+// its own per-participant access (design §2.1).
 export const Route = createFileRoute('/$locale/_renter/messages')({
+  beforeLoad: async ({ context, params }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
+    if (!isVisibleToViewer(isMessagingEnabled(), session?.user?.role)) {
+      throw redirect({ to: '/$locale', params: { locale: params.locale } })
+    }
+  },
   component: Outlet,
 })

--- a/packages/web/src/vite/config/feature-visibility.test.ts
+++ b/packages/web/src/vite/config/feature-visibility.test.ts
@@ -1,0 +1,33 @@
+import type { UserRole } from '@kuruma/shared/auth/roles'
+import { describe, expect, it } from 'vitest'
+import { isVisibleToViewer } from './feature-visibility'
+
+// Truth table for the admin-bypass visibility rule (design §4): a post-MVP feature
+// is hidden in beta (flag OFF) but always visible to the platform admin so the
+// owner can preview it on the live site. Roles are real members/non-members of the
+// shared PLATFORM_ROLES set; literals keep the table readable.
+const RENTER: UserRole = 'RENTER'
+const PLATFORM_ADMIN: UserRole = 'PLATFORM_ADMIN'
+const OPERATOR: UserRole = 'OPERATOR_OWNER'
+
+describe('isVisibleToViewer', () => {
+  it('hides a flagged-off feature from a renter', () => {
+    expect(isVisibleToViewer(false, RENTER)).toBe(false)
+  })
+
+  it('shows a flagged-off feature to the platform admin (owner preview bypass)', () => {
+    expect(isVisibleToViewer(false, PLATFORM_ADMIN)).toBe(true)
+  })
+
+  it('hides a flagged-off feature from an operator (bypass is platform-admin only)', () => {
+    expect(isVisibleToViewer(false, OPERATOR)).toBe(false)
+  })
+
+  it('hides a flagged-off feature from a signed-out viewer (undefined role)', () => {
+    expect(isVisibleToViewer(false, undefined)).toBe(false)
+  })
+
+  it('shows a flagged-on feature to everyone, including a renter', () => {
+    expect(isVisibleToViewer(true, RENTER)).toBe(true)
+  })
+})

--- a/packages/web/src/vite/config/feature-visibility.ts
+++ b/packages/web/src/vite/config/feature-visibility.ts
@@ -1,0 +1,18 @@
+import { isPlatformAdmin } from '@/lib/platform-roles'
+import type { UserRole } from '@kuruma/shared/auth/roles'
+
+/**
+ * Visibility rule for post-MVP features
+ * (design: docs/plans/2026-06-26-mvp-feature-gating-design.md §4).
+ *
+ * A feature whose build-time flag is OFF is hidden in beta — EXCEPT for the
+ * platform admin, who always sees it so the owner can preview every feature on the
+ * live beta site without a separate build. One deployment, two audiences.
+ *
+ * Visibility ONLY — this is NOT an authorization boundary. The API still enforces
+ * its own per-participant / per-role access; this just decides what the UI
+ * advertises (design §2.1). Never use it to guard a write or a money path.
+ */
+export function isVisibleToViewer(flagEnabled: boolean, role: UserRole | undefined): boolean {
+  return flagEnabled || isPlatformAdmin(role)
+}

--- a/packages/web/src/vite/config/features.ts
+++ b/packages/web/src/vite/config/features.ts
@@ -38,3 +38,16 @@ export function isOperatorSettingsEnabled(): boolean {
 export function isRenterDocumentsEnabled(): boolean {
   return isEnabled(import.meta.env.VITE_FEATURE_RENTER_DOCUMENTS)
 }
+
+/** In-app renter<->operator messaging (#1032). Hidden in beta; owner previews via admin bypass. */
+export function isMessagingEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_MESSAGING)
+}
+
+/**
+ * Operator scheduled vehicle blocks (#1101). Backend-only today; reserved so the
+ * operator UI is born gated when it lands. Hidden in beta; owner previews via bypass.
+ */
+export function isOperatorBlocksEnabled(): boolean {
+  return isEnabled(import.meta.env.VITE_FEATURE_OPERATOR_BLOCKS)
+}

--- a/packages/web/src/vite/config/index.ts
+++ b/packages/web/src/vite/config/index.ts
@@ -1,0 +1,5 @@
+// Barrel for the build-time config feature: post-MVP feature flags and the
+// admin-bypass visibility rule. Import these via `@/vite/config` (not the internal
+// files) so cross-feature consumers go through the barrel — see docs/architecture/modules.md.
+export * from './features'
+export * from './feature-visibility'

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -1,12 +1,12 @@
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { isRenterDocumentsEnabled } from '@/vite/config/features'
 import { useUnreadBadge } from '@/vite/messaging/unread-badge'
 import { LocaleSwitcher } from '@/vite/nav/LocaleSwitcher'
 import { MobileMenu, type NavItem } from '@/vite/nav/MobileMenu'
 import { NavBadge } from '@/vite/nav/NavBadge'
 import { NavbarClient } from '@/vite/nav/NavbarClient'
 import { visibleBusinessNavItems } from '@/vite/nav/business-nav-items'
+import { visibleRenterNavItems } from '@/vite/nav/renter-nav-items'
 import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import { useSession } from '@/vite/session'
 import { getViewMode, isBusiness } from '@/vite/view-mode'
@@ -15,10 +15,12 @@ import { Car } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 // Client navbar (the SPA reads the session via useSession, not server auth()).
-// Renter nav (#543): Browse is public (any renter-view session); My Bookings and
-// Documents are personal "my data" pages, so they are gated on the actual RENTER
-// role — NOT viewMode. An operator who switches to renter view must not see them,
-// or they would drift to tenant data (view state is not authorization state).
+// Renter nav (#543): Browse is public (any renter-view session). My Bookings and
+// Documents are personal "my data" pages gated on the actual RENTER role; Messages
+// is a post-MVP feature gated by the admin-bypass rule (hidden in beta, shown to the
+// platform admin for owner preview). That per-item split lives in renter-nav-items.ts
+// so the gating is unit-tested without rendering. View state is not authorization
+// state — an operator in renter view sees neither My Bookings nor Documents.
 export function Navbar() {
   const { data: session } = useSession()
   const t = useTranslations('nav')
@@ -37,28 +39,6 @@ export function Navbar() {
   // unlike the operator badge); only scanned in renter view.
   const { count: unreadMessages } = useUnreadBadge({ userId: session?.user?.id, enabled: isRenter })
 
-  const renterNavItems: readonly NavItem[] = isRenter
-    ? [
-        { to: '/$locale/bookings', label: t('myBookings') },
-        {
-          to: '/$locale/messages',
-          label: t('messages'),
-          // exactOptionalPropertyTypes: only attach the badge when there is one.
-          ...(unreadMessages > 0
-            ? {
-                badge: unreadMessages,
-                badgeLabel: t('unreadMessages', { count: unreadMessages }),
-              }
-            : {}),
-        },
-        // Documents (IDP upload, #459) is gated OFF for the beta demo: the
-        // instant-book flow no longer requires it. See vite/config/features.ts.
-        ...(isRenterDocumentsEnabled()
-          ? [{ to: '/$locale/documents' as const, label: t('documents') }]
-          : []),
-      ]
-    : []
-
   const navItems: readonly NavItem[] = isBusinessView
     ? visibleBusinessNavItems().map((item) => ({
         to: item.to,
@@ -69,7 +49,20 @@ export function Navbar() {
           : {}),
       }))
     : session?.user
-      ? [{ to: '/$locale/search', label: t('browse') }, ...renterNavItems]
+      ? [
+          { to: '/$locale/search', label: t('browse') },
+          ...visibleRenterNavItems(role).map((item) => ({
+            to: item.to,
+            label: t(item.labelKey),
+            // exactOptionalPropertyTypes: only attach the badge when there is one.
+            ...(item.to === '/$locale/messages' && unreadMessages > 0
+              ? {
+                  badge: unreadMessages,
+                  badgeLabel: t('unreadMessages', { count: unreadMessages }),
+                }
+              : {}),
+          })),
+        ]
       : []
 
   return (

--- a/packages/web/src/vite/nav/renter-nav-items.test.ts
+++ b/packages/web/src/vite/nav/renter-nav-items.test.ts
@@ -31,4 +31,14 @@ describe('visibleRenterNavItems', () => {
     vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
     expect(tos('RENTER')).toEqual(['/$locale/bookings', '/$locale/messages'])
   })
+
+  it('shows a renter Documents once the documents flag is on (gated on the real renter role)', () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
+    expect(tos('RENTER')).toEqual(['/$locale/bookings', '/$locale/documents'])
+  })
+
+  it('keeps Documents hidden from the admin even with the flag on — no bypass, it is renter-only "my data" (Messages still shows via bypass)', () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
+    expect(tos('PLATFORM_ADMIN')).toEqual(['/$locale/messages'])
+  })
 })

--- a/packages/web/src/vite/nav/renter-nav-items.test.ts
+++ b/packages/web/src/vite/nav/renter-nav-items.test.ts
@@ -1,0 +1,34 @@
+import type { UserRole } from '@kuruma/shared/auth/roles'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { visibleRenterNavItems } from './renter-nav-items'
+
+// `to` literals in render order, for compact truth-table assertions.
+const tos = (role: UserRole | undefined): readonly string[] =>
+  visibleRenterNavItems(role).map((item) => item.to)
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('visibleRenterNavItems', () => {
+  it('shows a renter only My Bookings in beta (messaging + documents flags off)', () => {
+    expect(tos('RENTER')).toEqual(['/$locale/bookings'])
+  })
+
+  it('shows the platform admin Messages but NOT My Bookings — bypass is visibility, My Bookings stays renter-only', () => {
+    expect(tos('PLATFORM_ADMIN')).toEqual(['/$locale/messages'])
+  })
+
+  it('hides every renter item from an operator in renter view (not a renter, not the admin, flags off)', () => {
+    expect(tos('OPERATOR_OWNER')).toEqual([])
+  })
+
+  it('hides every renter item from a signed-out viewer (undefined role)', () => {
+    expect(tos(undefined)).toEqual([])
+  })
+
+  it('shows a renter Messages once the messaging flag is on', () => {
+    vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
+    expect(tos('RENTER')).toEqual(['/$locale/bookings', '/$locale/messages'])
+  })
+})

--- a/packages/web/src/vite/nav/renter-nav-items.ts
+++ b/packages/web/src/vite/nav/renter-nav-items.ts
@@ -1,0 +1,36 @@
+import { isMessagingEnabled, isRenterDocumentsEnabled, isVisibleToViewer } from '@/vite/config'
+import type { UserRole } from '@kuruma/shared/auth/roles'
+
+// Single source of truth for the renter-view nav (#543), mirroring
+// business-nav-items.ts: Navbar builds the desktop list from this and passes it to
+// MobileMenu, so the desktop array and the mobile union can never drift.
+// `labelKey` is a key under the `nav` i18n namespace; the caller resolves it with
+// useTranslations('nav'). `to` values are real TanStack route literals so the typed
+// <Link> compiles.
+export const renterNavItems = [
+  { to: '/$locale/bookings', labelKey: 'myBookings' },
+  { to: '/$locale/messages', labelKey: 'messages' },
+  { to: '/$locale/documents', labelKey: 'documents' },
+] as const
+
+// Derived so the union can never drift from the array above.
+export type RenterNavTo = (typeof renterNavItems)[number]['to']
+
+// Per-item visibility (design: docs/plans/2026-06-26-mvp-feature-gating-design.md §4.1).
+// My Bookings and Documents are personal "my data" pages, gated on the REAL renter
+// role — an operator/admin in renter view must not see them (view state is not
+// authorization state). Messages is a post-MVP feature hidden in beta but shown to
+// the platform admin so the owner can preview it (admin bypass), so it is gated by
+// isVisibleToViewer and is deliberately NOT coupled to isRenter. Documents also needs
+// its own build-time flag (#459, OFF in beta).
+export function visibleRenterNavItems(
+  role: UserRole | undefined,
+): readonly (typeof renterNavItems)[number][] {
+  const isRenter = role === 'RENTER'
+  const gates: Record<RenterNavTo, boolean> = {
+    '/$locale/bookings': isRenter,
+    '/$locale/messages': isVisibleToViewer(isMessagingEnabled(), role),
+    '/$locale/documents': isRenter && isRenterDocumentsEnabled(),
+  }
+  return renterNavItems.filter((item) => gates[item.to])
+}

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -15,6 +15,8 @@ interface ImportMetaEnv {
   readonly VITE_FEATURE_OPERATOR_TEAM?: string
   readonly VITE_FEATURE_OPERATOR_SETTINGS?: string
   readonly VITE_FEATURE_RENTER_DOCUMENTS?: string
+  readonly VITE_FEATURE_MESSAGING?: string
+  readonly VITE_FEATURE_OPERATOR_BLOCKS?: string
   // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
   // injected by CI at build time; environment defaults to 'production'.
   readonly VITE_SENTRY_DSN?: string

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -72,6 +72,10 @@ const renter: Session = {
   user: { id: 'u2', role: 'RENTER', name: 'Ben', email: 'ben@example.com' },
   csrfToken: 'csrf-2',
 }
+const platformAdmin: Session = {
+  user: { id: 'u3', role: 'PLATFORM_ADMIN', name: 'Owner', email: 'owner@example.com' },
+  csrfToken: 'csrf-3',
+}
 
 function renderNavbar(data: Session | undefined) {
   mockUseSession.mockReturnValue({ data } as unknown as ReturnType<typeof useSession>)
@@ -191,9 +195,10 @@ describe('Navbar', () => {
   it('shows Browse, My Bookings, and Documents (no business markers) for a signed-in renter', () => {
     // Even with a non-zero count, the operator badge is gated to business view.
     mockUseBadge.mockReturnValue({ count: 5 })
-    // Documents is a post-MVP add-on gated behind a flag; enable it so this
-    // "full renter nav" assertion sees it (the OFF case is its own test below).
+    // Documents and Messages are post-MVP add-ons gated behind flags; enable both so
+    // this "full renter nav" assertion sees them (the beta-OFF case is its own test).
     vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
+    vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
     const { container } = renderNavbar(renter)
     expect(screen.getByText('Browse').closest('a')).toHaveAttribute('data-to', '/$locale/search')
     expect(screen.getByText('My Bookings').closest('a')).toHaveAttribute(
@@ -220,18 +225,23 @@ describe('Navbar', () => {
     expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '4')
   })
 
-  it('hides Documents in the beta MVP demo (renter-documents flag off)', () => {
+  it('hides Documents and Messages for a renter in the beta MVP demo (both post-MVP flags off)', () => {
     renderNavbar(renter)
     expect(screen.getByText('Browse')).toBeInTheDocument()
     expect(screen.getByText('My Bookings')).toBeInTheDocument()
-    // Messages stays — it is not gated behind the documents flag (#1032).
-    expect(screen.getByText('Messages')).toBeInTheDocument()
-    // The orphaned IDP-upload page is filtered out — Browse + My Bookings + Messages.
+    // Beta ships both add-ons OFF: the orphaned IDP-upload page (#459) and in-app
+    // messaging (#1032) are filtered out for a renter. Only the owner (PLATFORM_ADMIN)
+    // sees Messages, via the admin bypass — its own test below.
     expect(screen.queryByText('Documents')).toBeNull()
-    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '3')
+    expect(screen.queryByText('Messages')).toBeNull()
+    // Browse + My Bookings only.
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '2')
   })
 
   it('rides the unread-message count onto the Messages item as a red dot (#1032)', () => {
+    // Messaging is a post-MVP add-on; enable it so the renter sees the Messages item
+    // and its unread badge (hidden in default beta — see the beta-demo test above).
+    vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
     mockUnread.mockReturnValue({ count: 4 })
     renderNavbar(renter)
     const messagesLink = screen.getByText('Messages').closest('a') as HTMLElement
@@ -240,6 +250,23 @@ describe('Navbar', () => {
     expect(badge).toHaveAttribute('aria-label', '4 unread messages')
     // The dot is unique to Messages (no operator badge in renter view).
     expect(screen.getAllByRole('status')).toHaveLength(1)
+  })
+
+  it('shows Messages to the platform admin in renter view even with messaging hidden in beta (owner preview bypass)', () => {
+    // The owner previews post-MVP features on live beta: the messaging flag is OFF,
+    // but the admin bypass surfaces Messages. They must switch to renter view (Messages
+    // lives in the renter nav). My Bookings/Documents stay renter-only and must NOT
+    // appear — the bypass is visibility for the gated feature, not a renter promotion.
+    document.cookie = 'kuruma-view=renter; path=/'
+    renderNavbar(platformAdmin)
+    expect(screen.getByText('Messages').closest('a')).toHaveAttribute(
+      'data-to',
+      '/$locale/messages',
+    )
+    expect(screen.queryByText('My Bookings')).toBeNull()
+    expect(screen.queryByText('Documents')).toBeNull()
+    // Browse + Messages only.
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '2')
   })
 
   it('hides My Bookings/Documents for an operator in renter view — gating is by role, not view (P1, AC6)', () => {


### PR DESCRIPTION
## Summary

Beta shows only the agreed MVP surface, while the owner (PLATFORM_ADMIN) previews everything on the live beta URL via a single deploy + admin bypass.

- Mechanism: `isVisibleToViewer(flag, role) = flag || isPlatformAdmin(role)` — **visibility only, not API authz**. Hidden features stay reachable by the platform admin for preview; the API still enforces real authorization.
- Owner-chosen cut line for beta: **hide** in-app messaging + operator scheduled blocks. Class-deal cards / combo-assign **stay**.
- Feature flags read strictly (`=== 'true'`), fail-safe **OFF**.

## What changed (3 TDD slices)

- `vite/config/features.ts` — `isMessagingEnabled()` / `isOperatorBlocksEnabled()` (strict, fail-safe off).
- `vite/config/feature-visibility.ts` (new) — the bypass rule + truth-table test.
- `vite/config/index.ts` (new barrel) — consumers import `@/vite/config` (avoids reach-in lint).
- `vite/nav/renter-nav-items.ts` (new) — SSoT renter nav; Messages decoupled from `isRenter` so the bypass lands.
- `Navbar.tsx` consumes it; `Navbar.test.tsx` updated to the beta contract + admin-bypass test.
- `routes/$locale/_renter/messages.tsx` — `beforeLoad` redirects hidden viewers; the platform admin still reaches it.

Design: `docs/plans/2026-06-26-mvp-feature-gating-design.md`.

## Test plan

- [x] `bun run test` aggregate green — shared 780, api 2115, web 1344 (21 new/updated web tests).
- [x] `tsc` clean on web + api.
- [x] `lint:modules` exit 0 (reach-ins 160 ≤ baseline 161).
- [ ] HITL (owner): seed owner as `PLATFORM_ADMIN` on the beta DB, else the bypass has no one to bypass for — `PLATFORM_ADMIN_EMAILS=<email> DATABASE_URL=<beta> bun run db:seed`.

Unblocks a clean develop→beta promotion.

Refs #385, #1161