### PR TITLE
fix(#1228): requirePlatformMember fails closed (401) + doc /admin/* floor invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ Use them instead of manual `c.json({ success: true/false, ... })` construction.
 
 Enforced by `bun run --filter @kuruma/api lint:boundaries` (CI step) — which also flags any `new Drizzle*`/`new InMemory*` construction outside the composition root and the sanctioned `*-transaction.ts` factories.
 
+**Platform-admin surfaces MUST mount under `/admin/*` (#1164, #1228).** The structural read-floor `requirePlatformMember()` (mounted once as `app.use('/admin/*', requireAuth())` → `app.use('/admin/*', requirePlatformMember())` in `index.ts`) is **path-prefix-bound**: it only protects routes under that prefix. A platform route mounted anywhere else inherits NO structural authz and relies solely on its in-body `requirePlatform*` call — one forgotten call = an open admin surface. So: register every platform-admin router under `/admin/*`, never a sibling prefix. The per-handler `requirePlatform*` gates stay as defense-in-depth (and carry the stricter write-only `requirePlatformAdmin` distinction).
+
 ## Commands
 
 | Task | Command |

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -150,7 +150,12 @@ export function requireAuth(): MiddlewareHandler {
  *  so a read route never breaks if `PLATFORM_ROLES` ever widens past PLATFORM_ADMIN. */
 export function requirePlatformMember(): MiddlewareHandler {
   return async (c: Context, next) => {
-    requirePlatformRead(toCallerContext(requireUser(c)))
+    // Fail-closed and ordering-independent (#1228): if this ever runs without a
+    // preceding requireAuth, surface 401 (mirroring requireAuth's own no-user
+    // branch) instead of letting requireUser's plain Error fall through to 500.
+    const user = getUser(c)
+    if (!user) return fail(c, 'Unauthorized', 401)
+    requirePlatformRead(toCallerContext(user))
     return next()
   }
 }

--- a/packages/api/tests/middleware/platform-member.test.ts
+++ b/packages/api/tests/middleware/platform-member.test.ts
@@ -20,6 +20,25 @@ function appWith(role: Parameters<typeof testAuthMiddleware>[1]): Hono {
   return app
 }
 
+// #1228: the gate must be SELF-SUFFICIENT and ordering-independent. If it ever
+// runs without a preceding requireAuth (a future mis-wire), the no-user path must
+// fail CLOSED with 401 — not surface requireUser's plain Error as a 500.
+function appNoUser(): Hono {
+  const app = new Hono()
+  app.use('/admin/*', requirePlatformMember())
+  app.get('/admin/unguarded', (c) => c.json({ ok: true }))
+  setupGlobalHandlers(app)
+  return app
+}
+
+describe('requirePlatformMember fail-closed on no user (#1228)', () => {
+  it('401s (not 500) when no authenticated user is in context', async () => {
+    const res = await appNoUser().request('/admin/unguarded')
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('Unauthorized')
+  })
+})
+
 describe('requirePlatformMember structural /admin/* gate (#1164)', () => {
   it('403s a tenant operator on an in-body-ungated admin route', async () => {
     const res = await appWith('OPERATOR_OWNER').request('/admin/unguarded')


### PR DESCRIPTION
## What

Closes #1228. The two architect LOW nits deferred from #1213 (PR #1227), originally surfaced in #1164. API-only, no migration.

1. **`requirePlatformMember` now fails closed with 401, not 500.** It called `requireUser(c)`, which throws a plain `Error` → mapped to 500 by `onError`. On the no-user path it now uses `getUser(c)` + `fail(c, 'Unauthorized', 401)` — mirroring `requireAuth`'s own no-user branch. The gate is now **self-sufficient and ordering-independent**: even if it ever runs without a preceding `requireAuth` (a future mis-wire), it denies cleanly instead of 500-ing. Unreachable today (`requireAuth` runs first), so this is hardening, not a live-bug fix.

2. **Documented the path-prefix-bound floor in AGENTS.md.** `requirePlatformMember()` only protects routes under `/admin/*`; a platform route mounted on a sibling prefix inherits no structural authz. The note makes "all platform-admin surfaces mount under `/admin/*`" an explicit, reviewable invariant.

## Why a doc note (not a lint guard)

A linter for "every router using `requirePlatform*` is mounted under `/admin/*`" needs cross-file analysis of the composition-root mount graph — disproportionate for a single mount point. The invariant is cheaply enforced by the documented convention + the existing per-handler `requirePlatform*` defense-in-depth. Revisit if platform sub-apps proliferate.

## Verification

- RED-first test: `401s (not 500) when no authenticated user is in context` — failed at 500 before the fix, passes after.
- `bun run --filter @kuruma/api typecheck` — clean
- `lint:boundaries` — OK · biome — clean
- Full API suite — **2261 passed** (200 files)

## Test plan

- [ ] CI green (tsc / boundaries / biome / full suites)