### PR TITLE
fix(#1197,#1198): un-truncate needs-assignment worklist + pin event parse coverage

### DIFF
--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -247,12 +247,21 @@ export function bookingEventsQueryOptions(id: string) {
 // booking from this list in one cache-invalidation call.
 export const NEEDS_ASSIGNMENT_QUERY_KEY = ['operator-bookings', 'needs-assignment'] as const
 
+// #1197: pull a full page (the API caps `limit` at 100). Without an explicit
+// limit the route defaults to 20 and unwrap() drops `nextCursor`, so an operator
+// with >20 unassigned floats would silently see only 20 on this action worklist.
+const NEEDS_ASSIGNMENT_PAGE_LIMIT = 100
+
 export async function fetchNeedsAssignment(): Promise<RawOperatorBooking[]> {
   // `expand=renter` is supported alongside `needsAssignment=true` (the route
   // applies all filters before the expansion join), so renter name/email are
   // included when the user table has them. The rawOperatorBookingSchema already
   // carries the optional renter block, so no new schema is needed here.
-  const sp = new URLSearchParams({ needsAssignment: 'true', expand: 'renter' })
+  const sp = new URLSearchParams({
+    needsAssignment: 'true',
+    expand: 'renter',
+    limit: String(NEEDS_ASSIGNMENT_PAGE_LIMIT),
+  })
   const res = await fetch(`${getApiBaseUrl()}/bookings?${sp.toString()}`, {
     credentials: 'include',
   })

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -8,6 +8,7 @@ import {
   fetchBookingEvents,
   fetchCalendarBookings,
   fetchCalendarVehicles,
+  fetchNeedsAssignment,
   fetchOperatorBookingDetail,
   fetchSubstitutionCandidates,
   operatorBookingDetailQueryOptions,
@@ -186,6 +187,70 @@ describe('fetchBookingEvents', () => {
     )
 
     await expect(fetchBookingEvents('bk-1')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  // #1198: every discriminated-union arm needs a `.parse` round-trip — the
+  // output-covariant `satisfies z.ZodType` does NOT prove a wrong arm is caught
+  // (that hole shipped the original VEHICLE_ASSIGNED ParseError, #464).
+  it('parses a VEHICLE_SUBSTITUTED event payload through the schema', async () => {
+    const substituted = eventRaw({
+      type: 'VEHICLE_SUBSTITUTED',
+      payload: {
+        type: 'VEHICLE_SUBSTITUTED',
+        fromVehicleId: 'veh-old',
+        toVehicleId: 'veh-new',
+        reason: 'mechanical fault',
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [substituted] })),
+    )
+
+    const events = await fetchBookingEvents('bk-1')
+
+    expect(events).toEqual([substituted])
+  })
+
+  it('parses a legacy BOOKING_CANCELLED payload missing cancellationReason -> defaults to null', async () => {
+    // Pre-#868 rows carry no cancellationReason key; the schema's `.default(null)`
+    // is load-bearing — without it the whole timeline ParseErrors for old
+    // cancelled bookings. Assert the default actually applies.
+    const legacyCancelled = eventRaw({
+      type: 'BOOKING_CANCELLED',
+      payload: {
+        type: 'BOOKING_CANCELLED',
+        cancellationFee: 5000,
+        cancelledAt: '2026-07-01T02:00:00.000Z',
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [legacyCancelled] })),
+    )
+
+    const [event] = await fetchBookingEvents('bk-1')
+
+    expect(event?.payload).toEqual({
+      type: 'BOOKING_CANCELLED',
+      cancellationFee: 5000,
+      cancelledAt: '2026-07-01T02:00:00.000Z',
+      cancellationReason: null,
+    })
+  })
+})
+
+describe('fetchNeedsAssignment', () => {
+  it('requests a full page (limit=100) so the worklist is not truncated at the default 20 (#1197)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchNeedsAssignment()
+
+    const url = new URL(fetchMock.mock.calls[0]![0] as string, 'http://x')
+    expect(url.pathname).toBe('/api/bookings')
+    expect(url.searchParams.get('needsAssignment')).toBe('true')
+    expect(url.searchParams.get('limit')).toBe('100')
   })
 })
 


### PR DESCRIPTION
Two cheap `operator-bookings` quality fixes from the post-merge review of #464, batched (same module).

## #1197 — needs-assignment worklist silently truncated at 20
`fetchNeedsAssignment` sent no `limit`, so the API defaulted to 20 and `unwrap()` discards `nextCursor`. An operator with >20 unassigned CLASS_COMBO floats saw only 20 on an **action worklist**, with no "more" affordance, and the count badge under-reported.

**Fix:** pass `limit=100` (the API cap, matching `fetchCalendarBookings`). `floats.length` now reflects the full set for any realistic fleet (40-50 cars). True cursor pagination is YAGNI at this scale — noted, not built.

## #1198 — missing `.parse` coverage for two event arms
`VEHICLE_SUBSTITUTED` and `BOOKING_CANCELLED` were only exercised via `as` casts (in `BookingTimeline.test.tsx`), never round-tripped through `bookingEventSchema`. The union is pinned with output-covariant `satisfies z.ZodType`, which compiles a structurally-wrong arm — exactly how the original `VEHICLE_ASSIGNED` ParseError shipped (#464).

**Fix:** add `fetchBookingEvents` round-trip tests for a `VEHICLE_SUBSTITUTED` payload and a **legacy `BOOKING_CANCELLED`** payload missing `cancellationReason`, asserting the load-bearing `.default(null)` applies (without it the whole timeline ParseErrors for pre-#868 cancelled bookings).

## Tests (TDD)
The #1197 limit assertion went **red** first, green after the fix; the #1198 parse tests pin already-correct behavior. operator-bookings api suite **53/53**, full dir **173/173**, `tsc` (web+api) clean, no new module reach-ins.

No migration. Closes #1197. Closes #1198.
