### PR TITLE
fix(#1164): platform-admin dashboard GA hardening

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -17,7 +17,11 @@ import {
 } from './composition/services'
 import { setupGlobalHandlers } from './error-handlers'
 import { parseBoolFlag } from './lib/parse-bool-flag'
-import { provideOperatorSessionRevocation, requireAuth } from './middleware/auth'
+import {
+  provideOperatorSessionRevocation,
+  requireAuth,
+  requirePlatformMember,
+} from './middleware/auth'
 import { csrf } from './middleware/csrf'
 import { structuredLogger } from './middleware/logger'
 import { requestId } from './middleware/request-id'
@@ -333,6 +337,10 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   app.use('/customers', requireAuth())
   app.use('/users/*', requireAuth())
   app.use('/admin/*', requireAuth())
+  // Structural role gate (#1164): the whole /admin/* surface is platform-tier only,
+  // so a future sibling route that forgets its in-body requirePlatform* call is still
+  // authz-protected. Per-handler gates remain as defense-in-depth. Authn before authz.
+  app.use('/admin/*', requirePlatformMember())
   app.use('/documents/*', requireAuth())
   app.use('/documents', requireAuth())
   // locations + operators are auth-gated inside their factories (no public

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,6 +1,8 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import { getCookie } from 'hono/cookie'
 
+import { toCallerContext } from '../auth/context'
+import { requirePlatformRead } from '../auth/guards'
 import { SESSION_COOKIE, verifyApiKey, verifyJwt } from '../auth/jwt'
 import { type AuthUser, isAuthUser, isOperatorRole } from '../auth/roles'
 import { fail } from '../routes/helpers'
@@ -134,6 +136,21 @@ export function requireAuth(): MiddlewareHandler {
     if (await isOperatorSessionRevoked(c, user)) return fail(c, 'Unauthorized', 401)
 
     c.set('user', user)
+    return next()
+  }
+}
+
+/** Structural role gate for the whole `/admin/*` namespace (#1164). Mount it right
+ *  after `app.use('/admin/*', requireAuth())` so the user is already set; it rejects
+ *  any caller below the platform tier with 403 BEFORE the handler runs. This makes
+ *  the role gate structural rather than per-handler, so a future sibling admin route
+ *  that forgets its in-body `requirePlatform*` call is still authz-protected. The
+ *  per-handler gates stay as defense-in-depth (and carry the stricter write-only
+ *  `requirePlatformAdmin` distinction). Uses the platform-tier floor `requirePlatformRead`
+ *  so a read route never breaks if `PLATFORM_ROLES` ever widens past PLATFORM_ADMIN. */
+export function requirePlatformMember(): MiddlewareHandler {
+  return async (c: Context, next) => {
+    requirePlatformRead(toCallerContext(requireUser(c)))
     return next()
   }
 }

--- a/packages/api/src/routes/payment-anomalies.ts
+++ b/packages/api/src/routes/payment-anomalies.ts
@@ -1,4 +1,3 @@
-import type { PaymentAnomalyView } from '@kuruma/shared/types/payment-anomaly'
 import { resolvePaymentAnomalySchema } from '@kuruma/shared/validators/payment-anomaly'
 import { Hono } from 'hono'
 import {
@@ -9,30 +8,7 @@ import {
   toCallerContext,
 } from '../middleware/auth'
 import type { PaymentAnomalyService } from '../services/payment-anomaly'
-import type { PaymentAnomaly } from '../stores'
 import { fail, ok, parseBody } from './helpers'
-
-// Project a persisted anomaly onto the admin wire view (@kuruma/shared): drop the
-// internal checkout-session id (refunds are issued against the paymentIntent) and
-// `resolvedBy` (no user-join in v1), and serialize the timestamps as ISO. The
-// resolution audit fields are null exactly while the anomaly is unresolved.
-function toView(a: PaymentAnomaly): PaymentAnomalyView {
-  return {
-    id: a.id,
-    kind: a.kind,
-    operatorId: a.operatorId,
-    bookingId: a.bookingId,
-    receivedAmountJpy: a.receivedAmountJpy,
-    expectedAmountJpy: a.expectedAmountJpy,
-    currency: a.currency,
-    stripeEventId: a.stripeEventId,
-    stripePaymentIntentId: a.stripePaymentIntentId,
-    createdAt: a.createdAt.toISOString(),
-    resolvedAt: a.resolvedAt ? a.resolvedAt.toISOString() : null,
-    resolution: a.resolution,
-    note: a.note,
-  }
-}
 
 /**
  * Platform-admin payment anomalies (#508 P2; resolution UI #1075 slice 3). Cross-tenant
@@ -62,9 +38,8 @@ export function createPaymentAnomalyRoutes(service: PaymentAnomalyService) {
         return fail(c, 'status must be "resolved" or "unresolved"', 400)
       }
 
-      const anomalies = (
+      const anomalies =
         status === 'resolved' ? await service.listResolved(ctx) : await service.listUnresolved(ctx)
-      ).map(toView)
       return ok(c, { anomalies })
     })
     .post('/admin/payment-anomalies/:id/resolve', async (c) => {
@@ -80,6 +55,6 @@ export function createPaymentAnomalyRoutes(service: PaymentAnomalyService) {
         parsed.data.resolution,
         parsed.data.note ?? null,
       )
-      return ok(c, { anomaly: toView(anomaly) })
+      return ok(c, { anomaly })
     })
 }

--- a/packages/api/src/services/admin-revenue.ts
+++ b/packages/api/src/services/admin-revenue.ts
@@ -5,7 +5,8 @@ import type { OperatorRepository, PaymentEventRepository } from '../repositories
 
 /**
  * Platform-admin partner revenue report (#462). Imperative shell: it gates the
- * caller (only STAFF/ADMIN/PLATFORM_ADMIN — never OPERATOR_*), fetches the
+ * caller (only PLATFORM_ADMIN — never OPERATOR_*; legacy STAFF/ADMIN lost
+ * platform access in #487), fetches the
  * successful payments and operators, and hands them to the pure
  * {@link aggregateRevenueByPartner} core. `requirePlatformRead` lives here (not
  * only at the route) so the gate travels with the business logic — the payment

--- a/packages/api/src/services/payment-anomaly.ts
+++ b/packages/api/src/services/payment-anomaly.ts
@@ -1,4 +1,7 @@
-import type { PaymentAnomalyResolution } from '@kuruma/shared/types/payment-anomaly'
+import type {
+  PaymentAnomalyResolution,
+  PaymentAnomalyView,
+} from '@kuruma/shared/types/payment-anomaly'
 import {
   type CallerContext,
   NotFoundError,
@@ -7,6 +10,30 @@ import {
 } from '../middleware/auth'
 import type { PaymentAnomalyRepository } from '../repositories/types'
 import type { PaymentAnomaly } from '../stores'
+
+// Project a persisted anomaly onto the admin wire view (@kuruma/shared): drop the
+// internal checkout-session id (refunds are issued against the paymentIntent) and
+// `resolvedBy` (no user-join in v1), and serialize the timestamps as ISO. The
+// resolution audit fields are null exactly while the anomaly is unresolved. Lives
+// in the service (not the route) so the entity→wire boundary stays out of the
+// transport layer (#1164).
+function toView(a: PaymentAnomaly): PaymentAnomalyView {
+  return {
+    id: a.id,
+    kind: a.kind,
+    operatorId: a.operatorId,
+    bookingId: a.bookingId,
+    receivedAmountJpy: a.receivedAmountJpy,
+    expectedAmountJpy: a.expectedAmountJpy,
+    currency: a.currency,
+    stripeEventId: a.stripeEventId,
+    stripePaymentIntentId: a.stripePaymentIntentId,
+    createdAt: a.createdAt.toISOString(),
+    resolvedAt: a.resolvedAt ? a.resolvedAt.toISOString() : null,
+    resolution: a.resolution,
+    note: a.note,
+  }
+}
 
 /**
  * Platform-admin view of payment anomalies needing review (#508 P2). Imperative
@@ -18,14 +45,14 @@ import type { PaymentAnomaly } from '../stores'
 export class PaymentAnomalyService {
   constructor(private readonly anomalies: PaymentAnomalyRepository) {}
 
-  async listUnresolved(ctx: CallerContext): Promise<PaymentAnomaly[]> {
+  async listUnresolved(ctx: CallerContext): Promise<PaymentAnomalyView[]> {
     requirePlatformRead(ctx)
-    return this.anomalies.listUnresolved()
+    return (await this.anomalies.listUnresolved()).map(toView)
   }
 
-  async listResolved(ctx: CallerContext): Promise<PaymentAnomaly[]> {
+  async listResolved(ctx: CallerContext): Promise<PaymentAnomalyView[]> {
     requirePlatformRead(ctx)
-    return this.anomalies.listResolved()
+    return (await this.anomalies.listResolved()).map(toView)
   }
 
   /**
@@ -42,7 +69,7 @@ export class PaymentAnomalyService {
     id: string,
     resolution: PaymentAnomalyResolution,
     note: string | null,
-  ): Promise<PaymentAnomaly> {
+  ): Promise<PaymentAnomalyView> {
     requirePlatformAdmin(ctx)
     const resolved = await this.anomalies.resolve(id, {
       resolution,
@@ -50,6 +77,6 @@ export class PaymentAnomalyService {
       note,
     })
     if (!resolved) throw new NotFoundError('payment anomaly not found or already resolved')
-    return resolved
+    return toView(resolved)
   }
 }

--- a/packages/api/src/services/payment-anomaly.ts
+++ b/packages/api/src/services/payment-anomaly.ts
@@ -37,8 +37,8 @@ function toView(a: PaymentAnomaly): PaymentAnomalyView {
 
 /**
  * Platform-admin view of payment anomalies needing review (#508 P2). Imperative
- * shell: it gates the caller (only STAFF/ADMIN/PLATFORM_ADMIN — never OPERATOR_*)
- * then reads the unscoped repo. `requirePlatformRead` lives here (not only at the
+ * shell: it gates the caller (only PLATFORM_ADMIN — never OPERATOR_*; legacy
+ * STAFF/ADMIN lost platform access in #487) then reads the unscoped repo. `requirePlatformRead` lives here (not only at the
  * route) so the gate travels with the business logic — the repo's `listUnresolved`
  * is cross-operator, so this service is the authz chokepoint (mirrors #462 revenue).
  */

--- a/packages/api/tests/middleware/platform-member.test.ts
+++ b/packages/api/tests/middleware/platform-member.test.ts
@@ -1,0 +1,40 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import { requirePlatformMember } from '../../src/middleware/auth'
+import { testAuthMiddleware } from '../helpers/auth'
+
+// #1164: the /admin/* role gate must be STRUCTURAL, not only per-handler. A
+// sibling route added to an admin sub-app that forgets its in-body
+// requirePlatform* call must STILL reject a non-platform caller. We prove that by
+// mounting an admin route with NO in-body gate behind only the prefix middleware
+// and asserting authz still holds — the exact regression the issue describes.
+function appWith(role: Parameters<typeof testAuthMiddleware>[1]): Hono {
+  const app = new Hono()
+  app.use('/admin/*', testAuthMiddleware('u1', role))
+  app.use('/admin/*', requirePlatformMember())
+  // Deliberately NO in-body requirePlatform* call here — simulates a future sibling.
+  app.get('/admin/unguarded', (c) => c.json({ ok: true }))
+  setupGlobalHandlers(app)
+  return app
+}
+
+describe('requirePlatformMember structural /admin/* gate (#1164)', () => {
+  it('403s a tenant operator on an in-body-ungated admin route', async () => {
+    const res = await appWith('OPERATOR_OWNER').request('/admin/unguarded')
+    expect(res.status).toBe(403)
+    expect((await res.json()).error).toBe('Forbidden')
+  })
+
+  it('403s a renter on the same ungated route (only the platform tier passes)', async () => {
+    const res = await appWith('RENTER').request('/admin/unguarded')
+    expect(res.status).toBe(403)
+  })
+
+  it('admits PLATFORM_ADMIN through the structural gate', async () => {
+    const res = await appWith('PLATFORM_ADMIN').request('/admin/unguarded')
+    expect(res.status).toBe(200)
+    expect((await res.json()).ok).toBe(true)
+  })
+})

--- a/packages/api/tests/routes/payment-anomalies.test.ts
+++ b/packages/api/tests/routes/payment-anomalies.test.ts
@@ -122,3 +122,39 @@ describe('PaymentAnomalyService — defence-in-depth seal', () => {
     },
   )
 })
+
+describe('PaymentAnomalyService — wire projection lives in the service (#1164)', () => {
+  // The entity->wire projection moved out of the route into the service. Pin it at
+  // the service boundary so reverting it (service returning the persistence entity)
+  // fails here even if a route happened to re-project. Mutation-resistant: a Date
+  // createdAt or a leaked internal column trips these.
+  it('listUnresolved returns ISO-string views, not Date entities', async () => {
+    const service = new PaymentAnomalyService(seeded())
+    const views = await service.listUnresolved({ userId: 'platform', role: 'PLATFORM_ADMIN' })
+    expect(views).toHaveLength(1)
+    const view = views[0]
+    if (!view) throw new Error('expected one unresolved view')
+    expect(typeof view.createdAt).toBe('string')
+    expect(view.createdAt).toBe('2026-06-10T03:00:00.000Z')
+    expect(view.resolvedAt).toBeNull()
+    expect('stripeCheckoutSessionId' in view).toBe(false)
+    expect('resolvedBy' in view).toBe(false)
+  })
+
+  it('resolve returns a projected view with the ISO resolvedAt set', async () => {
+    const repo = seeded()
+    const service = new PaymentAnomalyService(repo)
+    const [unresolved] = await service.listUnresolved({ userId: 'p', role: 'PLATFORM_ADMIN' })
+    if (!unresolved) throw new Error('expected an unresolved anomaly to resolve')
+    const view = await service.resolve(
+      { userId: 'p', role: 'PLATFORM_ADMIN' },
+      unresolved.id,
+      'CONFIRMED_INTENDED',
+      'looks fine',
+    )
+    expect(view.resolution).toBe('CONFIRMED_INTENDED')
+    expect(view.note).toBe('looks fine')
+    expect(typeof view.resolvedAt).toBe('string')
+    expect('resolvedBy' in view).toBe(false)
+  })
+})

--- a/packages/web/src/routes/$locale/_admin.tsx
+++ b/packages/web/src/routes/$locale/_admin.tsx
@@ -5,7 +5,7 @@ import { sessionQueryOptions } from '@/vite/session'
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
 // Platform admin layout guard (#462 §2.3, ported from the frozen Next.js
-// `(admin)/layout.tsx`): admits PLATFORM_ADMIN + legacy STAFF/ADMIN only.
+// `(admin)/layout.tsx`): admits PLATFORM_ADMIN only (legacy STAFF/ADMIN revoked in #487).
 // Wrong role -> silent redirect to landing; signed-out -> login with returnTo.
 export const Route = createFileRoute('/$locale/_admin')({
   beforeLoad: async ({ context, params, location }) => {

--- a/packages/web/src/vite/guards.ts
+++ b/packages/web/src/vite/guards.ts
@@ -17,7 +17,7 @@ export function businessGuard(session: Session | null): GuardResult {
 }
 
 // A *tenant-scoped* operator session carries an operatorId (#521); bypass business
-// roles (PLATFORM_ADMIN, legacy STAFF/ADMIN) do not. This mirrors the API's read scope
+// roles (PLATFORM_ADMIN) do not. This mirrors the API's read scope
 // (`operatorReadScope(ctx).kind !== 'all'`) and gates the operator-portal write
 // affordances (Add/Edit/Archive) because those forms carry no operator picker: a write
 // needs a single target tenant, which only an operator session supplies. It is
@@ -42,6 +42,6 @@ export function adminGuard(session: Session | null): GuardResult {
   if (!session) return { type: 'login' }
   // Narrower than businessGuard: tenant-scoped OPERATOR_* roles clear the business
   // gate but must NOT reach the cross-tenant /admin portal (#462 §2.3). Legacy
-  // STAFF/ADMIN are still admitted (platform-roles.ts) until #487 revokes them.
+  // STAFF/ADMIN were revoked from platform access in #487 (platform-roles.ts).
   return isPlatformAdmin(session.user.role) ? { type: 'allow' } : { type: 'forbidden' }
 }


### PR DESCRIPTION
## What & why

GA hardening for the platform-admin dashboard surface (#1075 epic). Three tightly-scoped, defense-in-depth changes — no schema migration, no behavioral change for any legitimate caller.

### A — Structural `/admin/*` role gate (MED)
New `requirePlatformMember()` middleware mounted at the `/admin/*` prefix in the composition root, right after `app.use('/admin/*', requireAuth())`. Makes the role gate **structural**, not only per-handler: a future sibling admin route that forgets its in-body `requirePlatform*` call is now still authz-protected (fail-closed). Per-handler gates stay as defense-in-depth and keep the stricter write-only `requirePlatformAdmin` distinction. The floor delegates to the canonical `requirePlatformRead` guard — **one policy source, two enforcement points** (no drift), and it uses the *looser* read floor so it can never lock out a caller a per-handler gate already admits.

### B — Move payment-anomaly entity→wire projection into the service (MED)
`routes/payment-anomalies.ts` imported the `PaymentAnomaly` persistence entity from `../stores` and hand-rolled `toView` — a layer leak the boundary linter doesn't catch (it only blocks `../repositories/*`). Moved `toView` into `PaymentAnomalyService`; service methods now return `PaymentAnomalyView`, the route just forwards the DTO and no longer imports `../stores`. Matches the house pattern (`AdminRevenueService`/`AdminOverviewService` already return wire DTOs).

### C — Correct stale authz comments (LOW)
Five comments still described STAFF/ADMIN as admitted to the admin surface; post-#487 it admits `{PLATFORM_ADMIN}` only. Comment-only, no logic change.

## Tests
- `tests/middleware/platform-member.test.ts` (new): mounts an in-body-**ungated** `/admin` route behind only the prefix middleware; proves OPERATOR_OWNER/RENTER still 403 and PLATFORM_ADMIN 200 — the exact regression A defends against.
- `tests/routes/payment-anomalies.test.ts` (new block): pins the projection at the service boundary (ISO `createdAt` string, internal `stripeCheckoutSessionId`/`resolvedBy` columns dropped) so reverting B fails here.

## Verification
- tsc ×3 green · `lint:boundaries` OK · biome clean
- api **2207/2207** · web **1393/1393**
- code-reviewer: **SHIP** (no CRIT/HIGH/MED) · architect: **SHIP** (no CRIT/HIGH/MED, 2 LOW nits → deferred follow-up)

## Deferred follow-up (out of scope; issue to be filed)
- Extend `scripts/check-import-boundaries.ts` to also block `../stores` imports in `routes/` (closes the blind spot B navigated around), then refactor the 3 config slices (insurance-options / add-ons / fee-schedules) to DTO-projecting services.
- Architect LOW nits: a lint/doc guard that platform surfaces must mount under `/admin/` (the floor is path-prefix-bound), and optionally make `requirePlatformMember` fail-closed with 401 on its own (currently unreachable — `requireAuth` runs first).

Closes #1164