### PR TITLE
fix(#1152): block-aware operator assign/substitute

### DIFF
--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -44,11 +44,12 @@ export const LOCATIONS_REGION_FK = 'locations_regionId_regions_id_fk'
 
 /**
  * GiST EXCLUDE on vehicle_blocks (operatorId, vehicleId, [startAt,endAt)),
- * named explicitly in migration 0076 (#1101). A 23P01 on this name on the
+ * named explicitly in migration 0082 (#1101). A 23P01 on this name on the
  * block-create path means an operator scheduled an overlapping block on the
  * same vehicle. VehicleBlockService maps it to a 409 (VEHICLE_BLOCK_OVERLAP) —
- * kept apart from bookings_no_overlap (a 23P01 meaning "already booked"), which
- * the booking-creation service surfaces as VEHICLE_BLOCKED on the other side.
+ * kept apart from bookings_no_overlap (a 23P01 meaning "already booked").
+ * VEHICLE_BLOCKED is the distinct service-level NOT EXISTS guard for a booking
+ * landing on a block (create + operator assign/substitute, #1152), not a 23P01.
  */
 export const VEHICLE_BLOCKS_OVERLAP = 'vehicle_blocks_no_overlap'
 

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -334,7 +334,8 @@ export class BookingCreationService {
     // single GiST EXCLUDE can't span bookings + vehicle_blocks; the residual
     // schedule-during-checkout race is tiny + operator-recoverable at this scale
     // (documented PR follow-up). CLASS_COMBO has no car at book time, so this
-    // guard is SPECIFIC-only; the operator assign/substitute path re-checks.
+    // guard is SPECIFIC-only at book time; the operator assign/substitute path
+    // runs the same block check (#1152).
     const overlappingBlocks = await repos.vehicleBlockRepo.findOverlapping(
       assignedVehicleId,
       input.startAt,

--- a/packages/api/src/services/booking-lifecycle.ts
+++ b/packages/api/src/services/booking-lifecycle.ts
@@ -151,6 +151,24 @@ export class BookingLifecycleService {
             code: 'VEHICLE_DOCS_EXPIRE_BEFORE_RETURN',
           }
         }
+        // #1152: same scheduled-block guard as create/assign — a 23P01 EXCLUDE only
+        // covers booking-vs-booking, so reject substituting onto the replacement
+        // car's own maintenance/hold window (over [startAt, effectiveEndAt)) before
+        // we bother repricing.
+        const blockConflicts = await repos.vehicleBlockRepo.findOverlapping(
+          replacement.id,
+          booking.startAt,
+          booking.effectiveEndAt,
+        )
+        if (blockConflicts.length > 0) {
+          return {
+            ok: false,
+            status: 409,
+            error:
+              'Replacement vehicle is blocked (maintenance or hold) for the requested time range',
+            code: 'VEHICLE_BLOCKED',
+          }
+        }
 
         // Re-snapshot price from the new vehicle's rates (#429), preserving any
         // selected-insurance daily price already locked on the booking.
@@ -270,6 +288,22 @@ export class BookingLifecycleService {
             status: 400,
             error: "Vehicle's shaken or insurance expires before the booking ends",
             code: 'VEHICLE_DOCS_EXPIRE_BEFORE_RETURN',
+          }
+        // #1152: a scheduled vehicle_block (maintenance/hold) on the target car is a
+        // hard conflict — the SAME service-level guard SPECIFIC creation runs
+        // (booking-creation.ts). The GiST EXCLUDE spans only bookings, so blocks are
+        // checked here over the [startAt, effectiveEndAt) turnaround-inclusive window.
+        const blockConflicts = await repos.vehicleBlockRepo.findOverlapping(
+          car.id,
+          booking.startAt,
+          booking.effectiveEndAt,
+        )
+        if (blockConflicts.length > 0)
+          return {
+            ok: false,
+            status: 409,
+            error: 'Vehicle is blocked (maintenance or hold) for the requested time range',
+            code: 'VEHICLE_BLOCKED',
           }
 
         // No reprice — class-deal price is fixed by the rate plan. effectiveEndAt is

--- a/packages/api/tests/services/booking-assign.test.ts
+++ b/packages/api/tests/services/booking-assign.test.ts
@@ -13,6 +13,7 @@ import {
   InMemoryLocationRepository,
   InMemoryMaintenanceLogRepository,
   InMemoryUserRepository,
+  InMemoryVehicleBlockRepository,
   InMemoryVehicleClassRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
@@ -49,6 +50,7 @@ async function setup() {
   const userRepo = new InMemoryUserRepository()
   const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
   const classRatePlanRepo = new InMemoryClassRatePlanRepository()
+  const vehicleBlockRepo = new InMemoryVehicleBlockRepository()
 
   // Seed a vehicle class with a non-null ACRISS code.
   const vehicleClass = await vehicleClassRepo.create({
@@ -137,6 +139,7 @@ async function setup() {
     availabilityRepo,
     classRatePlanRepo,
     vehicleClassRepo,
+    vehicleBlockRepo,
   }
   // Pass-through: InMemory repos are single-threaded singletons (mirrors booking.test.ts).
   const runInTransactionFn: RunInTransaction = (fn) => fn(repos)
@@ -475,6 +478,70 @@ describe('BookingService.assignVehicle — car→car reassign (T4)', () => {
   })
 })
 
+// #1152: assigning a car onto its OWN scheduled vehicle_block (maintenance/hold)
+// must 409 — the same block guard SPECIFIC creation runs. Mirrors the
+// [startAt, effectiveEndAt) turnaround-inclusive window.
+describe('BookingService.assignVehicle — vehicle-block guard (#1152)', () => {
+  function scheduleBlock(
+    vehicleBlockRepo: InMemoryVehicleBlockRepository,
+    vehicleId: string,
+    startAt: Date,
+    endAt: Date,
+  ) {
+    return vehicleBlockRepo.create({
+      operatorId: OP_A,
+      vehicleId,
+      startAt,
+      endAt,
+      kind: 'MAINTENANCE',
+      reason: 'scheduled service',
+      notes: null,
+      createdBy: OPERATOR_USER_ID,
+    })
+  }
+
+  it('rejects assigning a car blocked during the rental window (409 VEHICLE_BLOCKED)', async () => {
+    const { service, float, car, vehicleBlockRepo, operatorCtx } = await setupFull()
+    // 12:00–18:00 on day 2 sits squarely inside [START, END).
+    await scheduleBlock(
+      vehicleBlockRepo,
+      car.id,
+      new Date('2027-06-02T12:00:00Z'),
+      new Date('2027-06-02T18:00:00Z'),
+    )
+    const res = await service.assignVehicle(operatorCtx, float.id, car.id, null)
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCKED' })
+  })
+
+  it('rejects when the block only overlaps the dropoff turnaround tail (proves effectiveEndAt window)', async () => {
+    const { service, float, car, vehicleBlockRepo, operatorCtx } = await setupFull()
+    // END is 2027-06-03T09:00Z, EFFECTIVE_END is 2027-06-05T09:00Z. A block on
+    // 2027-06-04 falls in the turnaround tail — caught only if the guard uses
+    // effectiveEndAt (a mutant using endAt would let this through).
+    await scheduleBlock(
+      vehicleBlockRepo,
+      car.id,
+      new Date('2027-06-04T00:00:00Z'),
+      new Date('2027-06-04T06:00:00Z'),
+    )
+    const res = await service.assignVehicle(operatorCtx, float.id, car.id, null)
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCKED' })
+  })
+
+  it('allows assigning when the block sits entirely after the turnaround window', async () => {
+    const { service, float, car, vehicleBlockRepo, operatorCtx } = await setupFull()
+    // Starts after EFFECTIVE_END (2027-06-05T09:00Z) — half-open, no overlap.
+    await scheduleBlock(
+      vehicleBlockRepo,
+      car.id,
+      new Date('2027-06-06T00:00:00Z'),
+      new Date('2027-06-06T06:00:00Z'),
+    )
+    const res = await service.assignVehicle(operatorCtx, float.id, car.id, null)
+    expect(res).toMatchObject({ ok: true })
+  })
+})
+
 // ---- helpers for guard tests ----
 
 // Returns all mutable repos (not just service) for fixture injection.
@@ -492,6 +559,7 @@ async function setupFull() {
   const userRepo = new InMemoryUserRepository()
   const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
   const classRatePlanRepo = new InMemoryClassRatePlanRepository()
+  const vehicleBlockRepo = new InMemoryVehicleBlockRepository()
 
   const vehicleClass = await vehicleClassRepo.create({
     operatorId: OP_A,
@@ -577,6 +645,7 @@ async function setupFull() {
     availabilityRepo,
     classRatePlanRepo,
     vehicleClassRepo,
+    vehicleBlockRepo,
   }
   const runInTransactionFn: RunInTransaction = (fn) => fn(repos)
 
@@ -605,6 +674,7 @@ async function setupFull() {
     bookingRepo,
     vehicleRepo,
     vehicleClassRepo,
+    vehicleBlockRepo,
     bookingEventRepo,
     operatorCtx,
   }
@@ -625,6 +695,7 @@ async function setupWithAssigned() {
   const userRepo = new InMemoryUserRepository()
   const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
   const classRatePlanRepo = new InMemoryClassRatePlanRepository()
+  const vehicleBlockRepo = new InMemoryVehicleBlockRepository()
 
   const vehicleClass = await vehicleClassRepo.create({
     operatorId: OP_A,
@@ -737,6 +808,7 @@ async function setupWithAssigned() {
     availabilityRepo,
     classRatePlanRepo,
     vehicleClassRepo,
+    vehicleBlockRepo,
   }
   const runInTransactionFn: RunInTransaction = (fn) => fn(repos)
 

--- a/packages/api/tests/services/booking-substitution.test.ts
+++ b/packages/api/tests/services/booking-substitution.test.ts
@@ -14,6 +14,7 @@ import {
   InMemoryLocationRepository,
   InMemoryMaintenanceLogRepository,
   InMemoryUserRepository,
+  InMemoryVehicleBlockRepository,
   InMemoryVehicleClassRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
@@ -167,5 +168,183 @@ describe('BookingService.substitute — CLASS_COMBO guard (T3 #464)', () => {
     // any vehicle existence or validation check (no leakage of that path).
     const res = await service.substitute(operatorCtx, combo.id, car.id, null)
     expect(res).toMatchObject({ ok: false, status: 409, code: 'USE_ASSIGN_FOR_COMBO' })
+  })
+})
+
+// #1152: substituting onto a replacement car that has its OWN scheduled block
+// (maintenance/hold) must 409 — the same guard create/assign run. A SPECIFIC
+// booking is required (CLASS_COMBO short-circuits at the assign-instead guard).
+async function setupSpecific() {
+  const bookingStore = new Map<string, Booking>()
+  const bookingRepo = new InMemoryBookingRepository(bookingStore)
+  const bookingEventRepo = new InMemoryBookingEventRepository()
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const vehicleClassRepo = new InMemoryVehicleClassRepository()
+  const locationRepo = new InMemoryLocationRepository()
+  const insuranceOptionRepo = new InMemoryInsuranceOptionRepository()
+  const addOnRepo = new InMemoryAddOnRepository()
+  const feeScheduleRepo = new InMemoryFeeScheduleRepository()
+  const maintenanceLogRepo = new InMemoryMaintenanceLogRepository()
+  const userRepo = new InMemoryUserRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(vehicleRepo, bookingRepo)
+  const classRatePlanRepo = new InMemoryClassRatePlanRepository()
+  const vehicleBlockRepo = new InMemoryVehicleBlockRepository()
+
+  const vehicleClass = await vehicleClassRepo.create({
+    operatorId: OP_A,
+    name: 'Compact',
+    slug: 'compact-subst-block',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: 2,
+    luggageSize: 'SMALL',
+    transmission: 'AUTO',
+    fuelType: null,
+    acrissCode: CLASS_ACRISS,
+    sortOrder: 1,
+    status: 'ACTIVE',
+  })
+
+  const carFields = (name: string, dailyRateJpy: number) => ({
+    operatorId: OP_A,
+    classId: vehicleClass.id,
+    pickupLocationId: LOC_ID,
+    name,
+    description: null,
+    photos: [],
+    seats: 5,
+    transmission: 'AUTO' as const,
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE' as const,
+    bufferMinutes: 60,
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-12-31',
+    insuranceExpiryDate: '2099-12-31',
+  })
+
+  const originalCar = await vehicleRepo.create(SYSTEM_CONTEXT, carFields('Original Car', 8000))
+  const replacement = await vehicleRepo.create(SYSTEM_CONTEXT, carFields('Replacement Car', 8000))
+
+  const booking = await bookingRepo.create(SYSTEM_CONTEXT, {
+    operatorId: OP_A,
+    renterId: RENTER_ID,
+    classId: vehicleClass.id,
+    requestedVehicleId: originalCar.id,
+    assignedVehicleId: originalCar.id,
+    pickupLocationId: LOC_ID,
+    dropoffLocationId: LOC_ID,
+    startAt: START,
+    endAt: END,
+    effectiveEndAt: EFFECTIVE_END,
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: 'SUBST-BLOCK01',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: TOTAL_PRICE,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+  })
+
+  const repos: TransactionRepos = {
+    vehicleRepo,
+    maintenanceLogRepo,
+    bookingRepo,
+    bookingEventRepo,
+    locationRepo,
+    insuranceOptionRepo,
+    addOnRepo,
+    feeScheduleRepo,
+    userRepo,
+    availabilityRepo,
+    classRatePlanRepo,
+    vehicleClassRepo,
+    vehicleBlockRepo,
+  }
+  const runInTransactionFn: RunInTransaction = (fn) => fn(repos)
+
+  const service = new BookingService(
+    bookingRepo,
+    runInTransactionFn,
+    vehicleRepo,
+    userRepo,
+    vehicleClassRepo,
+    undefined, // postCommit
+    undefined, // operatorRepo
+    bookingEventRepo,
+  )
+
+  const operatorCtx: CallerContext = {
+    userId: OPERATOR_USER_ID,
+    role: 'OPERATOR_OWNER',
+    operatorId: OP_A,
+    bypassScope: false,
+  }
+
+  return { service, booking, replacement, vehicleBlockRepo, operatorCtx }
+}
+
+describe('BookingService.substitute — vehicle-block guard (#1152)', () => {
+  it('rejects substituting onto a replacement blocked in the turnaround tail (409 VEHICLE_BLOCKED)', async () => {
+    const { service, booking, replacement, vehicleBlockRepo, operatorCtx } = await setupSpecific()
+    // END is 2028-06-03T09:00Z, EFFECTIVE_END is 2028-06-05T09:00Z. A 2028-06-04
+    // block lands in the dropoff tail — caught only if the guard checks against
+    // effectiveEndAt (a mutant using endAt would slip it through).
+    await vehicleBlockRepo.create({
+      operatorId: OP_A,
+      vehicleId: replacement.id,
+      startAt: new Date('2028-06-04T00:00:00Z'),
+      endAt: new Date('2028-06-04T06:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'scheduled service',
+      notes: null,
+      createdBy: OPERATOR_USER_ID,
+    })
+    const res = await service.substitute(operatorCtx, booking.id, replacement.id, null)
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCKED' })
+  })
+
+  it('rejects a block squarely inside the rental window (pins the startAt lower bound)', async () => {
+    const { service, booking, replacement, vehicleBlockRepo, operatorCtx } = await setupSpecific()
+    // 12:00–18:00 on day 2 sits inside [START, END). Caught only if the guard's
+    // lower bound is startAt — a mutant passing endAt as `from` would miss it.
+    await vehicleBlockRepo.create({
+      operatorId: OP_A,
+      vehicleId: replacement.id,
+      startAt: new Date('2028-06-02T12:00:00Z'),
+      endAt: new Date('2028-06-02T18:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'scheduled service',
+      notes: null,
+      createdBy: OPERATOR_USER_ID,
+    })
+    const res = await service.substitute(operatorCtx, booking.id, replacement.id, null)
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCKED' })
+  })
+
+  it('substitutes successfully when the replacement has no overlapping block', async () => {
+    const { service, booking, replacement, operatorCtx } = await setupSpecific()
+    const res = await service.substitute(operatorCtx, booking.id, replacement.id, null)
+    expect(res).toMatchObject({ ok: true })
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.booking.assignedVehicleId).toBe(replacement.id)
   })
 })

--- a/packages/shared/src/db/fleet.ts
+++ b/packages/shared/src/db/fleet.ts
@@ -223,8 +223,9 @@ export const maintenanceLogs = pgTable(
 // block-vs-block guarantee is the `vehicle_blocks_no_overlap` GiST EXCLUDE
 // constraint added in a custom migration (EXCLUDE is not expressible in the
 // drizzle table builder — same pattern as bookings_no_overlap). Booking-vs-block
-// is enforced in the service layer (NOT EXISTS + advisory lock), since a single
-// EXCLUDE index cannot span two tables.
+// is enforced in the service layer (a NOT EXISTS at booking create and on
+// operator assign/substitute, #1152), since a single EXCLUDE index cannot span
+// two tables.
 export const vehicleBlocks = pgTable(
   'vehicle_blocks',
   {


### PR DESCRIPTION
## Summary
Closes #1152.

The operator booking **assign/substitute** path only re-checked the booking-vs-booking GiST exclusion, never `vehicle_blocks`. An operator could therefore assign or substitute a vehicle onto its **own** scheduled maintenance / out-of-service / manual-hold block. SPECIFIC booking creation already guards this; assign/substitute did not.

### Fix
Mirror the creation guard into both `BookingLifecycleService.assignVehicle` and `.substitute` (`booking-lifecycle.ts`): a service-level `vehicleBlockRepo.findOverlapping(targetVehicleId, booking.startAt, booking.effectiveEndAt)` → `409 VEHICLE_BLOCKED`, placed after the road-legal check and before reprice/reassign. Same half-open `[startAt, effectiveEndAt)` turnaround-inclusive window and error `code` the create path uses, so callers branch on `code`, not message.

- The Drizzle tx factory already binds `vehicleBlockRepo` to the per-call tx connection (`drizzle/transaction.ts:62`), so the read is transaction-correct — no new wiring.
- Scope: operator-initiated, within-tenant, recoverable. Inherits the same documented residual check-then-act window as creation (no cross-table lock at this scale).

### Doc-comment corrections (were misleading)
- `booking-creation.ts` — the assign/substitute re-check now actually exists; cite #1152.
- `fleet.ts` — drop the false "advisory lock" claim for booking-vs-block (the advisory lock serializes CLASS_COMBO capacity on create only).
- `pg-errors.ts` — EXCLUDE migration `0076` → `0082`; clarify `VEHICLE_BLOCKED` is the service-level NOT EXISTS guard, not a `bookings_no_overlap` 23P01.

## Test plan
- [x] New InMemory unit tests (assign + substitute): reject a block **inside the rental window** (pins `startAt`), reject a block in the **turnaround tail** (pins `effectiveEndAt`), and allow when the block sits outside the window.
- [x] All 4 existing InMemory assign/substitute setups now wire `InMemoryVehicleBlockRepository` (happy-path tests would otherwise throw on the new read); added a happy-path substitute that asserts `assignedVehicleId === replacement.id`.
- [x] `findOverlapping` real-pg parity already covered (`tests/integration/booking-vehicle-block.test.ts`, #1106 conformance) — this PR introduces no new SQL.
- [x] Gates: **api 2121** (+6) · **shared 780** · **web 1330** · tsc (api+shared+web) · biome · lint:boundaries · lint:size — all green.
- [x] code-reviewer: **SHIP**, no CRITICAL/HIGH/MEDIUM.

No migration. Sibling of #1141 (combo-capacity counting gap) — this covers the assign/substitute gap.