### PR TITLE
fix(#1271): make operatorId immutable on config repo updates

### DIFF
--- a/packages/api/src/repositories/drizzle/add-on.ts
+++ b/packages/api/src/repositories/drizzle/add-on.ts
@@ -94,7 +94,9 @@ export class DrizzleAddOnRepository implements AddOnRepository {
   }
 
   async update(id: string, data: Partial<AddOn>): Promise<AddOn | undefined> {
-    const { id: _id, createdAt: _createdAt, ...fields } = data
+    // operatorId is an immutable tenant anchor (#1271): strip it like id so an
+    // update payload can never migrate the row to another operator.
+    const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data
     const [updated] = await this.db
       .update(addOnOptions)
       .set({ ...fields, updatedAt: sql`now()` })

--- a/packages/api/src/repositories/drizzle/fee-schedule.ts
+++ b/packages/api/src/repositories/drizzle/fee-schedule.ts
@@ -100,7 +100,10 @@ export class DrizzleFeeScheduleRepository implements FeeScheduleRepository {
   }
 
   async update(id: string, data: Partial<FeeSchedule>): Promise<FeeSchedule | undefined> {
-    const { id: _id, createdAt: _createdAt, ...fields } = data
+    // operatorId is an immutable tenant anchor (#1271): strip it like id so an
+    // update payload can never migrate the row to another operator (which the
+    // composite FK to vehicleClasses also depends on).
+    const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data
     const [updated] = await this.db
       .update(feeSchedules)
       .set({ ...fields, updatedAt: sql`now()` })

--- a/packages/api/src/repositories/drizzle/insurance-option.ts
+++ b/packages/api/src/repositories/drizzle/insurance-option.ts
@@ -111,7 +111,9 @@ export class DrizzleInsuranceOptionRepository implements InsuranceOptionReposito
     id: string,
     data: Partial<InsuranceOption>,
   ): Promise<InsuranceOption | undefined> {
-    const { id: _id, createdAt: _createdAt, ...fields } = data
+    // operatorId is an immutable tenant anchor (#1271): strip it like id so an
+    // update payload can never migrate the row to another operator.
+    const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data
     const [updated] = await this.db
       .update(insuranceOptions)
       .set({ ...fields, updatedAt: sql`now()` })

--- a/packages/api/src/repositories/in-memory/add-on.test.ts
+++ b/packages/api/src/repositories/in-memory/add-on.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { AddOn } from '../../stores'
+import { InMemoryAddOnRepository } from './add-on'
+
+// #1271: operatorId is a tenant anchor. The write layer must never let an
+// update payload migrate a row to another operator, regardless of the caller
+// or DTO upstream. This pins that invariant at the repository itself.
+const seed = (operatorId: string): Omit<AddOn, 'id' | 'createdAt' | 'updatedAt'> => ({
+  operatorId,
+  name: 'Baby Seat',
+  description: null,
+  priceJpy: 1500,
+  status: 'ACTIVE',
+})
+
+describe('InMemoryAddOnRepository.update — operatorId is an immutable tenant anchor', () => {
+  it('ignores operatorId in the update payload while still applying other fields', async () => {
+    const repo = new InMemoryAddOnRepository()
+    const created = await repo.create(seed('op_a'))
+
+    const updated = await repo.update(created.id, { operatorId: 'op_b', priceJpy: 3000 })
+
+    expect(updated?.operatorId).toBe('op_a')
+    expect(updated?.priceJpy).toBe(3000)
+  })
+})

--- a/packages/api/src/repositories/in-memory/add-on.ts
+++ b/packages/api/src/repositories/in-memory/add-on.ts
@@ -97,6 +97,9 @@ export class InMemoryAddOnRepository implements AddOnRepository {
       ...existing,
       ...data,
       id: existing.id,
+      // operatorId is an immutable tenant anchor (#1271): pin it like id so an
+      // update payload can never migrate the row to another operator.
+      operatorId: existing.operatorId,
       createdAt: existing.createdAt,
       updatedAt: new Date(),
     }

--- a/packages/api/src/repositories/in-memory/fee-schedule.test.ts
+++ b/packages/api/src/repositories/in-memory/fee-schedule.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import type { FeeSchedule } from '../../stores'
+import { InMemoryFeeScheduleRepository } from './fee-schedule'
+
+// #1271: operatorId is a tenant anchor — see add-on.test.ts. A fee's tenant is
+// also load-bearing for the composite FK to vehicleClasses, so an update must
+// never repoint it.
+const seed = (operatorId: string): Omit<FeeSchedule, 'id' | 'createdAt' | 'updatedAt'> => ({
+  operatorId,
+  vehicleClassId: null,
+  feeType: 'CLEANING_FLAT',
+  unit: 'FLAT',
+  amountJpy: 2000,
+  status: 'ACTIVE',
+})
+
+describe('InMemoryFeeScheduleRepository.update — operatorId is an immutable tenant anchor', () => {
+  it('ignores operatorId in the update payload while still applying other fields', async () => {
+    const repo = new InMemoryFeeScheduleRepository()
+    const created = await repo.create(seed('op_a'))
+
+    const updated = await repo.update(created.id, { operatorId: 'op_b', amountJpy: 3000 })
+
+    expect(updated?.operatorId).toBe('op_a')
+    expect(updated?.amountJpy).toBe(3000)
+  })
+})

--- a/packages/api/src/repositories/in-memory/fee-schedule.ts
+++ b/packages/api/src/repositories/in-memory/fee-schedule.ts
@@ -107,6 +107,10 @@ export class InMemoryFeeScheduleRepository implements FeeScheduleRepository {
       ...existing,
       ...data,
       id: existing.id,
+      // operatorId is an immutable tenant anchor (#1271): pin it like id so an
+      // update payload can never migrate the row to another operator (which the
+      // composite FK to vehicleClasses also depends on).
+      operatorId: existing.operatorId,
       createdAt: existing.createdAt,
       updatedAt: new Date(),
     }

--- a/packages/api/src/repositories/in-memory/insurance-option.test.ts
+++ b/packages/api/src/repositories/in-memory/insurance-option.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { InsuranceOption } from '../../stores'
+import { InMemoryInsuranceOptionRepository } from './insurance-option'
+
+// #1271: operatorId is a tenant anchor — see add-on.test.ts. Mirrored here so
+// the invariant is pinned per sibling config repo, not assumed by analogy.
+const seed = (operatorId: string): Omit<InsuranceOption, 'id' | 'createdAt' | 'updatedAt'> => ({
+  operatorId,
+  name: 'Premium',
+  description: null,
+  dailyPriceJpy: 1500,
+  deductibleJpy: 150000,
+  status: 'ACTIVE',
+})
+
+describe('InMemoryInsuranceOptionRepository.update — operatorId is an immutable tenant anchor', () => {
+  it('ignores operatorId in the update payload while still applying other fields', async () => {
+    const repo = new InMemoryInsuranceOptionRepository()
+    const created = await repo.create(seed('op_a'))
+
+    const updated = await repo.update(created.id, { operatorId: 'op_b', dailyPriceJpy: 2000 })
+
+    expect(updated?.operatorId).toBe('op_a')
+    expect(updated?.dailyPriceJpy).toBe(2000)
+  })
+})

--- a/packages/api/src/repositories/in-memory/insurance-option.ts
+++ b/packages/api/src/repositories/in-memory/insurance-option.ts
@@ -102,6 +102,9 @@ export class InMemoryInsuranceOptionRepository implements InsuranceOptionReposit
       ...existing,
       ...data,
       id: existing.id,
+      // operatorId is an immutable tenant anchor (#1271): pin it like id so an
+      // update payload can never migrate the row to another operator.
+      operatorId: existing.operatorId,
       createdAt: existing.createdAt,
       updatedAt: new Date(),
     }

--- a/packages/api/tests/integration/fee-schedules.test.ts
+++ b/packages/api/tests/integration/fee-schedules.test.ts
@@ -305,4 +305,16 @@ describe('cross-operator fee-schedule WRITE denial (service seal)', () => {
     const res = await service.update(ctxFor(opAId), feeA.id, { amountJpy: 3500 })
     expect(res).toMatchObject({ ok: true, feeSchedule: { amountJpy: 3500 } })
   })
+
+  it('[#1271] a direct repo update cannot migrate the row to another operator', async () => {
+    // Repo-layer anchor: even a caller that bypasses the service scope check (a
+    // future second caller) cannot repoint operatorId via the update payload.
+    const updated = await repo.update(feeA.id, { operatorId: opBId, amountJpy: 4321 })
+    expect(updated?.operatorId).toBe(opAId)
+    expect(updated?.amountJpy).toBe(4321)
+    expect(await repo.findById(SYSTEM_CONTEXT, feeA.id)).toMatchObject({
+      operatorId: opAId,
+      amountJpy: 4321,
+    })
+  })
 })

--- a/packages/api/tests/integration/insurance-options.test.ts
+++ b/packages/api/tests/integration/insurance-options.test.ts
@@ -186,4 +186,16 @@ describe('cross-operator insurance-option WRITE denial (service seal, #404)', ()
     const res = await service.update(ctxFor(opAId), optionA.id, { dailyPriceJpy: 2000 })
     expect(res).toMatchObject({ ok: true, option: { dailyPriceJpy: 2000 } })
   })
+
+  it('[#1271] a direct repo update cannot migrate the row to another operator', async () => {
+    // Repo-layer anchor: even a caller that bypasses the service scope check (a
+    // future second caller) cannot repoint operatorId via the update payload.
+    const updated = await repo.update(optionA.id, { operatorId: opBId, dailyPriceJpy: 4321 })
+    expect(updated?.operatorId).toBe(opAId)
+    expect(updated?.dailyPriceJpy).toBe(4321)
+    expect(await repo.findById(SYSTEM_CONTEXT, optionA.id)).toMatchObject({
+      operatorId: opAId,
+      dailyPriceJpy: 4321,
+    })
+  })
 })


### PR DESCRIPTION
Closes #1271.

## What

Make `operatorId` an **immutable tenant anchor** on the `update()` path of the three config repositories — add-on, insurance-option, fee-schedule — so an update payload can never migrate a row to another operator. This is **Option A** from the issue (the tiny, "tenant anchors are immutable" hardening); **Option B** (making `repo.update`/`archive` caller-scoped at the query itself) is intentionally out of scope.

## Why (defense-in-depth, not a live bug)

Tenant isolation on these edit paths currently rests on two upstream seals:

1. the service's caller-scoped `findById(ctx, id)` guard (cross-tenant id → 404, never mutates), and
2. the update DTO omitting `operatorId` (Zod strips an injected one).

Both hold today, so this was **never exploitable**. But the repo write layer itself was undefended: `update()` spread the payload into `.set(...)` without stripping `operatorId`, and keyed the `WHERE` by `id` alone. A future second caller of `repo.update` that skips the service guard, or a DTO that re-adds `operatorId`, would turn it into a cross-tenant tenant-migration IDOR. This pins the invariant at the layer that does the write.

## Change

- **Drizzle** (×3): strip `operatorId` in the destructure alongside `id`/`createdAt` — `const { id: _id, createdAt: _createdAt, operatorId: _operatorId, ...fields } = data`.
- **In-memory** (×3): force `operatorId: existing.operatorId` after the `...data` spread, mirroring how `id`/`createdAt` are already pinned.

`archive()` was already safe (only sets `status`/`updatedAt`). Legitimate field edits are unchanged.

## Tests

- **3 in-memory repo unit tests** (co-located) — RED→GREEN verified: pre-fix they failed with `expected 'op_b' to be 'op_a'`.
- **2 real-pg integration tests** — call the **Drizzle** driver's `update` directly with a payload `operatorId` (the "future second caller bypasses the service guard" scenario) and assert the row stays in its own tenant. RED-verified by temporarily reverting the Drizzle strip (test failed), then restored.

## Verification

- API unit: **2308 passed**
- Integration (insurance + fee, real pg16): **30 passed**
- `tsc --noEmit` (api): clean · `lint:boundaries`: OK · `biome check`: clean
- `lint:size` / `lint:modules`: pre-existing soft-warns on the web tree + seed files only (untouched here); baselines deliberately **not** bumped.

## Test plan

- [x] `operatorId` in an update payload is a no-op at the repo layer (all 3 entities, Drizzle + in-memory)
- [x] Legitimate field updates unaffected
- [x] In-memory doubles match Drizzle behavior
- [x] Existing add-on / insurance / fee-schedule suites stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
