### PR TITLE
fix(#1119): scope PARTNER booking reads to source=TRIP_COM (P1 cross-tenant leak)

### DIFF
--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -9,16 +9,21 @@ import { type Db, bookingColumns, toBooking } from './shared'
 export class DrizzleBookingRepository implements BookingRepository {
   constructor(private readonly db: Db) {}
 
-  // Three-way read scope (#392, proposal §6.2), mirroring the in-memory repo:
-  // bypass sees all, an operator sees only its tenant, a renter sees only their
-  // own. `null` = the `none` scope (operator missing operatorId) — read nothing.
+  // Read scope (#392, proposal §6.2; PARTNER channel scope #1119), mirroring the
+  // in-memory repo: the admin tier sees all, a PARTNER sees only its sourced
+  // bookings, an operator sees only its tenant, a renter sees only their own.
+  // `null` = the `none` scope (operator missing operatorId) — read nothing.
   // Otherwise returns the conditions to AND into the query (empty = unscoped).
+  // Exhaustive on the union so a new scope kind can't silently read every tenant.
   private scopeConditions(ctx: CallerContext): SQL[] | null {
     const scope = bookingReadScope(ctx)
     if (scope.kind === 'none') return null
     if (scope.kind === 'operator') return [eq(bookings.operatorId, scope.operatorId)]
     if (scope.kind === 'renter') return [eq(bookings.renterId, scope.renterId)]
-    return []
+    if (scope.kind === 'partner') return [eq(bookings.source, scope.source)]
+    if (scope.kind === 'all') return []
+    scope satisfies never
+    return null
   }
 
   async listRenterIdsForOperator(operatorId: string): Promise<string[]> {

--- a/packages/api/src/repositories/drizzle/overview.ts
+++ b/packages/api/src/repositories/drizzle/overview.ts
@@ -19,11 +19,14 @@ export class DrizzleOverviewRepository implements OverviewRepository {
 
   async getOperatorOverview(ctx: CallerContext, now: Date): Promise<OperatorOverview> {
     // Defence-in-depth (mirrors insurance/fees repos): reject RENTER/PARTNER
-    // here too, since bookingReadScope maps PARTNER to `all` — without this seal
-    // a PARTNER bypassing the route would read every operator's counts.
+    // here too — without this seal a non-operator bypassing the route would read
+    // operator counts. Only the admin tier (`all`) and OPERATOR_* (`operator`)
+    // own an operator overview; `partner` is a channel, not an operator (#1119).
     requireManagementRead(ctx)
     const scope = bookingReadScope(ctx)
-    if (scope.kind === 'none' || scope.kind === 'renter') return { ...ZERO }
+    if (scope.kind === 'none' || scope.kind === 'renter' || scope.kind === 'partner') {
+      return { ...ZERO }
+    }
     const opId = scope.kind === 'operator' ? scope.operatorId : undefined
 
     const bookingOp = opId ? eq(bookings.operatorId, opId) : undefined

--- a/packages/api/src/repositories/in-memory/booking-partner-scope.test.ts
+++ b/packages/api/src/repositories/in-memory/booking-partner-scope.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import { SYSTEM_CONTEXT } from '../../middleware/auth'
+import type { Booking } from '../../stores'
+import { InMemoryBookingRepository } from './booking'
+
+// #1119: a PARTNER (Trip.com) key must read ONLY the bookings it sourced
+// (source = TRIP_COM), never operators' DIRECT/walk-in bookings.
+const PARTNER: CallerContext = { userId: 'trip-com', role: 'PARTNER', bypassScope: true }
+
+type CreateInput = Omit<Booking, 'id' | 'createdAt' | 'updatedAt' | 'cancellationFeeSettlement'>
+
+function bookingInput(overrides: Partial<CreateInput> = {}): CreateInput {
+  return {
+    operatorId: 'op-1',
+    renterId: 'renter-1',
+    classId: 'class-1',
+    requestedVehicleId: 'veh-1',
+    assignedVehicleId: 'veh-1',
+    pickupLocationId: 'loc-1',
+    dropoffLocationId: 'loc-1',
+    startAt: new Date('2026-08-01T09:00:00Z'),
+    endAt: new Date('2026-08-01T17:00:00Z'),
+    effectiveEndAt: new Date('2026-08-01T17:00:00Z'),
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: 'BK-1',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 30_000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+    ...overrides,
+  }
+}
+
+async function seedTwo() {
+  const repo = new InMemoryBookingRepository()
+  const tripCom = await repo.create(
+    SYSTEM_CONTEXT,
+    bookingInput({
+      operatorId: 'op-1',
+      source: 'TRIP_COM',
+      assignedVehicleId: 'veh-a',
+      bookingCode: 'BK-TRIP',
+    }),
+  )
+  const direct = await repo.create(
+    SYSTEM_CONTEXT,
+    bookingInput({
+      operatorId: 'op-2',
+      source: 'DIRECT',
+      assignedVehicleId: 'veh-b',
+      bookingCode: 'BK-DIRECT',
+    }),
+  )
+  return { repo, tripCom, direct }
+}
+
+describe('InMemoryBookingRepository — PARTNER scope (#1119)', () => {
+  it('findAll returns only TRIP_COM-sourced bookings for a PARTNER', async () => {
+    const { repo, tripCom } = await seedTwo()
+    const rows = await repo.findAll(PARTNER)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe(tripCom.id)
+    expect(rows[0]?.source).toBe('TRIP_COM')
+  })
+
+  it('findById hides another operator DIRECT booking from a PARTNER', async () => {
+    const { repo, direct } = await seedTwo()
+    expect(await repo.findById(PARTNER, direct.id)).toBeUndefined()
+  })
+
+  it('findById returns the PARTNER own TRIP_COM booking', async () => {
+    const { repo, tripCom } = await seedTwo()
+    const found = await repo.findById(PARTNER, tripCom.id)
+    expect(found?.id).toBe(tripCom.id)
+  })
+
+  it('PLATFORM_ADMIN still sees every operator booking', async () => {
+    const { repo } = await seedTwo()
+    const rows = await repo.findAll(SYSTEM_CONTEXT)
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -58,16 +58,20 @@ export class InMemoryBookingRepository implements BookingRepository {
     this.store = store ?? new Map()
   }
 
-  // Three-way read scope (#392, proposal §6.2): bypass sees all, an operator
-  // sees only its tenant's bookings, a renter sees only their own. Replaces the
-  // legacy renter-vs-PRIVILEGED_ROLES split.
+  // Read scope (#392, proposal §6.2; PARTNER channel scope #1119): the admin
+  // tier sees all, a PARTNER sees only its sourced bookings, an operator sees
+  // only its tenant's, a renter sees only their own. Exhaustive on the union so a
+  // new scope kind can't silently fall through to reading every tenant's rows.
   private scopedValues(ctx: CallerContext): Booking[] {
     const scope = bookingReadScope(ctx)
     if (scope.kind === 'none') return []
     const all = [...this.store.values()]
     if (scope.kind === 'operator') return all.filter((b) => b.operatorId === scope.operatorId)
     if (scope.kind === 'renter') return all.filter((b) => b.renterId === scope.renterId)
-    return all
+    if (scope.kind === 'partner') return all.filter((b) => b.source === scope.source)
+    if (scope.kind === 'all') return all
+    scope satisfies never
+    return []
   }
 
   async listRenterIdsForOperator(operatorId: string): Promise<string[]> {
@@ -83,7 +87,10 @@ export class InMemoryBookingRepository implements BookingRepository {
     if (scope.kind === 'none') return false
     if (scope.kind === 'operator') return booking.operatorId === scope.operatorId
     if (scope.kind === 'renter') return booking.renterId === scope.renterId
-    return true
+    if (scope.kind === 'partner') return booking.source === scope.source
+    if (scope.kind === 'all') return true
+    scope satisfies never
+    return false
   }
 
   async findAll(ctx: CallerContext, filters?: BookingFilters): Promise<Booking[]> {

--- a/packages/api/src/repositories/in-memory/overview.ts
+++ b/packages/api/src/repositories/in-memory/overview.ts
@@ -19,12 +19,16 @@ export class InMemoryOverviewRepository implements OverviewRepository {
 
   async getOperatorOverview(ctx: CallerContext, now: Date): Promise<OperatorOverview> {
     // Defence-in-depth (mirrors insurance/fees repos): reject RENTER/PARTNER
-    // here too, since bookingReadScope maps PARTNER to `all` — without this seal
-    // a PARTNER bypassing the route would read every operator's counts.
+    // here too — without this seal a non-operator bypassing the route would read
+    // operator counts. Only the admin tier (`all`) and OPERATOR_* (`operator`)
+    // own an operator overview.
     requireManagementRead(ctx)
     const scope = bookingReadScope(ctx)
-    // `none` (operator without operatorId) + `renter` never see operator data.
-    if (scope.kind === 'none' || scope.kind === 'renter') return { ...ZERO }
+    // `none` (operator without operatorId), `renter`, and `partner` (a channel,
+    // not an operator) never see operator data.
+    if (scope.kind === 'none' || scope.kind === 'renter' || scope.kind === 'partner') {
+      return { ...ZERO }
+    }
 
     const [vehiclePage, bookings] = await Promise.all([
       this.vehicleRepo.findAll(SYSTEM_CONTEXT, { status: 'AVAILABLE' }),

--- a/packages/api/src/tenancy.test.ts
+++ b/packages/api/src/tenancy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from './middleware/auth'
+import { bookingReadScope } from './tenancy'
+
+describe('bookingReadScope', () => {
+  it('scopes a PARTNER to its own channel (source=TRIP_COM), not all bookings', () => {
+    // #1119: a Trip.com PARTNER key must NOT read operators' DIRECT bookings.
+    const partner: CallerContext = { userId: 'trip-com', role: 'PARTNER', bypassScope: true }
+    expect(bookingReadScope(partner)).toEqual({ kind: 'partner', source: 'TRIP_COM' })
+  })
+
+  it('keeps PLATFORM_ADMIN unscoped (sees all bookings)', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(bookingReadScope(admin)).toEqual({ kind: 'all' })
+  })
+
+  it('scopes an OPERATOR_OWNER to its tenant', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_OWNER', operatorId: 'op-1' }
+    expect(bookingReadScope(op)).toEqual({ kind: 'operator', operatorId: 'op-1' })
+  })
+
+  it('fails closed for an operator missing its operatorId', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_STAFF' }
+    expect(bookingReadScope(op)).toEqual({ kind: 'none' })
+  })
+
+  it('scopes a RENTER to their own bookings', () => {
+    const renter: CallerContext = { userId: 'r1', role: 'RENTER' }
+    expect(bookingReadScope(renter)).toEqual({ kind: 'renter', renterId: 'r1' })
+  })
+})

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -86,8 +86,15 @@ export type BookingReadScope =
   | { kind: 'renter'; renterId: string }
   | { kind: 'none' }
 
+// The single PARTNER role today IS Trip.com, so its channel is TRIP_COM. When a
+// second partner is onboarded this 1:1 must move onto the verified caller
+// identity (CallerContext.partnerSource, set in toCallerContext) — otherwise
+// every partner would share one source and read each other's bookings (#1119
+// follow-up). Named so that future change is one obvious edit, not a hunt.
+const PARTNER_SOURCE: BookingSource = 'TRIP_COM'
+
 export function bookingReadScope(ctx: CallerContext): BookingReadScope {
-  if (ctx.role === 'PARTNER') return { kind: 'partner', source: 'TRIP_COM' }
+  if (ctx.role === 'PARTNER') return { kind: 'partner', source: PARTNER_SOURCE }
   if (ctx.bypassScope) return { kind: 'all' }
   if (isOperatorRole(ctx.role)) {
     return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -1,3 +1,4 @@
+import type { BookingSource } from '@kuruma/shared/enums'
 import {
   type CallerContext,
   ForbiddenError,
@@ -67,19 +68,26 @@ export function applyCrossOperatorReadScope<F extends { operatorId?: string }>(
 /**
  * How a booking read is scoped (#392, proposal §6.2). Unlike the public vehicle
  * catalog (`operatorReadScope` maps renters to `all`), bookings are private:
- * - `all`      — bypass callers (PLATFORM_ADMIN / legacy STAFF/ADMIN/PARTNER).
- *                Gated on `ctx.bypassScope`, NOT a role string (slice-4 [P1]).
+ * - `all`      — the platform admin tier (PLATFORM_ADMIN). Gated on
+ *                `ctx.bypassScope`, NOT a role string (slice-4 [P1]).
+ * - `partner`  — a PARTNER channel (Trip.com): only the bookings it sourced
+ *                (`source = TRIP_COM`), across operators. NOT operators' DIRECT
+ *                bookings — that was a cross-tenant leak (#1119). Checked before
+ *                `bypassScope` because PARTNER still bypasses for OTHER reads
+ *                (user search, threads) via `SCOPE_BYPASS_ROLES`.
  * - `operator` — OPERATOR_* caller: only this tenant's bookings.
  * - `renter`   — every other caller (RENTER): only their own bookings.
  * - `none`     — OPERATOR_* missing operatorId: fail-closed (read nothing).
  */
 export type BookingReadScope =
   | { kind: 'all' }
+  | { kind: 'partner'; source: BookingSource }
   | { kind: 'operator'; operatorId: string }
   | { kind: 'renter'; renterId: string }
   | { kind: 'none' }
 
 export function bookingReadScope(ctx: CallerContext): BookingReadScope {
+  if (ctx.role === 'PARTNER') return { kind: 'partner', source: 'TRIP_COM' }
   if (ctx.bypassScope) return { kind: 'all' }
   if (isOperatorRole(ctx.role)) {
     return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }

--- a/packages/api/tests/integration/bookings.test.ts
+++ b/packages/api/tests/integration/bookings.test.ts
@@ -592,6 +592,39 @@ describe('POST /bookings via HTTP (real Postgres)', () => {
     expect(secondBody.error).toMatch(/already booked|No cars left/i)
   })
 
+  it('GET /bookings hides an operator DIRECT booking from a PARTNER key (#1119)', async () => {
+    // A renter books a DIRECT (source defaults to DIRECT) booking on Best Car
+    // Rental. A Trip.com PARTNER key calling the SAME endpoint must NOT see it —
+    // it reads only its own channel (source=TRIP_COM). Closes the cross-tenant
+    // leak where `bypassScope` mapped PARTNER to an unrestricted `all` read.
+    const created = await app.request('/bookings', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requestedVehicleId: httpVehicle.id,
+        pickupLocationId: testLocationId,
+        dropoffLocationId: testLocationId,
+        startAt: '2027-05-01T10:00:00Z',
+        endAt: '2027-05-01T14:00:00Z',
+        source: 'DIRECT',
+        disclaimerAccepted: true,
+      }),
+    })
+    expect(created.status).toBe(201)
+    const directId = (await created.json()).data.id
+    httpBookingIds.push(directId)
+
+    // The owning renter CAN see it — proves the row exists and is readable, so the
+    // PARTNER's absence below is scoping, not a missing booking.
+    const ownerView = await app.request('/bookings', { headers })
+    expect((await ownerView.json()).data.map((b: { id: string }) => b.id)).toContain(directId)
+
+    const partnerHeaders = await authHeaders({ sub: crypto.randomUUID(), role: 'PARTNER' })
+    const partnerView = await app.request('/bookings', { headers: partnerHeaders })
+    expect(partnerView.status).toBe(200)
+    expect((await partnerView.json()).data.map((b: { id: string }) => b.id)).not.toContain(directId)
+  })
+
   it('rejects a cross-operator dropoff with 400 (#882 same-operator one-way guardrail)', async () => {
     // #882: one-way rentals are SAME-operator only. A dropoff at ANOTHER
     // operator's location must be rejected — there is no shared rule/custody/

--- a/packages/api/tests/integration/tenancy-isolation.test.ts
+++ b/packages/api/tests/integration/tenancy-isolation.test.ts
@@ -84,6 +84,7 @@ describe('booking repo is operator-scoped (Drizzle, real Postgres)', () => {
   let vehicleAId: string
   let locationAId: string
   let bookingAId: string
+  let bookingTripId: string
 
   const ctxFor = (operatorId: string): CallerContext => ({
     userId: 'owner',
@@ -174,6 +175,26 @@ describe('booking repo is operator-scoped (Drizzle, real Postgres)', () => {
       }),
     )
     bookingAId = bookingA.id
+    // A Trip.com-sourced booking on the SAME operator, on the same car at a
+    // non-overlapping time (so the exclusion constraint stays satisfied). A
+    // PARTNER must see THIS one but not the DIRECT bookingA above (#1119).
+    const bookingTrip = await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      bookingInput({
+        operatorId: opAId,
+        renterId,
+        classId: classAId,
+        requestedVehicleId: vehicleAId,
+        assignedVehicleId: vehicleAId,
+        pickupLocationId: locationAId,
+        dropoffLocationId: locationAId,
+        startAt: new Date('2027-09-05T10:00:00Z'),
+        endAt: new Date('2027-09-05T14:00:00Z'),
+        status: 'CONFIRMED',
+        source: 'TRIP_COM',
+      }),
+    )
+    bookingTripId = bookingTrip.id
   })
 
   afterAll(async () => {
@@ -195,6 +216,23 @@ describe('booking repo is operator-scoped (Drizzle, real Postgres)', () => {
   it('operator findById cannot reach another tenant booking', async () => {
     expect(await bookingRepo.findById(ctxFor(opAId), bookingAId)).toMatchObject({ id: bookingAId })
     expect(await bookingRepo.findById(ctxFor(opBId), bookingAId)).toBeUndefined()
+  })
+
+  // #1119: a Trip.com PARTNER key reads only its own channel (source=TRIP_COM),
+  // never an operator's DIRECT booking — even though it bypasses scope elsewhere.
+  const partnerCtx: CallerContext = { userId: 'trip-com', role: 'PARTNER', bypassScope: true }
+
+  it('a PARTNER reads its TRIP_COM booking but not the operator DIRECT booking', async () => {
+    const ids = (await bookingRepo.findAll(partnerCtx)).map((b) => b.id)
+    expect(ids).toContain(bookingTripId)
+    expect(ids).not.toContain(bookingAId)
+  })
+
+  it('a PARTNER findById cannot reach a DIRECT booking', async () => {
+    expect(await bookingRepo.findById(partnerCtx, bookingTripId)).toMatchObject({
+      id: bookingTripId,
+    })
+    expect(await bookingRepo.findById(partnerCtx, bookingAId)).toBeUndefined()
   })
 
   it('operator cannot create a booking for another operator', async () => {

--- a/packages/api/tests/routes/admin-bookings-verify.test.ts
+++ b/packages/api/tests/routes/admin-bookings-verify.test.ts
@@ -16,9 +16,11 @@ import { makeInertConsentGate } from '../helpers/consent'
 // It establishes three code-grounded facts:
 //   1. A PLATFORM_ADMIN's `GET /bookings` DOES already return cross-operator rows
 //      (>=2 distinct operatorId) — cross-operator READ is not the gap.
-//   2. A PARTNER (Trip.com) gets the SAME cross-operator rows — `GET /bookings` is
-//      ungated (requireUser only) and scopes on `bypassScope`, which PARTNER
-//      shares. So it is NOT platform-only (the gap tracked separately as #1119).
+//   2. A PARTNER (Trip.com) is now scoped to its OWN channel (source=TRIP_COM)
+//      and no longer reads operators' DIRECT bookings — the cross-tenant leak
+//      closed in #1119. Either way `GET /bookings` is not platform-only: it
+//      serves renters/operators/partners by scope, so the oversight page still
+//      needs a dedicated platform-gated `GET /admin/bookings`.
 //   3. The raw row carries `operatorId` but NOT operator identity (name) nor any
 //      customer (renter name/email) — an oversight table cannot say WHICH operator
 //      or WHO booked. Plus it offers no operator/bookingCode/customer filters.
@@ -49,6 +51,13 @@ function mountBookingsAs(role: UserRole) {
   for (const b of [
     fullBooking({ operatorId: OP_A, assignedVehicleId: 'veh-a', requestedVehicleId: 'veh-a' }),
     fullBooking({ operatorId: OP_B, assignedVehicleId: 'veh-b', requestedVehicleId: 'veh-b' }),
+    // A Trip.com-sourced booking (on OP_A) — the only row a PARTNER may read (#1119).
+    fullBooking({
+      operatorId: OP_A,
+      source: 'TRIP_COM',
+      assignedVehicleId: 'veh-c',
+      requestedVehicleId: 'veh-c',
+    }),
   ]) {
     store.set(b.id, b)
   }
@@ -69,15 +78,16 @@ describe('#1092 verify-first: GET /bookings cross-operator behaviour', () => {
     expect(operatorIds).toEqual(new Set([OP_A, OP_B]))
   })
 
-  it('PARTNER gets the SAME cross-operator rows — GET /bookings is NOT platform-only (#1119)', async () => {
+  it('PARTNER reads ONLY its own channel (source=TRIP_COM), not operators DIRECT rows (#1119)', async () => {
     const res = await mountBookingsAs('PARTNER').request('/bookings')
     expect(res.status).toBe(200)
     const { data } = await res.json()
-    // PARTNER shares bypassScope (shared/auth/roles.ts SCOPE_BYPASS_ROLES), so it
-    // reaches every tenant's bookings here. This is exactly why platform-owner
-    // oversight cannot ride this endpoint — it needs requirePlatformAdmin.
+    // #1119: PARTNER no longer rides bypassScope for bookings — it reads only the
+    // bookings it sourced. The operators' DIRECT rows (OP_A/OP_B) are invisible;
+    // only the TRIP_COM row (seeded on OP_A) comes back.
+    expect(data.map((b: { source: string }) => b.source)).toEqual(['TRIP_COM'])
     const operatorIds = new Set(data.map((b: { operatorId: string }) => b.operatorId))
-    expect(operatorIds).toEqual(new Set([OP_A, OP_B]))
+    expect(operatorIds).toEqual(new Set([OP_A]))
   })
 
   it('the raw row carries operatorId but NO operator name or customer identity (the DTO gap)', async () => {

--- a/packages/shared/src/auth/roles.ts
+++ b/packages/shared/src/auth/roles.ts
@@ -84,10 +84,14 @@ export const BUSINESS_ROLES = union(MANAGEMENT_BASE_ROLES, OPERATOR_ROLES)
 export const OPERATOR_OWNER_WRITE_ROLES = union(MANAGEMENT_BASE_ROLES, roleSet('OPERATOR_OWNER'))
 
 /**
- * Cross-tenant read bypass — the platform tier PLUS PARTNER (Trip.com reads
- * bookings across tenants). Drives `CallerContext.bypassScope`. A distinct
- * instance from {@link PRIVILEGED_ROLES} (same members) because the two gate
- * different things and may still diverge later.
+ * Cross-tenant read bypass — the platform tier PLUS PARTNER. Drives
+ * `CallerContext.bypassScope`. NOTE (#1119): bookings are NO LONGER part of this
+ * bypass for PARTNER — a Trip.com key reads only its own channel
+ * (`bookingReadScope` -> `partner`, source=TRIP_COM), not operators' DIRECT
+ * bookings. `bypassScope` still grants PARTNER cross-tenant reads of the
+ * remaining surfaces it gates (e.g. user search in `customer.ts`); narrowing
+ * those the same way is the tracked follow-up. A distinct instance from
+ * {@link PRIVILEGED_ROLES} (same members) because the two gate different things.
  */
 export const SCOPE_BYPASS_ROLES = roleSet('PARTNER', 'PLATFORM_ADMIN')
 


### PR DESCRIPTION
## Summary

**P1 security fix — cross-operator booking read leak.** `GET /bookings` mapped every `bypassScope` caller to `BookingReadScope { kind: 'all' }`, and `PARTNER` (Trip.com) sits in `SCOPE_BYPASS_ROLES` — so a partner key could read **every operator's DIRECT bookings** across tenants, not just its own channel.

**Decision (no migration):** scope `PARTNER` to its own channel, `source = TRIP_COM`.

- Added a `{ kind: 'partner'; source }` arm to `BookingReadScope`, returned by `bookingReadScope(ctx)` **before** the `bypassScope` branch (`packages/api/src/tenancy.ts`). PARTNER still bypasses for the *other* surfaces it gates (user search, threads) — only bookings are narrowed.
- Hardened all booking read-scopers with `scope satisfies never` exhaustiveness guards so a future scope `kind` can't silently fall through to reading every tenant's rows. tsc caught a 7th consumer (`repositories/drizzle/overview.ts`) — fixed both its in-memory and Drizzle twins.
- Named the `PARTNER_SOURCE` constant + documented the 1:1 (single partner today) so onboarding a 2nd partner is one obvious edit (carry `source` on `CallerContext`) — tracked as follow-up #1168.
- Left `PARTNER` in `SCOPE_BYPASS_ROLES` deliberately (surgical scope); the same leak class in `customer.ts` user-search is the follow-up.

## Test Plan

- [x] `tsc --noEmit` ×3 packages — green
- [x] Aggregate `bun run test` — shared 780 / api 2124 / web 1330 — green
- [x] Integration suite (real pg) — 364 passed (54 files), incl. new `tenancy-isolation.test.ts` + `bookings.test.ts` cross-tenant cases
- [x] New unit coverage: `tenancy.test.ts` (partner scope arm), `booking-partner-scope.test.ts` (in-memory PARTNER filter)
- [x] `lint:boundaries` OK, biome clean, `db:verify` 83/83

Closes #1119

Follow-up: #1168 (same leak class in `customer.ts` PARTNER user-search; carry partner source on `CallerContext` before onboarding a 2nd partner).