### PR TITLE
fix(#1194): drop Russia from IDP_OK (1968 Vienna, not 1949 Geneva)

### DIFF
--- a/packages/shared/src/lib/driving-eligibility.test.ts
+++ b/packages/shared/src/lib/driving-eligibility.test.ts
@@ -33,7 +33,7 @@ describe('country reference data — full membership pinned', () => {
     ])
   })
 
-  it('IDP_OK is the pinned 101-country Japan-accepted Geneva set (Vietnam excluded)', () => {
+  it('IDP_OK is the pinned 100-country Japan-accepted Geneva set (Russia + Vietnam excluded)', () => {
     const expected = [
       'AE',
       'AL',
@@ -115,7 +115,6 @@ describe('country reference data — full membership pinned', () => {
       'PY',
       'RO',
       'RS',
-      'RU',
       'RW',
       'SE',
       'SG',
@@ -138,7 +137,7 @@ describe('country reference data — full membership pinned', () => {
       'ZW',
     ]
     expect([...IDP_OK_COUNTRIES].sort()).toEqual(expected.sort())
-    expect(IDP_OK_COUNTRIES.size).toBe(101)
+    expect(IDP_OK_COUNTRIES.size).toBe(100)
   })
 
   it('the only overlap between the two sets is FR/BE/MC/SI', () => {
@@ -184,8 +183,9 @@ describe('classifyDrivingEligibility — Geneva IDP jurisdictions', () => {
 describe('classifyDrivingEligibility — recognized but neither list', () => {
   // Real countries that are not Japan-accepted 1949 Geneva parties and not in the
   // translation set: China, Brazil (1968 Vienna), Indonesia, Mexico, Saudi Arabia,
-  // and Vietnam (disputed → safe-fail to a "verify before booking" warning).
-  it.each(['CN', 'BR', 'ID', 'MX', 'SA', 'VN'])(
+  // Russia (1968 Vienna, not Geneva — Japan rejects its IDP, #1194), and Vietnam
+  // (disputed → safe-fail to a "verify before booking" warning).
+  it.each(['CN', 'BR', 'ID', 'MX', 'SA', 'RU', 'VN'])(
     '%s is a recognized country on neither list -> NOT_ELIGIBLE',
     (code) => {
       expect(classifyDrivingEligibility(code)).toBe('NOT_ELIGIBLE')

--- a/packages/shared/src/lib/driving-eligibility.ts
+++ b/packages/shared/src/lib/driving-eligibility.ts
@@ -26,7 +26,9 @@
 //     are DELIBERATELY EXCLUDED — both are 1968 Vienna parties, NOT 1949 Geneva, so Japan
 //     does not accept their IDP (#1194); per safe-fail they classify NOT_ELIGIBLE. Georgia
 //     (GE) and Kyrgyzstan (KG) were verified as genuine 1949 Geneva parties (2026-06,
-//     UN Treaty Collection) and are retained.
+//     UN Treaty Collection) and are retained. The FULL set beyond these spot-checks is
+//     NOT yet reconciled entry-by-entry against the NPA list — do that before slice 2
+//     surfaces a clearing verdict to renters (a wrong IDP_OK clears an ineligible driver).
 
 export const ELIGIBILITY_CLASSES = [
   'IDP_OK',

--- a/packages/shared/src/lib/driving-eligibility.ts
+++ b/packages/shared/src/lib/driving-eligibility.ts
@@ -15,15 +15,18 @@
 // clearing an ineligible one is a refused car at the counter — the exact failure
 // this feature exists to prevent. Err toward the warning.
 //
-// Sources (lists change rarely; re-verify against Japan's NPA list when amending):
-//   - Translation-required set (7): JAF published list — Switzerland, Germany,
-//     France, Belgium, Monaco, Slovenia, Taiwan.
-//   - IDP-accepted set: Japan-accepted 1949 Geneva Convention parties, cross-checked
-//     across Japan-operational sources (JAF, ToCoo, kart.st, niconico). Vietnam is
-//     DELIBERATELY EXCLUDED — sources conflict (it is a 1968 Vienna party; Japan
-//     guidance commonly rejects its IDP), so per the safe-fail rule it warns.
-//     The full set must be reconciled against the NPA "List of Contracting States
-//     to the Geneva Convention" before slice 2 surfaces this to renters.
+// Sources (primary — re-verify when amending):
+//   - UN Treaty Collection, Convention on Road Traffic (Geneva 1949), participant list
+//     XI-B-1: https://treaties.un.org/pages/ViewDetailsV.aspx?mtdsg_no=XI-B-1&chapter=11
+//   - Japan NPA "List of Contracting States to the Geneva Convention" — the operational
+//     authority for which IDPs Japan accepts.
+//   - Translation-required set (7): JAF published list — Switzerland, Germany, France,
+//     Belgium, Monaco, Slovenia, Taiwan.
+//   - IDP-accepted set: Japan-accepted 1949 Geneva parties. Russia (RU) and Vietnam (VN)
+//     are DELIBERATELY EXCLUDED — both are 1968 Vienna parties, NOT 1949 Geneva, so Japan
+//     does not accept their IDP (#1194); per safe-fail they classify NOT_ELIGIBLE. Georgia
+//     (GE) and Kyrgyzstan (KG) were verified as genuine 1949 Geneva parties (2026-06,
+//     UN Treaty Collection) and are retained.
 
 export const ELIGIBILITY_CLASSES = [
   'IDP_OK',
@@ -50,7 +53,7 @@ export const TRANSLATION_REQUIRED_COUNTRIES: ReadonlySet<string> = new Set([
 
 // Japan-accepted 1949 Geneva Convention parties — Japan accepts an IDP issued by
 // these. ISO 3166-1 alpha-2. FR/BE/MC/SI also appear here, but the translation rule
-// above wins. Vietnam is deliberately excluded (see header). (101 entries.)
+// above wins. Russia and Vietnam are deliberately excluded (see header). (100 entries.)
 // Exported for the contract test that pins the full membership.
 export const IDP_OK_COUNTRIES: ReadonlySet<string> = new Set([
   'AL',
@@ -128,7 +131,6 @@ export const IDP_OK_COUNTRIES: ReadonlySet<string> = new Set([
   'PL',
   'PT',
   'RO',
-  'RU',
   'RW',
   'SM',
   'SN',


### PR DESCRIPTION
## Problem (post-merge review of #1069 slice 1)

The driving-eligibility classifier bucketed **`RU` (Russia) as `IDP_OK`**. Russia is a **1968 Vienna** Convention party, **not** a 1949 Geneva party, and isn't on Japan's JAF translation list — so **Japan does not accept a Russian IDP**. A Russian renter genuinely cannot drive in Japan, yet the classifier would clear them: a **false positive in a safety allow-list** (refused car at pickup; insurance/liability exposure if the counter misses it). A wrong "OK" is the exact failure this feature exists to prevent.

## Fix

- Remove `RU` from `IDP_OK_COUNTRIES` — it falls to `NOT_ELIGIBLE` via `Intl.DisplayNames` recognition (same safe-fail path as Vietnam).
- Pinned set size `101 → 100`; move `RU` into the `NOT_ELIGIBLE` test row.
- **Verified the two other review-flagged entries against the UN Treaty Collection (XI-B-1) and kept them** — Georgia (`GE`) and Kyrgyzstan (`KG`) are genuine 1949 Geneva parties; removing them would have wrongly denied eligible drivers. Good that the flags were checked, not actioned blindly.
- Upgraded the file's source citation from aggregators (Wikipedia/ToCoo/kart.st) to the **UN Treaty Collection + Japan NPA** primary sources.

No migration. Pure-shared data + test only — not live until #1069 slice 2 wires the classifier, but the data IS the slice-1 deliverable.

## Tests (TDD)

Inverted the pinned-set + classification assertions first → went **red** (2 fail) against the unfixed data, **green** after removing RU. `driving-eligibility.test.ts` 39/0; `tsc @kuruma/shared` clean. (Two unrelated `boundFetch` failures under raw `bun test` are a pre-existing runner artifact, not from this change.)

Closes #1194
