### PR TITLE
chore(scripts): harden lint-snapshot-index-parity parser (#1167)

### DIFF
--- a/scripts/lint-snapshot-index-parity.test.ts
+++ b/scripts/lint-snapshot-index-parity.test.ts
@@ -405,6 +405,10 @@ describe('isSnapshotShape — runtime guard for the snapshot JSON', () => {
     expect(isSnapshotShape({ tables: 'oops' })).toBe(false)
   })
 
+  test('rejects tables as null', () => {
+    expect(isSnapshotShape({ tables: null })).toBe(false)
+  })
+
   test('rejects a table value that is a primitive', () => {
     expect(isSnapshotShape({ tables: { t: 'oops' } })).toBe(false)
   })

--- a/scripts/lint-snapshot-index-parity.test.ts
+++ b/scripts/lint-snapshot-index-parity.test.ts
@@ -5,9 +5,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import {
   findDrift,
   findStaleBaseline,
+  isSnapshotShape,
   parseCreatedIndexes,
   parseDroppedColumns,
   parseDroppedIndexes,
+  readLatestSnapshot,
   readLiveMigrationIndexes,
 } from './lint-snapshot-index-parity'
 
@@ -250,5 +252,188 @@ describe('findStaleBaseline', () => {
     const snapshot = { tables: { 'public.accounts': { indexes: {} } } }
     const baseline = new Set(['accounts.idx_accounts_userId'])
     expect(findStaleBaseline(migrations, snapshot, baseline)).toEqual([])
+  })
+})
+
+// --- #1167 parser hardening ---
+
+describe('parseDroppedColumns — ALTER TABLE ONLY', () => {
+  // pg_dump emits `ALTER TABLE ONLY` for tables that have inheritance children
+  // (`ONLY` skips recursion into children). Common in hand-SQL when porting
+  // pg_dump output.
+  test('handles ALTER TABLE ONLY', () => {
+    expect(parseDroppedColumns('ALTER TABLE ONLY "t" DROP COLUMN "c";')).toEqual([
+      { table: 't', column: 'c' },
+    ])
+  })
+})
+
+describe('parser — schema-qualified identifiers', () => {
+  // pg_dump and many hand-SQL forms write `"public"."t"`. Today the regex skips
+  // them, so a cascade on such a table would not retire indexes.
+  test('parseCreatedIndexes handles "public"."t"', () => {
+    const sql = 'CREATE INDEX "idx_x" ON "public"."t" ("c");'
+    expect(parseCreatedIndexes(sql)).toEqual([{ table: 't', name: 'idx_x', columns: ['c'] }])
+  })
+
+  test('parseCreatedIndexes handles schema-qualified UNQUOTED ident', () => {
+    expect(parseCreatedIndexes('CREATE INDEX idx_x ON public.t (c);')).toEqual([
+      { table: 't', name: 'idx_x', columns: ['c'] },
+    ])
+  })
+
+  test('parseDroppedColumns handles "public"."t"', () => {
+    expect(parseDroppedColumns('ALTER TABLE "public"."t" DROP COLUMN "c";')).toEqual([
+      { table: 't', column: 'c' },
+    ])
+  })
+})
+
+describe('parseDroppedColumns — compound ALTER TABLE actions', () => {
+  // Postgres allows multiple actions in a single ALTER TABLE separated by `,`.
+  // pg_dump emits this shape. The regex used to match only the first DROP COLUMN.
+  test('captures every DROP COLUMN in a compound statement', () => {
+    const sql =
+      'ALTER TABLE "t" DROP CONSTRAINT "fk_x", DROP COLUMN "a", ADD COLUMN "d" text, DROP COLUMN "b";'
+    expect(parseDroppedColumns(sql)).toEqual([
+      { table: 't', column: 'a' },
+      { table: 't', column: 'b' },
+    ])
+  })
+
+  test('compound DROP COLUMN cascades into all covered indexes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'snapshot-lint-compound-'))
+    try {
+      writeFileSync(
+        join(dir, '0001_create.sql'),
+        'CREATE INDEX "idx_a" ON "t" ("a");\nCREATE INDEX "idx_b" ON "t" ("b");\nCREATE INDEX "idx_c" ON "t" ("c");',
+      )
+      writeFileSync(join(dir, '0002_drop.sql'), 'ALTER TABLE "t" DROP COLUMN "a", DROP COLUMN "b";')
+      expect(readLiveMigrationIndexes(dir).map((i) => i.name)).toEqual(['idx_c'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('parseCreatedIndexes — expression indexes and opclass', () => {
+  // Today `([^)]+)` stops at the inner `)` of `lower(email)`, mangling the
+  // column list and losing the underlying column reference. Same for opclass
+  // syntax `(col gin_trgm_ops)` — the opclass leaks into the column name.
+  test('extracts underlying column from an expression index', () => {
+    const sql = 'CREATE INDEX "idx_x" ON "t" (lower("email"));'
+    const [parsed] = parseCreatedIndexes(sql)
+    expect(parsed?.name).toBe('idx_x')
+    expect(parsed?.table).toBe('t')
+    expect(parsed?.columns).toContain('email')
+  })
+
+  test('strips opclass name from the column list', () => {
+    const sql = 'CREATE INDEX "idx_x" ON "t" ("col" gin_trgm_ops);'
+    const [parsed] = parseCreatedIndexes(sql)
+    expect(parsed?.columns).toEqual(['col'])
+  })
+
+  test('expression index cascade: dropping the underlying column drops the index', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'snapshot-lint-expr-'))
+    try {
+      writeFileSync(
+        join(dir, '0001_create.sql'),
+        'CREATE INDEX "idx_lower_email" ON "users" (lower("email"));',
+      )
+      writeFileSync(join(dir, '0002_drop.sql'), 'ALTER TABLE "users" DROP COLUMN "email";')
+      expect(readLiveMigrationIndexes(dir)).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('preserves a column-list followed by a WHERE clause', () => {
+    // Regression seal: balanced-paren scan must not greedily eat the WHERE.
+    const sql = 'CREATE UNIQUE INDEX "idx_x" ON "t" ("a", "b") WHERE ("a" IS NOT NULL);'
+    expect(parseCreatedIndexes(sql)).toEqual([{ table: 't', name: 'idx_x', columns: ['a', 'b'] }])
+  })
+})
+
+describe('readLiveMigrationIndexes — cascade visits every entry', () => {
+  // Regression seal for the map-iteration idiom: a single DROP COLUMN that
+  // cascades into multiple indexes must drop all of them, in any order.
+  test('cascades a single DROP COLUMN into multiple covering indexes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'snapshot-lint-cascade-'))
+    try {
+      writeFileSync(
+        join(dir, '0001_create.sql'),
+        [
+          'CREATE INDEX "idx_a" ON "t" ("a", "shared");',
+          'CREATE INDEX "idx_b" ON "t" ("shared");',
+          'CREATE INDEX "idx_c" ON "t" ("shared", "c");',
+          'CREATE INDEX "idx_other" ON "t" ("a");',
+        ].join('\n'),
+      )
+      writeFileSync(join(dir, '0002_drop.sql'), 'ALTER TABLE "t" DROP COLUMN "shared";')
+      expect(readLiveMigrationIndexes(dir).map((i) => i.name)).toEqual(['idx_other'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('isSnapshotShape — runtime guard for the snapshot JSON', () => {
+  test('accepts an empty object', () => {
+    expect(isSnapshotShape({})).toBe(true)
+  })
+
+  test('accepts the canonical shape', () => {
+    expect(
+      isSnapshotShape({ tables: { 'public.t': { indexes: { idx_x: { name: '...' } } } } }),
+    ).toBe(true)
+  })
+
+  test('accepts a table with no indexes key', () => {
+    expect(isSnapshotShape({ tables: { 'public.t': {} } })).toBe(true)
+  })
+
+  test('rejects null', () => {
+    expect(isSnapshotShape(null)).toBe(false)
+  })
+
+  test('rejects an array at the top level', () => {
+    expect(isSnapshotShape([])).toBe(false)
+  })
+
+  test('rejects tables as a non-object', () => {
+    expect(isSnapshotShape({ tables: 'oops' })).toBe(false)
+  })
+
+  test('rejects a table value that is a primitive', () => {
+    expect(isSnapshotShape({ tables: { t: 'oops' } })).toBe(false)
+  })
+
+  test('rejects indexes as a non-object', () => {
+    expect(isSnapshotShape({ tables: { t: { indexes: 'oops' } } })).toBe(false)
+  })
+})
+
+describe('readLatestSnapshot — applies the shape guard', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'snapshot-shape-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('returns the parsed snapshot for a valid file', () => {
+    writeFileSync(
+      join(dir, '0001_snapshot.json'),
+      JSON.stringify({ tables: { 'public.t': { indexes: { idx_x: {} } } } }),
+    )
+    const snap = readLatestSnapshot(dir)
+    expect(snap.tables?.['public.t']?.indexes).toHaveProperty('idx_x')
+  })
+
+  test('throws when the JSON does not match the snapshot shape', () => {
+    writeFileSync(join(dir, '0001_snapshot.json'), JSON.stringify([1, 2, 3]))
+    expect(() => readLatestSnapshot(dir)).toThrow(/snapshot shape/i)
   })
 })

--- a/scripts/lint-snapshot-index-parity.ts
+++ b/scripts/lint-snapshot-index-parity.ts
@@ -108,7 +108,15 @@ const FUNCTION_NAMES = new Set([
  *  Handles: bare `"col"` / `col`, opclass suffix (`"col" gin_trgm_ops`),
  *  ASC/DESC + NULLS FIRST/LAST, and function calls (`lower("email")`).
  *  Returns the underlying column references so a later DROP COLUMN cascade
- *  can match them. */
+ *  can match them.
+ *
+ *  Known limitation: the token regex pulls every identifier and filters only
+ *  the keyword / function sets above. Inside an expression we may emit SQL
+ *  keywords this set doesn't know (`FROM`, `FOR`, `AS`, `CASE`, …). This is
+ *  harmless unless a real column shares one of those names AND it's later
+ *  dropped — in which case we'd over-cascade and silently retire the index
+ *  in the lint's view. No such collision exists in the current tree. Extend
+ *  the keyword sets (or move to a real expression parser) if one appears. */
 function extractColumnsFromTerm(term: string): string[] {
   // Strip opclass suffix: a trailing `\w+_ops` / `\w+_pattern_ops` token
   // (gin_trgm_ops, text_pattern_ops, varchar_pattern_ops, jsonb_path_ops, ...).
@@ -205,7 +213,13 @@ export function parseDroppedIndexes(sql: string): string[] {
 export function parseDroppedColumns(sql: string): DroppedColumn[] {
   const cleaned = sql.replace(/--[^\n]*/g, '')
   // Capture (table, action-list) per ALTER TABLE statement, then scan the
-  // action list for every DROP COLUMN.
+  // action list for every DROP COLUMN. The `[^;]+` action capture is not
+  // quote-aware: an embedded `;` inside a string literal (e.g. an
+  // `ADD COLUMN ... DEFAULT 'foo;bar'`) would truncate the actions and lose
+  // a trailing DROP. We accept that under-capture because the failure mode
+  // is loud (the un-cascaded index stays surfaced as drift in the lint), not
+  // silent — switch to a real SQL tokenizer if you ever need the opposite
+  // bias.
   const stmtRe = new RegExp(
     String.raw`alter\s+table\s+(?:only\s+)?${SCHEMA_PREFIX}(?:"([^"]+)"|(\w+))\s+([^;]+)`,
     'gi',

--- a/scripts/lint-snapshot-index-parity.ts
+++ b/scripts/lint-snapshot-index-parity.ts
@@ -41,37 +41,153 @@ export interface DroppedColumn {
   column: string
 }
 
-/** Parse `CREATE [UNIQUE] INDEX [IF NOT EXISTS] "name" ON "table" (cols...)`.
- *  Captures the column list (leading + trailing) so a later `DROP COLUMN` on
- *  any covered column can drop this index too (Postgres cascades). Strips
- *  line comments so `-- CREATE INDEX ...` doesn't count. */
-export function parseCreatedIndexes(sql: string): MigrationIndex[] {
-  const cleaned = sql.replace(/--[^\n]*/g, '')
-  const re =
-    /create\s+(?:unique\s+)?index(?:\s+concurrently)?(?:\s+if\s+not\s+exists)?\s+(?:"([^"]+)"|(\w+))\s+on\s+(?:"([^"]+)"|(\w+))\s*(?:using\s+\w+\s*)?\(([^)]+)\)/gi
-  const out: MigrationIndex[] = []
-  for (const m of cleaned.matchAll(re)) {
+/** Walk `s` from `from` to find the next `(` and return the index of its
+ *  matching `)`. Tracks nesting so `lower(email)` inside an outer paren list
+ *  doesn't fool the scanner into closing early. Returns null if unbalanced. */
+function findBalancedParens(s: string, from: number): { open: number; close: number } | null {
+  const open = s.indexOf('(', from)
+  if (open === -1) return null
+  let depth = 0
+  for (let i = open; i < s.length; i++) {
+    if (s[i] === '(') depth++
+    else if (s[i] === ')') {
+      depth--
+      if (depth === 0) return { open, close: i }
+    }
+  }
+  return null
+}
+
+/** Split `s` on `sep` at paren-depth 0 — so `coalesce(a, b), c` yields two
+ *  terms, not three. */
+function splitTopLevel(s: string, sep: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let buf = ''
+  for (const c of s) {
+    if (c === '(') {
+      depth++
+      buf += c
+    } else if (c === ')') {
+      depth--
+      buf += c
+    } else if (c === sep && depth === 0) {
+      out.push(buf)
+      buf = ''
+    } else {
+      buf += c
+    }
+  }
+  if (buf.length > 0) out.push(buf)
+  return out
+}
+
+// Tokens that appear inside a column term but aren't column references.
+// `nulls first/last`, `collate ...`, sort direction — strip when extracting.
+const COL_SUFFIX_KEYWORDS = new Set(['asc', 'desc', 'nulls', 'first', 'last', 'collate'])
+// Common immutable functions used in expression indexes. Filtered out of
+// extracted identifiers so `lower("email")` yields `["email"]`, not
+// `["lower", "email"]`. Cascade matching is over column names only.
+const FUNCTION_NAMES = new Set([
+  'lower',
+  'upper',
+  'coalesce',
+  'concat',
+  'trim',
+  'btrim',
+  'ltrim',
+  'rtrim',
+  'substring',
+  'date_trunc',
+  'extract',
+  'to_tsvector',
+  'to_tsquery',
+])
+
+/** Extract the column names referenced by one term of an index column list.
+ *  Handles: bare `"col"` / `col`, opclass suffix (`"col" gin_trgm_ops`),
+ *  ASC/DESC + NULLS FIRST/LAST, and function calls (`lower("email")`).
+ *  Returns the underlying column references so a later DROP COLUMN cascade
+ *  can match them. */
+function extractColumnsFromTerm(term: string): string[] {
+  // Strip opclass suffix: a trailing `\w+_ops` / `\w+_pattern_ops` token
+  // (gin_trgm_ops, text_pattern_ops, varchar_pattern_ops, jsonb_path_ops, ...).
+  const stripped = term
+    .replace(/\s+\w+_(?:pattern_)?ops\s*$/i, '')
+    .replace(/\s+(asc|desc)\b.*$/i, '')
+    .trim()
+
+  // Fast-path: bare identifier (quoted or unquoted) — return as-is.
+  const bare = stripped.match(/^"([^"]+)"$|^([A-Za-z_][A-Za-z0-9_]*)$/)
+  if (bare) {
+    const name = bare[1] ?? bare[2]
+    return name ? [name] : []
+  }
+
+  // Expression: pull every identifier, drop keywords + known function names.
+  const tokenRe = /"([^"]+)"|\b([A-Za-z_][A-Za-z0-9_]*)\b/g
+  const out: string[] = []
+  for (const m of stripped.matchAll(tokenRe)) {
     const name = m[1] ?? m[2]
-    const table = m[3] ?? m[4]
-    const cols = (m[5] ?? '')
-      .split(',')
-      .map((c) =>
-        c
-          .trim()
-          .replace(/\s+(asc|desc)\b.*$/i, '')
-          .replace(/^"|"$/g, ''),
-      )
-      .filter((c) => c.length > 0)
-    if (name && table) out.push({ table, name, columns: cols })
+    if (!name) continue
+    const lower = name.toLowerCase()
+    if (COL_SUFFIX_KEYWORDS.has(lower)) continue
+    if (FUNCTION_NAMES.has(lower)) continue
+    out.push(name)
   }
   return out
 }
 
-/** Parse `DROP INDEX [IF EXISTS] "name"` so a retired index doesn't get
- *  flagged as drift forever. */
+// Optional `[schema.]` prefix on a table reference — accepts `public.t`,
+// `"public"."t"`, and the unqualified forms. We discard the schema (the lint
+// only cares about indexes in the default schema, and drizzle snapshots use
+// the `public.` prefix uniformly).
+const SCHEMA_PREFIX = String.raw`(?:(?:"[^"]+"|\w+)\s*\.\s*)?`
+
+/** Parse `CREATE [UNIQUE] INDEX [IF NOT EXISTS] "name" ON "table" (cols...)`.
+ *  Captures the underlying column references (including those inside
+ *  expression indexes like `lower("email")`) so a later `DROP COLUMN` on any
+ *  covered column can drop this index too (Postgres cascades). Handles
+ *  schema-qualified tables (`"public"."t"`), USING clauses, opclass suffixes,
+ *  and trailing WHERE predicates. Strips line comments so `-- CREATE INDEX ...`
+ *  doesn't count. */
+export function parseCreatedIndexes(sql: string): MigrationIndex[] {
+  const cleaned = sql.replace(/--[^\n]*/g, '')
+  // Match up through the optional `USING <method>` — the column list itself is
+  // grabbed by the balanced-paren scanner below so nested parens (expression
+  // indexes) don't break the column capture.
+  const prefixRe = new RegExp(
+    String.raw`create\s+(?:unique\s+)?index(?:\s+concurrently)?(?:\s+if\s+not\s+exists)?\s+(?:"([^"]+)"|(\w+))\s+on\s+${SCHEMA_PREFIX}(?:"([^"]+)"|(\w+))\s*(?:using\s+\w+\s*)?`,
+    'gi',
+  )
+  const out: MigrationIndex[] = []
+  for (const m of cleaned.matchAll(prefixRe)) {
+    const name = m[1] ?? m[2]
+    const table = m[3] ?? m[4]
+    if (!name || !table) continue
+    const after = (m.index ?? 0) + m[0].length
+    const parens = findBalancedParens(cleaned, after)
+    if (!parens) continue
+    const inner = cleaned.slice(parens.open + 1, parens.close)
+    const columns: string[] = []
+    for (const term of splitTopLevel(inner, ',')) {
+      for (const col of extractColumnsFromTerm(term)) {
+        if (col.length > 0) columns.push(col)
+      }
+    }
+    out.push({ table, name, columns })
+  }
+  return out
+}
+
+/** Parse `DROP INDEX [IF EXISTS] [schema.]"name"` so a retired index doesn't
+ *  get flagged as drift forever. */
 export function parseDroppedIndexes(sql: string): string[] {
   const cleaned = sql.replace(/--[^\n]*/g, '')
-  const re = /drop\s+index(?:\s+if\s+exists)?\s+(?:"([^"]+)"|(\w+))/gi
+  const re = new RegExp(
+    String.raw`drop\s+index(?:\s+if\s+exists)?\s+${SCHEMA_PREFIX}(?:"([^"]+)"|(\w+))`,
+    'gi',
+  )
   const out: string[] = []
   for (const m of cleaned.matchAll(re)) {
     const name = m[1] ?? m[2]
@@ -80,19 +196,30 @@ export function parseDroppedIndexes(sql: string): string[] {
   return out
 }
 
-/** Parse `ALTER TABLE "t" ... DROP COLUMN [IF EXISTS] "c"`. Postgres cascades
- *  a column drop into every index covering that column, so the lint must too —
- *  otherwise an index created on a since-dropped column is flagged forever as
- *  drift when it's actually gone from the DB. */
+/** Parse `ALTER TABLE [ONLY] [schema.]"t" <actions>` and pull every
+ *  `DROP COLUMN` from the actions list — Postgres allows compound actions
+ *  separated by `,` (e.g. `DROP CONSTRAINT fk, DROP COLUMN a, DROP COLUMN b`),
+ *  which `pg_dump` emits and the old regex missed. The cascade then drops
+ *  every index covering those columns; otherwise an index on a since-dropped
+ *  column is flagged as drift forever when it's actually gone from the DB. */
 export function parseDroppedColumns(sql: string): DroppedColumn[] {
   const cleaned = sql.replace(/--[^\n]*/g, '')
-  const re =
-    /alter\s+table\s+(?:"([^"]+)"|(\w+))\s+drop\s+column(?:\s+if\s+exists)?\s+(?:"([^"]+)"|(\w+))/gi
+  // Capture (table, action-list) per ALTER TABLE statement, then scan the
+  // action list for every DROP COLUMN.
+  const stmtRe = new RegExp(
+    String.raw`alter\s+table\s+(?:only\s+)?${SCHEMA_PREFIX}(?:"([^"]+)"|(\w+))\s+([^;]+)`,
+    'gi',
+  )
+  const dropColRe = /drop\s+column(?:\s+if\s+exists)?\s+(?:"([^"]+)"|(\w+))/gi
   const out: DroppedColumn[] = []
-  for (const m of cleaned.matchAll(re)) {
-    const table = m[1] ?? m[2]
-    const column = m[3] ?? m[4]
-    if (table && column) out.push({ table, column })
+  for (const stmt of cleaned.matchAll(stmtRe)) {
+    const table = stmt[1] ?? stmt[2]
+    const actions = stmt[3] ?? ''
+    if (!table) continue
+    for (const m of actions.matchAll(dropColRe)) {
+      const column = m[1] ?? m[2]
+      if (column) out.push({ table, column })
+    }
   }
   return out
 }
@@ -112,7 +239,10 @@ export function readLiveMigrationIndexes(drizzleDir: string): MigrationIndex[] {
     for (const ix of parseCreatedIndexes(sql)) live.set(ix.name, ix)
     for (const dropped of parseDroppedIndexes(sql)) live.delete(dropped)
     for (const { table, column } of parseDroppedColumns(sql)) {
-      for (const [name, ix] of live) {
+      // Snapshot the entries before iterating: `live.delete()` inside a live
+      // `Map.entries()` iterator works per spec but the safer idiom never has
+      // to rely on the runtime's iterator semantics.
+      for (const [name, ix] of [...live]) {
         if (ix.table === table && ix.columns.includes(column)) live.delete(name)
       }
     }
@@ -120,8 +250,28 @@ export function readLiveMigrationIndexes(drizzleDir: string): MigrationIndex[] {
   return [...live.values()]
 }
 
-interface SnapshotShape {
+export interface SnapshotShape {
   tables?: Record<string, { indexes?: Record<string, unknown> } | undefined>
+}
+
+/** Runtime guard for the small slice of the drizzle snapshot the lint reads.
+ *  The full snapshot is large and versioned by drizzle-kit; we only depend on
+ *  `tables[name].indexes` being a name → object map. This guard rejects shapes
+ *  that would have us swallow `undefined.indexes` or treat a non-object as a
+ *  bag of indexes. */
+export function isSnapshotShape(v: unknown): v is SnapshotShape {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return false
+  const tables = (v as { tables?: unknown }).tables
+  if (tables === undefined) return true
+  if (tables === null || typeof tables !== 'object' || Array.isArray(tables)) return false
+  for (const t of Object.values(tables)) {
+    if (t === undefined) continue
+    if (t === null || typeof t !== 'object' || Array.isArray(t)) return false
+    const indexes = (t as { indexes?: unknown }).indexes
+    if (indexes === undefined) continue
+    if (indexes === null || typeof indexes !== 'object' || Array.isArray(indexes)) return false
+  }
+  return true
 }
 
 export function readLatestSnapshot(metaDir: string): SnapshotShape {
@@ -130,7 +280,11 @@ export function readLatestSnapshot(metaDir: string): SnapshotShape {
     .sort()
   const latest = files.at(-1)
   if (!latest) throw new Error(`no snapshot found in ${metaDir}`)
-  return JSON.parse(readFileSync(join(metaDir, latest), 'utf8')) as SnapshotShape
+  const parsed: unknown = JSON.parse(readFileSync(join(metaDir, latest), 'utf8'))
+  if (!isSnapshotShape(parsed)) {
+    throw new Error(`snapshot shape invalid in ${latest}`)
+  }
+  return parsed
 }
 
 /** A migration index `name` on `table` is "declared" iff the snapshot has it


### PR DESCRIPTION
Drains the 6 deferred parser-hardening items from PR #1165's code-review (issue #1167). Lint behavior on the current tree is unchanged — `bun run lint:snapshot-index-parity` still reports 85 indexes all matched, BASELINE still empty post-#1177.

## Items

| Sev | What | Where |
|---|---|---|
| MED | Compound `ALTER TABLE … DROP CONSTRAINT fk, DROP COLUMN a, DROP COLUMN b` — captures every DROP COLUMN, not just the first action | `parseDroppedColumns` (statement-then-action two-step) |
| MED | Expression indexes (`lower("email")`) and opclass suffixes (`"col" gin_trgm_ops`) — cascade now retires expression indexes when their underlying column is dropped | `parseCreatedIndexes` + new `findBalancedParens` / `splitTopLevel` / `extractColumnsFromTerm` helpers |
| LOW | Schema-qualified `public.t` / `"public"."t"` | New `SCHEMA_PREFIX` regex fragment across 3 parsers |
| LOW | `ALTER TABLE ONLY` | Optional `only\s+` in `parseDroppedColumns` |
| LOW | `as SnapshotShape` cast | New exported `isSnapshotShape` runtime guard; `readLatestSnapshot` validates before returning |
| LOW | Map mutation during iteration | Cascade loop snapshots `live.entries()` via `[...live]` (was per-spec safe, now idiom-safe) |

## Trade-offs surfaced in code, not silent

Two MEDIUM items from review fold-in (commit 2/2) are documented in-line so a future reader sees the failure mode:
- `extractColumnsFromTerm`: keyword/function filter is not exhaustive — keywords like `FROM`/`AS` inside `SUBSTRING(...)` leak through. Harmless until a real column shares that name AND gets dropped.
- `parseDroppedColumns`: `[^;]+` action capture is not quote-aware — an embedded `;` in a `DEFAULT 'foo;bar'` truncates and loses a trailing DROP. Failure mode is loud (un-cascaded index stays surfaced as drift), not silent.

## Verification

- `bun test scripts/lint-snapshot-index-parity.test.ts` → 51 pass (was 29; +22 new tests for the 6 items + cascade + shape guard).
- `bun run lint:snapshot-index-parity` → 85 indexes match, snapshot in sync.
- Aggregate `bun run test` → shared 780 / api 2115 / web 1330, all green.
- `bun run db:verify` → clean (86 entries strictly increasing).
- Biome + tsc clean on touched files.

No schema change, no migration, no app code touched. Single-file standalone parser script + tests.

Closes #1167
Refs #1104, #1150, #1165