### PR TITLE
fix(#1195): settle review reveal on submit, not only on read

### DIFF
--- a/packages/api/src/services/review.test.ts
+++ b/packages/api/src/services/review.test.ts
@@ -293,6 +293,43 @@ describe('ReviewService — double-blind reveal on read', () => {
   })
 })
 
+describe('ReviewService.submit — reveal on write (#1195)', () => {
+  // settleReveal must run on submit, not only on a later getForBooking read. These assert the
+  // PERSISTED state directly (no read-repair) — a 3rd-party/API-only submitter never re-reads,
+  // and slice-5 aggregates filter publishedAt, so an unread both-submitted pair would undercount.
+  it('publishes BOTH sides the moment the second party submits — without any read', async () => {
+    const { service, reviewRepo } = makeHarness()
+    await service.submit(renterCtx, submitInput(), NOW) // renter -> operator (first, stays hidden)
+    const second = await service.submit(operatorCtx, submitInput({ subject: 'RENTER' }), NOW)
+
+    const persisted = await reviewRepo.findByBookingId(BOOKING_ID)
+    expect(persisted).toHaveLength(2)
+    expect(persisted.find((r) => r.authorRole === 'RENTER')?.publishedAt).toEqual(NOW)
+    expect(persisted.find((r) => r.authorRole === 'OPERATOR')?.publishedAt).toEqual(NOW)
+    // The submit response is honest about the post-settle publish.
+    expect(second.ok && second.review.publishedAt).toEqual(NOW)
+  })
+
+  it('keeps a lone first submitter hidden in the window — double-blind preserved', async () => {
+    const { service, reviewRepo } = makeHarness()
+    const first = await service.submit(renterCtx, submitInput(), NOW)
+
+    const persisted = await reviewRepo.findByBookingId(BOOKING_ID)
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]?.publishedAt).toBeNull()
+    expect(first.ok && first.review.publishedAt).toBeNull()
+  })
+
+  it('publishes the lone review on submit once the window has already elapsed', async () => {
+    const { service, reviewRepo } = makeHarness()
+    const only = await service.submit(renterCtx, submitInput(), AFTER_DEADLINE)
+
+    const persisted = await reviewRepo.findByBookingId(BOOKING_ID)
+    expect(persisted[0]?.publishedAt).toEqual(AFTER_DEADLINE)
+    expect(only.ok && only.review.publishedAt).toEqual(AFTER_DEADLINE)
+  })
+})
+
 describe('ReviewService — one review per operator (#1158)', () => {
   // A SECOND active staff member of the same operator. The operator->renter review
   // represents the operator (the tenant), not the individual staff user, so the first

--- a/packages/api/src/services/review.ts
+++ b/packages/api/src/services/review.ts
@@ -161,7 +161,16 @@ export class ReviewService {
     }
 
     try {
-      const review = await this.reviewRepo.insert(newReview)
+      const inserted = await this.reviewRepo.insert(newReview)
+      // Reveal on write, not only on read (#1195): if this submit completes a pair — or the
+      // 14-day window has already elapsed — publish both sides now, so API-only/3rd-party
+      // submitters (no refetch) and slice-5 aggregates (which filter publishedAt) don't wait
+      // for a later getForBooking or the daily sweep. Idempotent (publishMany is first-write-
+      // wins) and double-blind-safe: decideReveal still gates on counterpart-submitted-or-
+      // elapsed, so a lone first submitter inside the window stays hidden. Re-read so the
+      // response reflects the post-settle publishedAt.
+      await this.settleReveal(booking.id, now)
+      const review = (await this.reviewRepo.findById(inserted.id)) ?? inserted
       return { ok: true, review }
     } catch (err) {
       // Either seal trips ALREADY_REVIEWED: the per-author one (a resubmit of the same


### PR DESCRIPTION
## #1195 — settle review reveal on submit, not only on read

**Found via:** the post-merge code review of the reviews feature (#1067 slices 1–4) on develop you asked for.

`ReviewService.submit()` returned right after `insert` and never called `settleReveal`. The "both sides submitted ⇒ reveal" transition fired only on a later `getForBooking` read (read-repair). The daily sweep only catches `revealDeadlineAt <= now` rows, so a pair that both submit **inside** the 14-day window but is never re-read stayed hidden until day 14.

Masked today only because the web `ReviewForm` invalidates the query → refetch → settle. A 3rd-party/direct-API submitter gets no refetch; slice-5 aggregates (filter `publishedAt IS NOT NULL`) would systematically undercount mutually-submitted-but-unread pairs — biasing the very ratings the feature exists to produce.

### Fix
Call `await this.settleReveal(booking.id, now)` after a successful insert, then re-read so the response reflects the post-settle `publishedAt`. Idempotent (`publishMany` is first-write-wins) and double-blind-safe (`decideReveal` still gates on counterpart-submitted-or-elapsed — a lone first submitter inside the window stays hidden). The sweep stays as the pure window backstop.

### Tests (RED-first)
3 new tests assert the **persisted** state directly via the repo (no `getForBooking` read-repair, which would mask the bug):
- both sides publish the moment the second party submits
- a lone in-window first submitter stays hidden (double-blind guard)
- a lone submit after the window already elapsed publishes immediately

### Verification
- `review.test.ts` 30/30 · aggregate `bun run test` all green (shared/api/web 1383) · tsc×3 · lint:boundaries + biome clean · review-constraints real-pg integration **10/10**
- No schema/migration change.

Closes #1195

### Deferred (LOWs from the same review — slice 5/6)
- read path doesn't filter `moderationStatus` (wire when slice 6 moderation lands)
- `getForBooking` double-reads `findByBookingId`
- booking-existence 404-vs-403 oracle inconsistent with the uniform-404 review-id path
- no rate limiter on `POST`/`PATCH` reviews (currently seal-bounded)