### PR TITLE
fix(#1070): post-merge currency hardening — locale-tracking default, storage crash guard, a11y label

### DIFF
--- a/packages/web/src/lib/safe-storage.test.ts
+++ b/packages/web/src/lib/safe-storage.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readLocalStorage, writeLocalStorage } from './safe-storage'
+
+describe('safe-storage', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('reads a stored value through to localStorage', () => {
+    localStorage.setItem('k', 'v')
+    expect(readLocalStorage('k')).toBe('v')
+  })
+
+  it('returns null for a missing key', () => {
+    expect(readLocalStorage('absent')).toBeNull()
+  })
+
+  it('returns null instead of throwing when getItem throws (Safari block-cookies / sandboxed webview)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError: localStorage is not available')
+      },
+    })
+    expect(readLocalStorage('k')).toBeNull()
+  })
+
+  it('persists a value through to localStorage', () => {
+    writeLocalStorage('k2', 'v2')
+    expect(localStorage.getItem('k2')).toBe('v2')
+  })
+
+  it('swallows a throwing setItem instead of crashing the caller', () => {
+    vi.stubGlobal('localStorage', {
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+    })
+    expect(() => writeLocalStorage('k', 'v')).not.toThrow()
+  })
+})

--- a/packages/web/src/lib/safe-storage.ts
+++ b/packages/web/src/lib/safe-storage.ts
@@ -1,0 +1,23 @@
+/**
+ * localStorage access that never throws. Touching `window.localStorage` or its
+ * methods raises in real renter environments — Safari "Block all cookies", some
+ * privacy modes, and sandboxed in-app browser webviews (WeChat / LINE, common for
+ * inbound tourists). These run during render at the `$locale` root, so an unguarded
+ * throw blanks the whole app; degrade to the fallback / a silent no-op instead.
+ */
+export function readLocalStorage(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function writeLocalStorage(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // Storage unavailable (private-mode quota, sandboxed webview): the in-memory
+    // state still updates; the choice just won't survive a reload. Not worth surfacing.
+  }
+}

--- a/packages/web/src/vite/LayoutPreferenceProvider.tsx
+++ b/packages/web/src/vite/LayoutPreferenceProvider.tsx
@@ -1,3 +1,4 @@
+import { readLocalStorage, writeLocalStorage } from '@/lib/safe-storage'
 import type { LayoutPreference } from '@/vite/nav/business-sidebar-visibility'
 import { createContext, useCallback, useContext, useMemo, useState } from 'react'
 
@@ -19,7 +20,7 @@ const LayoutPreferenceContext = createContext<LayoutPreferenceContextValue>({
 // consumes the preference. Safe because this is a client-only SPA render (no SSR,
 // so no hydration mismatch).
 function readStoredPreference(): LayoutPreference {
-  const stored = localStorage.getItem(STORAGE_KEY)
+  const stored = readLocalStorage(STORAGE_KEY)
   return stored === 'sidebar' || stored === 'topnav' ? stored : DEFAULT_PREFERENCE
 }
 
@@ -29,7 +30,7 @@ export function LayoutPreferenceProvider({ children }: { readonly children: Reac
   const toggle = useCallback(() => {
     setPreference((prev) => {
       const next = prev === 'sidebar' ? 'topnav' : 'sidebar'
-      localStorage.setItem(STORAGE_KEY, next)
+      writeLocalStorage(STORAGE_KEY, next)
       return next
     })
   }, [])

--- a/packages/web/src/vite/currency/CurrencyProvider.test.tsx
+++ b/packages/web/src/vite/currency/CurrencyProvider.test.tsx
@@ -77,6 +77,54 @@ describe('CurrencyProvider currency preference', () => {
     expect(button.textContent).toBe('CNY')
     expect(localStorage.getItem(STORAGE_KEY)).toBe('CNY')
   })
+
+  it('tracks the locale for the default until the renter picks a currency', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    function Probe() {
+      return <span data-testid="cur">{useCurrency().currency}</span>
+    }
+    function Tree({ locale }: { locale: string }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale={locale} messages={{}}>
+            <CurrencyProvider>
+              <Probe />
+            </CurrencyProvider>
+          </IntlProvider>
+        </QueryClientProvider>
+      )
+    }
+    const { rerender } = render(<Tree locale="en" />)
+    expect(screen.getByTestId('cur').textContent).toBe('USD')
+
+    // Switch language WITHOUT remounting the provider — the unset default re-tracks
+    // the locale (regression: it used to freeze at the first-mount locale).
+    rerender(<Tree locale="ja" />)
+    expect(screen.getByTestId('cur').textContent).toBe('JPY')
+  })
+
+  it('a stored choice still wins over the locale default after a locale switch', () => {
+    localStorage.setItem(STORAGE_KEY, 'CNY')
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    function Probe() {
+      return <span data-testid="cur">{useCurrency().currency}</span>
+    }
+    function Tree({ locale }: { locale: string }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale={locale} messages={{}}>
+            <CurrencyProvider>
+              <Probe />
+            </CurrencyProvider>
+          </IntlProvider>
+        </QueryClientProvider>
+      )
+    }
+    const { rerender } = render(<Tree locale="en" />)
+    expect(screen.getByTestId('cur').textContent).toBe('CNY')
+    rerender(<Tree locale="ja" />)
+    expect(screen.getByTestId('cur').textContent).toBe('CNY')
+  })
 })
 
 describe('useIndicative', () => {
@@ -97,5 +145,15 @@ describe('useIndicative', () => {
     renderInProvider(<Probe />, 'ja')
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     expect(screen.getByTestId('ind').textContent).toBe('none')
+  })
+
+  it('normalizes a lower-case stored code so its rate still resolves', async () => {
+    // A tampered/legacy 'usd' must not silently miss the upper-case 'USD' rate key.
+    localStorage.setItem(STORAGE_KEY, 'usd')
+    function Probe() {
+      return <span data-testid="ind">{useIndicative().format(27000) ?? 'none'}</span>
+    }
+    renderInProvider(<Probe />, 'en')
+    await waitFor(() => expect(screen.getByTestId('ind').textContent).toBe('$181'))
   })
 })

--- a/packages/web/src/vite/currency/CurrencyProvider.tsx
+++ b/packages/web/src/vite/currency/CurrencyProvider.tsx
@@ -1,3 +1,4 @@
+import { readLocalStorage, writeLocalStorage } from '@/lib/safe-storage'
 import { formatIndicativePrice } from '@kuruma/shared/lib/indicative-price'
 import type { FxRates } from '@kuruma/shared/types/fx'
 import { useQuery } from '@tanstack/react-query'
@@ -23,12 +24,12 @@ const CurrencyContext = createContext<CurrencyContextValue>({
   rates: undefined,
 })
 
-// Read synchronously at init so a consumer never renders the locale default first
-// and flips to the stored choice after mount. Client-only SPA, so no SSR hydration
-// mismatch (mirrors LayoutPreferenceProvider). Any stored 3-letter code is honoured;
-// `formatIndicativePrice` rejects malformed/absent rates, so a stale code is inert.
-function readStoredCurrency(fallback: string): string {
-  return localStorage.getItem(STORAGE_KEY) ?? fallback
+// The renter's explicitly-chosen code, read synchronously at init so a stored
+// choice never flashes the default first. Normalized to upper-case: rate keys are
+// upper-case and `formatIndicativePrice` canonicalizes, so a lower-case stored or
+// tampered value would otherwise silently miss its rate. `null` = no choice yet.
+function readStoredCurrency(): string | null {
+  return readLocalStorage(STORAGE_KEY)?.toUpperCase() ?? null
 }
 
 export function CurrencyProvider({ children }: { readonly children: React.ReactNode }) {
@@ -36,13 +37,16 @@ export function CurrencyProvider({ children }: { readonly children: React.ReactN
   // Display-only; a failed fetch (e.g. 503) leaves rates undefined and the whole
   // UI falls back to JPY-only — never a blocking error.
   const { data: rates } = useQuery(fxRatesQueryOptions())
-  const [currency, setCurrencyState] = useState(() =>
-    readStoredCurrency(defaultCurrencyForLocale(locale)),
-  )
+  const [stored, setStored] = useState(readStoredCurrency)
+  // An explicit choice wins; until then the currency is DERIVED from the locale
+  // every render, so switching language updates the indicative default instead of
+  // freezing it at the locale present on first mount.
+  const currency = stored ?? defaultCurrencyForLocale(locale)
 
   const setCurrency = useCallback((next: string) => {
-    localStorage.setItem(STORAGE_KEY, next)
-    setCurrencyState(next)
+    const code = next.toUpperCase()
+    writeLocalStorage(STORAGE_KEY, code)
+    setStored(code)
   }, [])
 
   const value = useMemo(() => ({ currency, setCurrency, rates }), [currency, setCurrency, rates])

--- a/packages/web/src/vite/currency/CurrencySelector.test.tsx
+++ b/packages/web/src/vite/currency/CurrencySelector.test.tsx
@@ -61,9 +61,11 @@ describe('CurrencySelector trigger', () => {
     expect(screen.getByRole('button').textContent).toContain('CNY')
   })
 
-  it('carries a translated accessible label so the icon-only trigger is named', () => {
+  it('names the trigger with the translated label AND the visible code (WCAG 2.5.3)', () => {
     renderSelector('en')
-    expect(screen.getByRole('button').getAttribute('aria-label')).toBe(en.currency.label)
+    const label = screen.getByRole('button').getAttribute('aria-label') ?? ''
+    expect(label).toContain(en.currency.label)
+    expect(label).toContain('USD')
   })
 
   it('opens to the disclaimer, every currency option in order, the as-of date, and switches on click', async () => {

--- a/packages/web/src/vite/currency/CurrencySelector.tsx
+++ b/packages/web/src/vite/currency/CurrencySelector.tsx
@@ -33,7 +33,14 @@ export function CurrencySelector() {
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button variant="ghost" size="sm" className="gap-1.5" aria-label={t('label')}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5"
+            // Include the visible code so the accessible name contains the on-screen
+            // label (WCAG 2.5.3 Label in Name) — a voice-control "click USD" matches.
+            aria-label={`${t('label')}: ${currency}`}
+          >
             <Coins className="size-4" />
             <span className="hidden sm:inline">{currency}</span>
           </Button>

--- a/packages/web/src/vite/reservation/ConfirmStep.test.tsx
+++ b/packages/web/src/vite/reservation/ConfirmStep.test.tsx
@@ -1,0 +1,60 @@
+import { CurrencyProvider } from '@/vite/currency'
+import type { FxRates } from '@kuruma/shared/types/fx'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+import { ConfirmStep } from './ConfirmStep'
+import type { ReservationEstimate } from './pricing'
+
+const rates: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: 0.0067 } }
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+beforeEach(() => {
+  localStorage.clear()
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ success: true, data: rates }),
+  })
+})
+afterEach(() => fetchMock.mockReset())
+
+// base 10,000 ≠ total 30,000 on purpose, so converting the WRONG field shows a
+// different figure: total -> $201, base -> $67.
+const estimate: ReservationEstimate = { baseJpy: 10_000, insuranceJpy: 0, totalJpy: 30_000 }
+
+function renderConfirm() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        <CurrencyProvider>
+          <ConfirmStep
+            estimate={estimate}
+            selectedAddOns={[]}
+            insuranceName={null}
+            pickupAt={new Date('2026-09-10T10:00:00Z')}
+          />
+        </CurrencyProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ConfirmStep indicative total', () => {
+  it('converts the TOTAL (not the base) for the indicative note', async () => {
+    renderConfirm()
+    // 30,000 * 0.0067 = 201 -> "$201"; the base (10,000 -> "$67") must NOT appear.
+    await waitFor(() => expect(screen.getByText(/≈ \$201/)).toBeTruthy())
+    expect(screen.queryByText(/\$67\b/)).toBeNull()
+  })
+
+  it('shows the charged-in-JPY disclaimer while a converted figure is on screen', async () => {
+    renderConfirm()
+    await waitFor(() => expect(screen.getByText(en.currency.disclaimer)).toBeTruthy())
+  })
+})


### PR DESCRIPTION
Post-merge hardening follow-ups for the indicative multi-currency display (#1070, now closed — all 3 slices merged via #1185/#1189). Display-only; the money path is untouched. No migration.

An adversarial 2-agent bug-hunt against the merged web work surfaced 4 issues, all fixed + tested here.

## Fixes

1. **MEDIUM — frozen display-currency default.** The default was captured at first mount, so switching language afterward didn't move the indicative default. Now the currency is *derived* — `stored ?? defaultCurrencyForLocale(locale)` — so an unset default tracks the locale, while an explicit renter choice still persists and wins.
2. **MEDIUM — unguarded `localStorage` crashed the `$locale` subtree.** Touching `localStorage` throws in real renter environments (Safari "Block all cookies", sandboxed WeChat/LINE in-app webviews common for inbound tourists). New `@/lib/safe-storage` (`readLocalStorage`/`writeLocalStorage`) degrades to fallback / silent no-op; wired into `CurrencyProvider` + `LayoutPreferenceProvider`.
3. **LOW — case-sensitive rate lookup.** A lower-case/tampered stored code (`usd`) missed the upper-case `USD` rate key. Stored codes are now normalized upper-case on read and on write.
4. **LOW (a11y, WCAG 2.5.3 Label in Name).** `CurrencySelector`'s `aria-label` now includes the visible code (`Currency: USD`) so a voice-control "click USD" matches the on-screen label.

## Tests

8 files, +210/−16. Added: `safe-storage` (5), CurrencyProvider locale-tracking + stored-wins (2), lower-case rate normalization (1), `CurrencySelector` aria-label (updated), and a `ConfirmStep` render test pinning the indicative to `totalJpy` (not `baseJpy`) via a deliberate base≠total fixture.

## Gates (green locally)

- `@kuruma/web` test: **1390 passing**; web tsc clean.
- `@kuruma/shared` test: **793 passing**.
- biome / boundaries / size clean (pre-commit passed).
- Web-only change — touches zero shared/api files, so the api suite is N/A.

Refs #1070 (closed). These are follow-ups, not a re-open.