### PR TITLE
fix: scope vehicle classes by picked operator

### DIFF
--- a/packages/api/src/repositories/drizzle/vehicle-class.ts
+++ b/packages/api/src/repositories/drizzle/vehicle-class.ts
@@ -30,6 +30,9 @@ export class DrizzleVehicleClassRepository implements VehicleClassRepository {
     } else if (scope.kind === 'none') {
       conditions.push(sql`false`)
     }
+    if (filters?.operatorId) {
+      conditions.push(eq(vehicleClasses.operatorId, filters.operatorId))
+    }
 
     if (filters?.status) {
       conditions.push(eq(vehicleClasses.status, filters.status))

--- a/packages/api/src/repositories/in-memory/vehicle-class.ts
+++ b/packages/api/src/repositories/in-memory/vehicle-class.ts
@@ -16,9 +16,12 @@ export class InMemoryVehicleClassRepository implements VehicleClassRepository {
     const all = [...this.store.values()].filter((vc) =>
       scope.kind === 'operator' ? vc.operatorId === scope.operatorId : true,
     )
-    if (filters?.status) return all.filter((vc) => vc.status === filters.status)
-    if (filters?.includeArchived) return all
-    return all.filter((vc) => vc.status !== 'ARCHIVED')
+    const scoped = filters?.operatorId
+      ? all.filter((vc) => vc.operatorId === filters.operatorId)
+      : all
+    if (filters?.status) return scoped.filter((vc) => vc.status === filters.status)
+    if (filters?.includeArchived) return scoped
+    return scoped.filter((vc) => vc.status !== 'ARCHIVED')
   }
 
   async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -757,6 +757,7 @@ export interface MaintenanceLogRepository {
 export type { VehicleBlockRepository } from './types-vehicle-block'
 
 export interface VehicleClassFilters {
+  operatorId?: string
   status?: 'ACTIVE' | 'ARCHIVED'
   includeArchived?: boolean
 }

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -13,6 +13,7 @@ import {
   toCallerContext,
 } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
+import type { VehicleClassFilters } from '../services/filters'
 import type { VehicleClassService, VehicleClassUpdate } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
@@ -57,7 +58,7 @@ export function createVehicleClassRoutes(
         // includeArchived params are ignored here — archived inventory is never
         // publicly listable (#395). Admin-scoped archived views go through the
         // protected endpoints.
-        const classes = await service.findAll(PUBLIC_CONTEXT)
+        const classes = await service.findPublicCatalog(PUBLIC_CONTEXT)
         // Catalog changes minutes-to-hours, not per-request. 60s at the edge
         // cuts origin traffic ~95% while keeping propagation fast enough that
         // owner edits (rate change, name fix) are visible within a minute.
@@ -104,10 +105,18 @@ export function createVehicleClassRoutes(
         // non-operator 'all' scope would leak every tenant's classes + archived
         // rows to any cookie-authed caller hitting the source-agnostic API.
         requireManagementRead(ctx)
+        const filters: VehicleClassFilters = {}
+        const status = c.req.query('status')
+        if (status === 'ACTIVE' || status === 'ARCHIVED') filters.status = status
         const includeArchived = c.req.query('includeArchived') === 'true'
+        if (includeArchived) filters.includeArchived = true
         const classes = await service.findAll(
           ctx,
-          includeArchived ? { includeArchived } : undefined,
+          {
+            operatorId: c.req.query('operatorId'),
+            includeAll: c.req.query('includeAll') === 'true',
+          },
+          filters,
         )
         return ok(c, classes)
       })

--- a/packages/api/src/services/filters.ts
+++ b/packages/api/src/services/filters.ts
@@ -22,4 +22,5 @@ export type {
   InsuranceOptionFilters,
   LocationFilters,
   NotificationLogFilters,
+  VehicleClassFilters,
 } from '../repositories/types'

--- a/packages/api/src/services/vehicle-class.test.ts
+++ b/packages/api/src/services/vehicle-class.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SYSTEM_CONTEXT } from '../middleware/auth'
+import { SYSTEM_CONTEXT, ScopeRequiredError } from '../middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryVehicleClassRepository,
@@ -97,5 +97,43 @@ describe('VehicleClassService — cross-tenant photo-spoof guard (#967)', () => 
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.vehicleClass.photos).toEqual(['https://images.unsplash.com/photo-456?w=800'])
+  })
+})
+
+describe('VehicleClassService — cross-operator manage reads', () => {
+  it('requires a scope choice for all-scope callers', async () => {
+    const { service } = setup()
+
+    await expect(
+      service.findAll(SYSTEM_CONTEXT, { includeAll: false }, { includeArchived: true }),
+    ).rejects.toBeInstanceOf(ScopeRequiredError)
+  })
+
+  it('filters all-scope manage reads by the requested operator', async () => {
+    const { service } = setup()
+    await service.create(SYSTEM_CONTEXT, classData({ operatorId: 'op_a', slug: 'a-compact' }))
+    await service.create(SYSTEM_CONTEXT, classData({ operatorId: 'op_b', slug: 'b-compact' }))
+
+    const rows = await service.findAll(
+      SYSTEM_CONTEXT,
+      { operatorId: 'op_b', includeAll: false },
+      { includeArchived: true },
+    )
+
+    expect(rows.map((r) => r.slug)).toEqual(['b-compact'])
+  })
+
+  it('keeps explicit includeAll available for oversight reads', async () => {
+    const { service } = setup()
+    await service.create(SYSTEM_CONTEXT, classData({ operatorId: 'op_a', slug: 'a-compact' }))
+    await service.create(SYSTEM_CONTEXT, classData({ operatorId: 'op_b', slug: 'b-compact' }))
+
+    const rows = await service.findAll(
+      SYSTEM_CONTEXT,
+      { includeAll: true },
+      { includeArchived: true },
+    )
+
+    expect(rows.map((r) => r.slug).sort()).toEqual(['a-compact', 'b-compact'])
   })
 })

--- a/packages/api/src/services/vehicle-class.ts
+++ b/packages/api/src/services/vehicle-class.ts
@@ -8,6 +8,7 @@ import type {
   VehicleRepository,
 } from '../repositories/types'
 import type { VehicleClass } from '../stores'
+import { type CrossOperatorRead, applyCrossOperatorReadScope } from '../tenancy'
 
 export type CreateResult =
   | { ok: true; vehicleClass: VehicleClass }
@@ -76,8 +77,17 @@ export class VehicleClassService {
     }
   }
 
-  async findAll(ctx: CallerContext, filters?: VehicleClassFilters): Promise<VehicleClass[]> {
-    return this.repo.findAll(ctx, filters)
+  async findPublicCatalog(ctx: CallerContext): Promise<VehicleClass[]> {
+    return this.repo.findAll(ctx)
+  }
+
+  async findAll(
+    ctx: CallerContext,
+    read: CrossOperatorRead,
+    filters: VehicleClassFilters = {},
+  ): Promise<VehicleClass[]> {
+    const scopedFilters = applyCrossOperatorReadScope(ctx, read, filters)
+    return this.repo.findAll(ctx, scopedFilters)
   }
 
   async findById(ctx: CallerContext, id: string): Promise<VehicleClass | undefined> {

--- a/packages/api/tests/routes/vehicle-classes.test.ts
+++ b/packages/api/tests/routes/vehicle-classes.test.ts
@@ -130,7 +130,7 @@ describe('Vehicle Class CRUD Routes', () => {
       const { data } = await createRes.json()
       await app.request(`/vehicle-classes/${data.id}`, { method: 'DELETE' }) // soft-archive
 
-      const res = await app.request('/vehicle-classes/manage?includeArchived=true')
+      const res = await app.request('/vehicle-classes/manage?includeArchived=true&includeAll=true')
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.data).toHaveLength(1)
@@ -142,9 +142,34 @@ describe('Vehicle Class CRUD Routes', () => {
       const { data } = await createRes.json()
       await app.request(`/vehicle-classes/${data.id}`, { method: 'DELETE' })
 
-      const res = await app.request('/vehicle-classes/manage')
+      const res = await app.request('/vehicle-classes/manage?includeAll=true')
       const body = await res.json()
       expect(body.data).toEqual([])
+    })
+
+    it('requires bypass callers to choose operatorId or includeAll', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const staff = mountFor(repo, 'STAFF')
+
+      const res = await staff.request('/vehicle-classes/manage?includeArchived=true')
+
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe(
+        'operatorId or includeAll=true is required for cross-operator reads',
+      )
+    })
+
+    it('scopes bypass callers to the requested operatorId', async () => {
+      const repo = new InMemoryVehicleClassRepository()
+      const staff = mountFor(repo, 'STAFF')
+      await postFor(staff, OP_A, 'a-compact')
+      await postFor(staff, OP_B, 'b-compact')
+
+      const res = await staff.request(`/vehicle-classes/manage?operatorId=${OP_B}`)
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.map((row: { slug: string }) => row.slug)).toEqual(['b-compact'])
     })
 
     it('scopes the list to the caller operator (tenant isolation)', async () => {

--- a/packages/web/src/routes/$locale/_business/manage/classes.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/classes.tsx
@@ -1,12 +1,11 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
-import { isOperatorSession } from '@/vite/guards'
 import { AddClassDialog } from '@/vite/operator-classes/AddClassDialog'
 import { DeleteClassDialog } from '@/vite/operator-classes/DeleteClassDialog'
 import { EditClassDialog } from '@/vite/operator-classes/EditClassDialog'
 import { OperatorClassesView } from '@/vite/operator-classes/OperatorClassesView'
 import { type OperatorClass, operatorClassesQueryOptions } from '@/vite/operator-classes/api'
-import { sessionQueryOptions } from '@/vite/session'
+import { useOperatorScope } from '@/vite/operator-context'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
@@ -19,10 +18,14 @@ import { useTranslations } from 'use-intl'
 // `/vehicle-classes/manage` list). includeArchived:true so owners see their
 // soft-archived classes (muted badge). The loader prefetches into the query
 // cache (no FOUC); the component reads the same options via useSuspenseQuery.
-const classesQuery = operatorClassesQueryOptions({ includeArchived: true })
-
 export const Route = createFileRoute('/$locale/_business/manage/classes')({
-  loader: ({ context }) => context.queryClient.ensureQueryData(classesQuery),
+  loaderDeps: ({ search }: { search: { operator?: string | undefined } }) => ({
+    operator: search.operator,
+  }),
+  loader: ({ context, deps }) =>
+    context.queryClient.ensureQueryData(
+      operatorClassesQueryOptions({ includeArchived: true }, deps.operator),
+    ),
   pendingComponent: PageSkeleton,
   errorComponent: OperatorClassesError,
   component: OperatorClassesRoute,
@@ -30,17 +33,13 @@ export const Route = createFileRoute('/$locale/_business/manage/classes')({
 
 export function OperatorClassesRoute() {
   const t = useTranslations('business.classes')
-  const { data: classes } = useSuspenseQuery(classesQuery)
-  const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  const scope = useOperatorScope()
+  const { data: classes } = useSuspenseQuery(
+    operatorClassesQueryOptions({ includeArchived: true }, scope.pickedOperatorId),
+  )
   const [showAdd, setShowAdd] = useState(false)
   const [editing, setEditing] = useState<OperatorClass | null>(null)
   const [deleting, setDeleting] = useState<OperatorClass | null>(null)
-
-  // Bypass roles (PLATFORM_ADMIN / legacy STAFF·ADMIN — no operatorId) read the
-  // operator-scoped list for oversight but cannot write: a create needs a single
-  // target tenant they don't carry, and the portal has no operator picker. So the
-  // page is read-only for them, mirroring locations (#583, #529 review pattern).
-  const canWrite = isOperatorSession(session)
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -50,7 +49,7 @@ export function OperatorClassesRoute() {
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
             <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
           </div>
-          {canWrite && (
+          {scope.canWrite && (
             <Button onClick={() => setShowAdd(true)}>
               <Plus className="mr-1.5 size-4" />
               {t('addClass')}
@@ -59,13 +58,17 @@ export function OperatorClassesRoute() {
         </header>
         <OperatorClassesView
           classes={classes}
-          onEdit={canWrite ? setEditing : undefined}
-          onDelete={canWrite ? setDeleting : undefined}
+          onEdit={scope.canWrite ? setEditing : undefined}
+          onDelete={scope.canWrite ? setDeleting : undefined}
         />
       </div>
-      {canWrite && (
+      {scope.canWrite && (
         <>
-          <AddClassDialog open={showAdd} onOpenChange={setShowAdd} />
+          <AddClassDialog
+            open={showAdd}
+            onOpenChange={setShowAdd}
+            pickedOperatorId={scope.pickedOperatorId}
+          />
           <EditClassDialog
             vehicleClass={editing}
             onOpenChange={(open) => !open && setEditing(null)}

--- a/packages/web/src/routes/$locale/_business/manage/fees.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fees.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute('/$locale/_business/manage/fees')({
   loader: ({ context, deps }) =>
     Promise.all([
       context.queryClient.ensureQueryData(feeSchedulesQueryOptions(deps.operator)),
-      context.queryClient.ensureQueryData(operatorClassesQueryOptions()),
+      context.queryClient.ensureQueryData(operatorClassesQueryOptions({}, deps.operator)),
     ]),
   pendingComponent: PageSkeleton,
   errorComponent: OperatorFeesError,
@@ -37,13 +37,13 @@ export function OperatorFeesRoute() {
   const scope = useOperatorScope()
   const { data: session } = useSession()
   const { data: fees } = useSuspenseQuery(feeSchedulesQueryOptions(scope.pickedOperatorId))
-  const { data: classes } = useSuspenseQuery(operatorClassesQueryOptions())
+  const { data: classes } = useSuspenseQuery(
+    operatorClassesQueryOptions({}, scope.pickedOperatorId),
+  )
 
-  // P1b: picker-admins are read-only on fees until slice 3 scopes the class
-  // dropdown (/vehicle-classes/manage has no operatorId param yet, so a picked
-  // admin would see another tenant's classes and hit a composite-FK error on
-  // create). A real operator session writes under its own tenant as before, so
-  // override the scope's canWrite to operator-session-only here.
+  // Picker-admins stay read-only on fees in this slice. The class lookup is now
+  // scoped for display, but the fee create body still does not stamp the picked
+  // operatorId. A real operator session writes under its own tenant as before.
   const feesScope = { ...scope, canWrite: isOperatorSession(session ?? null) }
 
   return (

--- a/packages/web/src/vite/operator-classes/AddClassDialog.tsx
+++ b/packages/web/src/vite/operator-classes/AddClassDialog.tsx
@@ -7,24 +7,27 @@ import {
 } from '@/components/ui/dialog'
 import { ClassForm } from '@/vite/operator-classes/ClassForm'
 import { createOperatorClass } from '@/vite/operator-classes/api'
+import type { CreateVehicleClassInput } from '@kuruma/shared/validators/vehicle-class'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'use-intl'
 
 interface AddClassDialogProps {
   readonly open: boolean
   readonly onOpenChange: (open: boolean) => void
+  readonly pickedOperatorId?: string | undefined
 }
 
 // #528 slice 4. Create a class via the slice-2 client. On success, invalidate the
 // operator-classes list so the new row appears, then close. A slug collision
 // (server 409 "Slug already in use") surfaces inline and keeps the dialog open
 // so the owner can fix it — there is no client-side uniqueness pre-check.
-export function AddClassDialog({ open, onOpenChange }: AddClassDialogProps) {
+export function AddClassDialog({ open, onOpenChange, pickedOperatorId }: AddClassDialogProps) {
   const t = useTranslations('business.classes')
   const queryClient = useQueryClient()
 
   const { mutateAsync, isPending, error, reset } = useMutation({
-    mutationFn: createOperatorClass,
+    mutationFn: (data: CreateVehicleClassInput) =>
+      createOperatorClass(pickedOperatorId ? { ...data, operatorId: pickedOperatorId } : data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['operator-classes'] })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-classes/api.ts
+++ b/packages/web/src/vite/operator-classes/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import { buildScopeParam } from '@/vite/operator-context'
 import { LUGGAGE_SIZES, TRANSMISSIONS, VEHICLE_CLASS_STATUSES } from '@kuruma/shared/enums'
 import type {
   CreateVehicleClassInput,
@@ -57,22 +58,31 @@ export interface OperatorClassFilters {
 
 export async function fetchOperatorClasses(
   filters: OperatorClassFilters = {},
+  pickedOperatorId?: string,
 ): Promise<OperatorClass[]> {
   // includeArchived=true so the owner sees soft-deleted classes (muted badge)
   // and can tell why a slug is taken.
-  const qs = filters.includeArchived ? '?includeArchived=true' : ''
+  const params = [
+    filters.includeArchived ? 'includeArchived=true' : undefined,
+    buildScopeParam(pickedOperatorId),
+  ].filter((p): p is string => Boolean(p))
+  const qs = `?${params.join('&')}`
   const res = await fetch(`${getApiBaseUrl()}/vehicle-classes/manage${qs}`, {
     credentials: 'include',
   })
   return unwrap(res, operatorClassSchema.array())
 }
 
-export function operatorClassesQueryOptions(filters: OperatorClassFilters = {}) {
+export function operatorClassesQueryOptions(
+  filters: OperatorClassFilters = {},
+  pickedOperatorId?: string,
+) {
   return queryOptions({
     // Key on includeArchived so the active-only and with-archived views never
-    // collide on a stale cache entry.
-    queryKey: ['operator-classes', filters.includeArchived ?? false],
-    queryFn: () => fetchOperatorClasses(filters),
+    // collide, and on picked operator so context switches never serve another
+    // tenant's cached classes.
+    queryKey: ['operator-classes', filters.includeArchived ?? false, pickedOperatorId ?? 'all'],
+    queryFn: () => fetchOperatorClasses(filters, pickedOperatorId),
   })
 }
 

--- a/packages/web/src/vite/operator-context/operator-context.test.ts
+++ b/packages/web/src/vite/operator-context/operator-context.test.ts
@@ -79,6 +79,15 @@ describe('useIsOperatorContextRoute', () => {
     expect(result.current).toBe(true)
   })
 
+  it('is true on the classes page because it honors ?operator', () => {
+    h.matches = [
+      { routeId: '/$locale/_business' },
+      { routeId: '/$locale/_business/manage/classes' },
+    ]
+    const { result } = renderHook(() => useIsOperatorContextRoute())
+    expect(result.current).toBe(true)
+  })
+
   it('is false on an unscoped business route that does not honor ?operator', () => {
     h.matches = [{ routeId: '/$locale/_business' }, { routeId: '/$locale/_business/dashboard' }]
     const { result } = renderHook(() => useIsOperatorContextRoute())

--- a/packages/web/src/vite/operator-context/operator-context.ts
+++ b/packages/web/src/vite/operator-context/operator-context.ts
@@ -80,6 +80,7 @@ export type WithOperatorId<T> = T & { operatorId?: string }
 // dashboard, bookings, team) adds its route id here as it lands.
 export const OPERATOR_CONTEXT_ROUTE_IDS: ReadonlySet<string> = new Set([
   '/$locale/_business/manage/add-ons',
+  '/$locale/_business/manage/classes',
   '/$locale/_business/manage/fees',
   '/$locale/_business/manage/insurance',
   '/$locale/_business/manage/locations',

--- a/packages/web/tests/vite/operator-classes/AddClassDialog.test.tsx
+++ b/packages/web/tests/vite/operator-classes/AddClassDialog.test.tsx
@@ -10,7 +10,7 @@ import en from '../../../messages/en.json'
 
 vi.mock('@/vite/operator-classes/api', () => ({ createOperatorClass: vi.fn() }))
 
-function renderDialog() {
+function renderDialog(pickedOperatorId?: string) {
   const onOpenChange = vi.fn()
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -19,7 +19,7 @@ function renderDialog() {
   render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={en}>
-        <AddClassDialog open onOpenChange={onOpenChange} />
+        <AddClassDialog open onOpenChange={onOpenChange} pickedOperatorId={pickedOperatorId} />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -52,6 +52,18 @@ describe('AddClassDialog', () => {
       expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-classes'] })
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
+  })
+
+  it('adds the picked operatorId to create bodies for platform-admin context', async () => {
+    vi.mocked(createOperatorClass).mockResolvedValue({ id: 'c1' } as never)
+    renderDialog('op_9')
+
+    await fillAndSubmit()
+
+    await waitFor(() => expect(createOperatorClass).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(createOperatorClass).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ name: 'Compact', operatorId: 'op_9' }),
+    )
   })
 
   it('surfaces a slug collision (409) and keeps the dialog open', async () => {

--- a/packages/web/tests/vite/operator-classes/OperatorClassesRoute.test.tsx
+++ b/packages/web/tests/vite/operator-classes/OperatorClassesRoute.test.tsx
@@ -1,11 +1,13 @@
-import { OperatorClassesRoute } from '@/routes/$locale/_business/manage/classes'
+import { OperatorClassesRoute, Route } from '@/routes/$locale/_business/manage/classes'
 import { type OperatorClass, operatorClassesQueryOptions } from '@/vite/operator-classes/api'
-import type { Session } from '@/vite/session'
+import { useOperatorScope } from '@/vite/operator-context'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
+
+vi.mock('@/vite/operator-context', () => ({ useOperatorScope: vi.fn() }))
 
 const en = enMessages.business.classes
 
@@ -30,26 +32,22 @@ function vehicleClass(): OperatorClass {
   }
 }
 
-const operatorSession: Session = {
-  user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'acme' },
-  csrfToken: 't',
-}
-
-const bypassSession: Session = {
-  user: { id: 'u', role: 'PLATFORM_ADMIN' },
-  csrfToken: 't',
-}
-
 // Seed both queries the route reads via useSuspenseQuery so they resolve from cache
 // (no fetch, no router needed). staleTime=Infinity suppresses a background refetch.
-function renderRoute(session: Session) {
+function renderRoute(scope: { pickedOperatorId?: string; canWrite: boolean }) {
+  vi.mocked(useOperatorScope).mockReturnValue({
+    pickedOperatorId: scope.pickedOperatorId,
+    canWrite: scope.canWrite,
+    showOperator: false,
+    operatorNameById: new Map(),
+  })
   const queryClient = new QueryClient({
     defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
   })
-  queryClient.setQueryData(['session'], session)
-  queryClient.setQueryData(operatorClassesQueryOptions({ includeArchived: true }).queryKey, [
-    vehicleClass(),
-  ])
+  queryClient.setQueryData(
+    operatorClassesQueryOptions({ includeArchived: true }, scope.pickedOperatorId).queryKey,
+    [vehicleClass()],
+  )
   render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
@@ -61,17 +59,36 @@ function renderRoute(session: Session) {
 
 describe('OperatorClassesRoute write-affordance gating (#583)', () => {
   it('shows Add + row Edit/Delete for a tenant-scoped operator session', () => {
-    renderRoute(operatorSession)
+    renderRoute({ canWrite: true })
     expect(screen.getByRole('button', { name: en.addClass })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: en.editClass })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: en.deleteAction })).toBeInTheDocument()
   })
 
   it('hides Add + row actions for a bypass role with no operatorId, but still lists rows (read-only oversight)', () => {
-    renderRoute(bypassSession)
+    renderRoute({ canWrite: false })
     expect(screen.queryByRole('button', { name: en.addClass })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: en.editClass })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: en.deleteAction })).not.toBeInTheDocument()
     expect(screen.getByText('Compact')).toBeInTheDocument()
+  })
+})
+
+const loader = Route.options.loader as (args: {
+  context: { queryClient: { ensureQueryData: ReturnType<typeof vi.fn> } }
+  deps: { operator: string | undefined }
+}) => Promise<unknown>
+
+describe('OperatorClassesRoute loader', () => {
+  it('prefetches the classes list query scoped to the picked operator', async () => {
+    const ensureQueryData = vi.fn().mockResolvedValue([])
+
+    await loader({
+      context: { queryClient: { ensureQueryData } },
+      deps: { operator: 'op_9' },
+    })
+
+    const options = ensureQueryData.mock.calls[0]?.[0] as { queryKey: unknown }
+    expect(options.queryKey).toEqual(['operator-classes', true, 'op_9'])
   })
 })

--- a/packages/web/tests/vite/operator-classes/api.test.ts
+++ b/packages/web/tests/vite/operator-classes/api.test.ts
@@ -42,32 +42,50 @@ const validClass = {
 }
 
 describe('operator-classes api', () => {
-  it('fetches the operator-scoped manage list with includeArchived + cookie auth', async () => {
+  it('fetches the manage list with includeArchived + includeAll + cookie auth', async () => {
     const rows = [{ ...validClass, status: 'ARCHIVED' as const }]
     const fetchMock = stubFetch({ success: true, data: rows })
 
     const result = await fetchOperatorClasses({ includeArchived: true })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/manage?includeArchived=true', {
-      credentials: 'include',
-    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/vehicle-classes/manage?includeArchived=true&includeAll=true',
+      {
+        credentials: 'include',
+      },
+    )
     expect(result).toEqual(rows)
   })
 
-  it('omits the includeArchived param by default', async () => {
+  it('sends includeAll by default so bypass readers make an explicit all-operators choice', async () => {
     const fetchMock = stubFetch({ success: true, data: [] })
     await fetchOperatorClasses()
-    expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/manage', {
+    expect(fetchMock).toHaveBeenCalledWith('/api/vehicle-classes/manage?includeAll=true', {
       credentials: 'include',
     })
   })
 
-  it('keys queryOptions on includeArchived so archived/active views never collide', () => {
+  it('scopes the read to operatorId and drops includeAll when an admin picks a tenant', async () => {
+    const fetchMock = stubFetch({ success: true, data: [] })
+    await fetchOperatorClasses({ includeArchived: true }, 'op_9')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('operatorId=op_9')
+    expect(url).toContain('includeArchived=true')
+    expect(url).not.toContain('includeAll')
+  })
+
+  it('keys queryOptions on includeArchived and picked operator so scoped views never collide', () => {
     expect(operatorClassesQueryOptions({ includeArchived: true }).queryKey).toEqual([
       'operator-classes',
       true,
+      'all',
     ])
-    expect(operatorClassesQueryOptions().queryKey).toEqual(['operator-classes', false])
+    expect(operatorClassesQueryOptions({}, 'op_9').queryKey).toEqual([
+      'operator-classes',
+      false,
+      'op_9',
+    ])
   })
 
   it('create POSTs to the collection with cookie auth and JSON body', async () => {

--- a/packages/web/tests/vite/operator-fees/fees.route.test.ts
+++ b/packages/web/tests/vite/operator-fees/fees.route.test.ts
@@ -7,9 +7,9 @@ import { describe, expect, it, vi } from 'vitest'
 // classes (#528) into the query cache, so the component's useSuspenseQuery
 // resolves without a FOUC and the class dropdown is fed scoped classes. It reads
 // the operator from loaderDeps so a context switch refetches; the fee key is
-// scoped to the picked operator (or 'all'). The class dropdown is NOT scoped by
-// the picker yet (slice 3), so it stays parameterless — which is why fees is
-// read-only for picker-admins until then.
+// scoped to the picked operator (or 'all'). The class dropdown uses the same
+// picked operator now that /vehicle-classes/manage accepts operatorId; fees
+// writes remain operator-session-only until create bodies stamp picked operatorId.
 const loaderDeps = Route.options.loaderDeps as (args: {
   search: { operator?: string | undefined }
 }) => { operator: string | undefined }
@@ -32,7 +32,7 @@ describe('fees route loader', () => {
     const keys = ensureQueryData.mock.calls.map((c) => (c[0] as { queryKey: unknown }).queryKey)
     expect(keys).toContainEqual(['operator-fees', 'op_9'])
     // The operator-scoped class endpoint (#528), NOT the public catalog.
-    expect(keys).toContainEqual(['operator-classes', false])
+    expect(keys).toContainEqual(['operator-classes', false, 'op_9'])
   })
 
   it('defaults the fee key to the all-scope when no operator is picked', async () => {
@@ -41,6 +41,7 @@ describe('fees route loader', () => {
 
     const keys = ensureQueryData.mock.calls.map((c) => (c[0] as { queryKey: unknown }).queryKey)
     expect(keys).toContainEqual(['operator-fees', 'all'])
+    expect(keys).toContainEqual(['operator-classes', false, 'all'])
   })
 })
 


### PR DESCRIPTION
## Summary
- scope /vehicle-classes/manage reads with operatorId/includeAll for bypass readers
- thread the picked operator through the classes route loader, query key, and API client
- show the operator picker on /manage/classes and stamp picked operatorId into class creates

## Verification
- bun run test src/services/vehicle-class.test.ts tests/routes/vehicle-classes.test.ts (packages/api)
- bun run test src/vite/operator-context/operator-context.test.ts tests/vite/operator-classes/api.test.ts tests/vite/operator-classes/OperatorClassesRoute.test.tsx tests/vite/operator-classes/AddClassDialog.test.tsx (packages/web)
- bun run typecheck (packages/api)
- bun run typecheck (packages/web)
- bun run lint:boundaries (packages/api)
- pre-commit: Biome, file-size lint, module-boundary lint, API/web typecheck