### PR TITLE
fix(#1193): countClassCapacity counts only AVAILABLE cars (CLASS_COMBO overbook via MAINTENANCE)

### DIFF
--- a/packages/api/src/repositories/drizzle/availability.ts
+++ b/packages/api/src/repositories/drizzle/availability.ts
@@ -178,10 +178,13 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
     to: Date,
     asOf: Date,
   ): Promise<number> {
-    // #464 2d.2: road-legal supply side of the combo guard. status<>'RETIRED'
-    // (RETIRED = permanent fleet exit) and both certificates cover THROUGH the
-    // JST asOf day — same NULL≠current handling as findAvailableVehicles
-    // (NULL >= date is NULL, excluded).
+    // #464 2d.2 / #1193: road-legal supply side of the combo guard. Counts only
+    // status = 'AVAILABLE' — the exact predicate the assign gate enforces, and
+    // the same one findAvailableVehicles uses. RETIRED (permanent exit) and
+    // MAINTENANCE (temporary, unassignable, no known return) both fail it;
+    // counting either admits a float with no assignable car → overbook. Both
+    // certificates must cover THROUGH the JST asOf day — same NULL≠current
+    // handling as findAvailableVehicles (NULL >= date is NULL, excluded).
     const asOfIso = jstDateString(asOf)
     const fromIso = from.toISOString()
     const toIso = to.toISOString()
@@ -193,7 +196,7 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
           eq(vehicles.operatorId, operatorId),
           eq(vehicles.classId, classId),
           eq(vehicles.pickupLocationId, pickupLocationId),
-          sql`${vehicles.status} <> 'RETIRED'`,
+          eq(vehicles.status, 'AVAILABLE'),
           sql`${vehicles.shakenExpiryDate} >= ${asOfIso}::date AND ${vehicles.insuranceExpiryDate} >= ${asOfIso}::date`,
           // #1141: subtract cars scheduled off for the demand window — a block
           // overlapping [from, to) makes the car unavailable, so it is not real

--- a/packages/api/src/repositories/in-memory/availability.test.ts
+++ b/packages/api/src/repositories/in-memory/availability.test.ts
@@ -353,9 +353,10 @@ describe('InMemoryAvailabilityRepository.countClassDemand (#464)', () => {
 })
 
 // #464 slice 2d.2: countClassCapacity is the road-legal supply side of the
-// combo guard. RETIRED is the permanent fleet exit (never counts);
-// MAINTENANCE is temporary (still belongs to the class fleet, counts) — same
-// stance the existing #916 compliance gate takes for findAvailableVehicles.
+// combo guard. It must count only what the assign gate will accept — i.e.
+// status === 'AVAILABLE'. RETIRED (permanent exit) and MAINTENANCE (temporary,
+// unassignable) both fail that gate, so neither counts: counting a car the
+// assign step rejects is a guaranteed combo overbook at pickup (#1193).
 describe('InMemoryAvailabilityRepository.countClassCapacity (#464 slice 2d.2)', () => {
   const capacity = () =>
     availabilityRepo.countClassCapacity('op_a', 'class_compact', 'loc_osaka', FROM, TO, TO)
@@ -365,9 +366,9 @@ describe('InMemoryAvailabilityRepository.countClassCapacity (#464 slice 2d.2)', 
     expect(await capacity()).toBe(1)
   })
 
-  it('counts a MAINTENANCE vehicle (temporary state, still class fleet)', async () => {
+  it('excludes a MAINTENANCE vehicle (unassignable — assign gate rejects non-AVAILABLE, #1193)', async () => {
     await makeVehicle({ status: 'MAINTENANCE' })
-    expect(await capacity()).toBe(1)
+    expect(await capacity()).toBe(0)
   })
 
   it('excludes a RETIRED vehicle (permanent fleet exit)', async () => {

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -161,10 +161,13 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
     to: Date,
     asOf: Date,
   ): Promise<number> {
-    // #464 2d.2: road-legal supply side of the combo guard. RETIRED is the
-    // permanent fleet exit (never counts); MAINTENANCE is temporary and still
-    // belongs to the class fleet (counts). Doc-validity uses the same JST
-    // clock as findAvailableVehicles (§4 "one clock").
+    // #464 2d.2 / #1193: road-legal supply side of the combo guard. Counts only
+    // status === 'AVAILABLE' — the exact predicate the assign gate enforces
+    // (booking-lifecycle.ts rejects non-AVAILABLE). RETIRED (permanent exit) and
+    // MAINTENANCE (temporary, but unassignable and with no known return date)
+    // both fail that gate; counting either admits a float with no assignable car
+    // → overbook at pickup. Doc-validity uses the same JST clock as
+    // findAvailableVehicles (§4 "one clock").
     const { data: vehicles } = await this.vehicleRepo.findAll(SYSTEM_CONTEXT, {})
     const asOfIso = jstDateString(asOf)
     const roadLegal = vehicles.filter(
@@ -172,7 +175,7 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
         v.operatorId === operatorId &&
         v.classId === classId &&
         v.pickupLocationId === pickupLocationId &&
-        v.status !== 'RETIRED' &&
+        v.status === 'AVAILABLE' &&
         isRoadLegal(v, asOfIso),
     )
 

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -536,7 +536,7 @@ describe('DrizzleAvailabilityRepository', () => {
       capVehicleIds.length = 0
     })
 
-    it('counts AVAILABLE + MAINTENANCE road-legal vehicles, excludes RETIRED', async () => {
+    it('counts only AVAILABLE road-legal vehicles, excludes MAINTENANCE and RETIRED (#1193)', async () => {
       const available = await createTestVehicle({
         name: 'Cap A',
         status: 'AVAILABLE',
@@ -565,7 +565,9 @@ describe('DrizzleAvailabilityRepository', () => {
         ASOF,
         ASOF,
       )
-      expect(count).toBe(2)
+      // Only the AVAILABLE car is assignable; MAINTENANCE and RETIRED both fail
+      // the assign gate, so counting them would overbook the float (#1193).
+      expect(count).toBe(1)
     })
 
     it('excludes vehicles whose shaken/insurance certificate has lapsed at asOf', async () => {


### PR DESCRIPTION
## Problem (found by post-merge quality review of #1141)

`countClassCapacity` computed CLASS_COMBO class supply as `status <> 'RETIRED'` — which **includes `MAINTENANCE`**. But:
- the assign gate rejects any non-`AVAILABLE` car (`booking-lifecycle.ts:278`, `booking-creation.ts:222`), and
- the maintenance toggle writes only a status change + `maintenance_logs` row — **no `vehicle_blocks` row** — so #1141's block subtraction never caught it.

**Deterministic overbook (not a race):** operator has 1 road-legal car in a class/location; set it to `MAINTENANCE`. A CLASS_COMBO booking sees `demand=0, capacity=1` → accepted, paid, CONFIRMED. `assignVehicle` then 400s (status ≠ AVAILABLE) → float with zero assignable cars → overbook surfaces at pickup, exactly the failure #1141 set out to close.

## Fix

Align the supply predicate with the assign predicate (and with `findAvailableVehicles`, which already uses `= 'AVAILABLE'`): count `status = 'AVAILABLE'` only, in **both** the Drizzle and InMemory impls. `RETIRED` and `MAINTENANCE` both correctly drop out. Maintenance is open-ended (no known return date), so excluding it is correct, not merely safe.

No migration.

## Tests (TDD)

- Inverted the two tests that **enshrined** the bug (in-memory `availability.test.ts`, real-pg `tests/integration/availability.test.ts`) to assert MAINTENANCE is **not** counted — they went red against the old impl, green after the fix.
- in-memory availability **36 pass / 0 fail**; repositories suite **113/0**; combo-guard consumers (flat-search, storefront-search, booking) **97/0**; `tsc` (api+web) + `lint:boundaries` clean. The real-pg integration assertion is verified by CI's real-db lane.

## Follow-up (not in this PR)

Longer-term, the maintenance toggle could write a time-windowed `vehicle_blocks` row so the existing #1101 subtraction handles temporary unavailability with a return date — tracked in #1193.

Closes #1193
