### PR TITLE
feat(#1070): pure indicative-price formatter (slice 2)

### DIFF
--- a/packages/shared/src/lib/indicative-price.test.ts
+++ b/packages/shared/src/lib/indicative-price.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatIndicativePrice } from './indicative-price'
+
+/**
+ * #1070 indicative multi-currency display. The JPY amount is authoritative and
+ * always charged; `formatIndicativePrice` is a pure, display-only ballpark in the
+ * renter's chosen currency. `rate` is JPY→currency (USD 0.0067 ⇒ 1 JPY = 0.0067
+ * USD), passed in from a server-side daily cache — never fetched here.
+ */
+describe('formatIndicativePrice', () => {
+  test('converts whole yen to the target currency via the rate', () => {
+    expect(formatIndicativePrice(10000, 'USD', 0.0067)).toBe('$67')
+  })
+
+  test('uses the currencys own symbol, not the dollar sign', () => {
+    expect(formatIndicativePrice(10000, 'EUR', 0.006)).toBe('€60')
+    expect(formatIndicativePrice(10000, 'CNY', 0.048)).toBe('CN¥480')
+    expect(formatIndicativePrice(10000, 'AUD', 0.007)).toBe('A$70')
+  })
+
+  test('groups thousands in the converted figure', () => {
+    expect(formatIndicativePrice(1_000_000, 'USD', 0.0067)).toBe('$6,700')
+  })
+
+  test('rounds to whole currency units (half-up)', () => {
+    expect(formatIndicativePrice(1000, 'USD', 0.0067)).toBe('$7') // 6.7 → 7
+    expect(formatIndicativePrice(1000, 'USD', 0.0061)).toBe('$6') // 6.1 → 6
+  })
+
+  test('shows a zero-yen price as a zero indicative figure', () => {
+    expect(formatIndicativePrice(0, 'USD', 0.0067)).toBe('$0')
+  })
+
+  test('returns null when the chosen currency is JPY (no self-conversion)', () => {
+    expect(formatIndicativePrice(10000, 'JPY', 1)).toBeNull()
+  })
+
+  test('returns null when the rate is absent', () => {
+    expect(formatIndicativePrice(10000, 'USD', null)).toBeNull()
+    expect(formatIndicativePrice(10000, 'USD', undefined)).toBeNull()
+  })
+
+  test('returns null for a non-positive or non-finite rate', () => {
+    expect(formatIndicativePrice(10000, 'USD', 0)).toBeNull()
+    expect(formatIndicativePrice(10000, 'USD', -0.0067)).toBeNull()
+    expect(formatIndicativePrice(10000, 'USD', Number.NaN)).toBeNull()
+    expect(formatIndicativePrice(10000, 'USD', Number.POSITIVE_INFINITY)).toBeNull()
+  })
+
+  test('returns null for a malformed currency code (never throws)', () => {
+    expect(formatIndicativePrice(10000, 'DOLLARS', 0.0067)).toBeNull()
+    expect(formatIndicativePrice(10000, 'US', 0.0067)).toBeNull()
+    expect(formatIndicativePrice(10000, '', 0.0067)).toBeNull()
+  })
+
+  test('returns null for a non-finite yen amount', () => {
+    expect(formatIndicativePrice(Number.NaN, 'USD', 0.0067)).toBeNull()
+    expect(formatIndicativePrice(Number.POSITIVE_INFINITY, 'USD', 0.0067)).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/indicative-price.test.ts
+++ b/packages/shared/src/lib/indicative-price.test.ts
@@ -32,6 +32,16 @@ describe('formatIndicativePrice', () => {
     expect(formatIndicativePrice(0, 'USD', 0.0067)).toBe('$0')
   })
 
+  test('rounds half away from zero (pins halfExpand, not halfEven)', () => {
+    expect(formatIndicativePrice(13, 'USD', 0.5)).toBe('$7') // 6.5 → 7
+  })
+
+  test('treats the currency code case-insensitively (Intl canonicalizes too)', () => {
+    expect(formatIndicativePrice(10000, 'usd', 0.0067)).toBe('$67')
+    // 'jpy' must hit the JPY self-conversion guard, not render a converted ¥ figure
+    expect(formatIndicativePrice(10000, 'jpy', 0.0067)).toBeNull()
+  })
+
   test('returns null when the chosen currency is JPY (no self-conversion)', () => {
     expect(formatIndicativePrice(10000, 'JPY', 1)).toBeNull()
   })

--- a/packages/shared/src/lib/indicative-price.ts
+++ b/packages/shared/src/lib/indicative-price.ts
@@ -1,0 +1,37 @@
+/** ISO 4217 codes are three ASCII letters; `Intl.NumberFormat` throws on any
+ *  other shape, so we reject malformed codes before constructing it. */
+const CURRENCY_CODE = /^[A-Za-z]{3}$/
+
+/** A single base locale keeps the indicative figure deterministic and gives
+ *  international renters Western digit grouping with the currency's own symbol
+ *  (e.g. `CN¥480`, which also disambiguates the Chinese yuan from `¥` JPY). */
+const INDICATIVE_LOCALE = 'en-US'
+
+/**
+ * Format an indicative converted price for an international renter (#1070).
+ *
+ * The JPY amount is authoritative and is what Stripe charges; this is a
+ * display-only ballpark in the renter's chosen currency. Pure — the daily FX
+ * `rate` (JPY→`currency`, e.g. USD `0.0067` ⇒ 1 JPY = 0.0067 USD) is passed in
+ * from a server-side cache, never fetched here.
+ *
+ * Returns the formatted target-currency figure rounded to whole units
+ * (`"$67"`), or `null` when no indicative figure should be shown — the chosen
+ * currency IS JPY, the rate is absent/invalid, the amount is non-finite, or the
+ * currency code is malformed — so the caller renders the plain JPY amount alone.
+ */
+export function formatIndicativePrice(
+  jpy: number,
+  currency: string,
+  rate: number | null | undefined,
+): string | null {
+  if (currency === 'JPY' || !CURRENCY_CODE.test(currency)) return null
+  if (rate == null || !Number.isFinite(rate) || rate <= 0) return null
+  if (!Number.isFinite(jpy)) return null
+
+  return new Intl.NumberFormat(INDICATIVE_LOCALE, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(jpy * rate)
+}

--- a/packages/shared/src/lib/indicative-price.ts
+++ b/packages/shared/src/lib/indicative-price.ts
@@ -25,13 +25,18 @@ export function formatIndicativePrice(
   currency: string,
   rate: number | null | undefined,
 ): string | null {
-  if (currency === 'JPY' || !CURRENCY_CODE.test(currency)) return null
+  // Canonicalize before guarding: `Intl.NumberFormat` uppercases the code
+  // internally, so an uppercase-only `=== 'JPY'` check on the raw input would let
+  // a lowercase `'jpy'` slip through and render a converted ¥ figure next to the
+  // authoritative JPY amount — the opposite of the JPY self-conversion guard.
+  const code = currency.toUpperCase()
+  if (code === 'JPY' || !CURRENCY_CODE.test(code)) return null
   if (rate == null || !Number.isFinite(rate) || rate <= 0) return null
   if (!Number.isFinite(jpy)) return null
 
   return new Intl.NumberFormat(INDICATIVE_LOCALE, {
     style: 'currency',
-    currency,
+    currency: code,
     maximumFractionDigits: 0,
   }).format(jpy * rate)
 }


### PR DESCRIPTION
## Slice 2 of 3 — #1070 indicative multi-currency price display

Adds a pure, display-only converter to `@kuruma/shared`. The JPY amount stays
authoritative and is what Stripe charges (JPY-only, zero-decimal); this renders a
ballpark in the renter's chosen currency next to it. **Zero payment risk** — the
checkout path is untouched.

### What landed
`formatIndicativePrice(jpy, currency, rate)` in `packages/shared/src/lib/indicative-price.ts`:
- `rate` is JPY→currency (daily, cached server-side in slice 1), **passed in — no I/O** (mirrors `formatGeoContext`'s shape).
- Returns the formatted target-currency figure rounded to whole units (`"$67"`).
- Returns `null` (caller renders plain JPY alone) when: currency is `JPY`, rate is absent/non-positive/non-finite, amount is non-finite, or the code is malformed.
- `Intl.NumberFormat` on a fixed `en-US` base → deterministic output + the currency's own symbol (`CN¥` also disambiguates CNY from `¥` JPY).

### Scope notes
- **No migration** (rates live in a cache, not the DB — by design across all 3 slices).
- **No `package.json` export yet** — slice 3 (web consumer) wires the `./lib/indicative-price` subpath when it imports it, mirroring the #1069 driving-eligibility slice-1 precedent (pure fn lands first, consumer wires the export).
- Foundational greenfield slice landing alone (cf #1069 slice 1, #1081 reviews schema).

### Tests
10 mutation-resistant TDD tests (RED→GREEN): conversion math, per-currency symbols, thousands grouping, half-up rounding, zero-yen, and all five null guards.

Gates: shared 790 / api 2115 / web 1330 (aggregate green), shared `tsc --noEmit` clean, biome clean, pre-commit boundaries + size + tsc×2 green.

Refs #1070 (stays open — slices 1 & 3 to follow).