### PR TITLE
refactor(api): unify dashboard read-scope vocabulary on bookingReadScope (picker scope prereqs)

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -87,6 +87,33 @@ It is a CI step (`.github/workflows/ci.yml`) and flags:
 
 `*.test.ts` files are exempt — they legitimately construct concretes to exercise DI.
 
+### Tenant read-scope helpers (`tenancy.ts`)
+
+Scoped reads are filtered by operator through helpers in `tenancy.ts`. Two
+adjudicate a cross-operator (`all`-scope) caller, and they are deliberately
+different — match the one to your read:
+
+- **Strict — `applyCrossOperatorReadScope` (config lists).** A bypass caller
+  must scope explicitly: it throws `ScopeRequiredError` (→ 400) when neither an
+  `operatorId` nor `includeAll` is supplied. Use for tenant-owned inventory
+  lists (add-ons, insurance, locations, vehicle classes) where "every operator
+  at once" is an opt-in, never the silent default.
+- **Lenient — `narrowReadToOperator` (aggregate reads).** A missing operatorId
+  is the legitimate "all operators" default (dashboard / fleet overview), so it
+  never throws; it only narrows when an id is present. It takes the read's
+  **scope resolver** as an argument and honors the requested id only when that
+  resolver returns `all`. Pass the vocabulary that matches the read's privacy
+  model: the private overview / fleet reads pass `bookingReadScope` (only a true
+  bypass admin is `all`; renter / partner / legacy STAFF/ADMIN map to non-`all`
+  kinds and drop their id), NOT `operatorReadScope` (the catalog vocabulary that
+  maps every non-operator role to `all`). A `bookingReadScope`-private endpoint
+  passes its own resolver, so the id can never leak across a vocabulary
+  mismatch (#1272).
+
+In both cases the repository re-clamps to the caller's own tenant, so these
+helpers only govern the `all` scope — a foreign `?operatorId=` can never widen a
+tenant-scoped caller (the H2 invariant).
+
 ---
 
 ## packages/web — feature folders + barrel imports

--- a/packages/api/src/repositories/drizzle/fleet-overview.ts
+++ b/packages/api/src/repositories/drizzle/fleet-overview.ts
@@ -2,9 +2,9 @@ import { bookings, users, vehicles } from '@kuruma/shared/db/schema'
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import { and, inArray, ne, sql } from 'drizzle-orm'
 import { eq } from 'drizzle-orm'
-import type { CallerContext } from '../../middleware/auth'
+import { type CallerContext, requireManagementRead } from '../../middleware/auth'
 import type { Vehicle } from '../../stores'
-import { operatorReadScope } from '../../tenancy'
+import { bookingReadScope } from '../../tenancy'
 import type { FleetOverviewRepository } from '../types'
 import {
   type Db,
@@ -36,16 +36,21 @@ export class DrizzleFleetOverviewRepository implements FleetOverviewRepository {
   ): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_MS)
 
-    // Tenant scope (#594): operators see only their own vehicles; bypass roles
-    // see all; a scoped caller with no tenant sees nothing. Mirrors
+    // Defence-in-depth (mirrors the overview repo): reject RENTER/PARTNER so a
+    // non-management caller bypassing the route gate reads no fleet.
+    requireManagementRead(ctx)
+    // #1273: scope from bookingReadScope — the SAME vocabulary the overview card
+    // uses — so the two dashboard reads agree. `none` (operator without tenant),
+    // `renter` (legacy STAFF/ADMIN post-#487), and `partner` (a channel, not an
+    // operator) see nothing, matching overview's zeros. Mirrors
     // DrizzleVehicleRepository.findAll — the repo is the tenant boundary.
     //
     // Picker narrowing (#407 slice 4): an `all` (bypass) caller who named an
     // operator is scoped to that operator; honored ONLY in the `all` branch, so a
     // foreign id can never widen a tenant. Bookings (round-trip 2) constrain to
     // these vehicle ids, so narrowing the vehicle query narrows both.
-    const scope = operatorReadScope(ctx)
-    if (scope.kind === 'none') return []
+    const scope = bookingReadScope(ctx)
+    if (scope.kind === 'none' || scope.kind === 'renter' || scope.kind === 'partner') return []
     const vehicleWhere =
       scope.kind === 'operator'
         ? eq(vehicles.operatorId, scope.operatorId)

--- a/packages/api/src/repositories/in-memory/fleet-overview.ts
+++ b/packages/api/src/repositories/in-memory/fleet-overview.ts
@@ -1,6 +1,6 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
-import type { CallerContext } from '../../middleware/auth'
-import { operatorReadScope } from '../../tenancy'
+import { type CallerContext, requireManagementRead } from '../../middleware/auth'
+import { bookingReadScope } from '../../tenancy'
 import type {
   BookingRepository,
   FleetOverviewRepository,
@@ -44,6 +44,16 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
   ): Promise<FleetVehicleOverview[]> {
     const windowStart = new Date(now.getTime() - UTILIZATION_WINDOW_HOURS * 60 * 60 * 1000)
 
+    // Defence-in-depth (mirrors the overview repo): reject RENTER/PARTNER here
+    // too, so a non-management caller bypassing the route gate reads no fleet.
+    requireManagementRead(ctx)
+    // #1273: scope from bookingReadScope, the SAME vocabulary the overview card
+    // uses, so the two dashboard reads agree. `none` (operator without operatorId),
+    // `renter` (legacy STAFF/ADMIN post-#487), and `partner` (a channel, not an
+    // operator) never see operator fleet — return empty, matching overview's zeros.
+    const scope = bookingReadScope(ctx)
+    if (scope.kind === 'none' || scope.kind === 'renter' || scope.kind === 'partner') return []
+
     // Scope BOTH reads to the caller's tenant (#594). VehicleRepository.findAll
     // and BookingRepository.findAll each apply their own operator scope, so an
     // OPERATOR_* caller never reads another tenant's rows (isolation at the read,
@@ -60,7 +70,7 @@ export class InMemoryFleetOverviewRepository implements FleetOverviewRepository 
     // its own vehicles above, so the filter is honored ONLY for `all` — a foreign
     // id can never widen a tenant, and bookings narrow with the vehicle set below.
     const vehicles =
-      operatorReadScope(ctx).kind === 'all' && operatorId
+      scope.kind === 'all' && operatorId
         ? allVehicles.filter((v) => v.operatorId === operatorId)
         : allVehicles
     const allBookings = await this.bookingRepo.findAll(ctx)

--- a/packages/api/src/repositories/types-overview.ts
+++ b/packages/api/src/repositories/types-overview.ts
@@ -1,0 +1,39 @@
+import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
+import type { OperatorOverview } from '@kuruma/shared/types/overview'
+import type { CallerContext } from '../middleware/auth'
+
+// The projection DTOs live in @kuruma/shared; re-exported here so the
+// repositories/types barrel keeps its historical surface (#1265).
+export type { OperatorOverview } from '@kuruma/shared/types/overview'
+export type { FleetVehicleOverview, FleetBookingSummary } from '@kuruma/shared/types/fleet'
+
+// Aggregated read for the owner-facing /manage/vehicles list. Enriches
+// each vehicle with utilization %, booking count, and current/next
+// booking state. Computed per-request — NOT denormalized into the
+// vehicles table. See issue #52 and @kuruma/shared/types/fleet.
+//
+// Split from VehicleRepository because it reads across multiple tables
+// (vehicles + bookings + users.name) — following the same boundary as
+// AvailabilityRepository, which also reads vehicles + bookings.
+export interface FleetOverviewRepository {
+  // `now` is injected so time cutoffs live in callers; tests pass a fixed Date.
+  // `ctx` scopes the read (#594); `operatorId` (#407 slice 4, bypass-gated)
+  // narrows a bypass caller to one operator — see narrowReadToOperator.
+  findFleetOverview(
+    ctx: CallerContext,
+    now: Date,
+    operatorId?: string,
+  ): Promise<FleetVehicleOverview[]>
+}
+
+/**
+ * Operator-scoped dashboard counts (#524). `ctx` decides the tenant scope via
+ * {@link bookingReadScope}: bypass roles aggregate across all operators, an
+ * OPERATOR_* caller sees only its own tenant, and an operator missing its
+ * operatorId fails closed to zeros (mirrors how its own bookings list behaves).
+ * `now` is injected so "upcoming" is deterministic in tests.
+ */
+export interface OverviewRepository {
+  // `operatorId` (#407 slice 4, bypass-gated): narrows a bypass caller — see narrowReadToOperator.
+  getOperatorOverview(ctx: CallerContext, now: Date, operatorId?: string): Promise<OperatorOverview>
+}

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -21,19 +21,15 @@ export type {
   Review,
 } from '../stores'
 export type { DashboardStats } from '@kuruma/shared/types/stats'
-export type { OperatorOverview } from '@kuruma/shared/types/overview'
-export type { FleetVehicleOverview, FleetBookingSummary } from '@kuruma/shared/types/fleet'
 export type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 export type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
 
 import type { CoordinateSource } from '@kuruma/shared/db/schema'
 import type { Customer, CustomerSort, CustomerWithBookings } from '@kuruma/shared/types/customer'
-import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type {
   OperatorBookingCounts,
   VehicleComplianceCounts,
 } from '@kuruma/shared/types/operator-summary'
-import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import type { DashboardStats } from '@kuruma/shared/types/stats'
 import type { VehicleDetail } from '@kuruma/shared/types/vehicle-detail'
 import type { OperatorRole } from '@kuruma/shared/validators/provider-invite'
@@ -350,25 +346,6 @@ export interface VehicleRepository {
   removePhotoByUrl(ctx: CallerContext, id: string, url: string): Promise<Vehicle | undefined>
 }
 
-// Aggregated read for the owner-facing /manage/vehicles list. Enriches
-// each vehicle with utilization %, booking count, and current/next
-// booking state. Computed per-request — NOT denormalized into the
-// vehicles table. See issue #52 and @kuruma/shared/types/fleet.
-//
-// Split from VehicleRepository because it reads across multiple tables
-// (vehicles + bookings + users.name) — following the same boundary as
-// AvailabilityRepository, which also reads vehicles + bookings.
-export interface FleetOverviewRepository {
-  // `now` is injected so time cutoffs live in callers; tests pass a fixed Date.
-  // `ctx` scopes the read (#594); `operatorId` (#407 slice 4, bypass-gated)
-  // narrows a bypass caller to one operator — see narrowReadToOperator.
-  findFleetOverview(
-    ctx: CallerContext,
-    now: Date,
-    operatorId?: string,
-  ): Promise<FleetVehicleOverview[]>
-}
-
 /**
  * #396: UserRepository is intentionally NOT operator-scoped — it takes no
  * CallerContext. This stays safe because every ingress already blocks
@@ -522,18 +499,6 @@ export interface BookingRepository {
 
 export interface StatsRepository {
   getDashboardStats(): Promise<DashboardStats>
-}
-
-/**
- * Operator-scoped dashboard counts (#524). `ctx` decides the tenant scope via
- * {@link bookingReadScope}: bypass roles aggregate across all operators, an
- * OPERATOR_* caller sees only its own tenant, and an operator missing its
- * operatorId fails closed to zeros (mirrors how its own bookings list behaves).
- * `now` is injected so "upcoming" is deterministic in tests.
- */
-export interface OverviewRepository {
-  // `operatorId` (#407 slice 4, bypass-gated): narrows a bypass caller — see narrowReadToOperator.
-  getOperatorOverview(ctx: CallerContext, now: Date, operatorId?: string): Promise<OperatorOverview>
 }
 
 /**
@@ -740,3 +705,15 @@ export type {
 // Reviews bounded-context data access (#1067 slice 1) lives in its own module;
 // re-exported for callers (mirrors the payment/consent split above).
 export type { NewReview, ReviewEdit, ReviewRepository } from './types-review'
+
+// Dashboard overview + fleet-overview aggregate reads (#1265) live in their own
+// module to keep this barrel under the file-size cap; re-exported for callers.
+// The projection DTOs (OperatorOverview / FleetVehicleOverview / FleetBookingSummary)
+// ride along so the barrel keeps its historical surface.
+export type {
+  FleetBookingSummary,
+  FleetOverviewRepository,
+  FleetVehicleOverview,
+  OperatorOverview,
+  OverviewRepository,
+} from './types-overview'

--- a/packages/api/src/routes/fleet-overview.ts
+++ b/packages/api/src/routes/fleet-overview.ts
@@ -6,12 +6,13 @@ import { fail, ok } from './helpers'
 export function createFleetOverviewRoutes(service: FleetOverviewService) {
   return new Hono().get('/vehicles/fleet-overview', async (c) => {
     const user = requireUser(c)
-    // Admit STAFF roles AND tenant-scoped operators (#594); RENTER/PARTNER are
-    // rejected here BEFORE the repo's operatorReadScope runs (that helper maps a
-    // RENTER to {kind:'all'}, so without this gate a renter would read the whole
-    // cross-operator fleet). Operators are then bounded to their own tenant by
-    // the repository's operator predicate — the repo, not the route, is the
-    // tenant boundary (#386 F2 / #397).
+    // Admit MANAGEMENT_READ_ROLES (#594); RENTER/PARTNER are rejected here. The
+    // repo also fail-closes them (#1273: it reads bookingReadScope, under which
+    // RENTER/PARTNER never reach `all` and requireManagementRead throws) — this
+    // gate is the outer seal of that defense-in-depth, returning a clean 403
+    // rather than an empty 200. Operators are bounded to their own tenant by the
+    // repository's operator predicate — the repo, not the route, is the tenant
+    // boundary (#386 F2 / #397).
     if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
     // #407 slice 4: the operator-context picker narrows a bypass admin to one

--- a/packages/api/src/services/fleet-overview.ts
+++ b/packages/api/src/services/fleet-overview.ts
@@ -1,7 +1,7 @@
 import type { FleetVehicleOverview } from '@kuruma/shared/types/fleet'
 import type { CallerContext } from '../middleware/auth'
 import type { FleetOverviewRepository } from '../repositories/types'
-import { narrowReadToOperator } from '../tenancy'
+import { bookingReadScope, narrowReadToOperator } from '../tenancy'
 
 // Thin service wrapping FleetOverviewRepository. Its only job is to own
 // the clock — `now` defaults to `new Date()` here so routes don't have
@@ -18,7 +18,12 @@ export class FleetOverviewService {
   ): Promise<FleetVehicleOverview[]> {
     // #407 slice 4: a bypass admin using the operator-context picker narrows the
     // cross-operator fleet to one operator. narrowReadToOperator drops the id to
-    // undefined for any tenant-scoped caller, so a foreign id never widens.
-    return this.repo.findFleetOverview(ctx, now, narrowReadToOperator(ctx, requestedOperatorId))
+    // undefined for any non-`all` caller under bookingReadScope (this read's
+    // private-read vocabulary), so a renter/partner/tenant id never widens (#1272).
+    return this.repo.findFleetOverview(
+      ctx,
+      now,
+      narrowReadToOperator(ctx, requestedOperatorId, bookingReadScope),
+    )
   }
 }

--- a/packages/api/src/services/overview.ts
+++ b/packages/api/src/services/overview.ts
@@ -1,7 +1,7 @@
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import type { CallerContext } from '../middleware/auth'
 import type { OverviewRepository } from '../repositories/types'
-import { narrowReadToOperator } from '../tenancy'
+import { bookingReadScope, narrowReadToOperator } from '../tenancy'
 
 /**
  * Thin service over {@link OverviewRepository} (#524). Its only job is to own
@@ -19,7 +19,12 @@ export class OverviewService {
   ): Promise<OperatorOverview> {
     // #407 slice 4: a bypass admin using the operator-context picker narrows the
     // cross-operator aggregate to one operator. narrowReadToOperator drops the id
-    // to undefined for any tenant-scoped caller, so a foreign id never widens.
-    return this.repo.getOperatorOverview(ctx, now, narrowReadToOperator(ctx, requestedOperatorId))
+    // to undefined for any non-`all` caller under bookingReadScope (this read's
+    // private-read vocabulary), so a renter/partner/tenant id never widens (#1272).
+    return this.repo.getOperatorOverview(
+      ctx,
+      now,
+      narrowReadToOperator(ctx, requestedOperatorId, bookingReadScope),
+    )
   }
 }

--- a/packages/api/src/tenancy.test.ts
+++ b/packages/api/src/tenancy.test.ts
@@ -3,6 +3,7 @@ import type { CallerContext } from './middleware/auth'
 import {
   bookingReadScope,
   narrowReadToOperator,
+  operatorReadScope,
   threadReadScope,
   vehicleBlockReadScope,
 } from './tenancy'
@@ -70,34 +71,59 @@ describe('narrowReadToOperator', () => {
   const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
   const operator: CallerContext = { userId: 'u1', role: 'OPERATOR_OWNER', operatorId: 'op-self' }
 
-  it('narrows an all-scope caller to the requested operator', () => {
-    expect(narrowReadToOperator(admin, 'op-target')).toBe('op-target')
+  it('narrows an all-scope caller to the requested operator (bookingReadScope)', () => {
+    expect(narrowReadToOperator(admin, 'op-target', bookingReadScope)).toBe('op-target')
   })
 
   it('returns undefined for an all-scope caller who requests no operator (aggregate)', () => {
-    expect(narrowReadToOperator(admin, undefined)).toBeUndefined()
+    expect(narrowReadToOperator(admin, undefined, bookingReadScope)).toBeUndefined()
   })
 
-  it('ignores a requested operatorId for a tenant-scoped caller (never widens across tenants)', () => {
+  it('drops a requested operatorId for a tenant-scoped caller (never widens across tenants)', () => {
     // The H2 invariant: a foreign operatorId param must not let an OPERATOR_*
     // caller read another tenant. Their own scope still applies at the repo.
-    expect(narrowReadToOperator(operator, 'op-other')).toBeUndefined()
-    expect(narrowReadToOperator(operator, 'op-self')).toBeUndefined()
+    expect(narrowReadToOperator(operator, 'op-other', bookingReadScope)).toBeUndefined()
+    expect(narrowReadToOperator(operator, 'op-self', bookingReadScope)).toBeUndefined()
   })
 
   it('returns undefined for an operator missing its operatorId (fail-closed)', () => {
     const noOp: CallerContext = { userId: 'u2', role: 'OPERATOR_STAFF' }
-    expect(narrowReadToOperator(noOp, 'op-target')).toBeUndefined()
+    expect(narrowReadToOperator(noOp, 'op-target', bookingReadScope)).toBeUndefined()
   })
 
-  it('ECHOES the requested id for a renter (operatorReadScope maps to all) — the route/repo, not this helper, gate it (#1272)', () => {
-    // The helper is an echo, not the scope gate: operatorReadScope maps every
-    // non-operator role to `all`, so a renter's requested id passes through here.
-    // Safe only because MANAGEMENT_READ_ROLES 403s renters at the route before the
-    // service runs. Pinned so a future bookingReadScope-private consumer that reuses
-    // this helper without re-clamping (the #1272 trap) fails loudly, not silently.
+  it('DROPS a renter requested id under bookingReadScope (private-read vocabulary)', () => {
+    // #1272: the helper no longer echoes non-bypass ids. bookingReadScope maps a
+    // renter to `renter` (not `all`), so the requested id drops here — closing the
+    // trap where a future bookingReadScope-private consumer reused this helper and
+    // silently leaked a renter's `?operatorId=` across tenants.
     const renter: CallerContext = { userId: 'r1', role: 'RENTER' }
-    expect(narrowReadToOperator(renter, 'op-target')).toBe('op-target')
+    expect(narrowReadToOperator(renter, 'op-target', bookingReadScope)).toBeUndefined()
+  })
+
+  it('DROPS a PARTNER channel requested id under bookingReadScope', () => {
+    // A Trip.com PARTNER key carries bypassScope=true; bookingReadScope maps it to
+    // `partner` (its own sourced bookings), NOT `all`, so the id drops.
+    const partner: CallerContext = { userId: 'trip-com', role: 'PARTNER', bypassScope: true }
+    expect(narrowReadToOperator(partner, 'op-target', bookingReadScope)).toBeUndefined()
+  })
+
+  it('DROPS legacy STAFF/ADMIN requested ids under bookingReadScope', () => {
+    // #487 removed legacy STAFF/ADMIN from the bypass set; bookingReadScope maps
+    // them to `renter`, so their requested id drops (parity with the overview repo,
+    // which already reads nothing for them).
+    const staff: CallerContext = { userId: 's1', role: 'STAFF', bypassScope: false }
+    const legacyAdmin: CallerContext = { userId: 'a1', role: 'ADMIN', bypassScope: false }
+    expect(narrowReadToOperator(staff, 'op-target', bookingReadScope)).toBeUndefined()
+    expect(narrowReadToOperator(legacyAdmin, 'op-target', bookingReadScope)).toBeUndefined()
+  })
+
+  it('HONORS the same renter id under operatorReadScope — the resolver picks the vocabulary', () => {
+    // The behavior is not hard-coded to one scope: passing the catalog vocabulary
+    // (operatorReadScope maps a renter to `all`) makes the id pass through. Callers
+    // choose the resolver that matches their read's privacy model; the aggregate
+    // reads pass bookingReadScope precisely so renter/partner ids drop.
+    const renter: CallerContext = { userId: 'r1', role: 'RENTER' }
+    expect(narrowReadToOperator(renter, 'op-target', operatorReadScope)).toBe('op-target')
   })
 })
 

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -101,8 +101,8 @@ export function applyCrossOperatorReadScope<F extends { operatorId?: string }>(
  * Resolve a bypass-only operator narrowing for an aggregate read (#407, picker
  * slice 4 — dashboard/fleet-overview). An `all`-scope caller (a bypass admin
  * using the operator-context picker) may narrow a cross-operator aggregate to a
- * single operator; every tenant-scoped caller ignores a requested operatorId, so
- * a foreign `?operatorId=` can never widen their scope (the H2 invariant).
+ * single operator; every non-`all` caller drops a requested operatorId, so a
+ * foreign `?operatorId=` can never widen their scope (the H2 invariant).
  *
  * Unlike {@link applyCrossOperatorReadScope}, a missing operatorId is NOT a 400:
  * these reads default to "all operators", so the absence of a pick is the
@@ -111,20 +111,24 @@ export function applyCrossOperatorReadScope<F extends { operatorId?: string }>(
  * lists were strict before the picker; these aggregate reads keep their working
  * no-param contract and only add narrowing.
  *
- * AUTHORITY — this helper is an ECHO, not the scope gate. It reads
- * `operatorReadScope`, which maps every non-operator role (incl. RENTER/PARTNER)
- * to `all`, so it returns the requested id for those roles too. That is only safe
- * because each consumer independently re-gates: the route (MANAGEMENT_READ_ROLES
- * → 403) rejects renter/partner, and the repo re-clamps to its own tenant. A
- * future `bookingReadScope`-private endpoint (slices 5a/5b/6) must NOT trust this
- * id blindly — it must re-clamp with its own scope vocabulary, or the two
- * vocabularies disagree and a private read leaks. Reconcile before then: #1272.
+ * VOCABULARY (#1272) — the caller passes the scope resolver that matches its
+ * read's privacy model, and the id is honored ONLY when that resolver returns
+ * `all`. The aggregate reads pass {@link bookingReadScope} (private-read
+ * vocabulary), under which only a true bypass admin is `all`; renter, partner,
+ * and legacy STAFF/ADMIN map to non-`all` kinds, so their requested id drops
+ * here. This closes the earlier echo trap: the helper used to key off
+ * `operatorReadScope` (catalog vocabulary), which maps every non-operator role to
+ * `all` and so echoed a renter's `?operatorId=` — safe only while the route
+ * 403'd renters, but a latent leak for a future `bookingReadScope`-private
+ * consumer (slices 5a/5b/6) that reused this helper without re-clamping. Now that
+ * consumer passes its own scope resolver, so the vocabularies cannot disagree.
  */
 export function narrowReadToOperator(
   ctx: CallerContext,
   requestedOperatorId: string | undefined,
+  resolveScope: (ctx: CallerContext) => { kind: string },
 ): string | undefined {
-  return operatorReadScope(ctx).kind === 'all' ? requestedOperatorId : undefined
+  return resolveScope(ctx).kind === 'all' ? requestedOperatorId : undefined
 }
 
 /**

--- a/packages/api/tests/integration/fleet-overview.test.ts
+++ b/packages/api/tests/integration/fleet-overview.test.ts
@@ -183,6 +183,17 @@ describe('fleet-overview is operator-scoped (Drizzle, real Postgres)', () => {
     expect(ids).toContain(vehicleBId)
   })
 
+  // #1273: legacy STAFF/ADMIN resolve to `renter` under bookingReadScope, so the
+  // fleet card must read nothing — matching the overview card and the #487
+  // phase-out. Before the fix this SQL path used operatorReadScope (legacy ->
+  // `all`) and leaked the whole fleet; asserted against real Postgres.
+  it('a legacy STAFF/ADMIN sees nothing — parity with overview + in-memory', async () => {
+    const staff: CallerContext = { userId: 'legacy', role: 'STAFF', bypassScope: false }
+    const admin: CallerContext = { userId: 'legacy', role: 'ADMIN', bypassScope: false }
+    expect(await fleetRepo.findFleetOverview(staff, NOW)).toEqual([])
+    expect(await fleetRepo.findFleetOverview(admin, NOW)).toEqual([])
+  })
+
   it('includes the operator’s RETIRED vehicles (#600 — parity with in-memory)', async () => {
     const rows = await fleetRepo.findFleetOverview(ctxFor(opAId), NOW)
     const retired = rows.find((r) => r.id === retiredVehicleAId)

--- a/packages/api/tests/services/fleet-overview.test.ts
+++ b/packages/api/tests/services/fleet-overview.test.ts
@@ -4,7 +4,7 @@
 // fail intermittently — so every assertion depends on the injected Date.
 
 import { describe, expect, it } from 'vitest'
-import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import { type CallerContext, ForbiddenError, SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
   InMemoryBookingRepository,
   InMemoryFleetOverviewRepository,
@@ -14,6 +14,7 @@ import {
 import { FleetOverviewService } from '../../src/services/fleet-overview'
 import type { Booking, Vehicle } from '../../src/stores'
 import { bookingInput } from '../helpers/booking'
+import { operatorCtx } from '../helpers/context'
 
 async function seedVehicle(
   repo: InMemoryVehicleRepository,
@@ -117,5 +118,54 @@ describe('FleetOverviewService — clock injection', () => {
       new Date('2026-05-02T00:00:00Z'),
     )
     expect(afterBooking[0]?.currentBooking).toBeNull()
+  })
+})
+
+// #1273: the two operator-dashboard cards must resolve read scope from the SAME
+// vocabulary. Overview scopes via bookingReadScope (legacy STAFF/ADMIN -> renter
+// -> zero); fleet-overview used to scope via operatorReadScope (legacy -> all ->
+// the whole fleet), so the cards disagreed for a legacy session. Reconciled onto
+// bookingReadScope: legacy STAFF/ADMIN now read nothing here too, matching both
+// the overview card and the vehicleBlockReadScope precedent (#487 phase-out).
+describe('FleetOverviewService — scope parity with the overview card (#1273)', () => {
+  const now = new Date('2026-05-01T00:00:00Z')
+
+  async function fleetWithOneVehiclePerOperator(): Promise<FleetOverviewService> {
+    const vehicleRepo = new InMemoryVehicleRepository()
+    const bookingRepo = new InMemoryBookingRepository()
+    await seedVehicle(vehicleRepo, { operatorId: 'op-a', name: 'A-car' })
+    await seedVehicle(vehicleRepo, { operatorId: 'op-b', name: 'B-car' })
+    return new FleetOverviewService(new InMemoryFleetOverviewRepository(vehicleRepo, bookingRepo))
+  }
+
+  it('returns [] for a legacy STAFF/ADMIN, matching overview (never the whole fleet)', async () => {
+    const service = await fleetWithOneVehiclePerOperator()
+    const staff: CallerContext = { userId: 'legacy', role: 'STAFF', bypassScope: false }
+    const admin: CallerContext = { userId: 'legacy', role: 'ADMIN', bypassScope: false }
+    expect(await service.findFleetOverview(staff, now)).toEqual([])
+    expect(await service.findFleetOverview(admin, now)).toEqual([])
+  })
+
+  it('rejects RENTER / PARTNER at the repo seal (defence-in-depth)', async () => {
+    const service = await fleetWithOneVehiclePerOperator()
+    const renter: CallerContext = { userId: 'r', role: 'RENTER', bypassScope: false }
+    const partner: CallerContext = { userId: 'trip', role: 'PARTNER', bypassScope: true }
+    await expect(service.findFleetOverview(renter, now)).rejects.toThrow(ForbiddenError)
+    await expect(service.findFleetOverview(partner, now)).rejects.toThrow(ForbiddenError)
+  })
+
+  it('scopes an OPERATOR_* caller to its own tenant fleet', async () => {
+    const service = await fleetWithOneVehiclePerOperator()
+    const rows = await service.findFleetOverview(operatorCtx('op-a'), now)
+    expect(rows.map((r) => r.operatorId)).toEqual(['op-a'])
+  })
+
+  it('aggregates all operators for a bypass admin, and narrows to a picked operator', async () => {
+    const service = await fleetWithOneVehiclePerOperator()
+    const admin: CallerContext = { userId: 'pa', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const all = await service.findFleetOverview(admin, now)
+    expect(all.map((r) => r.operatorId).sort()).toEqual(['op-a', 'op-b'])
+    const narrowed = await service.findFleetOverview(admin, now, 'op-a')
+    expect(narrowed.map((r) => r.operatorId)).toEqual(['op-a'])
   })
 })


### PR DESCRIPTION
Clears the API-tenancy prerequisites before picker slice 5a. The two dashboard aggregate reads disagreed on scope vocabulary; this unifies them on `bookingReadScope` (matching the `vehicleBlockReadScope` precedent and the #487 legacy-role phase-out) so the picker's narrowing helper can be safely reused by a future private-read endpoint.

Closes #1265
Closes #1273
Closes #1272
Refs #1230

## Commits (one PR, three issues)

1. **#1265 — extract Overview/FleetOverview repo interfaces into `types-overview.ts`.** Pure move; `types.ts` re-exports all five symbols, zero behavior change. `types.ts` 742 -> 719 lines (headroom under the 800 cap).
2. **#1273 — reconcile fleet-overview read scope onto `bookingReadScope`.** The fleet-overview repos (in-memory + Drizzle) now `requireManagementRead(ctx)` + narrow off `bookingReadScope`, returning `[]` for `none`/`renter`/`partner` and narrowing only when `kind === 'all'`. Legacy STAFF/ADMIN now read nothing (parity with the overview repo, which already used `bookingReadScope`). Previously fleet-overview used `operatorReadScope`, under which legacy STAFF/ADMIN read the whole fleet.
3. **#1272 — parameterize `narrowReadToOperator(ctx, id, resolveScope)`.** The helper keyed off `operatorReadScope` (catalog vocabulary: every non-operator role maps to `all`), so it echoed a renter/partner/legacy `?operatorId=` back to the repo -- safe only because the routes 403 those roles, but a latent leak for a future `bookingReadScope`-private consumer that reused it. It now takes the read's scope resolver and honors the id only when that resolver returns `all`; both callers pass `bookingReadScope`. Docs: strict `applyCrossOperatorReadScope` (config lists) vs lenient `narrowReadToOperator` (aggregate reads) rule in `docs/architecture/modules.md`. Also fixed the now-stale threat-model comment on the fleet-overview route.

No migration. No behavior change for the roles each route admits; this closes a vocabulary mismatch that would otherwise ship silently.

## Security (tenancy)

The H2 invariant holds on every path: a foreign `?operatorId=` can never widen a tenant-scoped caller. Each aggregate read is triple-defended -- route gate (`MANAGEMENT_READ_ROLES` -> 403), service id-drop (`narrowReadToOperator`), repo re-clamp (`bookingReadScope`). A `code-reviewer` pass traced every role (renter, partner, legacy STAFF/ADMIN, OPERATOR_* with foreign id, OPERATOR_* missing operatorId, PLATFORM_ADMIN) and returned SHIPPABLE with no CRITICAL/HIGH/MEDIUM; its two LOW findings (stale route comment, unused generic type param) are folded in.

## Test plan

- [x] api unit (`vitest run`): 2392 passed
- [x] `narrowReadToOperator` tests pin both the drop path (bookingReadScope: renter/partner/legacy -> undefined) and the honor path (operatorReadScope: renter -> id) -- RED-verified before the fix
- [x] fleet-overview real-pg integration: 11 passed (incl. legacy STAFF/ADMIN -> `[]`)
- [x] `tsc --noEmit` clean; `lint:boundaries` OK; biome clean
- [x] Rebased onto latest `origin/develop` (`b40e22f1`), zero file overlap