### PR TITLE
fix(web): fleet page 400 — class-options read needs includeAll for bypass admin

### DIFF
--- a/packages/web/src/vite/operator-fleet/api.ts
+++ b/packages/web/src/vite/operator-fleet/api.ts
@@ -223,15 +223,19 @@ export function vehicleRowFromDetail(d: VehicleDetailResponse): OperatorFleetVeh
 
 // Minimal class list for the Add/Edit form's class dropdown — kept here so the
 // form slice (#526 follow-up) reads it without touching the classes feature
-// (#528). Operator-scoped server-side.
+// (#528). Operator callers stay tenant-scoped server-side; a bypass admin must
+// explicitly opt into the cross-operator read.
 
 export async function fetchVehicleClassOptions(): Promise<VehicleClassOption[]> {
-  // `/manage` is the tenant-scoped, session-authed class list (#528). The public
+  // `/manage` is the session-authed class list (#528). The public
   // `/vehicle-classes` is PUBLIC_CONTEXT 'all'-scope — it would leak every
-  // operator's classes into this operator's own form dropdown. Depends on #528
-  // (the /manage route) being on trunk first. The schema strips the full class
-  // rows down to {id,name} for the dropdown.
-  const res = await fetch(`${getApiBaseUrl()}/vehicle-classes/manage`, { credentials: 'include' })
+  // operator's classes into this operator's own form dropdown. `includeAll=true`
+  // satisfies the private route's explicit cross-operator read contract for
+  // bypass roles (else they 400); OPERATOR_* callers stay scoped by the API.
+  // Fleet is not a picker route, so there is no `?operator` to honor here.
+  const res = await fetch(`${getApiBaseUrl()}/vehicle-classes/manage?includeAll=true`, {
+    credentials: 'include',
+  })
   return unwrap(res, vehicleClassOptionsListSchema)
 }
 

--- a/packages/web/tests/vite/operator-fleet/api.test.ts
+++ b/packages/web/tests/vite/operator-fleet/api.test.ts
@@ -8,6 +8,7 @@ import {
   bulkUpdateVehicleStatus,
   createVehicle,
   fetchOperatorFleet,
+  fetchVehicleClassOptions,
   fetchVehicleDetail,
   retireVehicle,
   updateVehicle,
@@ -283,6 +284,21 @@ describe('fetchOperatorFleet (#711 response validation)', () => {
     )
 
     await expect(fetchOperatorFleet()).rejects.toBeInstanceOf(ParseError)
+  })
+})
+
+describe('fetchVehicleClassOptions', () => {
+  it('opts into the cross-operator class read so a bypass admin does not 400', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchVehicleClassOptions()
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    const parsed = new URL(url as string, 'http://x')
+    expect(parsed.pathname).toBe('/api/vehicle-classes/manage')
+    expect(parsed.searchParams.get('includeAll')).toBe('true')
+    expect((init as RequestInit).credentials).toBe('include')
   })
 })
 


### PR DESCRIPTION
## Bug
On beta, `/manage/fleet` shows **"Couldn't load your fleet"** for a PLATFORM_ADMIN. `GET /api/vehicle-classes/manage` returns **400**:
```json
{ "success": false, "error": "operatorId or includeAll=true is required for cross-operator reads" }
```

## Root cause
`fetchVehicleClassOptions` (the fleet Add/Edit class dropdown read) called `/vehicle-classes/manage` with **no scope param**. For a bypass caller (operatorId:null, cross-operator read scope) the private route requires `operatorId` or `includeAll=true`, so it 400'd and the whole page fell to its error boundary. #1237 fixed the *classes/fees* consumers of this endpoint but missed this *fleet* consumer.

## Fix
Append `?includeAll=true`. Fleet is **not** a picker route (not in `OPERATOR_CONTEXT_ROUTE_IDS`), so there's no `?operator` to honor here — `includeAll=true` satisfies the endpoint's cross-operator contract. `OPERATOR_*` callers stay tenant-scoped server-side (the requirement only applies to cross-operator reads), so their behavior is unchanged. One-line change inside `operator-fleet/api.ts`; no consumer touched.

## Test plan
- [x] RED-first test: `fetchVehicleClassOptions` request carries `includeAll=true`
- [x] Full web suite **1525/1525**, web typecheck clean, biome clean
- [ ] Visual: as PLATFORM_ADMIN on beta, `/manage/fleet` loads (no 400)