### PR TITLE
fix(#1270): key VEHICLE review class to the assigned car, not booking.classId

### DIFF
--- a/packages/api/src/composition/review-reveal-sweep.ts
+++ b/packages/api/src/composition/review-reveal-sweep.ts
@@ -23,6 +23,7 @@ export function buildReviewRevealSweep(
   const service = new ReviewService(
     repos.reviewRepo,
     repos.bookingRepo,
+    repos.vehicleRepo,
     repos.bookingEventRepo,
     repos.operatorMembershipRepo,
   )

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -480,6 +480,7 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const reviewService = new ReviewService(
     reviewRepo,
     bookingRepo,
+    vehicleRepo,
     bookingEventRepo,
     operatorMembershipRepo,
   )

--- a/packages/api/src/services/review.test.ts
+++ b/packages/api/src/services/review.test.ts
@@ -5,8 +5,10 @@ import { InMemoryBookingRepository } from '../repositories/in-memory/booking'
 import { InMemoryBookingEventRepository } from '../repositories/in-memory/booking-event'
 import { InMemoryOperatorMembershipRepository } from '../repositories/in-memory/operator-membership'
 import { InMemoryReviewRepository } from '../repositories/in-memory/review'
-import type { Booking, BookingEvent, OperatorMembership, Review } from '../stores'
+import { InMemoryVehicleRepository } from '../repositories/in-memory/vehicle'
+import type { Booking, BookingEvent, OperatorMembership, Review, Vehicle } from '../stores'
 import { ReviewService } from './review'
+import { ReviewAggregateService } from './review-aggregate'
 
 const OPERATOR_ID = 'op-1'
 const RENTER_ID = 'renter-1'
@@ -66,6 +68,39 @@ function makeBooking(overrides: Partial<Booking> = {}): Booking {
   }
 }
 
+function makeVehicle(overrides: Partial<Vehicle> = {}): Vehicle {
+  return {
+    id: VEHICLE_ID,
+    operatorId: OPERATOR_ID,
+    classId: CLASS_ID,
+    pickupLocationId: 'loc-1',
+    name: 'Toyota Yaris',
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: null,
+    luggageSize: null,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: null,
+    insuranceExpiryDate: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
 function completionEvent(bookingId = BOOKING_ID, createdAt = COMPLETED_AT): BookingEvent {
   return {
     id: `evt-${bookingId}`,
@@ -100,15 +135,18 @@ function makeHarness(
     events?: BookingEvent[]
     memberships?: OperatorMembership[]
     reviews?: Review[]
+    vehicles?: Vehicle[]
   } = {},
 ): Harness {
   const bookingStore = new Map((opts.bookings ?? [makeBooking()]).map((b) => [b.id, b]))
   const memberStore = new Map((opts.memberships ?? [activeMembership()]).map((m) => [m.id, m]))
   const reviewStore = new Map((opts.reviews ?? []).map((r) => [r.id, r]))
+  const vehicleStore = new Map((opts.vehicles ?? [makeVehicle()]).map((v) => [v.id, v]))
   const reviewRepo = new InMemoryReviewRepository(reviewStore)
   const service = new ReviewService(
     reviewRepo,
     new InMemoryBookingRepository(bookingStore),
+    new InMemoryVehicleRepository(vehicleStore),
     new InMemoryBookingEventRepository(opts.events ?? [completionEvent()]),
     new InMemoryOperatorMembershipRepository(memberStore),
   )
@@ -157,6 +195,57 @@ describe('ReviewService.submit — derivation', () => {
     expect(result.review.authorRole).toBe('OPERATOR')
     expect(result.review.subject).toBe('RENTER')
     expect(result.review.subjectVehicleId).toBeNull()
+  })
+})
+
+describe('ReviewService.submit — VEHICLE class derived from the assigned car (#1270)', () => {
+  // Substitution / assignVehicle can swap in a same-ACRISS car of a DIFFERENT class without
+  // touching booking.classId. The review of the car actually driven must count under that
+  // car's real class (what the storefront badge reads), not the class originally booked.
+  const BOOKED_CLASS = 'class-booked'
+  const ACTUAL_CLASS = 'class-actual'
+  const SUB_VEHICLE = 'veh-sub'
+
+  const substitutedHarness = (subClassId: string | null) =>
+    makeHarness({
+      bookings: [makeBooking({ classId: BOOKED_CLASS, assignedVehicleId: SUB_VEHICLE })],
+      vehicles: [makeVehicle({ id: SUB_VEHICLE, classId: subClassId })],
+    })
+
+  it('keys subjectClassId to the assigned vehicle’s class, not the booked class', async () => {
+    const { service } = substitutedHarness(ACTUAL_CLASS)
+    const result = await service.submit(renterCtx, submitInput({ subject: 'VEHICLE' }), NOW)
+    if (!result.ok) throw new Error(`expected ok, got ${result.error}`)
+    expect(result.review.subjectVehicleId).toBe(SUB_VEHICLE)
+    expect(result.review.subjectClassId).toBe(ACTUAL_CLASS)
+  })
+
+  it('stores a null subjectClassId when the assigned car has no class', async () => {
+    const { service } = substitutedHarness(null)
+    const result = await service.submit(renterCtx, submitInput({ subject: 'VEHICLE' }), NOW)
+    if (!result.ok) throw new Error(`expected ok, got ${result.error}`)
+    expect(result.review.subjectVehicleId).toBe(SUB_VEHICLE)
+    expect(result.review.subjectClassId).toBeNull()
+  })
+
+  it('aggregates the review under the assigned car’s class — not the booked class', async () => {
+    const { service, reviewRepo } = substitutedHarness(ACTUAL_CLASS)
+    // Submit past the reveal window so the lone VEHICLE review publishes immediately (#1195),
+    // making it visible to the published+visible aggregate scan.
+    const submitted = await service.submit(
+      renterCtx,
+      submitInput({ subject: 'VEHICLE', overall: 4 }),
+      AFTER_DEADLINE,
+    )
+    if (!submitted.ok) throw new Error(`expected ok, got ${submitted.error}`)
+    expect(submitted.review.publishedAt).toEqual(AFTER_DEADLINE)
+
+    const aggregate = new ReviewAggregateService(reviewRepo)
+    expect(await aggregate.forClasses([ACTUAL_CLASS])).toEqual({
+      [ACTUAL_CLASS]: { avg: 4, count: 1 },
+    })
+    // The booked class must NOT absorb the review of a car that isn't in it.
+    expect(await aggregate.forClasses([BOOKED_CLASS])).toEqual({ [BOOKED_CLASS]: null })
   })
 })
 

--- a/packages/api/src/services/review.ts
+++ b/packages/api/src/services/review.ts
@@ -14,6 +14,7 @@ import type {
   OperatorMembershipRepository,
   ReviewEdit,
   ReviewRepository,
+  VehicleRepository,
 } from '../repositories/types'
 import type { Booking, Review } from '../stores'
 
@@ -85,6 +86,7 @@ export class ReviewService {
   constructor(
     private readonly reviewRepo: ReviewRepository,
     private readonly bookingRepo: BookingRepository,
+    private readonly vehicleRepo: VehicleRepository,
     private readonly bookingEventRepo: BookingEventRepository,
     private readonly operatorMembershipRepo: OperatorMembershipRepository,
   ) {}
@@ -135,6 +137,17 @@ export class ReviewService {
     const completedAt = await this.findCompletedAt(booking.id)
     if (!completedAt) return fail(409, 'COMPLETION_TIME_UNKNOWN')
 
+    // Key the class to the car ACTUALLY driven, not booking.classId: substitution / assignVehicle
+    // can swap in a same-ACRISS car of a DIFFERENT class without touching booking.classId (#1270),
+    // and the storefront badge reads the vehicle's own class — so a class-X car's review must land
+    // under class X. Derive it from the assigned vehicle so subjectVehicleId and subjectClassId
+    // agree. Null when the car has no class (or, defensively, is gone): the one-way
+    // reviews_class_subject_chk permits a VEHICLE review with a null class.
+    const subjectClassId =
+      subjectVehicleId === null
+        ? null
+        : ((await this.vehicleRepo.findById(SYSTEM_CONTEXT, subjectVehicleId))?.classId ?? null)
+
     const newReview: NewReview = {
       bookingId: booking.id,
       operatorId: booking.operatorId,
@@ -142,9 +155,7 @@ export class ReviewService {
       authorRole: role,
       subject: input.subject,
       subjectVehicleId,
-      // A vehicle review carries the booking's class (substitution preserves it); the
-      // class CHECK is one-way so a non-vehicle review's null is fine.
-      subjectClassId: input.subject === 'VEHICLE' ? booking.classId : null,
+      subjectClassId,
       overall: input.overall,
       subRatings,
       comment: input.comment ?? null,

--- a/packages/api/tests/routes/reviews.test.ts
+++ b/packages/api/tests/routes/reviews.test.ts
@@ -4,9 +4,10 @@ import { InMemoryBookingRepository } from '../../src/repositories/in-memory/book
 import { InMemoryBookingEventRepository } from '../../src/repositories/in-memory/booking-event'
 import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
 import { InMemoryReviewRepository } from '../../src/repositories/in-memory/review'
+import { InMemoryVehicleRepository } from '../../src/repositories/in-memory/vehicle'
 import { createReviewRoutes } from '../../src/routes/reviews'
 import { ReviewService } from '../../src/services/review'
-import type { Booking, BookingEvent, OperatorMembership } from '../../src/stores'
+import type { Booking, BookingEvent, OperatorMembership, Vehicle } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 
 // bookingId is UUID-validated at the route boundary, so it must be a real UUID.
@@ -24,6 +25,7 @@ const COMPLETED_AT = new Date()
 
 let reviewRepo: InMemoryReviewRepository
 let bookingRepo: InMemoryBookingRepository
+let vehicleRepo: InMemoryVehicleRepository
 let eventRepo: InMemoryBookingEventRepository
 let memberRepo: InMemoryOperatorMembershipRepository
 
@@ -69,6 +71,36 @@ const completionEvent: BookingEvent = {
   createdAt: COMPLETED_AT,
 }
 
+const vehicle: Vehicle = {
+  id: VEHICLE_ID,
+  operatorId: OPERATOR_ID,
+  classId: CLASS_ID,
+  pickupLocationId: 'loc-1',
+  name: 'Toyota Yaris',
+  description: null,
+  photos: [],
+  seats: 5,
+  luggageCapacity: null,
+  luggageSize: null,
+  transmission: 'AUTO',
+  fuelType: null,
+  licensePlate: null,
+  status: 'AVAILABLE',
+  minRentalHours: null,
+  maxRentalHours: null,
+  advanceBookingHours: null,
+  make: null,
+  model: null,
+  year: null,
+  color: null,
+  dailyRateJpy: 8000,
+  hourlyRateJpy: null,
+  shakenExpiryDate: null,
+  insuranceExpiryDate: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+
 const membership: OperatorMembership = {
   id: 'mem-1',
   userId: OP_USER_ID,
@@ -83,7 +115,9 @@ function routes(): Hono {
   const a = new Hono()
   return a.route(
     '/',
-    createReviewRoutes(new ReviewService(reviewRepo, bookingRepo, eventRepo, memberRepo)),
+    createReviewRoutes(
+      new ReviewService(reviewRepo, bookingRepo, vehicleRepo, eventRepo, memberRepo),
+    ),
   )
 }
 
@@ -104,6 +138,7 @@ function submit(app: Hono, subject: 'OPERATOR' | 'VEHICLE' | 'RENTER', extra: ob
 beforeEach(() => {
   reviewRepo = new InMemoryReviewRepository()
   bookingRepo = new InMemoryBookingRepository(new Map([[booking.id, booking]]))
+  vehicleRepo = new InMemoryVehicleRepository(new Map([[vehicle.id, vehicle]]))
   eventRepo = new InMemoryBookingEventRepository([completionEvent])
   memberRepo = new InMemoryOperatorMembershipRepository(new Map([[membership.id, membership]]))
 })


### PR DESCRIPTION
## Problem

A VEHICLE review stored `subjectClassId = booking.classId` (the *booked* class). But `substitute` / `assignVehicle` accept a replacement sharing the same **ACRISS code**, not the same class id, and `reassignVehicle` never rewrites `booking.classId`. So when an operator has two same-ACRISS classes (or a CLASS_COMBO booking is assigned a car of a different class), the review of the car *actually driven* counted under the booked class — while the storefront badge reads the displayed `vehicle.classId`. Class X's badge undercounts; class Y's overcounts.

Found in the #1221 review; pre-existing (slice 5 is just the first reader of `subjectClassId`).

## Fix

Derive `subjectClassId` from the **assigned vehicle** at submit, so `subjectVehicleId` and `subjectClassId` come from the same source and match what the storefront displays.

- `ReviewService` gains a `vehicleRepo` dependency (wired in `index.ts` and the `review-reveal-sweep` composition).
- VEHICLE reviews: `subjectClassId = assignedVehicle.classId`, `null` when the car has no class (the one-way `reviews_class_subject_chk` permits it). Non-VEHICLE reviews stay `null` as before.
- The vehicle is loaded with `SYSTEM_CONTEXT` (like the booking already is); `subjectVehicleId` comes from the server-trusted `booking.assignedVehicleId`, never user input.
- Corrected the stale `review.ts` comment ("substitution preserves it" was false).

**No schema change.** **Forward-only:** VEHICLE reviews written before this change for substituted cars stay keyed to the booked class (substitution is rare in beta; a backfill isn't worth it — noted on the issue).

## Tests

- `review.test.ts` (#1270 block): (1) subjectClassId keys to the assigned car's class, not the booked class; (2) null when the assigned car has no class; (3) end-to-end — the review aggregates under the assigned car's class and the booked class returns `null`. All three fail if the code reverts to `booking.classId`.
- Updated `review.test.ts` + `tests/routes/reviews.test.ts` harnesses to seed a vehicle store and pass `vehicleRepo`.

## Verification

- Full api unit suite: **2370 passed**.
- `tsc --noEmit` (api): **0 errors**. Boundaries lint, file-size lint, biome: clean.
- Review-aggregate/constraint **integration** tests insert rows directly with explicit `subjectClassId` — orthogonal to this service-derivation change, unaffected.

Closes #1270