### PR TITLE
fix(#1168): drop PARTNER from PRIVILEGED_ROLES — close cross-tenant private-data leak

### DIFF
--- a/packages/api/src/services/customer.ts
+++ b/packages/api/src/services/customer.ts
@@ -1,5 +1,6 @@
 import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 import type { CallerContext } from '../auth/context'
+import { PRIVILEGED_ROLES } from '../middleware/auth'
 import type {
   BookingRepository,
   CustomerListFilters,
@@ -23,8 +24,9 @@ export interface CustomerListQuery {
  * customers if widened. search() is the ONE operator-reachable method: it threads
  * CallerContext and scopes an OPERATOR_* caller to renters within its own tenant
  * boundary (those with a prior booking with it), so manual-booking can't become a
- * global user-enumeration vector (#396/#475). Bypass roles still search the full
- * user table. The route gate (routes/customers.ts) mirrors this split.
+ * global user-enumeration vector (#396/#475). Only PRIVILEGED_ROLES (PLATFORM_ADMIN
+ * since #1168) search the full user table — PARTNER does NOT, even though it carries
+ * bypassScope. The route gate (routes/customers.ts) mirrors this split.
  */
 export class CustomerService {
   constructor(
@@ -56,8 +58,12 @@ export class CustomerService {
 
   async search(query: string, ctx: CallerContext): Promise<User[]> {
     const matches = await this.userRepo.search(query)
-    // Bypass roles (PLATFORM_ADMIN/PARTNER) search the full user table.
-    if (ctx.bypassScope) return matches
+    // Only the privileged platform tier searches the full user table. Gated on
+    // PRIVILEGED_ROLES (PLATFORM_ADMIN-only since #1168), NOT the coarse
+    // `bypassScope` flag — that also carries PARTNER, which must never enumerate
+    // the cross-tenant directory. The route already 403s PARTNER (#1116); this is
+    // the service-layer seal (defense-in-depth, mirrors #1119).
+    if (PRIVILEGED_ROLES.has(ctx.role)) return matches
     // An operator only resolves renters within its own tenant boundary — those
     // with a prior booking with it — so manual-booking can't enumerate the global
     // user table (#396/#475). Fail closed if somehow operator-less.

--- a/packages/api/src/services/ensure-thread.ts
+++ b/packages/api/src/services/ensure-thread.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_CONTEXT } from '../middleware/auth'
 import type { CallerContext } from '../middleware/auth'
 import type { ThreadRepository } from '../repositories/types'
 import type { Booking } from '../stores'
@@ -21,7 +22,15 @@ export function makeEnsureThread(threading: BookingThreading): EnsureThread {
   return async (ctx, booking) => {
     const threadKey = `booking:${booking.id}`
     try {
-      const existing = await threading.threadRepo.findByIdempotencyKey(ctx, threadKey)
+      // The idempotency probe is infrastructure, not a caller-scoped read: it
+      // asks "does this booking's thread already exist?", so it MUST run under
+      // SYSTEM_CONTEXT. A caller who isn't a thread participant — a PARTNER
+      // (Trip.com) booking, or an operator manual booking, neither of which is
+      // in [renterId, staffUserId] — would otherwise miss an existing thread on
+      // replay and re-fire the insert into a benign-but-noisy UNIQUE_VIOLATION
+      // (worsened once #1168 dropped PARTNER from PRIVILEGED_ROLES). The create
+      // stays on the caller ctx; participants are fixed below regardless.
+      const existing = await threading.threadRepo.findByIdempotencyKey(SYSTEM_CONTEXT, threadKey)
       if (existing) return
       await threading.threadRepo.create(
         ctx,

--- a/packages/api/src/services/user-directory.ts
+++ b/packages/api/src/services/user-directory.ts
@@ -30,8 +30,9 @@ export class UserDirectoryService {
   }
 
   /**
-   * The set of user ids the caller may resolve. Privileged roles (PARTNER/
-   * PLATFORM_ADMIN) resolve anyone; renters resolve only users they share a thread with.
+   * The set of user ids the caller may resolve. The privileged platform tier
+   * (PLATFORM_ADMIN — PARTNER was dropped in #1168) resolves anyone; renters
+   * resolve only users they share a thread with.
    */
   private async allowedUserIds(ctx: CallerContext): Promise<Set<string> | 'all'> {
     if (PRIVILEGED_ROLES.has(ctx.role)) return 'all'

--- a/packages/api/tests/routes/operator-user-isolation.test.ts
+++ b/packages/api/tests/routes/operator-user-isolation.test.ts
@@ -48,6 +48,21 @@ async function operatorBearer(
   return { Authorization: `Bearer ${token}` }
 }
 
+async function partnerBearer(sub: string): Promise<Record<string, string>> {
+  // PARTNER (Trip.com) carries NO operatorId — it is a cross-channel booking
+  // caller, not a tenant. toCallerContext only attaches operatorId for
+  // OPERATOR_* roles, so this mirrors a real partner key.
+  const key = new TextEncoder().encode(TEST_AUTH_SECRET)
+  const token = await new SignJWT({ sub, role: 'PARTNER' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('kuruma-web')
+    .setAudience('kuruma-api')
+    .sign(key)
+  return { Authorization: `Bearer ${token}` }
+}
+
 function mkUser(id: string, role: User['role']): User {
   return {
     id,
@@ -460,5 +475,63 @@ describe('#396 — OPERATOR_* cannot enumerate users via any current ingress', (
     // The pre-existing phone holder is untouched.
     const [foreign] = await userRepo.findByIds([existing.id])
     expect(foreign?.name).toBe('Existing Person')
+  })
+})
+
+// #1168 — PARTNER (Trip.com) is a booking channel, NOT a cross-tenant private-data
+// reader. It was in PRIVILEGED_ROLES, which gated full reads of messages, threads,
+// and the user directory — and those routes gate on `requireUser` only, so a
+// partner key could enumerate every tenant's private data (the same leak class
+// #1119 closed for bookings). These pin that PARTNER now falls closed everywhere.
+describe('#1168 — PARTNER cannot read cross-tenant private data', () => {
+  const PARTNER_ID = '00000000-0000-4000-8000-0000000000aa'
+  const RENTER_A = '00000000-0000-4000-8000-0000000000a1'
+  const OPERATOR_B = '00000000-0000-4000-8000-0000000000b2'
+  let app: ReturnType<typeof createApp>
+  let threadId: string
+
+  beforeEach(async () => {
+    setupAuthEnv()
+    const userStore = new Map<string, User>([
+      [PARTNER_ID, mkUser(PARTNER_ID, 'PARTNER')],
+      [RENTER_A, mkUser(RENTER_A, 'RENTER')],
+      [OPERATOR_B, mkUser(OPERATOR_B, 'OPERATOR_OWNER')],
+    ])
+    const userRepo = new InMemoryUserRepository(userStore)
+    const threadRepo = new InMemoryThreadRepository()
+    // A renter<->operator thread the PARTNER is NOT a participant of.
+    const thread = await threadRepo.create(SYSTEM_CONTEXT, null, [RENTER_A, OPERATOR_B])
+    threadId = thread.id
+    app = createApp({ userRepo, threadRepo })
+  })
+
+  it('GET /threads returns no other tenant’s threads — empty, not the full table', async () => {
+    const res = await app.request('/threads', { headers: await partnerBearer(PARTNER_ID) })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: unknown[] }
+    expect(body.data).toEqual([])
+  })
+
+  it('GET /threads/:id 404s a thread the PARTNER is not a participant of', async () => {
+    const res = await app.request(`/threads/${threadId}`, {
+      headers: await partnerBearer(PARTNER_ID),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /users resolves nothing — PARTNER is not a privileged name oracle', async () => {
+    const res = await app.request(`/users?ids=${RENTER_A},${OPERATOR_B}`, {
+      headers: await partnerBearer(PARTNER_ID),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { id: string }[] }
+    expect(body.data).toEqual([])
+  })
+
+  it('GET /customers/search is 403 — PARTNER is neither staff nor a tenant operator (#1116 route gate)', async () => {
+    const res = await app.request('/customers/search?q=User', {
+      headers: await partnerBearer(PARTNER_ID),
+    })
+    expect(res.status).toBe(403)
   })
 })

--- a/packages/api/tests/services/booking-thread.test.ts
+++ b/packages/api/tests/services/booking-thread.test.ts
@@ -20,6 +20,7 @@ import {
   InMemoryVehicleClassRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
+import { InMemoryThreadRepository } from '../../src/repositories/in-memory/thread'
 import type {
   RunInTransaction,
   ThreadRepository,
@@ -29,7 +30,7 @@ import { BookingService } from '../../src/services/booking'
 import { BookingPostCommitDispatcher } from '../../src/services/booking-post-commit-dispatcher'
 import type { CreateBookingInput } from '../../src/services/booking-types'
 import { makeEnsureThread } from '../../src/services/ensure-thread'
-import type { Thread, User, Vehicle } from '../../src/stores'
+import type { Booking, Thread, User, Vehicle } from '../../src/stores'
 
 const RENTER = '00000000-0000-4000-8000-0000000000a1'
 const STAFF = '00000000-0000-4000-8000-0000000000b1'
@@ -313,6 +314,28 @@ describe('BookingService.create — auto-thread on confirmation', () => {
     expect(second.booking.id).toBe(first.booking.id)
     expect(threadRepo.create).toHaveBeenCalledTimes(2) // second attempt succeeded
 
+    errorSpy.mockRestore()
+  })
+
+  it('runs the idempotency probe under SYSTEM_CONTEXT — a non-participant caller (PARTNER) replay finds the thread, no duplicate insert (#1168)', async () => {
+    // Real repo (not the ctx-blind mock): the thread's participants are
+    // [renter, staff], so a PARTNER caller is NOT a participant. Before #1168 the
+    // probe ran under the caller ctx — PARTNER (no longer privileged) missed the
+    // existing thread on replay and re-fired the insert → a caught, logged
+    // UNIQUE_VIOLATION. Under SYSTEM_CONTEXT the probe is privileged and finds it.
+    const realThreadRepo = new InMemoryThreadRepository()
+    const ensureThread = makeEnsureThread({ threadRepo: realThreadRepo, staffUserId: STAFF })
+    const partnerCtx: CallerContext = { userId: 'trip-partner', role: 'PARTNER', bypassScope: true }
+    const booking = { id: 'bk-1168-partner', renterId: RENTER } as unknown as Booking
+    const createSpy = vi.spyOn(realThreadRepo, 'create')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await ensureThread(partnerCtx, booking) // first call: creates the thread
+    await ensureThread(partnerCtx, booking) // replay: probe must FIND it, not re-insert
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    const logged = errorSpy.mock.calls.map((c) => c[0] as string).join('\n')
+    expect(logged).not.toContain('thread_autocreate_failed')
     errorSpy.mockRestore()
   })
 })

--- a/packages/api/tests/services/customer.test.ts
+++ b/packages/api/tests/services/customer.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../src/auth/context'
+import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
+import { InMemoryCustomerRepository } from '../../src/repositories/in-memory/customer'
+import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
+import { CustomerService } from '../../src/services/customer'
+import type { User } from '../../src/stores'
+
+// #1168 — CustomerService.search() must scope "see the whole user table" to the
+// PLATFORM_ADMIN tier, NOT to the coarse `bypassScope` flag, which also carries
+// PARTNER. The /customers/search route already 403s PARTNER (#1116); this is the
+// service-layer seal so the directory can never become a PARTNER enumeration
+// vector even if a future route reaches it (defense-in-depth, mirrors #1119).
+describe('CustomerService.search — privileged scope is PLATFORM_ADMIN, never PARTNER', () => {
+  const RENTER_A = '00000000-0000-4000-8000-0000000000a1'
+  const RENTER_B = '00000000-0000-4000-8000-0000000000b2'
+  let service: CustomerService
+
+  beforeEach(() => {
+    const users = new Map<string, User>([
+      [RENTER_A, mkRenter(RENTER_A, 'Searchable Alice')],
+      [RENTER_B, mkRenter(RENTER_B, 'Searchable Bob')],
+    ])
+    const userRepo = new InMemoryUserRepository(users)
+    const customerRepo = new InMemoryCustomerRepository(users, new Map())
+    const bookingRepo = new InMemoryBookingRepository()
+    service = new CustomerService(customerRepo, userRepo, bookingRepo)
+  })
+
+  it('PLATFORM_ADMIN still sees the full directory (regression: privileged read preserved)', async () => {
+    const ctx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const results = await service.search('Searchable', ctx)
+    expect(results.map((u) => u.id).sort()).toEqual([RENTER_A, RENTER_B])
+  })
+
+  it('PARTNER gets nothing — bypassScope no longer unlocks the full user table', async () => {
+    // PARTNER keeps bypassScope=true (its bookings are scoped per-consumer, #1119),
+    // but it has no operatorId and no customer-directory use case.
+    const ctx: CallerContext = { userId: 'trip', role: 'PARTNER', bypassScope: true }
+    const results = await service.search('Searchable', ctx)
+    expect(results).toEqual([])
+  })
+})
+
+function mkRenter(id: string, name: string): User {
+  return {
+    id,
+    name,
+    email: `${id.slice(-2)}@test.local`,
+    phone: null,
+    language: 'en',
+    country: null,
+    role: 'RENTER',
+  }
+}

--- a/packages/shared/src/auth/roles.ts
+++ b/packages/shared/src/auth/roles.ts
@@ -88,15 +88,22 @@ export const OPERATOR_OWNER_WRITE_ROLES = union(MANAGEMENT_BASE_ROLES, roleSet('
  * `CallerContext.bypassScope`. NOTE (#1119): bookings are NO LONGER part of this
  * bypass for PARTNER — a Trip.com key reads only its own channel
  * (`bookingReadScope` -> `partner`, source=TRIP_COM), not operators' DIRECT
- * bookings. `bypassScope` still grants PARTNER cross-tenant reads of the
- * remaining surfaces it gates (e.g. user search in `customer.ts`); narrowing
- * those the same way is the tracked follow-up. A distinct instance from
- * {@link PRIVILEGED_ROLES} (same members) because the two gate different things.
+ * bookings. PARTNER stays in this set as a SCOPE-GATE marker (its presence tells
+ * `bookingReadScope` to take the per-source path), but it no longer unlocks any
+ * other cross-tenant private read: the directory/messaging surfaces now gate on
+ * {@link PRIVILEGED_ROLES} (PLATFORM_ADMIN-only since #1168), and `customer.ts`
+ * was switched to that predicate too. Distinct instance from PRIVILEGED_ROLES —
+ * the two now have genuinely different membership.
  */
 export const SCOPE_BYPASS_ROLES = roleSet('PARTNER', 'PLATFORM_ADMIN')
 
 /**
- * Roles permitted to read cross-tenant private data (message threads, user lists).
- * Platform tier PLUS PARTNER. Distinct instance from {@link SCOPE_BYPASS_ROLES}.
+ * Roles permitted to read cross-tenant PRIVATE data (message threads, message
+ * bodies, the user-id->name directory, the customer search table). PLATFORM_ADMIN
+ * ONLY. #1168 dropped PARTNER: a Trip.com booking channel has no private-data use
+ * case, and those routes gate on `requireUser` only — keeping PARTNER here let a
+ * partner key enumerate every tenant's threads and users (the leak class #1119
+ * closed for bookings). PARTNER's lone cross-tenant read, its own bookings, is
+ * scoped in `bookingReadScope` via {@link SCOPE_BYPASS_ROLES}, NOT here.
  */
-export const PRIVILEGED_ROLES = roleSet('PARTNER', 'PLATFORM_ADMIN')
+export const PRIVILEGED_ROLES = roleSet('PLATFORM_ADMIN')

--- a/packages/shared/tests/auth/roles.test.ts
+++ b/packages/shared/tests/auth/roles.test.ts
@@ -54,14 +54,21 @@ describe('canonical role sets (#487 prep — single source of truth)', () => {
     expect(BUSINESS_ROLES.has('OPERATOR_STAFF')).toBe(true)
   })
 
-  it('SCOPE_BYPASS_ROLES and PRIVILEGED_ROLES = PARTNER + PLATFORM_ADMIN — legacy STAFF/ADMIN revoked (#487), distinct instances', () => {
-    const expected = ['PARTNER', 'PLATFORM_ADMIN']
-    expect(members(SCOPE_BYPASS_ROLES)).toEqual(expected)
-    expect(members(PRIVILEGED_ROLES)).toEqual(expected)
-    // #487 dropped legacy STAFF/ADMIN from cross-tenant bypass + privileged reads;
-    // PARTNER (Trip.com) stays. Same members today, but kept as distinct instances
-    // because they gate different things (bypass flag vs direct cross-tenant reads)
-    // and may still diverge later (e.g. PARTNER dropped for message threads).
+  it('SCOPE_BYPASS_ROLES = PARTNER + PLATFORM_ADMIN — PARTNER keeps the bypass flag (its bookings are scoped per-consumer, #1119)', () => {
+    expect(members(SCOPE_BYPASS_ROLES)).toEqual(['PARTNER', 'PLATFORM_ADMIN'])
+  })
+
+  it('PRIVILEGED_ROLES = PLATFORM_ADMIN only — PARTNER dropped (#1168), the divergence #487 anticipated', () => {
+    // #1168: PARTNER (Trip.com) is a booking channel with no cross-tenant
+    // private-data use case. It was conflated with the platform admin tier in
+    // PRIVILEGED_ROLES, which gated full reads of messages, threads, and the user
+    // directory — a reachable cross-tenant leak (those routes gate on requireUser
+    // only). PARTNER's one cross-tenant read, its own bookings, is scoped in
+    // bookingReadScope (#1119) via the still-PARTNER SCOPE_BYPASS_ROLES, NOT here.
+    expect(members(PRIVILEGED_ROLES)).toEqual(['PLATFORM_ADMIN'])
+    expect(PRIVILEGED_ROLES.has('PARTNER')).toBe(false)
+    expect(SCOPE_BYPASS_ROLES.has('PARTNER')).toBe(true)
+    // Still distinct instances — now with genuinely different membership.
     expect(SCOPE_BYPASS_ROLES).not.toBe(PRIVILEGED_ROLES)
   })
 


### PR DESCRIPTION
## Summary

**Security (P2) — cross-tenant private-data leak, same class as #1119.** The `PARTNER` role (Trip.com — a machine booking channel, no tenant, no `operatorId`) was a member of `PRIVILEGED_ROLES` alongside `PLATFORM_ADMIN`. `PRIVILEGED_ROLES` gates "read ALL cross-tenant private data" in the thread/message repos, the message service, and the user directory. The `/threads`, `/threads/:id`, and `/users` routes gate on `requireUser` only (any authenticated caller) — so a partner key could **enumerate every tenant's message threads, message bodies, and the user-id→name directory**.

### The fix
- **`PRIVILEGED_ROLES = {PLATFORM_ADMIN}`** — PARTNER dropped. Every consumer falls **closed** for PARTNER: thread/message reads → empty/`undefined` (PARTNER is never a participant); `createThread` → must be a participant; user-directory → self-only. No legitimate PARTNER flow breaks — it is a pure booking channel with no messaging/directory surface (no test ever asserted one). This is the exact divergence the roles characterization test predicted in #487.
- **`customer.ts` search()** now gates the full-table read on `PRIVILEGED_ROLES.has(ctx.role)` instead of the coarse `bypassScope` flag (which still carries PARTNER). The route already 403s PARTNER (#1116); this is the service-layer seal (defense-in-depth).
- **PARTNER keeps `SCOPE_BYPASS_ROLES`** — its lone cross-tenant read (its own bookings) is scoped in `bookingReadScope` (#1119) via that set, intentionally unchanged.

### Review fixes folded in (code-reviewer, both LOW)
- `ensure-thread.ts`: the thread idempotency *probe* is infrastructure, not a caller-scoped read → runs under `SYSTEM_CONTEXT`, so a non-participant caller (PARTNER / operator manual booking) finds an existing thread on replay instead of re-firing the insert into a benign-but-noisy `UNIQUE_VIOLATION`. Proven RED without the fix.
- `user-directory.ts`: corrected a stale "PARTNER resolves anyone" comment.

## Scope
Closes the **reachable security leak (Part 1 of #1168)**. Part 2 (carry `partnerSource` on `CallerContext` for multi-partner correctness) is **latent** with one partner today and split to **#1182** (YAGNI until partner #2).

## Test Plan
- [x] `tsc --noEmit` ×3 — green
- [x] Aggregate `bun run test` — shared 781 / api 2136 / web 1339
- [x] Integration (real pg) — 364 passed
- [x] Roles characterization split (PRIVILEGED diverges from SCOPE_BYPASS); route-level PARTNER isolation (threads/users empty, customer 403); `CustomerService` PARTNER→[] unit + PLATFORM_ADMIN regression; ensure-thread non-participant-replay (mutation-proven)
- [x] `lint:boundaries` OK, biome clean

⚠️ Note: a full-suite aggregate run once showed 5 non-deterministic failures in `auth-middleware`/`auth-session`/`rate-limit` wiring tests (a pre-existing parallelism flake — "500 with valid JWT"); they pass in isolation (31/31) and on api-only re-run (2136/2136). Unrelated to this diff (no auth/CSRF/rate-limit code touched).

Closes #1168
Refs #1119, #1182