### PR TITLE
fix(#1196): reject a vehicle block scheduled over a live booking

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -416,7 +416,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     maintenanceLogRepo,
     runInTransaction,
   )
-  const vehicleBlockService = new VehicleBlockService(vehicleRepo, vehicleBlockRepo)
+  const vehicleBlockService = new VehicleBlockService(vehicleRepo, vehicleBlockRepo, bookingRepo)
   const fleetOverviewService = new FleetOverviewService(fleetOverviewRepo)
   const overviewService = new OverviewService(overviewRepo)
   const adminRevenueService = new AdminRevenueService(paymentEventRepo, operatorRepo)

--- a/packages/api/src/repositories/drizzle/booking.ts
+++ b/packages/api/src/repositories/drizzle/booking.ts
@@ -195,6 +195,30 @@ export class DrizzleBookingRepository implements BookingRepository {
     return row?.value ?? 0
   }
 
+  // #1196: reverse of the booking→block guard. Same `tstzrange && tstzrange`
+  // overlap the bookings_no_overlap exclusion rides on, so the half-open,
+  // turnaround-inclusive [startAt, effectiveEndAt) window matches the in-memory
+  // adapter exactly. Unscoped — the vehicle is already tenant-resolved by the caller.
+  async findActiveOverlappingForVehicle(
+    vehicleId: string,
+    from: Date,
+    to: Date,
+  ): Promise<Booking[]> {
+    const fromIso = from.toISOString()
+    const toIso = to.toISOString()
+    const rows = await this.db
+      .select(bookingColumns)
+      .from(bookings)
+      .where(
+        and(
+          eq(bookings.assignedVehicleId, vehicleId),
+          inArray(bookings.status, ['CONFIRMED', 'ACTIVE'] as const),
+          sql`tstzrange("startAt", "effectiveEndAt") && tstzrange(${fromIso}::timestamptz, ${toIso}::timestamptz)`,
+        ),
+      )
+    return rows.map(toBooking)
+  }
+
   async countActiveForLocation(locationId: string): Promise<number> {
     const [row] = await this.db
       .select({ value: count() })

--- a/packages/api/src/repositories/in-memory/booking.ts
+++ b/packages/api/src/repositories/in-memory/booking.ts
@@ -82,6 +82,18 @@ export class InMemoryBookingRepository implements BookingRepository {
     return [...ids]
   }
 
+  // #1196: reuses the same pure overlap predicate the exclusion check rides on
+  // (assigned vehicle, BLOCKING_STATUSES, turnaround-inclusive [startAt,
+  // effectiveEndAt)) so the reverse block→booking guard is byte-for-byte the same
+  // window as the booking→block one. Unscoped — the caller resolved the vehicle.
+  async findActiveOverlappingForVehicle(
+    vehicleId: string,
+    from: Date,
+    to: Date,
+  ): Promise<Booking[]> {
+    return getConflictingBookings([...this.store.values()], vehicleId, from, to)
+  }
+
   private isVisible(ctx: CallerContext, booking: Booking): boolean {
     const scope = bookingReadScope(ctx)
     if (scope.kind === 'none') return false

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -455,6 +455,12 @@ export interface BookingRepository {
    *  vehicle set. Used to guard operations that assume no live bookings exist
    *  for those vehicles — e.g. archiving a vehicle class. */
   countActiveForVehicles(vehicleIds: string[]): Promise<number>
+  /** #1196: CONFIRMED/ACTIVE bookings on `vehicleId` whose turnaround-inclusive
+   *  [startAt, effectiveEndAt) window overlaps [from, to). Mirrors
+   *  VehicleBlockRepository.findOverlapping for the REVERSE guard — VehicleBlockService
+   *  rejects a block scheduled over a live booking. Unscoped by design: the vehicle is
+   *  already tenant-resolved by the caller, and authz lives in the service. */
+  findActiveOverlappingForVehicle(vehicleId: string, from: Date, to: Date): Promise<Booking[]>
   /** Counts bookings in BLOCKING_STATUSES (CONFIRMED, ACTIVE) that reference the
    *  given location as pickup OR dropoff. Guards archiving a location still in
    *  live use (#412). */

--- a/packages/api/src/services/vehicle-block.test.ts
+++ b/packages/api/src/services/vehicle-block.test.ts
@@ -1,20 +1,68 @@
 import type { CreateVehicleBlockInput } from '@kuruma/shared/validators/vehicle-block'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
+import { InMemoryBookingRepository } from '../repositories/in-memory/booking'
 import { InMemoryVehicleRepository } from '../repositories/in-memory/vehicle'
 import { InMemoryVehicleBlockRepository } from '../repositories/in-memory/vehicle-block'
-import type { Vehicle } from '../stores'
+import type { Booking, Vehicle } from '../stores'
 import { VehicleBlockService } from './vehicle-block'
 
 let vehicleRepo: InMemoryVehicleRepository
 let blockRepo: InMemoryVehicleBlockRepository
+let bookingRepo: InMemoryBookingRepository
 let service: VehicleBlockService
 
 beforeEach(() => {
   vehicleRepo = new InMemoryVehicleRepository()
   blockRepo = new InMemoryVehicleBlockRepository()
-  service = new VehicleBlockService(vehicleRepo, blockRepo)
+  bookingRepo = new InMemoryBookingRepository()
+  service = new VehicleBlockService(vehicleRepo, blockRepo, bookingRepo)
 })
+
+// A complete Booking with sane defaults; tests override only the fields the
+// reverse block→booking guard keys on (assignedVehicleId, status, the window).
+function makeBooking(overrides: Partial<Booking>): Booking {
+  return {
+    id: crypto.randomUUID(),
+    operatorId: 'op_a',
+    renterId: 'renter_1',
+    classId: 'class_1',
+    requestedVehicleId: null,
+    assignedVehicleId: null,
+    pickupLocationId: 'loc_1',
+    dropoffLocationId: 'loc_1',
+    startAt: new Date('2026-07-01T09:00:00.000Z'),
+    endAt: new Date('2026-07-01T17:00:00.000Z'),
+    effectiveEndAt: new Date('2026-07-01T17:00:00.000Z'),
+    status: 'CONFIRMED',
+    source: 'DIRECT',
+    fulfillmentMode: 'SPECIFIC',
+    bookingCode: 'TESTBK01',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: null,
+    cancellationFee: null,
+    cancellationFeeSettlement: 'ADVISORY',
+    cancelledAt: null,
+    idempotencyKey: null,
+    disclaimerAcknowledgedAt: null,
+    disclaimerTermsVersion: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+// A service whose booking repo is pre-seeded with the given bookings, so the
+// reverse guard sees a live booking on the car. Other repos stay shared/empty.
+function serviceWithBookings(bookings: Booking[]): VehicleBlockService {
+  const seeded = new InMemoryBookingRepository(new Map(bookings.map((b) => [b.id, b])))
+  return new VehicleBlockService(vehicleRepo, blockRepo, seeded)
+}
 
 function ctxFor(operatorId: string): CallerContext {
   return { userId: `user_${operatorId}`, role: 'OPERATOR_OWNER', operatorId }
@@ -129,6 +177,98 @@ describe('VehicleBlockService.createBlock', () => {
     await expect(service.createBlock(renter, vehicle.id, blockInput())).rejects.toThrow(
       'fleet write scope required',
     )
+  })
+})
+
+describe('VehicleBlockService.createBlock — reverse block→booking guard (#1196)', () => {
+  it('returns 409 BLOCK_BOOKING_CONFLICT when a CONFIRMED booking overlaps the block window', async () => {
+    const vehicle = await seedVehicle('op_a')
+    // booking 08:00–12:00 overlaps the default block 09:00–17:00 on the same car.
+    const booking = makeBooking({
+      assignedVehicleId: vehicle.id,
+      startAt: new Date('2026-07-01T08:00:00.000Z'),
+      endAt: new Date('2026-07-01T12:00:00.000Z'),
+      effectiveEndAt: new Date('2026-07-01T12:00:00.000Z'),
+    })
+    const svc = serviceWithBookings([booking])
+
+    const result = await svc.createBlock(ctxFor('op_a'), vehicle.id, blockInput())
+
+    expect(result).toMatchObject({ ok: false, status: 409, code: 'BLOCK_BOOKING_CONFLICT' })
+  })
+
+  it('returns 409 BLOCK_BOOKING_CONFLICT when an ACTIVE booking overlaps the block window', async () => {
+    const vehicle = await seedVehicle('op_a')
+    // ACTIVE is the other blocking status; a mutation dropping it must fail this.
+    const booking = makeBooking({
+      assignedVehicleId: vehicle.id,
+      status: 'ACTIVE',
+      startAt: new Date('2026-07-01T08:00:00.000Z'),
+      endAt: new Date('2026-07-01T12:00:00.000Z'),
+      effectiveEndAt: new Date('2026-07-01T12:00:00.000Z'),
+    })
+    const svc = serviceWithBookings([booking])
+
+    const result = await svc.createBlock(ctxFor('op_a'), vehicle.id, blockInput())
+
+    expect(result).toMatchObject({ ok: false, status: 409, code: 'BLOCK_BOOKING_CONFLICT' })
+  })
+
+  it('rejects a block that lands only in the booking dropoff turnaround tail (effectiveEndAt)', async () => {
+    const vehicle = await seedVehicle('op_a')
+    // ends 17:00 but effectiveEndAt 18:00 (1h turnaround); block 17:30–17:45 sits in the tail.
+    const booking = makeBooking({
+      assignedVehicleId: vehicle.id,
+      startAt: new Date('2026-07-01T09:00:00.000Z'),
+      endAt: new Date('2026-07-01T17:00:00.000Z'),
+      effectiveEndAt: new Date('2026-07-01T18:00:00.000Z'),
+    })
+    const svc = serviceWithBookings([booking])
+
+    const result = await svc.createBlock(
+      ctxFor('op_a'),
+      vehicle.id,
+      blockInput({ startAt: '2026-07-01T17:30:00.000Z', endAt: '2026-07-01T17:45:00.000Z' }),
+    )
+
+    expect(result).toMatchObject({ ok: false, status: 409, code: 'BLOCK_BOOKING_CONFLICT' })
+  })
+
+  it('allows the block when the only overlapping booking is CANCELLED (not a blocking status)', async () => {
+    const vehicle = await seedVehicle('op_a')
+    const booking = makeBooking({ assignedVehicleId: vehicle.id, status: 'CANCELLED' })
+    const svc = serviceWithBookings([booking])
+
+    const result = await svc.createBlock(ctxFor('op_a'), vehicle.id, blockInput())
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows a block adjacent to a booking (block.startAt === booking.effectiveEndAt — half-open)', async () => {
+    const vehicle = await seedVehicle('op_a')
+    const booking = makeBooking({
+      assignedVehicleId: vehicle.id,
+      startAt: new Date('2026-07-01T00:00:00.000Z'),
+      endAt: new Date('2026-07-01T09:00:00.000Z'),
+      effectiveEndAt: new Date('2026-07-01T09:00:00.000Z'),
+    })
+    const svc = serviceWithBookings([booking])
+
+    // default block starts 09:00 — exactly the booking's effectiveEndAt, so no overlap.
+    const result = await svc.createBlock(ctxFor('op_a'), vehicle.id, blockInput())
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows the block when the overlapping booking is on a different vehicle', async () => {
+    const vehicle = await seedVehicle('op_a')
+    const other = await seedVehicle('op_a')
+    const booking = makeBooking({ assignedVehicleId: other.id })
+    const svc = serviceWithBookings([booking])
+
+    const result = await svc.createBlock(ctxFor('op_a'), vehicle.id, blockInput())
+
+    expect(result.ok).toBe(true)
   })
 })
 

--- a/packages/api/src/services/vehicle-block.ts
+++ b/packages/api/src/services/vehicle-block.ts
@@ -2,7 +2,12 @@ import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import type { CreateVehicleBlockInput } from '@kuruma/shared/validators/vehicle-block'
 import { type CallerContext, requireFleetWriteScope } from '../middleware/auth'
 import { PG_ERROR, VEHICLE_BLOCKS_OVERLAP, pgConstraintName, pgErrorCode } from '../pg-errors'
-import type { VehicleBlock, VehicleBlockRepository, VehicleRepository } from '../repositories/types'
+import type {
+  BookingRepository,
+  VehicleBlock,
+  VehicleBlockRepository,
+  VehicleRepository,
+} from '../repositories/types'
 
 export type VehicleBlockResult =
   | { ok: true; block: VehicleBlock }
@@ -11,6 +16,8 @@ export type VehicleBlockResult =
 const VEHICLE_NOT_FOUND_MESSAGE = 'Vehicle not found'
 const BLOCK_NOT_FOUND_MESSAGE = 'Block not found'
 const OVERLAP_MESSAGE = 'This vehicle is already blocked for an overlapping window'
+const BOOKING_CONFLICT_MESSAGE =
+  'This vehicle has a confirmed or active booking in the requested window'
 
 // The GiST EXCLUDE is named `vehicle_blocks_no_overlap`; match the name (not the
 // bare 23P01) so a block-vs-block clash is told apart from any other exclusion.
@@ -34,6 +41,10 @@ export class VehicleBlockService {
   constructor(
     private readonly vehicleRepo: VehicleRepository,
     private readonly vehicleBlockRepo: VehicleBlockRepository,
+    // #1196: narrow read port (ISP) for the reverse block→booking guard. Only the
+    // overlap lookup is needed, so the service can't reach into the rest of the
+    // booking repo; the composition root injects the concrete BookingRepository.
+    private readonly bookingRepo: Pick<BookingRepository, 'findActiveOverlappingForVehicle'>,
   ) {}
 
   async createBlock(
@@ -45,6 +56,26 @@ export class VehicleBlockService {
 
     const vehicle = await this.vehicleRepo.findById(ctx, vehicleId)
     if (!vehicle) return { ok: false, error: VEHICLE_NOT_FOUND_MESSAGE, status: 404 }
+
+    // #1196: reject a block that would silently take a car off the calendar while
+    // a CONFIRMED/ACTIVE booking still holds it — the reverse of the booking→block
+    // VEHICLE_BLOCKED guard, over the same turnaround-inclusive window. Like that
+    // guard, this is a service-level NOT EXISTS (no single GiST EXCLUDE can span
+    // bookings + vehicle_blocks); the residual schedule-during-checkout race is the
+    // same tiny, operator-recoverable one documented on the booking side.
+    const bookingConflicts = await this.bookingRepo.findActiveOverlappingForVehicle(
+      vehicle.id,
+      new Date(input.startAt),
+      new Date(input.endAt),
+    )
+    if (bookingConflicts.length > 0) {
+      return {
+        ok: false,
+        error: BOOKING_CONFLICT_MESSAGE,
+        status: 409,
+        code: 'BLOCK_BOOKING_CONFLICT' satisfies ErrorCode,
+      }
+    }
 
     try {
       const block = await this.vehicleBlockRepo.create({

--- a/packages/api/tests/integration/booking-vehicle-block.test.ts
+++ b/packages/api/tests/integration/booking-vehicle-block.test.ts
@@ -12,6 +12,7 @@ import {
   createDrizzleTransaction,
 } from '../../src/repositories/drizzle'
 import { BookingService } from '../../src/services/booking'
+import { VehicleBlockService } from '../../src/services/vehicle-block'
 import {
   cleanupBookings,
   cleanupLocations,
@@ -45,6 +46,15 @@ const service = new BookingService(
   undefined,
   vehicleClassRepo,
 )
+
+// #1196: the reverse guard runs the Drizzle findActiveOverlappingForVehicle SQL
+// against real pg — proving the tstzrange overlap matches the in-memory adapter.
+const vehicleBlockService = new VehicleBlockService(vehicleRepo, blockRepo, bookingRepo)
+const opCtx: CallerContext = {
+  userId: 'op-user',
+  role: 'OPERATOR_OWNER',
+  operatorId: BEST_CAR_RENTAL_OPERATOR_ID,
+}
 
 // 60-minute turnaround so effectiveEndAt = endAt + 1h, giving a small tail the
 // block guard must also defend (must-fix #1).
@@ -194,5 +204,57 @@ describe('booking-vs-block guard (real pg, #1101)', () => {
 
     expect(res.ok).toBe(true)
     if (res.ok) createdBookingIds.push(res.booking.id)
+  })
+})
+
+describe('block-vs-booking guard (real pg, #1196)', () => {
+  it('rejects a block scheduled over a CONFIRMED booking on the rental window (409 BLOCK_BOOKING_CONFLICT)', async () => {
+    const vehicleId = await seedVehicle('Block Over Booking Car 1')
+    const booked = await bookVehicle(vehicleId)
+    expect(booked.ok).toBe(true)
+    if (booked.ok) createdBookingIds.push(booked.booking.id)
+
+    const res = await vehicleBlockService.createBlock(opCtx, vehicleId, {
+      kind: 'MAINTENANCE',
+      reason: 'in-shop',
+      startAt: '2027-10-01T12:00:00.000Z',
+      endAt: '2027-10-01T18:00:00.000Z',
+    })
+
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'BLOCK_BOOKING_CONFLICT' })
+  })
+
+  it('rejects a block that overlaps only the booking dropoff turnaround tail', async () => {
+    const vehicleId = await seedVehicle('Block Over Booking Car 2')
+    const booked = await bookVehicle(vehicleId)
+    expect(booked.ok).toBe(true)
+    if (booked.ok) createdBookingIds.push(booked.booking.id)
+
+    // endAt 09:00, effectiveEndAt 10:00 (60-min turnaround); 09:30–09:45 is the tail.
+    const res = await vehicleBlockService.createBlock(opCtx, vehicleId, {
+      kind: 'MAINTENANCE',
+      reason: 'tail',
+      startAt: '2027-10-02T09:30:00.000Z',
+      endAt: '2027-10-02T09:45:00.000Z',
+    })
+
+    expect(res).toMatchObject({ ok: false, status: 409, code: 'BLOCK_BOOKING_CONFLICT' })
+  })
+
+  it('allows a block entirely after the booking turnaround window', async () => {
+    const vehicleId = await seedVehicle('Block Over Booking Car 3')
+    const booked = await bookVehicle(vehicleId)
+    expect(booked.ok).toBe(true)
+    if (booked.ok) createdBookingIds.push(booked.booking.id)
+
+    const res = await vehicleBlockService.createBlock(opCtx, vehicleId, {
+      kind: 'MAINTENANCE',
+      reason: 'later',
+      startAt: '2027-10-05T00:00:00.000Z',
+      endAt: '2027-10-05T06:00:00.000Z',
+    })
+
+    expect(res.ok).toBe(true)
+    if (res.ok) createdBlockIds.push(res.block.id)
   })
 })

--- a/packages/api/tests/integration/vehicle-blocks.test.ts
+++ b/packages/api/tests/integration/vehicle-blocks.test.ts
@@ -7,6 +7,7 @@ import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { pgConstraintName, pgErrorCode } from '../../src/pg-errors'
 import {
   DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
   DrizzleVehicleBlockRepository,
   DrizzleVehicleRepository,
 } from '../../src/repositories/drizzle'
@@ -285,7 +286,11 @@ describe('vehicle_blocks availability subtraction', () => {
 // (VEHICLE_BLOCK_OVERLAP). vehicleA persists from the first beforeAll; the
 // top-level afterEach cleans every block this describe creates.
 describe('VehicleBlockService against Postgres', () => {
-  const service = new VehicleBlockService(vehicleRepo, new DrizzleVehicleBlockRepository(db))
+  const service = new VehicleBlockService(
+    vehicleRepo,
+    new DrizzleVehicleBlockRepository(db),
+    new DrizzleBookingRepository(db),
+  )
 
   function input(startAt: Date, endAt: Date) {
     return {

--- a/packages/api/tests/routes/vehicle-blocks.test.ts
+++ b/packages/api/tests/routes/vehicle-blocks.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT, type UserRole } from '../../src/middleware/auth'
 import {
+  InMemoryBookingRepository,
   InMemoryVehicleBlockRepository,
   InMemoryVehicleRepository,
 } from '../../src/repositories/in-memory'
@@ -50,11 +51,15 @@ const validBody = {
 
 let vehicleRepo: InMemoryVehicleRepository
 let blockRepo: InMemoryVehicleBlockRepository
+let bookingRepo: InMemoryBookingRepository
 
 function appAs(role: UserRole, operatorId?: string): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware('caller', role, operatorId))
-  a.route('/', createVehicleBlockRoutes(new VehicleBlockService(vehicleRepo, blockRepo)))
+  a.route(
+    '/',
+    createVehicleBlockRoutes(new VehicleBlockService(vehicleRepo, blockRepo, bookingRepo)),
+  )
   return a
 }
 
@@ -69,6 +74,7 @@ function postBlock(app: Hono, vehicleId: string, body: unknown = validBody) {
 beforeEach(() => {
   vehicleRepo = new InMemoryVehicleRepository()
   blockRepo = new InMemoryVehicleBlockRepository()
+  bookingRepo = new InMemoryBookingRepository()
 })
 
 describe('POST /vehicles/:vehicleId/blocks', () => {

--- a/packages/shared/src/db/fleet.ts
+++ b/packages/shared/src/db/fleet.ts
@@ -223,13 +223,15 @@ export const maintenanceLogs = pgTable(
 // [startAt, endAt) window — maintenance, out-of-service, or a manual operator
 // hold. Unlike maintenance_logs (reactive, cost-tracking, welded to the binary
 // vehicle.status=MAINTENANCE toggle), a block is forward-looking and is the
-// availability primitive: a CONFIRMED/ACTIVE booking cannot overlap one. The
-// block-vs-block guarantee is the `vehicle_blocks_no_overlap` GiST EXCLUDE
+// availability primitive: a CONFIRMED/ACTIVE booking and a block cannot overlap.
+// The block-vs-block guarantee is the `vehicle_blocks_no_overlap` GiST EXCLUDE
 // constraint added in a custom migration (EXCLUDE is not expressible in the
 // drizzle table builder — same pattern as bookings_no_overlap). Booking-vs-block
-// is enforced in the service layer (a NOT EXISTS at booking create and on
-// operator assign/substitute, #1152), since a single EXCLUDE index cannot span
-// two tables.
+// is enforced in the service layer in BOTH directions, since a single EXCLUDE
+// index cannot span two tables: a booking landing on a block is rejected at
+// booking create + operator assign/substitute (#1152), and a block scheduled
+// over a live booking is rejected at block create (#1196) — both over the same
+// turnaround-inclusive window.
 export const vehicleBlocks = pgTable(
   'vehicle_blocks',
   {

--- a/packages/shared/src/lib/error-codes.test.ts
+++ b/packages/shared/src/lib/error-codes.test.ts
@@ -12,6 +12,7 @@ import { ERROR_CODES } from './error-codes'
 describe('ERROR_CODES', () => {
   test('is the exhaustive set of envelope failure codes the API emits', () => {
     expect([...ERROR_CODES].sort()).toEqual([
+      'BLOCK_BOOKING_CONFLICT',
       'CLASS_COMBO_SOLD_OUT',
       'CLASS_HAS_ACTIVE_BOOKINGS',
       'CONSENT_REQUIRED',

--- a/packages/shared/src/lib/error-codes.ts
+++ b/packages/shared/src/lib/error-codes.ts
@@ -49,6 +49,11 @@ export const ERROR_CODES = [
   // existing block on the same car (the vehicle_blocks_no_overlap GiST EXCLUDE);
   // block create 409s. Distinct from VEHICLE_BLOCKED (a booking hitting a block).
   'VEHICLE_BLOCK_OVERLAP',
+  // #1196: an operator schedules a vehicle block whose window overlaps a
+  // CONFIRMED/ACTIVE booking on the same car (turnaround-inclusive) — the reverse
+  // of VEHICLE_BLOCKED. Block create 409s rather than silently taking a car with a
+  // live booking off the calendar (the renter still shows up).
+  'BLOCK_BOOKING_CONFLICT',
   // #464 assign: operator assigns a concrete car to a CLASS_COMBO float.
   //  NOT_A_COMBO         — target booking is not a CLASS_COMBO (e.g. a SPECIFIC booking)
   //  INVALID_STATUS      — booking is in a terminal status (CANCELLED / COMPLETED)


### PR DESCRIPTION
## Problem

`VehicleBlockService.createBlock` only checked **block-vs-block** overlap (the `vehicle_blocks_no_overlap` GiST EXCLUDE). An operator could schedule a maintenance / out-of-service / manual-hold block over a window where the car still held a **CONFIRMED/ACTIVE** booking — silently taking a booked car off the calendar while the renter still shows up. This is the missing reverse of the booking→block guard (#1101/#1152).

## Fix

Mirror the booking→block guard at the service layer, over the same turnaround-inclusive `[startAt, effectiveEndAt)` window:

- New `BookingRepository.findActiveOverlappingForVehicle(vehicleId, from, to)` port.
  - **Drizzle:** `tstzrange("startAt","effectiveEndAt") && tstzrange(from,to)` + `status IN (CONFIRMED, ACTIVE)`.
  - **In-memory:** reuses the existing `getConflictingBookings` predicate, so both adapters share the exact same window semantics.
- Injected **ISP-narrow** as `Pick<BookingRepository,'findActiveOverlappingForVehicle'>` (3rd ctor arg; concrete wired only in the composition root `index.ts`).
- `createBlock` runs the guard after vehicle resolution → returns **409 `BLOCK_BOOKING_CONFLICT`** (new error code) when a live booking overlaps.

No migration. Like the booking side, this is a service-level `NOT EXISTS` (no single GiST EXCLUDE can span two tables); the residual schedule-during-checkout race is the same tiny, operator-recoverable one documented on the booking side.

## Tests

- **6 in-memory unit tests** (`vehicle-block.test.ts`): CONFIRMED overlap → 409, ACTIVE overlap → 409, turnaround-tail (`effectiveEndAt`) overlap → 409, CANCELLED non-blocking → allowed, half-open adjacency (`block.startAt === booking.effectiveEndAt`) → allowed, different vehicle → allowed.
- **3 real-pg integration tests** (`booking-vehicle-block.test.ts`): proves the Drizzle `tstzrange` SQL matches the in-memory adapter — over-rental-window → 409, turnaround-tail → 409, after-window → allowed.
- Existing ctor sites updated to 3-arg.

## Verification

- api suite `2250/2250`, vehicle-block unit `17/17`
- tsc ×3 (shared/api/web), biome, `lint:boundaries` all exit 0
- Reviewed by code-reviewer + architect: both **SHIP**, no CRITICAL/HIGH

Closes #1196