### PR TITLE
test(operator-context): de-tautologize operator-badge negative assertions

### DIFF
--- a/packages/web/src/vite/operator-context/OperatorBadge.test.tsx
+++ b/packages/web/src/vite/operator-context/OperatorBadge.test.tsx
@@ -21,6 +21,11 @@ describe('OperatorBadge', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('renders nothing for an empty operator name (the guard hinges on this case)', () => {
+    const { container } = wrap(<OperatorBadge name="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
   it('shows the operator name as visible text', () => {
     wrap(<OperatorBadge name="Sakura Rentals" />)
     expect(screen.getByText('Sakura Rentals')).toBeInTheDocument()

--- a/packages/web/tests/vite/operator-add-ons/OperatorAddOnsView.test.tsx
+++ b/packages/web/tests/vite/operator-add-ons/OperatorAddOnsView.test.tsx
@@ -116,9 +116,11 @@ describe('OperatorAddOnsView', () => {
   })
 
   it('scoped-write mode: shows the Add button and no operator label', () => {
-    render(<OperatorAddOnsView addOns={[addOn]} scope={scopedWriteScope} />, { wrapper })
+    // showOperator:false suppresses the badge even though op_1 -> Sakura resolves.
+    const scope = { ...scopedWriteScope, operatorNameById: new Map([['op_1', 'Sakura']]) }
+    render(<OperatorAddOnsView addOns={[addOn]} scope={scope} />, { wrapper })
     expect(screen.getByRole('button', { name: 'addOption' })).toBeInTheDocument()
-    expect(screen.queryByLabelText(/^Operator:/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Sakura')).not.toBeInTheDocument()
   })
 
   it('read-only mode hides the per-row Edit/Archive affordances', () => {

--- a/packages/web/tests/vite/operator-fees/OperatorFeesView.test.tsx
+++ b/packages/web/tests/vite/operator-fees/OperatorFeesView.test.tsx
@@ -136,12 +136,15 @@ describe('OperatorFeesView', () => {
       <OperatorFeesView
         fees={[operatorWideFee]}
         classes={classes}
-        scope={scope({ canWrite: true })}
+        scope={scope({ canWrite: true, operatorNameById: new Map([['op_1', 'Sakura']]) })}
       />,
       { wrapper },
     )
     expect(screen.getByRole('button', { name: 'addFee' })).toBeInTheDocument()
-    expect(screen.queryByLabelText(/^Operator:/)).not.toBeInTheDocument()
+    // showOperator:false must suppress the badge even when the name IS resolvable
+    // (op_1 -> Sakura). Asserting the name text, not the aria-label prefix, keeps
+    // this meaningful under the mocked translator (the prefix is mocked away).
+    expect(screen.queryByText('Sakura')).not.toBeInTheDocument()
   })
 
   it('read-only mode hides the per-row Edit/Archive affordances', () => {

--- a/packages/web/tests/vite/operator-insurance/OperatorInsuranceView.test.tsx
+++ b/packages/web/tests/vite/operator-insurance/OperatorInsuranceView.test.tsx
@@ -119,9 +119,11 @@ describe('OperatorInsuranceView', () => {
   })
 
   it('scoped-write mode: shows the Add button and no operator label', () => {
-    render(<OperatorInsuranceView options={[option]} scope={scopedWriteScope} />, { wrapper })
+    // showOperator:false suppresses the badge even though op_1 -> Sakura resolves.
+    const scope = { ...scopedWriteScope, operatorNameById: new Map([['op_1', 'Sakura']]) }
+    render(<OperatorInsuranceView options={[option]} scope={scope} />, { wrapper })
     expect(screen.getByRole('button', { name: 'addOption' })).toBeInTheDocument()
-    expect(screen.queryByLabelText(/^Operator:/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Sakura')).not.toBeInTheDocument()
   })
 
   it('read-only mode hides the per-row Edit/Archive affordances', () => {

--- a/packages/web/tests/vite/operator-locations/OperatorLocationsView.test.tsx
+++ b/packages/web/tests/vite/operator-locations/OperatorLocationsView.test.tsx
@@ -173,9 +173,13 @@ describe('OperatorLocationsView', () => {
   })
 
   it('scoped-write mode: shows the Add button and no operator label', () => {
-    renderView([location()], scopedWriteScope)
+    // showOperator:false suppresses the badge even though op_1 -> Sakura resolves.
+    renderView([location()], {
+      ...scopedWriteScope,
+      operatorNameById: new Map([['op_1', 'Sakura']]),
+    })
     expect(screen.getByRole('button', { name: en.addLocation })).toBeInTheDocument()
-    expect(screen.queryByLabelText(/^Operator:/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Sakura')).not.toBeInTheDocument()
   })
 
   it('read-only mode hides the per-row Edit/Archive affordances', () => {


### PR DESCRIPTION
Post-merge review of #1249 (via code-reviewer agent + architect-review skill) surfaced two **test-hardening** gaps. Both fixed here. **Test-only — no production changes.**

## 1. Tautological negative assertions in the 4 config-view suites
`OperatorFeesView`, `OperatorInsuranceView`, `OperatorAddOnsView` mock `use-intl` (translator returns the key), so their `queryByLabelText(/^Operator:/)` **absence** assertion could never match the mocked label — it passed regardless of whether a badge leaked (the *Mocked-Dependency Tautology*).

**Fix:** each negative test now gives the scope a *resolvable* operator name (`op_1 -> Sakura`) with `showOperator: false`, and asserts the **name text** is absent. So the test now fails if a view drops the `showOperator ? … : undefined` guard.

**Mutation-verified:** temporarily dropping that guard in `OperatorFeesView` makes the hardened test fail (it was green before the fix); reverted. Works uniformly under the mocked suites *and* the locations suite (real `IntlProvider`).

## 2. `OperatorBadge` empty-string edge
`OperatorBadge.test.tsx` covered `name={undefined}` but not `name=""` — the exact case the `if (!name) return null` guard hinges on. Added.

## Test plan
- [x] 45 tests green across the 5 affected suites
- [x] Mutation check: guard-drop → hardened test fails → revert
- [x] tsc (web+api), biome, boundaries, file-size all pass (pre-commit)

Follow-up to #1249 / #1247.