### PR TITLE
fix(#1194): reconcile driving-eligibility IDP_OK against Keishicho (drop 16 false-accepts)

### DIFF
--- a/packages/shared/src/lib/driving-eligibility.test.ts
+++ b/packages/shared/src/lib/driving-eligibility.test.ts
@@ -33,28 +33,21 @@ describe('country reference data — full membership pinned', () => {
     ])
   })
 
-  it('IDP_OK is the pinned 101-country Japan-accepted Geneva set (Vietnam excluded)', () => {
+  it('IDP_OK is the pinned 85-country Japan-accepted Geneva set (Keishicho-excluded + Vietnam removed)', () => {
     const expected = [
       'AE',
-      'AL',
       'AR',
       'AT',
       'AU',
       'BB',
-      'BD',
-      'BE',
       'BF',
-      'BG',
       'BJ',
       'BN',
-      'BW',
       'CA',
       'CD',
       'CF',
       'CG',
-      'CI',
       'CL',
-      'CU',
       'CY',
       'CZ',
       'DK',
@@ -66,10 +59,8 @@ describe('country reference data — full membership pinned', () => {
       'ES',
       'FI',
       'FJ',
-      'FR',
       'GB',
       'GE',
-      'GH',
       'GR',
       'GT',
       'HR',
@@ -88,16 +79,13 @@ describe('country reference data — full membership pinned', () => {
       'KR',
       'LA',
       'LB',
-      'LI',
       'LK',
       'LS',
       'LT',
       'LU',
       'MA',
-      'ME',
       'MG',
       'ML',
-      'MC',
       'MT',
       'MW',
       'MY',
@@ -114,9 +102,6 @@ describe('country reference data — full membership pinned', () => {
       'PT',
       'PY',
       'RO',
-      'RS',
-      'RU',
-      'RW',
       'SE',
       'SG',
       'SI',
@@ -135,19 +120,45 @@ describe('country reference data — full membership pinned', () => {
       'VA',
       'VE',
       'ZA',
-      'ZW',
     ]
     expect([...IDP_OK_COUNTRIES].sort()).toEqual(expected.sort())
-    expect(IDP_OK_COUNTRIES.size).toBe(101)
+    expect(IDP_OK_COUNTRIES.size).toBe(85)
   })
 
-  it('the only overlap between the two sets is FR/BE/MC/SI', () => {
+  it('the only overlap between the two sets is SI (Slovenia)', () => {
+    // FR/BE/MC left IDP_OK (their IDPs are not Geneva-format → not valid in Japan);
+    // SI is the lone remaining dual-member (its translation-set membership is being
+    // re-verified separately — see #1194 follow-up).
     const overlap = [...IDP_OK_COUNTRIES].filter((c) => TRANSLATION_REQUIRED_COUNTRIES.has(c))
-    expect(overlap.sort()).toEqual(['BE', 'FR', 'MC', 'SI'])
+    expect(overlap.sort()).toEqual(['SI'])
   })
 
   it('known not-accepted origins are absent from IDP_OK', () => {
-    for (const code of ['VN', 'CN', 'ID', 'DE', 'CH', 'TW']) {
+    for (const code of [
+      'VN',
+      'CN',
+      'ID',
+      'DE',
+      'CH',
+      'TW',
+      // Keishicho "Geneva parties that do NOT issue Geneva-format IDPs" — invalid in Japan:
+      'FR',
+      'BE',
+      'MC',
+      'AL',
+      'BD',
+      'BG',
+      'BW',
+      'CI',
+      'CU',
+      'GH',
+      'LI',
+      'ME',
+      'RS',
+      'RU',
+      'RW',
+      'ZW',
+    ]) {
       expect(IDP_OK_COUNTRIES.has(code)).toBe(false)
     }
   })
@@ -163,9 +174,10 @@ describe('classifyDrivingEligibility — translation-required (JAF) jurisdiction
     },
   )
 
-  it('the translation rule wins for jurisdictions that are ALSO Geneva parties (FR/BE/MC/SI precedence)', () => {
-    // France, Belgium, Monaco and Slovenia are 1949 Geneva contracting parties,
-    // but Japan binds them to the translation path — translation must be checked first.
+  it('the translation path applies to FR/BE/MC/SI (translation checked before IDP_OK)', () => {
+    // All four are 1949 Geneva parties bound to the translation path. FR/BE/MC are no
+    // longer in IDP_OK (their IDPs are not Geneva-format); SI remains in both, so the
+    // translation-first precedence still governs it.
     for (const code of ['FR', 'BE', 'MC', 'SI']) {
       expect(classifyDrivingEligibility(code)).toBe('TRANSLATION_REQUIRED')
     }
@@ -187,6 +199,20 @@ describe('classifyDrivingEligibility — recognized but neither list', () => {
   // and Vietnam (disputed → safe-fail to a "verify before booking" warning).
   it.each(['CN', 'BR', 'ID', 'MX', 'SA', 'VN'])(
     '%s is a recognized country on neither list -> NOT_ELIGIBLE',
+    (code) => {
+      expect(classifyDrivingEligibility(code)).toBe('NOT_ELIGIBLE')
+    },
+  )
+})
+
+describe('classifyDrivingEligibility — 1949 parties that issue non-Geneva-format IDPs', () => {
+  // These ARE 1949 Geneva Convention parties, but Japan (Tokyo Metropolitan Police,
+  // 2026-06-12) lists them as NOT issuing Geneva-FORMAT IDPs, so their IDP is not
+  // valid for driving in Japan, and they have no translation arrangement (unlike
+  // FR/BE/MC) — the renter must convert to a JP licence. Classify NOT_ELIGIBLE.
+  // RU (Russia) is the case reported in #1194.
+  it.each(['RU', 'AL', 'BD', 'BG', 'BW', 'CI', 'CU', 'GH', 'LI', 'ME', 'RS', 'RW', 'ZW'])(
+    '%s is a 1949 party whose IDP Japan does not accept -> NOT_ELIGIBLE',
     (code) => {
       expect(classifyDrivingEligibility(code)).toBe('NOT_ELIGIBLE')
     },

--- a/packages/shared/src/lib/driving-eligibility.ts
+++ b/packages/shared/src/lib/driving-eligibility.ts
@@ -15,15 +15,19 @@
 // clearing an ineligible one is a refused car at the counter — the exact failure
 // this feature exists to prevent. Err toward the warning.
 //
-// Sources (lists change rarely; re-verify against Japan's NPA list when amending):
-//   - Translation-required set (7): JAF published list — Switzerland, Germany,
-//     France, Belgium, Monaco, Slovenia, Taiwan.
-//   - IDP-accepted set: Japan-accepted 1949 Geneva Convention parties, cross-checked
-//     across Japan-operational sources (JAF, ToCoo, kart.st, niconico). Vietnam is
-//     DELIBERATELY EXCLUDED — sources conflict (it is a 1968 Vienna party; Japan
-//     guidance commonly rejects its IDP), so per the safe-fail rule it warns.
-//     The full set must be reconciled against the NPA "List of Contracting States
-//     to the Geneva Convention" before slice 2 surfaces this to renters.
+// Sources (PRIMARY — re-verify HERE when amending, NOT against rental-site aggregators):
+//   - Who Japan accepts (operational truth): Tokyo Metropolitan Police (Keishicho),
+//     https://www.keishicho.metro.tokyo.lg.jp/menkyo/menkyo/kokugai/kokugai04.html
+//     (as of 2026-06-12). KEY NUANCE: being a 1949 party is NOT sufficient — Japan also
+//     publishes a list of 1949 parties that do NOT issue a Geneva-FORMAT IDP (e.g. Russia
+//     issues a 1968-Vienna-format permit), whose IDP is NOT valid in Japan. Those are
+//     excluded from IDP_OK: the 3 with a translation arrangement (FR/BE/MC) sit in the
+//     translation set; the rest classify NOT_ELIGIBLE.
+//   - Who is a 1949 party (treaty status): UN Treaty Collection, chapter XI-B-1,
+//     https://treaties.un.org/Pages/ViewDetailsV.aspx?src=TREATY&mtdsg_no=XI-B-1&chapter=11
+//   - Vietnam is DELIBERATELY EXCLUDED (disputed; safe-fail to a warning).
+//   - Aggregators (JAF mirrors, ToCoo, kart.st, niconico) reproduce the raw parties
+//     roster and omit the exclusion overlay — they are what caused the original drift (#1194).
 
 export const ELIGIBILITY_CLASSES = [
   'IDP_OK',
@@ -34,9 +38,11 @@ export const ELIGIBILITY_CLASSES = [
 
 export type EligibilityClass = (typeof ELIGIBILITY_CLASSES)[number]
 
-// The 7 jurisdictions whose home licenses need a JAF/embassy Japanese translation,
-// NOT a Geneva IDP. This is the binding rule even for the four that are also Geneva
-// parties (FR/BE/MC/SI), so this set is checked FIRST. ISO 3166-1 alpha-2.
+// Jurisdictions Japan accepts only via a JAF/embassy Japanese translation, NOT a Geneva
+// IDP. FR/BE/MC are 1949 parties that do NOT issue a Geneva-format IDP, so they are
+// excluded from IDP_OK. This set is checked FIRST, so the translation rule wins for any
+// code also in IDP_OK — currently only SI, whose translation-set membership is being
+// re-verified (#1194 follow-up). ISO 3166-1 alpha-2.
 // Exported for the contract test that pins the full membership (data IS the feature).
 export const TRANSLATION_REQUIRED_COUNTRIES: ReadonlySet<string> = new Set([
   'CH',
@@ -48,112 +54,97 @@ export const TRANSLATION_REQUIRED_COUNTRIES: ReadonlySet<string> = new Set([
   'TW',
 ])
 
-// Japan-accepted 1949 Geneva Convention parties — Japan accepts an IDP issued by
-// these. ISO 3166-1 alpha-2. FR/BE/MC/SI also appear here, but the translation rule
-// above wins. Vietnam is deliberately excluded (see header). (101 entries.)
-// Exported for the contract test that pins the full membership.
+// 1949 Geneva Convention parties whose Geneva-FORMAT IDP Japan actually honours.
+// ISO 3166-1 alpha-2, sorted. = (UN list of 1949 parties) MINUS Japan's published
+// "Geneva party that does NOT issue a Geneva-format IDP" exclusion list (see header)
+// MINUS Vietnam (disputed). SI also appears in the translation set, where the
+// translation rule wins. Exported for the contract test that pins membership. (85 entries.)
 export const IDP_OK_COUNTRIES: ReadonlySet<string> = new Set([
-  'AL',
-  'DZ',
+  'AE',
   'AR',
-  'AU',
   'AT',
-  'BD',
+  'AU',
   'BB',
-  'BE',
-  'BJ',
-  'BW',
-  'BN',
-  'BG',
   'BF',
-  'KH',
+  'BJ',
+  'BN',
   'CA',
+  'CD',
   'CF',
-  'CL',
   'CG',
-  'CI',
-  'HR',
-  'CU',
+  'CL',
   'CY',
   'CZ',
-  'CD',
   'DK',
   'DO',
+  'DZ',
   'EC',
-  'EG',
   'EE',
-  'FJ',
+  'EG',
+  'ES',
   'FI',
-  'FR',
+  'FJ',
+  'GB',
   'GE',
-  'GH',
   'GR',
   'GT',
+  'HR',
   'HT',
-  'VA',
   'HU',
-  'IS',
-  'IN',
   'IE',
   'IL',
+  'IN',
+  'IS',
   'IT',
   'JM',
-  'JP',
   'JO',
+  'JP',
   'KG',
+  'KH',
+  'KR',
   'LA',
   'LB',
+  'LK',
   'LS',
-  'LI',
   'LT',
   'LU',
+  'MA',
   'MG',
-  'MW',
-  'MY',
   'ML',
   'MT',
-  'MC',
-  'ME',
-  'MA',
+  'MW',
+  'MY',
   'NA',
-  'NL',
-  'NZ',
   'NE',
   'NG',
+  'NL',
   'NO',
-  'PG',
-  'PY',
+  'NZ',
   'PE',
+  'PG',
   'PH',
   'PL',
   'PT',
+  'PY',
   'RO',
-  'RU',
-  'RW',
+  'SE',
+  'SG',
+  'SI',
+  'SK',
+  'SL',
   'SM',
   'SN',
-  'RS',
-  'SL',
-  'SG',
-  'SK',
-  'SI',
-  'ZA',
-  'KR',
-  'ES',
-  'LK',
-  'SE',
   'SY',
-  'TH',
   'TG',
-  'TT',
+  'TH',
   'TN',
   'TR',
+  'TT',
   'UG',
-  'AE',
-  'GB',
   'US',
+  'VA',
   'VE',
-  'ZW',
+  'ZA',
 ])
 
 const ALPHA2 = /^[A-Z]{2}$/
@@ -185,10 +176,17 @@ function isRecognizedCountry(code: string): boolean {
 }
 
 /**
- * Classify a license-issuing jurisdiction into the document a foreign driver needs
- * to drive in Japan. Pure and total — never throws; empty/malformed/unassigned input
- * is `UNKNOWN`. The translation-required set is checked before the Geneva IDP set so
- * the binding rule wins for the jurisdictions on both (FR/BE/MC/SI).
+ * Classify a license-issuing jurisdiction into the document a foreign driver needs to
+ * drive in Japan. Never throws; empty/malformed/unassigned input is `UNKNOWN`.
+ *
+ * Determinism: the IDP_OK / TRANSLATION_REQUIRED classification is fully data-driven and
+ * deterministic. The residual NOT_ELIGIBLE-vs-UNKNOWN split relies on `Intl.DisplayNames`,
+ * whose recognized-region set is ICU-version-dependent (Bun vs workerd), so that one
+ * boundary can differ across runtimes. Back it with an explicit ISO-3166-1 set before
+ * slice 2 branches on the distinction (#1194 follow-up).
+ *
+ * The translation set is checked before IDP_OK so the translation rule wins for any code
+ * in both (currently only SI).
  *
  * @param countryCode ISO 3166-1 alpha-2 of the license-issuing jurisdiction (any case).
  */


### PR DESCRIPTION
## Summary

The issue's premise — "RU misclassified as `IDP_OK` because it's a 1968 Vienna (not 1949 Geneva) party" — is **directionally right but factually wrong about the reason**. RU, GE, and KG are all genuine **1949 Geneva parties** (UN Treaty Collection XI-B-1).

The real defect: our `IDP_OK` set was built from the *1949-parties roster*, but Japan additionally **excludes 1949 parties that don't issue Geneva-FORMAT IDPs**. Against the Tokyo Metropolitan Police (Keishicho) list (as of May 2026), **16 of our 101 `IDP_OK` countries were false-accepts** — the exact dangerous direction this module exists to prevent.

## Authoritative sources (replace the aggregator citations in the file header)

- **Who Japan accepts (operational truth):** Keishicho 国際運転免許証 page — publishes the decisive overlay *"ジュネーブ条約締約国のうち、ジュネーブ様式の国際運転免許証未発給国"* (Geneva parties that do NOT issue Geneva-format IDPs → invalid in Japan).
- **Who is a 1949 party:** UN Treaty Collection XI-B-1.
- Verified ×3 (two research-agent fetches + one manual) — identical verbatim list. The aggregator/prefectural lists that omit this overlay are the source of the original error.

## Changes (all tightening or behavior-neutral — nothing loosened)

1. **13 removed from `IDP_OK` → `NOT_ELIGIBLE`:** AL, BD, BG, BW, CI, CU, GH, LI, ME, RS, RU, RW, ZW. (Behavioral fix: "your IDP works" → "not eligible / verify at pickup".)
2. **FR, BE, MC removed from `IDP_OK`** but kept in the translation set → `TRANSLATION_REQUIRED`. Behavior-neutral (classifier checks the translation set first); makes `IDP_OK` mean exactly "Japan accepts this IDP".

**Resulting sets:** `IDP_OK` **101 → 85**; `TRANSLATION_REQUIRED` **7 (unchanged)**; overlap **4 → 1** (`SI`).

**Kept (clean keeps, same Keishicho authority):** GE, KG — verified 1949 parties NOT on the exclusion list.

## Product / rollout note (owner sign-off)

Removes 13 countries (incl. Russia, Bulgaria, Serbia, Bangladesh, Cuba) from "can drive on an IDP." This is the legally-correct, liability-protective state (Japan genuinely refuses those IDPs at the counter). Slice 1 is **data-only / not yet wired**, so it surfaces no UI change until #1069 slice 2 — timing is right. No migration, no API/web.

## Follow-ups filed

- **SI** — verify Japan's *statutory* translation set vs a primary source (NPA/embassy); drop SI from translation set only if confirmed (lone loosening direction — highest evidence bar).
- **BH** — verify-then-add (false-accept is the dangerous direction; status quo `NOT_ELIGIBLE` is safe-fail).
- **Explicit ISO-3166-1 alpha-2 set** to replace `Intl.DisplayNames` in `isRecognizedCountry` — the `NOT_ELIGIBLE`↔`UNKNOWN` split is currently ICU-version-dependent (Bun local vs workerd prod). **Hard blocker on #1069 slice 2** (which renders the two states differently).

## Test plan

- [x] `bunx vitest run packages/shared driving-eligibility` — **51/51 green** (TDD, RU-first then full set; pinned 85-member membership + overlap + absence tests).
- [x] `@kuruma/shared typecheck` clean.
- [x] Rebased onto current develop (`304ebf47`) with zero conflicts.
- [ ] Owner squash-merge.

Closes #1194