### PR TITLE
feat(#1101): vehicle-blocks fleet-wide read endpoint (Slice A of 2)

### DIFF
--- a/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
+++ b/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
@@ -75,13 +75,14 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
    return { kind: 'none' } // in-gate but neither bypass nor tenant (legacy STAFF/ADMIN): read nothing
    ```
    (RENTER/PARTNER never reach it — route-gated out.) Repo consumer keeps a `scope satisfies never` guard.
-2. **Repo** — add `findOverlappingInRange(scope, from, to): Promise<VehicleBlock[]>` to
-   `VehicleBlockRepository` (`types-vehicle-block.ts`), taking the scope union (not a bare operatorId):
-   `all` → no operator filter; `operator` → `operatorId =`; `none` → `[]`. Implement in both
-   `in-memory/vehicle-block.ts` and `drizzle/vehicle-block.ts` with the half-open
-   `tstzrange(startAt,endAt) && tstzrange(from,to)` overlap (adjacent = no overlap; mirror `findOverlapping`).
-3. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: resolve via `vehicleBlockReadScope(ctx)`,
-   call `findOverlappingInRange(scope, from, to)`. Returns `VehicleBlock[]`.
+2. **Repo** — add `findOverlappingInRange(ctx, from, to): Promise<VehicleBlock[]>` to
+   `VehicleBlockRepository` (`types-vehicle-block.ts`). Per the codebase convention (`in-memory/vehicle-class.ts`
+   imports `operatorReadScope` and resolves scope **inside** the repo), the method takes `ctx` and calls
+   `vehicleBlockReadScope(ctx)` itself: `all` → no operator filter; `operator` → `operatorId =`; `none` → `[]`
+   (Drizzle: `sql\`false\``). Implement in both `in-memory/vehicle-block.ts` and `drizzle/vehicle-block.ts` with
+   the half-open `tstzrange(startAt,endAt) && tstzrange(from,to)` overlap (adjacent = no overlap; mirror `findOverlapping`).
+3. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: thin delegation to
+   `findOverlappingInRange(ctx, from, to)` (scope enforced in the repo). Returns `VehicleBlock[]`.
 4. **Route** — `GET /vehicle-blocks?from&to` (fleet-wide collection read; top-level resource, clearer than a
    bare `/blocks` and unambiguous vs the `POST`/`DELETE /vehicles/:vehicleId/blocks` writes). Gate
    `MANAGEMENT_READ_ROLES.has(role)` else 403 (mirror `routes/maintenance-logs.ts:13`). The time window is the

--- a/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
+++ b/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
@@ -50,47 +50,87 @@ react-calendar-timeline spike (separate, unmerged).
 
 Vertical slice with standalone value: the fleet's blocks become queryable.
 
-1. **Repo** — add `findOverlappingForOperator(operatorId, from, to): Promise<VehicleBlock[]>` to
-   `VehicleBlockRepository` (`types-vehicle-block.ts`); implement in both `in-memory/vehicle-block.ts`
-   (filter store by operatorId + half-open `[from,to)` overlap) and `drizzle/vehicle-block.ts`
-   (`tstzrange(startAt,endAt) && tstzrange(from,to)` + `operatorId =`). Half-open; adjacent = no overlap
-   (mirror existing `findOverlapping`).
-2. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: resolve operator scope using the **same
-   read-scope resolver the operator calendar bookings read already uses** (not the write-scope helper), then
-   call `findOverlappingForOperator(operatorId, from, to)`. Returns `VehicleBlock[]`. Verify the exact
-   resolver name against the `GET /bookings` calendar handler during TDD; do not invent a second scoping path.
-3. **Route** — `GET /blocks?from&to` (fleet-wide, root-mounted). Use `parseDateRange` from `routes/helpers.ts`
-   for `from`/`to`; gate mirrors the operator calendar bookings read (`MANAGEMENT_READ_ROLES`). Returns
-   `ok([...blocks])`. Wire in `index.ts`.
-4. **Tests (TDD):** in-memory repo parity (operator isolation + overlap window); service operator-scope;
-   route happy-path + cross-operator returns only caller's blocks + bad range → 400; real-pg range query.
+> **Scope contract first (review P1).** Blocks are operator-internal management data — never
+> renter- or partner-facing — so unlike `GET /bookings` (open to all authed users, scoped in the repo)
+> the blocks read is **gated to `MANAGEMENT_READ_ROLES`** (= `BUSINESS_ROLES`: PLATFORM_ADMIN + tenant
+> operators; RENTER/PARTNER → 403 at the route). Within that gate the **row-scope is an explicit union**
+> mirroring `bookingReadScope`'s admin/operator arms (minus partner/renter, which the gate already excludes):
+> ```ts
+> type VehicleBlockReadScope =
+>   | { kind: 'all' }                         // PLATFORM_ADMIN (ctx.bypassScope) — cross-operator preview (#1161)
+>   | { kind: 'operator'; operatorId: string } // OPERATOR_* with operatorId — own tenant only
+>   | { kind: 'none' }                         // OPERATOR_* missing operatorId — fail-closed, read nothing
+> ```
+
+1. **Scope resolver** — add `vehicleBlockReadScope(ctx): VehicleBlockReadScope` in `tenancy.ts` beside
+   `bookingReadScope`: `ctx.bypassScope → all`; `isOperatorRole && operatorId → operator`; operator
+   without operatorId → `none`. (RENTER/PARTNER never reach it — route-gated out.) Mirrors #1119's
+   `scope satisfies never` exhaustiveness guard.
+2. **Repo** — add `findOverlappingInRange(scope, from, to): Promise<VehicleBlock[]>` to
+   `VehicleBlockRepository` (`types-vehicle-block.ts`), taking the scope union (not a bare operatorId):
+   `all` → no operator filter; `operator` → `operatorId =`; `none` → `[]`. Implement in both
+   `in-memory/vehicle-block.ts` and `drizzle/vehicle-block.ts` with the half-open
+   `tstzrange(startAt,endAt) && tstzrange(from,to)` overlap (adjacent = no overlap; mirror `findOverlapping`).
+3. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: resolve via `vehicleBlockReadScope(ctx)`,
+   call `findOverlappingInRange(scope, from, to)`. Returns `VehicleBlock[]`.
+4. **Route** — `GET /blocks?from&to` (fleet-wide, root-mounted). Gate `MANAGEMENT_READ_ROLES.has(role)`
+   else 403 (mirror `routes/maintenance-logs.ts:13`); `parseDateRange` for the window; `ok([...blocks])`.
+   Wire in `index.ts`.
+5. **Tests (TDD):** repo `findOverlappingInRange` for each scope arm (in-memory + real-pg parity);
+   **service-level scoping** — admin (`all`) sees blocks across two operators, operator sees only its own,
+   operator-without-operatorId (`none`) sees nothing; route — happy path, RENTER/PARTNER → 403, bad range → 400.
 
 ## Slice B — web UI (own PR), extends `operator-bookings`
 
-5. **`api.ts`** — `fetchCalendarBlocks(from, to)` → `GET /blocks?from&to`, parsed by `calendarBlockSchema`;
+> **Discriminated calendar item (review P1.2).** The existing `CalendarEvent` smuggles "this is a booking"
+> through `status` (`STATUS_CLASS[event.status]`, `BookingsCalendar.tsx:103`), `filterEvents`'s
+> `{ resourceId; status }` constraint (`useCalendarFilters.ts:53`), and the route click handler treating
+> every `id` as a booking id (`index.tsx:134`). Blocks have no `status`. So introduce an explicit discriminant
+> rather than overloading the booking shape:
+> ```ts
+> type BookingCalendarEvent = CalendarEvent & { type: 'booking' }       // carries status
+> type BlockCalendarEvent  = { type: 'block'; id; title; start; end; resourceId; kind } // carries kind, no status
+> type CalendarItem = BookingCalendarEvent | BlockCalendarEvent
+> ```
+> Every consumer switches on `type` at the boundary: styling, filtering, and click dispatch.
+
+6. **`api.ts`** — `fetchCalendarBlocks(from, to)` → `GET /blocks?from&to`, parsed by `calendarBlockSchema`;
    `operatorCalendarBlocksQueryOptions(from, to)` (queryKey `['operator-bookings','blocks',from,to]`);
    `createBlock(vehicleId, input, csrf)` → POST; `deleteBlock(vehicleId, blockId, csrf)` → DELETE. Mutations
    invalidate `OPERATOR_BOOKINGS_KEY` (prefix cascade covers calendar + blocks).
-6. **`schema.ts`** — `calendarBlockSchema` DTO (`id, vehicleId, startAt, endAt, kind, reason, notes, createdBy`).
-7. **`calendar-events.ts`** — `blocksToCalendarEvents(blocks)`: map to react-big-calendar events keyed by
-   `resourceId = vehicleId`, tagged `type: 'block'` + `kind`. Merge with booking events for one `events` array.
-8. **`BookingsCalendar.tsx`** — render block bands distinctly (neutral/hatched background, per-kind color +
-   icon, via `eventPropGetter`); add a legend; enable `selectable` so an empty-slot drag opens the create
-   dialog prefilled with vehicle + range; `onSelectEvent` on a block opens the detail dialog. Whole blocks
-   layer gated behind `isVisibleToViewer(isOperatorBlocksEnabled(), role)`.
-9. **`ScheduleBlockDialog.tsx`** (new) — vehicle picker (defaults to slot vehicle), kind select, start/end,
-   reason, notes; shadcn base-ui (no `asChild`); validates against the shared create schema; on success closes
-   + invalidates. Surfaces 409 (block-vs-block overlap) as a friendly "overlaps an existing block" message.
-10. **`BlockDetailDialog.tsx`** (new) — shows vehicle, kind, window, reason, notes, createdBy; Delete button
-    + confirm (hard delete); on success closes + invalidates.
-11. **i18n** — `blocks` namespace in `messages/{en,ja,zh}.json` (kinds, dialog labels, legend, errors).
-12. **Tests:** transform unit (`blocksToCalendarEvents` styling/keys); dialog round-trip (create → invalidate,
-    delete → invalidate) with mocked api; feature-gate hides the layer for a non-admin when flag OFF.
+7. **`schema.ts`** — `calendarBlockSchema` DTO: `id, vehicleId, startAt, endAt, kind, reason, notes`.
+   **Omit `createdBy`** (review P2): it is a raw audit user id (`fleet.ts:250`), not a display record;
+   surfacing it would need enrichment that isn't in this slice's scope (YAGNI).
+8. **`calendar-events.ts`** — tag existing booking events `type: 'booking'`; add
+   `blocksToCalendarEvents(blocks): BlockCalendarEvent[]` (keyed by `resourceId = vehicleId`, carrying `kind`,
+   no `status`). The component merges both into one `CalendarItem[]`.
+9. **`useCalendarFilters.ts`** — widen `filterEvents` to the `CalendarItem` union: the **status filter applies
+   only to `type:'booking'` items**; blocks are filtered by vehicle (`resourceId`) only. Define this explicitly
+   and test it — a status filter must never silently hide or show a block by accident.
+10. **`BookingsCalendar.tsx`** — `eventPropGetter` switches on `type`: booking → `STATUS_CLASS[status]`,
+    block → per-`kind` band class (neutral/hatched, distinct from status colors) + legend. `onSelectEvent`
+    passes the **item** (not bare id) so the parent can dispatch by `type`. Enable `selectable` so an empty-slot
+    drag opens the create dialog prefilled with vehicle + range. Whole blocks layer gated behind
+    `isVisibleToViewer(isOperatorBlocksEnabled(), role)`.
+11. **Route click dispatch (`bookings/index.tsx`)** — `handleSelectEvent` switches on `type`: `'booking'` →
+    navigate to the booking detail (today's behavior); `'block'` → open `BlockDetailDialog`.
+12. **`ScheduleBlockDialog.tsx`** (new) — vehicle picker (defaults to slot vehicle), kind select, start/end,
+    reason, notes; shadcn base-ui (no `asChild`); validates against the shared create schema; on success closes
+    + invalidates. Surfaces 409 (block-vs-block overlap) as a friendly "overlaps an existing block" message.
+13. **`BlockDetailDialog.tsx`** (new) — shows vehicle, kind, window, reason, notes (no `createdBy`); Delete
+    button + confirm (hard delete); on success closes + invalidates.
+14. **i18n** — `blocks` namespace in `messages/{en,ja,zh}.json` (kinds, dialog labels, legend, errors).
+15. **Tests:** transform unit (`blocksToCalendarEvents` keys/kind); **mixed `CalendarItem[]`** through
+    `filterEvents` (status filter hides a booking but never a block) and `eventPropGetter` (block gets a
+    kind class, booking a status class); **click dispatch** (block → dialog, booking → navigate); dialog
+    round-trip (create/delete → invalidate) with mocked api; feature-gate hides the layer for a non-admin when flag OFF.
 
 ## Risks / notes
 
-- **Scope resolution reuse:** `listBlocks` must use the *same* operator-scope resolver as the calendar
-  bookings read so platform-admin and operator see a consistent fleet. Don't invent a second scoping path.
+- **Row-scope is the contract, not the gate (review P1):** the role gate (`MANAGEMENT_READ_ROLES`) answers
+  "may this caller enter"; the `VehicleBlockReadScope` union answers "which tenant's rows" — both are required.
+  `all` (admin) is exercised by a test that seeds two operators and asserts cross-operator visibility, so
+  admin preview can't silently break and an operator can't accidentally read another tenant.
 - **Visual disambiguation:** block bands must read as clearly *not bookings* (bookings are status-colored);
   use a muted/hatched treatment + kind icon + legend.
 - **Feature-boundary lint (#1110):** keep all new files inside `operator-bookings`; export only through its
@@ -100,8 +140,11 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
 
 ## Acceptance criteria
 
-- Block renders on the operator calendar in the correct vehicle column + window, visually distinct by kind.
+- Block renders on the operator calendar in the correct vehicle column + window, visually distinct by kind
+  (never mistaken for a booking), with a status filter that leaves blocks untouched.
 - Create via button (manual) and via slot-select (prefilled) both round-trip and refresh the calendar.
-- Click a block → detail dialog → delete restores the slot (calendar refreshes).
-- All block reads/writes operator-scoped (cross-operator never visible/mutable).
+- Click a block → detail dialog → delete restores the slot (calendar refreshes); clicking a booking still
+  navigates to the booking detail.
+- Read row-scope: operator sees only its own blocks; PLATFORM_ADMIN preview sees across operators; RENTER/
+  PARTNER → 403. Writes remain operator-scoped (cross-operator never mutable).
 - Entire blocks layer hidden unless `isVisibleToViewer(isOperatorBlocksEnabled(), role)`.

--- a/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
+++ b/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
@@ -59,13 +59,22 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
 > type VehicleBlockReadScope =
 >   | { kind: 'all' }                         // PLATFORM_ADMIN (ctx.bypassScope) — cross-operator preview (#1161)
 >   | { kind: 'operator'; operatorId: string } // OPERATOR_* with operatorId — own tenant only
->   | { kind: 'none' }                         // OPERATOR_* missing operatorId — fail-closed, read nothing
+>   | { kind: 'none' }                         // anyone else in-gate — fail-closed, read nothing
 > ```
 
 1. **Scope resolver** — add `vehicleBlockReadScope(ctx): VehicleBlockReadScope` in `tenancy.ts` beside
-   `bookingReadScope`: `ctx.bypassScope → all`; `isOperatorRole && operatorId → operator`; operator
-   without operatorId → `none`. (RENTER/PARTNER never reach it — route-gated out.) Mirrors #1119's
-   `scope satisfies never` exhaustiveness guard.
+   `bookingReadScope`. **The resolver must be total over the gate's admitted set and fail closed** —
+   `MANAGEMENT_READ_ROLES` (= `BUSINESS_ROLES`) admits legacy `STAFF`/`ADMIN` too, and #487 removed them
+   from `SCOPE_BYPASS_ROLES`, so they pass the gate but are neither bypass nor `isOperatorRole`. Do **not**
+   copy `operatorReadScope` (`tenancy.ts:36`, `!isOperatorRole → all`) — that catalog pattern would hand
+   legacy admins a cross-tenant read. Explicit, fail-closed:
+   ```ts
+   if (ctx.bypassScope) return { kind: 'all' }
+   if (isOperatorRole(ctx.role))
+     return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }
+   return { kind: 'none' } // in-gate but neither bypass nor tenant (legacy STAFF/ADMIN): read nothing
+   ```
+   (RENTER/PARTNER never reach it — route-gated out.) Repo consumer keeps a `scope satisfies never` guard.
 2. **Repo** — add `findOverlappingInRange(scope, from, to): Promise<VehicleBlock[]>` to
    `VehicleBlockRepository` (`types-vehicle-block.ts`), taking the scope union (not a bare operatorId):
    `all` → no operator filter; `operator` → `operatorId =`; `none` → `[]`. Implement in both
@@ -73,12 +82,16 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
    `tstzrange(startAt,endAt) && tstzrange(from,to)` overlap (adjacent = no overlap; mirror `findOverlapping`).
 3. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: resolve via `vehicleBlockReadScope(ctx)`,
    call `findOverlappingInRange(scope, from, to)`. Returns `VehicleBlock[]`.
-4. **Route** — `GET /blocks?from&to` (fleet-wide, root-mounted). Gate `MANAGEMENT_READ_ROLES.has(role)`
-   else 403 (mirror `routes/maintenance-logs.ts:13`); `parseDateRange` for the window; `ok([...blocks])`.
-   Wire in `index.ts`.
+4. **Route** — `GET /vehicle-blocks?from&to` (fleet-wide collection read; top-level resource, clearer than a
+   bare `/blocks` and unambiguous vs the `POST`/`DELETE /vehicles/:vehicleId/blocks` writes). Gate
+   `MANAGEMENT_READ_ROLES.has(role)` else 403 (mirror `routes/maintenance-logs.ts:13`). The time window is the
+   only bound (no limit/cursor), so make the range **required** — `parseDateRange(c, true)` → 400 when
+   `from`/`to` are missing, so no caller can trigger an all-time fleet-wide (or cross-operator) dump.
+   `ok([...blocks])`. Wire in `index.ts`.
 5. **Tests (TDD):** repo `findOverlappingInRange` for each scope arm (in-memory + real-pg parity);
    **service-level scoping** — admin (`all`) sees blocks across two operators, operator sees only its own,
-   operator-without-operatorId (`none`) sees nothing; route — happy path, RENTER/PARTNER → 403, bad range → 400.
+   operator-without-operatorId AND an in-gate non-bypass non-operator (legacy `STAFF`/`ADMIN`) both → `none`
+   (empty); route — happy path, RENTER/PARTNER → 403, missing/bad range → 400.
 
 ## Slice B — web UI (own PR), extends `operator-bookings`
 
@@ -94,7 +107,7 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
 > ```
 > Every consumer switches on `type` at the boundary: styling, filtering, and click dispatch.
 
-6. **`api.ts`** — `fetchCalendarBlocks(from, to)` → `GET /blocks?from&to`, parsed by `calendarBlockSchema`;
+6. **`api.ts`** — `fetchCalendarBlocks(from, to)` → `GET /vehicle-blocks?from&to`, parsed by `calendarBlockSchema`;
    `operatorCalendarBlocksQueryOptions(from, to)` (queryKey `['operator-bookings','blocks',from,to]`);
    `createBlock(vehicleId, input, csrf)` → POST; `deleteBlock(vehicleId, blockId, csrf)` → DELETE. Mutations
    invalidate `OPERATOR_BOOKINGS_KEY` (prefix cascade covers calendar + blocks).
@@ -123,7 +136,9 @@ Vertical slice with standalone value: the fleet's blocks become queryable.
 15. **Tests:** transform unit (`blocksToCalendarEvents` keys/kind); **mixed `CalendarItem[]`** through
     `filterEvents` (status filter hides a booking but never a block) and `eventPropGetter` (block gets a
     kind class, booking a status class); **click dispatch** (block → dialog, booking → navigate); dialog
-    round-trip (create/delete → invalidate) with mocked api; feature-gate hides the layer for a non-admin when flag OFF.
+    round-trip (create/delete → invalidate) with mocked api; **feature-gate both halves** of
+    `isVisibleToViewer` (`feature-visibility.ts:16` = `flag || isPlatformAdmin(role)`): flag-OFF + non-admin →
+    hidden, AND flag-OFF + PLATFORM_ADMIN → visible (the admin-bypass half is the easy-to-regress one).
 
 ## Risks / notes
 

--- a/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
+++ b/docs/plans/2026-06-26-vehicle-blocks-calendar-design.md
@@ -1,0 +1,107 @@
+# Scheduled vehicle blocks on the operator calendar (#1101)
+
+> Slice 2 of epic #1099 (operator calendar UX overhaul). Design doc.
+> Status: approved 2026-06-26. Branch `feat/1101-blocks-calendar-ui` off develop `e877b6a1`.
+
+## Context
+
+The `vehicle_blocks` backend already shipped (#1142 table + block-vs-block `EXCLUDE`,
+#1152 assign/substitute block-awareness, #1159 class-capacity subtraction). Availability
+search and booking-overlap rejection already account for blocks, so two of the issue's
+acceptance criteria are **already met**:
+
+- Blocked vehicle excluded from `GET /availability` + storefront search.
+- Booking overlapping a block → 409.
+
+What remains for #1101 is making blocks **visible and manageable** on the operator
+calendar — plus the one piece of backend the UI cannot work without: a **read endpoint**.
+
+### What exists today (develop `e877b6a1`)
+
+- **Write API:** `POST /vehicles/:vehicleId/blocks`, `DELETE /vehicles/:vehicleId/blocks/:blockId`
+  (`packages/api/src/routes/vehicle-blocks.ts`). Hard delete, operator-scoped, server-derived `operatorId`.
+- **Service:** `VehicleBlockService.createBlock` / `deleteBlock` (`services/vehicle-block.ts`).
+- **Repo:** `VehicleBlockRepository` with `create` / `findById` / `findOverlapping(vehicleId, from, to)` / `delete`
+  (`repositories/{in-memory,drizzle}/vehicle-block.ts`, iface `types-vehicle-block.ts`).
+- **Validator:** `createVehicleBlockSchema` (`validators/vehicle-block.ts`) — `kind` ∈
+  `MAINTENANCE | OUT_OF_SERVICE | MANUAL`, `reason` (1–500), `startAt`/`endAt` ISO, `notes?` ≤2000, `.strict()`.
+- **Calendar surface:** `operator-bookings/BookingsCalendar.tsx` — react-big-calendar, day/week/month,
+  vehicle resource columns; bookings fetched via `GET /bookings?from&to`, transformed in `calendar-events.ts`.
+- **Feature flag:** `isOperatorBlocksEnabled()` (`config/features.ts`) — OFF by default; gate via
+  `isVisibleToViewer(flag, role)` (`config/feature-visibility.ts`, platform-admin bypass per #1161).
+
+### The gap
+
+There is **no read/list endpoint** for blocks — only `findById` + per-vehicle `findOverlapping`.
+The calendar shows the whole fleet, so it needs a fleet-wide range query.
+
+## Scope
+
+**In:** fleet-wide read endpoint; render blocks on the calendar; create (button + slot-select);
+view/delete (click band → detail dialog); i18n; feature gating.
+
+**Out (already shipped):** the table, EXCLUDE constraint, availability subtraction, booking guard.
+**Out (YAGNI):** soft-cancel/edit of a block (delete + recreate); recurring blocks; the #1100
+react-calendar-timeline spike (separate, unmerged).
+
+**No migration** — read-only addition over existing schema.
+
+## Slice A — backend read endpoint (own PR)
+
+Vertical slice with standalone value: the fleet's blocks become queryable.
+
+1. **Repo** — add `findOverlappingForOperator(operatorId, from, to): Promise<VehicleBlock[]>` to
+   `VehicleBlockRepository` (`types-vehicle-block.ts`); implement in both `in-memory/vehicle-block.ts`
+   (filter store by operatorId + half-open `[from,to)` overlap) and `drizzle/vehicle-block.ts`
+   (`tstzrange(startAt,endAt) && tstzrange(from,to)` + `operatorId =`). Half-open; adjacent = no overlap
+   (mirror existing `findOverlapping`).
+2. **Service** — `VehicleBlockService.listBlocks(ctx, from, to)`: resolve operator scope using the **same
+   read-scope resolver the operator calendar bookings read already uses** (not the write-scope helper), then
+   call `findOverlappingForOperator(operatorId, from, to)`. Returns `VehicleBlock[]`. Verify the exact
+   resolver name against the `GET /bookings` calendar handler during TDD; do not invent a second scoping path.
+3. **Route** — `GET /blocks?from&to` (fleet-wide, root-mounted). Use `parseDateRange` from `routes/helpers.ts`
+   for `from`/`to`; gate mirrors the operator calendar bookings read (`MANAGEMENT_READ_ROLES`). Returns
+   `ok([...blocks])`. Wire in `index.ts`.
+4. **Tests (TDD):** in-memory repo parity (operator isolation + overlap window); service operator-scope;
+   route happy-path + cross-operator returns only caller's blocks + bad range → 400; real-pg range query.
+
+## Slice B — web UI (own PR), extends `operator-bookings`
+
+5. **`api.ts`** — `fetchCalendarBlocks(from, to)` → `GET /blocks?from&to`, parsed by `calendarBlockSchema`;
+   `operatorCalendarBlocksQueryOptions(from, to)` (queryKey `['operator-bookings','blocks',from,to]`);
+   `createBlock(vehicleId, input, csrf)` → POST; `deleteBlock(vehicleId, blockId, csrf)` → DELETE. Mutations
+   invalidate `OPERATOR_BOOKINGS_KEY` (prefix cascade covers calendar + blocks).
+6. **`schema.ts`** — `calendarBlockSchema` DTO (`id, vehicleId, startAt, endAt, kind, reason, notes, createdBy`).
+7. **`calendar-events.ts`** — `blocksToCalendarEvents(blocks)`: map to react-big-calendar events keyed by
+   `resourceId = vehicleId`, tagged `type: 'block'` + `kind`. Merge with booking events for one `events` array.
+8. **`BookingsCalendar.tsx`** — render block bands distinctly (neutral/hatched background, per-kind color +
+   icon, via `eventPropGetter`); add a legend; enable `selectable` so an empty-slot drag opens the create
+   dialog prefilled with vehicle + range; `onSelectEvent` on a block opens the detail dialog. Whole blocks
+   layer gated behind `isVisibleToViewer(isOperatorBlocksEnabled(), role)`.
+9. **`ScheduleBlockDialog.tsx`** (new) — vehicle picker (defaults to slot vehicle), kind select, start/end,
+   reason, notes; shadcn base-ui (no `asChild`); validates against the shared create schema; on success closes
+   + invalidates. Surfaces 409 (block-vs-block overlap) as a friendly "overlaps an existing block" message.
+10. **`BlockDetailDialog.tsx`** (new) — shows vehicle, kind, window, reason, notes, createdBy; Delete button
+    + confirm (hard delete); on success closes + invalidates.
+11. **i18n** — `blocks` namespace in `messages/{en,ja,zh}.json` (kinds, dialog labels, legend, errors).
+12. **Tests:** transform unit (`blocksToCalendarEvents` styling/keys); dialog round-trip (create → invalidate,
+    delete → invalidate) with mocked api; feature-gate hides the layer for a non-admin when flag OFF.
+
+## Risks / notes
+
+- **Scope resolution reuse:** `listBlocks` must use the *same* operator-scope resolver as the calendar
+  bookings read so platform-admin and operator see a consistent fleet. Don't invent a second scoping path.
+- **Visual disambiguation:** block bands must read as clearly *not bookings* (bookings are status-colored);
+  use a muted/hatched treatment + kind icon + legend.
+- **Feature-boundary lint (#1110):** keep all new files inside `operator-bookings`; export only through its
+  barrel if anything is consumed elsewhere.
+- **Create race:** schedule-during-checkout race is tiny at 1 operator / 40–50 cars and operationally
+  recoverable (shows on calendar; operator substitutes) — no advisory lock in this slice (issue's "optional").
+
+## Acceptance criteria
+
+- Block renders on the operator calendar in the correct vehicle column + window, visually distinct by kind.
+- Create via button (manual) and via slot-select (prefilled) both round-trip and refresh the calendar.
+- Click a block → detail dialog → delete restores the slot (calendar refreshes).
+- All block reads/writes operator-scoped (cross-operator never visible/mutable).
+- Entire blocks layer hidden unless `isVisibleToViewer(isOperatorBlocksEnabled(), role)`.

--- a/docs/plans/2026-06-26-vehicle-blocks-read-endpoint-plan.md
+++ b/docs/plans/2026-06-26-vehicle-blocks-read-endpoint-plan.md
@@ -1,0 +1,528 @@
+# Vehicle-Blocks Read Endpoint (Slice A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fleet-wide, operator-scoped `GET /vehicle-blocks?from&to` read endpoint so the operator calendar can fetch blocks for a window. (Slice A of #1101; Slice B — the web UI — is a separate plan written after this merges.)
+
+**Architecture:** Mirror the existing read-scope convention exactly: the repository takes `CallerContext` and resolves a `VehicleBlockReadScope` union internally (as `in-memory/vehicle-class.ts` does with `operatorReadScope`). A new `vehicleBlockReadScope(ctx)` resolver in `tenancy.ts` is **total and fail-closed** — `MANAGEMENT_READ_ROLES` admits legacy `STAFF`/`ADMIN` who are neither bypass nor operator, and they must read nothing rather than fall through to `all`. The route gates `MANAGEMENT_READ_ROLES` (RENTER/PARTNER → 403) and requires the date range.
+
+**Tech Stack:** Hono, Drizzle (Postgres `tstzrange && tstzrange` GiST), Vitest, Bun, neon-http.
+
+**Spec:** `docs/plans/2026-06-26-vehicle-blocks-calendar-design.md`. (Note: that spec sketched `findOverlappingInRange(scope, …)`; this plan uses `(ctx, …)` resolving scope internally, matching the `vehicle-class` repo convention discovered during planning.)
+
+**Branch:** `feat/1101-blocks-calendar-ui` (worktree `~/Dev/kuruma-1101-blocks-ui`, off develop). **No migration.**
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `packages/api/src/tenancy.ts` | `VehicleBlockReadScope` type + `vehicleBlockReadScope(ctx)` resolver | Modify |
+| `packages/api/src/tenancy.test.ts` | Resolver unit tests | Modify |
+| `packages/api/src/repositories/types-vehicle-block.ts` | Add `findOverlappingInRange(ctx, from, to)` to interface | Modify |
+| `packages/api/src/repositories/in-memory/vehicle-block.ts` | In-memory impl | Modify |
+| `packages/api/src/repositories/in-memory/vehicle-block.test.ts` | In-memory scope tests | Modify |
+| `packages/api/src/repositories/drizzle/vehicle-block.ts` | Drizzle impl | Modify |
+| `packages/api/src/services/vehicle-block.ts` | `listBlocks(ctx, from, to)` | Modify |
+| `packages/api/src/services/vehicle-block.test.ts` | Service scope tests | Modify |
+| `packages/api/src/routes/vehicle-blocks.ts` | `GET /vehicle-blocks` + auth for the new path | Modify |
+| `packages/api/tests/routes/vehicle-blocks.test.ts` | Route tests (200/403/400) | Modify |
+| `packages/api/tests/integration/vehicle-blocks.test.ts` | real-pg range + cross-operator | Modify |
+
+No `index.ts` change: the `GET` lives inside the already-mounted `createVehicleBlockRoutes` factory.
+
+---
+
+## Task 1: `vehicleBlockReadScope` resolver
+
+**Files:**
+- Modify: `packages/api/src/tenancy.ts` (add after `operatorReadScope`, ~line 39)
+- Test: `packages/api/src/tenancy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/api/src/tenancy.test.ts` (it already imports `describe, expect, it`, `CallerContext`, and from `./tenancy`):
+
+```typescript
+import { vehicleBlockReadScope } from './tenancy'
+
+describe('vehicleBlockReadScope', () => {
+  it('returns all for a bypass caller (PLATFORM_ADMIN)', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(vehicleBlockReadScope(admin)).toEqual({ kind: 'all' })
+  })
+
+  it('returns operator for an OPERATOR_* caller with operatorId', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_OWNER', operatorId: 'op-1' }
+    expect(vehicleBlockReadScope(op)).toEqual({ kind: 'operator', operatorId: 'op-1' })
+  })
+
+  it('returns none for an OPERATOR_* caller missing operatorId (fail-closed)', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_STAFF' }
+    expect(vehicleBlockReadScope(op)).toEqual({ kind: 'none' })
+  })
+
+  it('returns none for an in-gate non-bypass non-operator (legacy STAFF/ADMIN)', () => {
+    // STAFF/ADMIN pass MANAGEMENT_READ_ROLES but #487 removed them from
+    // SCOPE_BYPASS_ROLES — they must read nothing, not fall through to `all`.
+    const staff: CallerContext = { userId: 's1', role: 'STAFF', bypassScope: false }
+    const admin: CallerContext = { userId: 'a1', role: 'ADMIN', bypassScope: false }
+    expect(vehicleBlockReadScope(staff)).toEqual({ kind: 'none' })
+    expect(vehicleBlockReadScope(admin)).toEqual({ kind: 'none' })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run --filter @kuruma/api test -- tenancy.test.ts`
+Expected: FAIL — `vehicleBlockReadScope is not a function` / not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/api/src/tenancy.ts`, immediately after `operatorReadScope` (line 39), add:
+
+```typescript
+/**
+ * #1101: row-scope for the fleet-wide blocks read. Blocks are operator-internal
+ * management data, so the route gates MANAGEMENT_READ_ROLES (RENTER/PARTNER → 403
+ * before this runs). This resolver must be TOTAL over the gate's admitted set and
+ * fail closed: MANAGEMENT_READ_ROLES (= BUSINESS_ROLES) also admits legacy
+ * STAFF/ADMIN, and #487 removed them from SCOPE_BYPASS_ROLES, so they are neither
+ * bypass nor isOperatorRole — they must read nothing. Do NOT copy
+ * `operatorReadScope` (`!isOperatorRole → all`): that catalog pattern would leak
+ * cross-tenant blocks to a legacy admin.
+ */
+export type VehicleBlockReadScope =
+  | { kind: 'all' }
+  | { kind: 'operator'; operatorId: string }
+  | { kind: 'none' }
+
+export function vehicleBlockReadScope(ctx: CallerContext): VehicleBlockReadScope {
+  if (ctx.bypassScope) return { kind: 'all' }
+  if (isOperatorRole(ctx.role)) {
+    return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }
+  }
+  return { kind: 'none' } // in-gate but neither bypass nor tenant: read nothing
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test -- tenancy.test.ts`
+Expected: PASS (all 4 new `vehicleBlockReadScope` cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/tenancy.ts packages/api/src/tenancy.test.ts
+git commit -m "feat(#1101): add fail-closed vehicleBlockReadScope resolver"
+```
+
+---
+
+## Task 2: `findOverlappingInRange` — interface + in-memory
+
+**Files:**
+- Modify: `packages/api/src/repositories/types-vehicle-block.ts`
+- Modify: `packages/api/src/repositories/in-memory/vehicle-block.ts`
+- Test: `packages/api/src/repositories/in-memory/vehicle-block.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the top-level `describe('InMemoryVehicleBlockRepository', …)` in `vehicle-block.test.ts`. It already has `OP='op_a'`, `VEH='veh_1'`, `T0`, `hours`, `seed`, `repo`. Add a context helper import + a new describe:
+
+```typescript
+import type { CallerContext } from '../../middleware/auth'
+
+const adminCtx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+const opACtx: CallerContext = { userId: 'u_a', role: 'OPERATOR_OWNER', operatorId: 'op_a' }
+const opBCtx: CallerContext = { userId: 'u_b', role: 'OPERATOR_OWNER', operatorId: 'op_b' }
+
+describe('findOverlappingInRange', () => {
+  it('operator scope returns only the caller-tenant blocks overlapping the window', async () => {
+    const mine = await seed({ operatorId: 'op_a', startAt: hours(10), endAt: hours(20) })
+    await seed({ operatorId: 'op_b', vehicleId: 'veh_b', startAt: hours(10), endAt: hours(20) })
+    const hits = await repo.findOverlappingInRange(opACtx, hours(12), hours(18))
+    expect(hits).toEqual([mine])
+  })
+
+  it('all scope (admin) returns blocks across operators in the window', async () => {
+    const a = await seed({ operatorId: 'op_a', startAt: hours(10), endAt: hours(20) })
+    const b = await seed({ operatorId: 'op_b', vehicleId: 'veh_b', startAt: hours(10), endAt: hours(20) })
+    const hits = await repo.findOverlappingInRange(adminCtx, hours(0), hours(48))
+    expect(new Set(hits)).toEqual(new Set([a, b]))
+  })
+
+  it('none scope (operator missing operatorId) returns []', async () => {
+    await seed({ startAt: hours(10), endAt: hours(20) })
+    const noneCtx: CallerContext = { userId: 'u', role: 'OPERATOR_STAFF' }
+    expect(await repo.findOverlappingInRange(noneCtx, hours(0), hours(48))).toEqual([])
+  })
+
+  it('excludes a block outside the window (half-open, adjacent = no overlap)', async () => {
+    await seed({ operatorId: 'op_b', startAt: hours(0), endAt: hours(10) })
+    // window starts exactly where the block ends
+    expect(await repo.findOverlappingInRange(opBCtx, hours(10), hours(20))).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run --filter @kuruma/api test -- in-memory/vehicle-block.test.ts`
+Expected: FAIL — `repo.findOverlappingInRange is not a function`.
+
+- [ ] **Step 3a: Add to the interface**
+
+In `packages/api/src/repositories/types-vehicle-block.ts`, add the `CallerContext` import and the method (after `findOverlapping`, line 20):
+
+```typescript
+import type { CallerContext } from '../middleware/auth'
+import type { VehicleBlock } from '../stores'
+```
+
+```typescript
+  /** Fleet-wide blocks whose [startAt, endAt) overlaps [from, to), row-scoped by
+   *  `vehicleBlockReadScope(ctx)` — `all` (admin) spans operators, `operator`
+   *  filters to the tenant, `none` returns []. Powers the operator calendar read. */
+  findOverlappingInRange(ctx: CallerContext, from: Date, to: Date): Promise<VehicleBlock[]>
+```
+
+- [ ] **Step 3b: Implement in-memory**
+
+In `packages/api/src/repositories/in-memory/vehicle-block.ts`, add imports + method:
+
+```typescript
+import type { CallerContext } from '../../middleware/auth'
+import { vehicleBlockReadScope } from '../../tenancy'
+```
+
+Add inside the class (after `findOverlapping`, line 52):
+
+```typescript
+  async findOverlappingInRange(
+    ctx: CallerContext,
+    from: Date,
+    to: Date,
+  ): Promise<VehicleBlock[]> {
+    const scope = vehicleBlockReadScope(ctx)
+    if (scope.kind === 'none') return []
+    return [...this.store.values()].filter(
+      (b) =>
+        b.startAt < to &&
+        b.endAt > from &&
+        (scope.kind === 'operator' ? b.operatorId === scope.operatorId : true),
+    )
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test -- in-memory/vehicle-block.test.ts`
+Expected: PASS (4 new `findOverlappingInRange` cases green; existing tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/repositories/types-vehicle-block.ts \
+  packages/api/src/repositories/in-memory/vehicle-block.ts \
+  packages/api/src/repositories/in-memory/vehicle-block.test.ts
+git commit -m "feat(#1101): findOverlappingInRange (interface + in-memory, scope-aware)"
+```
+
+---
+
+## Task 3: `findOverlappingInRange` — Drizzle (real-pg)
+
+**Files:**
+- Modify: `packages/api/src/repositories/drizzle/vehicle-block.ts`
+- Test: `packages/api/tests/integration/vehicle-blocks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/api/tests/integration/vehicle-blocks.test.ts` (uses `DrizzleVehicleBlockRepository(db)`, `SYSTEM_CONTEXT`, and the existing seed helpers `seedLocation`/`seedVehicleClass`/`vehicleRepo.create`). Seed two operators' vehicles, one block each, and assert scope:
+
+```typescript
+it('findOverlappingInRange: operator scope returns only the tenant blocks in the window', async () => {
+  // (Reuse the file's existing two-operator seed helpers; create one block per op.)
+  const opACtx: CallerContext = { userId: 'u_a', role: 'OPERATOR_OWNER', operatorId: opA.id }
+  const from = new Date('2026-07-01T00:00:00Z')
+  const to = new Date('2026-07-02T00:00:00Z')
+
+  const mine = await blockRepo.create({
+    operatorId: opA.id, vehicleId: vehicleA.id,
+    startAt: new Date('2026-07-01T09:00:00Z'), endAt: new Date('2026-07-01T17:00:00Z'),
+    kind: 'MAINTENANCE', reason: 'shaken', notes: null, createdBy: 'u_a',
+  })
+  await blockRepo.create({
+    operatorId: opB.id, vehicleId: vehicleB.id,
+    startAt: new Date('2026-07-01T09:00:00Z'), endAt: new Date('2026-07-01T17:00:00Z'),
+    kind: 'MAINTENANCE', reason: 'shaken', notes: null, createdBy: 'u_b',
+  })
+
+  const operatorHits = await blockRepo.findOverlappingInRange(opACtx, from, to)
+  expect(operatorHits.map((b) => b.id)).toEqual([mine.id])
+
+  const adminHits = await blockRepo.findOverlappingInRange(SYSTEM_CONTEXT, from, to)
+  expect(adminHits.length).toBe(2) // all scope spans both operators
+})
+```
+
+> If the file doesn't already expose `opA/opB/vehicleA/vehicleB/blockRepo`, add them mirroring the existing setup in that file (it already constructs `DrizzleVehicleBlockRepository(db)` and seeds vehicles). Import `CallerContext` from `../../src/middleware/auth`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (real pg must be up — the file's `./setup` handles the test DB):
+`bun run --filter @kuruma/api test -- integration/vehicle-blocks.test.ts`
+Expected: FAIL — `blockRepo.findOverlappingInRange is not a function`.
+
+- [ ] **Step 3: Implement Drizzle**
+
+In `packages/api/src/repositories/drizzle/vehicle-block.ts`, extend imports and add the method (after `findOverlapping`, line 52). Mirror the `vehicle-class.ts` scope-branching idiom (`operator → eq`, `none → sql\`false\``):
+
+```typescript
+import { and, eq, sql, type SQL } from 'drizzle-orm'
+import type { CallerContext } from '../../middleware/auth'
+import { vehicleBlockReadScope } from '../../tenancy'
+```
+
+```typescript
+  async findOverlappingInRange(
+    ctx: CallerContext,
+    from: Date,
+    to: Date,
+  ): Promise<VehicleBlock[]> {
+    const scope = vehicleBlockReadScope(ctx)
+    const conditions: SQL[] = [
+      sql`tstzrange("startAt", "endAt") && tstzrange(${from.toISOString()}::timestamptz, ${to.toISOString()}::timestamptz)`,
+    ]
+    if (scope.kind === 'operator') {
+      conditions.push(eq(vehicleBlocks.operatorId, scope.operatorId))
+    } else if (scope.kind === 'none') {
+      conditions.push(sql`false`)
+    }
+    const rows = await this.db
+      .select(vehicleBlockColumns)
+      .from(vehicleBlocks)
+      .where(and(...conditions))
+    return rows.map(toVehicleBlock)
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test -- integration/vehicle-blocks.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/repositories/drizzle/vehicle-block.ts \
+  packages/api/tests/integration/vehicle-blocks.test.ts
+git commit -m "feat(#1101): findOverlappingInRange Drizzle impl + real-pg scope test"
+```
+
+---
+
+## Task 4: `VehicleBlockService.listBlocks`
+
+**Files:**
+- Modify: `packages/api/src/services/vehicle-block.ts`
+- Test: `packages/api/src/services/vehicle-block.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/api/src/services/vehicle-block.test.ts` (has `ctxFor(operatorId)` returning an `OPERATOR_OWNER` ctx, and seeds vehicles via `vehicleRepo.create(SYSTEM_CONTEXT, …)`). Add:
+
+```typescript
+describe('listBlocks', () => {
+  it('operator caller sees only its own blocks in the window', async () => {
+    const vA = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    const vB = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-b'))
+    await blockRepo.create({
+      operatorId: 'op-a', vehicleId: vA.id,
+      startAt: new Date('2026-07-01T09:00:00Z'), endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE', reason: 'x', notes: null, createdBy: 'u',
+    })
+    await blockRepo.create({
+      operatorId: 'op-b', vehicleId: vB.id,
+      startAt: new Date('2026-07-01T09:00:00Z'), endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE', reason: 'y', notes: null, createdBy: 'u',
+    })
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-02T00:00:00Z')
+
+    const own = await service.listBlocks(ctxFor('op-a'), from, to)
+    expect(own.map((b) => b.operatorId)).toEqual(['op-a'])
+
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const all = await service.listBlocks(admin, from, to)
+    expect(all.length).toBe(2)
+  })
+})
+```
+
+> Match the file's existing helper names. If it lacks `vehicleInput`/`blockRepo`, mirror the route test's `vehicleInput(operatorId)` and the `beforeEach` that builds `new InMemoryVehicleBlockRepository()`. `service` is the `VehicleBlockService` built in the file's setup.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run --filter @kuruma/api test -- services/vehicle-block.test.ts`
+Expected: FAIL — `service.listBlocks is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `packages/api/src/services/vehicle-block.ts`, add the method to the class (after `deleteBlock`, line 95):
+
+```typescript
+  /**
+   * Fleet-wide read for the operator calendar. Row-scope is enforced in the repo
+   * via `vehicleBlockReadScope(ctx)` (operator → own tenant, admin → all, else →
+   * []), so this is a thin delegation — no separate scope check to drift.
+   */
+  async listBlocks(ctx: CallerContext, from: Date, to: Date): Promise<VehicleBlock[]> {
+    return this.vehicleBlockRepo.findOverlappingInRange(ctx, from, to)
+  }
+```
+
+(`CallerContext` and `VehicleBlock` are already imported in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test -- services/vehicle-block.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/services/vehicle-block.ts \
+  packages/api/src/services/vehicle-block.test.ts
+git commit -m "feat(#1101): VehicleBlockService.listBlocks (scoped fleet read)"
+```
+
+---
+
+## Task 5: `GET /vehicle-blocks` route
+
+**Files:**
+- Modify: `packages/api/src/routes/vehicle-blocks.ts`
+- Test: `packages/api/tests/routes/vehicle-blocks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/api/tests/routes/vehicle-blocks.test.ts` (has `appAs(role, operatorId)`, `vehicleRepo`/`blockRepo`, `vehicleInput`, `testAuthMiddleware`). Add:
+
+```typescript
+const RANGE = '?from=2026-07-01T00:00:00.000Z&to=2026-07-02T00:00:00.000Z'
+
+async function getBlocks(app: Hono, query = RANGE) {
+  return app.request(`/vehicle-blocks${query}`)
+}
+
+describe('GET /vehicle-blocks', () => {
+  it('returns the operator-scoped blocks in the window (200)', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    await blockRepo.create({
+      operatorId: 'op-a', vehicleId: vehicle.id,
+      startAt: new Date('2026-07-01T09:00:00Z'), endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE', reason: 'shaken', notes: null, createdBy: 'u',
+    })
+    const res = await getBlocks(appAs('OPERATOR_OWNER', 'op-a'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success: boolean; data: Array<{ operatorId: string }> }
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0]?.operatorId).toBe('op-a')
+  })
+
+  it('rejects RENTER and PARTNER with 403', async () => {
+    expect((await getBlocks(appAs('RENTER'))).status).toBe(403)
+    expect((await getBlocks(appAs('PARTNER'))).status).toBe(403)
+  })
+
+  it('returns 400 when from/to are missing', async () => {
+    const res = await getBlocks(appAs('OPERATOR_OWNER', 'op-a'), '')
+    expect(res.status).toBe(400)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run --filter @kuruma/api test -- routes/vehicle-blocks.test.ts`
+Expected: FAIL — `GET /vehicle-blocks` 404s (route not defined), so status assertions fail.
+
+- [ ] **Step 3: Implement the route**
+
+In `packages/api/src/routes/vehicle-blocks.ts`:
+
+a) Extend imports — add `MANAGEMENT_READ_ROLES` and `parseDateRange`:
+
+```typescript
+import {
+  FLEET_WRITE_ROLES,
+  MANAGEMENT_READ_ROLES,
+  requireAuth,
+  requireUser,
+  toCallerContext,
+} from '../middleware/auth'
+import { fail, ok, parseBody, parseDateRange, parseId } from './helpers'
+```
+
+b) Guard the new path (after the existing `app.use(...)` lines, ~line 13):
+
+```typescript
+  // The fleet-wide read lives at a top-level path, so it is NOT covered by the
+  // app-level `/vehicles/*` requireAuth — guard it here (requireUser throws 500
+  // without it). Reads are management-tier (RENTER/PARTNER excluded at the gate).
+  app.use('/vehicle-blocks', requireAuth())
+```
+
+c) Add the handler to the returned chain (before the closing `}` of the chain, e.g. after the `.delete(...)` block):
+
+```typescript
+    .get('/vehicle-blocks', async (c) => {
+      const user = requireUser(c)
+      if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
+      // The time window is the only bound (no limit/cursor), so require it: an
+      // omitted range must 400, never dump all-time fleet-wide (or cross-operator).
+      const range = parseDateRange(c, true)
+      if (!range.ok) return range.response
+
+      const blocks = await service.listBlocks(toCallerContext(user), range.from, range.to)
+      return ok(c, blocks)
+    })
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test -- routes/vehicle-blocks.test.ts`
+Expected: PASS (3 new GET cases + all existing POST/DELETE cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/routes/vehicle-blocks.ts \
+  packages/api/tests/routes/vehicle-blocks.test.ts
+git commit -m "feat(#1101): GET /vehicle-blocks fleet-wide read (management-gated, range-required)"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] **Typecheck:** `bun run --filter @kuruma/api typecheck` (or `tsc --noEmit`) → 0 errors.
+- [ ] **Boundaries lint:** `bun run --filter @kuruma/api lint:boundaries` → exit 0 (no route→repo import; scope type/resolver live in `tenancy.ts`).
+- [ ] **Aggregate tests:** `bun run test` → shared + api + web all green (per the run-aggregate-before-push rule; per-package filters skip shared contract tests).
+- [ ] **Format:** `bun run format` (biome). Re-read edited files afterward if biome reorders imports.
+- [ ] **Push + PR:** rebase onto `origin/develop` first; PR body `Closes #1101` is premature (Slice B remains) — use `Refs #1101` and note "Slice A of 2; Slice B = web UI". Base = `develop`. Owner squash-merges (no `--admin`).
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** read endpoint (✓ Tasks 2-5), explicit `VehicleBlockReadScope` union + fail-closed resolver incl. legacy-admin arm (✓ Task 1 + test), `MANAGEMENT_READ_ROLES` gate with RENTER/PARTNER 403 (✓ Task 5), required range → 400 (✓ Task 5), in-memory ⇄ Drizzle parity (✓ Tasks 2-3), `/vehicle-blocks` path (✓ Task 5). Slice B (web) intentionally deferred to its own plan.
+- **Type consistency:** `findOverlappingInRange(ctx, from, to)` signature identical across interface (Task 2), in-memory (Task 2), Drizzle (Task 3), service (Task 4), route call (Task 5). `vehicleBlockReadScope` returns the same union consumed by both repos.
+- **Placeholder scan:** the two "match the file's existing helpers" notes (Tasks 3-4) point at concrete, named helpers already present in those test files (`seedVehicleClass`, `vehicleInput`, `blockRepo`) — adapt-to-existing, not invent-from-scratch.

--- a/packages/api/src/repositories/drizzle/vehicle-block.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-block.ts
@@ -1,5 +1,7 @@
 import { vehicleBlocks } from '@kuruma/shared/db/schema'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, sql, type SQL } from 'drizzle-orm'
+import type { CallerContext } from '../../middleware/auth'
+import { vehicleBlockReadScope } from '../../tenancy'
 import type { VehicleBlock } from '../../stores'
 import type { VehicleBlockRepository } from '../types'
 import { type Db, toVehicleBlock, vehicleBlockColumns } from './shared'
@@ -48,6 +50,27 @@ export class DrizzleVehicleBlockRepository implements VehicleBlockRepository {
           sql`tstzrange("startAt", "endAt") && tstzrange(${fromIso}::timestamptz, ${toIso}::timestamptz)`,
         ),
       )
+    return rows.map(toVehicleBlock)
+  }
+
+  async findOverlappingInRange(
+    ctx: CallerContext,
+    from: Date,
+    to: Date,
+  ): Promise<VehicleBlock[]> {
+    const scope = vehicleBlockReadScope(ctx)
+    const conditions: SQL[] = [
+      sql`tstzrange("startAt", "endAt") && tstzrange(${from.toISOString()}::timestamptz, ${to.toISOString()}::timestamptz)`,
+    ]
+    if (scope.kind === 'operator') {
+      conditions.push(eq(vehicleBlocks.operatorId, scope.operatorId))
+    } else if (scope.kind === 'none') {
+      conditions.push(sql`false`)
+    }
+    const rows = await this.db
+      .select(vehicleBlockColumns)
+      .from(vehicleBlocks)
+      .where(and(...conditions))
     return rows.map(toVehicleBlock)
   }
 

--- a/packages/api/src/repositories/in-memory/vehicle-block.test.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-block.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
 import { InMemoryVehicleBlockRepository } from './vehicle-block'
 
 const OP = 'op_a'
 const VEH = 'veh_1'
+
+const adminCtx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+const opACtx: CallerContext = { userId: 'u_a', role: 'OPERATOR_OWNER', operatorId: 'op_a' }
+const opBCtx: CallerContext = { userId: 'u_b', role: 'OPERATOR_OWNER', operatorId: 'op_b' }
 
 const T0 = new Date('2026-09-01T00:00:00Z')
 const hours = (n: number) => new Date(T0.getTime() + n * 3_600_000)
@@ -67,6 +72,33 @@ describe('InMemoryVehicleBlockRepository', () => {
     it('returns a block that fully contains the query range', async () => {
       const block = await seed({ startAt: hours(0), endAt: hours(48) })
       expect(await repo.findOverlapping(VEH, hours(20), hours(28))).toEqual([block])
+    })
+  })
+
+  describe('findOverlappingInRange', () => {
+    it('operator scope returns only the caller-tenant blocks overlapping the window', async () => {
+      const mine = await seed({ operatorId: 'op_a', startAt: hours(10), endAt: hours(20) })
+      await seed({ operatorId: 'op_b', vehicleId: 'veh_b', startAt: hours(10), endAt: hours(20) })
+      const hits = await repo.findOverlappingInRange(opACtx, hours(12), hours(18))
+      expect(hits).toEqual([mine])
+    })
+
+    it('all scope (admin) returns blocks across operators in the window', async () => {
+      const a = await seed({ operatorId: 'op_a', startAt: hours(10), endAt: hours(20) })
+      const b = await seed({ operatorId: 'op_b', vehicleId: 'veh_b', startAt: hours(10), endAt: hours(20) })
+      const hits = await repo.findOverlappingInRange(adminCtx, hours(0), hours(48))
+      expect(new Set(hits)).toEqual(new Set([a, b]))
+    })
+
+    it('none scope (operator missing operatorId) returns []', async () => {
+      await seed({ startAt: hours(10), endAt: hours(20) })
+      const noneCtx: CallerContext = { userId: 'u', role: 'OPERATOR_STAFF' }
+      expect(await repo.findOverlappingInRange(noneCtx, hours(0), hours(48))).toEqual([])
+    })
+
+    it('excludes a block outside the window (half-open, adjacent = no overlap)', async () => {
+      await seed({ operatorId: 'op_b', startAt: hours(0), endAt: hours(10) })
+      expect(await repo.findOverlappingInRange(opBCtx, hours(10), hours(20))).toEqual([])
     })
   })
 

--- a/packages/api/src/repositories/in-memory/vehicle-block.test.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-block.test.ts
@@ -85,7 +85,12 @@ describe('InMemoryVehicleBlockRepository', () => {
 
     it('all scope (admin) returns blocks across operators in the window', async () => {
       const a = await seed({ operatorId: 'op_a', startAt: hours(10), endAt: hours(20) })
-      const b = await seed({ operatorId: 'op_b', vehicleId: 'veh_b', startAt: hours(10), endAt: hours(20) })
+      const b = await seed({
+        operatorId: 'op_b',
+        vehicleId: 'veh_b',
+        startAt: hours(10),
+        endAt: hours(20),
+      })
       const hits = await repo.findOverlappingInRange(adminCtx, hours(0), hours(48))
       expect(new Set(hits)).toEqual(new Set([a, b]))
     })

--- a/packages/api/src/repositories/in-memory/vehicle-block.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-block.ts
@@ -1,4 +1,6 @@
 import { PG_ERROR, VEHICLE_BLOCKS_OVERLAP } from '../../pg-errors'
+import type { CallerContext } from '../../middleware/auth'
+import { vehicleBlockReadScope } from '../../tenancy'
 import type { VehicleBlock } from '../../stores'
 import type { VehicleBlockRepository } from '../types'
 
@@ -48,6 +50,21 @@ export class InMemoryVehicleBlockRepository implements VehicleBlockRepository {
     // overlap — mirrors the GiST `&&` on tstzrange and the booking exclusion.
     return [...this.store.values()].filter(
       (b) => b.vehicleId === vehicleId && b.startAt < to && b.endAt > from,
+    )
+  }
+
+  async findOverlappingInRange(
+    ctx: CallerContext,
+    from: Date,
+    to: Date,
+  ): Promise<VehicleBlock[]> {
+    const scope = vehicleBlockReadScope(ctx)
+    if (scope.kind === 'none') return []
+    return [...this.store.values()].filter(
+      (b) =>
+        b.startAt < to &&
+        b.endAt > from &&
+        (scope.kind === 'operator' ? b.operatorId === scope.operatorId : true),
     )
   }
 

--- a/packages/api/src/repositories/in-memory/vehicle-block.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-block.ts
@@ -1,7 +1,7 @@
-import { PG_ERROR, VEHICLE_BLOCKS_OVERLAP } from '../../pg-errors'
 import type { CallerContext } from '../../middleware/auth'
-import { vehicleBlockReadScope } from '../../tenancy'
+import { PG_ERROR, VEHICLE_BLOCKS_OVERLAP } from '../../pg-errors'
 import type { VehicleBlock } from '../../stores'
+import { vehicleBlockReadScope } from '../../tenancy'
 import type { VehicleBlockRepository } from '../types'
 
 // Faithful mirror of the `vehicle_blocks_no_overlap` GiST EXCLUDE (#1101, same
@@ -53,11 +53,7 @@ export class InMemoryVehicleBlockRepository implements VehicleBlockRepository {
     )
   }
 
-  async findOverlappingInRange(
-    ctx: CallerContext,
-    from: Date,
-    to: Date,
-  ): Promise<VehicleBlock[]> {
+  async findOverlappingInRange(ctx: CallerContext, from: Date, to: Date): Promise<VehicleBlock[]> {
     const scope = vehicleBlockReadScope(ctx)
     if (scope.kind === 'none') return []
     return [...this.store.values()].filter(

--- a/packages/api/src/repositories/types-vehicle-block.ts
+++ b/packages/api/src/repositories/types-vehicle-block.ts
@@ -1,3 +1,4 @@
+import type { CallerContext } from '../middleware/auth'
 import type { VehicleBlock } from '../stores'
 
 /**
@@ -18,6 +19,10 @@ export interface VehicleBlockRepository {
    *  on both ends — adjacent windows (block.endAt === from) do NOT overlap,
    *  matching the GiST `&&` on tstzrange and the booking exclusion. */
   findOverlapping(vehicleId: string, from: Date, to: Date): Promise<VehicleBlock[]>
+  /** Fleet-wide blocks whose [startAt, endAt) overlaps [from, to), row-scoped by
+   *  `vehicleBlockReadScope(ctx)` — `all` (admin) spans operators, `operator`
+   *  filters to the tenant, `none` returns []. Powers the operator calendar read. */
+  findOverlappingInRange(ctx: CallerContext, from: Date, to: Date): Promise<VehicleBlock[]>
   /** Operator-scoped hard delete (defence-in-depth, must-fix #4): returns the
    *  removed block, or undefined when no block with that id belongs to the
    *  operator (unknown id OR another tenant's block). */

--- a/packages/api/src/routes/vehicle-blocks.ts
+++ b/packages/api/src/routes/vehicle-blocks.ts
@@ -1,8 +1,14 @@
 import { createVehicleBlockSchema } from '@kuruma/shared/validators/vehicle-block'
 import { Hono } from 'hono'
-import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import {
+  FLEET_WRITE_ROLES,
+  MANAGEMENT_READ_ROLES,
+  requireAuth,
+  requireUser,
+  toCallerContext,
+} from '../middleware/auth'
 import type { VehicleBlockService } from '../services/vehicle-block'
-import { fail, ok, parseBody, parseId } from './helpers'
+import { fail, ok, parseBody, parseDateRange, parseId } from './helpers'
 
 export function createVehicleBlockRoutes(service: VehicleBlockService) {
   const app = new Hono()
@@ -12,7 +18,24 @@ export function createVehicleBlockRoutes(service: VehicleBlockService) {
   app.use('/vehicles/:vehicleId/blocks', requireAuth())
   app.use('/vehicles/:vehicleId/blocks/*', requireAuth())
 
+  // The fleet-wide read lives at a top-level path, so it is NOT covered by the
+  // vehicle-scoped requireAuth above — guard it here (requireUser throws 500
+  // without it). Reads are management-tier (RENTER/PARTNER excluded at the gate).
+  app.use('/vehicle-blocks', requireAuth())
+
   return app
+    .get('/vehicle-blocks', async (c) => {
+      const user = requireUser(c)
+      if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
+      // The time window is the only bound (no limit/cursor), so require it: an
+      // omitted range must 400, never dump all-time fleet-wide (or cross-operator).
+      const range = parseDateRange(c, true)
+      if (!range.ok) return range.response
+
+      const blocks = await service.listBlocks(toCallerContext(user), range.from, range.to)
+      return ok(c, blocks)
+    })
     .post('/vehicles/:vehicleId/blocks', async (c) => {
       const user = requireUser(c)
       // Fleet writes admit STAFF roles AND tenant operators; RENTER / PARTNER are

--- a/packages/api/src/services/vehicle-block.test.ts
+++ b/packages/api/src/services/vehicle-block.test.ts
@@ -132,6 +132,42 @@ describe('VehicleBlockService.createBlock', () => {
   })
 })
 
+describe('VehicleBlockService.listBlocks', () => {
+  it('operator caller sees only its own blocks in the window', async () => {
+    const vA = await seedVehicle('op_a')
+    const vB = await seedVehicle('op_b')
+    await blockRepo.create({
+      operatorId: 'op_a',
+      vehicleId: vA.id,
+      startAt: new Date('2026-07-01T09:00:00Z'),
+      endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'x',
+      notes: null,
+      createdBy: 'u',
+    })
+    await blockRepo.create({
+      operatorId: 'op_b',
+      vehicleId: vB.id,
+      startAt: new Date('2026-07-01T09:00:00Z'),
+      endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'y',
+      notes: null,
+      createdBy: 'u',
+    })
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-02T00:00:00Z')
+
+    const own = await service.listBlocks(ctxFor('op_a'), from, to)
+    expect(own.map((b) => b.operatorId)).toEqual(['op_a'])
+
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const all = await service.listBlocks(admin, from, to)
+    expect(all.map((b) => b.operatorId).sort()).toEqual(['op_a', 'op_b'])
+  })
+})
+
 describe('VehicleBlockService.deleteBlock', () => {
   it('removes a block the operator owns', async () => {
     const vehicle = await seedVehicle('op_a')

--- a/packages/api/src/services/vehicle-block.ts
+++ b/packages/api/src/services/vehicle-block.ts
@@ -93,4 +93,13 @@ export class VehicleBlockService {
     if (!removed) return { ok: false, error: BLOCK_NOT_FOUND_MESSAGE, status: 404 }
     return { ok: true, block: removed }
   }
+
+  /**
+   * Fleet-wide read for the operator calendar. Row-scope is enforced in the repo
+   * via `vehicleBlockReadScope(ctx)` (operator → own tenant, admin → all, else →
+   * []), so this is a thin delegation — no separate scope check to drift.
+   */
+  async listBlocks(ctx: CallerContext, from: Date, to: Date): Promise<VehicleBlock[]> {
+    return this.vehicleBlockRepo.findOverlappingInRange(ctx, from, to)
+  }
 }

--- a/packages/api/src/tenancy.test.ts
+++ b/packages/api/src/tenancy.test.ts
@@ -52,4 +52,11 @@ describe('vehicleBlockReadScope', () => {
     expect(vehicleBlockReadScope(staff)).toEqual({ kind: 'none' })
     expect(vehicleBlockReadScope(admin)).toEqual({ kind: 'none' })
   })
+
+  it('returns none for a PARTNER despite its bypassScope (fail-closed before bypass)', () => {
+    // A Trip.com PARTNER key carries bypassScope=true via SCOPE_BYPASS_ROLES; a
+    // bypass-first resolver would leak every operator's blocks to the channel.
+    const partner: CallerContext = { userId: 'trip-com', role: 'PARTNER', bypassScope: true }
+    expect(vehicleBlockReadScope(partner)).toEqual({ kind: 'none' })
+  })
 })

--- a/packages/api/src/tenancy.test.ts
+++ b/packages/api/src/tenancy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { CallerContext } from './middleware/auth'
-import { bookingReadScope } from './tenancy'
+import { bookingReadScope, vehicleBlockReadScope } from './tenancy'
 
 describe('bookingReadScope', () => {
   it('scopes a PARTNER to its own channel (source=TRIP_COM), not all bookings', () => {
@@ -27,5 +27,29 @@ describe('bookingReadScope', () => {
   it('scopes a RENTER to their own bookings', () => {
     const renter: CallerContext = { userId: 'r1', role: 'RENTER' }
     expect(bookingReadScope(renter)).toEqual({ kind: 'renter', renterId: 'r1' })
+  })
+})
+
+describe('vehicleBlockReadScope', () => {
+  it('returns all for a bypass caller (PLATFORM_ADMIN)', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(vehicleBlockReadScope(admin)).toEqual({ kind: 'all' })
+  })
+
+  it('returns operator for an OPERATOR_* caller with operatorId', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_OWNER', operatorId: 'op-1' }
+    expect(vehicleBlockReadScope(op)).toEqual({ kind: 'operator', operatorId: 'op-1' })
+  })
+
+  it('returns none for an OPERATOR_* caller missing operatorId (fail-closed)', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_STAFF' }
+    expect(vehicleBlockReadScope(op)).toEqual({ kind: 'none' })
+  })
+
+  it('returns none for an in-gate non-bypass non-operator (legacy STAFF/ADMIN)', () => {
+    const staff: CallerContext = { userId: 's1', role: 'STAFF', bypassScope: false }
+    const admin: CallerContext = { userId: 'a1', role: 'ADMIN', bypassScope: false }
+    expect(vehicleBlockReadScope(staff)).toEqual({ kind: 'none' })
+    expect(vehicleBlockReadScope(admin)).toEqual({ kind: 'none' })
   })
 })

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -47,6 +47,13 @@ export function operatorReadScope(ctx: CallerContext): OperatorReadScope {
  * bypass nor isOperatorRole — they must read nothing. Do NOT copy
  * `operatorReadScope` (`!isOperatorRole → all`): that catalog pattern would leak
  * cross-tenant blocks to a legacy admin.
+ *
+ * PARTNER is branched to `none` BEFORE the bypass check (mirroring
+ * `bookingReadScope`): a PARTNER key carries `bypassScope: true` via
+ * SCOPE_BYPASS_ROLES, so a bypass-first resolver would hand Trip.com every
+ * operator's blocks. The route gate 403s PARTNER today, but encoding the denial
+ * here makes the resolver safe to reuse on a future route without the leak
+ * shipping silently.
  */
 export type VehicleBlockReadScope =
   | { kind: 'all' }
@@ -54,6 +61,7 @@ export type VehicleBlockReadScope =
   | { kind: 'none' }
 
 export function vehicleBlockReadScope(ctx: CallerContext): VehicleBlockReadScope {
+  if (ctx.role === 'PARTNER') return { kind: 'none' } // never expose internal blocks to a channel
   if (ctx.bypassScope) return { kind: 'all' }
   if (isOperatorRole(ctx.role)) {
     return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -39,6 +39,29 @@ export function operatorReadScope(ctx: CallerContext): OperatorReadScope {
 }
 
 /**
+ * #1101: row-scope for the fleet-wide blocks read. Blocks are operator-internal
+ * management data, so the route gates MANAGEMENT_READ_ROLES (RENTER/PARTNER → 403
+ * before this runs). This resolver must be TOTAL over the gate's admitted set and
+ * fail closed: MANAGEMENT_READ_ROLES (= BUSINESS_ROLES) also admits legacy
+ * STAFF/ADMIN, and #487 removed them from SCOPE_BYPASS_ROLES, so they are neither
+ * bypass nor isOperatorRole — they must read nothing. Do NOT copy
+ * `operatorReadScope` (`!isOperatorRole → all`): that catalog pattern would leak
+ * cross-tenant blocks to a legacy admin.
+ */
+export type VehicleBlockReadScope =
+  | { kind: 'all' }
+  | { kind: 'operator'; operatorId: string }
+  | { kind: 'none' }
+
+export function vehicleBlockReadScope(ctx: CallerContext): VehicleBlockReadScope {
+  if (ctx.bypassScope) return { kind: 'all' }
+  if (isOperatorRole(ctx.role)) {
+    return ctx.operatorId ? { kind: 'operator', operatorId: ctx.operatorId } : { kind: 'none' }
+  }
+  return { kind: 'none' } // in-gate but neither bypass nor tenant: read nothing
+}
+
+/**
  * The two transport-supplied knobs a cross-operator list read carries: an explicit
  * target `operatorId`, or `includeAll` to opt into reading every tenant at once.
  */

--- a/packages/api/tests/integration/vehicle-blocks.test.ts
+++ b/packages/api/tests/integration/vehicle-blocks.test.ts
@@ -2,6 +2,7 @@ import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { vehicleBlocks } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../src/middleware/auth'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { pgConstraintName, pgErrorCode } from '../../src/pg-errors'
 import {
@@ -322,5 +323,110 @@ describe('VehicleBlockService against Postgres', () => {
     )
 
     expect(overlap).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCK_OVERLAP' })
+  })
+})
+
+// #1101 slice A (task 3): proves DrizzleVehicleBlockRepository.findOverlappingInRange
+// scopes rows correctly by vehicleBlockReadScope — all / operator / none — and by
+// the date window. Uses a dedicated vehicle so the results are isolated.
+describe('DrizzleVehicleBlockRepository.findOverlappingInRange scoping', () => {
+  const blockRepo = new DrizzleVehicleBlockRepository(db)
+
+  const FROM = new Date('2026-07-01T00:00:00Z')
+  const TO = new Date('2026-07-02T00:00:00Z')
+  const BLOCK_START = new Date('2026-07-01T09:00:00Z')
+  const BLOCK_END = new Date('2026-07-01T17:00:00Z')
+  const NON_OVERLAP_FROM = new Date('2026-08-01T00:00:00Z')
+  const NON_OVERLAP_TO = new Date('2026-08-02T00:00:00Z')
+
+  let scopeVehicleId: string
+  let scopeBlockId: string
+  const scopeVehicleIds: string[] = []
+  const scopeClassIds: string[] = []
+  const scopeLocationIds: string[] = []
+  const scopeBlockIds: string[] = []
+
+  const opCtx: CallerContext = {
+    userId: 'u-scope-test',
+    role: 'OPERATOR_OWNER',
+    operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+  }
+  const otherOpCtx: CallerContext = {
+    userId: 'u-scope-test',
+    role: 'OPERATOR_OWNER',
+    operatorId: '00000000-0000-0000-0000-000000000000',
+  }
+
+  beforeAll(async () => {
+    const klass = await seedVehicleClass('block-scope')
+    scopeClassIds.push(klass.id)
+    const location = await seedLocation('block-scope')
+    scopeLocationIds.push(location.id)
+
+    scopeVehicleId = (
+      await vehicleRepo.create(SYSTEM_CONTEXT, {
+        operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+        classId: klass.id,
+        pickupLocationId: location.id,
+        name: 'Scope Test Vehicle',
+        description: null,
+        seats: 5,
+        transmission: 'AUTO',
+        fuelType: null,
+        licensePlate: null,
+        status: 'AVAILABLE',
+        minRentalHours: null,
+        maxRentalHours: null,
+        advanceBookingHours: null,
+        dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      })
+    ).id
+    scopeVehicleIds.push(scopeVehicleId)
+
+    const block = await blockRepo.create({
+      operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+      vehicleId: scopeVehicleId,
+      startAt: BLOCK_START,
+      endAt: BLOCK_END,
+      kind: 'MAINTENANCE',
+      reason: 'scope test block',
+      notes: null,
+      createdBy: 'system',
+    })
+    scopeBlockId = block.id
+    scopeBlockIds.push(block.id)
+  })
+
+  afterEach(async () => {
+    // scopeBlockIds are cleaned up in afterAll to persist across the 4 assertions
+  })
+
+  afterAll(async () => {
+    if (scopeBlockIds.length > 0) {
+      await db.delete(vehicleBlocks).where(inArray(vehicleBlocks.id, scopeBlockIds))
+    }
+    await cleanupVehicles(scopeVehicleIds)
+    await cleanupVehicleClasses(scopeClassIds)
+    await cleanupLocations(scopeLocationIds)
+  })
+
+  it('SYSTEM_CONTEXT (all scope) includes the block within the window', async () => {
+    const hits = await blockRepo.findOverlappingInRange(SYSTEM_CONTEXT, FROM, TO)
+    expect(hits.map((b) => b.id)).toContain(scopeBlockId)
+  })
+
+  it('matching operatorId (operator scope) includes the block', async () => {
+    const hits = await blockRepo.findOverlappingInRange(opCtx, FROM, TO)
+    expect(hits.map((b) => b.id)).toContain(scopeBlockId)
+  })
+
+  it('non-matching operatorId (operator scope) returns []', async () => {
+    const hits = await blockRepo.findOverlappingInRange(otherOpCtx, FROM, TO)
+    expect(hits).toEqual([])
+  })
+
+  it('non-overlapping window returns [] even for matching operator', async () => {
+    const hits = await blockRepo.findOverlappingInRange(opCtx, NON_OVERLAP_FROM, NON_OVERLAP_TO)
+    expect(hits).toEqual([])
   })
 })

--- a/packages/api/tests/integration/vehicle-blocks.test.ts
+++ b/packages/api/tests/integration/vehicle-blocks.test.ts
@@ -397,10 +397,6 @@ describe('DrizzleVehicleBlockRepository.findOverlappingInRange scoping', () => {
     scopeBlockIds.push(block.id)
   })
 
-  afterEach(async () => {
-    // scopeBlockIds are cleaned up in afterAll to persist across the 4 assertions
-  })
-
   afterAll(async () => {
     if (scopeBlockIds.length > 0) {
       await db.delete(vehicleBlocks).where(inArray(vehicleBlocks.id, scopeBlockIds))
@@ -425,8 +421,14 @@ describe('DrizzleVehicleBlockRepository.findOverlappingInRange scoping', () => {
     expect(hits).toEqual([])
   })
 
-  it('non-overlapping window returns [] even for matching operator', async () => {
+  it('non-overlapping window excludes the seeded block even for matching operator', async () => {
     const hits = await blockRepo.findOverlappingInRange(opCtx, NON_OVERLAP_FROM, NON_OVERLAP_TO)
+    expect(hits.map((b) => b.id)).not.toContain(scopeBlockId)
+  })
+
+  it('none scope (RENTER caller) returns [] even within the window', async () => {
+    const renterCtx: CallerContext = { userId: 'r1', role: 'RENTER' }
+    const hits = await blockRepo.findOverlappingInRange(renterCtx, FROM, TO)
     expect(hits).toEqual([])
   })
 })

--- a/packages/api/tests/routes/vehicle-blocks.test.ts
+++ b/packages/api/tests/routes/vehicle-blocks.test.ts
@@ -133,6 +133,58 @@ describe('POST /vehicles/:vehicleId/blocks', () => {
   })
 })
 
+const RANGE = '?from=2026-07-01T00:00:00.000Z&to=2026-07-02T00:00:00.000Z'
+
+function getBlocks(app: Hono, query = RANGE) {
+  return app.request(`/vehicle-blocks${query}`)
+}
+
+describe('GET /vehicle-blocks', () => {
+  it('returns the operator-scoped blocks in the window (200)', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    await blockRepo.create({
+      operatorId: 'op-a',
+      vehicleId: vehicle.id,
+      startAt: new Date('2026-07-01T09:00:00Z'),
+      endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'shaken',
+      notes: null,
+      createdBy: 'u',
+    })
+    // A foreign-operator block in the same window: the response must still hold
+    // only op-a's block, proving the route wires the caller context through to
+    // the scoped service read (not a fleet-wide dump).
+    const foreignVehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-b'))
+    await blockRepo.create({
+      operatorId: 'op-b',
+      vehicleId: foreignVehicle.id,
+      startAt: new Date('2026-07-01T09:00:00Z'),
+      endAt: new Date('2026-07-01T17:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'shaken',
+      notes: null,
+      createdBy: 'u',
+    })
+    const res = await getBlocks(appAs('OPERATOR_OWNER', 'op-a'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success: boolean; data: Array<{ operatorId: string }> }
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0]?.operatorId).toBe('op-a')
+  })
+
+  it('rejects RENTER and PARTNER with 403', async () => {
+    expect((await getBlocks(appAs('RENTER'))).status).toBe(403)
+    expect((await getBlocks(appAs('PARTNER'))).status).toBe(403)
+  })
+
+  it('returns 400 when from/to are missing', async () => {
+    const res = await getBlocks(appAs('OPERATOR_OWNER', 'op-a'), '')
+    expect(res.status).toBe(400)
+  })
+})
+
 describe('DELETE /vehicles/:vehicleId/blocks/:blockId', () => {
   async function seedBlock(operatorId: string): Promise<{ vehicleId: string; blockId: string }> {
     const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(operatorId))


### PR DESCRIPTION
## Slice A of 2 — `GET /vehicle-blocks` read endpoint

Refs #1101 (epic #1099 slice 2). **Not `Closes`** — Slice B (the operator-calendar web UI) is a separate plan/PR written after this merges.

The backend table / GiST EXCLUDE / availability / booking-guard for vehicle blocks already shipped (#1142/#1152/#1159). This slice adds the one missing piece: a fleet-wide, operator-scoped read so the calendar can fetch blocks for a window. **No migration.**

### What this adds

`GET /vehicle-blocks?from&to` → the blocks whose `[startAt, endAt)` overlaps `[from, to)`, row-scoped to the caller:
- **PLATFORM_ADMIN** (bypass) → all operators' blocks
- **OPERATOR_OWNER / OPERATOR_STAFF** → only their own tenant (fail-closed to `[]` if `operatorId` is missing)
- **legacy STAFF/ADMIN** (in the gate but not bypass/tenant) → `[]`
- **PARTNER** → `[]` (fail-closed before the bypass check; see below)
- **RENTER / PARTNER** → `403` at the route gate

The date range is **required** (`parseDateRange(c, true)` → `400` on omit), so the endpoint can never dump all-time or cross-operator data.

### Design

Mirrors the existing `vehicle-class.ts` read-scope convention: the **repository** takes `CallerContext` and resolves a `VehicleBlockReadScope` union internally via a new, **total + fail-closed** `vehicleBlockReadScope(ctx)` resolver in `tenancy.ts`. It deliberately does **not** copy `operatorReadScope`'s `!isOperatorRole → all` catalog pattern (which would leak cross-tenant blocks to a legacy admin). InMemory and Drizzle scoping are provably identical (same 3 arms; half-open `startAt < to && endAt > from` ⟺ `tstzrange && tstzrange`).

Layers (route → service → repo, boundaries enforced):
- `tenancy.ts` — `VehicleBlockReadScope` type + `vehicleBlockReadScope(ctx)` resolver
- `findOverlappingInRange(ctx, from, to)` — repo interface + InMemory + Drizzle impls
- `VehicleBlockService.listBlocks(ctx, from, to)` — thin delegation (scope lives in the repo)
- `routes/vehicle-blocks.ts` — `GET` with `MANAGEMENT_READ_ROLES` gate + required range + path-level `requireAuth()`

### Review findings folded in
- **Service test** hardened: admin-scope assertion pins both tenants (`['op_a','op_b']`), not just count.
- **Route 200 test** seeds a foreign `op-b` block so it proves the route→service context wiring filters (not a fleet-wide dump).
- **MEDIUM (final review):** `vehicleBlockReadScope` now branches `PARTNER → none` **before** the bypass check, mirroring `bookingReadScope`. A PARTNER key carries `bypassScope: true` via `SCOPE_BYPASS_ROLES`; a bypass-first resolver would hand Trip.com every operator's blocks. Live wiring was already safe (route 403s PARTNER), but the resolver is now safe to reuse on a future route without the leak shipping silently. +1 resolver test.

### Deferred (LOW, non-blocking)
- No `from < to` validation inside the repo method (unreachable — `parseDateRange(c, true)` enforces it at the route). Optional contract comment only.
- Route-level `none`-arm (legacy STAFF/ADMIN → `200 []`) is covered at the resolver + repo layers but not end-to-end at the route. Low composition risk.

### Test plan
- [x] `tenancy.test.ts` — resolver: admin/operator/none/legacy-STAFF-ADMIN/**PARTNER** arms
- [x] InMemory `findOverlappingInRange` — operator/all/none scope + half-open boundary
- [x] Drizzle real-pg (`integration/vehicle-blocks.test.ts`, 16/16) — operator vs all scope, `none → sql\`false\``
- [x] Service `listBlocks` — operator vs admin
- [x] Route — 200 (scoped, foreign block excluded) / 403 RENTER+PARTNER / 400 missing range
- [x] Aggregate `bun run test` — shared 793 / api 2245 / web 1411, all green
- [x] `tsc --noEmit` ×2, `lint:boundaries`, `biome check` — all exit 0

Executed via subagent-driven development (implementer → spec review → code-quality review per task, + final whole-slice review = SHIP).