### PR TITLE
feat(operator-context): scope settings page by picked operator (picker slice 2)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -823,6 +823,8 @@
       "retry": "Try again",
       "saved": "Settings saved.",
       "noOperatorContext": "This page edits a single operator's profile. Use the admin portal to manage operators.",
+      "pickOperatorPrompt": "Select an operator from the picker above to view and edit its settings.",
+      "editingAs": "Editing settings for {name}",
       "form": {
         "name": "Business name",
         "namePlaceholder": "e.g. Osaka Car Rental",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -823,6 +823,8 @@
       "retry": "再試行",
       "saved": "設定を保存しました。",
       "noOperatorContext": "このページは単一の事業者プロフィールを編集します。事業者の管理は管理ポータルをご利用ください。",
+      "pickOperatorPrompt": "上部の選択メニューから事業者を選ぶと、その設定を表示・編集できます。",
+      "editingAs": "{name} の設定を編集中",
       "form": {
         "name": "事業者名",
         "namePlaceholder": "例：大阪レンタカー",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -823,6 +823,8 @@
       "retry": "重试",
       "saved": "设置已保存。",
       "noOperatorContext": "此页面用于编辑单个运营商的资料。请使用管理门户来管理运营商。",
+      "pickOperatorPrompt": "请从上方的选择器中选择一个运营商，以查看并编辑其设置。",
+      "editingAs": "正在编辑 {name} 的设置",
       "form": {
         "name": "商家名称",
         "namePlaceholder": "例如：大阪租车",

--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -1,6 +1,7 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { isOperatorSettingsEnabled } from '@/vite/config/features'
-import { isOperatorOwnerSession } from '@/vite/guards'
+import { canPickOperatorContext, canWriteAsOperatorOwner } from '@/vite/guards'
+import { useOperatorContext } from '@/vite/operator-context'
 import { SettingsForm } from '@/vite/operator-settings/SettingsForm'
 import {
   operatorProfileQueryKey,
@@ -33,9 +34,14 @@ export const Route = createFileRoute('/$locale/_business/manage/settings')({
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }
   },
-  loader: async ({ context }) => {
+  loaderDeps: ({ search }: { search: { operator?: string | undefined } }) => ({
+    operator: search.operator,
+  }),
+  loader: async ({ context, deps }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
-    const operatorId = session?.user.operatorId
+    // Effective id: own operator session id wins; a bypass admin falls back to the
+    // picked param. Matches OperatorSettingsRoute exactly (one resolution, two readers).
+    const operatorId = session?.user.operatorId ?? deps.operator
     if (operatorId) {
       await context.queryClient.ensureQueryData(operatorProfileQueryOptions(operatorId))
     }
@@ -48,7 +54,11 @@ export const Route = createFileRoute('/$locale/_business/manage/settings')({
 export function OperatorSettingsRoute() {
   const t = useTranslations('business.settings')
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
-  const operatorId = session?.user.operatorId
+  const { pickedOperatorId } = useOperatorContext()
+  // Effective operator id: a real operator session's own id always wins; a bypass
+  // admin falls back to the picked id. Mirrors the loader (must stay in lockstep).
+  const operatorId = session?.user.operatorId ?? pickedOperatorId
+  const canPick = canPickOperatorContext(session ?? null)
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -57,14 +67,19 @@ export function OperatorSettingsRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        {operatorId ? (
+        {session && operatorId ? (
           <OperatorSettings
+            // Reset local saved/error state when the picker swaps tenants (architect M2).
+            key={operatorId}
             operatorId={operatorId}
             csrfToken={session.csrfToken}
-            canEditHandoff={isOperatorOwnerSession(session)}
+            canEditHandoff={canWriteAsOperatorOwner(session ?? null, pickedOperatorId)}
+            showOperatorBadge={canPick && Boolean(pickedOperatorId)}
           />
         ) : (
-          <p className="text-muted-foreground">{t('noOperatorContext')}</p>
+          <p className="text-muted-foreground">
+            {canPick ? t('pickOperatorPrompt') : t('noOperatorContext')}
+          </p>
         )}
       </div>
     </main>
@@ -75,10 +90,12 @@ function OperatorSettings({
   operatorId,
   csrfToken,
   canEditHandoff,
+  showOperatorBadge,
 }: {
   operatorId: string
   csrfToken: string
   canEditHandoff: boolean
+  showOperatorBadge: boolean
 }) {
   const t = useTranslations('business.settings')
   const queryClient = useQueryClient()
@@ -97,6 +114,11 @@ function OperatorSettings({
 
   return (
     <>
+      {showOperatorBadge && (
+        <p className="mb-4 inline-block rounded-full bg-muted px-3 py-1 text-sm text-muted-foreground">
+          {t('editingAs', { name: profile.name })}
+        </p>
+      )}
       {error && (
         <p className="text-sm text-destructive mb-4">
           {error instanceof Error ? error.message : String(error)}

--- a/packages/web/src/vite/operator-context/operator-context.test.ts
+++ b/packages/web/src/vite/operator-context/operator-context.test.ts
@@ -93,4 +93,13 @@ describe('useIsOperatorContextRoute', () => {
     const { result } = renderHook(() => useIsOperatorContextRoute())
     expect(result.current).toBe(false)
   })
+
+  it('is true on the settings route (slice 2 honors ?operator)', () => {
+    h.matches = [
+      { routeId: '/$locale/_business' },
+      { routeId: '/$locale/_business/manage/settings' },
+    ]
+    const { result } = renderHook(() => useIsOperatorContextRoute())
+    expect(result.current).toBe(true)
+  })
 })

--- a/packages/web/src/vite/operator-context/operator-context.ts
+++ b/packages/web/src/vite/operator-context/operator-context.ts
@@ -84,6 +84,7 @@ export const OPERATOR_CONTEXT_ROUTE_IDS: ReadonlySet<string> = new Set([
   '/$locale/_business/manage/fees',
   '/$locale/_business/manage/insurance',
   '/$locale/_business/manage/locations',
+  '/$locale/_business/manage/settings', // slice 2 — picker honored on settings
 ])
 
 // True when the active route is one that honors `?operator` (a descendant match

--- a/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
@@ -4,8 +4,19 @@ import type { Session } from '@/vite/session'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
+
+// The route reads the picked operator from the `_business` search param via
+// useOperatorContext, which (in production) calls getRouteApi(...).useSearch().
+// These tests render the component without a router, so stub that one read and
+// drive the picked id per-test through the hoisted holder. Everything else in the
+// barrel (guards-free) is the real module so route-id wiring isn't masked.
+const h = vi.hoisted(() => ({ picked: undefined as string | undefined }))
+vi.mock('@/vite/operator-context', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/vite/operator-context')>()),
+  useOperatorContext: () => ({ pickedOperatorId: h.picked }),
+}))
 
 const en = enMessages.business.settings
 
@@ -32,6 +43,12 @@ const bypassSession: Session = {
   user: { id: 'u', role: 'PLATFORM_ADMIN' },
   csrfToken: 't',
 }
+// Legacy STAFF/ADMIN ∈ BUSINESS_ROLES but cannot pick (not PLATFORM_ADMIN) and
+// carry no operatorId, so they still hit the terminal noOperatorContext arm.
+const legacyStaffSession: Session = {
+  user: { id: 'u', role: 'STAFF' },
+  csrfToken: 't',
+}
 
 // Seed both queries the route reads via useSuspenseQuery so they resolve from
 // cache (no fetch, no router). The profile is keyed by operatorId.
@@ -51,6 +68,11 @@ function renderRoute(session: Session) {
 }
 
 describe('OperatorSettingsRoute (#903)', () => {
+  // Reset the picked operator so the owner/staff cases fall back to their own id.
+  beforeEach(() => {
+    h.picked = undefined
+  })
+
   it('prefills the profile and lets an owner edit the handoff URL', () => {
     renderRoute(ownerSession)
     expect(screen.getByLabelText(en.form.name)).toHaveValue('Acme Cars')
@@ -65,8 +87,25 @@ describe('OperatorSettingsRoute (#903)', () => {
     expect(screen.getByText(en.form.handoffOwnerOnly)).toBeInTheDocument()
   })
 
-  it('shows a not-applicable notice (no form) for a bypass role with no operatorId', () => {
+  it('lets a platform admin who picked an operator edit its profile incl. handoff', () => {
+    h.picked = OP_ID // the profile is seeded under OP_ID; admin has no own operatorId
     renderRoute(bypassSession)
+    expect(screen.getByLabelText(en.form.name)).toHaveValue('Acme Cars')
+    const handoff = screen.getByLabelText(en.form.handoffUrl)
+    expect(handoff).not.toBeDisabled() // admin-as-owner (spec §7)
+    expect(screen.getByText('Editing settings for Acme Cars')).toBeInTheDocument()
+  })
+
+  it('shows the pick-operator prompt (no form) for a platform admin with no pick', () => {
+    h.picked = undefined
+    renderRoute(bypassSession)
+    expect(screen.getByText(en.pickOperatorPrompt)).toBeInTheDocument()
+    expect(screen.queryByLabelText(en.form.name)).not.toBeInTheDocument()
+  })
+
+  it('shows the terminal no-operator-context notice (no form) for a legacy STAFF session', () => {
+    h.picked = undefined
+    renderRoute(legacyStaffSession)
     expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
     expect(screen.queryByLabelText(en.form.name)).not.toBeInTheDocument()
   })

--- a/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
@@ -81,6 +81,16 @@ describe('OperatorSettingsRoute (#903)', () => {
     expect(handoff).not.toBeDisabled()
   })
 
+  it('ignores a stray ?operator pick for an operator session — own id wins', () => {
+    // Own operator session id must beat the picked id (operatorId ?? picked).
+    // Only OP_ID's profile is seeded, so if the operands were flipped the
+    // component would resolve op_foreign, suspend on the unseeded query and
+    // never render this name — pinning the trusted-id-wins precedence.
+    h.picked = 'op_foreign'
+    renderRoute(ownerSession)
+    expect(screen.getByLabelText(en.form.name)).toHaveValue('Acme Cars')
+  })
+
   it('disables the handoff URL and shows the owner-only note for OPERATOR_STAFF', () => {
     renderRoute(staffSession)
     expect(screen.getByLabelText(en.form.handoffUrl)).toBeDisabled()

--- a/packages/web/tests/vite/operator-settings/settings.route.test.ts
+++ b/packages/web/tests/vite/operator-settings/settings.route.test.ts
@@ -32,3 +32,44 @@ describe('/manage/settings feature-flag guard', () => {
     expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
   })
 })
+
+// The loader prefetches the EFFECTIVE operator's profile so the component's
+// useSuspenseQuery resolves without a FOUC. Effective id = own operatorId (operator
+// session) ?? deps.operator (bypass admin's pick) — the same resolution the
+// component uses (one derivation, two readers must stay in lockstep).
+const loader = Route.options.loader as (args: {
+  context: { queryClient: { ensureQueryData: ReturnType<typeof vi.fn> } }
+  deps: { operator: string | undefined }
+}) => Promise<unknown>
+const loaderDeps = Route.options.loaderDeps as (a: {
+  search: { operator?: string }
+}) => { operator?: string }
+
+describe('/manage/settings loader effective-id prefetch', () => {
+  it('threads the operator search param through loaderDeps', () => {
+    expect(loaderDeps({ search: { operator: 'op_9' } })).toEqual({ operator: 'op_9' })
+  })
+
+  it('prefetches the PICKED operator profile for a bypass admin (no own operatorId)', async () => {
+    const ensureQueryData = vi
+      .fn()
+      .mockResolvedValueOnce({ user: { id: 'u', role: 'PLATFORM_ADMIN' }, csrfToken: 't' }) // session
+      .mockResolvedValueOnce({}) // profile
+    await loader({ context: { queryClient: { ensureQueryData } }, deps: { operator: 'op_9' } })
+    const profileCall = ensureQueryData.mock.calls[1][0] as { queryKey: unknown }
+    expect(profileCall.queryKey).toEqual(['operator-profile', 'op_9'])
+  })
+
+  it("uses an operator session's own id and ignores a stray ?operator param", async () => {
+    const ensureQueryData = vi
+      .fn()
+      .mockResolvedValueOnce({
+        user: { id: 'u', role: 'OPERATOR_OWNER', operatorId: 'op_self' },
+        csrfToken: 't',
+      })
+      .mockResolvedValueOnce({})
+    await loader({ context: { queryClient: { ensureQueryData } }, deps: { operator: 'op_9' } })
+    const profileCall = ensureQueryData.mock.calls[1][0] as { queryKey: unknown }
+    expect(profileCall.queryKey).toEqual(['operator-profile', 'op_self'])
+  })
+})


### PR DESCRIPTION
## What

Slice 2 of the admin operator-context picker (#407 / epic #1075): the **operator settings page** now honors the `?operator` picker the same way add-ons / insurance / locations / fleet already do on develop.

- **Loader keys on the picked operator** (`loaderDeps` on `?operator`) so a platform-admin context switch refetches instead of serving another tenant's cached profile.
- **Effective-id resolution in lockstep** (loader + component): a real operator session's own id always wins; a bypass admin falls back to the picked id.
- Guards swapped to the picker-aware `canPickOperatorContext` / `canWriteAsOperatorOwner` (replacing `isOperatorOwnerSession`).
- `key={operatorId}` resets local saved/error state when the picker swaps tenants (architect M2).
- **"Editing as <name>" badge** when an admin has picked a tenant; **pick-prompt** message when an admin hasn't picked yet (vs the plain no-context message for non-admins).
- i18n `editingAs` + `pickOperatorPrompt` for en/ja/zh.

## Why

Without this, the settings page was the one remaining `/manage/*` config surface that ignored the picker — a platform admin previewing a tenant would see/edit the wrong operator's profile. This closes the gap so all config pages behave identically.

## Scope note

The add-ons / insurance / locations / fleet halves of this slice already landed on develop via parallel work (in the cleaner `scope`-object form), so this PR is settings-only.

## Test plan

- [x] `bun run --filter @kuruma/web typecheck` — clean
- [x] Full web suite — **1523/1523** green (incl. new `operator-settings` route + render tests and `operator-context` cases)
- [x] `biome check` — clean
- [ ] Visual: as PLATFORM_ADMIN on beta, pick a tenant on `/manage/settings`, confirm badge + scoped profile; confirm an operator-owner session is unchanged