### PR TITLE
feat(calendar): booking quick-view (hover-peek / click-pin) on the operator calendar

### DIFF
--- a/docs/plans/2026-06-27-calendar-quickview-design.md
+++ b/docs/plans/2026-06-27-calendar-quickview-design.md
@@ -1,0 +1,220 @@
+# Bookings calendar quick-view (hover-peek / click-pin)
+
+Date: 2026-06-27
+Status: Design — pending review
+Area: `packages/web` operator bookings calendar (`/$locale/manage/bookings`)
+
+## Problem
+
+On the operator bookings calendar, the only way to see a booking's details is to
+click an event and load the full-page trip-detail route (`.../$bookingId`). That is a
+full navigation for what is usually a glance ("who, which car, when, how much?").
+Scanning a week of bookings means a click-in / back / click-in loop.
+
+## Goal
+
+Surface a booking's key facts inline, without leaving the calendar:
+
+- **Hover** an event chip → a transient preview card appears (a peek).
+- **Click** an event chip → the same card **pins** (stays open when the mouse leaves).
+- **Click outside / Esc** → the pinned card closes.
+- **Click the card** → navigate to the full trip-detail page (for the actions/timeline
+  that don't belong in a peek).
+
+No new API calls: the card shows only data the calendar already has in hand.
+
+## Non-goals
+
+- No insurance / add-on / fee breakdown in the card (that stays on the detail page).
+- No indicative multi-currency in the card (JPY only; detail page owns currency, #1070).
+- No change to event chip colors, the toolbar, filters, or slot-click manual booking.
+
+## Interaction model (per event chip)
+
+Local state on each chip: `hovering`, `pinned`. Derived: `open = hovering || pinned`.
+
+Transitions are driven by **named, reason-aware events** — never by a bare `open` boolean
+(see the State Machine Ambiguity note below):
+
+| Event (source) | Effect |
+|---|---|
+| `mouseenter` (after `HOVER_OPEN_DELAY_MS ≈ 120`) | `hovering = true` |
+| `mouseleave` (cancels a pending open) | `hovering = false` |
+| `onOpenChange(true, …)` — any trigger activation (click / Enter / Space) | `pinned = true` |
+| `onOpenChange(false, reason ∈ {outside-press, escape-key, focus-out})` — a **dismiss** | `pinned = false`, `hovering = false` |
+| `onOpenChange(false, reason = trigger-press)` — a toggle-close | **ignored** (clicking a chip only ever pins; it never closes its own card) |
+| activate the card body (a `<Link>`) | navigate to detail page |
+
+So a chip click **only ever pins**; the card is dismissed **only** by clicking away, Esc, or
+focus leaving it. (Re-clicking the same chip does nothing — matching "clicking away closes",
+not "re-click toggles".) Two cards may be visible at once (one pinned + one hovered) —
+harmless and even useful for comparison, so no cross-chip coordination is needed; state
+stays local to the chip.
+
+**Key implementation subtlety (must be covered by a test):** the chip is a base-ui
+`Popover` in **controlled** mode (`open = hovering || pinned`). base-ui's trigger toggles on
+click and reports the change through `onOpenChange(open, eventDetails)` — and it can report
+`open=false` for a `trigger-press`. A bare-boolean handler would let a hover-open click pin
+and then immediately clear (library-event-order dependent). The handler therefore **branches
+on `eventDetails.reason`**: any open-intent pins; only `outside-press` / `escape-key` /
+`focus-out` dismiss; `trigger-press` closes are ignored. Hover is driven by our own
+`mouseenter`/`mouseleave` handlers, **not** base-ui's `openOnHover`. (Confirm the exact
+`reason` strings against the installed `@base-ui/react` version during implementation.)
+
+> **Learn: State Machine Ambiguity.** When a component has multiple event sources (hover,
+> click, outside-press, Esc), a generic `open: boolean` hides intent and lets library event
+> ordering decide behavior — flaky UI. Heuristic: model transitions as named, reason-tagged
+> events, not just `open: true/false`.
+
+## Components (new — small, presentational, testable in isolation)
+
+### `BookingQuickView.tsx`
+
+The card. Pure render of in-hand fields; no state, no fetch.
+
+- Props: the enriched event fields + `locale`.
+- Renders: status (colored dot + label) · booking code, renter, vehicle, pickup–return,
+  total. A trailing "View full details →" affordance.
+- A **block `<Link>` wraps the card body inside the popup** (`<PopoverContent><Link
+  className="block …">{fields}</Link></PopoverContent>`) — NOT the popup rendered as a Link.
+  base-ui puts `role="dialog"` + `tabIndex={-1}` on the popup element, so rendering the popup
+  itself as the Link (via `render`) would clone those onto the anchor — it would neither be
+  exposed as a link nor be tabbable. An inner block Link keeps the whole card clickable *and*
+  keyboard/AT-navigable (a real `<a>` with link role); the card has no nested interactive
+  elements, so a card-wide link is valid.
+- `to="/$locale/manage/bookings/$bookingId"`, `params={{ locale, bookingId: event.id }}`.
+- Null-safe: missing vehicle → "—"; missing total → omit the total row.
+
+### `CalendarEventChip.tsx`
+
+The react-big-calendar custom event component (`components={{ event }}`).
+
+- Receives rbc's `EventProps<CalendarEvent>`; uses `event`.
+- Renders the chip title as the **`PopoverTrigger`** (a button filling the event box, so
+  the whole chip is the hover/click target), and the `BookingQuickView` as the popup.
+- Owns the `hovering`/`pinned` state machine above; receives `locale` as a prop.
+- A pending-open timeout ref is cleared on `mouseleave` and unmount.
+
+`locale` reaches the chip without a context: rbc only hands custom event components
+`{ event, ... }`, so `BookingsCalendar` supplies `locale` by closing over it in the
+`components` map — `event: (props) => <CalendarEventChip {...props} locale={locale} />` —
+inside a `useMemo([locale])` so the map keeps a stable identity (an unstable `components`
+object remounts every event on each render, dropping open cards). Simpler than a provider
+and trivially testable.
+
+## Data — no extra fetch
+
+`CalendarBookingRow` already carries `bookingCode`, `renterName`, `totalPrice`, `vehicleId`;
+vehicle **names** come from the fleet list the route already loads
+(`operatorCalendarVehiclesQueryOptions`). So we enrich the event at transform time:
+
+```ts
+// calendar-events.ts
+export interface CalendarEvent {
+  id: string
+  title: string
+  start: Date
+  end: Date
+  resourceId: string
+  status: OperatorBookingStatus
+  // --- new: in-hand fields the quick-view card needs (self-describing event) ---
+  bookingCode: string
+  renterName: string | null
+  renterEmail: string | null   // carried so the card's renter line keeps the chip's fallback
+  vehicleName: string | null   // resolved from the fleet map; null when unassigned
+  totalPrice: number | null
+}
+
+export function toCalendarEvents(
+  rows: readonly CalendarBookingRow[],
+  vehicles: readonly { id: string; name: string }[],
+): CalendarEvent[] {
+  const nameById = new Map(vehicles.map((v) => [v.id, v.name]))
+  return rows.map((r) => ({
+    ...,
+    bookingCode: r.bookingCode,
+    renterName: r.renterName,
+    renterEmail: r.renterEmail,
+    vehicleName: r.vehicleId ? (nameById.get(r.vehicleId) ?? null) : null,
+    totalPrice: r.totalPrice,
+  }))
+}
+```
+
+The event becomes self-describing (Tell-Don't-Ask): the chip needs no extra lookups to
+render its card. The card's renter line mirrors the chip title's fallback —
+`renterName ?? renterEmail` (→ "—" only when both are null) — so the card never shows blank
+while the chip shows an email.
+
+## Wiring changes
+
+- **`index.tsx` (route):** `toCalendarEvents(bookings, vehicles)`. **Delete** `handleSelectEvent`
+  and stop passing `onSelectEvent` — navigation now lives in the card's `<Link>`, so a chip
+  click pins instead of navigating.
+- **`BookingsCalendar.tsx`:** build the rbc `components` map in a `useMemo([locale])` —
+  `{ toolbar: () => null, event: (props) => <CalendarEventChip {...props} locale={locale} /> }`
+  — replacing the module-level `CALENDAR_COMPONENTS` const (it now depends on `locale`).
+  Remove the `onSelectEvent` prop and `handleSelectEvent`. `eventPropGetter` (status color on
+  the `.rbc-event` wrapper) and `onSelectSlot` (manual-booking) are untouched.
+
+## Navigation is pin-first (deliberate)
+
+Hover shows a **non-interactive peek**: because the card is portaled, the gap between chip
+and card means moving the pointer toward the card fires `mouseleave` and closes it before the
+pointer arrives. That is intended — to act on a booking you **click** the chip (which pins
+the card), then click the pinned card to open the detail page. This matches the requested
+flow ("hover to show … click to show the modal … click the modal to open the detail page").
+We deliberately do **not** build a hoverable bridge / close-delay (the HoverCard pattern) —
+it adds timing complexity for a peek that is read-only by design.
+
+## i18n
+
+**No new keys.** The card reuses existing `business.bookings.calendar` keys (verified present
+in en / ja / zh): `viewFullDetails` for the affordance, and `sidebar.statuses.{CONFIRMED,
+ACTIVE,COMPLETED,CANCELLED}` for the status label. The card carries **no per-field labels**
+(renter / vehicle / dates / total render as plain values under the status + code header — a
+peek, not a form), so there is nothing to translate. This supersedes an earlier draft that
+proposed a `quickView` label block; it was dropped as unnecessary (YAGNI).
+
+## Formatting
+
+Use `packages/web/src/lib/format.ts` — **not** browser-local formatting:
+
+- Price: `formatJpy(totalPrice)` (zero-decimal yen, e.g. `¥27,000`).
+- Dates: `formatDateTime(date, locale)`, which is **pinned to `Asia/Tokyo`**. The card shows
+  a range `formatDateTime(start, locale) – formatDateTime(end, locale)`. This matters: the
+  business runs in Osaka, and browser-local formatting would shift a booking's pickup/return
+  time for a non-JST operator (and make tests machine-dependent).
+
+## Testing (TDD, vitest + testing-library, mutation-resistant)
+
+1. **`calendar-events.test.ts` (extend):** `toCalendarEvents` attaches `bookingCode`,
+   `renterName`, `renterEmail`, `totalPrice`; resolves `vehicleName` from the fleet map;
+   `vehicleName` is `null` for an unassigned (class-only) booking.
+2. **`BookingQuickView.test.tsx`:** renders code / renter / vehicle / formatted range /
+   total; the card is a `<Link>` with `to` + `params.bookingId === event.id`; the renter
+   line falls back to `renterEmail` when `renterName` is null (and "—" when both null);
+   null vehicle renders "—"; null total omits the total row; the formatted time is JST
+   (assert a fixed UTC instant renders its Tokyo wall-clock, machine-independent).
+3. **`CalendarEventChip.test.tsx`** (chip rendered directly with a `locale` prop, not the
+   full rbc grid; fake timers for the hover delay):
+   - `mouseenter` → card appears after the delay; `mouseleave` before the delay → no card.
+   - hover-open then `mouseleave` → card closes (not pinned).
+   - click → card pins and **survives** a subsequent `mouseleave`.
+   - **a second click on the pinned chip does NOT close it** (the reason-aware guard: a
+     `trigger-press` close is ignored — this is the P1 regression test).
+   - Esc / outside press while pinned → card closes.
+4. **Wiring (extend the existing `BookingsCalendar` / route test):** assert the route enriches
+   events via `toCalendarEvents(bookings, vehicles)` (a rendered event exposes its
+   `vehicleName`), and that `BookingsCalendar` hands rbc a custom `components.event` (a chip,
+   not rbc's default, renders for an event) — so the transform/card/chip units are actually
+   connected, not just individually correct.
+
+## Files
+
+New: `BookingQuickView.tsx`, `CalendarEventChip.tsx`, `BookingQuickView.test.tsx`,
+`CalendarEventChip.test.tsx`.
+Modified: `calendar-events.ts`, `BookingsCalendar.tsx`, route `index.tsx`,
+`messages/{en,ja,zh}.json`, `calendar-events.test.ts`, and the existing
+`BookingsCalendar`/route wiring test. Reuses `lib/format.ts` (`formatDateTime`, `formatJpy`).
+No new context module, API, schema, or migration changes.

--- a/docs/plans/2026-06-30-calendar-quickview-implementation-plan.md
+++ b/docs/plans/2026-06-30-calendar-quickview-implementation-plan.md
@@ -1,0 +1,779 @@
+# Bookings Calendar Quick-View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator see a booking's key facts inline on the calendar (hover to peek, click to pin a card, click the card to open the full detail page) instead of full-navigating on every event click.
+
+**Architecture:** Each react-big-calendar (rbc) event renders a custom `CalendarEventChip` that owns a controlled base-ui `Popover`. Local `hovering`/`pinned` state drives `open`; transitions are reason-aware (a chip click only ever pins; only outside-press/Esc/focus-out dismiss). The popup is a `BookingQuickView` card rendered as a TanStack `<Link>` to the detail route. No new API calls — the calendar event is enriched at transform time with the fields it already has in hand.
+
+**Tech Stack:** Vite + TanStack Router SPA, react-big-calendar, `@base-ui/react` v1.3.0 Popover, use-intl, vitest + @testing-library/react.
+
+**Spec:** `docs/plans/2026-06-27-calendar-quickview-design.md`
+
+**Prerequisite:** Work in a fresh worktree off `origin/develop` (branch `feat/calendar-quickview`); `bun install` first. Carry the spec + this plan into the branch. No route is added, so no `routeTree.gen.ts` regen is needed. Run web tests with `bunx vitest --root packages/web run <path>`.
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/web/src/vite/operator-bookings/calendar-events.ts` | enrich `CalendarEvent` + `toCalendarEvents(rows, vehicles)` | Modify |
+| `packages/web/src/lib/event-colors.ts` | host the shared `STATUS_DOT` map (moved from `CalendarSidebar`) | Modify |
+| `packages/web/src/vite/operator-bookings/CalendarSidebar.tsx` | import the shared `STATUS_DOT` (drop its local copy) | Modify |
+| `packages/web/src/vite/operator-bookings/BookingQuickView.tsx` | pure card body (fields only, no Popover/Link) | Create |
+| `packages/web/src/vite/operator-bookings/CalendarEventChip.tsx` | rbc custom event component: Popover + state machine + Link wrap | Create |
+| `packages/web/src/vite/operator-bookings/BookingsCalendar.tsx` | wire `components.event` (memoized w/ locale); drop `onSelectEvent` | Modify |
+| `packages/web/src/routes/$locale/_business/manage/bookings/index.tsx` | `toCalendarEvents(bookings, vehicles)`; drop navigate-on-click | Modify |
+| `packages/web/tests/vite/operator-bookings/calendar-events.test.ts` | transform enrichment tests | Modify |
+| `packages/web/tests/vite/operator-bookings/BookingQuickView.test.tsx` | card render + fallbacks + JST | Create |
+| `packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx` | hover/pin/dismiss + Link target | Create |
+| `packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx` | assert `components.event` wired; drop `onSelectEvent` | Modify |
+| `packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx` | assert route enriches events with `vehicleName` | Modify |
+
+No new i18n keys: the card reuses `business.bookings.calendar.viewFullDetails` and `business.bookings.calendar.sidebar.statuses.{STATUS}`, which already exist in en/ja/zh.
+
+---
+
+## Task 1: Enrich the calendar event transform
+
+**Files:**
+- Modify: `packages/web/src/vite/operator-bookings/calendar-events.ts:23-49`
+- Test: `packages/web/tests/vite/operator-bookings/calendar-events.test.ts`
+
+- [ ] **Step 1: Update the existing transform tests to the new shape (RED)**
+
+Replace the first `describe('toCalendarEvents', …)` block (lines 29-53) with:
+
+```ts
+const fleet = [
+  { id: 'veh-1', name: 'Toyota Aqua' },
+  { id: 'veh-2', name: 'Nissan Note' },
+]
+
+describe('toCalendarEvents', () => {
+  it('maps a row to an rbc event with the in-hand quick-view fields', () => {
+    expect(toCalendarEvents([row()], fleet)).toEqual([
+      {
+        id: 'bk-1',
+        title: 'Jane',
+        start: new Date('2026-07-01T01:00:00.000Z'),
+        end: new Date('2026-07-03T02:00:00.000Z'),
+        resourceId: 'veh-1',
+        status: 'CONFIRMED',
+        bookingCode: 'ABCD2345',
+        renterName: 'Jane',
+        renterEmail: 'jane@example.com',
+        vehicleName: 'Toyota Aqua',
+        totalPrice: 24000,
+      },
+    ])
+  })
+
+  it('titles by renterEmail when the name is null, then by bookingCode when both are null', () => {
+    expect(toCalendarEvents([row({ renterName: null })], fleet)[0]!.title).toBe('jane@example.com')
+    expect(
+      toCalendarEvents([row({ renterName: null, renterEmail: null })], fleet)[0]!.title,
+    ).toBe('ABCD2345')
+  })
+
+  it('resolves vehicleName from the fleet map and is null for an unassigned booking', () => {
+    expect(toCalendarEvents([row({ vehicleId: 'veh-2' })], fleet)[0]!.vehicleName).toBe('Nissan Note')
+    expect(toCalendarEvents([row({ vehicleId: null })], fleet)[0]!.vehicleName).toBeNull()
+    expect(toCalendarEvents([row({ vehicleId: null })], fleet)[0]!.resourceId).toBe('')
+  })
+
+  it('is null for a vehicleId absent from the fleet map (deleted car)', () => {
+    expect(toCalendarEvents([row({ vehicleId: 'gone' })], fleet)[0]!.vehicleName).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/calendar-events.test.ts`
+Expected: FAIL — `toCalendarEvents` takes 1 arg / events lack `bookingCode` etc.
+
+- [ ] **Step 3: Enrich the interface and transform (GREEN)**
+
+In `calendar-events.ts`, extend the interface (after line 31, inside `CalendarEvent`):
+
+```ts
+  status: OperatorBookingStatus
+  // --- in-hand fields the quick-view card renders (self-describing event) ---
+  bookingCode: string
+  renterName: string | null
+  renterEmail: string | null
+  vehicleName: string | null
+  totalPrice: number | null
+}
+```
+
+Replace `toCalendarEvents` (lines 40-49) with:
+
+```ts
+export function toCalendarEvents(
+  rows: readonly CalendarBookingRow[],
+  vehicles: readonly { id: string; name: string }[],
+): CalendarEvent[] {
+  const nameById = new Map(vehicles.map((v) => [v.id, v.name]))
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.renterName ?? r.renterEmail ?? r.bookingCode,
+    start: new Date(r.startAt),
+    end: new Date(r.effectiveEndAt),
+    resourceId: r.vehicleId ?? '',
+    status: r.status,
+    bookingCode: r.bookingCode,
+    renterName: r.renterName,
+    renterEmail: r.renterEmail,
+    vehicleName: r.vehicleId ? (nameById.get(r.vehicleId) ?? null) : null,
+    totalPrice: r.totalPrice,
+  }))
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/calendar-events.test.ts`
+Expected: PASS (all `toCalendarEvents`, `fleetToResources`, `calendarRange`, parse tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/operator-bookings/calendar-events.ts \
+        packages/web/tests/vite/operator-bookings/calendar-events.test.ts
+git commit -m "feat(calendar): enrich calendar events with in-hand quick-view fields"
+```
+
+---
+
+## Task 2: Promote the shared `STATUS_DOT` map
+
+`CalendarSidebar.tsx` already defines a `STATUS_DOT` color map (lines 21-26) identical to what the card needs. Don't duplicate it — move it to `event-colors.ts` (beside `STATUS_CLASS`) so the sidebar swatch and the card dot are one source, then point both at it.
+
+**Files:**
+- Modify: `packages/web/src/lib/event-colors.ts`
+- Modify: `packages/web/src/vite/operator-bookings/CalendarSidebar.tsx:21-26`
+
+No new test (a static color map; the sidebar's existing tests still pass since output is unchanged, and the card test asserts the status label).
+
+- [ ] **Step 1: Add the shared `STATUS_DOT` to `event-colors.ts`**
+
+Append to `event-colors.ts`:
+
+```ts
+// Tailwind dot color per status, shared by the calendar sidebar swatch and the
+// quick-view card dot. Tracks STATUS_CLASS / calendar-theme.css so a status's
+// color homes change together.
+export const STATUS_DOT: Record<BookingStatus, string> = {
+  CONFIRMED: 'bg-blue-500',
+  ACTIVE: 'bg-green-500',
+  COMPLETED: 'bg-gray-400',
+  CANCELLED: 'bg-red-500',
+}
+```
+
+- [ ] **Step 2: Point `CalendarSidebar` at the shared map**
+
+In `CalendarSidebar.tsx`, delete the local `STATUS_DOT` const (lines 19-26) and import it instead. Add to the existing imports:
+
+```ts
+import { STATUS_DOT } from '@/lib/event-colors'
+```
+
+- [ ] **Step 3: Verify the move typechecks (no behavior change)**
+
+There is no `CalendarSidebar.test.tsx`, and the web Vitest config has no `passWithNoTests`, so don't target a per-file test here. Just typecheck:
+
+Run: `bunx tsc --noEmit -p packages/web/tsconfig.json`
+Expected: clean — `CalendarSidebar` resolves the imported `STATUS_DOT`, no unused-const error. The map value is unchanged, so the sidebar render (exercised by `OperatorBookingsRoute.test.tsx`) is unaffected; the full suite in Task 7 confirms it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/lib/event-colors.ts \
+        packages/web/src/vite/operator-bookings/CalendarSidebar.tsx
+git commit -m "refactor(calendar): promote shared STATUS_DOT map to event-colors"
+```
+
+---
+
+## Task 3: `BookingQuickView` card
+
+**Files:**
+- Create: `packages/web/src/vite/operator-bookings/BookingQuickView.tsx`
+- Test: `packages/web/tests/vite/operator-bookings/BookingQuickView.test.tsx`
+
+- [ ] **Step 1: Write the failing test (RED)**
+
+```tsx
+import { BookingQuickView } from '@/vite/operator-bookings/BookingQuickView'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+const event = (over: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  id: 'bk-1',
+  title: 'Jane Doe',
+  start: new Date('2026-07-01T01:00:00.000Z'), // 10:00 JST
+  end: new Date('2026-07-03T02:00:00.000Z'), // 11:00 JST
+  resourceId: 'veh-1',
+  status: 'ACTIVE',
+  bookingCode: 'ABCD2345',
+  renterName: 'Jane Doe',
+  renterEmail: 'jane@example.com',
+  vehicleName: 'Toyota Aqua',
+  totalPrice: 24000,
+  ...over,
+})
+
+function renderCard(over: Partial<CalendarEvent> = {}) {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <BookingQuickView event={event(over)} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('BookingQuickView', () => {
+  it('shows status label, code, renter, vehicle, total, and the view-details affordance', () => {
+    renderCard()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('ABCD2345')).toBeInTheDocument()
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+    expect(screen.getByText('¥24,000')).toBeInTheDocument()
+    expect(screen.getByText(/View full details/)).toBeInTheDocument()
+  })
+
+  it('formats the time range in JST regardless of the host timezone', () => {
+    renderCard()
+    // 01:00Z..02:00Z render as 10:00..11:00 Asia/Tokyo (machine-independent).
+    expect(screen.getByText(/10:00/)).toBeInTheDocument()
+    expect(screen.getByText(/11:00/)).toBeInTheDocument()
+  })
+
+  it('falls back to renterEmail then "—" for the renter line', () => {
+    renderCard({ renterName: null })
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument()
+  })
+
+  it('shows "—" for an unassigned vehicle and omits the total when null', () => {
+    renderCard({ vehicleName: null, totalPrice: null })
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.queryByText(/¥/)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/BookingQuickView.test.tsx`
+Expected: FAIL — module `BookingQuickView` not found.
+
+- [ ] **Step 3: Implement the card (GREEN)**
+
+```tsx
+import { STATUS_DOT } from '@/lib/event-colors'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { useTranslations } from 'use-intl'
+
+interface BookingQuickViewProps {
+  readonly event: CalendarEvent
+  readonly locale: string
+}
+
+// Pure presentational card body for the calendar quick-view. No Popover, no Link
+// (the chip wraps it) — so it renders standalone and tests with just an IntlProvider.
+export function BookingQuickView({ event, locale }: BookingQuickViewProps) {
+  const t = useTranslations('business.bookings.calendar')
+  const renter = event.renterName ?? event.renterEmail ?? '—'
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-block size-2 shrink-0 rounded-full ${STATUS_DOT[event.status]}`}
+          aria-hidden
+        />
+        <span className="font-medium">{t(`sidebar.statuses.${event.status}`)}</span>
+        <span className="ml-auto text-muted-foreground">{event.bookingCode}</span>
+      </div>
+      <div>{renter}</div>
+      <div className="text-muted-foreground">{event.vehicleName ?? '—'}</div>
+      <div className="text-muted-foreground">
+        {formatDateTime(event.start, locale)} – {formatDateTime(event.end, locale)}
+      </div>
+      {event.totalPrice != null && <div className="font-medium">{formatJpy(event.totalPrice)}</div>}
+      <div className="mt-1 font-medium text-primary">{t('viewFullDetails')} →</div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/BookingQuickView.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/operator-bookings/BookingQuickView.tsx \
+        packages/web/tests/vite/operator-bookings/BookingQuickView.test.tsx
+git commit -m "feat(calendar): BookingQuickView card (in-hand fields, JST, status dot)"
+```
+
+---
+
+## Task 4: `CalendarEventChip` (Popover + reason-aware state machine)
+
+**Files:**
+- Create: `packages/web/src/vite/operator-bookings/CalendarEventChip.tsx`
+- Test: `packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx`
+
+The single trickiest unit. The state machine (from the spec):
+- `open = hovering || pinned`.
+- `mouseenter` → after `HOVER_OPEN_DELAY_MS` → `hovering = true`; `mouseleave` → cancel + `hovering = false`.
+- chip `onClick` → `pinned = true` (covers click + keyboard Enter/Space on the button). Pinning via `onClick`, **not** via `onOpenChange(true)`, so a hover-open card *pins* on click instead of base-ui toggling it shut.
+- `onOpenChange(false, reason)` → dismiss (clear both) **only** when `reason ∈ {outside-press, escape-key, focus-out}`; a `trigger-press` close is ignored.
+- The popup keeps its own `role="dialog"`; a **block `<Link>` inside** it wraps the card (do NOT render the popup itself as the Link — base-ui puts `role="dialog"` + `tabIndex={-1}` on the popup element, and `render` would clone those onto the `<Link>`, so it would neither expose as a link nor be tabbable). `initialFocus={false}` on the popup so a hover-open never steals focus; the inner `<Link>` stays keyboard-reachable by Tab.
+
+- [ ] **Step 1: Write the failing test (RED)**
+
+```tsx
+import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Stub the TanStack Link as a plain anchor exposing its target + carried params,
+// so the chip renders without a RouterProvider (mirrors SearchResultRow.test.tsx).
+vi.mock('@tanstack/react-router', async () => ({
+  ...(await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')),
+  Link: ({
+    to,
+    params,
+    children,
+    ...rest
+  }: {
+    to: string
+    params?: { locale?: string; bookingId?: string }
+    children: ReactNode
+  }) => (
+    <a href={to} data-to={to} data-locale={params?.locale} data-bookingid={params?.bookingId} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+const event: CalendarEvent = {
+  id: 'bk-1',
+  title: 'Jane Doe',
+  start: new Date('2026-07-01T01:00:00.000Z'),
+  end: new Date('2026-07-03T02:00:00.000Z'),
+  resourceId: 'veh-1',
+  status: 'ACTIVE',
+  bookingCode: 'ABCD2345',
+  renterName: 'Jane Doe',
+  renterEmail: 'jane@example.com',
+  vehicleName: 'Toyota Aqua',
+  totalPrice: 24000,
+}
+
+// rbc passes EventProps; the chip only reads `event` + the injected `locale`.
+function renderChip() {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      {/* biome-ignore lint/suspicious/noExplicitAny: rbc EventProps stub */}
+      <CalendarEventChip {...({ event } as any)} locale="en" />
+    </IntlProvider>,
+  )
+  return screen.getByRole('button', { name: /Jane Doe/ })
+}
+
+const card = () => screen.queryByText('Toyota Aqua') // unique to the open card
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+})
+
+describe('CalendarEventChip', () => {
+  it('opens a transient card on hover after the delay', () => {
+    const trigger = renderChip()
+    expect(card()).toBeNull()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('does not open if the pointer leaves before the delay', () => {
+    const trigger = renderChip()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(60))
+    fireEvent.mouseLeave(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    expect(card()).toBeNull()
+  })
+
+  it('closes a hover-opened card when the pointer leaves (not pinned)', () => {
+    const trigger = renderChip()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    fireEvent.mouseLeave(trigger)
+    expect(card()).toBeNull()
+  })
+
+  it('pins on click so the card survives a subsequent mouseleave', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    fireEvent.mouseLeave(trigger)
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('does not close a pinned card on a second chip click (reason-aware guard)', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('dismisses a pinned card on Escape', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    act(() => fireEvent.keyDown(document.body, { key: 'Escape' }))
+    expect(card()).toBeNull()
+  })
+
+  it('dismisses a pinned card on an outside click', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    // base-ui's mouse outsidePress defaults to `intentional` — it dismisses on a
+    // real outside *click*, not a bare pointerdown, so drive a click on the body.
+    act(() => fireEvent.click(document.body))
+    expect(card()).toBeNull()
+  })
+
+  it('renders the card as a Link (inside the popup) to the booking detail route', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('data-to', '/$locale/manage/bookings/$bookingId')
+    expect(link).toHaveAttribute('data-bookingid', 'bk-1')
+    expect(link).toHaveAttribute('data-locale', 'en')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/CalendarEventChip.test.tsx`
+Expected: FAIL — module `CalendarEventChip` not found.
+
+- [ ] **Step 3: Implement the chip (GREEN)**
+
+```tsx
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { BookingQuickView } from '@/vite/operator-bookings/BookingQuickView'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { Link } from '@tanstack/react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { EventProps } from 'react-big-calendar'
+
+const HOVER_OPEN_DELAY_MS = 120
+// base-ui v1.3.0 onOpenChange reasons that mean "the user dismissed the card".
+// A `trigger-press` close (toggle) is deliberately NOT here: a chip click only pins.
+const DISMISS_REASONS = new Set(['outside-press', 'escape-key', 'focus-out'])
+
+type ChipProps = EventProps<CalendarEvent> & { readonly locale: string }
+
+// rbc custom event component. Renders the event title as a Popover trigger and a
+// BookingQuickView card as the popup. Owns a local hover/pin state machine; the card
+// is a Link so clicking it (or pressing Enter on it) opens the full detail page.
+export function CalendarEventChip({ event, locale }: ChipProps) {
+  const [hovering, setHovering] = useState(false)
+  const [pinned, setPinned] = useState(false)
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (openTimer.current) {
+      clearTimeout(openTimer.current)
+      openTimer.current = null
+    }
+  }, [])
+
+  const handleEnter = useCallback(() => {
+    clearTimer()
+    openTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS)
+  }, [clearTimer])
+
+  const handleLeave = useCallback(() => {
+    clearTimer()
+    setHovering(false)
+  }, [clearTimer])
+
+  useEffect(() => clearTimer, [clearTimer])
+
+  const handleOpenChange = useCallback((next: boolean, details: { reason: string }) => {
+    if (!next && DISMISS_REASONS.has(details.reason)) {
+      setPinned(false)
+      setHovering(false)
+    }
+  }, [])
+
+  return (
+    <Popover open={hovering || pinned} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        type="button"
+        className="block h-full w-full truncate text-left"
+        onClick={() => setPinned(true)}
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+      >
+        {event.title}
+      </PopoverTrigger>
+      <PopoverContent initialFocus={false} className="p-0">
+        <Link
+          to="/$locale/manage/bookings/$bookingId"
+          params={{ locale, bookingId: event.id }}
+          className="block rounded-lg p-2.5 text-inherit no-underline hover:bg-muted"
+        >
+          <BookingQuickView event={event} locale={locale} />
+        </Link>
+      </PopoverContent>
+    </Popover>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/CalendarEventChip.test.tsx`
+Expected: PASS (7 tests).
+
+If the Escape or pin tests are flaky under jsdom + base-ui portals: confirm the card text is queried from `document.body` (portal target) — `screen.queryByText` already searches the whole document, so no change is usually needed. Do NOT weaken assertions to `toBeTruthy`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/operator-bookings/CalendarEventChip.tsx \
+        packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx
+git commit -m "feat(calendar): CalendarEventChip hover-peek/click-pin quick-view popover"
+```
+
+---
+
+## Task 5: Wire the chip into `BookingsCalendar`
+
+**Files:**
+- Modify: `packages/web/src/vite/operator-bookings/BookingsCalendar.tsx`
+- Test: `packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx`
+
+- [ ] **Step 1: Update the test (RED)**
+
+In `BookingsCalendar.test.tsx`, remove `onSelectEvent={vi.fn()}` from the `renderCalendar` JSX (the prop is gone). Then add to the `describe` block:
+
+```ts
+it('hands rbc a custom event component (the quick-view chip)', () => {
+  renderCalendar(vi.fn())
+  expect(typeof (calendarProps.components as { event?: unknown }).event).toBe('function')
+})
+
+it('no longer wires a navigate-on-click handler to rbc', () => {
+  renderCalendar(vi.fn())
+  expect(calendarProps.onSelectEvent).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/BookingsCalendar.test.tsx`
+Expected: FAIL — `onSelectEvent` still passed; `components.event` undefined; and a TS error on the removed prop once Step 3 lands.
+
+- [ ] **Step 3: Implement the wiring (GREEN)**
+
+In `BookingsCalendar.tsx`:
+
+1. Add imports:
+```ts
+import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
+import { Calendar, type EventProps, type SlotInfo } from 'react-big-calendar'
+```
+(extend the existing `react-big-calendar` import to include `EventProps`.)
+
+2. Delete the module-level `CALENDAR_COMPONENTS` const (line 20).
+
+3. In `BookingsCalendarProps`, delete the `onSelectEvent` member (lines 31-33).
+
+4. Delete `onSelectEvent` from the destructured params and delete `handleSelectEvent` (lines 92-95).
+
+5. After `eventPropGetter`, add the memoized components map:
+```ts
+const components = useMemo(
+  () => ({
+    toolbar: () => null,
+    event: (props: EventProps<CalendarEvent>) => <CalendarEventChip {...props} locale={locale} />,
+  }),
+  [locale],
+)
+```
+
+6. On `<Calendar>`, delete `onSelectEvent={handleSelectEvent}` and change `components={CALENDAR_COMPONENTS}` to `components={components}`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/BookingsCalendar.test.tsx`
+Expected: PASS (slot-selection tests + the 2 new wiring tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/vite/operator-bookings/BookingsCalendar.tsx \
+        packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
+git commit -m "feat(calendar): render quick-view chip as rbc event; drop navigate-on-click"
+```
+
+---
+
+## Task 6: Wire the route (enrich events; drop navigation)
+
+**Files:**
+- Modify: `packages/web/src/routes/$locale/_business/manage/bookings/index.tsx:108,134-139,165-175`
+- Test: `packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx`
+
+- [ ] **Step 1: Add the enrichment-wiring test (RED)**
+
+In `OperatorBookingsRoute.test.tsx`, add inside the existing `describe`:
+
+```ts
+it('enriches calendar events with the assigned vehicle name (transform wiring)', () => {
+  const booking: api.CalendarBookingRow = {
+    id: 'bk-1',
+    bookingCode: 'ABCD2345',
+    status: 'CONFIRMED',
+    startAt: '2026-07-01T01:00:00.000Z',
+    effectiveEndAt: '2026-07-03T02:00:00.000Z',
+    vehicleId: 'veh-1',
+    renterName: 'Jane',
+    renterEmail: null,
+    totalPrice: 24000,
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
+  })
+  queryClient.setQueryData(['session'], operatorSession)
+  queryClient.setQueryData(api.operatorCalendarQueryOptions(from, to).queryKey, [booking])
+  queryClient.setQueryData(api.operatorCalendarVehiclesQueryOptions().queryKey, [
+    { id: 'veh-1', name: 'Toyota Aqua' },
+  ])
+  queryClient.setQueryData(operatorLocationsQueryOptions().queryKey, [])
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <OperatorBookingsRoute />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+  const events = calendarProps.events as Array<{ id: string; vehicleName: string | null }>
+  expect(events).toHaveLength(1)
+  expect(events[0]).toMatchObject({ id: 'bk-1', vehicleName: 'Toyota Aqua' })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx`
+Expected: FAIL — events lack `vehicleName` (route still calls `toCalendarEvents(bookings)`), and a TS error on the removed `onSelectEvent` prop after Step 3.
+
+- [ ] **Step 3: Implement the route changes (GREEN)**
+
+In `index.tsx`:
+
+1. Line 108 — pass the fleet to the transform:
+```ts
+const events = useMemo(() => toCalendarEvents(bookings, vehicles), [bookings, vehicles])
+```
+
+2. Delete `handleSelectEvent` (lines 134-139).
+
+3. In the `<BookingsCalendar …>` JSX, delete the `onSelectEvent={handleSelectEvent}` prop (line 173). Leave `locale`, `events`, `resources`, view/date handlers, and `onSelectSlot` unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx`
+Expected: PASS (existing manual-booking tests + the new enrichment test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+# Single-quote the path: an unquoted $locale is expanded away by the shell.
+git add 'packages/web/src/routes/$locale/_business/manage/bookings/index.tsx' \
+        packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+git commit -m "feat(calendar): enrich events with fleet in route; click pins instead of navigating"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Typecheck the web package**
+
+Run: `bunx tsc --noEmit -p packages/web/tsconfig.json`
+Expected: no errors. (Watch for any other caller of `toCalendarEvents` — there should be only the route and the test.)
+
+- [ ] **Step 2: Run the full operator-bookings suite**
+
+Run: `bunx vitest --root packages/web run tests/vite/operator-bookings`
+Expected: all green (transform, card, chip, calendar wiring, route wiring).
+
+- [ ] **Step 3: Lint + format**
+
+Run: `bun run lint && bun run format`
+Expected: exit 0. (Biome may reorder imports — re-read files before any further edit.)
+
+- [ ] **Step 4: Build the web package (catches route-tree / bundler issues)**
+
+Run: `bun run --filter @kuruma/web build`
+Expected: build succeeds. No `routeTree.gen.ts` change is expected (no route added).
+
+- [ ] **Step 5: Manual smoke (browser)**
+
+Run `bun run dev`, open `/<locale>/manage/bookings`. Verify: hovering an event shows the card after ~120ms; it disappears on mouse-out; clicking pins it; clicking the pinned card opens the detail page; clicking elsewhere / Esc closes a pinned card; times read in JST.
+
+- [ ] **Step 6: Final commit (if lint/format changed anything)**
+
+Do NOT use `git add -A` — the worktree carries an untracked `tmp/`. Inspect, then stage only the feature paths:
+
+```bash
+git status --short
+# Single-quote the $locale route path; include it since Task 6 modifies it and
+# format may have touched it after that commit.
+git add packages/web/src/vite/operator-bookings packages/web/src/lib/event-colors.ts \
+        packages/web/tests/vite/operator-bookings \
+        'packages/web/src/routes/$locale/_business/manage/bookings/index.tsx'
+git commit -m "chore(calendar): lint/format quick-view"
+```
+
+---
+
+## Self-review notes (coverage check)
+
+- Spec interaction model (hover-peek / click-pin / dismiss / card-as-Link) → Tasks 3, 4.
+- Spec P1 reason-aware state machine → Task 4 (`DISMISS_REASONS`, `onClick` pins, second-click regression test).
+- Spec P2 renter fallback → Task 1 (`renterEmail`) + Task 3 (renter line + test).
+- Spec P2 JST formatting → Task 3 (`formatDateTime`) + test.
+- Spec P2 wiring tests → Tasks 5 (`components.event`) + 6 (route enrichment).
+- Spec P3 no context module → Task 5 (memoized inline wrapper).
+- Spec "no new API/i18n keys" → reuses `viewFullDetails` + `sidebar.statuses.*` (verified present in en/ja/zh).

--- a/e2e/real-db/calendar-quickview.auth.spec.ts
+++ b/e2e/real-db/calendar-quickview.auth.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+// #1099 quick-view: an operator peeks a booking's key facts inline on the calendar
+// (hover to open a card, click to pin it, click the card to open the full detail
+// page) instead of full-navigating on every event click. Runs on the project-default
+// OPERATOR_OWNER `page` (Best Car Rental) against the seeded fixture.
+//
+// The seed mints UUID ids (db/seed-id.ts), so the detail URL carries a UUID, not the
+// input slug. But renter names and booking codes are inserted literally, so we anchor
+// on Best Car Rental's offset-0 ACTIVE booking (seed-data/bookings.ts
+// `bk_demo_best_suv_sub`): renter "Chen Wei", code "B4N8RXY2". Its start is today, so
+// it always falls inside this week's window regardless of when the smoke runs.
+const RENTER_NAME = 'Chen Wei'
+const BOOKING_CODE = 'B4N8RXY2'
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+test('operator peeks then pins a booking quick-view card, then opens its detail page', async ({
+  page,
+}) => {
+  // Week view renders booking chips (the default timeline view shows fleet rows, no
+  // chips). No ?date -> this week, which contains the offset-0 booking.
+  await page.goto('/en/manage/bookings?view=week')
+  await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
+
+  // The chip is a Popover trigger button titled with the renter. Best's calendar
+  // carries exactly one Chen Wei event (their other bookings are on other tenants).
+  const chip = page.getByRole('button', { name: new RegExp(RENTER_NAME) }).first()
+  await expect(chip).toBeVisible({ timeout: 20_000 })
+
+  // The booking code renders ONLY inside the open card, never in the chip title, so
+  // it is the unambiguous proof the quick-view opened.
+  const cardCode = page.getByText(BOOKING_CODE)
+  await expect(cardCode).toBeHidden()
+
+  await test.step('hover peeks the card', async () => {
+    await chip.hover()
+    // Opens after HOVER_OPEN_DELAY_MS (120ms); toBeVisible auto-waits past it.
+    await expect(cardCode).toBeVisible()
+  })
+
+  await test.step('click pins the card so it survives the pointer leaving', async () => {
+    await chip.click()
+    // Move the pointer well away; a pinned card must stay open (a hover-only card
+    // would close here).
+    await page.mouse.move(0, 0)
+    await expect(cardCode).toBeVisible()
+  })
+
+  await test.step('clicking the pinned card opens the full booking detail page', async () => {
+    // The whole card is a TanStack <Link>; its accessible name carries the
+    // view-details affordance.
+    await page.getByRole('link', { name: /View full details/ }).click()
+    await expect(page).toHaveURL(new RegExp(`/en/manage/bookings/${UUID}`))
+  })
+})

--- a/e2e/real-db/marketplace-happy-path.auth.spec.ts
+++ b/e2e/real-db/marketplace-happy-path.auth.spec.ts
@@ -127,13 +127,15 @@ test.describe('marketplace happy path — renter books, operator sees it (real D
       // the booking's far-future month (clear of the seeded ~-5..+7d bookings, so this
       // run's booking is the only event in view). Month view ignores the day-view
       // vehicle-resource columns, so the event renders regardless of car assignment.
-      // The event is titled with the renter; clicking it opens the trip detail, which
-      // carries the per-run unique reservation code — the token that ties it to THIS run.
+      // The event is a quick-view chip titled with the renter (#1099): clicking it
+      // pins a card, and the card is the Link that opens the trip detail — which
+      // carries the per-run unique reservation code, the token that ties it to THIS run.
       await page.goto('/en/manage/bookings?view=month&date=2026-07-15')
       await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
-      const event = page.getByText(RENTER_NAME).first()
-      await expect(event).toBeVisible({ timeout: 20_000 })
-      await event.click()
+      const chip = page.getByRole('button', { name: new RegExp(RENTER_NAME) }).first()
+      await expect(chip).toBeVisible({ timeout: 20_000 })
+      await chip.click() // pins the quick-view card (the click no longer navigates)
+      await page.getByRole('link', { name: /View full details/ }).click()
       await expect(page).toHaveURL(new RegExp(`/manage/bookings/${UUID}`))
       await expect(page.getByText(bookingCode)).toBeVisible({ timeout: 20_000 })
     })

--- a/packages/web/src/lib/event-colors.ts
+++ b/packages/web/src/lib/event-colors.ts
@@ -14,3 +14,13 @@ export const BLOCK_KIND_CLASS: Record<VehicleBlockKind, string> = {
   OUT_OF_SERVICE: 'rbc-event--block-out-of-service',
   MANUAL: 'rbc-event--block-manual',
 }
+
+// Tailwind dot color per status, shared by the calendar sidebar swatch and the
+// quick-view card dot. Tracks STATUS_CLASS / calendar-theme.css so a status's
+// color homes change together.
+export const STATUS_DOT: Record<BookingStatus, string> = {
+  CONFIRMED: 'bg-blue-500',
+  ACTIVE: 'bg-green-500',
+  COMPLETED: 'bg-gray-400',
+  CANCELLED: 'bg-red-500',
+}

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -151,7 +151,7 @@ export function OperatorBookingsRoute() {
     enabled: canViewBlocks && view !== 'timeline',
   })
 
-  const events = useMemo(() => toCalendarEvents(bookings), [bookings])
+  const events = useMemo(() => toCalendarEvents(bookings, vehicles), [bookings, vehicles])
   const blockEvents = useMemo(
     () => (canViewBlocks ? blocksToCalendarEvents(blocks ?? []) : []),
     [canViewBlocks, blocks],

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -214,18 +214,15 @@ export function OperatorBookingsRoute() {
     [navigate, locale],
   )
 
-  const handleSelectEvent = useCallback(
-    (item: CalendarItem) => {
-      // #1101: dispatch by the discriminant. A booking navigates to its detail page;
-      // a block opens the block-detail dialog (view + delete).
-      if (item.type === 'booking') {
-        navigateToBooking(item.id)
-      } else {
-        setSelectedBlock(item)
-      }
-    },
-    [navigateToBooking],
-  )
+  const handleSelectEvent = useCallback((item: CalendarItem) => {
+    // #1101: dispatch by the discriminant. A block opens its detail dialog (view +
+    // delete). A booking is handled by the CalendarEventChip's own popover
+    // (hover-peek / click-pin), whose inner <Link> owns navigation — so an rbc
+    // event-click is a no-op for bookings here; navigating would defeat the pin.
+    if (item.type === 'block') {
+      setSelectedBlock(item)
+    }
+  }, [])
 
   // Both the header button and a calendar slot-click open the dialog; a slot also
   // prefills the pickup/return range (the button opens an empty range).

--- a/packages/web/src/vite/operator-bookings/BookingQuickView.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingQuickView.tsx
@@ -1,0 +1,36 @@
+import { STATUS_DOT } from '@/lib/event-colors'
+import { formatDateTime, formatJpy } from '@/lib/format'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { useTranslations } from 'use-intl'
+
+interface BookingQuickViewProps {
+  readonly event: CalendarEvent
+  readonly locale: string
+}
+
+// Pure presentational card body for the calendar quick-view. No Popover, no Link
+// (the chip wraps it) — so it renders standalone and tests with just an IntlProvider.
+export function BookingQuickView({ event, locale }: BookingQuickViewProps) {
+  const t = useTranslations('business.bookings.calendar')
+  const renter = event.renterName ?? event.renterEmail ?? '—'
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-block size-2 shrink-0 rounded-full ${STATUS_DOT[event.status]}`}
+          aria-hidden
+        />
+        <span className="font-medium">{t(`sidebar.statuses.${event.status}`)}</span>
+        <span className="ml-auto text-muted-foreground">{event.bookingCode}</span>
+      </div>
+      <div>{renter}</div>
+      <div className="text-muted-foreground">{event.vehicleName ?? '—'}</div>
+      <div className="text-muted-foreground">
+        {formatDateTime(event.start, locale)} – {formatDateTime(event.end, locale)}
+      </div>
+      {event.totalPrice != null && <div className="font-medium">{formatJpy(event.totalPrice)}</div>}
+      <div className="mt-1 font-medium text-primary">{t('viewFullDetails')} →</div>
+    </div>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
@@ -1,4 +1,5 @@
 import { localizer } from '@/lib/rbc-localizer'
+import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
 import { CalendarToolbar } from '@/vite/operator-bookings/CalendarToolbar'
 import {
   type CalendarItem,
@@ -9,7 +10,7 @@ import {
 } from '@/vite/operator-bookings/calendar-events'
 import { endOfWeek, startOfWeek } from 'date-fns'
 import { useCallback, useMemo } from 'react'
-import { Calendar, type SlotInfo, type View } from 'react-big-calendar'
+import { Calendar, type EventProps, type SlotInfo, type View } from 'react-big-calendar'
 import { useTranslations } from 'use-intl'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
 import './calendar-theme.css'
@@ -18,9 +19,6 @@ import './calendar-theme.css'
 // component, not an rbc view) — typed as rbc's `View` so the Calendar prop checks.
 const RBC_VIEWS: View[] = ['day', 'week', 'month']
 const SCROLL_TO_TIME = new Date(1970, 0, 1, 8, 0, 0)
-// rbc's built-in toolbar is suppressed — we render CalendarToolbar ourselves so
-// navigation drives the URL (search params) rather than rbc's internal state.
-const CALENDAR_COMPONENTS = { toolbar: () => null } as const
 
 interface BookingsCalendarProps {
   // #1101: bookings AND scheduled blocks, on one vehicle axis (the discriminated union).
@@ -118,6 +116,23 @@ export function BookingsCalendar({
     [],
   )
 
+  // rbc renders each band through `components.event`. A booking becomes the
+  // interactive quick-view chip (hover-peek / click-pin); a block stays a plain band
+  // so its existing click -> block-detail-dialog path (onSelectEvent) is untouched.
+  // The toolbar is suppressed here — the route renders CalendarToolbar itself.
+  const components = useMemo(
+    () => ({
+      toolbar: () => null,
+      event: (props: EventProps<CalendarItem>) =>
+        props.event.type === 'booking' ? (
+          <CalendarEventChip event={props.event} locale={locale} />
+        ) : (
+          <span className="truncate">{props.event.title}</span>
+        ),
+    }),
+    [locale],
+  )
+
   const messages = useMemo(
     () => ({
       today: t('today'),
@@ -169,7 +184,7 @@ export function BookingsCalendar({
         scrollToTime={SCROLL_TO_TIME}
         style={calendarStyle}
         messages={messages}
-        components={CALENDAR_COMPONENTS}
+        components={components}
         popup
       />
     </div>

--- a/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
@@ -120,6 +120,10 @@ export function BookingsCalendar({
   // interactive quick-view chip (hover-peek / click-pin); a block stays a plain band
   // so its existing click -> block-detail-dialog path (onSelectEvent) is untouched.
   // The toolbar is suppressed here — the route renders CalendarToolbar itself.
+  // Scale note: this mounts one base-ui Popover per booking band. Fine at this fleet
+  // size (day/week are sparse; the default timeline view uses no chips). If a dense
+  // month view ever regresses, hoist a single calendar-level Popover keyed to the
+  // hovered/pinned event id instead of one-per-event.
   const components = useMemo(
     () => ({
       toolbar: () => null,

--- a/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
@@ -1,13 +1,20 @@
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { BookingQuickView } from '@/vite/operator-bookings/BookingQuickView'
 import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import type { Popover as PopoverPrimitive } from '@base-ui/react/popover'
 import { Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 const HOVER_OPEN_DELAY_MS = 120
-// base-ui v1.3.0 onOpenChange reasons that mean "the user dismissed the card".
-// A `trigger-press` close (toggle) is deliberately NOT here: a chip click only pins.
-const DISMISS_REASONS = new Set(['outside-press', 'escape-key', 'focus-out'])
+// base-ui onOpenChange reasons that mean "the user dismissed the card". A
+// `trigger-press` close (toggle) is deliberately NOT here: a chip click only pins.
+// Typed off base-ui's reason union so a typo (which would silently fail *open* —
+// the card would just never dismiss on that reason) is a compile error.
+const DISMISS_REASONS = new Set<PopoverPrimitive.Root.ChangeEventReason>([
+  'outside-press',
+  'escape-key',
+  'focus-out',
+])
 
 interface ChipProps {
   // Only bookings get a chip (the calendar wiring renders blocks plainly), so this
@@ -44,12 +51,15 @@ export function CalendarEventChip({ event, locale }: ChipProps) {
 
   useEffect(() => clearTimer, [clearTimer])
 
-  const handleOpenChange = useCallback((next: boolean, details: { reason: string }) => {
-    if (!next && DISMISS_REASONS.has(details.reason)) {
-      setPinned(false)
-      setHovering(false)
-    }
-  }, [])
+  const handleOpenChange = useCallback(
+    (next: boolean, details: PopoverPrimitive.Root.ChangeEventDetails) => {
+      if (!next && DISMISS_REASONS.has(details.reason)) {
+        setPinned(false)
+        setHovering(false)
+      }
+    },
+    [],
+  )
 
   return (
     <Popover open={hovering || pinned} onOpenChange={handleOpenChange}>

--- a/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
@@ -1,0 +1,76 @@
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { BookingQuickView } from '@/vite/operator-bookings/BookingQuickView'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { Link } from '@tanstack/react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const HOVER_OPEN_DELAY_MS = 120
+// base-ui v1.3.0 onOpenChange reasons that mean "the user dismissed the card".
+// A `trigger-press` close (toggle) is deliberately NOT here: a chip click only pins.
+const DISMISS_REASONS = new Set(['outside-press', 'escape-key', 'focus-out'])
+
+interface ChipProps {
+  // Only bookings get a chip (the calendar wiring renders blocks plainly), so this
+  // takes the base event, not the CalendarItem union — it never reads the discriminant.
+  readonly event: CalendarEvent
+  readonly locale: string
+}
+
+// rbc custom event component for a booking band. Renders the event title as a Popover
+// trigger and a BookingQuickView card as the popup. Owns a local hover/pin state
+// machine; the card is a Link so clicking it (or pressing Enter on it) opens the full
+// detail page.
+export function CalendarEventChip({ event, locale }: ChipProps) {
+  const [hovering, setHovering] = useState(false)
+  const [pinned, setPinned] = useState(false)
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (openTimer.current) {
+      clearTimeout(openTimer.current)
+      openTimer.current = null
+    }
+  }, [])
+
+  const handleEnter = useCallback(() => {
+    clearTimer()
+    openTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS)
+  }, [clearTimer])
+
+  const handleLeave = useCallback(() => {
+    clearTimer()
+    setHovering(false)
+  }, [clearTimer])
+
+  useEffect(() => clearTimer, [clearTimer])
+
+  const handleOpenChange = useCallback((next: boolean, details: { reason: string }) => {
+    if (!next && DISMISS_REASONS.has(details.reason)) {
+      setPinned(false)
+      setHovering(false)
+    }
+  }, [])
+
+  return (
+    <Popover open={hovering || pinned} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        type="button"
+        className="block h-full w-full truncate text-left"
+        onClick={() => setPinned(true)}
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+      >
+        {event.title}
+      </PopoverTrigger>
+      <PopoverContent initialFocus={false} className="p-0">
+        <Link
+          to="/$locale/manage/bookings/$bookingId"
+          params={{ locale, bookingId: event.id }}
+          className="block rounded-lg p-2.5 text-inherit no-underline hover:bg-muted"
+        >
+          <BookingQuickView event={event} locale={locale} />
+        </Link>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/web/src/vite/operator-bookings/CalendarSidebar.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarSidebar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
+import { STATUS_DOT } from '@/lib/event-colors'
 import { UnassignedFloatsList } from '@/vite/operator-bookings/UnassignedFloatsList'
-import type { OperatorBookingStatus } from '@/vite/operator-bookings/api'
 import type { CalendarFiltersApi } from '@/vite/operator-bookings/useCalendarFilters'
 import { BOOKING_STATUSES } from '@kuruma/shared/enums'
 import { useTranslations } from 'use-intl'
@@ -16,15 +16,6 @@ interface CalendarSidebarProps {
 }
 
 const STATUSES = BOOKING_STATUSES
-
-// Dot color tracks STATUS_CLASS / calendar-theme.css so the sidebar swatch stays
-// in sync with the calendar event color.
-const STATUS_DOT: Record<OperatorBookingStatus, string> = {
-  CONFIRMED: 'bg-blue-500',
-  ACTIVE: 'bg-green-500',
-  COMPLETED: 'bg-gray-400',
-  CANCELLED: 'bg-red-500',
-}
 
 // Presentational filter sidebar (#525 Slice C), driven entirely by the filters
 // API from useCalendarFilters. Hidden below md (the calendar takes the full width

--- a/packages/web/src/vite/operator-bookings/calendar-events.ts
+++ b/packages/web/src/vite/operator-bookings/calendar-events.ts
@@ -40,6 +40,12 @@ export interface CalendarEvent {
   // for a class-only booking with no assigned car: it has no column to live in.
   resourceId: string
   status: OperatorBookingStatus
+  // --- in-hand fields the quick-view card renders (self-describing event) ---
+  bookingCode: string
+  renterName: string | null
+  renterEmail: string | null
+  vehicleName: string | null
+  totalPrice: number | null
 }
 
 /** One vehicle column in day view. */
@@ -80,7 +86,11 @@ export function calendarItemClassName(item: CalendarItem): string {
   return item.type === 'booking' ? (STATUS_CLASS[item.status] ?? '') : BLOCK_KIND_CLASS[item.kind]
 }
 
-export function toCalendarEvents(rows: readonly CalendarBookingRow[]): BookingCalendarEvent[] {
+export function toCalendarEvents(
+  rows: readonly CalendarBookingRow[],
+  vehicles: readonly { id: string; name: string }[],
+): BookingCalendarEvent[] {
+  const nameById = new Map(vehicles.map((v) => [v.id, v.name]))
   return rows.map((r) => ({
     type: 'booking',
     id: r.id,
@@ -89,6 +99,11 @@ export function toCalendarEvents(rows: readonly CalendarBookingRow[]): BookingCa
     end: new Date(r.effectiveEndAt),
     resourceId: r.vehicleId ?? '',
     status: r.status,
+    bookingCode: r.bookingCode,
+    renterName: r.renterName,
+    renterEmail: r.renterEmail,
+    vehicleName: r.vehicleId ? (nameById.get(r.vehicleId) ?? null) : null,
+    totalPrice: r.totalPrice,
   }))
 }
 

--- a/packages/web/tests/vite/operator-bookings/BookingQuickView.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingQuickView.test.tsx
@@ -1,0 +1,63 @@
+import { formatJpy } from '@/lib/format'
+import { BookingQuickView } from '@/vite/operator-bookings/BookingQuickView'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it } from 'vitest'
+import en from '../../../messages/en.json'
+
+const event = (over: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  id: 'bk-1',
+  title: 'Jane Doe',
+  start: new Date('2026-07-01T01:00:00.000Z'), // 10:00 JST
+  end: new Date('2026-07-03T02:00:00.000Z'), // 11:00 JST
+  resourceId: 'veh-1',
+  status: 'ACTIVE',
+  bookingCode: 'ABCD2345',
+  renterName: 'Jane Doe',
+  renterEmail: 'jane@example.com',
+  vehicleName: 'Toyota Aqua',
+  totalPrice: 24000,
+  ...over,
+})
+
+function renderCard(over: Partial<CalendarEvent> = {}) {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      <BookingQuickView event={event(over)} locale="en" />
+    </IntlProvider>,
+  )
+}
+
+describe('BookingQuickView', () => {
+  it('shows status label, code, renter, vehicle, total, and the view-details affordance', () => {
+    renderCard()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('ABCD2345')).toBeInTheDocument()
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('Toyota Aqua')).toBeInTheDocument()
+    // Assert against the real formatter, not a hardcoded glyph — Node's full-ICU
+    // renders JPY with the fullwidth yen (U+FFE5), the browser likewise.
+    expect(screen.getByText(formatJpy(24000))).toBeInTheDocument()
+    expect(screen.getByText(/View full details/)).toBeInTheDocument()
+  })
+
+  it('formats the time range in JST regardless of the host timezone', () => {
+    renderCard()
+    // 01:00Z..02:00Z render as 10:00..11:00 Asia/Tokyo (machine-independent).
+    expect(screen.getByText(/10:00/)).toBeInTheDocument()
+    expect(screen.getByText(/11:00/)).toBeInTheDocument()
+  })
+
+  it('falls back to renterEmail then "—" for the renter line', () => {
+    renderCard({ renterName: null })
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument()
+  })
+
+  it('shows "—" for an unassigned vehicle and omits the total when null', () => {
+    renderCard({ vehicleName: null, totalPrice: null })
+    expect(screen.getByText('—')).toBeInTheDocument()
+    // No currency glyph at all when the total is null (match either yen codepoint).
+    expect(screen.queryByText(/[¥￥]/)).toBeNull()
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
@@ -1,7 +1,13 @@
 import { BookingsCalendar } from '@/vite/operator-bookings/BookingsCalendar'
-import type { CalendarEvent, CalendarResource } from '@/vite/operator-bookings/calendar-events'
-import { render } from '@testing-library/react'
-import type { SlotInfo } from 'react-big-calendar'
+import type {
+  BlockCalendarEvent,
+  BookingCalendarEvent,
+  CalendarItem,
+  CalendarResource,
+} from '@/vite/operator-bookings/calendar-events'
+import { render, within } from '@testing-library/react'
+import type { ComponentType } from 'react'
+import type { EventProps, SlotInfo } from 'react-big-calendar'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
@@ -23,7 +29,7 @@ function renderCalendar(onSelectSlot?: (range: { start: Date; end: Date }) => vo
   render(
     <IntlProvider locale="en" messages={enMessages}>
       <BookingsCalendar
-        events={[] as readonly CalendarEvent[]}
+        events={[] as readonly CalendarItem[]}
         resources={[] as readonly CalendarResource[]}
         view="week"
         date={new Date('2026-07-01T00:00:00.000Z')}
@@ -60,5 +66,73 @@ describe('BookingsCalendar slot-selection seam (#589 1d)', () => {
   it('disables selection when onSelectSlot is omitted (read-only calendar)', () => {
     renderCalendar(undefined)
     expect(calendarProps.selectable).toBe(false)
+  })
+})
+
+// #1099 quick-view over #1101 blocks: rbc renders each band via components.event.
+// A booking becomes the interactive chip; a block stays a plain, non-interactive band
+// whose click still flows through onSelectEvent to the block-detail dialog.
+describe('BookingsCalendar event rendering (quick-view chip vs block band)', () => {
+  const bookingItem: BookingCalendarEvent = {
+    type: 'booking',
+    id: 'bk-1',
+    title: 'Jane Doe',
+    start: new Date('2026-07-01T01:00:00.000Z'),
+    end: new Date('2026-07-03T02:00:00.000Z'),
+    resourceId: 'veh-1',
+    status: 'ACTIVE',
+    bookingCode: 'ABCD2345',
+    renterName: 'Jane Doe',
+    renterEmail: 'jane@example.com',
+    vehicleName: 'Toyota Aqua',
+    totalPrice: 24000,
+  }
+  const blockItem: BlockCalendarEvent = {
+    type: 'block',
+    id: 'blk-1',
+    title: 'Oil change',
+    start: new Date('2026-07-02T00:00:00.000Z'),
+    end: new Date('2026-07-03T00:00:00.000Z'),
+    resourceId: 'veh-2',
+    kind: 'MAINTENANCE',
+    reason: 'Oil change',
+    notes: null,
+  }
+
+  // Grab the rbc `components.event` the calendar wired, then render it in isolation
+  // (scoped with `within`) so the calendar's own toolbar buttons don't leak into the
+  // role query.
+  function renderEvent(item: CalendarItem) {
+    renderCalendar(vi.fn())
+    const EventComp = (
+      calendarProps.components as { event: ComponentType<EventProps<CalendarItem>> }
+    ).event
+    return render(
+      <IntlProvider locale="en" messages={enMessages}>
+        {/* biome-ignore lint/suspicious/noExplicitAny: rbc injects the rest of EventProps at runtime */}
+        <EventComp {...({ event: item, title: item.title } as any)} />
+      </IntlProvider>,
+    )
+  }
+
+  it('wires a custom event component onto rbc', () => {
+    renderCalendar(vi.fn())
+    expect(typeof (calendarProps.components as { event?: unknown }).event).toBe('function')
+  })
+
+  it('renders a booking as the interactive quick-view chip (a button)', () => {
+    const { container } = renderEvent(bookingItem)
+    expect(within(container).getByRole('button', { name: /Jane Doe/ })).toBeInTheDocument()
+  })
+
+  it('renders a scheduled block as a plain band (no quick-view chip)', () => {
+    const { container } = renderEvent(blockItem)
+    expect(within(container).queryByRole('button')).toBeNull()
+    expect(within(container).getByText('Oil change')).toBeInTheDocument()
+  })
+
+  it('keeps onSelectEvent wired so a block click still reaches the detail dialog', () => {
+    renderCalendar(vi.fn())
+    expect(typeof calendarProps.onSelectEvent).toBe('function')
   })
 })

--- a/packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx
@@ -1,0 +1,135 @@
+import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
+import type { CalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Stub the TanStack Link as a plain anchor exposing its target + carried params,
+// so the chip renders without a RouterProvider (mirrors SearchResultRow.test.tsx).
+vi.mock('@tanstack/react-router', async () => ({
+  ...(await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')),
+  Link: ({
+    to,
+    params,
+    children,
+    ...rest
+  }: {
+    to: string
+    params?: { locale?: string; bookingId?: string }
+    children: ReactNode
+  }) => (
+    <a
+      href={to}
+      data-to={to}
+      data-locale={params?.locale}
+      data-bookingid={params?.bookingId}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
+}))
+
+const event: CalendarEvent = {
+  id: 'bk-1',
+  title: 'Jane Doe',
+  start: new Date('2026-07-01T01:00:00.000Z'),
+  end: new Date('2026-07-03T02:00:00.000Z'),
+  resourceId: 'veh-1',
+  status: 'ACTIVE',
+  bookingCode: 'ABCD2345',
+  renterName: 'Jane Doe',
+  renterEmail: 'jane@example.com',
+  vehicleName: 'Toyota Aqua',
+  totalPrice: 24000,
+}
+
+// rbc passes EventProps; the chip only reads `event` + the injected `locale`.
+function renderChip() {
+  render(
+    <IntlProvider locale="en" messages={en}>
+      {/* biome-ignore lint/suspicious/noExplicitAny: rbc EventProps stub */}
+      <CalendarEventChip {...({ event } as any)} locale="en" />
+    </IntlProvider>,
+  )
+  return screen.getByRole('button', { name: /Jane Doe/ })
+}
+
+const card = () => screen.queryByText('Toyota Aqua') // unique to the open card
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+})
+
+describe('CalendarEventChip', () => {
+  it('opens a transient card on hover after the delay', () => {
+    const trigger = renderChip()
+    expect(card()).toBeNull()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('does not open if the pointer leaves before the delay', () => {
+    const trigger = renderChip()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(60))
+    fireEvent.mouseLeave(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    expect(card()).toBeNull()
+  })
+
+  it('closes a hover-opened card when the pointer leaves (not pinned)', () => {
+    const trigger = renderChip()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    fireEvent.mouseLeave(trigger)
+    expect(card()).toBeNull()
+  })
+
+  it('pins on click so the card survives a subsequent mouseleave', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    fireEvent.mouseLeave(trigger)
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('does not close a pinned card on a second chip click (reason-aware guard)', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+  })
+
+  it('dismisses a pinned card on Escape', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    act(() => fireEvent.keyDown(document.body, { key: 'Escape' }))
+    expect(card()).toBeNull()
+  })
+
+  it('dismisses a pinned card on an outside click', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    expect(card()).toBeInTheDocument()
+    // base-ui's mouse outsidePress defaults to `intentional` — it dismisses on a
+    // real outside *click*, not a bare pointerdown, so drive a click on the body.
+    act(() => fireEvent.click(document.body))
+    expect(card()).toBeNull()
+  })
+
+  it('renders the card as a Link (inside the popup) to the booking detail route', () => {
+    const trigger = renderChip()
+    fireEvent.click(trigger)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('data-to', '/$locale/manage/bookings/$bookingId')
+    expect(link).toHaveAttribute('data-bookingid', 'bk-1')
+    expect(link).toHaveAttribute('data-locale', 'en')
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -222,6 +222,21 @@ describe('OperatorBookingsRoute manual-booking affordance (#589 1d)', () => {
   })
 })
 
+describe('OperatorBookingsRoute quick-view enrichment (#1099)', () => {
+  it('enriches calendar events with the assigned vehicle name (transform wiring)', () => {
+    // veh-1 -> 'Prius' in blocksFleet; the route resolves the name at transform time
+    // so the quick-view card renders it with no extra fetch.
+    renderRoute(operatorSession, blocksFleet, [], { bookings: [calendarBooking] })
+    const events = calendarProps.events as Array<{
+      id: string
+      type: string
+      vehicleName: string | null
+    }>
+    const booking = events.find((e) => e.type === 'booking')
+    expect(booking).toMatchObject({ id: 'bk-1', vehicleName: 'Prius' })
+  })
+})
+
 describe('OperatorBookingsRoute default view (#1100)', () => {
   it('lands on the fleet timeline board when no view param is present', () => {
     searchState.value = { date: ANCHOR } // view omitted -> DEFAULT_VIEW = 'timeline'

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -287,7 +287,7 @@ describe('OperatorBookingsRoute blocks layer (#1101)', () => {
     expect(screen.queryByRole('button', { name: B.detail.deleteAction })).not.toBeInTheDocument()
   })
 
-  it('dispatches a clicked booking to its detail page and a clicked block to the detail dialog', () => {
+  it('does not navigate on a calendar booking click (its chip Link owns it) but opens the detail dialog for a block', () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_BLOCKS', 'true')
     renderRoute(operatorSession, blocksFleet, [], {
       bookings: [calendarBooking],
@@ -298,12 +298,12 @@ describe('OperatorBookingsRoute blocks layer (#1101)', () => {
     const booking = events.find((e) => e.type === 'booking')
     const block = events.find((e) => e.type === 'block')
 
+    // The CalendarEventChip's inner <Link> owns booking navigation now; rbc's
+    // event-click must be a no-op for a booking (navigating would defeat the pin).
     act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(booking))
-    expect(navigate).toHaveBeenCalledWith({
-      to: '/$locale/manage/bookings/$bookingId',
-      params: { locale: 'en', bookingId: 'bk-1' },
-    })
+    expect(navigate).not.toHaveBeenCalled()
 
+    // A block still routes through the shared handler to open its detail dialog.
     act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(block))
     expect(screen.getByText(B.detail.dialogTitle)).toBeInTheDocument()
   })

--- a/packages/web/tests/vite/operator-bookings/calendar-events.test.ts
+++ b/packages/web/tests/vite/operator-bookings/calendar-events.test.ts
@@ -31,9 +31,14 @@ const row = (over: Partial<CalendarBookingRow> = {}): CalendarBookingRow => ({
   ...over,
 })
 
+const fleet = [
+  { id: 'veh-1', name: 'Toyota Aqua' },
+  { id: 'veh-2', name: 'Nissan Note' },
+]
+
 describe('toCalendarEvents', () => {
-  it('maps a row to an rbc event bound to its vehicle column, ending at the turnaround end', () => {
-    expect(toCalendarEvents([row()])).toEqual([
+  it('maps a row to an rbc event with the in-hand quick-view fields', () => {
+    expect(toCalendarEvents([row()], fleet)).toEqual([
       {
         // #1101: every booking event carries the discriminant so a block can never
         // be mistaken for one (and vice versa) at any consuming switch.
@@ -44,19 +49,32 @@ describe('toCalendarEvents', () => {
         end: new Date('2026-07-03T02:00:00.000Z'),
         resourceId: 'veh-1',
         status: 'CONFIRMED',
+        bookingCode: 'ABCD2345',
+        renterName: 'Jane',
+        renterEmail: 'jane@example.com',
+        vehicleName: 'Toyota Aqua',
+        totalPrice: 24000,
       },
     ])
   })
 
   it('titles by renterEmail when the name is null, then by bookingCode when both are null', () => {
-    expect(toCalendarEvents([row({ renterName: null })])[0]!.title).toBe('jane@example.com')
-    expect(toCalendarEvents([row({ renterName: null, renterEmail: null })])[0]!.title).toBe(
+    expect(toCalendarEvents([row({ renterName: null })], fleet)[0]!.title).toBe('jane@example.com')
+    expect(toCalendarEvents([row({ renterName: null, renterEmail: null })], fleet)[0]!.title).toBe(
       'ABCD2345',
     )
   })
 
-  it('binds an unassigned (class-only) booking to no column via an empty resourceId', () => {
-    expect(toCalendarEvents([row({ vehicleId: null })])[0]!.resourceId).toBe('')
+  it('resolves vehicleName from the fleet map and is null for an unassigned booking', () => {
+    expect(toCalendarEvents([row({ vehicleId: 'veh-2' })], fleet)[0]!.vehicleName).toBe(
+      'Nissan Note',
+    )
+    expect(toCalendarEvents([row({ vehicleId: null })], fleet)[0]!.vehicleName).toBeNull()
+    expect(toCalendarEvents([row({ vehicleId: null })], fleet)[0]!.resourceId).toBe('')
+  })
+
+  it('is null for a vehicleId absent from the fleet map (deleted car)', () => {
+    expect(toCalendarEvents([row({ vehicleId: 'gone' })], fleet)[0]!.vehicleName).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Operators can now peek a booking's key facts inline on the bookings calendar instead of full-navigating on every event click:

- **Hover** a booking band → a quick-view card opens after ~120ms (renter, vehicle, booking code, JST time range, total, status).
- **Click** the band → the card *pins* (survives the pointer leaving); Esc / outside-click / focus-out dismiss it.
- **Click the card** → opens the full booking detail page (the whole card is a TanStack `<Link>`).

No new API call and no new i18n keys — the calendar event is enriched at transform time with fields already in hand, and the card reuses `business.bookings.calendar.viewFullDetails` + `sidebar.statuses.*`.

### How it's built
- `calendar-events.ts` — `toCalendarEvents(rows, vehicles)` enriches each event with `bookingCode / renterName / renterEmail / vehicleName / totalPrice` (vehicleName joined live from the fleet list — derived, not stored).
- `BookingQuickView.tsx` — pure presentational card (no Popover, no Link).
- `CalendarEventChip.tsx` — the rbc custom event component: a base-ui `Popover` with a reason-aware hover/pin state machine (a chip click only ever *pins*; only outside-press/escape-key/focus-out dismiss).
- `BookingsCalendar.tsx` — wires `components.event` (memoized on `locale`); a booking renders the chip, a block stays a plain band.
- Shared `STATUS_DOT` promoted to `lib/event-colors.ts` (one source for the sidebar swatch + card dot).
- Route `handleSelectEvent` booking arm is now a **no-op** (the chip's Link owns navigation); the block arm still opens the block-detail dialog.

## Notes for the reviewer
- **Adapted to #1243.** The plan predates #1243's discriminated-union `CalendarItem = booking | block`. The chip renders for `type==='booking'` only; blocks render plainly. Route dispatch and `components.event` branch on the same discriminant.
- **Required E2E fix.** Removing click-to-navigate broke `marketplace-happy-path.auth.spec.ts` step 6a (it clicked a calendar event and asserted navigation). Updated it to click the chip (pins) then click through the card — otherwise the `e2e-real-db` CI job would fail on merge.
- **Deferred (Minor):** a keyboard-Tab-into-popup unit assertion (jsdom portal focus is flaky). Mouse navigation is covered by the new e2e; keyboard reachability is by base-ui's focus management.

## Reviews
code-reviewer and architect both returned **ship-quality, zero blockers**. Folded two nits: typed the popover dismiss reasons off base-ui's real reason union (a typo now fails to compile instead of silently failing *open*), and documented the per-event-Popover scale escape hatch.

## Test plan
- [x] `tsc --noEmit` web + api (post-rebase)
- [x] Web unit suite: `tests/vite/operator-bookings` — **217/217** (new: CalendarEventChip 8, BookingQuickView 4; updated: BookingsCalendar, OperatorBookingsRoute, calendar-events)
- [x] `bun run lint && bun run format` — clean
- [x] `@kuruma/web build` — succeeds, no `routeTree.gen.ts` drift
- [x] **Real-browser smoke** via committed real-db E2E (`calendar-quickview.auth.spec.ts`): peek → pin (survives `mouse.move`) → card-click navigates to the detail UUID. Full `e2e-real-db` lane **21/21** green against a seeded Postgres.

Part of the operator-calendar epic #1099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)