### PR TITLE
chore(ci): rotate GOOGLE_TRANSLATE_API_KEY onto the API Worker

### DIFF
--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -95,6 +95,16 @@ jobs:
           # docs/runbooks/2026-06-24-consent-signing-key.md.
           echo "${{ secrets.CONSENT_SIGNING_KEY }}" | npx wrangler secret put CONSENT_SIGNING_KEY
           echo "${{ secrets.CONSENT_SIGNING_KEY_ID }}" | npx wrangler secret put CONSENT_SIGNING_KEY_ID
+          # Message translation (Google Cloud Translation v2). GOOGLE_TRANSLATE_API_KEY is
+          # a secret; createTranslationProvider() (services/translation-provider-factory.ts)
+          # falls back to a throwing sentinel in production when absent, so an un-set key
+          # 500s POST /messages/:id/translate on first use but does NOT block boot. Set the
+          # GitHub Secret FIRST. Like Stripe + Sentry + Consent above, deploy.yml's
+          # required-secret presence check intentionally does NOT include it yet (would break
+          # deploys before the secret exists); add GOOGLE_TRANSLATE_API_KEY there once
+          # translation is live in production. Provider is DI-swappable behind the
+          # TranslationProvider port if we ever move off Google.
+          echo "${{ secrets.GOOGLE_TRANSLATE_API_KEY }}" | npx wrangler secret put GOOGLE_TRANSLATE_API_KEY
           # `bun run deploy` (not bare `npx wrangler deploy`) so a rotation ships the
           # same SENTRY_RELEASE (commit SHA) + --outdir as deploy.yml — otherwise the
           # promoted version would fall back to CF_VERSION_METADATA.id while Sentry


### PR DESCRIPTION
## What

Wires the message-translation secret \`GOOGLE_TRANSLATE_API_KEY\` into \`rotate-secrets.yml\` so the Google Cloud Translation provider works in production once messaging is enabled.

## Why

Translation sits behind the \`TranslationProvider\` port; the concrete \`GoogleTranslationProvider\` reads \`process.env.GOOGLE_TRANSLATE_API_KEY\`. In prod without the key, \`createTranslationProvider()\` returns a throwing sentinel, so \`POST /messages/:id/translate\` 500s on first use. The key was never wired into any workflow.

## Pattern followed

Mirrors the Stripe / Sentry / Consent secrets: pushed by \`rotate-secrets.yml\`, but **deliberately kept out of \`deploy.yml\`'s required-secret presence check** until translation is live (adding it before the secret exists would break beta deploys). Fails on use, not at boot.

## Test plan

- [ ] Add the \`GOOGLE_TRANSLATE_API_KEY\` GitHub Secret (done by owner).
- [ ] Merge → promote to \`beta\`.
- [ ] Run **Rotate Worker Secrets** from \`beta\`.
- [ ] Confirm the key appears in \`wrangler secret list\` on \`kuruma-api\`.

## Follow-up

Once translation is confirmed live, add \`GOOGLE_TRANSLATE_API_KEY\` to the presence-check loop in \`deploy.yml\` (~line 100) for drift detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)