### PR TITLE
fix(web): add 'Back to site' link to admin sidebar

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1257,7 +1257,8 @@
       "anomalies": "Payment Anomalies",
       "documents": "Documents",
       "governance": "Consent governance",
-      "customers": "Customers"
+      "customers": "Customers",
+      "backToSite": "Back to site"
     },
     "home": {
       "title": "Platform Admin",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1257,7 +1257,8 @@
       "anomalies": "決済の異常",
       "documents": "書類",
       "governance": "同意ガバナンス",
-      "customers": "顧客"
+      "customers": "顧客",
+      "backToSite": "サイトに戻る"
     },
     "home": {
       "title": "プラットフォーム管理",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1257,7 +1257,8 @@
       "anomalies": "支付异常",
       "documents": "证件",
       "governance": "同意治理",
-      "customers": "客户"
+      "customers": "客户",
+      "backToSite": "返回网站"
     },
     "home": {
       "title": "平台管理",

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import {
   AlertTriangle,
+  ArrowLeft,
   Banknote,
   CalendarCheck,
   FileCheck,
@@ -41,6 +42,16 @@ export function AdminSidebar() {
       className="flex md:flex-col w-full md:w-56 shrink-0 border-b md:border-b-0 md:border-r border-sidebar-border bg-sidebar"
     >
       <nav className="flex flex-row md:flex-col gap-1 p-3 overflow-x-auto">
+        {/* Escape hatch: on /admin the global nav links are CSS-hidden, so without
+            this the only way back to the customer site is the easily-missed logo. */}
+        <Link
+          to="/$locale"
+          params={{ locale }}
+          className={`${LINK_CLASSNAME} text-muted-foreground md:mb-1 md:border-b md:border-sidebar-border md:pb-3 md:rounded-b-none`}
+        >
+          <ArrowLeft className="size-5" />
+          {t('nav.backToSite')}
+        </Link>
         {SIDEBAR_ITEMS.map(({ to, icon: Icon, labelKey }) => (
           <Link
             key={to}

--- a/packages/web/tests/vite/nav/AdminSidebar.test.tsx
+++ b/packages/web/tests/vite/nav/AdminSidebar.test.tsx
@@ -43,6 +43,11 @@ describe('AdminSidebar', () => {
     )
   })
 
+  it('renders a Back to site link to the marketplace home so the admin can leave the portal', () => {
+    renderSidebar()
+    expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('data-to', '/$locale')
+  })
+
   it('marks its root with data-admin-sidebar so the global nav is suppressed', () => {
     // globals.css: `:root:has([data-admin-sidebar]) [data-global-nav]` is hidden.
     // Without this marker the always-mounted <Navbar/> double-renders on /admin.


### PR DESCRIPTION
## What

The `/admin` platform portal CSS-hides the global nav's middle links (`:root:has([data-admin-sidebar]) [data-global-nav]`, #481), so the only way back to the customer-facing site was the easily-missed Kuruma logo. A platform admin — e.g. the owner previewing hidden beta features (#1161 admin bypass) — gets visually trapped in the dashboard; clicking the view-switch only flips a cookie and re-renders `/admin`, so it feels stuck.

## Fix

Add a discoverable **"← Back to site"** link as the first item in `AdminSidebar`, linking to the locale home (`/$locale`). i18n'd in en/ja/zh (`admin.nav.backToSite`). Visually separated from the portal nav items with a back-arrow icon + divider.

## Test plan

- [x] TDD: new `AdminSidebar.test.tsx` case asserts the link renders with `data-to="/$locale"` (RED → GREEN).
- [x] i18n parity test green (key present in all 3 locales).
- [x] Full web suite: 1380 passed; tsc clean; biome format clean; `lint:modules` exit 0.
- [ ] After deploy: from `/admin`, the back link returns to the renter site where the owner can preview Messages.

Found during live beta verification of #1161. No issue filed — small UX fix surfaced in testing.
