### PR TITLE
fix(#1247): localize operator badge aria-label (ja/zh a11y)

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -886,7 +886,8 @@
     },
     "operatorContext": {
       "label": "Operator",
-      "all": "All operators"
+      "all": "All operators",
+      "badge": "Operator: {name}"
     }
   },
   "messaging": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -886,7 +886,8 @@
     },
     "operatorContext": {
       "label": "事業者",
-      "all": "すべての事業者"
+      "all": "すべての事業者",
+      "badge": "事業者: {name}"
     }
   },
   "messaging": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -886,7 +886,8 @@
     },
     "operatorContext": {
       "label": "运营商",
-      "all": "所有运营商"
+      "all": "所有运营商",
+      "badge": "运营商：{name}"
     }
   },
   "messaging": {

--- a/packages/web/src/vite/operator-add-ons/AddOnRow.tsx
+++ b/packages/web/src/vite/operator-add-ons/AddOnRow.tsx
@@ -1,8 +1,8 @@
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatJpy } from '@/lib/format'
 import { AddOnStatusBadge } from '@/vite/operator-add-ons/AddOnStatusBadge'
 import type { AddOnData } from '@/vite/operator-add-ons/api'
+import { OperatorBadge } from '@/vite/operator-context'
 import { Coins, Pencil, Trash2 } from 'lucide-react'
 import { useTranslations } from 'use-intl'
 
@@ -24,11 +24,7 @@ export function AddOnRow({ addOn: a, canWrite, operatorName, onEdit, onArchive }
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-lg font-medium truncate">{a.name}</h3>
           <AddOnStatusBadge status={a.status} />
-          {operatorName && (
-            <Badge variant="secondary" aria-label={`Operator: ${operatorName}`}>
-              {operatorName}
-            </Badge>
-          )}
+          <OperatorBadge name={operatorName} />
         </div>
         {a.description && (
           <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{a.description}</p>

--- a/packages/web/src/vite/operator-context/OperatorBadge.test.tsx
+++ b/packages/web/src/vite/operator-context/OperatorBadge.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import type React from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+import { OperatorBadge } from './OperatorBadge'
+
+function wrap(ui: React.ReactNode) {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      {ui}
+    </IntlProvider>,
+  )
+}
+
+afterEach(cleanup)
+
+describe('OperatorBadge', () => {
+  it('renders nothing when no operator name is given', () => {
+    const { container } = wrap(<OperatorBadge name={undefined} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the operator name as visible text', () => {
+    wrap(<OperatorBadge name="Sakura Rentals" />)
+    expect(screen.getByText('Sakura Rentals')).toBeInTheDocument()
+  })
+
+  it('localizes the aria-label with the name interpolated, not a hardcoded prefix', () => {
+    wrap(<OperatorBadge name="Sakura Rentals" />)
+    // business.operatorContext.badge = "Operator: {name}" in messages/en.json.
+    // A regression to a hardcoded English string or a dropped {name} fails here.
+    expect(screen.getByLabelText('Operator: Sakura Rentals')).toBeInTheDocument()
+  })
+})

--- a/packages/web/src/vite/operator-context/OperatorBadge.tsx
+++ b/packages/web/src/vite/operator-context/OperatorBadge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@/components/ui/badge'
+import { useTranslations } from 'use-intl'
+
+interface OperatorBadgeProps {
+  /** Operator label for cross-tenant (all-mode) reads; undefined hides the badge. */
+  name?: string | undefined
+}
+
+// Per-operator label shown on config rows when a platform admin reads across
+// tenants. The aria-label is localized (not a hardcoded "Operator:" prefix) so
+// ja/zh screen-reader users don't get an English announcement — the product's
+// core users are international tourists. Centralized here so the four config
+// surfaces (add-ons, fees, insurance, locations) localize the badge once.
+export function OperatorBadge({ name }: OperatorBadgeProps) {
+  const t = useTranslations('business.operatorContext')
+  if (!name) return null
+  return (
+    <Badge variant="secondary" aria-label={t('badge', { name })}>
+      {name}
+    </Badge>
+  )
+}

--- a/packages/web/src/vite/operator-context/index.ts
+++ b/packages/web/src/vite/operator-context/index.ts
@@ -3,6 +3,7 @@
 // internal modules — so the vite cross-feature reach-in ratchet stays flat
 // (scripts/lint-module-boundaries.ts, docs/architecture/modules.md).
 export { fetchOperators, operatorsQueryOptions, type OperatorSummary } from './api'
+export { OperatorBadge } from './OperatorBadge'
 export { OperatorContextPicker } from './OperatorContextPicker'
 export {
   buildScopeParam,

--- a/packages/web/src/vite/operator-fees/FeeRow.tsx
+++ b/packages/web/src/vite/operator-fees/FeeRow.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatJpy } from '@/lib/format'
+import { OperatorBadge } from '@/vite/operator-context'
 import { FeeScheduleStatusBadge } from '@/vite/operator-fees/FeeScheduleStatusBadge'
 import type { FeeScheduleData } from '@/vite/operator-fees/api'
 import { Pencil, Trash2 } from 'lucide-react'
@@ -26,11 +26,7 @@ export function FeeRow({ fee, className, canWrite, operatorName, onEdit, onArchi
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-lg font-medium truncate">{t(`type.${fee.feeType}`)}</h3>
           <FeeScheduleStatusBadge status={fee.status} />
-          {operatorName && (
-            <Badge variant="secondary" aria-label={`Operator: ${operatorName}`}>
-              {operatorName}
-            </Badge>
-          )}
+          <OperatorBadge name={operatorName} />
         </div>
         <div className="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
           <span className="font-medium text-foreground">

--- a/packages/web/src/vite/operator-insurance/InsuranceRow.tsx
+++ b/packages/web/src/vite/operator-insurance/InsuranceRow.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatJpy } from '@/lib/format'
+import { OperatorBadge } from '@/vite/operator-context'
 import { InsuranceStatusBadge } from '@/vite/operator-insurance/InsuranceStatusBadge'
 import type { InsuranceOptionData } from '@/vite/operator-insurance/api'
 import { Coins, Pencil, ShieldCheck, Trash2 } from 'lucide-react'
@@ -31,11 +31,7 @@ export function InsuranceRow({
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-lg font-medium truncate">{o.name}</h3>
           <InsuranceStatusBadge status={o.status} />
-          {operatorName && (
-            <Badge variant="secondary" aria-label={`Operator: ${operatorName}`}>
-              {operatorName}
-            </Badge>
-          )}
+          <OperatorBadge name={operatorName} />
         </div>
         {o.description && (
           <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{o.description}</p>

--- a/packages/web/src/vite/operator-locations/OperatorLocationsView.tsx
+++ b/packages/web/src/vite/operator-locations/OperatorLocationsView.tsx
@@ -1,6 +1,5 @@
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import type { OperatorScope } from '@/vite/operator-context'
+import { OperatorBadge, type OperatorScope } from '@/vite/operator-context'
 import { AddLocationDialog } from '@/vite/operator-locations/AddLocationDialog'
 import { ArchiveLocationDialog } from '@/vite/operator-locations/ArchiveLocationDialog'
 import { EditLocationDialog } from '@/vite/operator-locations/EditLocationDialog'
@@ -114,11 +113,7 @@ function LocationRow({ location: l, canWrite, operatorName, onEdit, onArchive }:
           <h3 className="truncate text-lg font-medium">{l.name}</h3>
           <LocationStatusBadge status={l.status} />
           <LocationPinBadge coordinateSource={l.coordinateSource} />
-          {operatorName && (
-            <Badge variant="secondary" aria-label={`Operator: ${operatorName}`}>
-              {operatorName}
-            </Badge>
-          )}
+          <OperatorBadge name={operatorName} />
         </div>
         <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
           <MapPin className="size-3.5 shrink-0" />


### PR DESCRIPTION
## Why
The per-operator badge shown on platform-admin config rows hardcoded an English `aria-label={`Operator: ${name}`}` in four files. The product's core users are ja/zh tourists — screen readers announced English even when the visible badge text was localized. Surfaced by a post-merge code-review of the operator-context picker (#1231, which merged without this fix).

## What
- New shared `OperatorBadge` component in the `operator-context` feature — single localization point, DRY across the four config surfaces; returns `null` when there's no operator name.
- Interpolated `business.operatorContext.badge` key added in **en/ja/zh**.
- Swapped the inline badge in `AddOnRow`, `FeeRow`, `InsuranceRow`, `OperatorLocationsView` to `<OperatorBadge name={operatorName} />`.

Web-only a11y/i18n. **No API / schema / migration changes.**

## Test plan
- [x] New `OperatorBadge.test.tsx` (real `IntlProvider` + `en.json`): null render, visible name, and localized aria-label `"Operator: {name}"` with the name interpolated (a regression to a hardcoded prefix or dropped `{name}` fails the test).
- [x] 4 existing config-view test suites stay green (160 tests).
- [x] `tsc` (web+api), biome, file-size, module-boundaries all pass (pre-commit hook).

Closes #1247