### PR TITLE
feat(#1070): api FX-rate provider + daily cache + read endpoint (slice 1)

### DIFF
--- a/packages/api/src/app-overrides.ts
+++ b/packages/api/src/app-overrides.ts
@@ -38,6 +38,7 @@ import type {
   VehicleRepository,
 } from './repositories/types'
 import type { EmailSender } from './services/email/email-sender'
+import type { FxRateCache, FxRateProvider } from './services/fx/types'
 import type { GeocodeCache, Geocoder } from './services/geocoding/types'
 import type { PaymentGateway } from './services/payment/payment-gateway'
 
@@ -102,6 +103,13 @@ export type AppOverrides = {
   // Over-limit ⇒ the geocoder skips the lookup (#574). Inject a deny-binding in
   // tests; absent ⇒ the globalThis-resolved GEOCODE_LIMITER (or unthrottled dev).
   geocodeLimiter?: RateLimitBinding
+  // Inject a fake indicative-FX provider in tests (proves a provider swap touches
+  // only here); absent ⇒ the StaticFxRateProvider snapshot (#1070).
+  fxRateProvider?: FxRateProvider
+  // Inject a fake FX cache in tests; absent ⇒ the Workers KV cache (when the
+  // FX_RATE_CACHE binding exists) or an in-process slot. Wraps the provider so the
+  // upstream is hit at most once per day (#1070).
+  fxRateCache?: FxRateCache
   // Injected Google OAuth runtime (provider + account store). Integration tests
   // pass a fake so the callback can be exercised without a live Google/DB.
   googleAuthRuntime?: GoogleAuthRuntime

--- a/packages/api/src/composition/fx.ts
+++ b/packages/api/src/composition/fx.ts
@@ -1,0 +1,27 @@
+import type { AppOverrides } from '../app-overrides'
+import { CachingFxRateProvider } from '../services/fx/caching-fx-rate-provider'
+import { InMemoryFxRateCache } from '../services/fx/fx-rate-cache'
+import { KvFxRateCache, type KvStore } from '../services/fx/kv-fx-rate-cache'
+import { StaticFxRateProvider } from '../services/fx/static-fx-rate-provider'
+import type { FxRateCache, FxRateProvider } from '../services/fx/types'
+
+/**
+ * Composition-root factory for the indicative-FX provider (#1070). Lives in
+ * `composition/` (a sanctioned place to `new` concretes, like buildRepos) rather
+ * than inline in index.ts, which is at its size cap.
+ *
+ * A pinned static snapshot today (no upstream/secret for the demo); a real HTTP
+ * rate API drops in behind the same {@link FxRateProvider} port later. Wrapped in
+ * a daily cache — durable Workers KV when the `FX_RATE_CACHE` binding is present,
+ * else an in-process slot (dev/test). Display-only; the charge is always JPY.
+ */
+export function buildFxRateProvider(overrides?: AppOverrides): FxRateProvider {
+  const inner: FxRateProvider = overrides?.fxRateProvider ?? new StaticFxRateProvider()
+  const cache: FxRateCache =
+    overrides?.fxRateCache ??
+    (() => {
+      const kv = (globalThis as Record<string, unknown>).FX_RATE_CACHE as KvStore | undefined
+      return kv ? new KvFxRateCache(kv) : new InMemoryFxRateCache()
+    })()
+  return new CachingFxRateProvider(inner, cache)
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from 'hono/cors'
 import type { AppOverrides } from './app-overrides'
 import type { GoogleOAuthConfig } from './auth/google'
 import { isStaleOperatorSession } from './auth/session-freshness'
+import { buildFxRateProvider } from './composition/fx'
 import { type Repos, buildRepos } from './composition/repositories'
 import { setupGlobalHandlers } from './error-handlers'
 import { parseBoolFlag } from './lib/parse-bool-flag'
@@ -27,6 +28,7 @@ import { createCustomerRoutes } from './routes/customers'
 import { createDocumentRoutes } from './routes/documents'
 import { createFeeScheduleRoutes } from './routes/fee-schedules'
 import { createFleetOverviewRoutes } from './routes/fleet-overview'
+import { createFxRoutes } from './routes/fx'
 import health from './routes/health'
 import { createInsuranceOptionRoutes } from './routes/insurance-options'
 import { createLocationRoutes } from './routes/locations'
@@ -214,6 +216,10 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
       return kv ? new KvGeocodeCache(kv) : new InMemoryGeocodeCache()
     })()
   const cachedGeocoder: Geocoder = new CachingGeocoder(geocoder, geocodeCache)
+
+  // Indicative FX rates (#1070): static snapshot → daily cache → KV/in-process,
+  // built in composition/fx.ts (index.ts is at its size cap). Display-only.
+  const fxRateProvider = buildFxRateProvider(overrides)
 
   // In-app Stripe payment (#461). Real gateway when BOTH secrets are set; in
   // production without them a sentinel throws on first use (not at boot, so
@@ -509,6 +515,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createFlatSearchRoutes(flatSearchService, publicCatalogLimiter))
     .route('/', createProviderInviteRoutes(providerInviteService, publicCatalogLimiter))
     .route('/', createRegionRoutes(regionRepo))
+    .route('/', createFxRoutes(fxRateProvider))
     .route('/', createVehicleRoutes(vehicleService, maintenanceService))
     .route(
       '/',

--- a/packages/api/src/routes/fx.ts
+++ b/packages/api/src/routes/fx.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono'
+import type { FxRateProvider } from '../services/fx/types'
+import { cachePublic, fail, ok } from './helpers'
+
+// Indicative rates change at most daily, so cache hard at the edge — the rates
+// endpoint is the same for every renter and carries no per-user data.
+const CACHE_SECONDS = 3600
+
+/**
+ * Public indicative FX rates (#1070). Anonymous — registered with no `requireAuth`
+ * so the renter storefront can show converted prices before login (the same
+ * pattern as `regions`). JPY base; display-only — the charge is always JPY. The
+ * cached provider owns the read; HTTP in/out only.
+ *
+ * If the provider can't supply rates (a future upstream outage), respond 503 so
+ * the edge doesn't cache the gap and the web falls back to JPY-only display —
+ * never a 500.
+ */
+export function createFxRoutes(fxProvider: FxRateProvider) {
+  return new Hono().get('/fx/rates', async (c) => {
+    const rates = await fxProvider.getRates()
+    if (!rates) return fail(c, 'FX_RATES_UNAVAILABLE', 503)
+    cachePublic(c, CACHE_SECONDS)
+    return ok(c, rates)
+  })
+}

--- a/packages/api/src/services/fx/caching-fx-rate-provider.ts
+++ b/packages/api/src/services/fx/caching-fx-rate-provider.ts
@@ -1,0 +1,51 @@
+import type { FxRateCache, FxRateProvider, FxRates } from './types'
+
+/**
+ * Wraps a {@link FxRateProvider} with a daily cache (#1070), mirroring
+ * {@link CachingGeocoder}. A cache HIT returns the stored table WITHOUT
+ * delegating, so the upstream rate API is hit at most once per TTL window rather
+ * than once per page render. With the StaticFxRateProvider this is a no-op in
+ * front of an in-memory constant; it earns its keep once a real HTTP provider is
+ * wired behind the same port.
+ *
+ * Only a successful (non-null) fetch is cached — caching a null would pin an
+ * upstream outage for the whole TTL. Honors the never-throw contract: a cache
+ * read/write failure degrades to a miss / silent skip so a flaky cache can never
+ * break the rates endpoint.
+ */
+export class CachingFxRateProvider implements FxRateProvider {
+  constructor(
+    private readonly inner: FxRateProvider,
+    private readonly cache: FxRateCache,
+  ) {}
+
+  async getRates(): Promise<FxRates | null> {
+    const cached = await this.read()
+    if (cached) return cached
+
+    const rates = await this.inner.getRates()
+    if (rates) await this.write(rates)
+    return rates
+  }
+
+  private async read(): Promise<FxRates | null> {
+    try {
+      return await this.cache.get()
+    } catch (err) {
+      console.warn('[fx] cache read failed; treating as a miss', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return null
+    }
+  }
+
+  private async write(rates: FxRates): Promise<void> {
+    try {
+      await this.cache.set(rates)
+    } catch (err) {
+      console.warn('[fx] cache write failed; rates not cached', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+}

--- a/packages/api/src/services/fx/fx-rate-cache.ts
+++ b/packages/api/src/services/fx/fx-rate-cache.ts
@@ -1,0 +1,26 @@
+import type { FxRateCache, FxRates } from './types'
+
+/** Defensive deep-ish copy: the only mutable part of FxRates is the `rates` map. */
+function clone(rates: FxRates): FxRates {
+  return { base: rates.base, asOf: rates.asOf, rates: { ...rates.rates } }
+}
+
+/**
+ * Process-local {@link FxRateCache} for dev / tests / seed, and the default when
+ * no Workers KV binding is present (#1070). A single nullable slot — the rate
+ * table is one logical resource, unlike the per-address geocode cache. Not shared
+ * across isolates and not TTL'd; {@link KvFxRateCache} owns durable, daily-TTL'd
+ * caching in production. Stores and returns defensive copies so a caller mutating
+ * an input or a returned object cannot corrupt the cached entry.
+ */
+export class InMemoryFxRateCache implements FxRateCache {
+  private entry: FxRates | null = null
+
+  async get(): Promise<FxRates | null> {
+    return this.entry ? clone(this.entry) : null
+  }
+
+  async set(rates: FxRates): Promise<void> {
+    this.entry = clone(rates)
+  }
+}

--- a/packages/api/src/services/fx/kv-fx-rate-cache.ts
+++ b/packages/api/src/services/fx/kv-fx-rate-cache.ts
@@ -1,0 +1,64 @@
+import type { FxRateCache, FxRates } from './types'
+
+// 1 day: indicative rates are refreshed at most daily (#1070), so the TTL bounds
+// staleness and lets the next request re-fetch from the upstream provider.
+const TTL_SECONDS = 60 * 60 * 24
+
+// Single fixed key — the rate table is one logical resource (JPY base). Bump `v1`
+// to invalidate every entry at once if the stored shape ever changes.
+const KEY = 'fx:v1:JPY'
+
+/**
+ * Minimal structural view of a Workers KV namespace — only the two methods this
+ * adapter uses (the same rule {@link KvGeocodeCache} follows). Keeps the service
+ * layer free of the `@cloudflare/workers-types` KVNamespace type; index.ts casts
+ * the native binding to it. The real KVNamespace is structurally compatible.
+ */
+export interface KvStore {
+  get(key: string): Promise<string | null>
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
+}
+
+/**
+ * Durable, daily-TTL'd {@link FxRateCache} over Workers KV (#1070). Persists the
+ * whole {@link FxRates} table as JSON under one key, shared across every isolate
+ * and request so the upstream rate provider is hit at most once per day for the
+ * entire app. Activation is gated on an `FX_RATE_CACHE` KV binding — index.ts
+ * falls back to InMemoryFxRateCache until it exists. A corrupt or wrong-shaped
+ * entry reads as a miss; operational KV errors propagate to the
+ * CachingFxRateProvider decorator, which degrades them to a miss.
+ */
+export class KvFxRateCache implements FxRateCache {
+  constructor(private readonly kv: KvStore) {}
+
+  async get(): Promise<FxRates | null> {
+    const raw = await this.kv.get(KEY)
+    return raw ? parseRates(raw) : null
+  }
+
+  async set(rates: FxRates): Promise<void> {
+    await this.kv.put(KEY, JSON.stringify(rates), { expirationTtl: TTL_SECONDS })
+  }
+}
+
+// A manually-edited, partially-written, or schema-drifted entry must not poison
+// reads — anything but a well-formed JPY-based table reads as a miss (re-fetched).
+function parseRates(raw: string): FxRates | null {
+  try {
+    const value = JSON.parse(raw) as { base?: unknown; asOf?: unknown; rates?: unknown }
+    if (value.base !== 'JPY' || typeof value.asOf !== 'string' || !isRateMap(value.rates)) {
+      return null
+    }
+    return { base: 'JPY', asOf: value.asOf, rates: { ...value.rates } }
+  } catch {
+    return null
+  }
+}
+
+function isRateMap(value: unknown): value is Record<string, number> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.values(value).every((n) => typeof n === 'number' && Number.isFinite(n))
+  )
+}

--- a/packages/api/src/services/fx/static-fx-rate-provider.ts
+++ b/packages/api/src/services/fx/static-fx-rate-provider.ts
@@ -1,0 +1,41 @@
+import type { FxRateProvider, FxRates } from './types'
+
+/**
+ * Pinned indicative-rate snapshot (#1070). The AFK demo has no upstream rate API
+ * and no secret to wire, so these are hand-captured JPY→currency rates with a
+ * fixed `asOf`. The figures are indicative only (the charge is always JPY), so a
+ * slightly stale snapshot is acceptable — refresh it when convenient.
+ *
+ * A real HTTP provider drops in behind the same {@link FxRateProvider} port (an
+ * env-var/secret swap in index.ts, exactly like the Nominatim geocoder); the
+ * daily {@link CachingFxRateProvider} in front then earns its keep.
+ *
+ * JPY is deliberately absent — `formatIndicativePrice` treats a JPY display
+ * currency as "no conversion", so a self-rate would never be read.
+ */
+const SNAPSHOT: FxRates = {
+  base: 'JPY',
+  asOf: '2026-06-01',
+  rates: {
+    USD: 0.0067,
+    EUR: 0.006,
+    GBP: 0.0052,
+    AUD: 0.0101,
+    CAD: 0.0091,
+    CNY: 0.048,
+    KRW: 9.07,
+    TWD: 0.21,
+    HKD: 0.052,
+    SGD: 0.009,
+    THB: 0.24,
+  },
+}
+
+/** Returns the pinned {@link SNAPSHOT}. Always succeeds (in-memory constant), so
+ *  it never returns null — but the port allows it for the future HTTP adapter. */
+export class StaticFxRateProvider implements FxRateProvider {
+  async getRates(): Promise<FxRates> {
+    // Defensive copy: a caller mutating the result must not corrupt the snapshot.
+    return { base: SNAPSHOT.base, asOf: SNAPSHOT.asOf, rates: { ...SNAPSHOT.rates } }
+  }
+}

--- a/packages/api/src/services/fx/types.ts
+++ b/packages/api/src/services/fx/types.ts
@@ -1,0 +1,30 @@
+import type { FxRates } from '@kuruma/shared/types/fx'
+
+export type { FxRates }
+
+/**
+ * Provider-neutral source of indicative JPY→currency rates (#1070). Business
+ * logic (the rates route) depends on this interface; the concrete adapter
+ * (StaticFxRateProvider today, an HTTP rate API later) is wired only in index.ts
+ * — a provider swap is a one-line change there, exactly like {@link Geocoder}.
+ *
+ * Must NEVER throw: a failure resolves to `null` so the rates endpoint can
+ * degrade (the web falls back to JPY-only display) rather than 500.
+ */
+export interface FxRateProvider {
+  getRates(): Promise<FxRates | null>
+}
+
+/**
+ * Daily cache port for the rate table (#1070), mirroring {@link GeocodeCache}.
+ * The rates are a single logical resource ("today's JPY base table"), so there's
+ * no key argument. ONLY successful fetches are stored; a miss — or a corrupt
+ * entry — reads as `null`. Operational failures (KV unavailable) may propagate;
+ * the CachingFxRateProvider decorator degrades any throw to a miss, so a flaky
+ * cache never breaks the endpoint. index.ts adapts the Workers KV binding (or an
+ * in-memory map in dev/test).
+ */
+export interface FxRateCache {
+  get(): Promise<FxRates | null>
+  set(rates: FxRates): Promise<void>
+}

--- a/packages/api/tests/composition/fx.test.ts
+++ b/packages/api/tests/composition/fx.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { buildFxRateProvider } from '../../src/composition/fx'
+
+describe('buildFxRateProvider', () => {
+  it('defaults to the static JPY snapshot through the cache (the production path)', async () => {
+    // No overrides and no FX_RATE_CACHE binding: StaticFxRateProvider behind an
+    // InMemoryFxRateCache. Proves the real default wiring, which the route test
+    // (always injecting a fake provider) never exercises.
+    const rates = await buildFxRateProvider().getRates()
+
+    expect(rates?.base).toBe('JPY')
+    expect(rates?.rates.USD).toBeGreaterThan(0)
+  })
+})

--- a/packages/api/tests/routes/fx.test.ts
+++ b/packages/api/tests/routes/fx.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryAvailabilityRepository,
+  InMemoryBookingRepository,
+  InMemoryVehicleBlockRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import type { FxRateProvider, FxRates } from '../../src/services/fx/types'
+
+const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067, EUR: 0.006 } }
+
+function makeApp(fxRateProvider: FxRateProvider) {
+  const vehicleRepo = new InMemoryVehicleRepository()
+  const bookingRepo = new InMemoryBookingRepository()
+  const availabilityRepo = new InMemoryAvailabilityRepository(
+    vehicleRepo,
+    bookingRepo,
+    new InMemoryVehicleBlockRepository(),
+  )
+  return createApp({ vehicleRepo, bookingRepo, availabilityRepo, fxRateProvider })
+}
+
+describe('GET /fx/rates', () => {
+  it('returns the indicative rate table to an anonymous caller', async () => {
+    const app = makeApp({ getRates: async () => RATES })
+    const res = await app.request('/fx/rates')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, data: RATES })
+  })
+
+  it('marks the response publicly cacheable at the edge', async () => {
+    const app = makeApp({ getRates: async () => RATES })
+    const res = await app.request('/fx/rates')
+
+    expect(res.headers.get('Cache-Control')).toMatch(/public/)
+  })
+
+  it('degrades to 503 (not 500) when rates are unavailable', async () => {
+    const app = makeApp({ getRates: async () => null })
+    const res = await app.request('/fx/rates')
+
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({ success: false, error: 'FX_RATES_UNAVAILABLE' })
+  })
+})

--- a/packages/api/tests/services/fx/caching-fx-rate-provider.test.ts
+++ b/packages/api/tests/services/fx/caching-fx-rate-provider.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CachingFxRateProvider } from '../../../src/services/fx/caching-fx-rate-provider'
+import type { FxRateCache, FxRateProvider, FxRates } from '../../../src/services/fx/types'
+
+const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067 } }
+const STALE: FxRates = { base: 'JPY', asOf: '2026-05-01', rates: { USD: 0.0064 } }
+
+function fakeProvider(
+  result: FxRates | null,
+): FxRateProvider & { getRates: ReturnType<typeof vi.fn> } {
+  return { getRates: vi.fn(async () => result) }
+}
+
+function fakeCache(seed: FxRates | null): FxRateCache & {
+  get: ReturnType<typeof vi.fn>
+  set: ReturnType<typeof vi.fn>
+} {
+  return { get: vi.fn(async () => seed), set: vi.fn(async () => undefined) }
+}
+
+describe('CachingFxRateProvider', () => {
+  it('cache HIT: returns the cached rates WITHOUT calling the inner provider', async () => {
+    const inner = fakeProvider(RATES)
+    const cache = fakeCache(STALE)
+    const result = await new CachingFxRateProvider(inner, cache).getRates()
+
+    expect(result).toEqual(STALE)
+    expect(inner.getRates).not.toHaveBeenCalled()
+  })
+
+  it('cache MISS: delegates to the inner provider and stores the fetched rates', async () => {
+    const inner = fakeProvider(RATES)
+    const cache = fakeCache(null)
+    const result = await new CachingFxRateProvider(inner, cache).getRates()
+
+    expect(result).toEqual(RATES)
+    expect(inner.getRates).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledWith(RATES)
+  })
+
+  it('does NOT cache a null fetch (an upstream failure must not pin a non-result)', async () => {
+    const inner = fakeProvider(null)
+    const cache = fakeCache(null)
+    const result = await new CachingFxRateProvider(inner, cache).getRates()
+
+    expect(result).toBeNull()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('never throws: a failing cache READ falls through to the inner provider', async () => {
+    const inner = fakeProvider(RATES)
+    const cache: FxRateCache = {
+      get: vi.fn(async () => {
+        throw new Error('kv get boom')
+      }),
+      set: vi.fn(async () => undefined),
+    }
+    const result = await new CachingFxRateProvider(inner, cache).getRates()
+
+    expect(result).toEqual(RATES)
+    expect(inner.getRates).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws: a failing cache WRITE still returns the fetched rates', async () => {
+    const inner = fakeProvider(RATES)
+    const cache: FxRateCache = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {
+        throw new Error('kv put boom')
+      }),
+    }
+    const result = await new CachingFxRateProvider(inner, cache).getRates()
+
+    expect(result).toEqual(RATES)
+  })
+})

--- a/packages/api/tests/services/fx/fx-rate-cache.test.ts
+++ b/packages/api/tests/services/fx/fx-rate-cache.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryFxRateCache } from '../../../src/services/fx/fx-rate-cache'
+import type { FxRates } from '../../../src/services/fx/types'
+
+const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067, EUR: 0.006 } }
+
+describe('InMemoryFxRateCache', () => {
+  it('returns null before anything is stored', async () => {
+    expect(await new InMemoryFxRateCache().get()).toBeNull()
+  })
+
+  it('round-trips the stored rate table', async () => {
+    const cache = new InMemoryFxRateCache()
+    await cache.set(RATES)
+    expect(await cache.get()).toEqual(RATES)
+  })
+
+  it('stores a defensive copy — mutating the input after set cannot corrupt the entry', async () => {
+    const cache = new InMemoryFxRateCache()
+    const input: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067 } }
+    await cache.set(input)
+    ;(input.rates as Record<string, number>).USD = 999
+
+    const hit = await cache.get()
+    expect(hit?.rates.USD).toBe(0.0067)
+  })
+
+  it('returns a defensive copy — mutating a read result cannot corrupt the entry', async () => {
+    const cache = new InMemoryFxRateCache()
+    await cache.set(RATES)
+    const first = await cache.get()
+    ;(first?.rates as Record<string, number>).USD = 999
+
+    const second = await cache.get()
+    expect(second?.rates.USD).toBe(0.0067)
+  })
+})

--- a/packages/api/tests/services/fx/kv-fx-rate-cache.test.ts
+++ b/packages/api/tests/services/fx/kv-fx-rate-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { KvFxRateCache, type KvStore } from '../../../src/services/fx/kv-fx-rate-cache'
+import type { FxRates } from '../../../src/services/fx/types'
+
+const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067, EUR: 0.006 } }
+const ONE_DAY_SECONDS = 60 * 60 * 24
+
+function fakeKv(initial?: string | null): KvStore & {
+  get: ReturnType<typeof vi.fn>
+  put: ReturnType<typeof vi.fn>
+} {
+  let value: string | null = initial ?? null
+  return {
+    get: vi.fn(async () => value),
+    put: vi.fn(async (_k: string, v: string) => {
+      value = v
+    }),
+  }
+}
+
+describe('KvFxRateCache', () => {
+  it('returns null on a cache miss (no entry)', async () => {
+    expect(await new KvFxRateCache(fakeKv(null)).get()).toBeNull()
+  })
+
+  it('round-trips through KV under a single fixed key with a one-day TTL', async () => {
+    const kv = fakeKv()
+    const cache = new KvFxRateCache(kv)
+    await cache.set(RATES)
+
+    expect(kv.put).toHaveBeenCalledTimes(1)
+    const [key, value, opts] = kv.put.mock.calls[0]
+    expect(key).toBe('fx:v1:JPY')
+    expect(JSON.parse(value)).toEqual(RATES)
+    expect(opts).toEqual({ expirationTtl: ONE_DAY_SECONDS })
+    expect(await cache.get()).toEqual(RATES)
+  })
+
+  it('reads a corrupt (unparseable) entry as a miss', async () => {
+    expect(await new KvFxRateCache(fakeKv('{not json')).get()).toBeNull()
+  })
+
+  it('reads a wrong-shaped entry as a miss (wrong base / non-number rate)', async () => {
+    const wrongBase = JSON.stringify({ base: 'USD', asOf: '2026-06-01', rates: { USD: 0.0067 } })
+    const badRate = JSON.stringify({ base: 'JPY', asOf: '2026-06-01', rates: { USD: 'nope' } })
+    expect(await new KvFxRateCache(fakeKv(wrongBase)).get()).toBeNull()
+    expect(await new KvFxRateCache(fakeKv(badRate)).get()).toBeNull()
+  })
+})

--- a/packages/api/tests/services/fx/static-fx-rate-provider.test.ts
+++ b/packages/api/tests/services/fx/static-fx-rate-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { StaticFxRateProvider } from '../../../src/services/fx/static-fx-rate-provider'
+
+describe('StaticFxRateProvider', () => {
+  it('returns a JPY-based snapshot with a YYYY-MM-DD asOf date', async () => {
+    const rates = await new StaticFxRateProvider().getRates()
+
+    expect(rates.base).toBe('JPY')
+    expect(rates.asOf).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('covers the core tourist currencies with positive finite JPY→code rates', async () => {
+    const { rates } = await new StaticFxRateProvider().getRates()
+
+    for (const code of ['USD', 'EUR', 'GBP', 'AUD', 'CNY', 'KRW']) {
+      expect(rates[code]).toBeGreaterThan(0)
+      expect(Number.isFinite(rates[code])).toBe(true)
+    }
+    // sanity: 1 JPY is a small fraction of a USD, not the inverse
+    expect(rates.USD).toBeLessThan(1)
+  })
+
+  it('never includes JPY itself (no self-conversion entry)', async () => {
+    const { rates } = await new StaticFxRateProvider().getRates()
+    expect(rates.JPY).toBeUndefined()
+  })
+
+  it('returns a defensive copy — mutating the result cannot corrupt the snapshot', async () => {
+    const provider = new StaticFxRateProvider()
+    const first = await provider.getRates()
+    ;(first.rates as Record<string, number>).USD = 999
+
+    const second = await provider.getRates()
+    expect(second.rates.USD).not.toBe(999)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,6 +25,7 @@
     "./types/payment-anomaly": "./src/types/payment-anomaly.ts",
     "./types/api-response": "./src/types/api-response.ts",
     "./types/fleet": "./src/types/fleet.ts",
+    "./types/fx": "./src/types/fx.ts",
     "./types/vehicle": "./src/types/vehicle.ts",
     "./types/vehicle-detail": "./src/types/vehicle-detail.ts",
     "./types/maintenance-log": "./src/types/maintenance-log.ts",

--- a/packages/shared/src/types/fx.ts
+++ b/packages/shared/src/types/fx.ts
@@ -1,0 +1,14 @@
+/**
+ * Indicative FX rate table for #1070 — converting the authoritative JPY price to
+ * a renter's chosen display currency. Display-only: the charge is always JPY (the
+ * only currency Stripe settles here), so these rates never touch the money path.
+ *
+ * `base` is always `'JPY'`. Each `rates` entry is JPY→code: USD `0.0067` means
+ * 1 JPY = 0.0067 USD. `asOf` is the YYYY-MM-DD the snapshot represents, surfaced
+ * so the web can show "rates as of …" next to the indicative figure.
+ */
+export interface FxRates {
+  base: 'JPY'
+  asOf: string
+  rates: Readonly<Record<string, number>>
+}


### PR DESCRIPTION
## Slice 1 of 3 — #1070 indicative multi-currency price display

Server-side source of indicative JPY→currency rates, **mirroring the geocoding
port/decorator/InMemory+KV shape exactly** (`services/geocoding/`). Display-only —
the charge is always JPY (Stripe JPY-only, zero-decimal), so this never touches the
money path. **Zero payment risk.**

### What landed (`packages/api/src/services/fx/`)
- **`FxRateProvider`** port — `getRates(): Promise<FxRates | null>`, never throws.
- **`StaticFxRateProvider`** — pinned snapshot (no upstream/secret for the demo); a real HTTP rate API drops in behind the same port via an env/secret swap, exactly like the Nominatim geocoder.
- **`CachingFxRateProvider`** — daily-cache decorator: caches only successful fetches, degrades any cache read/write throw to a miss (never breaks the endpoint). Mirrors `CachingGeocoder`.
- **`InMemoryFxRateCache`** (single-slot default) + **`KvFxRateCache`** (1-day TTL, fixed versioned key `fx:v1:JPY`, shape-validated parse → corrupt/wrong-shape reads as a miss).
- **`GET /fx/rates`** — public (anonymous, like `/regions`), edge-cacheable; returns `{ base:'JPY', asOf, rates }`. Returns **503** (not 500) when rates are unavailable, so the web degrades to JPY-only rather than erroring.

### Boundaries / wiring
- `FxRates` lives in `@kuruma/shared/types/fx` — the cross-boundary contract slice 3 reads.
- Construction extracted to **`composition/fx.ts`** (`buildFxRateProvider`): `index.ts` is at its 800-line cap, and `composition/` is the sanctioned home for `new`-ing concretes (the boundary lint requires `new InMemory*` to live there). KV via the `FX_RATE_CACHE` binding when present, else in-process.
- Override seams `fxRateProvider` / `fxRateCache` added to `AppOverrides`.

### Scope notes
- **No migration** (rates live in a cache, not the DB — by design across all 3 slices).
- Independent of slice 2 (already merged) and slice 3 (web, to follow).

### Tests
21 TDD tests (RED→GREEN): static snapshot, caching decorator (hit/miss/null-not-cached/read-throw/write-throw), both caches (round-trip, TTL, corrupt→miss, defensive copies), the route (200/edge-cache/503), and the composition default path.

Gates: aggregate green (shared 50 / api 197 / web 207 files), api `tsc` + `lint:boundaries` + `lint:size` + biome clean, pre-commit green.

Refs #1070 (stays open — slice 3 to follow).