### PR TITLE
feat(#1067 slice 3): renter review prompt UI + post-trip email

### DIFF
--- a/drizzle/0083_add_review_prompt_notification_kind.sql
+++ b/drizzle/0083_add_review_prompt_notification_kind.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."notification_kind" ADD VALUE 'RENTER_REVIEW_PROMPT';

--- a/drizzle/0086_add_review_prompt_notification_kind.sql
+++ b/drizzle/0086_add_review_prompt_notification_kind.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."notification_kind" ADD VALUE 'RENTER_REVIEW_PROMPT';

--- a/drizzle/meta/0083_snapshot.json
+++ b/drizzle/meta/0083_snapshot.json
@@ -1,0 +1,5399 @@
+{
+  "id": "1a263d98-8221-4ecb-9167-d7879c053fdf",
+  "prevId": "9913b60f-aa9b-4ad5-a6ac-bc3895e6745c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nameEn": {
+          "name": "nameEn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameJa": {
+          "name": "nameJa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameZh": {
+          "name": "nameZh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignable": {
+          "name": "assignable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "region_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_regions_parentId": {
+          "name": "idx_regions_parentId",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_unique": {
+          "name": "regions_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parentId_regions_id_fk": {
+          "name": "regions_parentId_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.renter_documents": {
+      "name": "renter_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiryDate": {
+          "name": "expiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_renter_documents_renterId": {
+          "name": "idx_renter_documents_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_verifierId": {
+          "name": "idx_renter_documents_verifierId",
+          "columns": [
+            {
+              "expression": "verifierId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_status": {
+          "name": "idx_renter_documents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "renter_documents_renterId_users_id_fk": {
+          "name": "renter_documents_renterId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "renter_documents_verifierId_users_id_fk": {
+          "name": "renter_documents_verifierId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coordinate_source": {
+          "name": "coordinate_source",
+          "type": "coordinate_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatingHours": {
+          "name": "operatingHours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Tokyo'"
+        },
+        "defaultTurnaroundMinutes": {
+          "name": "defaultTurnaroundMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2880
+        },
+        "regionId": {
+          "name": "regionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_operatorId": {
+          "name": "idx_locations_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_regionId": {
+          "name": "idx_locations_regionId",
+          "columns": [
+            {
+              "expression": "regionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_operatorId_active_name_unique": {
+          "name": "locations_operatorId_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"status\" <> 'ARCHIVED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_operatorId_operators_id_fk": {
+          "name": "locations_operatorId_operators_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "locations_regionId_regions_id_fk": {
+          "name": "locations_regionId_regions_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_operatorId_id_unique": {
+          "name": "locations_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "locations_turnaround_min_60": {
+          "name": "locations_turnaround_min_60",
+          "value": "\"locations\".\"defaultTurnaroundMinutes\" >= 60"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_blocks": {
+      "name": "vehicle_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "vehicle_block_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_blocks_vehicleId": {
+          "name": "idx_vehicle_blocks_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicle_blocks_operatorId": {
+          "name": "idx_vehicle_blocks_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_blocks_operatorId_operators_id_fk": {
+          "name": "vehicle_blocks_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_blocks",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicle_blocks_operatorId_vehicleId_fk": {
+          "name": "vehicle_blocks_operatorId_vehicleId_fk",
+          "tableFrom": "vehicle_blocks",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_blocks_end_after_start": {
+          "name": "vehicle_blocks_end_after_start",
+          "value": "\"vehicle_blocks\".\"endAt\" > \"vehicle_blocks\".\"startAt\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acrissCode": {
+          "name": "acrissCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_acriss_code_format": {
+          "name": "vehicle_classes_acriss_code_format",
+          "value": "\"vehicle_classes\".\"acrissCode\" IS NULL OR \"vehicle_classes\".\"acrissCode\" ~ '^[A-Z9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_pickupLocationId": {
+          "name": "idx_vehicles_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_available": {
+          "name": "idx_vehicles_available",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vehicles\".\"status\" = 'AVAILABLE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_pickupLocationId_fk": {
+          "name": "vehicles_operatorId_pickupLocationId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "operatorId",
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        },
+        "vehicles_operatorId_id_unique": {
+          "name": "vehicles_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.class_rate_plans": {
+      "name": "class_rate_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayRateJpy": {
+          "name": "dayRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_class_rate_plans_operator": {
+          "name": "idx_class_rate_plans_operator",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_class": {
+          "name": "idx_class_rate_plans_class",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_pickup_location": {
+          "name": "idx_class_rate_plans_pickup_location",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "class_rate_plans_operatorId_operators_id_fk": {
+          "name": "class_rate_plans_operatorId_operators_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_pickupLocationId_locations_id_fk": {
+          "name": "class_rate_plans_pickupLocationId_locations_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_operator_class_fk": {
+          "name": "class_rate_plans_operator_class_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "class_rate_plans_operator_class_location_unique": {
+          "name": "class_rate_plans_operator_class_location_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "classId",
+            "pickupLocationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "class_rate_plans_day_rate_non_negative": {
+          "name": "class_rate_plans_day_rate_non_negative",
+          "value": "\"class_rate_plans\".\"dayRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleClassId": {
+          "name": "vehicleClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "fee_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fee_schedule_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_schedules_operator_class": {
+          "name": "idx_fee_schedules_operator_class",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_schedules_vehicle_class": {
+          "name": "idx_fee_schedules_vehicle_class",
+          "columns": [
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_class_unique": {
+          "name": "fee_schedules_active_class_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_operatorwide_unique": {
+          "name": "fee_schedules_active_operatorwide_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_schedules_operatorId_operators_id_fk": {
+          "name": "fee_schedules_operatorId_operators_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fee_schedules_operator_class_fk": {
+          "name": "fee_schedules_operator_class_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleClassId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fee_schedules_amount_non_negative": {
+          "name": "fee_schedules_amount_non_negative",
+          "value": "\"fee_schedules\".\"amountJpy\" >= 0"
+        },
+        "fee_schedules_feetype_unit_coherent": {
+          "name": "fee_schedules_feetype_unit_coherent",
+          "value": "(\"fee_schedules\".\"feeType\" = 'OVERTIME_HOURLY' AND \"fee_schedules\".\"unit\" = 'PER_HOUR') OR (\"fee_schedules\".\"feeType\" = 'CLEANING_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT') OR (\"fee_schedules\".\"feeType\" = 'NO_FUEL_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_options": {
+      "name": "insurance_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyPriceJpy": {
+          "name": "dailyPriceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deductibleJpy": {
+          "name": "deductibleJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_insurance_options_operatorId": {
+          "name": "idx_insurance_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_options_active_name_unique": {
+          "name": "insurance_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_options_operatorId_operators_id_fk": {
+          "name": "insurance_options_operatorId_operators_id_fk",
+          "tableFrom": "insurance_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_options_operatorId_id_unique": {
+          "name": "insurance_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "insurance_options_daily_price_non_negative": {
+          "name": "insurance_options_daily_price_non_negative",
+          "value": "\"insurance_options\".\"dailyPriceJpy\" >= 0"
+        },
+        "insurance_options_deductible_non_negative": {
+          "name": "insurance_options_deductible_non_negative",
+          "value": "\"insurance_options\".\"deductibleJpy\" IS NULL OR \"insurance_options\".\"deductibleJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_events": {
+      "name": "booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booking_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_booking_events_bookingId": {
+          "name": "idx_booking_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_events_actorId": {
+          "name": "idx_booking_events_actorId",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_events_bookingId_bookings_id_fk": {
+          "name": "booking_events_bookingId_bookings_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "booking_events_actorId_users_id_fk": {
+          "name": "booking_events_actorId_users_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestedVehicleId": {
+          "name": "requestedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedVehicleId": {
+          "name": "assignedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropoffLocationId": {
+          "name": "dropoffLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "fulfillmentMode": {
+          "name": "fulfillmentMode",
+          "type": "booking_fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPECIFIC'"
+        },
+        "bookingCode": {
+          "name": "bookingCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insuranceOptionId": {
+          "name": "insuranceOptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceSnapshot": {
+          "name": "insuranceSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeSnapshot": {
+          "name": "feeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "addOnSnapshot": {
+          "name": "addOnSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFeeSettlement": {
+          "name": "cancellationFeeSettlement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADVISORY'"
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerAcknowledgedAt": {
+          "name": "disclaimerAcknowledgedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerTermsVersion": {
+          "name": "disclaimerTermsVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_operatorId": {
+          "name": "idx_bookings_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_requestedVehicleId": {
+          "name": "idx_bookings_requestedVehicleId",
+          "columns": [
+            {
+              "expression": "requestedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_assignedVehicleId": {
+          "name": "idx_bookings_assignedVehicleId",
+          "columns": [
+            {
+              "expression": "assignedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_pickupLocationId": {
+          "name": "idx_bookings_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_dropoffLocationId": {
+          "name": "idx_bookings_dropoffLocationId",
+          "columns": [
+            {
+              "expression": "dropoffLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_insuranceOptionId": {
+          "name": "idx_bookings_insuranceOptionId",
+          "columns": [
+            {
+              "expression": "insuranceOptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_operatorId_operators_id_fk": {
+          "name": "bookings_operatorId_operators_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_pickupLocationId_locations_id_fk": {
+          "name": "bookings_pickupLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_dropoffLocationId_locations_id_fk": {
+          "name": "bookings_dropoffLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "dropoffLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_class_fk": {
+          "name": "bookings_operator_class_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_requested_vehicle_fk": {
+          "name": "bookings_operator_requested_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "requestedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_assigned_vehicle_fk": {
+          "name": "bookings_operator_assigned_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "assignedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_insurance_fk": {
+          "name": "bookings_operator_insurance_fk",
+          "tableFrom": "bookings",
+          "tableTo": "insurance_options",
+          "columnsFrom": [
+            "operatorId",
+            "insuranceOptionId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookings_bookingCode_unique": {
+          "name": "bookings_bookingCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bookings_specific_requires_assigned": {
+          "name": "bookings_specific_requires_assigned",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"assignedVehicleId\" IS NOT NULL"
+        },
+        "bookings_specific_requires_requested": {
+          "name": "bookings_specific_requires_requested",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"requestedVehicleId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_anomalies": {
+      "name": "payment_anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAmountJpy": {
+          "name": "receivedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedAmountJpy": {
+          "name": "expectedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "payment_anomaly_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_anomalies_operatorId": {
+          "name": "idx_payment_anomalies_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_anomalies_bookingId": {
+          "name": "idx_payment_anomalies_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_anomalies_stripeEventId_unique": {
+          "name": "payment_anomalies_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_anomalies_operatorId_operators_id_fk": {
+          "name": "payment_anomalies_operatorId_operators_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_anomalies_bookingId_bookings_id_fk": {
+          "name": "payment_anomalies_bookingId_bookings_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_events": {
+      "name": "payment_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grossJpy": {
+          "name": "grossJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFeeJpy": {
+          "name": "platformFeeJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "netToPartnerJpy": {
+          "name": "netToPartnerJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'jpy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_events_operatorId": {
+          "name": "idx_payment_events_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_events_bookingId": {
+          "name": "idx_payment_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeEventId_unique": {
+          "name": "payment_events_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeCheckoutSessionId_unique": {
+          "name": "payment_events_stripeCheckoutSessionId_unique",
+          "columns": [
+            {
+              "expression": "stripeCheckoutSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_one_success_per_booking": {
+          "name": "payment_events_one_success_per_booking",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'SUCCEEDED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_events_operatorId_operators_id_fk": {
+          "name": "payment_events_operatorId_operators_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_events_bookingId_bookings_id_fk": {
+          "name": "payment_events_bookingId_bookings_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_refunds": {
+      "name": "payment_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeRefundId": {
+          "name": "stripeRefundId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_refunds_operatorId": {
+          "name": "idx_payment_refunds_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_bookingId_unique": {
+          "name": "payment_refunds_bookingId_unique",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_stripeRefundId_unique": {
+          "name": "payment_refunds_stripeRefundId_unique",
+          "columns": [
+            {
+              "expression": "stripeRefundId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripeRefundId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_refunds_bookingId_bookings_id_fk": {
+          "name": "payment_refunds_bookingId_bookings_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_refunds_operatorId_operators_id_fk": {
+          "name": "payment_refunds_operatorId_operators_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_refunds_amount_non_negative": {
+          "name": "payment_refunds_amount_non_negative",
+          "value": "\"payment_refunds\".\"amountJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_threadId": {
+          "name": "idx_messages_threadId",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_senderId": {
+          "name": "idx_messages_senderId",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_idempotency_key": {
+          "name": "messages_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thread_participants_threadId": {
+          "name": "idx_thread_participants_threadId",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_participants_userId": {
+          "name": "idx_thread_participants_userId",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_threads_bookingId": {
+          "name": "idx_threads_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threads_idempotency_key": {
+          "name": "threads_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "providerMessageId": {
+          "name": "providerMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_bookingId": {
+          "name": "idx_notification_log_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_log_operatorId": {
+          "name": "idx_notification_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_bookingId_bookings_id_fk": {
+          "name": "notification_log_bookingId_bookings_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_log_operatorId_operators_id_fk": {
+          "name": "notification_log_operatorId_operators_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_log_idempotency_unique": {
+          "name": "notification_log_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotencyKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "audit_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_operatorId": {
+          "name": "idx_audit_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_kind": {
+          "name": "idx_audit_log_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compliance_alert_log": {
+      "name": "compliance_alert_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentType": {
+          "name": "documentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thresholdBand": {
+          "name": "thresholdBand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_compliance_alert_log_operatorId": {
+          "name": "idx_compliance_alert_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compliance_alert_log_vehicleId": {
+          "name": "idx_compliance_alert_log_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compliance_alert_log_operatorId_operators_id_fk": {
+          "name": "compliance_alert_log_operatorId_operators_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "compliance_alert_log_vehicleId_vehicles_id_fk": {
+          "name": "compliance_alert_log_vehicleId_vehicles_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compliance_alert_log_band_unique": {
+          "name": "compliance_alert_log_band_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vehicleId",
+            "documentType",
+            "thresholdBand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.add_on_options": {
+      "name": "add_on_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceJpy": {
+          "name": "priceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "add_on_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_add_on_options_operatorId": {
+          "name": "idx_add_on_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "add_on_options_active_name_unique": {
+          "name": "add_on_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "add_on_options_operatorId_operators_id_fk": {
+          "name": "add_on_options_operatorId_operators_id_fk",
+          "tableFrom": "add_on_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "add_on_options_operatorId_id_unique": {
+          "name": "add_on_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "add_on_options_price_non_negative": {
+          "name": "add_on_options_price_non_negative",
+          "value": "\"add_on_options\".\"priceJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operator_memberships": {
+      "name": "operator_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_memberships_active_user_unique": {
+          "name": "operator_memberships_active_user_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operator_memberships_operatorId": {
+          "name": "idx_operator_memberships_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_memberships_userId_users_id_fk": {
+          "name": "operator_memberships_userId_users_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_memberships_operatorId_operators_id_fk": {
+          "name": "operator_memberships_operatorId_operators_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_invites": {
+      "name": "provider_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedByUserId": {
+          "name": "acceptedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_invites_tokenHash_unique": {
+          "name": "provider_invites_tokenHash_unique",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_invites_pending_email_unique": {
+          "name": "provider_invites_pending_email_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'PENDING'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_email": {
+          "name": "idx_provider_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_operatorId": {
+          "name": "idx_provider_invites_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_invitedByUserId": {
+          "name": "idx_provider_invites_invitedByUserId",
+          "columns": [
+            {
+              "expression": "invitedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_acceptedByUserId": {
+          "name": "idx_provider_invites_acceptedByUserId",
+          "columns": [
+            {
+              "expression": "acceptedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_invites_operatorId_operators_id_fk": {
+          "name": "provider_invites_operatorId_operators_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provider_invites_invitedByUserId_users_id_fk": {
+          "name": "provider_invites_invitedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_invites_acceptedByUserId_users_id_fk": {
+          "name": "provider_invites_acceptedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acceptedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_acceptances": {
+      "name": "consent_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentType": {
+          "name": "consentType",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatorMembershipId": {
+          "name": "operatorMembershipId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorRole": {
+          "name": "actorRole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "consent_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLICKWRAP'"
+        },
+        "recordSignature": {
+          "name": "recordSignature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingKeyId": {
+          "name": "signingKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureRef": {
+          "name": "signatureRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentSnapshot": {
+          "name": "documentSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureCanonicalVersion": {
+          "name": "signatureCanonicalVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_unique_booking_liability": {
+          "name": "consent_unique_booking_liability",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_user_document": {
+          "name": "consent_unique_user_document",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NULL AND \"consent_acceptances\".\"operatorId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_operator_document": {
+          "name": "consent_unique_operator_document",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"operatorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_document_type_idx": {
+          "name": "consent_acceptances_document_type_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_membership_idx": {
+          "name": "consent_acceptances_membership_idx",
+          "columns": [
+            {
+              "expression": "operatorMembershipId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_consent_type_idx": {
+          "name": "consent_acceptances_consent_type_idx",
+          "columns": [
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_acceptances_userId_users_id_fk": {
+          "name": "consent_acceptances_userId_users_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorId_operators_id_fk": {
+          "name": "consent_acceptances_operatorId_operators_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorMembershipId_operator_memberships_id_fk": {
+          "name": "consent_acceptances_operatorMembershipId_operator_memberships_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operator_memberships",
+          "columnsFrom": [
+            "operatorMembershipId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_bookingId_bookings_id_fk": {
+          "name": "consent_acceptances_bookingId_bookings_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_document_type_fk": {
+          "name": "consent_acceptances_document_type_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "consent_documents",
+          "columnsFrom": [
+            "documentId",
+            "consentType"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_liability_booking_chk": {
+          "name": "consent_liability_booking_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'RENTER_LIABILITY') = (\"consent_acceptances\".\"bookingId\" IS NOT NULL)"
+        },
+        "consent_operator_agreement_chk": {
+          "name": "consent_operator_agreement_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'OPERATOR_AGREEMENT') = (\"consent_acceptances\".\"operatorId\" IS NOT NULL)"
+        },
+        "consent_membership_implies_operator_chk": {
+          "name": "consent_membership_implies_operator_chk",
+          "value": "\"consent_acceptances\".\"operatorMembershipId\" IS NULL OR \"consent_acceptances\".\"operatorId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_documents": {
+      "name": "consent_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptanceLabel": {
+          "name": "acceptanceLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "consent_doc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "effectiveFrom": {
+          "name": "effectiveFrom",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_documents_type_version_locale_unique": {
+          "name": "consent_documents_type_version_locale_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "version",
+            "locale"
+          ]
+        },
+        "consent_documents_id_type_unique": {
+          "name": "consent_documents_id_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorRole": {
+          "name": "authorRole",
+          "type": "review_author_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "review_subject",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectVehicleId": {
+          "name": "subjectVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectClassId": {
+          "name": "subjectClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall": {
+          "name": "overall",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subRatings": {
+          "name": "subRatings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderationStatus": {
+          "name": "moderationStatus",
+          "type": "review_moderation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VISIBLE'"
+        },
+        "revealDeadlineAt": {
+          "name": "revealDeadlineAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_bookingId": {
+          "name": "idx_reviews_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_authorUserId": {
+          "name": "idx_reviews_authorUserId",
+          "columns": [
+            {
+              "expression": "authorUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_operator_published": {
+          "name": "idx_reviews_operator_published",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_vehicle": {
+          "name": "idx_reviews_subject_vehicle",
+          "columns": [
+            {
+              "expression": "subjectVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_class": {
+          "name": "idx_reviews_subject_class",
+          "columns": [
+            {
+              "expression": "subjectClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_reveal_due": {
+          "name": "idx_reviews_reveal_due",
+          "columns": [
+            {
+              "expression": "revealDeadlineAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"publishedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_bookingId_bookings_id_fk": {
+          "name": "reviews_bookingId_bookings_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_operatorId_operators_id_fk": {
+          "name": "reviews_operatorId_operators_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_authorUserId_users_id_fk": {
+          "name": "reviews_authorUserId_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectVehicleId_vehicles_id_fk": {
+          "name": "reviews_subjectVehicleId_vehicles_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "subjectVehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectClassId_vehicle_classes_id_fk": {
+          "name": "reviews_subjectClassId_vehicle_classes_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "subjectClassId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_author_subject_per_booking_unique": {
+          "name": "reviews_author_subject_per_booking_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingId",
+            "authorUserId",
+            "subject"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_overall_range_chk": {
+          "name": "reviews_overall_range_chk",
+          "value": "\"reviews\".\"overall\" BETWEEN 1 AND 5"
+        },
+        "reviews_subject_pairing_chk": {
+          "name": "reviews_subject_pairing_chk",
+          "value": "(\"reviews\".\"authorRole\" = 'OPERATOR') = (\"reviews\".\"subject\" = 'RENTER')"
+        },
+        "reviews_vehicle_subject_chk": {
+          "name": "reviews_vehicle_subject_chk",
+          "value": "(\"reviews\".\"subject\" = 'VEHICLE') = (\"reviews\".\"subjectVehicleId\" IS NOT NULL)"
+        },
+        "reviews_class_subject_chk": {
+          "name": "reviews_class_subject_chk",
+          "value": "\"reviews\".\"subjectClassId\" IS NULL OR \"reviews\".\"subject\" = 'VEHICLE'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_status": {
+      "name": "document_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "IDP",
+        "PASSPORT"
+      ]
+    },
+    "public.region_status": {
+      "name": "region_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "PREFECTURE",
+        "CITY",
+        "AREA"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.coordinate_source": {
+      "name": "coordinate_source",
+      "schema": "public",
+      "values": [
+        "GEOCODED",
+        "MANUAL",
+        "PENDING"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.luggage_size": {
+      "name": "luggage_size",
+      "schema": "public",
+      "values": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_block_kind": {
+      "name": "vehicle_block_kind",
+      "schema": "public",
+      "values": [
+        "MAINTENANCE",
+        "OUT_OF_SERVICE",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.fee_schedule_status": {
+      "name": "fee_schedule_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "OVERTIME_HOURLY",
+        "CLEANING_FLAT",
+        "NO_FUEL_FLAT"
+      ]
+    },
+    "public.fee_unit": {
+      "name": "fee_unit",
+      "schema": "public",
+      "values": [
+        "PER_HOUR",
+        "PER_DAY",
+        "PER_KM",
+        "FLAT"
+      ]
+    },
+    "public.insurance_status": {
+      "name": "insurance_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.booking_event_type": {
+      "name": "booking_event_type",
+      "schema": "public",
+      "values": [
+        "BOOKING_CREATED",
+        "VEHICLE_SUBSTITUTED",
+        "VEHICLE_ASSIGNED",
+        "BOOKING_CANCELLED",
+        "STATUS_CHANGED"
+      ]
+    },
+    "public.booking_fulfillment_mode": {
+      "name": "booking_fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "SPECIFIC",
+        "CLASS_COMBO"
+      ]
+    },
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.payment_anomaly_kind": {
+      "name": "payment_anomaly_kind",
+      "schema": "public",
+      "values": [
+        "DOUBLE_PAYMENT",
+        "AMOUNT_MISMATCH"
+      ]
+    },
+    "public.payment_anomaly_resolution": {
+      "name": "payment_anomaly_resolution",
+      "schema": "public",
+      "values": [
+        "BENIGN",
+        "INVESTIGATED",
+        "REFUNDED_EXTERNALLY"
+      ]
+    },
+    "public.payment_event_status": {
+      "name": "payment_event_status",
+      "schema": "public",
+      "values": [
+        "SUCCEEDED"
+      ]
+    },
+    "public.payment_refund_status": {
+      "name": "payment_refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.notification_kind": {
+      "name": "notification_kind",
+      "schema": "public",
+      "values": [
+        "OPERATOR_BOOKING_ALERT",
+        "RENTER_BOOKING_CONFIRM",
+        "RENTER_SUBSTITUTION",
+        "RENTER_CANCELLATION",
+        "RENTER_TRIP_STARTED",
+        "RENTER_TRIP_COMPLETED",
+        "RENTER_REVIEW_PROMPT"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "DEAD",
+        "NO_RECIPIENT"
+      ]
+    },
+    "public.audit_event_kind": {
+      "name": "audit_event_kind",
+      "schema": "public",
+      "values": [
+        "PROVIDER_INVITE_CREATED",
+        "OPERATOR_PROFILE_UPDATED",
+        "OPERATOR_MEMBER_DEACTIVATED"
+      ]
+    },
+    "public.add_on_status": {
+      "name": "add_on_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.operator_membership_status": {
+      "name": "operator_membership_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED"
+      ]
+    },
+    "public.operator_role": {
+      "name": "operator_role",
+      "schema": "public",
+      "values": [
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF"
+      ]
+    },
+    "public.provider_invite_status": {
+      "name": "provider_invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED"
+      ]
+    },
+    "public.consent_doc_status": {
+      "name": "consent_doc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PUBLISHED",
+        "ARCHIVED"
+      ]
+    },
+    "public.consent_method": {
+      "name": "consent_method",
+      "schema": "public",
+      "values": [
+        "CLICKWRAP",
+        "ESIGN",
+        "IMPORTED"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "RENTER_TOS",
+        "PRIVACY_POLICY",
+        "RENTER_LIABILITY",
+        "OPERATOR_AGREEMENT"
+      ]
+    },
+    "public.review_author_role": {
+      "name": "review_author_role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "OPERATOR"
+      ]
+    },
+    "public.review_moderation_status": {
+      "name": "review_moderation_status",
+      "schema": "public",
+      "values": [
+        "VISIBLE",
+        "HIDDEN"
+      ]
+    },
+    "public.review_subject": {
+      "name": "review_subject",
+      "schema": "public",
+      "values": [
+        "OPERATOR",
+        "VEHICLE",
+        "RENTER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0086_snapshot.json
+++ b/drizzle/meta/0086_snapshot.json
@@ -1,0 +1,5477 @@
+{
+  "id": "6b99426e-b429-48a6-9987-b82562612ab4",
+  "prevId": "7fefa442-b8da-498e-af91-ada5df2aaf8e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nameEn": {
+          "name": "nameEn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameJa": {
+          "name": "nameJa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameZh": {
+          "name": "nameZh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "region_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignable": {
+          "name": "assignable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "region_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_regions_parentId": {
+          "name": "idx_regions_parentId",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_unique": {
+          "name": "regions_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parentId_regions_id_fk": {
+          "name": "regions_parentId_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.renter_documents": {
+      "name": "renter_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storageKey": {
+          "name": "storageKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiryDate": {
+          "name": "expiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifierId": {
+          "name": "verifierId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_renter_documents_renterId": {
+          "name": "idx_renter_documents_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_verifierId": {
+          "name": "idx_renter_documents_verifierId",
+          "columns": [
+            {
+              "expression": "verifierId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_renter_documents_status": {
+          "name": "idx_renter_documents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "renter_documents_renterId_users_id_fk": {
+          "name": "renter_documents_renterId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "renter_documents_verifierId_users_id_fk": {
+          "name": "renter_documents_verifierId_users_id_fk",
+          "tableFrom": "renter_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verifierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_userId": {
+          "name": "idx_accounts_userId",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pre_auth_handoff_url": {
+          "name": "pre_auth_handoff_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_slug_unique": {
+          "name": "operators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RENTER'"
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_operatorId": {
+          "name": "idx_users_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_operatorId_operators_id_fk": {
+          "name": "users_operatorId_operators_id_fk",
+          "tableFrom": "users",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coordinate_source": {
+          "name": "coordinate_source",
+          "type": "coordinate_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatingHours": {
+          "name": "operatingHours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Tokyo'"
+        },
+        "defaultTurnaroundMinutes": {
+          "name": "defaultTurnaroundMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2880
+        },
+        "regionId": {
+          "name": "regionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_operatorId": {
+          "name": "idx_locations_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_regionId": {
+          "name": "idx_locations_regionId",
+          "columns": [
+            {
+              "expression": "regionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_operatorId_active_name_unique": {
+          "name": "locations_operatorId_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"status\" <> 'ARCHIVED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_operatorId_operators_id_fk": {
+          "name": "locations_operatorId_operators_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "locations_regionId_regions_id_fk": {
+          "name": "locations_regionId_regions_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_operatorId_id_unique": {
+          "name": "locations_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "locations_turnaround_min_60": {
+          "name": "locations_turnaround_min_60",
+          "value": "\"locations\".\"defaultTurnaroundMinutes\" >= 60"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.maintenance_logs": {
+      "name": "maintenance_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costJpy": {
+          "name": "costJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_maintenance_logs_vehicleId": {
+          "name": "idx_maintenance_logs_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maintenance_logs_vehicleId_vehicles_id_fk": {
+          "name": "maintenance_logs_vehicleId_vehicles_id_fk",
+          "tableFrom": "maintenance_logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "maintenance_cost_non_negative": {
+          "name": "maintenance_cost_non_negative",
+          "value": "\"maintenance_logs\".\"costJpy\" IS NULL OR \"maintenance_logs\".\"costJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_blocks": {
+      "name": "vehicle_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "vehicle_block_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_blocks_vehicleId": {
+          "name": "idx_vehicle_blocks_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicle_blocks_operatorId": {
+          "name": "idx_vehicle_blocks_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_blocks_operatorId_operators_id_fk": {
+          "name": "vehicle_blocks_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_blocks",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicle_blocks_operatorId_vehicleId_fk": {
+          "name": "vehicle_blocks_operatorId_vehicleId_fk",
+          "tableFrom": "vehicle_blocks",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_blocks_end_after_start": {
+          "name": "vehicle_blocks_end_after_start",
+          "value": "\"vehicle_blocks\".\"endAt\" > \"vehicle_blocks\".\"startAt\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicle_classes": {
+      "name": "vehicle_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acrissCode": {
+          "name": "acrissCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_class_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicle_classes_operatorId": {
+          "name": "idx_vehicle_classes_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_classes_operatorId_operators_id_fk": {
+          "name": "vehicle_classes_operatorId_operators_id_fk",
+          "tableFrom": "vehicle_classes",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicle_classes_slug_unique": {
+          "name": "vehicle_classes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "vehicle_classes_operatorId_id_unique": {
+          "name": "vehicle_classes_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicle_classes_acriss_code_format": {
+          "name": "vehicle_classes_acriss_code_format",
+          "value": "\"vehicle_classes\".\"acrissCode\" IS NULL OR \"vehicle_classes\".\"acrissCode\" ~ '^[A-Z9]{4}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "luggageCapacity": {
+          "name": "luggageCapacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luggageSize": {
+          "name": "luggageSize",
+          "type": "luggage_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transmission": {
+          "name": "transmission",
+          "type": "transmission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuelType": {
+          "name": "fuelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensePlate": {
+          "name": "licensePlate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "minRentalHours": {
+          "name": "minRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxRentalHours": {
+          "name": "maxRentalHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanceBookingHours": {
+          "name": "advanceBookingHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyRateJpy": {
+          "name": "dailyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourlyRateJpy": {
+          "name": "hourlyRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shakenExpiryDate": {
+          "name": "shakenExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceExpiryDate": {
+          "name": "insuranceExpiryDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vehicles_classId": {
+          "name": "idx_vehicles_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_operatorId": {
+          "name": "idx_vehicles_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_pickupLocationId": {
+          "name": "idx_vehicles_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vehicles_available": {
+          "name": "idx_vehicles_available",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vehicles\".\"status\" = 'AVAILABLE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicles_operatorId_operators_id_fk": {
+          "name": "vehicles_operatorId_operators_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_classId_fk": {
+          "name": "vehicles_operatorId_classId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_operatorId_pickupLocationId_fk": {
+          "name": "vehicles_operatorId_pickupLocationId_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "operatorId",
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vehicles_licensePlate_unique": {
+          "name": "vehicles_licensePlate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "licensePlate"
+          ]
+        },
+        "vehicles_operatorId_id_unique": {
+          "name": "vehicles_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vehicles_pricing_at_least_one": {
+          "name": "vehicles_pricing_at_least_one",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NOT NULL OR \"vehicles\".\"hourlyRateJpy\" IS NOT NULL"
+        },
+        "vehicles_daily_rate_non_negative": {
+          "name": "vehicles_daily_rate_non_negative",
+          "value": "\"vehicles\".\"dailyRateJpy\" IS NULL OR \"vehicles\".\"dailyRateJpy\" >= 0"
+        },
+        "vehicles_hourly_rate_non_negative": {
+          "name": "vehicles_hourly_rate_non_negative",
+          "value": "\"vehicles\".\"hourlyRateJpy\" IS NULL OR \"vehicles\".\"hourlyRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.class_rate_plans": {
+      "name": "class_rate_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayRateJpy": {
+          "name": "dayRateJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_class_rate_plans_operator": {
+          "name": "idx_class_rate_plans_operator",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_class": {
+          "name": "idx_class_rate_plans_class",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_class_rate_plans_pickup_location": {
+          "name": "idx_class_rate_plans_pickup_location",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "class_rate_plans_operatorId_operators_id_fk": {
+          "name": "class_rate_plans_operatorId_operators_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_pickupLocationId_locations_id_fk": {
+          "name": "class_rate_plans_pickupLocationId_locations_id_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "class_rate_plans_operator_class_fk": {
+          "name": "class_rate_plans_operator_class_fk",
+          "tableFrom": "class_rate_plans",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "class_rate_plans_operator_class_location_unique": {
+          "name": "class_rate_plans_operator_class_location_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "classId",
+            "pickupLocationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "class_rate_plans_day_rate_non_negative": {
+          "name": "class_rate_plans_day_rate_non_negative",
+          "value": "\"class_rate_plans\".\"dayRateJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_schedules": {
+      "name": "fee_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleClassId": {
+          "name": "vehicleClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "fee_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fee_schedule_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_schedules_operator_class": {
+          "name": "idx_fee_schedules_operator_class",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_schedules_vehicle_class": {
+          "name": "idx_fee_schedules_vehicle_class",
+          "columns": [
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_class_unique": {
+          "name": "fee_schedules_active_class_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicleClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fee_schedules_active_operatorwide_unique": {
+          "name": "fee_schedules_active_operatorwide_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE' AND \"vehicleClassId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_schedules_operatorId_operators_id_fk": {
+          "name": "fee_schedules_operatorId_operators_id_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fee_schedules_operator_class_fk": {
+          "name": "fee_schedules_operator_class_fk",
+          "tableFrom": "fee_schedules",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "vehicleClassId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fee_schedules_amount_non_negative": {
+          "name": "fee_schedules_amount_non_negative",
+          "value": "\"fee_schedules\".\"amountJpy\" >= 0"
+        },
+        "fee_schedules_feetype_unit_coherent": {
+          "name": "fee_schedules_feetype_unit_coherent",
+          "value": "(\"fee_schedules\".\"feeType\" = 'OVERTIME_HOURLY' AND \"fee_schedules\".\"unit\" = 'PER_HOUR') OR (\"fee_schedules\".\"feeType\" = 'CLEANING_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT') OR (\"fee_schedules\".\"feeType\" = 'NO_FUEL_FLAT' AND \"fee_schedules\".\"unit\" = 'FLAT')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_options": {
+      "name": "insurance_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyPriceJpy": {
+          "name": "dailyPriceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deductibleJpy": {
+          "name": "deductibleJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_insurance_options_operatorId": {
+          "name": "idx_insurance_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_options_active_name_unique": {
+          "name": "insurance_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_options_operatorId_operators_id_fk": {
+          "name": "insurance_options_operatorId_operators_id_fk",
+          "tableFrom": "insurance_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "insurance_options_operatorId_id_unique": {
+          "name": "insurance_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "insurance_options_daily_price_non_negative": {
+          "name": "insurance_options_daily_price_non_negative",
+          "value": "\"insurance_options\".\"dailyPriceJpy\" >= 0"
+        },
+        "insurance_options_deductible_non_negative": {
+          "name": "insurance_options_deductible_non_negative",
+          "value": "\"insurance_options\".\"deductibleJpy\" IS NULL OR \"insurance_options\".\"deductibleJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_events": {
+      "name": "booking_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "booking_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_booking_events_bookingId": {
+          "name": "idx_booking_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_events_actorId": {
+          "name": "idx_booking_events_actorId",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_events_bookingId_bookings_id_fk": {
+          "name": "booking_events_bookingId_bookings_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "booking_events_actorId_users_id_fk": {
+          "name": "booking_events_actorId_users_id_fk",
+          "tableFrom": "booking_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renterId": {
+          "name": "renterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classId": {
+          "name": "classId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestedVehicleId": {
+          "name": "requestedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedVehicleId": {
+          "name": "assignedVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickupLocationId": {
+          "name": "pickupLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropoffLocationId": {
+          "name": "dropoffLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effectiveEndAt": {
+          "name": "effectiveEndAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONFIRMED'"
+        },
+        "source": {
+          "name": "source",
+          "type": "booking_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DIRECT'"
+        },
+        "fulfillmentMode": {
+          "name": "fulfillmentMode",
+          "type": "booking_fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPECIFIC'"
+        },
+        "bookingCode": {
+          "name": "bookingCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insuranceOptionId": {
+          "name": "insuranceOptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insuranceSnapshot": {
+          "name": "insuranceSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeSnapshot": {
+          "name": "feeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "addOnSnapshot": {
+          "name": "addOnSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFee": {
+          "name": "cancellationFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationFeeSettlement": {
+          "name": "cancellationFeeSettlement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ADVISORY'"
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerAcknowledgedAt": {
+          "name": "disclaimerAcknowledgedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclaimerTermsVersion": {
+          "name": "disclaimerTermsVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bookings_classId": {
+          "name": "idx_bookings_classId",
+          "columns": [
+            {
+              "expression": "classId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_operatorId": {
+          "name": "idx_bookings_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_requestedVehicleId": {
+          "name": "idx_bookings_requestedVehicleId",
+          "columns": [
+            {
+              "expression": "requestedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_assignedVehicleId": {
+          "name": "idx_bookings_assignedVehicleId",
+          "columns": [
+            {
+              "expression": "assignedVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_pickupLocationId": {
+          "name": "idx_bookings_pickupLocationId",
+          "columns": [
+            {
+              "expression": "pickupLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_dropoffLocationId": {
+          "name": "idx_bookings_dropoffLocationId",
+          "columns": [
+            {
+              "expression": "dropoffLocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_insuranceOptionId": {
+          "name": "idx_bookings_insuranceOptionId",
+          "columns": [
+            {
+              "expression": "insuranceOptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_renterId": {
+          "name": "idx_bookings_renterId",
+          "columns": [
+            {
+              "expression": "renterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bookings_status": {
+          "name": "idx_bookings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookings_idempotency_key": {
+          "name": "bookings_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_operatorId_operators_id_fk": {
+          "name": "bookings_operatorId_operators_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bookings_renterId_users_id_fk": {
+          "name": "bookings_renterId_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "renterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_pickupLocationId_locations_id_fk": {
+          "name": "bookings_pickupLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "pickupLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_dropoffLocationId_locations_id_fk": {
+          "name": "bookings_dropoffLocationId_locations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "dropoffLocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_class_fk": {
+          "name": "bookings_operator_class_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "operatorId",
+            "classId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_requested_vehicle_fk": {
+          "name": "bookings_operator_requested_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "requestedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_assigned_vehicle_fk": {
+          "name": "bookings_operator_assigned_vehicle_fk",
+          "tableFrom": "bookings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "operatorId",
+            "assignedVehicleId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bookings_operator_insurance_fk": {
+          "name": "bookings_operator_insurance_fk",
+          "tableFrom": "bookings",
+          "tableTo": "insurance_options",
+          "columnsFrom": [
+            "operatorId",
+            "insuranceOptionId"
+          ],
+          "columnsTo": [
+            "operatorId",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookings_bookingCode_unique": {
+          "name": "bookings_bookingCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bookings_specific_requires_assigned": {
+          "name": "bookings_specific_requires_assigned",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"assignedVehicleId\" IS NOT NULL"
+        },
+        "bookings_specific_requires_requested": {
+          "name": "bookings_specific_requires_requested",
+          "value": "\"bookings\".\"fulfillmentMode\" <> 'SPECIFIC' OR \"bookings\".\"requestedVehicleId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_anomalies": {
+      "name": "payment_anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_anomaly_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAmountJpy": {
+          "name": "receivedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedAmountJpy": {
+          "name": "expectedAmountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "payment_anomaly_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_anomalies_operatorId": {
+          "name": "idx_payment_anomalies_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_anomalies_bookingId": {
+          "name": "idx_payment_anomalies_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_anomalies_stripeEventId_unique": {
+          "name": "payment_anomalies_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_anomalies_operatorId_operators_id_fk": {
+          "name": "payment_anomalies_operatorId_operators_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_anomalies_bookingId_bookings_id_fk": {
+          "name": "payment_anomalies_bookingId_bookings_id_fk",
+          "tableFrom": "payment_anomalies",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_events": {
+      "name": "payment_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventId": {
+          "name": "stripeEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeCheckoutSessionId": {
+          "name": "stripeCheckoutSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grossJpy": {
+          "name": "grossJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFeeJpy": {
+          "name": "platformFeeJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "netToPartnerJpy": {
+          "name": "netToPartnerJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'jpy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_events_operatorId": {
+          "name": "idx_payment_events_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_events_bookingId": {
+          "name": "idx_payment_events_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeEventId_unique": {
+          "name": "payment_events_stripeEventId_unique",
+          "columns": [
+            {
+              "expression": "stripeEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_stripeCheckoutSessionId_unique": {
+          "name": "payment_events_stripeCheckoutSessionId_unique",
+          "columns": [
+            {
+              "expression": "stripeCheckoutSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_events_one_success_per_booking": {
+          "name": "payment_events_one_success_per_booking",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'SUCCEEDED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_events_operatorId_operators_id_fk": {
+          "name": "payment_events_operatorId_operators_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payment_events_bookingId_bookings_id_fk": {
+          "name": "payment_events_bookingId_bookings_id_fk",
+          "tableFrom": "payment_events",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_refunds": {
+      "name": "payment_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeRefundId": {
+          "name": "stripeRefundId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountJpy": {
+          "name": "amountJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_refunds_operatorId": {
+          "name": "idx_payment_refunds_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_bookingId_unique": {
+          "name": "payment_refunds_bookingId_unique",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_refunds_stripeRefundId_unique": {
+          "name": "payment_refunds_stripeRefundId_unique",
+          "columns": [
+            {
+              "expression": "stripeRefundId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripeRefundId\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_refunds_bookingId_bookings_id_fk": {
+          "name": "payment_refunds_bookingId_bookings_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_refunds_operatorId_operators_id_fk": {
+          "name": "payment_refunds_operatorId_operators_id_fk",
+          "tableFrom": "payment_refunds",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_refunds_amount_non_negative": {
+          "name": "payment_refunds_amount_non_negative",
+          "value": "\"payment_refunds\".\"amountJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceLanguage": {
+          "name": "sourceLanguage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_threadId": {
+          "name": "idx_messages_threadId",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_senderId": {
+          "name": "idx_messages_senderId",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_idempotency_key": {
+          "name": "messages_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_threadId_threads_id_fk": {
+          "name": "messages_threadId_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_senderId_users_id_fk": {
+          "name": "messages_senderId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_participants": {
+      "name": "thread_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thread_participants_threadId": {
+          "name": "idx_thread_participants_threadId",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_participants_userId": {
+          "name": "idx_thread_participants_userId",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_participants_threadId_threads_id_fk": {
+          "name": "thread_participants_threadId_threads_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "threadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_participants_userId_users_id_fk": {
+          "name": "thread_participants_userId_users_id_fk",
+          "tableFrom": "thread_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thread_participants_thread_user": {
+          "name": "thread_participants_thread_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_threads_bookingId": {
+          "name": "idx_threads_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threads_idempotency_key": {
+          "name": "threads_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threads_bookingId_bookings_id_fk": {
+          "name": "threads_bookingId_bookings_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "notification_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QUEUED'"
+        },
+        "providerMessageId": {
+          "name": "providerMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_bookingId": {
+          "name": "idx_notification_log_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_log_operatorId": {
+          "name": "idx_notification_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_bookingId_bookings_id_fk": {
+          "name": "notification_log_bookingId_bookings_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_log_operatorId_operators_id_fk": {
+          "name": "notification_log_operatorId_operators_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_log_idempotency_unique": {
+          "name": "notification_log_idempotency_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotencyKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "audit_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldValue": {
+          "name": "oldValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_operatorId": {
+          "name": "idx_audit_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_kind": {
+          "name": "idx_audit_log_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compliance_alert_log": {
+      "name": "compliance_alert_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicleId": {
+          "name": "vehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentType": {
+          "name": "documentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thresholdBand": {
+          "name": "thresholdBand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_compliance_alert_log_operatorId": {
+          "name": "idx_compliance_alert_log_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compliance_alert_log_vehicleId": {
+          "name": "idx_compliance_alert_log_vehicleId",
+          "columns": [
+            {
+              "expression": "vehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compliance_alert_log_operatorId_operators_id_fk": {
+          "name": "compliance_alert_log_operatorId_operators_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "compliance_alert_log_vehicleId_vehicles_id_fk": {
+          "name": "compliance_alert_log_vehicleId_vehicles_id_fk",
+          "tableFrom": "compliance_alert_log",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compliance_alert_log_band_unique": {
+          "name": "compliance_alert_log_band_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vehicleId",
+            "documentType",
+            "thresholdBand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.add_on_options": {
+      "name": "add_on_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceJpy": {
+          "name": "priceJpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "add_on_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_add_on_options_operatorId": {
+          "name": "idx_add_on_options_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "add_on_options_active_name_unique": {
+          "name": "add_on_options_active_name_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "add_on_options_operatorId_operators_id_fk": {
+          "name": "add_on_options_operatorId_operators_id_fk",
+          "tableFrom": "add_on_options",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "add_on_options_operatorId_id_unique": {
+          "name": "add_on_options_operatorId_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "operatorId",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "add_on_options_price_non_negative": {
+          "name": "add_on_options_price_non_negative",
+          "value": "\"add_on_options\".\"priceJpy\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operator_memberships": {
+      "name": "operator_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_memberships_active_user_unique": {
+          "name": "operator_memberships_active_user_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operator_memberships_operatorId": {
+          "name": "idx_operator_memberships_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_memberships_userId_users_id_fk": {
+          "name": "operator_memberships_userId_users_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_memberships_operatorId_operators_id_fk": {
+          "name": "operator_memberships_operatorId_operators_id_fk",
+          "tableFrom": "operator_memberships",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_invites": {
+      "name": "provider_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "operator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedByUserId": {
+          "name": "acceptedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_invites_tokenHash_unique": {
+          "name": "provider_invites_tokenHash_unique",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_invites_pending_email_unique": {
+          "name": "provider_invites_pending_email_unique",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'PENDING'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_email": {
+          "name": "idx_provider_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_operatorId": {
+          "name": "idx_provider_invites_operatorId",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_invitedByUserId": {
+          "name": "idx_provider_invites_invitedByUserId",
+          "columns": [
+            {
+              "expression": "invitedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_invites_acceptedByUserId": {
+          "name": "idx_provider_invites_acceptedByUserId",
+          "columns": [
+            {
+              "expression": "acceptedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_invites_operatorId_operators_id_fk": {
+          "name": "provider_invites_operatorId_operators_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provider_invites_invitedByUserId_users_id_fk": {
+          "name": "provider_invites_invitedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_invites_acceptedByUserId_users_id_fk": {
+          "name": "provider_invites_acceptedByUserId_users_id_fk",
+          "tableFrom": "provider_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acceptedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_acceptances": {
+      "name": "consent_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentType": {
+          "name": "consentType",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operatorMembershipId": {
+          "name": "operatorMembershipId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorRole": {
+          "name": "actorRole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "consent_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLICKWRAP'"
+        },
+        "recordSignature": {
+          "name": "recordSignature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingKeyId": {
+          "name": "signingKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureRef": {
+          "name": "signatureRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentSnapshot": {
+          "name": "documentSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureCanonicalVersion": {
+          "name": "signatureCanonicalVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_unique_booking_liability": {
+          "name": "consent_unique_booking_liability",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_user_document": {
+          "name": "consent_unique_user_document",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"bookingId\" IS NULL AND \"consent_acceptances\".\"operatorId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_unique_operator_document": {
+          "name": "consent_unique_operator_document",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"consent_acceptances\".\"operatorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_document_type_idx": {
+          "name": "consent_acceptances_document_type_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_membership_idx": {
+          "name": "consent_acceptances_membership_idx",
+          "columns": [
+            {
+              "expression": "operatorMembershipId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_acceptances_consent_type_idx": {
+          "name": "consent_acceptances_consent_type_idx",
+          "columns": [
+            {
+              "expression": "consentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_acceptances_userId_users_id_fk": {
+          "name": "consent_acceptances_userId_users_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorId_operators_id_fk": {
+          "name": "consent_acceptances_operatorId_operators_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_operatorMembershipId_operator_memberships_id_fk": {
+          "name": "consent_acceptances_operatorMembershipId_operator_memberships_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "operator_memberships",
+          "columnsFrom": [
+            "operatorMembershipId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_bookingId_bookings_id_fk": {
+          "name": "consent_acceptances_bookingId_bookings_id_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "consent_acceptances_document_type_fk": {
+          "name": "consent_acceptances_document_type_fk",
+          "tableFrom": "consent_acceptances",
+          "tableTo": "consent_documents",
+          "columnsFrom": [
+            "documentId",
+            "consentType"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_liability_booking_chk": {
+          "name": "consent_liability_booking_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'RENTER_LIABILITY') = (\"consent_acceptances\".\"bookingId\" IS NOT NULL)"
+        },
+        "consent_operator_agreement_chk": {
+          "name": "consent_operator_agreement_chk",
+          "value": "(\"consent_acceptances\".\"consentType\" = 'OPERATOR_AGREEMENT') = (\"consent_acceptances\".\"operatorId\" IS NOT NULL)"
+        },
+        "consent_membership_implies_operator_chk": {
+          "name": "consent_membership_implies_operator_chk",
+          "value": "\"consent_acceptances\".\"operatorMembershipId\" IS NULL OR \"consent_acceptances\".\"operatorId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_documents": {
+      "name": "consent_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptanceLabel": {
+          "name": "acceptanceLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "consent_doc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "effectiveFrom": {
+          "name": "effectiveFrom",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_documents_type_version_locale_unique": {
+          "name": "consent_documents_type_version_locale_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "version",
+            "locale"
+          ]
+        },
+        "consent_documents_id_type_unique": {
+          "name": "consent_documents_id_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bookingId": {
+          "name": "bookingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operatorId": {
+          "name": "operatorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorUserId": {
+          "name": "authorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorRole": {
+          "name": "authorRole",
+          "type": "review_author_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "review_subject",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectVehicleId": {
+          "name": "subjectVehicleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectClassId": {
+          "name": "subjectClassId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overall": {
+          "name": "overall",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subRatings": {
+          "name": "subRatings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderationStatus": {
+          "name": "moderationStatus",
+          "type": "review_moderation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VISIBLE'"
+        },
+        "revealDeadlineAt": {
+          "name": "revealDeadlineAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_bookingId": {
+          "name": "idx_reviews_bookingId",
+          "columns": [
+            {
+              "expression": "bookingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_authorUserId": {
+          "name": "idx_reviews_authorUserId",
+          "columns": [
+            {
+              "expression": "authorUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_operator_published": {
+          "name": "idx_reviews_operator_published",
+          "columns": [
+            {
+              "expression": "operatorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_vehicle": {
+          "name": "idx_reviews_subject_vehicle",
+          "columns": [
+            {
+              "expression": "subjectVehicleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_subject_class": {
+          "name": "idx_reviews_subject_class",
+          "columns": [
+            {
+              "expression": "subjectClassId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_reveal_due": {
+          "name": "idx_reviews_reveal_due",
+          "columns": [
+            {
+              "expression": "revealDeadlineAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"publishedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_bookingId_bookings_id_fk": {
+          "name": "reviews_bookingId_bookings_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "bookingId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_operatorId_operators_id_fk": {
+          "name": "reviews_operatorId_operators_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operatorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_authorUserId_users_id_fk": {
+          "name": "reviews_authorUserId_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectVehicleId_vehicles_id_fk": {
+          "name": "reviews_subjectVehicleId_vehicles_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "subjectVehicleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_subjectClassId_vehicle_classes_id_fk": {
+          "name": "reviews_subjectClassId_vehicle_classes_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "vehicle_classes",
+          "columnsFrom": [
+            "subjectClassId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_author_subject_per_booking_unique": {
+          "name": "reviews_author_subject_per_booking_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bookingId",
+            "authorUserId",
+            "subject"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviews_overall_range_chk": {
+          "name": "reviews_overall_range_chk",
+          "value": "\"reviews\".\"overall\" BETWEEN 1 AND 5"
+        },
+        "reviews_subject_pairing_chk": {
+          "name": "reviews_subject_pairing_chk",
+          "value": "(\"reviews\".\"authorRole\" = 'OPERATOR') = (\"reviews\".\"subject\" = 'RENTER')"
+        },
+        "reviews_vehicle_subject_chk": {
+          "name": "reviews_vehicle_subject_chk",
+          "value": "(\"reviews\".\"subject\" = 'VEHICLE') = (\"reviews\".\"subjectVehicleId\" IS NOT NULL)"
+        },
+        "reviews_class_subject_chk": {
+          "name": "reviews_class_subject_chk",
+          "value": "\"reviews\".\"subjectClassId\" IS NULL OR \"reviews\".\"subject\" = 'VEHICLE'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_status": {
+      "name": "document_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "IDP",
+        "PASSPORT"
+      ]
+    },
+    "public.region_status": {
+      "name": "region_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.region_type": {
+      "name": "region_type",
+      "schema": "public",
+      "values": [
+        "PREFECTURE",
+        "CITY",
+        "AREA"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "STAFF",
+        "ADMIN",
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF",
+        "PLATFORM_ADMIN"
+      ]
+    },
+    "public.coordinate_source": {
+      "name": "coordinate_source",
+      "schema": "public",
+      "values": [
+        "GEOCODED",
+        "MANUAL",
+        "PENDING"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.luggage_size": {
+      "name": "luggage_size",
+      "schema": "public",
+      "values": [
+        "SMALL",
+        "MEDIUM",
+        "LARGE"
+      ]
+    },
+    "public.transmission": {
+      "name": "transmission",
+      "schema": "public",
+      "values": [
+        "AUTO",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_block_kind": {
+      "name": "vehicle_block_kind",
+      "schema": "public",
+      "values": [
+        "MAINTENANCE",
+        "OUT_OF_SERVICE",
+        "MANUAL"
+      ]
+    },
+    "public.vehicle_class_status": {
+      "name": "vehicle_class_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.fee_schedule_status": {
+      "name": "fee_schedule_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "OVERTIME_HOURLY",
+        "CLEANING_FLAT",
+        "NO_FUEL_FLAT"
+      ]
+    },
+    "public.fee_unit": {
+      "name": "fee_unit",
+      "schema": "public",
+      "values": [
+        "PER_HOUR",
+        "PER_DAY",
+        "PER_KM",
+        "FLAT"
+      ]
+    },
+    "public.insurance_status": {
+      "name": "insurance_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.booking_event_type": {
+      "name": "booking_event_type",
+      "schema": "public",
+      "values": [
+        "BOOKING_CREATED",
+        "VEHICLE_SUBSTITUTED",
+        "VEHICLE_ASSIGNED",
+        "BOOKING_CANCELLED",
+        "STATUS_CHANGED"
+      ]
+    },
+    "public.booking_fulfillment_mode": {
+      "name": "booking_fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "SPECIFIC",
+        "CLASS_COMBO"
+      ]
+    },
+    "public.booking_source": {
+      "name": "booking_source",
+      "schema": "public",
+      "values": [
+        "DIRECT",
+        "TRIP_COM",
+        "MANUAL",
+        "OTHER"
+      ]
+    },
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "CONFIRMED",
+        "ACTIVE",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.payment_anomaly_kind": {
+      "name": "payment_anomaly_kind",
+      "schema": "public",
+      "values": [
+        "DOUBLE_PAYMENT",
+        "AMOUNT_MISMATCH"
+      ]
+    },
+    "public.payment_anomaly_resolution": {
+      "name": "payment_anomaly_resolution",
+      "schema": "public",
+      "values": [
+        "BENIGN",
+        "INVESTIGATED",
+        "REFUNDED_EXTERNALLY"
+      ]
+    },
+    "public.payment_event_status": {
+      "name": "payment_event_status",
+      "schema": "public",
+      "values": [
+        "SUCCEEDED"
+      ]
+    },
+    "public.payment_refund_status": {
+      "name": "payment_refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.notification_kind": {
+      "name": "notification_kind",
+      "schema": "public",
+      "values": [
+        "OPERATOR_BOOKING_ALERT",
+        "RENTER_BOOKING_CONFIRM",
+        "RENTER_SUBSTITUTION",
+        "RENTER_CANCELLATION",
+        "RENTER_TRIP_STARTED",
+        "RENTER_TRIP_COMPLETED",
+        "RENTER_REVIEW_PROMPT"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "QUEUED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "DEAD",
+        "NO_RECIPIENT"
+      ]
+    },
+    "public.audit_event_kind": {
+      "name": "audit_event_kind",
+      "schema": "public",
+      "values": [
+        "PROVIDER_INVITE_CREATED",
+        "OPERATOR_PROFILE_UPDATED",
+        "OPERATOR_MEMBER_DEACTIVATED"
+      ]
+    },
+    "public.add_on_status": {
+      "name": "add_on_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED"
+      ]
+    },
+    "public.operator_membership_status": {
+      "name": "operator_membership_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED"
+      ]
+    },
+    "public.operator_role": {
+      "name": "operator_role",
+      "schema": "public",
+      "values": [
+        "OPERATOR_OWNER",
+        "OPERATOR_STAFF"
+      ]
+    },
+    "public.provider_invite_status": {
+      "name": "provider_invite_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REVOKED"
+      ]
+    },
+    "public.consent_doc_status": {
+      "name": "consent_doc_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PUBLISHED",
+        "ARCHIVED"
+      ]
+    },
+    "public.consent_method": {
+      "name": "consent_method",
+      "schema": "public",
+      "values": [
+        "CLICKWRAP",
+        "ESIGN",
+        "IMPORTED"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "RENTER_TOS",
+        "PRIVACY_POLICY",
+        "RENTER_LIABILITY",
+        "OPERATOR_AGREEMENT"
+      ]
+    },
+    "public.review_author_role": {
+      "name": "review_author_role",
+      "schema": "public",
+      "values": [
+        "RENTER",
+        "OPERATOR"
+      ]
+    },
+    "public.review_moderation_status": {
+      "name": "review_moderation_status",
+      "schema": "public",
+      "values": [
+        "VISIBLE",
+        "HIDDEN"
+      ]
+    },
+    "public.review_subject": {
+      "name": "review_subject",
+      "schema": "public",
+      "values": [
+        "OPERATOR",
+        "VEHICLE",
+        "RENTER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1782511881385,
       "tag": "0082_vehicle_blocks_exclusion",
       "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1782516484724,
+      "tag": "0083_add_review_prompt_notification_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1782517065469,
       "tag": "0085_codify-bookings-indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1782518014088,
+      "tag": "0086_add_review_prompt_notification_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/services/email/templates/messages/index.ts
+++ b/packages/api/src/services/email/templates/messages/index.ts
@@ -48,6 +48,12 @@ export interface EmailStrings {
   tripStartedHeading: string
   tripCompletedSubject: string
   tripCompletedHeading: string
+  // #1083 post-trip review prompt
+  reviewPromptSubject: string // booking code appended
+  reviewPromptHeading: string
+  reviewPromptTitle: string
+  reviewPromptExplain: string
+  reviewPromptCta: string
   // Fee-type display names
   feeLabels: Record<FeeType, string>
   // #916 §5.4 compliance digest (operator-facing fleet reminder)
@@ -96,6 +102,12 @@ const en: EmailStrings = {
   tripStartedHeading: 'Your rental has started. Enjoy the drive!',
   tripCompletedSubject: 'Trip completed —',
   tripCompletedHeading: 'Your rental is complete. Thank you for choosing us!',
+  reviewPromptSubject: 'How was your trip? —',
+  reviewPromptHeading: 'Your trip is complete. Share how it went to help fellow travelers.',
+  reviewPromptTitle: 'Rate your trip',
+  reviewPromptExplain:
+    'Rate the operator and the vehicle. Reviews stay hidden until both sides submit or 14 days pass.',
+  reviewPromptCta: 'Write a review',
   feeLabels: {
     OVERTIME_HOURLY: 'Overtime (per hour)',
     CLEANING_FLAT: 'Cleaning',
@@ -153,6 +165,13 @@ const ja: EmailStrings = {
   tripStartedHeading: 'レンタルが開始されました。よい旅を!',
   tripCompletedSubject: 'レンタル完了のお知らせ —',
   tripCompletedHeading: 'レンタルが完了しました。ご利用ありがとうございました!',
+  reviewPromptSubject: 'ご利用はいかがでしたか —',
+  reviewPromptHeading:
+    'ご利用ありがとうございました。体験を共有して、他の旅行者の参考にしましょう。',
+  reviewPromptTitle: '旅行を評価する',
+  reviewPromptExplain:
+    'オペレーターと車両を評価してください。レビューは双方が投稿するか14日が経過するまで公開されません。',
+  reviewPromptCta: 'レビューを書く',
   feeLabels: {
     OVERTIME_HOURLY: '延長料金（1時間あたり）',
     CLEANING_FLAT: 'クリーニング',
@@ -210,6 +229,11 @@ const zh: EmailStrings = {
   tripStartedHeading: '您的租赁已开始。祝您旅途愉快!',
   tripCompletedSubject: '行程完成通知 —',
   tripCompletedHeading: '您的租赁已完成。感谢您的惠顾!',
+  reviewPromptSubject: '您的行程体验如何 —',
+  reviewPromptHeading: '您的行程已完成。分享您的体验，帮助其他旅行者。',
+  reviewPromptTitle: '评价您的行程',
+  reviewPromptExplain: '评价运营商和车辆。在双方都提交或14天后，评价才会公开。',
+  reviewPromptCta: '撰写评价',
   feeLabels: {
     OVERTIME_HOURLY: '超时费(每小时)',
     CLEANING_FLAT: '清洁费',

--- a/packages/api/src/services/email/templates/renter-review-prompt.ts
+++ b/packages/api/src/services/email/templates/renter-review-prompt.ts
@@ -1,0 +1,43 @@
+import { formatDateTime } from './format'
+import { type RenderedEmail, renderCtaSection, renderRowsEmail } from './layout'
+import { emailStrings } from './messages'
+
+/**
+ * #1083 post-trip review prompt. Fired on the COMPLETED trigger alongside the
+ * trip-completed notice (distinct kind so the idempotency key never collides).
+ * Snapshot-only — booking code + rental period + a deep link back to the renter's
+ * My Bookings review form; it reads no booking relations (RELATIONS_BY_KIND set is
+ * empty). `reviewUrl` is null when WEB_ORIGIN is unset; the email still sends, just
+ * without the CTA, mirroring the operator-alert deep-link gating.
+ */
+export interface RenterReviewPromptData {
+  bookingCode: string
+  startAt: Date
+  endAt: Date
+  reviewUrl: string | null
+}
+
+export function renderRenterReviewPrompt(
+  data: RenterReviewPromptData,
+  locale: string,
+): RenderedEmail {
+  const m = emailStrings(locale)
+  const rows: Array<[string, string]> = [
+    [m.bookingCodeLabel, data.bookingCode],
+    [m.periodLabel, `${formatDateTime(data.startAt)} – ${formatDateTime(data.endAt)}`],
+  ]
+  const body = renderRowsEmail(m.reviewPromptHeading, rows)
+  const cta = data.reviewUrl
+    ? renderCtaSection(
+        m.reviewPromptTitle,
+        data.reviewUrl,
+        m.reviewPromptCta,
+        m.reviewPromptExplain,
+      )
+    : { html: '', text: '' }
+  return {
+    subject: `${m.reviewPromptSubject} ${data.bookingCode}`,
+    html: `${body.html}${cta.html}`,
+    text: `${body.text}${cta.text}`,
+  }
+}

--- a/packages/api/src/services/notification-dispatcher.ts
+++ b/packages/api/src/services/notification-dispatcher.ts
@@ -12,6 +12,7 @@ import type { EmailSender } from './email/email-sender'
 import { renderOperatorAlert } from './email/templates/operator-alert'
 import { renderRenterCancellation } from './email/templates/renter-cancellation'
 import { renderRenterConfirmation } from './email/templates/renter-confirmation'
+import { renderRenterReviewPrompt } from './email/templates/renter-review-prompt'
 import { renderRenterStatusUpdate } from './email/templates/renter-status-update'
 import { renderRenterSubstitution } from './email/templates/renter-substitution'
 import type { ResolveOperatorRecipients } from './operator-recipients'
@@ -35,7 +36,8 @@ export const TRIGGER_KINDS: Record<LifecycleTrigger, Kind[]> = {
   SUBSTITUTED: ['RENTER_SUBSTITUTION'],
   CANCELLED: ['RENTER_CANCELLATION'],
   ACTIVATED: ['RENTER_TRIP_STARTED'],
-  COMPLETED: ['RENTER_TRIP_COMPLETED'],
+  // #1083: completion sends the trip-completed notice AND the review prompt.
+  COMPLETED: ['RENTER_TRIP_COMPLETED', 'RENTER_REVIEW_PROMPT'],
 }
 
 // The booking relations a notification email can render. Everything else a
@@ -57,6 +59,8 @@ export const RELATIONS_BY_KIND: Record<Kind, ReadonlySet<NotificationRelation>> 
   RENTER_TRIP_STARTED: new Set(['vehicle', 'pickup', 'dropoff']),
   RENTER_TRIP_COMPLETED: new Set(['vehicle', 'pickup', 'dropoff']),
   OPERATOR_BOOKING_ALERT: new Set(['vehicle', 'pickup', 'dropoff']),
+  // Snapshot-only: booking code + period + a CTA back to My Bookings. Zero reads.
+  RENTER_REVIEW_PROMPT: new Set(),
 }
 
 const DEFAULT_OPERATOR_LOCALE = 'ja' // §12.2
@@ -344,6 +348,23 @@ export class NotificationDispatcher {
             locale,
           ),
         )
+      case 'RENTER_REVIEW_PROMPT': {
+        // Deep link to the renter's My Bookings list, where the review prompt lives.
+        // Trailing slash stripped so a misconfigured WEB_ORIGIN can't emit `//{locale}`.
+        const base = this.config.webBaseUrl?.replace(/\/+$/, '')
+        const reviewUrl = base ? `${base}/${locale}/bookings` : null
+        return envelope(
+          renderRenterReviewPrompt(
+            {
+              bookingCode: booking.bookingCode,
+              startAt: booking.startAt,
+              endAt: booking.endAt,
+              reviewUrl,
+            },
+            locale,
+          ),
+        )
+      }
       case 'OPERATOR_BOOKING_ALERT': {
         const [renter] = await this.userRepo.findByIds([booking.renterId])
         // Strip a trailing slash so a misconfigured WEB_ORIGIN can't emit a

--- a/packages/api/tests/services/email/templates.test.ts
+++ b/packages/api/tests/services/email/templates.test.ts
@@ -5,6 +5,8 @@ import type { RenterCancellationData } from '../../../src/services/email/templat
 import { renderRenterCancellation } from '../../../src/services/email/templates/renter-cancellation'
 import type { RenterConfirmationData } from '../../../src/services/email/templates/renter-confirmation'
 import { renderRenterConfirmation } from '../../../src/services/email/templates/renter-confirmation'
+import type { RenterReviewPromptData } from '../../../src/services/email/templates/renter-review-prompt'
+import { renderRenterReviewPrompt } from '../../../src/services/email/templates/renter-review-prompt'
 import type { RenterStatusUpdateData } from '../../../src/services/email/templates/renter-status-update'
 import { renderRenterStatusUpdate } from '../../../src/services/email/templates/renter-status-update'
 
@@ -224,6 +226,45 @@ describe('renderRenterStatusUpdate', () => {
 
   it('falls back to the en subject for an unknown locale', () => {
     expect(renderRenterStatusUpdate(baseStatus, 'fr').subject).toContain('Trip started')
+  })
+})
+
+describe('renderRenterReviewPrompt', () => {
+  const basePrompt: RenterReviewPromptData = {
+    bookingCode: 'RVEW1234',
+    startAt: new Date('2026-07-01T10:00:00Z'),
+    endAt: new Date('2026-07-03T18:00:00Z'),
+    reviewUrl: 'https://app.kuruma.jp/en/bookings',
+  }
+
+  it('localizes a distinct subject for en/ja/zh and appends the booking code', () => {
+    const en = renderRenterReviewPrompt(basePrompt, 'en').subject
+    const ja = renderRenterReviewPrompt(basePrompt, 'ja').subject
+    const zh = renderRenterReviewPrompt(basePrompt, 'zh').subject
+    expect(en).toContain('RVEW1234')
+    expect(ja).toContain('RVEW1234')
+    expect(zh).toContain('RVEW1234')
+    // mutation-resistant: the three locales are genuinely different strings
+    expect(new Set([en, ja, zh]).size).toBe(3)
+  })
+
+  it('renders the review CTA link in html and text when reviewUrl is present', () => {
+    const { html, text } = renderRenterReviewPrompt(basePrompt, 'en')
+    expect(html).toContain('href="https://app.kuruma.jp/en/bookings"')
+    expect(text).toContain('https://app.kuruma.jp/en/bookings')
+    expect(html).toContain('RVEW1234')
+    expect(html).not.toMatch(UUID_RE)
+  })
+
+  it('omits the CTA entirely when reviewUrl is null but still names the booking', () => {
+    const { subject, html } = renderRenterReviewPrompt({ ...basePrompt, reviewUrl: null }, 'en')
+    expect(subject).toContain('RVEW1234')
+    expect(html).not.toContain('href=')
+  })
+
+  it('falls back to the en subject for an unknown locale', () => {
+    const en = renderRenterReviewPrompt(basePrompt, 'en').subject
+    expect(renderRenterReviewPrompt(basePrompt, 'fr').subject).toBe(en)
   })
 })
 

--- a/packages/api/tests/services/notification-dispatcher.test.ts
+++ b/packages/api/tests/services/notification-dispatcher.test.ts
@@ -486,7 +486,9 @@ describe('NotificationDispatcher', () => {
       )
       expect((await kindsFor('CANCELLED')).rows.map((r) => r.kind)).toEqual(['RENTER_CANCELLATION'])
       expect((await kindsFor('ACTIVATED')).rows.map((r) => r.kind)).toEqual(['RENTER_TRIP_STARTED'])
-      expect((await kindsFor('COMPLETED')).rows.map((r) => r.kind)).toEqual([
+      // #1083: COMPLETED now also fans out the post-trip review prompt.
+      expect((await kindsFor('COMPLETED')).rows.map((r) => r.kind).sort()).toEqual([
+        'RENTER_REVIEW_PROMPT',
         'RENTER_TRIP_COMPLETED',
       ])
     })
@@ -506,15 +508,18 @@ describe('NotificationDispatcher', () => {
       await dispatcher.dispatch(booking, 'ACTIVATED')
       await dispatcher.dispatch(booking, 'COMPLETED')
       const rows = await logRepo.findAll({ userId: 'x', role: 'PLATFORM_ADMIN', bypassScope: true })
+      // #1083: COMPLETED fans out RENTER_TRIP_COMPLETED + RENTER_REVIEW_PROMPT.
       expect(rows.map((r) => r.kind).sort()).toEqual([
+        'RENTER_REVIEW_PROMPT',
         'RENTER_TRIP_COMPLETED',
         'RENTER_TRIP_STARTED',
       ])
       expect(rows.map((r) => r.idempotencyKey).sort()).toEqual([
+        `notify:${booking.id}:RENTER_REVIEW_PROMPT`,
         `notify:${booking.id}:RENTER_TRIP_COMPLETED`,
         `notify:${booking.id}:RENTER_TRIP_STARTED`,
       ])
-      expect(sender.send as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2)
+      expect(sender.send as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(3)
     })
 
     // #1114/#1151: `buildMessage` once eager-fetched operator+vehicle+pickup+dropoff
@@ -551,6 +556,7 @@ describe('NotificationDispatcher', () => {
         RENTER_TRIP_STARTED: ['vehicle', 'pickup', 'dropoff'],
         RENTER_TRIP_COMPLETED: ['vehicle', 'pickup', 'dropoff'],
         OPERATOR_BOOKING_ALERT: ['vehicle', 'pickup', 'dropoff'],
+        RENTER_REVIEW_PROMPT: [], // snapshot-only: code + period + CTA, no relations
       }
 
       function buildInstrumented() {

--- a/packages/shared/src/db/notification.ts
+++ b/packages/shared/src/db/notification.ts
@@ -13,6 +13,9 @@ export const notificationKindEnum = pgEnum('notification_kind', [
   'RENTER_CANCELLATION', // -> renter: booking was cancelled
   'RENTER_TRIP_STARTED', // -> renter: status advanced to ACTIVE
   'RENTER_TRIP_COMPLETED', // -> renter: status advanced to COMPLETED
+  // #1083: post-trip review prompt, fired on COMPLETED alongside the trip-completed
+  // notice. Distinct kind so notify:<booking>:<kind> never collides between the two.
+  'RENTER_REVIEW_PROMPT', // -> renter: rate the operator + vehicle after the trip
 ])
 // SENDING is the in-flight lease between QUEUED and SENT/FAILED — it closes the
 // concurrent-send race (atomic claim, architect P1). Reclaimable ONLY after the

--- a/packages/shared/tests/db/schema.test.ts
+++ b/packages/shared/tests/db/schema.test.ts
@@ -123,6 +123,7 @@ describe('schema exports', () => {
       'RENTER_CANCELLATION',
       'RENTER_TRIP_STARTED',
       'RENTER_TRIP_COMPLETED',
+      'RENTER_REVIEW_PROMPT',
     ])
   })
 

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1519,5 +1519,31 @@
       "continue": "Continue",
       "toPayment": "Continue to payment"
     }
+  },
+  "reviews": {
+    "prompt": {
+      "cta": "Leave a review",
+      "title": "Review your trip",
+      "description": "How was booking {code}? Your feedback helps fellow travelers."
+    },
+    "form": {
+      "subject": {
+        "OPERATOR": "The operator",
+        "VEHICLE": "The vehicle"
+      },
+      "overall": "Overall rating",
+      "starLabel": "{n} stars",
+      "dimension": {
+        "cleanliness": "Cleanliness",
+        "accuracy": "Accuracy",
+        "communication": "Communication",
+        "value": "Value"
+      },
+      "commentLabel": "Comment about {subject}",
+      "commentPlaceholder": "Share details of your experience (optional)",
+      "submit": "Submit review",
+      "pending": "Submitting…",
+      "error": "Something went wrong. Please try again."
+    }
   }
 }

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1519,5 +1519,31 @@
       "continue": "次へ",
       "toPayment": "お支払いへ進む"
     }
+  },
+  "reviews": {
+    "prompt": {
+      "cta": "レビューを書く",
+      "title": "旅行を評価する",
+      "description": "ご予約 {code} はいかがでしたか?あなたの声が他の旅行者の参考になります。"
+    },
+    "form": {
+      "subject": {
+        "OPERATOR": "オペレーター",
+        "VEHICLE": "車両"
+      },
+      "overall": "総合評価",
+      "starLabel": "星{n}つ",
+      "dimension": {
+        "cleanliness": "清潔さ",
+        "accuracy": "正確さ",
+        "communication": "コミュニケーション",
+        "value": "価格に見合う価値"
+      },
+      "commentLabel": "{subject}についてのコメント",
+      "commentPlaceholder": "ご利用体験の詳細をご記入ください(任意)",
+      "submit": "レビューを送信",
+      "pending": "送信中…",
+      "error": "エラーが発生しました。もう一度お試しください。"
+    }
   }
 }

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1519,5 +1519,31 @@
       "continue": "继续",
       "toPayment": "继续支付"
     }
+  },
+  "reviews": {
+    "prompt": {
+      "cta": "撰写评价",
+      "title": "评价您的行程",
+      "description": "预订 {code} 的体验如何？您的反馈将帮助其他旅行者。"
+    },
+    "form": {
+      "subject": {
+        "OPERATOR": "运营商",
+        "VEHICLE": "车辆"
+      },
+      "overall": "总体评分",
+      "starLabel": "{n} 星",
+      "dimension": {
+        "cleanliness": "清洁度",
+        "accuracy": "准确性",
+        "communication": "沟通",
+        "value": "性价比"
+      },
+      "commentLabel": "关于{subject}的评论",
+      "commentPlaceholder": "分享您的体验详情(可选)",
+      "submit": "提交评价",
+      "pending": "提交中…",
+      "error": "出现错误，请重试。"
+    }
   }
 }

--- a/packages/web/src/routes/$locale/_renter/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_renter/bookings/index.tsx
@@ -3,8 +3,9 @@ import { MyBookingsView } from '@/vite/bookings/MyBookingsView'
 import { myBookingsQueryOptions } from '@/vite/bookings/api'
 import { threadsQueryOptions } from '@/vite/messaging/api'
 import { indexThreadIdsByBooking } from '@/vite/messaging/booking-threads'
+import { renterReviewedSubjects, reviewsForBookingQueryOptions } from '@/vite/reviews'
 import { sessionQueryOptions } from '@/vite/session'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useQueries, useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import {
   type ErrorComponentProps,
   createFileRoute,
@@ -50,6 +51,20 @@ function MyBookingsRoute() {
   const { data: threads } = useQuery(threadsQueryOptions())
   const threadIdByBooking = threads ? indexThreadIdsByBooking(threads) : {}
 
+  // #1083: resolve each COMPLETED booking's reviews without blocking the list (the
+  // post-trip prompt appears once its query lands). One light read per completed
+  // trip — renter scale; aligned to `completed` by index.
+  const completed = bookings.filter((b) => b.status === 'COMPLETED')
+  const reviewQueries = useQueries({
+    queries: completed.map((b) => reviewsForBookingQueryOptions(b.id)),
+  })
+  const reviewedSubjectsByBooking = Object.fromEntries(
+    completed.flatMap((b, i) => {
+      const data = reviewQueries[i]?.data
+      return data ? [[b.id, renterReviewedSubjects(data)] as const] : []
+    }),
+  )
+
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-3xl">
@@ -57,7 +72,12 @@ function MyBookingsRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        <MyBookingsView bookings={bookings} locale={locale} threadIdByBooking={threadIdByBooking} />
+        <MyBookingsView
+          bookings={bookings}
+          locale={locale}
+          threadIdByBooking={threadIdByBooking}
+          reviewedSubjectsByBooking={reviewedSubjectsByBooking}
+        />
       </div>
     </main>
   )

--- a/packages/web/src/vite/bookings/MyBookingsView.tsx
+++ b/packages/web/src/vite/bookings/MyBookingsView.tsx
@@ -3,6 +3,8 @@ import { formatDateTime, formatJpy } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import type { MyBookingRow } from '@/vite/bookings/api'
 import { MessageHostLink } from '@/vite/messaging/MessageHostLink'
+import { ReviewPrompt } from '@/vite/reviews'
+import type { ReviewSubject } from '@kuruma/shared/enums'
 import { Link } from '@tanstack/react-router'
 import { CalendarX } from 'lucide-react'
 import { useTranslations } from 'use-intl'
@@ -12,13 +14,22 @@ interface MyBookingsViewProps {
   readonly locale: string
   /** bookingId -> threadId (#1032); a row links to its conversation when present. */
   readonly threadIdByBooking: Readonly<Record<string, string>>
+  /** #1083: bookingId -> the renter's already-reviewed subjects for a COMPLETED
+   *  booking. A key's presence means the review state has loaded; absent => not yet
+   *  resolved (the post-trip prompt stays hidden until then). */
+  readonly reviewedSubjectsByBooking?: Readonly<Record<string, readonly ReviewSubject[]>>
 }
 
 // Presentational list + empty state for the renter's own bookings (#543). The
 // route owns the loader/useSuspenseQuery and the renterId; this stays a pure
 // function of the resolved rows so it is unit-testable (FC/IS — the shell does
 // I/O, this renders). Each card links to the booking's confirmation/detail page.
-export function MyBookingsView({ bookings, locale, threadIdByBooking }: MyBookingsViewProps) {
+export function MyBookingsView({
+  bookings,
+  locale,
+  threadIdByBooking,
+  reviewedSubjectsByBooking = {},
+}: MyBookingsViewProps) {
   const t = useTranslations('bookings.list')
 
   if (bookings.length === 0) {
@@ -41,6 +52,9 @@ export function MyBookingsView({ bookings, locale, threadIdByBooking }: MyBookin
     <ul className="flex flex-col gap-3">
       {bookings.map((booking) => {
         const threadId = threadIdByBooking[booking.id]
+        // #1083: show the post-trip prompt only once the review state has resolved
+        // (an empty array = loaded, nothing reviewed yet; undefined = still loading).
+        const reviewed = reviewedSubjectsByBooking[booking.id]
         return (
           <li
             key={booking.id}
@@ -70,6 +84,13 @@ export function MyBookingsView({ bookings, locale, threadIdByBooking }: MyBookin
             </Link>
             {threadId ? (
               <MessageHostLink threadId={threadId} locale={locale} className="self-start" />
+            ) : null}
+            {booking.status === 'COMPLETED' && reviewed !== undefined ? (
+              <ReviewPrompt
+                bookingId={booking.id}
+                bookingCode={booking.bookingCode}
+                reviewedSubjects={reviewed}
+              />
             ) : null}
           </li>
         )

--- a/packages/web/src/vite/reviews/ReviewForm.tsx
+++ b/packages/web/src/vite/reviews/ReviewForm.tsx
@@ -43,13 +43,26 @@ export function ReviewForm({ bookingId, csrfToken, subjects, onSubmitted }: Revi
   }
 
   const mutation = useMutation({
-    mutationFn: (inputs: SubmitReviewInput[]) =>
-      Promise.all(inputs.map((input) => submitReview(input, csrfToken))),
+    mutationFn: async (inputs: SubmitReviewInput[]) => {
+      // Independent writes (one per subject): settle each on its own. A 409
+      // ALREADY_REVIEWED is benign — that subject is on record — but a real failure
+      // on one must NOT be masked by another's success (Promise.all would collapse
+      // them). allSettled lets a genuine failure surface while keeping saved siblings.
+      const results = await Promise.allSettled(
+        inputs.map((input) => submitReview(input, csrfToken)),
+      )
+      for (const r of results) {
+        if (r.status === 'rejected' && !(r.reason instanceof ApiError && r.reason.status === 409)) {
+          throw r.reason
+        }
+      }
+    },
     onSuccess: settle,
-    onError: (error) => {
-      // 409 ALREADY_REVIEWED: the renter's intent is already on record, so settle
-      // and close rather than surface an error for an idempotent re-submit.
-      if (error instanceof ApiError && error.status === 409) settle()
+    onError: () => {
+      // A sibling may have persisted before another failed — refresh so the prompt
+      // reflects server truth on reopen, but keep THIS form open showing the error
+      // (re-submitting a saved subject just 409s benignly).
+      queryClient.invalidateQueries({ queryKey: REVIEWS_KEY })
     },
   })
 
@@ -83,8 +96,8 @@ export function ReviewForm({ bookingId, csrfToken, subjects, onSubmitted }: Revi
     mutation.mutate(buildInputs())
   }
 
-  const showError =
-    mutation.isError && !(mutation.error instanceof ApiError && mutation.error.status === 409)
+  // Only a genuine failure rejects now (benign 409s resolve inside mutationFn).
+  const showError = mutation.isError
 
   return (
     <form

--- a/packages/web/src/vite/reviews/ReviewForm.tsx
+++ b/packages/web/src/vite/reviews/ReviewForm.tsx
@@ -1,0 +1,135 @@
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { ApiError } from '@/lib/api-error'
+import { StarRating } from '@/vite/reviews/StarRating'
+import {
+  RENTER_OPERATOR_DIMENSIONS,
+  REVIEWS_KEY,
+  type RenterReviewSubject,
+  type SubmitReviewInput,
+  submitReview,
+} from '@/vite/reviews/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRef, useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+// Mirrors the server's submitReviewSchema comment cap so the textarea can't submit a
+// body the API would 400.
+const COMMENT_MAX = 2000
+
+interface ReviewFormProps {
+  readonly bookingId: string
+  readonly csrfToken: string
+  /** The subjects still pending for this booking, in render order. */
+  readonly subjects: readonly RenterReviewSubject[]
+  readonly onSubmitted: () => void
+}
+
+// #1083: the renter rates each pending subject (operator + vehicle) and submits them
+// together. Overall (1-5) is required per subject; the operator sub-dimensions and the
+// comment are optional. One POST /reviews per subject; a benign 409 (a double-submit
+// got there first) settles like success. On success it invalidates the reviews prefix
+// so the prompt disappears, and closes via onSubmitted.
+export function ReviewForm({ bookingId, csrfToken, subjects, onSubmitted }: ReviewFormProps) {
+  const t = useTranslations('reviews.form')
+  const queryClient = useQueryClient()
+  const [overall, setOverall] = useState<Record<string, number>>({})
+  const [comment, setComment] = useState<Record<string, string>>({})
+  const [dims, setDims] = useState<Record<string, number>>({})
+
+  function settle() {
+    queryClient.invalidateQueries({ queryKey: REVIEWS_KEY })
+    onSubmitted()
+  }
+
+  const mutation = useMutation({
+    mutationFn: (inputs: SubmitReviewInput[]) =>
+      Promise.all(inputs.map((input) => submitReview(input, csrfToken))),
+    onSuccess: settle,
+    onError: (error) => {
+      // 409 ALREADY_REVIEWED: the renter's intent is already on record, so settle
+      // and close rather than surface an error for an idempotent re-submit.
+      if (error instanceof ApiError && error.status === 409) settle()
+    },
+  })
+
+  // Synchronous in-flight guard: isPending only flips between renders, so a
+  // double-click in one frame would fire two submits (mirrors CancelBookingDialog).
+  const inFlightRef = useRef(false)
+  if (!mutation.isPending && inFlightRef.current) inFlightRef.current = false
+
+  const ready = subjects.every((s) => (overall[s] ?? 0) >= 1)
+
+  function buildInputs(): SubmitReviewInput[] {
+    return subjects.map((subject) => {
+      const text = comment[subject]?.trim()
+      const base: SubmitReviewInput = {
+        bookingId,
+        subject,
+        overall: overall[subject] ?? 0,
+        ...(text ? { comment: text } : {}),
+      }
+      if (subject !== 'OPERATOR') return base
+      const entries = RENTER_OPERATOR_DIMENSIONS.map((d) => [d, dims[d] ?? 0] as const).filter(
+        ([, v]) => v >= 1,
+      )
+      return entries.length > 0 ? { ...base, subRatings: Object.fromEntries(entries) } : base
+    })
+  }
+
+  function handleSubmit() {
+    if (!ready || inFlightRef.current || mutation.isPending) return
+    inFlightRef.current = true
+    mutation.mutate(buildInputs())
+  }
+
+  const showError =
+    mutation.isError && !(mutation.error instanceof ApiError && mutation.error.status === 409)
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleSubmit()
+      }}
+      className="space-y-5"
+    >
+      {subjects.map((subject) => (
+        <fieldset key={subject} className="space-y-2">
+          <legend className="text-sm font-semibold">{t(`subject.${subject}`)}</legend>
+          <StarRating
+            name={`overall-${subject}`}
+            label={t('overall')}
+            value={overall[subject] ?? 0}
+            onChange={(v) => setOverall((prev) => ({ ...prev, [subject]: v }))}
+            starLabel={(n) => t('starLabel', { n })}
+          />
+          {subject === 'OPERATOR'
+            ? RENTER_OPERATOR_DIMENSIONS.map((d) => (
+                <StarRating
+                  key={d}
+                  name={`dim-${subject}-${d}`}
+                  label={t(`dimension.${d}`)}
+                  value={dims[d] ?? 0}
+                  onChange={(v) => setDims((prev) => ({ ...prev, [d]: v }))}
+                  starLabel={(n) => t('starLabel', { n })}
+                />
+              ))
+            : null}
+          <Textarea
+            value={comment[subject] ?? ''}
+            onChange={(e) => setComment((prev) => ({ ...prev, [subject]: e.target.value }))}
+            placeholder={t('commentPlaceholder')}
+            aria-label={t('commentLabel', { subject: t(`subject.${subject}`) })}
+            rows={2}
+            maxLength={COMMENT_MAX}
+          />
+        </fieldset>
+      ))}
+      {showError ? <output className="block text-sm text-destructive">{t('error')}</output> : null}
+      <Button type="submit" disabled={!ready || mutation.isPending} className="w-full">
+        {mutation.isPending ? t('pending') : t('submit')}
+      </Button>
+    </form>
+  )
+}

--- a/packages/web/src/vite/reviews/ReviewPrompt.tsx
+++ b/packages/web/src/vite/reviews/ReviewPrompt.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { ReviewForm } from '@/vite/reviews/ReviewForm'
+import { pendingReviewSubjects } from '@/vite/reviews/api'
+import { useSession } from '@/vite/session'
+import type { ReviewSubject } from '@kuruma/shared/enums'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+
+interface ReviewPromptProps {
+  readonly bookingId: string
+  readonly bookingCode: string
+  /** Subjects the renter has already reviewed for this booking (resolved upstream). */
+  readonly reviewedSubjects: readonly ReviewSubject[]
+}
+
+// #1083: the post-trip review CTA shown on a COMPLETED booking in My Bookings. It
+// renders only while a subject is still unreviewed (both done -> nothing) and only
+// for an authenticated session (the submit is CSRF-gated). Opens a dialog hosting the
+// ReviewForm for exactly the pending subjects.
+export function ReviewPrompt({ bookingId, bookingCode, reviewedSubjects }: ReviewPromptProps) {
+  const t = useTranslations('reviews.prompt')
+  const { data: session } = useSession()
+  const [open, setOpen] = useState(false)
+  const pending = pendingReviewSubjects(reviewedSubjects)
+
+  if (pending.length === 0 || !session) return null
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button variant="outline" size="sm" className="self-start" />}>
+        {t('cta')}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{t('description', { code: bookingCode })}</DialogDescription>
+        </DialogHeader>
+        <ReviewForm
+          bookingId={bookingId}
+          csrfToken={session.csrfToken}
+          subjects={pending}
+          onSubmitted={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/src/vite/reviews/StarRating.tsx
+++ b/packages/web/src/vite/reviews/StarRating.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/utils'
+import { Star } from 'lucide-react'
+
+const STARS = [1, 2, 3, 4, 5] as const
+
+interface StarRatingProps {
+  /** Unique radio-group name so sibling ratings stay mutually independent. */
+  readonly name: string
+  /** Visible label for the rating row, also the group's accessible name. */
+  readonly label: string
+  /** Current selection, 1-5; 0 means unset. */
+  readonly value: number
+  readonly onChange: (value: number) => void
+  /** Builds the per-star accessible name, e.g. n => `${n} stars`. */
+  readonly starLabel: (n: number) => string
+}
+
+// A 1-5 star input built from native radios (visually hidden, the star icon is the
+// label) — keyboard + screen-reader reachable with real radio-group semantics, and
+// stars up to the selection render filled. Controlled; the parent owns the value.
+export function StarRating({ name, label, value, onChange, starLabel }: StarRatingProps) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <div className="flex gap-0.5">
+        {STARS.map((n) => (
+          <label
+            key={n}
+            className="cursor-pointer rounded p-0.5 focus-within:ring-2 focus-within:ring-ring"
+          >
+            <input
+              type="radio"
+              name={name}
+              checked={value === n}
+              onChange={() => onChange(n)}
+              aria-label={starLabel(n)}
+              className="sr-only"
+            />
+            <Star
+              aria-hidden
+              className={cn(
+                'size-5',
+                n <= value ? 'fill-amber-500 text-amber-500' : 'text-muted-foreground/40',
+              )}
+            />
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/vite/reviews/api.ts
+++ b/packages/web/src/vite/reviews/api.ts
@@ -1,0 +1,120 @@
+import { unwrap } from '@/lib/api-error'
+import { getApiBaseUrl } from '@/vite/api-base'
+import {
+  REVIEW_AUTHOR_ROLES,
+  REVIEW_SUBJECTS,
+  type ReviewAuthorRole,
+  type ReviewSubject,
+} from '@kuruma/shared/enums'
+import { queryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+// #1083: the two subjects a renter rates after a trip, in form order. The operator
+// also carries optional sub-dimensions; the vehicle is stars + comment only (the
+// slice-2 DIRECTION map rejects sub-dimensions on a renter→VEHICLE review).
+export const RENTER_REVIEW_SUBJECTS = ['OPERATOR', 'VEHICLE'] as const
+export type RenterReviewSubject = (typeof RENTER_REVIEW_SUBJECTS)[number]
+
+// Renter→operator sub-dimensions (slice-2 service DIRECTION map). All optional.
+export const RENTER_OPERATOR_DIMENSIONS = [
+  'cleanliness',
+  'accuracy',
+  'communication',
+  'value',
+] as const
+export type RenterOperatorDimension = (typeof RENTER_OPERATOR_DIMENSIONS)[number]
+
+// JSON-serialized review (#1082) as the renter read model sees it. A lean subset of
+// the API entity — enough to decide which subjects remain unreviewed and to show a
+// submitted rating; zod strips the rest of the row at the seam.
+export interface ReviewDto {
+  id: string
+  bookingId: string
+  authorRole: ReviewAuthorRole
+  subject: ReviewSubject
+  overall: number
+  comment: string | null
+  publishedAt: string | null
+}
+
+// #711: pin the runtime parse to the DTO via `satisfies z.ZodType<…>` so a dropped
+// field fails as a ParseError at the seam, not as `undefined` in render.
+const reviewDtoSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  authorRole: z.enum(REVIEW_AUTHOR_ROLES),
+  subject: z.enum(REVIEW_SUBJECTS),
+  overall: z.number(),
+  comment: z.string().nullable(),
+  publishedAt: z.string().nullable(),
+}) satisfies z.ZodType<ReviewDto>
+
+// What the renter submits for ONE subject. The server derives operatorId, authorRole,
+// and the reveal window — none are client fields. `subRatings` is sent only when
+// non-empty (a vehicle review carries none); `comment` only when non-blank.
+export interface SubmitReviewInput {
+  bookingId: string
+  subject: RenterReviewSubject
+  overall: number
+  subRatings?: Record<string, number>
+  comment?: string | null
+}
+
+// POST /reviews (#1082) — cookie-authenticated + CSRF-gated, so the caller echoes the
+// session CSRF token. `unwrap` throws an ApiError carrying the status, so the form can
+// treat 409 ALREADY_REVIEWED as benign.
+export async function submitReview(
+  input: SubmitReviewInput,
+  csrfToken: string,
+): Promise<ReviewDto> {
+  const subRatings =
+    input.subRatings && Object.keys(input.subRatings).length > 0 ? input.subRatings : undefined
+  const comment = input.comment?.trim() ? input.comment.trim() : undefined
+  const res = await fetch(`${getApiBaseUrl()}/reviews`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify({
+      bookingId: input.bookingId,
+      subject: input.subject,
+      overall: input.overall,
+      ...(subRatings ? { subRatings } : {}),
+      ...(comment ? { comment } : {}),
+    }),
+  })
+  const { review } = await unwrap(res, z.object({ review: reviewDtoSchema }))
+  return review
+}
+
+// GET /bookings/:bookingId/reviews (#1082) — participant-scoped, double-blind. Returns
+// the caller's own rows plus any revealed counterparty rows.
+export async function fetchReviewsForBooking(bookingId: string): Promise<ReviewDto[]> {
+  const res = await fetch(`${getApiBaseUrl()}/bookings/${encodeURIComponent(bookingId)}/reviews`, {
+    credentials: 'include',
+  })
+  const { reviews } = await unwrap(res, z.object({ reviews: z.array(reviewDtoSchema) }))
+  return reviews
+}
+
+export function reviewsForBookingQueryOptions(bookingId: string) {
+  return queryOptions({
+    queryKey: ['reviews', bookingId],
+    queryFn: () => fetchReviewsForBooking(bookingId),
+  })
+}
+
+// #1083: the prefix every reviews query is keyed under. A submit invalidates THIS key;
+// React Query's prefix match refreshes every booking's reviews in one call.
+export const REVIEWS_KEY = ['reviews'] as const
+
+// The subjects the renter has already reviewed for a booking — drives prompt
+// visibility. A renter only ever authors RENTER-role rows, so the published
+// counterparty (OPERATOR) rows the read may also return are excluded here.
+export function renterReviewedSubjects(reviews: readonly ReviewDto[]): ReviewSubject[] {
+  return reviews.filter((r) => r.authorRole === 'RENTER').map((r) => r.subject)
+}
+
+// The renter-review subjects still missing for a booking (form order preserved).
+export function pendingReviewSubjects(reviewed: readonly ReviewSubject[]): RenterReviewSubject[] {
+  return RENTER_REVIEW_SUBJECTS.filter((s) => !reviewed.includes(s))
+}

--- a/packages/web/src/vite/reviews/index.ts
+++ b/packages/web/src/vite/reviews/index.ts
@@ -1,0 +1,5 @@
+// Public surface of the reviews feature (#1083). Cross-feature importers (My
+// Bookings, the renter bookings route) consume the feature through this barrel, not
+// its internals — see docs/architecture/modules.md.
+export { ReviewPrompt } from './ReviewPrompt'
+export { renterReviewedSubjects, reviewsForBookingQueryOptions } from './api'

--- a/packages/web/tests/vite/bookings/MyBookingsView.test.tsx
+++ b/packages/web/tests/vite/bookings/MyBookingsView.test.tsx
@@ -1,5 +1,9 @@
 import { MyBookingsView } from '@/vite/bookings/MyBookingsView'
 import type { MyBookingRow } from '@/vite/bookings/api'
+import type { Session } from '@/vite/session'
+import { sessionQueryOptions } from '@/vite/session'
+import type { ReviewSubject } from '@kuruma/shared/enums'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
@@ -40,11 +44,28 @@ function makeRow(over: Partial<MyBookingRow> = {}): MyBookingRow {
   }
 }
 
-function renderView(bookings: MyBookingRow[], threadIdByBooking: Record<string, string> = {}) {
+const SESSION: Session = { user: { id: 'renter-1', role: 'RENTER' }, csrfToken: 'csrf-1' }
+
+function renderView(
+  bookings: MyBookingRow[],
+  threadIdByBooking: Record<string, string> = {},
+  reviewedSubjectsByBooking: Record<string, readonly ReviewSubject[]> = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  })
+  queryClient.setQueryData(sessionQueryOptions().queryKey, SESSION)
   return render(
-    <IntlProvider locale="en" messages={en}>
-      <MyBookingsView bookings={bookings} locale="en" threadIdByBooking={threadIdByBooking} />
-    </IntlProvider>,
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        <MyBookingsView
+          bookings={bookings}
+          locale="en"
+          threadIdByBooking={threadIdByBooking}
+          reviewedSubjectsByBooking={reviewedSubjectsByBooking}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
   )
 }
 
@@ -87,6 +108,27 @@ describe('MyBookingsView', () => {
   it('renders the per-status label for a cancelled booking', () => {
     renderView([makeRow({ status: 'CANCELLED' })])
     expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
+
+  // #1083: the post-trip review prompt shows on a COMPLETED booking the renter
+  // hasn't fully reviewed, and stays hidden otherwise.
+  it('shows the review prompt on a COMPLETED booking with subjects still unreviewed', () => {
+    renderView([makeRow({ id: 'bk-9', status: 'COMPLETED' })], {}, { 'bk-9': [] })
+    expect(screen.getByRole('button', { name: en.reviews.prompt.cta })).toBeInTheDocument()
+  })
+
+  it('hides the review prompt once both subjects on a COMPLETED booking are reviewed', () => {
+    renderView(
+      [makeRow({ id: 'bk-9', status: 'COMPLETED' })],
+      {},
+      { 'bk-9': ['OPERATOR', 'VEHICLE'] },
+    )
+    expect(screen.queryByRole('button', { name: en.reviews.prompt.cta })).not.toBeInTheDocument()
+  })
+
+  it('never shows the review prompt on a non-COMPLETED booking', () => {
+    renderView([makeRow({ id: 'bk-9', status: 'CONFIRMED' })], {}, { 'bk-9': [] })
+    expect(screen.queryByRole('button', { name: en.reviews.prompt.cta })).not.toBeInTheDocument()
   })
 
   it('shows a friendly empty state with a Browse-cars CTA to search when there are none', () => {

--- a/packages/web/tests/vite/reviews/ReviewForm.test.tsx
+++ b/packages/web/tests/vite/reviews/ReviewForm.test.tsx
@@ -105,4 +105,28 @@ describe('ReviewForm', () => {
     const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }]
     expect(init.headers['X-CSRF-Token']).toBe('csrf-xyz')
   })
+
+  it('keeps the form open and surfaces an error when one subject genuinely fails', async () => {
+    // OPERATOR persists, VEHICLE 500s — Promise.allSettled must not let the success
+    // mask the failure: the form stays open (onSubmitted not called) with an error.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const subject = (JSON.parse(init.body) as { subject: string }).subject
+        return subject === 'VEHICLE'
+          ? { status: 500, json: async () => ({ success: false, error: 'boom' }) }
+          : {
+              status: 201,
+              json: async () => ({ success: true, data: { review: { subject } } }),
+            }
+      }),
+    )
+    const { onSubmitted } = renderForm()
+    setStars('overall-OPERATOR', 5)
+    setStars('overall-VEHICLE', 4)
+    fireEvent.click(screen.getByRole('button', { name: f.submit }))
+
+    expect(await screen.findByText(f.error)).toBeInTheDocument()
+    expect(onSubmitted).not.toHaveBeenCalled()
+  })
 })

--- a/packages/web/tests/vite/reviews/ReviewForm.test.tsx
+++ b/packages/web/tests/vite/reviews/ReviewForm.test.tsx
@@ -1,0 +1,108 @@
+import { ReviewForm } from '@/vite/reviews/ReviewForm'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+const f = en.reviews.form
+
+function renderForm(onSubmitted = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  )
+  render(
+    <ReviewForm
+      bookingId="bk-1"
+      csrfToken="csrf-xyz"
+      subjects={['OPERATOR', 'VEHICLE']}
+      onSubmitted={onSubmitted}
+    />,
+    { wrapper },
+  )
+  return { onSubmitted }
+}
+
+// Each star is a native radio keyed by its group `name` + `${n} stars` label, so a
+// rating is selected unambiguously even with several rating rows in one form.
+function setStars(groupName: string, stars: number) {
+  const radio = document.querySelector<HTMLInputElement>(
+    `input[name="${groupName}"][aria-label="${stars} stars"]`,
+  )
+  if (!radio) throw new Error(`no star radio for ${groupName} = ${stars}`)
+  fireEvent.click(radio)
+}
+
+function bodyOf(call: unknown): Record<string, unknown> {
+  const [, init] = call as [string, { body: string }]
+  return JSON.parse(init.body)
+}
+
+describe('ReviewForm', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        status: 201,
+        json: async () => ({
+          success: true,
+          data: {
+            review: {
+              id: 'r1',
+              bookingId: 'bk-1',
+              authorRole: 'RENTER',
+              subject: 'OPERATOR',
+              overall: 5,
+              comment: null,
+              publishedAt: null,
+            },
+          },
+        }),
+      })),
+    )
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('disables submit until every pending subject has an overall rating', () => {
+    renderForm()
+    const submit = screen.getByRole('button', { name: f.submit })
+    expect(submit).toBeDisabled()
+    setStars('overall-OPERATOR', 5)
+    expect(submit).toBeDisabled() // vehicle still unrated
+    setStars('overall-VEHICLE', 4)
+    expect(submit).toBeEnabled()
+  })
+
+  it('posts one review per subject with the rated values; operator carries sub-dimensions, vehicle does not', async () => {
+    const { onSubmitted } = renderForm()
+    setStars('overall-OPERATOR', 5)
+    setStars('dim-OPERATOR-cleanliness', 3)
+    setStars('overall-VEHICLE', 4)
+    fireEvent.click(screen.getByRole('button', { name: f.submit }))
+
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalledTimes(1))
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const bodies = fetchMock.mock.calls.map(bodyOf)
+    const operator = bodies.find((b) => b.subject === 'OPERATOR')
+    const vehicle = bodies.find((b) => b.subject === 'VEHICLE')
+    expect(operator).toEqual({
+      bookingId: 'bk-1',
+      subject: 'OPERATOR',
+      overall: 5,
+      subRatings: { cleanliness: 3 },
+    })
+    expect(vehicle).toEqual({ bookingId: 'bk-1', subject: 'VEHICLE', overall: 4 })
+
+    // CSRF token rides on the write
+    const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }]
+    expect(init.headers['X-CSRF-Token']).toBe('csrf-xyz')
+  })
+})

--- a/packages/web/tests/vite/reviews/ReviewPrompt.test.tsx
+++ b/packages/web/tests/vite/reviews/ReviewPrompt.test.tsx
@@ -1,0 +1,49 @@
+import { ReviewPrompt } from '@/vite/reviews/ReviewPrompt'
+import type { Session } from '@/vite/session'
+import { sessionQueryOptions } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+const SESSION: Session = {
+  user: { id: 'renter-1', role: 'RENTER' },
+  csrfToken: 'csrf-xyz',
+}
+
+function renderPrompt(reviewedSubjects: string[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  })
+  queryClient.setQueryData(sessionQueryOptions().queryKey, SESSION)
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  )
+  return render(
+    <ReviewPrompt bookingId="bk-1" bookingCode="RVEW1234" reviewedSubjects={reviewedSubjects} />,
+    { wrapper },
+  )
+}
+
+describe('ReviewPrompt', () => {
+  it('shows the review CTA when the renter has reviewed neither subject', () => {
+    renderPrompt([])
+    expect(screen.getByRole('button', { name: en.reviews.prompt.cta })).toBeInTheDocument()
+  })
+
+  it('shows the CTA when only one of the two subjects is still pending', () => {
+    renderPrompt(['OPERATOR'])
+    expect(screen.getByRole('button', { name: en.reviews.prompt.cta })).toBeInTheDocument()
+  })
+
+  it('renders nothing once both subjects have been reviewed', () => {
+    renderPrompt(['OPERATOR', 'VEHICLE'])
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Slice 3 of the reviews epic (#1067) — renter review prompt + post-trip email

Builds on slice 2 (#1082: `ReviewService` + `ReviewRepository` + `POST /reviews` + `GET /bookings/:id/reviews`). A vertical web→api slice that lets a renter review a completed trip and nudges them to via email.

### API
- New `RENTER_REVIEW_PROMPT` `notification_kind` (migration `0086`, enum `ADD VALUE`) dispatched on the **COMPLETED** trigger alongside `RENTER_TRIP_COMPLETED` — a distinct kind so the `notify:<booking>:<kind>` idempotency key never collides.
- New `renter-review-prompt.ts` email template: snapshot-only (booking code + rental period + a CTA deep-link to My Bookings via `WEB_ORIGIN`, null-safe). Declared `RELATIONS_BY_KIND = ∅`, so it issues **zero** repo reads; the #1151 conformance oracle gains a matching entry proving no relation-name leak.
- Five `en/ja/zh` email message keys (compile-locked lock-step).

### Web (`packages/web/src/vite/reviews/`)
- `ReviewForm` — overall stars per subject, optional operator sub-dimensions (cleanliness/accuracy/communication/value), optional comment. Submits one `POST /reviews` per pending subject (OPERATOR + VEHICLE) via `Promise.allSettled` so a real failure on one isn't masked by another's success.
- `ReviewPrompt` — CTA shown only for a COMPLETED booking the renter hasn't fully reviewed, and only with a session (the write is CSRF-gated). `StarRating` uses native radios (real radio-group a11y).
- Wired into `MyBookingsView` (kept presentational) + the renter bookings route, which resolves each COMPLETED booking's reviews via `useQueries` (non-blocking, mirrors threads) into a `reviewedSubjectsByBooking` map.
- `reviews.{prompt,form}.*` copy in `en/ja/zh` (parity guard green, 1227 keys). Cross-feature consumers reach the feature through a `@/vite/reviews` barrel (module-boundary baseline unchanged).

### Tests
- Email golden (en/ja/zh subjects + CTA present/absent), COMPLETED fan-out emits **both** kinds with distinct keys (send ×3), `RELATIONS_BY_KIND` conformance entry, #710 enum contract sync.
- Web: prompt visibility (shows unreviewed / hides when both done / never on non-COMPLETED); form posts the exact per-subject payloads (operator carries sub-dimensions, vehicle does not, CSRF header present); partial-failure keeps the form open and surfaces the error.

### Verification
- Aggregate `bun run test`: shared **780**, api **2120**, web **1339** — all green. `tsc` ×3 clean. `db:verify` green (87 migrations, `when`-monotonic, journal↔DB synced). i18n parity + module-boundary lints pass.
- Code review (code-reviewer agent): SHIP — the one MEDIUM (Promise.all partial-failure) is fixed in this PR.

### Notes / acceptance
- Renter can submit reviews for subjects OPERATOR and VEHICLE from My Bookings on a COMPLETED booking; the post-trip email CTA links to the form; all copy exists in en/ja/zh.
- Does **not** touch the #1158 operator-side dedup question (that gates slice 5 / #1085, not this slice).

Closes #1083
Refs #1067