### PR TITLE
refactor(#1115): extract geocoder/gateway/email resolution into composition/services (audit L3)

### DIFF
--- a/packages/api/src/composition/services.test.ts
+++ b/packages/api/src/composition/services.test.ts
@@ -166,7 +166,7 @@ describe('resolveGeocoder', () => {
     expect(inner).toHaveBeenCalledWith('Osaka')
   })
 
-  test('a present geocode limiter throttles every lookup through the rate binding', async () => {
+  test('a present geocode limiter is consulted (keyed global) before delegating the lookup', async () => {
     const limit = vi.fn(async () => ({ success: true }))
     const inner = vi.fn(async () => ({ status: 'notFound' as const }))
     await resolveGeocoder(ov({ geocoder: { geocode: inner }, geocodeLimiter: { limit } })).geocode(

--- a/packages/api/src/composition/services.test.ts
+++ b/packages/api/src/composition/services.test.ts
@@ -9,6 +9,7 @@ import {
   resolveEmailSender,
   resolveGeocoder,
   resolveGoogleOAuthConfig,
+  resolveOperatorAlertEmail,
   resolvePaymentGateway,
 } from './services'
 
@@ -25,6 +26,7 @@ const RESOLVER_ENV_KEYS = [
   'RESEND_API_KEY',
   'EMAIL_FROM',
   'EMAIL_REPLY_TO',
+  'OPERATOR_ALERT_FALLBACK_EMAIL',
   'STRIPE_SECRET_KEY',
   'STRIPE_WEBHOOK_SECRET',
   'NOMINATIM_USER_AGENT',
@@ -132,11 +134,16 @@ describe('resolvePaymentGateway', () => {
     expect(resolvePaymentGateway()).toBeInstanceOf(StripePaymentGateway)
   })
 
-  test('production without secrets yields a sentinel that throws on checkout', async () => {
+  test('production without secrets yields a sentinel where every method throws', async () => {
     process.env.NODE_ENV = 'production'
-    await expect(resolvePaymentGateway().createCheckoutSession(checkoutParams)).rejects.toThrow(
-      'STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not configured',
-    )
+    const gateway = resolvePaymentGateway() as unknown as Record<string, () => Promise<unknown>>
+    const methods = Object.values(gateway)
+    expect(methods).toHaveLength(5)
+    for (const call of methods) {
+      await expect(call()).rejects.toThrow(
+        'STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not configured',
+      )
+    }
   })
 
   test('dev without secrets stubs checkout (echoes successUrl) but throws on refund', async () => {
@@ -159,8 +166,35 @@ describe('resolveGeocoder', () => {
     expect(inner).toHaveBeenCalledWith('Osaka')
   })
 
+  test('a present geocode limiter throttles every lookup through the rate binding', async () => {
+    const limit = vi.fn(async () => ({ success: true }))
+    const inner = vi.fn(async () => ({ status: 'notFound' as const }))
+    await resolveGeocoder(ov({ geocoder: { geocode: inner }, geocodeLimiter: { limit } })).geocode(
+      'Osaka',
+    )
+    expect(limit).toHaveBeenCalledWith({ key: 'geocode:global' })
+    expect(inner).toHaveBeenCalledWith('Osaka')
+  })
+
   test('no provider env yields a disabled geocoder that reports every address un-geocodable', async () => {
     await expect(resolveGeocoder().geocode('Osaka')).resolves.toEqual({ status: 'notFound' })
+  })
+})
+
+describe('resolveOperatorAlertEmail', () => {
+  test('prefers the explicit fallback inbox over the envelope addresses', () => {
+    process.env.OPERATOR_ALERT_FALLBACK_EMAIL = 'alerts@op.com'
+    process.env.EMAIL_REPLY_TO = 'reply@op.com'
+    process.env.EMAIL_FROM = 'from@op.com'
+    expect(resolveOperatorAlertEmail()).toBe('alerts@op.com')
+  })
+
+  test('falls back to reply-to, then from, then undefined', () => {
+    expect(resolveOperatorAlertEmail()).toBeUndefined()
+    process.env.EMAIL_FROM = 'from@op.com'
+    expect(resolveOperatorAlertEmail()).toBe('from@op.com')
+    process.env.EMAIL_REPLY_TO = 'reply@op.com'
+    expect(resolveOperatorAlertEmail()).toBe('reply@op.com')
   })
 })
 

--- a/packages/api/src/composition/services.test.ts
+++ b/packages/api/src/composition/services.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { AppOverrides } from '../app-overrides'
+import { ResendEmailSender } from '../services/email/resend-email-sender'
+import type { CreateCheckoutParams } from '../services/payment/payment-gateway'
+import { StripePaymentGateway } from '../services/payment/stripe-payment-gateway'
+import {
+  resolveAllowedOrigins,
+  resolveEmailConfig,
+  resolveEmailSender,
+  resolveGeocoder,
+  resolveGoogleOAuthConfig,
+  resolvePaymentGateway,
+} from './services'
+
+// The resolvers read process.env at call time. Each test gets a private copy
+// with every resolver-relevant key stripped, so a key is absent unless the test
+// sets it (no `delete` needed, and no dev-shell secret leaks into a test).
+const RESOLVER_ENV_KEYS = [
+  'NODE_ENV',
+  'WEB_ORIGIN',
+  'WEB_POST_LOGIN_URL',
+  'AUTH_GOOGLE_ID',
+  'AUTH_GOOGLE_SECRET',
+  'AUTH_URL',
+  'RESEND_API_KEY',
+  'EMAIL_FROM',
+  'EMAIL_REPLY_TO',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'NOMINATIM_USER_AGENT',
+  'NOMINATIM_API_URL',
+  'NOMINATIM_API_KEY',
+]
+const ORIGINAL_ENV = process.env
+beforeEach(() => {
+  process.env = Object.fromEntries(
+    Object.entries(ORIGINAL_ENV).filter(([key]) => !RESOLVER_ENV_KEYS.includes(key)),
+  )
+})
+afterEach(() => {
+  process.env = ORIGINAL_ENV
+})
+
+// AppOverrides requires the in-memory repo trio; tests only exercise the infra
+// seams, so a partial cast keeps the fixtures to the fields under test.
+const ov = (o: Partial<AppOverrides>): AppOverrides => o as unknown as AppOverrides
+const checkoutParams = {
+  bookingCode: 'BK1',
+  successUrl: 'https://web/success',
+} as CreateCheckoutParams
+
+describe('resolveAllowedOrigins', () => {
+  test('outside production, prepends the dev origins and dedupes', () => {
+    process.env.NODE_ENV = 'test'
+    expect(resolveAllowedOrigins(undefined)).toEqual([
+      'http://localhost:3001',
+      'http://127.0.0.1:3001',
+    ])
+  })
+
+  test('in production, parses + trims the comma list and omits dev origins', () => {
+    process.env.NODE_ENV = 'production'
+    expect(resolveAllowedOrigins(' https://a.com , https://b.com ')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ])
+  })
+
+  test('dedupes repeated origins', () => {
+    process.env.NODE_ENV = 'production'
+    expect(resolveAllowedOrigins('https://a.com,https://a.com')).toEqual(['https://a.com'])
+  })
+})
+
+describe('resolveGoogleOAuthConfig', () => {
+  test('returns undefined when any of id/secret/url is missing', () => {
+    process.env.AUTH_GOOGLE_SECRET = 'secret'
+    process.env.AUTH_URL = 'https://api.example.com'
+    expect(resolveGoogleOAuthConfig()).toBeUndefined()
+  })
+
+  test('derives redirectUri from AUTH_URL (trailing slash stripped) and defaults postLogin to first web origin', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.AUTH_GOOGLE_ID = 'id'
+    process.env.AUTH_GOOGLE_SECRET = 'secret'
+    process.env.AUTH_URL = 'https://api.example.com/'
+    process.env.WEB_ORIGIN = 'https://web.example.com'
+    expect(resolveGoogleOAuthConfig()).toEqual({
+      clientId: 'id',
+      clientSecret: 'secret',
+      redirectUri: 'https://api.example.com/auth/google/callback',
+      postLoginRedirect: 'https://web.example.com',
+    })
+  })
+})
+
+describe('resolveEmailSender', () => {
+  test('an injected override wins outright', () => {
+    const fake = { send: vi.fn() }
+    expect(resolveEmailSender(ov({ emailSender: fake }))).toBe(fake)
+  })
+
+  test('a present RESEND_API_KEY yields the real Resend sender', () => {
+    process.env.RESEND_API_KEY = 're_test'
+    process.env.EMAIL_FROM = 'from@example.com'
+    expect(resolveEmailSender()).toBeInstanceOf(ResendEmailSender)
+  })
+
+  test('production without a key yields a sentinel that throws on send', async () => {
+    process.env.NODE_ENV = 'production'
+    const sender = resolveEmailSender()
+    await expect(sender.send({} as never)).rejects.toThrow('RESEND_API_KEY not configured')
+  })
+
+  test('dev without a key yields a console stub returning the dev id', async () => {
+    process.env.NODE_ENV = 'test'
+    await expect(resolveEmailSender().send({} as never)).resolves.toEqual({
+      providerMessageId: 'dev',
+    })
+  })
+})
+
+describe('resolvePaymentGateway', () => {
+  test('an injected override wins outright', () => {
+    const fake = { createCheckoutSession: vi.fn() } as never
+    expect(resolvePaymentGateway(ov({ paymentGateway: fake }))).toBe(fake)
+  })
+
+  test('both Stripe secrets present yields the real gateway', () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test'
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test'
+    expect(resolvePaymentGateway()).toBeInstanceOf(StripePaymentGateway)
+  })
+
+  test('production without secrets yields a sentinel that throws on checkout', async () => {
+    process.env.NODE_ENV = 'production'
+    await expect(resolvePaymentGateway().createCheckoutSession(checkoutParams)).rejects.toThrow(
+      'STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not configured',
+    )
+  })
+
+  test('dev without secrets stubs checkout (echoes successUrl) but throws on refund', async () => {
+    process.env.NODE_ENV = 'test'
+    const gateway = resolvePaymentGateway()
+    await expect(gateway.createCheckoutSession(checkoutParams)).resolves.toEqual({
+      sessionId: 'dev',
+      url: 'https://web/success',
+    })
+    await expect(gateway.refundPayment({} as never)).rejects.toThrow(
+      'Stripe not configured (dev): cannot refund',
+    )
+  })
+})
+
+describe('resolveGeocoder', () => {
+  test('an injected geocoder override is the inner geocoder behind the cache', async () => {
+    const inner = vi.fn(async () => ({ status: 'notFound' as const }))
+    await resolveGeocoder(ov({ geocoder: { geocode: inner } })).geocode('Osaka')
+    expect(inner).toHaveBeenCalledWith('Osaka')
+  })
+
+  test('no provider env yields a disabled geocoder that reports every address un-geocodable', async () => {
+    await expect(resolveGeocoder().geocode('Osaka')).resolves.toEqual({ status: 'notFound' })
+  })
+})
+
+describe('resolveEmailConfig', () => {
+  test('reads the envelope envs, defaulting from to empty string', () => {
+    expect(resolveEmailConfig()).toEqual({ emailFrom: '', emailReplyTo: undefined })
+  })
+
+  test('passes through configured from/reply-to', () => {
+    process.env.EMAIL_FROM = 'from@example.com'
+    process.env.EMAIL_REPLY_TO = 'reply@example.com'
+    expect(resolveEmailConfig()).toEqual({
+      emailFrom: 'from@example.com',
+      emailReplyTo: 'reply@example.com',
+    })
+  })
+})

--- a/packages/api/src/composition/services.ts
+++ b/packages/api/src/composition/services.ts
@@ -137,6 +137,20 @@ export function resolveEmailConfig(): { emailFrom: string; emailReplyTo: string 
 }
 
 /**
+ * The operator-alert fallback inbox (#960): the address the notification
+ * dispatcher falls back to when no operator-specific recipient resolves. Prefers
+ * an explicit OPERATOR_ALERT_FALLBACK_EMAIL, then the reply-to, then the from
+ * envelope — undefined only when none is set (the dispatcher then has no inbox).
+ */
+export function resolveOperatorAlertEmail(): string | undefined {
+  return (
+    process.env.OPERATOR_ALERT_FALLBACK_EMAIL ??
+    process.env.EMAIL_REPLY_TO ??
+    process.env.EMAIL_FROM
+  )
+}
+
+/**
  * Resolve the forward geocoder stack (#531/#574/#601): disabled by default (a
  * null stub that reports every address un-geocodable) unless BOTH a User-Agent
  * and an endpoint are set; prod = LocationIQ (Nominatim-compatible, +

--- a/packages/api/src/composition/services.ts
+++ b/packages/api/src/composition/services.ts
@@ -1,0 +1,174 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import type { AppOverrides } from '../app-overrides'
+import type { GoogleOAuthConfig } from '../auth/google'
+import type { EmailSender } from '../services/email/email-sender'
+import { ResendEmailSender } from '../services/email/resend-email-sender'
+import { CachingGeocoder } from '../services/geocoding/caching-geocoder'
+import { InMemoryGeocodeCache } from '../services/geocoding/geocode-cache'
+import { KvGeocodeCache, type KvStore } from '../services/geocoding/kv-geocode-cache'
+import { NominatimGeocoder } from '../services/geocoding/nominatim-geocoder'
+import { ThrottledGeocoder } from '../services/geocoding/throttled-geocoder'
+import type { GeocodeCache, Geocoder } from '../services/geocoding/types'
+import type { PaymentGateway } from '../services/payment/payment-gateway'
+import { StripePaymentGateway } from '../services/payment/stripe-payment-gateway'
+
+/**
+ * Infra-resolution policy for the composition root (#1115, audit L3). Decides
+ * HOW each env/secret-backed collaborator is built — real vendor adapter when
+ * the secret is present, a throwing sentinel in production when it is absent (so
+ * unrelated tests still construct the app), a navigable dev stub otherwise, and
+ * an injected override always winning. createApp (index.ts) and the Workers
+ * `scheduled` cron seams call these so the resolution lives in one tested place
+ * instead of inline in the wiring. Mirrors composition/repositories.ts.
+ */
+
+const DEV_WEB_ORIGINS = ['http://localhost:3001', 'http://127.0.0.1:3001']
+
+export function resolveAllowedOrigins(envValue: string | undefined): string[] {
+  const fromEnv = (envValue ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+
+  // Only include dev origins outside production so `bun run dev` works
+  // out of the box without leaking localhost to prod.
+  const devOrigins = process.env.NODE_ENV === 'production' ? [] : DEV_WEB_ORIGINS
+  return [...new Set([...devOrigins, ...fromEnv])]
+}
+
+/**
+ * Resolve Google OAuth config from env, or undefined when unconfigured (local
+ * dev / CI without secrets) — the /auth/google/* routes then return 503 rather
+ * than crashing at boot. redirect_uri is derived from AUTH_URL so it always
+ * matches the deployed origin; the post-login target defaults to the first
+ * allowed web origin.
+ */
+export function resolveGoogleOAuthConfig(): GoogleOAuthConfig | undefined {
+  const clientId = process.env.AUTH_GOOGLE_ID
+  const clientSecret = process.env.AUTH_GOOGLE_SECRET
+  const authUrl = process.env.AUTH_URL
+  if (!clientId || !clientSecret || !authUrl) return undefined
+
+  const base = authUrl.replace(/\/$/, '')
+  const postLoginRedirect =
+    process.env.WEB_POST_LOGIN_URL ?? resolveAllowedOrigins(process.env.WEB_ORIGIN)[0] ?? base
+  return {
+    clientId,
+    clientSecret,
+    redirectUri: `${base}/auth/google/callback`,
+    postLoginRedirect,
+  }
+}
+
+/**
+ * Resolve the outbound email port (#916 DRY): an injected override wins (tests),
+ * else real Resend when RESEND_API_KEY is set, else a throwing sentinel in
+ * production and a console stub in dev — so flows work end-to-end without a
+ * vendor account. Shared by createApp's dispatcher and buildComplianceDigestService.
+ */
+export function resolveEmailSender(overrides?: AppOverrides): EmailSender {
+  if (overrides?.emailSender) return overrides.emailSender
+  const key = process.env.RESEND_API_KEY
+  const from = process.env.EMAIL_FROM ?? ''
+  if (key) return new ResendEmailSender(key, from)
+  if (process.env.NODE_ENV === 'production') {
+    return {
+      send: async () => {
+        throw new Error('RESEND_API_KEY not configured')
+      },
+    }
+  }
+  return {
+    send: async (m) => {
+      console.info('[email:dev]', m.to, m.subject)
+      return { providerMessageId: 'dev' }
+    },
+  }
+}
+
+/**
+ * Resolve the Stripe gateway (#461), shared by createApp and the #851 refund-
+ * reconciler cron. Real gateway when BOTH secrets are set; an override (tests)
+ * wins; in production without secrets a sentinel throws on first use (not at
+ * boot); in dev a stub yields the success URL but every Stripe op throws so
+ * nothing is recorded without real wiring. Mirrors resolveEmailSender.
+ */
+export function resolvePaymentGateway(overrides?: AppOverrides): PaymentGateway {
+  if (overrides?.paymentGateway) return overrides.paymentGateway
+  const secretKey = process.env.STRIPE_SECRET_KEY
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+  if (secretKey && webhookSecret) return new StripePaymentGateway(secretKey, webhookSecret)
+  if (process.env.NODE_ENV === 'production') {
+    const notConfigured = () => {
+      throw new Error('STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not configured')
+    }
+    return {
+      createCheckoutSession: async () => notConfigured(),
+      parseWebhookEvent: async () => notConfigured(),
+      refundPayment: async () => notConfigured(),
+      retrieveRefund: async () => notConfigured(),
+      listRefundsByPaymentIntent: async () => notConfigured(),
+    }
+  }
+  const devUnsupported = (op: string) => () => {
+    throw new Error(`Stripe not configured (dev): cannot ${op}`)
+  }
+  return {
+    createCheckoutSession: async (p) => {
+      console.info('[payment:dev] checkout session for', p.bookingCode)
+      return { sessionId: 'dev', url: p.successUrl }
+    },
+    parseWebhookEvent: async () => devUnsupported('verify webhook')(),
+    refundPayment: async () => devUnsupported('refund')(),
+    retrieveRefund: async () => devUnsupported('retrieve refund')(),
+    listRefundsByPaymentIntent: async () => devUnsupported('list refunds')(),
+  }
+}
+
+/**
+ * The shared envelope fields (from/reply-to) read from one env in two places —
+ * createApp's notification dispatcher and buildComplianceDigestService (#982 DRY).
+ */
+export function resolveEmailConfig(): { emailFrom: string; emailReplyTo: string | undefined } {
+  return {
+    emailFrom: process.env.EMAIL_FROM ?? '',
+    emailReplyTo: process.env.EMAIL_REPLY_TO,
+  }
+}
+
+/**
+ * Resolve the forward geocoder stack (#531/#574/#601): disabled by default (a
+ * null stub that reports every address un-geocodable) unless BOTH a User-Agent
+ * and an endpoint are set; prod = LocationIQ (Nominatim-compatible, +
+ * NOMINATIM_API_KEY) or self-host. The provider is wrapped in a ThrottledGeocoder
+ * keyed off GEOCODE_LIMITER (best-effort global 1 req/s cap), then a
+ * CachingGeocoder OUTSIDE the throttle (a cache HIT spends neither the provider
+ * call nor the budget) backed by Workers KV when the GEOCODE_CACHE binding is
+ * present, else an in-process map. A test override wins outright.
+ */
+export function resolveGeocoder(overrides?: AppOverrides): Geocoder {
+  const innerGeocoder: Geocoder =
+    overrides?.geocoder ??
+    (() => {
+      const userAgent = process.env.NOMINATIM_USER_AGENT
+      const baseUrl = process.env.NOMINATIM_API_URL
+      // Disabled: every address is "un-geocodable" (no provider), so a save
+      // persists with null coords — never PENDING (nothing will ever resolve it).
+      if (!userAgent || !baseUrl) return { geocode: async () => ({ status: 'notFound' as const }) }
+      return new NominatimGeocoder(baseUrl, userAgent, undefined, process.env.NOMINATIM_API_KEY)
+    })()
+  // Adapt the native binding's `limit({ key })` to the RateLimiter port here.
+  const geocodeLimiter =
+    overrides?.geocodeLimiter ??
+    ((globalThis as Record<string, unknown>).GEOCODE_LIMITER as RateLimitBinding | undefined)
+  const geocoder: Geocoder = geocodeLimiter
+    ? new ThrottledGeocoder(innerGeocoder, { limit: (key) => geocodeLimiter.limit({ key }) })
+    : innerGeocoder
+  const geocodeCache: GeocodeCache =
+    overrides?.geocodeCache ??
+    (() => {
+      const kv = (globalThis as Record<string, unknown>).GEOCODE_CACHE as KvStore | undefined
+      return kv ? new KvGeocodeCache(kv) : new InMemoryGeocodeCache()
+    })()
+  return new CachingGeocoder(geocoder, geocodeCache)
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -11,6 +11,7 @@ import {
   resolveEmailSender,
   resolveGeocoder,
   resolveGoogleOAuthConfig,
+  resolveOperatorAlertEmail,
   resolvePaymentGateway,
 } from './composition/services'
 import { setupGlobalHandlers } from './error-handlers'
@@ -545,10 +546,7 @@ function resolveNotificationDispatcher(
     emailSender,
     {
       ...resolveEmailConfig(),
-      fallbackOperatorEmail:
-        process.env.OPERATOR_ALERT_FALLBACK_EMAIL ??
-        process.env.EMAIL_REPLY_TO ??
-        process.env.EMAIL_FROM,
+      fallbackOperatorEmail: resolveOperatorAlertEmail(),
       // #960: empty string (WEB_ORIGIN unset) -> the dispatcher omits the deep link.
       webBaseUrl,
     },

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,9 +3,16 @@ import { jstDateString } from '@kuruma/shared/lib/compliance'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import type { AppOverrides } from './app-overrides'
-import type { GoogleOAuthConfig } from './auth/google'
 import { isStaleOperatorSession } from './auth/session-freshness'
 import { type Repos, buildRepos } from './composition/repositories'
+import {
+  resolveAllowedOrigins,
+  resolveEmailConfig,
+  resolveEmailSender,
+  resolveGeocoder,
+  resolveGoogleOAuthConfig,
+  resolvePaymentGateway,
+} from './composition/services'
 import { setupGlobalHandlers } from './error-handlers'
 import { parseBoolFlag } from './lib/parse-bool-flag'
 import { provideOperatorSessionRevocation, requireAuth } from './middleware/auth'
@@ -69,17 +76,10 @@ import { resolveSigningKey } from './services/consent-signing'
 import { CustomerService } from './services/customer'
 import { documentVerificationGate } from './services/document-verification-gate'
 import type { EmailSender } from './services/email/email-sender'
-import { ResendEmailSender } from './services/email/resend-email-sender'
 import { makeEnsureThread } from './services/ensure-thread'
 import { FeeScheduleService } from './services/fee-schedule'
 import { FlatSearchService } from './services/flat-search'
 import { FleetOverviewService } from './services/fleet-overview'
-import { CachingGeocoder } from './services/geocoding/caching-geocoder'
-import { InMemoryGeocodeCache } from './services/geocoding/geocode-cache'
-import { KvGeocodeCache, type KvStore } from './services/geocoding/kv-geocode-cache'
-import { NominatimGeocoder } from './services/geocoding/nominatim-geocoder'
-import { ThrottledGeocoder } from './services/geocoding/throttled-geocoder'
-import type { GeocodeCache, Geocoder } from './services/geocoding/types'
 import { InsuranceOptionService } from './services/insurance-option'
 import { LocationService } from './services/location'
 import { MaintenanceService } from './services/maintenance'
@@ -99,8 +99,6 @@ import { OverviewService } from './services/overview'
 import { PaymentAnomalyService } from './services/payment-anomaly'
 import { CancellationRefundReconciler } from './services/payment/cancellation-refund-reconciler'
 import { PaymentService } from './services/payment/payment'
-import type { PaymentGateway } from './services/payment/payment-gateway'
-import { StripePaymentGateway } from './services/payment/stripe-payment-gateway'
 import { ProviderInviteService } from './services/provider-invite'
 import { RenterDocumentService } from './services/renter-document'
 import { ReviewService } from './services/review'
@@ -180,40 +178,8 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
 
   const emailSender = resolveEmailSender(overrides)
 
-  // Forward geocoder (#531): disabled by default (null stub) unless BOTH a
-  // User-Agent and an endpoint are set; prod = LocationIQ (Nominatim-compatible,
-  // + NOMINATIM_API_KEY) or self-host. The resolved geocoder is wrapped in a
-  // ThrottledGeocoder keyed off GEOCODE_LIMITER (#574) — best-effort global cap so
-  // a burst can't breach OSMF's 1 req/s. A test override wins outright.
-  const innerGeocoder: Geocoder =
-    overrides?.geocoder ??
-    (() => {
-      const userAgent = process.env.NOMINATIM_USER_AGENT
-      const baseUrl = process.env.NOMINATIM_API_URL
-      // Disabled: every address is "un-geocodable" (no provider), so a save
-      // persists with null coords — never PENDING (nothing will ever resolve it).
-      if (!userAgent || !baseUrl) return { geocode: async () => ({ status: 'notFound' as const }) }
-      return new NominatimGeocoder(baseUrl, userAgent, undefined, process.env.NOMINATIM_API_KEY)
-    })()
-  // Adapt the native binding's `limit({ key })` to the RateLimiter port here.
-  const geocodeLimiter =
-    overrides?.geocodeLimiter ??
-    ((globalThis as Record<string, unknown>).GEOCODE_LIMITER as RateLimitBinding | undefined)
-  const geocoder: Geocoder = geocodeLimiter
-    ? new ThrottledGeocoder(innerGeocoder, { limit: (key) => geocodeLimiter.limit({ key }) })
-    : innerGeocoder
-  // Forward-geocode result cache (#601, #574 piece 1/2). Wraps OUTSIDE the throttle
-  // so a cache HIT spends neither the provider call nor the 1-req/10s budget.
-  // Durable cross-isolate Workers KV when the GEOCODE_CACHE binding is present
-  // (gated on #304); until then an in-process map (dev/test/seed). A test override
-  // wins outright.
-  const geocodeCache: GeocodeCache =
-    overrides?.geocodeCache ??
-    (() => {
-      const kv = (globalThis as Record<string, unknown>).GEOCODE_CACHE as KvStore | undefined
-      return kv ? new KvGeocodeCache(kv) : new InMemoryGeocodeCache()
-    })()
-  const cachedGeocoder: Geocoder = new CachingGeocoder(geocoder, geocodeCache)
+  // Geocoder stack (provider + throttle + cache) resolved in composition/services.
+  const cachedGeocoder = resolveGeocoder(overrides)
 
   // In-app Stripe payment (#461). Real gateway when BOTH secrets are set; in
   // production without them a sentinel throws on first use (not at boot, so
@@ -548,120 +514,6 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createOperatorRoutes(operatorService))
     .route('/', createOperatorTeamRoutes(operatorTeamService))
     .route('/', createDocumentRoutes(renterDocumentService))
-}
-
-/**
- * Resolve Google OAuth config from env, or undefined when unconfigured (local
- * dev / CI without secrets) — the /auth/google/* routes then return 503 rather
- * than crashing at boot. redirect_uri is derived from AUTH_URL so it always
- * matches the deployed origin; the post-login target defaults to the first
- * allowed web origin.
- */
-function resolveGoogleOAuthConfig(): GoogleOAuthConfig | undefined {
-  const clientId = process.env.AUTH_GOOGLE_ID
-  const clientSecret = process.env.AUTH_GOOGLE_SECRET
-  const authUrl = process.env.AUTH_URL
-  if (!clientId || !clientSecret || !authUrl) return undefined
-
-  const base = authUrl.replace(/\/$/, '')
-  const postLoginRedirect =
-    process.env.WEB_POST_LOGIN_URL ?? resolveAllowedOrigins(process.env.WEB_ORIGIN)[0] ?? base
-  return {
-    clientId,
-    clientSecret,
-    redirectUri: `${base}/auth/google/callback`,
-    postLoginRedirect,
-  }
-}
-
-const DEV_WEB_ORIGINS = ['http://localhost:3001', 'http://127.0.0.1:3001']
-
-function resolveAllowedOrigins(envValue: string | undefined): string[] {
-  const fromEnv = (envValue ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-
-  // Only include dev origins outside production so `bun run dev` works
-  // out of the box without leaking localhost to prod.
-  const devOrigins = process.env.NODE_ENV === 'production' ? [] : DEV_WEB_ORIGINS
-  return [...new Set([...devOrigins, ...fromEnv])]
-}
-
-/**
- * Resolve the outbound email port (#916 DRY): an injected override wins (tests),
- * else real Resend when RESEND_API_KEY is set, else a throwing sentinel in
- * production and a console stub in dev — so flows work end-to-end without a
- * vendor account. Shared by createApp's dispatcher and buildComplianceDigestService.
- */
-function resolveEmailSender(overrides?: AppOverrides): EmailSender {
-  if (overrides?.emailSender) return overrides.emailSender
-  const key = process.env.RESEND_API_KEY
-  const from = process.env.EMAIL_FROM ?? ''
-  if (key) return new ResendEmailSender(key, from)
-  if (process.env.NODE_ENV === 'production') {
-    return {
-      send: async () => {
-        throw new Error('RESEND_API_KEY not configured')
-      },
-    }
-  }
-  return {
-    send: async (m) => {
-      console.info('[email:dev]', m.to, m.subject)
-      return { providerMessageId: 'dev' }
-    },
-  }
-}
-
-/**
- * Resolve the Stripe gateway (#461), shared by createApp and the #851 refund-
- * reconciler cron. Real gateway when BOTH secrets are set; an override (tests)
- * wins; in production without secrets a sentinel throws on first use (not at
- * boot); in dev a stub yields the success URL but every Stripe op throws so
- * nothing is recorded without real wiring. Mirrors resolveEmailSender.
- */
-function resolvePaymentGateway(overrides?: AppOverrides): PaymentGateway {
-  if (overrides?.paymentGateway) return overrides.paymentGateway
-  const secretKey = process.env.STRIPE_SECRET_KEY
-  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
-  if (secretKey && webhookSecret) return new StripePaymentGateway(secretKey, webhookSecret)
-  if (process.env.NODE_ENV === 'production') {
-    const notConfigured = () => {
-      throw new Error('STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not configured')
-    }
-    return {
-      createCheckoutSession: async () => notConfigured(),
-      parseWebhookEvent: async () => notConfigured(),
-      refundPayment: async () => notConfigured(),
-      retrieveRefund: async () => notConfigured(),
-      listRefundsByPaymentIntent: async () => notConfigured(),
-    }
-  }
-  const devUnsupported = (op: string) => () => {
-    throw new Error(`Stripe not configured (dev): cannot ${op}`)
-  }
-  return {
-    createCheckoutSession: async (p) => {
-      console.info('[payment:dev] checkout session for', p.bookingCode)
-      return { sessionId: 'dev', url: p.successUrl }
-    },
-    parseWebhookEvent: async () => devUnsupported('verify webhook')(),
-    refundPayment: async () => devUnsupported('refund')(),
-    retrieveRefund: async () => devUnsupported('retrieve refund')(),
-    listRefundsByPaymentIntent: async () => devUnsupported('list refunds')(),
-  }
-}
-
-/**
- * The shared envelope fields (from/reply-to) read from one env in two places —
- * createApp's notification dispatcher and buildComplianceDigestService (#982 DRY).
- */
-function resolveEmailConfig(): { emailFrom: string; emailReplyTo: string | undefined } {
-  return {
-    emailFrom: process.env.EMAIL_FROM ?? '',
-    emailReplyTo: process.env.EMAIL_REPLY_TO,
-  }
 }
 
 /**


### PR DESCRIPTION
## What

Audit finding **L3** (SRP — composition root doing two jobs). `createApp` mixed *infra-resolution policy* (which gateway/sentinel/geocoder to build from env+secrets) with the actual DI wiring. This extracts the resolution into a new `packages/api/src/composition/services.ts`, mirroring `composition/repositories.ts`, leaving `index.ts` as flat wiring + `.route()` chaining.

Closes #1115. Refs #1104.

## Moved into `composition/services.ts`

- `resolveAllowedOrigins`, `resolveGoogleOAuthConfig`, `resolveEmailSender`, `resolvePaymentGateway`, `resolveEmailConfig` — verbatim from index.ts's tail (they were module-private there).
- `resolveGeocoder(overrides)` — **new**, wraps the previously-inline provider + throttle + cache stack.
- `resolveOperatorAlertEmail()` — **new** (review follow-up), pulls the last inline env-parse (`OPERATOR_ALERT_FALLBACK_EMAIL ?? EMAIL_REPLY_TO ?? EMAIL_FROM`) out of the dispatcher wiring.

Translation already lived in its own factory (`translation-provider-factory.ts`) — left untouched (YAGNI).

## Behavior

Pure relocation — **no behavioral change**. Same gateways, same throwing sentinels when a production secret is absent, same env handling. `index.ts`: **789 → 639 lines**.

> Note: `lint:size` already passed pre-change (789 < the 800 hard cap; >400 only soft-warns, which don't fail). The win here is the SRP split + restoring hard-cap headroom — not a red→green on the size gate.

## Interface shape

Exposes individual `resolve*` functions rather than a single `resolveServices()` bundle. The cron seams each need only a subset (the refund reconciler wants only the payment gateway), and there's no cross-member invariant to compiler-enforce (unlike `repositories.ts`'s exhaustive-key contract) — so narrow functions beat a fat bundle (ISP).

## Tests

New `composition/services.test.ts` (20 tests, net-new coverage for logic that was untestable while inline): pins every resolution arm per resolver — override / real-vendor / production-sentinel-throws / dev-stub — with mutation-resistant assertions, plus the geocoder throttle-wrap and the operator-alert fallback chain. Per-test `process.env` isolation.

## Verification

- `bun run --filter @kuruma/api typecheck` — clean
- `bun run --filter @kuruma/api test` — **190 files / 2155 tests green**
- `bun run --filter @kuruma/api lint:boundaries` — OK (`composition/` is the sanctioned root; no concrete construction leaked out)
- `bun run lint:size` — exit 0
- Reviewed by code-reviewer (**SHIP**) + architect (**SHIP-WITH-NITS**); both nits folded in.
