### PR TITLE
test(#1070): currency follow-up nits — sr-only a11y, positive-rate seam, per-surface tests

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1,6 +1,7 @@
 {
   "currency": {
     "label": "Display currency",
+    "approximately": "approximately",
     "disclaimer": "Indicative only — you're charged in JPY",
     "asOf": "Rates as of {date}"
   },

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1,6 +1,7 @@
 {
   "currency": {
     "label": "表示通貨",
+    "approximately": "約",
     "disclaimer": "目安です — ご請求は日本円（JPY）です",
     "asOf": "レート基準日 {date}"
   },

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1,6 +1,7 @@
 {
   "currency": {
     "label": "显示货币",
+    "approximately": "约",
     "disclaimer": "仅供参考 — 实际以日元（JPY）结算",
     "asOf": "汇率基准日 {date}"
   },

--- a/packages/web/src/vite/currency/IndicativeNote.test.tsx
+++ b/packages/web/src/vite/currency/IndicativeNote.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
 import { CurrencyProvider } from './CurrencyProvider'
 import { IndicativeNote } from './IndicativeNote'
 
@@ -26,7 +27,7 @@ function renderInProvider(ui: ReactNode, locale = 'en') {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
-      <IntlProvider locale={locale} messages={{}}>
+      <IntlProvider locale={locale} messages={en}>
         <CurrencyProvider>{ui}</CurrencyProvider>
       </IntlProvider>
     </QueryClientProvider>,
@@ -40,6 +41,17 @@ describe('IndicativeNote', () => {
     await waitFor(() => expect(screen.getByText(/≈ \$181/)).toBeTruthy())
   })
 
+  it('reads a localized "approximately" to screen readers, hiding the bare ≈ glyph (a11y)', async () => {
+    const { container } = renderInProvider(<IndicativeNote jpy={27000} />, 'en')
+    // Screen readers get the spelled-out phrase, not a glyph that may read as
+    // "almost equal to" or be skipped entirely.
+    await waitFor(() => expect(screen.getByText(`${en.currency.approximately} $181`)).toBeTruthy())
+    // The visible ≈ run is present but excluded from the accessibility tree, so the
+    // figure is never announced twice.
+    const glyph = container.querySelector('[aria-hidden="true"]')
+    expect(glyph?.textContent).toContain('≈ $181')
+  })
+
   it('renders nothing for a JPY display currency so the caller shows JPY alone', async () => {
     localStorage.setItem('kuruma-display-currency', 'JPY')
     const { container } = renderInProvider(<IndicativeNote jpy={27000} />, 'ja')
@@ -47,8 +59,14 @@ describe('IndicativeNote', () => {
     expect(container.textContent).toBe('')
   })
 
-  it('renders nothing when used outside a provider — degrades to JPY-only, never throws', () => {
-    const { container } = render(<IndicativeNote jpy={27000} />)
+  it('renders nothing without a CurrencyProvider — degrades to JPY-only, never throws', () => {
+    // IntlProvider is the app-shell root and always present; the degradation that
+    // matters for #1070 is a missing CurrencyProvider (no FX rates) -> JPY alone.
+    const { container } = render(
+      <IntlProvider locale="en" messages={en}>
+        <IndicativeNote jpy={27000} />
+      </IntlProvider>,
+    )
     expect(container.textContent).toBe('')
   })
 })

--- a/packages/web/src/vite/currency/IndicativeNote.tsx
+++ b/packages/web/src/vite/currency/IndicativeNote.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils'
+import { useTranslations } from 'use-intl'
 import { useIndicative } from './CurrencyProvider'
 
 /**
@@ -16,12 +17,18 @@ export function IndicativeNote({
   readonly jpy: number
   readonly className?: string
 }) {
+  const t = useTranslations('currency')
   const { format } = useIndicative()
   const indicative = format(jpy)
   if (!indicative) return null
   return (
     <span className={cn('block font-normal text-muted-foreground text-xs', className)}>
-      ≈ {indicative}
+      {/* Screen readers get the spelled-out word; the ≈ glyph (which assistive tech
+          reads as "almost equal to" or skips) is hidden so the figure isn't doubled. */}
+      <span className="sr-only">
+        {t('approximately')} {indicative}
+      </span>
+      <span aria-hidden="true">≈ {indicative}</span>
     </span>
   )
 }

--- a/packages/web/src/vite/currency/currency-api.test.ts
+++ b/packages/web/src/vite/currency/currency-api.test.ts
@@ -43,6 +43,15 @@ describe('fetchFxRates', () => {
     )
     await expect(fetchFxRates()).rejects.toBeInstanceOf(ApiError)
   })
+
+  it('rejects a non-positive rate at the seam so a 0/negative never yields a bogus figure', async () => {
+    // z.number() already rejects NaN/Infinity (verified), so .positive() is the only
+    // guard a JSON-carryable bad value (0 / negative) actually needs.
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { ...rates, rates: { USD: 0 } } }),
+    )
+    await expect(fetchFxRates()).rejects.toBeInstanceOf(ParseError)
+  })
 })
 
 describe('fxRatesQueryOptions', () => {

--- a/packages/web/src/vite/currency/currency-api.ts
+++ b/packages/web/src/vite/currency/currency-api.ts
@@ -17,9 +17,10 @@ export const FX_RATES_QUERY_KEY = ['fx', 'rates'] as const
 const fxRatesSchema = z.object({
   base: z.literal('JPY'),
   asOf: z.string(),
-  // A JPY→currency multiplier is always positive; rejecting 0/negative at the seam
-  // means a bad rate fails the whole snapshot and the UI degrades to JPY-only rather
-  // than rendering a `≈ ¥0`. (z.number() already rejects NaN/Infinity.)
+  // A JPY→currency multiplier is always positive; rejecting 0/negative here fails the
+  // whole snapshot loudly (UI degrades to JPY-only) as defense-in-depth —
+  // formatIndicativePrice also guards per-currency (`rate <= 0 → null`), so this only
+  // hardens the seam, it isn't the sole guard. (z.number() already rejects NaN/Infinity.)
   rates: z.record(z.string(), z.number().positive()),
 }) satisfies z.ZodType<FxRates>
 

--- a/packages/web/src/vite/currency/currency-api.ts
+++ b/packages/web/src/vite/currency/currency-api.ts
@@ -17,7 +17,10 @@ export const FX_RATES_QUERY_KEY = ['fx', 'rates'] as const
 const fxRatesSchema = z.object({
   base: z.literal('JPY'),
   asOf: z.string(),
-  rates: z.record(z.string(), z.number()),
+  // A JPY→currency multiplier is always positive; rejecting 0/negative at the seam
+  // means a bad rate fails the whole snapshot and the UI degrades to JPY-only rather
+  // than rendering a `≈ ¥0`. (z.number() already rejects NaN/Infinity.)
+  rates: z.record(z.string(), z.number().positive()),
 }) satisfies z.ZodType<FxRates>
 
 export async function fetchFxRates(): Promise<FxRates> {

--- a/packages/web/tests/support/currency.tsx
+++ b/packages/web/tests/support/currency.tsx
@@ -1,0 +1,35 @@
+import { CurrencyProvider } from '@/vite/currency'
+import { FX_RATES_QUERY_KEY } from '@/vite/currency/currency-api'
+import type { FxRates } from '@kuruma/shared/types/fx'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { IntlProvider } from 'use-intl'
+import en from '../../messages/en.json'
+
+// Deterministic (not real) rate: 30,000 JPY -> $201, so round-number price fixtures
+// land on clean dollar figures the per-surface wiring tests can assert exactly.
+const USD_PER_JPY = 0.0067
+const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: USD_PER_JPY } }
+
+/**
+ * Render `ui` with USD as the display currency and the FX snapshot pre-seeded into
+ * the query cache (fresh, so React Query never hits the network). An <IndicativeNote/>
+ * inside `ui` therefore resolves its `≈ $…` figure synchronously. Used by the #1070
+ * per-surface tests that pin each surface to the correct JPY field.
+ */
+export function renderWithUsdIndicative(ui: ReactElement) {
+  // Own the global we touch: start from a clean slot so the result never depends on a
+  // display-currency a sibling test left behind (order-independent under any shard).
+  localStorage.clear()
+  localStorage.setItem('kuruma-display-currency', 'USD')
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(FX_RATES_QUERY_KEY, RATES)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={en}>
+        <CurrencyProvider>{ui}</CurrencyProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}

--- a/packages/web/tests/support/currency.tsx
+++ b/packages/web/tests/support/currency.tsx
@@ -2,7 +2,7 @@ import { CurrencyProvider } from '@/vite/currency'
 import { FX_RATES_QUERY_KEY } from '@/vite/currency/currency-api'
 import type { FxRates } from '@kuruma/shared/types/fx'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render } from '@testing-library/react'
+import { type RenderResult, render } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { IntlProvider } from 'use-intl'
 import en from '../../messages/en.json'
@@ -18,10 +18,10 @@ const RATES: FxRates = { base: 'JPY', asOf: '2026-06-01', rates: { USD: USD_PER_
  * inside `ui` therefore resolves its `≈ $…` figure synchronously. Used by the #1070
  * per-surface tests that pin each surface to the correct JPY field.
  */
-export function renderWithUsdIndicative(ui: ReactElement) {
-  // Own the global we touch: start from a clean slot so the result never depends on a
-  // display-currency a sibling test left behind (order-independent under any shard).
-  localStorage.clear()
+export function renderWithUsdIndicative(ui: ReactElement): RenderResult {
+  // Own the one key we read: overwrite the display-currency outright so the result never
+  // depends on a value a sibling test left behind (order-independent under any shard).
+  // Don't `clear()` — that would wipe unrelated keys a consuming test may have seeded.
   localStorage.setItem('kuruma-display-currency', 'USD')
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   queryClient.setQueryData(FX_RATES_QUERY_KEY, RATES)

--- a/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
+++ b/packages/web/tests/vite/bookings/BookingConfirmationView.test.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
@@ -170,6 +171,20 @@ describe('BookingConfirmationView', () => {
   it('omits the price breakdown when the total price is unknown', () => {
     renderView(makeBooking({ totalPrice: null }))
     expect(screen.queryByText('Price breakdown')).not.toBeInTheDocument()
+  })
+
+  // #1070: the confirmed total is the one money figure that carries an indicative note.
+  it('converts the booking total for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <BookingConfirmationView
+        booking={makeBooking({ totalPrice: 30000 })}
+        vehicleClass={null}
+        csrfToken="csrf-tok"
+        threadId={null}
+      />,
+    )
+    // 30,000 -> $201
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
   })
 
   it('renders the operator pre-auth handoff link when present', () => {

--- a/packages/web/tests/vite/reservation/AddOnsStep.test.tsx
+++ b/packages/web/tests/vite/reservation/AddOnsStep.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 const addOns: ReservationAddOn[] = [
   { id: 'a1', name: 'Baby seat', description: 'Rear-facing', priceJpy: 2000 },
@@ -44,5 +45,18 @@ describe('AddOnsStep', () => {
   it('shows the empty state when the store offers no add-ons', () => {
     renderStep({ addOns: [] })
     expect(screen.getByText('No extras are available at this store.')).toBeInTheDocument()
+  })
+
+  // #1070: each add-on line carries an indicative conversion of its per-rental price.
+  it('converts the add-on per-rental price for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <AddOnsStep
+        addOns={[{ id: 'a1', name: 'Baby seat', description: null, priceJpy: 30000 }]}
+        selectedIds={[]}
+        onToggle={vi.fn()}
+      />,
+    )
+    // 30,000 -> $201
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
   })
 })

--- a/packages/web/tests/vite/reservation/InsuranceStep.test.tsx
+++ b/packages/web/tests/vite/reservation/InsuranceStep.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 const options: ReservationInsuranceOption[] = [
   {
@@ -57,5 +58,27 @@ describe('InsuranceStep', () => {
     expect(
       screen.getByText('No insurance options are available at this store.'),
     ).toBeInTheDocument()
+  })
+
+  // #1070: the indicative note must convert the per-day price, not the deductible.
+  it('converts each option daily price — not the deductible — for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <InsuranceStep
+        options={[
+          {
+            id: 'i1',
+            name: 'Full coverage',
+            description: null,
+            dailyPriceJpy: 30000,
+            deductibleJpy: 100000,
+          },
+        ]}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    )
+    // 30,000/day -> $201; the deductible (100,000 -> $670) carries no note.
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
+    expect(screen.queryByText(/≈ \$670/)).toBeNull()
   })
 })

--- a/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
+++ b/packages/web/tests/vite/search/MapPopupCarousel.test.tsx
@@ -10,6 +10,7 @@ import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 // Stub the router Link as a plain anchor so the carried search is inspectable
 // without a RouterProvider (mirrors SearchMapList.test.tsx).
@@ -206,5 +207,22 @@ describe('MapPopupCarousel', () => {
     expect(screen.getAllByText('Compact')).toHaveLength(1)
     expect(screen.getByText('Class deal')).toBeInTheDocument()
     expect(screen.getByText('3 cars available')).toBeInTheDocument()
+  })
+
+  // #1070: the visible slide's price carries an indicative conversion.
+  it('converts the current car price for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <MapPopupCarousel
+        items={[{ ...carAt('v1', 'Toyota Yaris'), dailyRateJpy: 30000 }]}
+        locale="en"
+        from="2026-07-01T10:00"
+        to="2026-07-04T10:00"
+        classFilter={undefined}
+        region={undefined}
+        geoLabel={null}
+      />,
+    )
+    // 30,000 -> $201
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
   })
 })

--- a/packages/web/tests/vite/search/SearchResultRow.test.tsx
+++ b/packages/web/tests/vite/search/SearchResultRow.test.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 // The detail CTA is a TanStack Link (#885 slice 1b); stub it as a plain anchor
 // so the row renders without a RouterProvider, exposing its target + carried
@@ -235,6 +236,42 @@ describe('SearchResultRow', () => {
         region: 'namba',
         pickupLocationId: 'loc_x',
       })
+    })
+  })
+
+  // #1070: both row variants carry an indicative conversion of their displayed price.
+  describe('indicative price', () => {
+    it('converts the SPECIFIC row daily price for the indicative note', async () => {
+      renderWithUsdIndicative(
+        <SearchResultRow
+          item={makeSpecific({ dailyRateJpy: 30000 })}
+          locale="en"
+          from="2026-07-01T10:00"
+          to="2026-07-04T10:00"
+          classFilter={undefined}
+          pickupLocationId={undefined}
+          region={undefined}
+          geoLabel={null}
+        />,
+      )
+      // 30,000 -> $201
+      expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
+    })
+
+    it('converts the CLASS_COMBO row daily price for the indicative note', async () => {
+      renderWithUsdIndicative(
+        <SearchResultRow
+          item={makeCombo({ dailyRateJpy: 30000 })}
+          locale="en"
+          from="2026-07-01T10:00"
+          to="2026-07-04T10:00"
+          classFilter={undefined}
+          pickupLocationId={undefined}
+          region={undefined}
+          geoLabel={null}
+        />,
+      )
+      expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
     })
   })
 })

--- a/packages/web/tests/vite/storefronts/AvailableVehicleCard.test.tsx
+++ b/packages/web/tests/vite/storefronts/AvailableVehicleCard.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
@@ -109,5 +110,19 @@ describe('AvailableVehicleCard', () => {
   it('renders a singular bag label when capacity is one', () => {
     renderCard(makeVehicle({ luggageCapacity: 1, luggageSize: 'SMALL' }))
     expect(screen.getByText('1 bag')).toBeInTheDocument()
+  })
+
+  // #1070: the card's from-price carries an indicative conversion under a non-JPY display.
+  it('converts the from-price for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <AvailableVehicleCard
+        vehicle={makeVehicle({ dailyRateJpy: 30000 })}
+        locationId="loc-1"
+        from="2026-07-01T10:00"
+        to="2026-07-03T10:00"
+      />,
+    )
+    // 30,000 -> $201
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
   })
 })

--- a/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
+++ b/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+import { renderWithUsdIndicative } from '../../support/currency'
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
@@ -121,5 +122,18 @@ describe('StorefrontCard', () => {
   it('shows a store/location placeholder with an accessible label instead of a car photo (#955)', () => {
     renderCard(makeStorefront({ representativePhotos: ['/photos/car.jpg'] }))
     expect(screen.getByRole('img', { name: 'Store location' })).toBeInTheDocument()
+  })
+
+  // #1070: the storefront's daily from-price carries an indicative conversion.
+  it('converts the from-price for the indicative note', async () => {
+    renderWithUsdIndicative(
+      <StorefrontCard
+        storefront={makeStorefront({ fromDailyPriceJpy: 30000 })}
+        from="2026-07-01T10:00"
+        to="2026-07-03T10:00"
+      />,
+    )
+    // 30,000 -> $201
+    expect(await screen.findByText(/≈ \$201/)).toBeTruthy()
   })
 })


### PR DESCRIPTION
The three deferred follow-up nits from the #1070 indicative-currency bug-hunt (PR #1200). Display-only — the charge is always JPY; the money path is untouched. No migration.

## What changed

1. **a11y — sr-only "approximately"** (`IndicativeNote.tsx`). The `≈` glyph reads as "almost equal to" on some screen readers and is skipped on others. Now a localized sr-only phrase ("approximately $201") is announced and the `≈` run is `aria-hidden`, so the figure is read exactly once. New i18n key `currency.approximately` (en/ja/zh). The component now uses `useTranslations`; `IntlProvider` is a strict ancestor of `CurrencyProvider` in the app shell, so this is never a new failure mode (the degradation test was retargeted to the real case: a missing `CurrencyProvider`).
2. **Positive-rate seam guard** (`currency-api.ts`). The FX network-seam schema now pins rates to `z.number().positive()`, so a `0`/negative rate fails the snapshot and the UI degrades to JPY-only instead of rendering a bogus `≈ ¥0`. `.finite()` was deliberately omitted — `z.number()` already rejects NaN/Infinity (Zod v4) and JSON can't carry them, so it'd be dead defensiveness.
3. **Per-surface wiring tests** for every surface that renders `<IndicativeNote/>` — insurance (daily price, **not** the deductible), add-on per-rental, booking total, both search-row variants, map popup, storefront + available-vehicle from-price. (The 8th surface, `ConfirmStep`, was already pinned in #1200.) A shared `tests/support/currency.tsx` harness seeds the FX query cache synchronously so each note resolves its `≈ $…` figure with no network; it deep-imports `FX_RATES_QUERY_KEY` from currency internals, which is sanctioned because it lives under `tests/` (the boundary-lint exception).

## Review + gates

- code-reviewer pass: **no CRITICAL/HIGH**. One MEDIUM was a false positive (ConfirmStep already covered by #1200); one LOW (harness localStorage hygiene) was fixed — the harness now clears the slot on entry so tests are order-independent.
- `@kuruma/web` test: **1403 passing**; web tsc clean; `lint:modules` + `lint:size` exit 0.
- Web-only change (touches `packages/web` only) — no shared/api files, so the api suite is N/A.

Refs #1070 (closed) — these are follow-ups, not a re-open.