### PR TITLE
fix(web): exact-match Back to site link so it is not active on admin routes

### DIFF
--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -12,7 +12,9 @@ import {
 } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
-const SIDEBAR_ITEMS = [
+// Exported so the active-state test can derive its router tree from the single
+// source of truth — a hard-coded copy there silently rots when an item is added.
+export const SIDEBAR_ITEMS = [
   { to: '/$locale/admin', icon: LayoutDashboard, labelKey: 'nav.overview' },
   { to: '/$locale/admin/operators', icon: Building2, labelKey: 'nav.operators' },
   { to: '/$locale/admin/bookings', icon: CalendarCheck, labelKey: 'nav.bookings' },
@@ -24,8 +26,8 @@ const SIDEBAR_ITEMS = [
 ] as const
 
 // Single static className; active state is the `aria-current="page"` attribute
-// (set by TanStack's activeProps) + the `aria-[current=page]:*` Tailwind variants.
-// SPA has no SSR, so the Next.js `mounted` hydration guard (#25) is unnecessary.
+// (auto-set by TanStack on the active <Link>) + the `aria-[current=page]:*`
+// Tailwind variants. SPA has no SSR, so the Next.js `mounted` guard (#25) is gone.
 const LINK_CLASSNAME =
   'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ' +
   'text-sidebar-foreground hover:bg-sidebar-accent/50 ' +
@@ -64,8 +66,8 @@ export function AdminSidebar() {
             to={to}
             params={{ locale }}
             // Exact: the index link (/admin) must not stay active on /admin/revenue.
+            // (TanStack auto-applies aria-current="page" to the active link.)
             activeOptions={{ exact: true }}
-            activeProps={{ 'aria-current': 'page' }}
             className={LINK_CLASSNAME}
           >
             <Icon className="size-5" />

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -47,6 +47,10 @@ export function AdminSidebar() {
         <Link
           to="/$locale"
           params={{ locale }}
+          // Exact, or TanStack's default prefix match makes `/$locale` active on
+          // every `/$locale/admin/*` route — auto-stamping `aria-current="page"`
+          // (and the active styling) onto this escape hatch on every admin page.
+          activeOptions={{ exact: true }}
           className={`${LINK_CLASSNAME} text-muted-foreground md:mb-1 md:border-b md:border-sidebar-border md:pb-3 md:rounded-b-none`}
         >
           <ArrowLeft className="size-5" />

--- a/packages/web/tests/vite/nav/AdminSidebar.activeState.test.tsx
+++ b/packages/web/tests/vite/nav/AdminSidebar.activeState.test.tsx
@@ -1,4 +1,4 @@
-import { AdminSidebar } from '@/vite/nav/AdminSidebar'
+import { AdminSidebar, SIDEBAR_ITEMS } from '@/vite/nav/AdminSidebar'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -16,7 +16,13 @@ import en from '../../../messages/en.json'
 // <Link> is auto-given `aria-current="page"`, and a NON-exact match treats
 // `/$locale` as active on every `/$locale/admin/*` route. Without exact matching
 // the "Back to site" escape hatch lights up as the current section on every admin
-// page (and mis-announces itself to screen readers). Stubbed Link can't see this.
+// page (and mis-announces itself to screen readers). A stubbed Link can't see this.
+
+// Derive the admin route tree from SIDEBAR_ITEMS so it can never drift from the
+// real sidebar: `/$locale/admin` -> index route, `/$locale/admin/x` -> child `x`.
+const ADMIN_PREFIX = '/$locale/admin'
+const leafPath = (to: string) => to.slice(ADMIN_PREFIX.length).replace(/^\//, '') || '/'
+
 function renderAdminSidebarAt(pathname: string) {
   const rootRoute = createRootRoute()
   const localeRoute = createRoute({ getParentRoute: () => rootRoute, path: '$locale' })
@@ -25,15 +31,7 @@ function renderAdminSidebarAt(pathname: string) {
     createRoute({ getParentRoute: () => adminRoute, path, component: () => <AdminSidebar /> })
   const routeTree = rootRoute.addChildren([
     localeRoute.addChildren([
-      adminRoute.addChildren([
-        sidebarChild('/'),
-        sidebarChild('bookings'),
-        sidebarChild('revenue'),
-        sidebarChild('anomalies'),
-        sidebarChild('documents'),
-        sidebarChild('customers'),
-        sidebarChild('governance'),
-      ]),
+      adminRoute.addChildren(SIDEBAR_ITEMS.map((item) => sidebarChild(leafPath(item.to)))),
     ]),
   ])
   const router = createRouter({

--- a/packages/web/tests/vite/nav/AdminSidebar.activeState.test.tsx
+++ b/packages/web/tests/vite/nav/AdminSidebar.activeState.test.tsx
@@ -1,0 +1,66 @@
+import { AdminSidebar } from '@/vite/nav/AdminSidebar'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Unlike AdminSidebar.test.tsx (which stubs Link to a plain anchor), this mounts a
+// REAL TanStack router so the framework's active-prop behavior runs: an active
+// <Link> is auto-given `aria-current="page"`, and a NON-exact match treats
+// `/$locale` as active on every `/$locale/admin/*` route. Without exact matching
+// the "Back to site" escape hatch lights up as the current section on every admin
+// page (and mis-announces itself to screen readers). Stubbed Link can't see this.
+function renderAdminSidebarAt(pathname: string) {
+  const rootRoute = createRootRoute()
+  const localeRoute = createRoute({ getParentRoute: () => rootRoute, path: '$locale' })
+  const adminRoute = createRoute({ getParentRoute: () => localeRoute, path: 'admin' })
+  const sidebarChild = (path: string) =>
+    createRoute({ getParentRoute: () => adminRoute, path, component: () => <AdminSidebar /> })
+  const routeTree = rootRoute.addChildren([
+    localeRoute.addChildren([
+      adminRoute.addChildren([
+        sidebarChild('/'),
+        sidebarChild('bookings'),
+        sidebarChild('revenue'),
+        sidebarChild('anomalies'),
+        sidebarChild('documents'),
+        sidebarChild('customers'),
+        sidebarChild('governance'),
+      ]),
+    ]),
+  ])
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [pathname] }),
+  })
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <RouterProvider router={router} />
+    </IntlProvider>,
+  )
+}
+
+describe('AdminSidebar active state (real router)', () => {
+  it('does not mark "Back to site" as the current page on a nested admin route', async () => {
+    renderAdminSidebarAt('/en/admin/bookings')
+    const backToSite = (await screen.findByText('Back to site')).closest('a')
+    expect(backToSite).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks only the matched section link as the current page', async () => {
+    renderAdminSidebarAt('/en/admin/bookings')
+    expect((await screen.findByText('Bookings')).closest('a')).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+    // Exact matching on section links: the /admin index stays inactive on a child route.
+    expect(screen.getByText('Overview').closest('a')).not.toHaveAttribute('aria-current')
+  })
+})


### PR DESCRIPTION
Closes #1211

Addresses the **P2** finding from the beta-branch review (reviewed `origin/beta` at `f2adc826`).

## Problem
`AdminSidebar`’s "Back to site" escape hatch is `<Link to="/$locale">` with no `activeOptions`. Verified against TanStack Router `1.170.15` source:

- `isActive` with no `activeOptions.exact` is a **prefix match**: `"/en/admin/bookings".startsWith("/en")` → active (`link.js:217`).
- Active links get `STATIC_ACTIVE_PROPS = { "data-status":"active", "aria-current":"page" }` spread automatically (`link.js:369,381`) — the explicit `activeProps` on the section links is in fact redundant.
- The back-to-site link carries `LINK_CLASSNAME`, which includes `aria-[current=page]:bg-sidebar-accent …`.

So on **every** `/admin/*` route the escape hatch lit up as the current section, and screen readers heard `aria-current="page"` on it.

## Fix
One line: `activeOptions={{ exact: true }}` on the back-to-site `Link`. It is then only active on `/$locale` itself (which never renders the admin sidebar), so it never highlights inside the portal.

## Test
The existing `AdminSidebar.test.tsx` mocks `Link` to a plain anchor, so it cannot see this framework behavior — exactly as the reviewer noted. Added `AdminSidebar.activeState.test.tsx`, which mounts a **real** TanStack router at `/en/admin/bookings` and asserts:
- back-to-site has **no** `aria-current` (RED before the fix, GREEN after),
- only the matched section link (`Bookings`) carries `aria-current="page"`, and the `/admin` index link does not — proving the router is genuinely wired.

## Verification
- `AdminSidebar.activeState.test.tsx` RED → GREEN on the one-line fix.
- Full `tests/vite/nav/` suite: 37 passed.
- `web typecheck` exit 0, biome clean, `lint:modules` exit 0.

## Note on the other finding
The **P3** CurrencyProvider locale-default finding is **already fixed on `develop`** (PR #1200, `269f3ea8`): `const currency = stored ?? defaultCurrencyForLocale(locale)` derives every render. Beta was reviewed behind develop; it lands there on the next `develop→beta` promotion. No code change needed here.