### PR TITLE
feat(#1262): pickup-location picker in the operator vehicle form

### DIFF
--- a/packages/api/tests/integration/vehicle-pickup-location-storefront.test.ts
+++ b/packages/api/tests/integration/vehicle-pickup-location-storefront.test.ts
@@ -1,0 +1,182 @@
+import { locations, operators, vehicleClasses, vehicles } from '@kuruma/shared/db/schema'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import { PUBLIC_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleAvailabilityRepository,
+  DrizzleBookingRepository,
+  DrizzleLocationRepository,
+  DrizzleRegionRepository,
+  DrizzleStorefrontRepository,
+  DrizzleVehicleClassRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { StorefrontSearchService } from '../../src/services/storefront-search'
+import type { Location } from '../../src/stores'
+import { setupAuthEnv, signTestJwt } from '../helpers/auth'
+import { DEFAULT_DAILY_RATE_JPY, db } from './setup'
+
+// #1262: the operator-authored-inventory loop, end to end. Before this slice the
+// fleet vehicle form omitted the pickup-location picker, so a UI-created vehicle
+// always had pickupLocationId = null and never surfaced to renters (storefront
+// search groups available cars by pickupLocationId — a null-location car is
+// dropped). This suite proves the fixed contract from the write side: an OPERATOR
+// session POSTs a vehicle at its own ACTIVE location, and that vehicle is then
+// discoverable through the SAME availability scan + storefront card a renter hits.
+// The form's ability to SET the location is covered by the web VehicleForm tests;
+// this proves the value it now writes actually makes the car bookable.
+
+const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const opId = `op_plsf_${uniq}`
+const ownerUserId = crypto.randomUUID()
+
+// A fixed future availability window. Operating hours are a booking-time concern,
+// not part of the availability listing, so any future slot works (mirrors
+// storefronts.test.ts). Far-future doc expiries keep the §5.2 gate satisfied.
+const FROM = new Date('2026-08-01T10:00:00Z')
+const TO = new Date('2026-08-01T14:00:00Z')
+
+const availabilityRepo = new DrizzleAvailabilityRepository(db)
+const storefrontSearch = new StorefrontSearchService(
+  new DrizzleStorefrontRepository(db),
+  availabilityRepo,
+  new DrizzleVehicleClassRepository(db),
+  new DrizzleRegionRepository(db),
+)
+
+let app: ReturnType<typeof createApp>
+let headers: Record<string, string>
+let location: Location
+let classId: string
+let locatedVehicleId: string
+
+const vehicleBody = (extra: Record<string, unknown>) => ({
+  name: `Toyota Aqua ${uniq}`,
+  classId,
+  seats: 5,
+  transmission: 'AUTO' as const,
+  bufferMinutes: 60,
+  dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+  // #916: create requires future-dated shaken + insurance (§5.0).
+  shakenExpiryDate: '2099-06-15',
+  insuranceExpiryDate: '2099-01-01',
+  ...extra,
+})
+
+const createVehicle = (body: unknown) =>
+  app.request('/vehicles', { method: 'POST', headers, body: JSON.stringify(body) })
+
+beforeAll(async () => {
+  setupAuthEnv()
+  await db.insert(operators).values({ id: opId, slug: `plsf-${uniq}`, name: 'PLSF Operator' })
+
+  const locationRepo = new DrizzleLocationRepository(db)
+  location = await locationRepo.create({
+    operatorId: opId,
+    name: `Namba ${uniq}`,
+    address: '1-1 Namba, Chuo-ku, Osaka',
+    operatingHours: { openTime: '09:00', closeTime: '20:00' },
+    timezone: 'Asia/Tokyo',
+    defaultTurnaroundMinutes: 60,
+    status: 'ACTIVE',
+  })
+
+  const [klass] = await db
+    .insert(vehicleClasses)
+    .values({
+      id: crypto.randomUUID(),
+      operatorId: opId,
+      name: `Compact ${uniq}`,
+      slug: `class-compact-${uniq}`,
+      description: null,
+      photos: [],
+      seats: 5,
+      luggageCapacity: 2,
+      transmission: 'AUTO',
+      fuelType: null,
+      acrissCode: 'CCAR',
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      sortOrder: 0,
+      status: 'ACTIVE',
+    })
+    .returning({ id: vehicleClasses.id })
+  if (!klass) throw new Error('failed to seed class')
+  classId = klass.id
+
+  app = createApp({
+    vehicleRepo: new DrizzleVehicleRepository(db),
+    bookingRepo: new DrizzleBookingRepository(db),
+    availabilityRepo,
+    locationRepo,
+  })
+  // Operator session: the operatorId rides in the JWT. The fleet form never names
+  // a tenant (the client can't), so the body carries NO operatorId — the service
+  // derives it from the session, exactly like a cookie-authed operator would.
+  const token = await signTestJwt({ sub: ownerUserId, role: 'OPERATOR_OWNER', operatorId: opId })
+  headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+  // A baseline bookable car AT the location — a live positive control so the
+  // null-location test can prove the availability scan actually returns rows
+  // (not a vacuously-empty result) before asserting the homeless car is absent.
+  const baseline = await createVehicle(
+    vehicleBody({ name: `Baseline ${uniq}`, pickupLocationId: location.id }),
+  )
+  locatedVehicleId = (await baseline.json()).data.id
+})
+
+afterAll(async () => {
+  await db.delete(vehicles).where(eq(vehicles.operatorId, opId))
+  await db.delete(vehicleClasses).where(eq(vehicleClasses.operatorId, opId))
+  await db.delete(locations).where(eq(locations.operatorId, opId))
+  await db.delete(operators).where(eq(operators.id, opId))
+})
+
+describe('a UI-created vehicle surfaces in storefront search (#1262)', () => {
+  it('POSTs a vehicle at the operator’s location and a renter finds it there', async () => {
+    const res = await createVehicle(vehicleBody({ pickupLocationId: location.id }))
+    expect(res.status).toBe(201)
+    const created = (await res.json()).data
+    expect(created.pickupLocationId).toBe(location.id)
+
+    // The exact availability scan storefront search runs: the new vehicle is
+    // discoverable at its location for a future window (id AND name pinned).
+    const available = await availabilityRepo.findAvailableVehicles(FROM, TO, {
+      locationId: location.id,
+    })
+    const found = available.find((v) => v.id === created.id)
+    expect(found?.name).toBe(`Toyota Aqua ${uniq}`)
+
+    // End-to-end renter path: searching the storefront by the operator’s new
+    // location returns a card whose class summary counts the newly-created car.
+    const result = await storefrontSearch.search(PUBLIC_CONTEXT, {
+      from: FROM,
+      to: TO,
+      pickupLocationId: location.id,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('storefront search returned an error result')
+    const card = result.data.storefronts.find((s) => s.locationId === location.id)
+    const availableInCard =
+      card?.classSummaries.reduce((sum, cs) => sum + cs.availableCount, 0) ?? 0
+    expect(availableInCard).toBeGreaterThanOrEqual(1)
+  })
+
+  it('a vehicle created with NO pickup location stays invisible to renters (the pre-#1262 gap)', async () => {
+    const res = await createVehicle(vehicleBody({ name: `Homeless Car ${uniq}` }))
+    expect(res.status).toBe(201)
+    const created = (await res.json()).data
+    expect(created.pickupLocationId).toBeNull()
+
+    // A null pickupLocationId is grouped out of every storefront card, so the
+    // renter never sees it — exactly the invisibility #1262 lets the operator fix.
+    const available = await availabilityRepo.findAvailableVehicles(FROM, TO, {
+      locationId: location.id,
+    })
+    // Positive control: the scan IS live (the baseline located car is returned),
+    // so the homeless car's absence is a real exclusion, not an empty result.
+    expect(available.map((v) => v.id)).toContain(locatedVehicleId)
+    expect(available.map((v) => v.id)).not.toContain(created.id)
+  })
+})

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -416,6 +416,7 @@
         "pickupLocation": "Pickup location",
         "pickupLocationNone": "No pickup location",
         "pickupLocationCurrent": "Current pickup location",
+        "pickupLocationEmptyHint": "Create a pickup location first so this vehicle can appear in search.",
         "operator": "Operator",
         "operatorPlaceholder": "Select an operator",
         "operatorRequired": "Select an operator to continue"

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -416,6 +416,7 @@
         "pickupLocation": "受取場所",
         "pickupLocationNone": "受取場所なし",
         "pickupLocationCurrent": "現在の受取場所",
+        "pickupLocationEmptyHint": "この車両を検索に表示させるには、まず受取場所を作成してください。",
         "operator": "事業者",
         "operatorPlaceholder": "事業者を選択",
         "operatorRequired": "続行するには事業者を選択してください"

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -416,6 +416,7 @@
         "pickupLocation": "取车地点",
         "pickupLocationNone": "无取车地点",
         "pickupLocationCurrent": "当前取车地点",
+        "pickupLocationEmptyHint": "请先创建取车地点，这样该车辆才能出现在搜索结果中。",
         "operator": "运营商",
         "operatorPlaceholder": "选择运营商",
         "operatorRequired": "请选择运营商以继续"

--- a/packages/web/src/vite/operator-fleet/EditVehicleSheet.tsx
+++ b/packages/web/src/vite/operator-fleet/EditVehicleSheet.tsx
@@ -3,6 +3,7 @@ import { PhotoUpload } from '@/vite/operator-fleet/PhotoUpload'
 import { VehicleForm } from '@/vite/operator-fleet/VehicleForm'
 import {
   type OperatorFleetVehicle,
+  pickupLocationOptionsQueryOptions,
   vehicleClassOptionsQueryOptions,
 } from '@/vite/operator-fleet/api'
 import { useQuery } from '@tanstack/react-query'
@@ -21,14 +22,20 @@ interface EditVehicleSheetProps {
 
 // Slide-over host that composes the add/edit form with photo management (#560).
 // It owns no fleet state — the parent passes the target vehicle (null = create)
-// and the open flag. Class options are fetched lazily (only while open) and the
-// dropdown is hidden when empty (unless the edited vehicle's class was archived
-// and must be preserved — #456), so a failed/absent class list never blocks the
-// form. PhotoUpload renders in both modes: in create mode it shows its own
-// "save the vehicle first" hint, since photos attach to a persisted vehicle id.
+// and the open flag. Class and pickup-location options are fetched lazily (only
+// while open); the class dropdown is hidden when empty (unless the edited
+// vehicle's class was archived and must be preserved — #456), and the location
+// picker shows a "create a location first" hint when empty (#1262) so a failed or
+// absent list never blocks the form. PhotoUpload renders in both modes: in create
+// mode it shows its own "save the vehicle first" hint, since photos attach to a
+// persisted vehicle id.
 export function EditVehicleSheet({ open, vehicle, onOpenChange, onSaved }: EditVehicleSheetProps) {
   const t = useTranslations('business.vehicles')
   const { data: classOptions } = useQuery({ ...vehicleClassOptionsQueryOptions(), enabled: open })
+  const { data: locationOptions } = useQuery({
+    ...pickupLocationOptionsQueryOptions(),
+    enabled: open,
+  })
   const isEdit = vehicle != null
 
   return (
@@ -41,6 +48,7 @@ export function EditVehicleSheet({ open, vehicle, onOpenChange, onSaved }: EditV
           <VehicleForm
             vehicle={vehicle}
             classOptions={classOptions ?? []}
+            locationOptions={locationOptions ?? []}
             onSaved={onSaved}
             onCancel={() => onOpenChange(false)}
           />

--- a/packages/web/src/vite/operator-fleet/VehicleForm.tsx
+++ b/packages/web/src/vite/operator-fleet/VehicleForm.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   FLEET_QUERY_KEY,
   type OperatorFleetVehicle,
+  type PickupLocationOption,
   type VehicleClassOption,
   createVehicle,
   updateVehicle,
@@ -24,11 +25,12 @@ import { useTranslations } from 'use-intl'
 import type { z } from 'zod'
 
 // Controlled Add/Edit vehicle form for the Vite operator-fleet shell (#555).
-// Parent owns open/close and class fetching; this component owns only the field
-// state + the create/update mutation. Operator and pickup-location pickers from
-// the frozen Next form are intentionally omitted: the operator is derived from
-// the session cookie server-side (the client never names a tenant — see api.ts),
-// and locations are a later slice.
+// Parent owns open/close and option fetching; this component owns only the field
+// state + the create/update mutation. The operator picker stays omitted — the
+// tenant is derived from the session cookie server-side (the client never names a
+// tenant — see api.ts). The pickup-location picker (#1262) IS present: without a
+// pickupLocationId a UI-created vehicle never surfaces in storefront search, so
+// the location must be settable purely through the form.
 //
 // The `classOptions` prop is fed by the parent's vehicleClassOptionsQueryOptions(),
 // which reads the session-scoped /vehicle-classes/manage endpoint (#528) — the
@@ -50,6 +52,8 @@ interface VehicleFormProps {
   readonly vehicle: OperatorFleetVehicle | null
   /** Class options for the dropdown (parent fetches; cross-tenant until #528). */
   readonly classOptions: readonly VehicleClassOption[]
+  /** Pickup-location options (parent fetches; session-scoped, incl. archived). */
+  readonly locationOptions: readonly PickupLocationOption[]
   /** Called after a create/update mutation succeeds. */
   readonly onSaved: () => void
   /** Called when the user cancels without saving. */
@@ -84,6 +88,7 @@ function defaultsFromVehicle(vehicle: OperatorFleetVehicle | null): Partial<Vehi
       maxRentalHours: 72,
       advanceBookingHours: null,
       classId: null,
+      pickupLocationId: null,
       // Blank by default — both fields inherit the class luggage when null.
       luggageCapacity: null,
       luggageSize: null,
@@ -100,6 +105,7 @@ function defaultsFromVehicle(vehicle: OperatorFleetVehicle | null): Partial<Vehi
     licensePlate: vehicle.licensePlate ?? '',
     photos: vehicle.photos,
     classId: vehicle.classId,
+    pickupLocationId: vehicle.pickupLocationId,
     make: vehicle.make ?? '',
     model: vehicle.model ?? '',
     year: vehicle.year,
@@ -118,7 +124,13 @@ function defaultsFromVehicle(vehicle: OperatorFleetVehicle | null): Partial<Vehi
   }
 }
 
-export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: VehicleFormProps) {
+export function VehicleForm({
+  vehicle,
+  classOptions,
+  locationOptions,
+  onSaved,
+  onCancel,
+}: VehicleFormProps) {
   const t = useTranslations('business.vehicles.form')
   // Luggage-size option labels live under the top-level `luggageSize.*` namespace.
   const tLuggage = useTranslations('luggageSize')
@@ -132,6 +144,21 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
   const assignedClassId = vehicle?.classId ?? null
   const assignedClassMissing =
     assignedClassId != null && !classOptions.some((klass) => klass.id === assignedClassId)
+
+  // Only ACTIVE locations are selectable, but an edited vehicle may point at a
+  // since-archived location (filtered out of the selectable list yet still present
+  // because the parent fetches includeArchived=true). Preserve it as a labelled
+  // fallback option so a save never silently clears the pickupLocationId — the
+  // exact non-surfacing state #1262 exists to fix. Mirrors the "Current class"
+  // handling above, but we have the archived row's real name to show.
+  const assignedLocationId = vehicle?.pickupLocationId ?? null
+  const activeLocationOptions = locationOptions.filter((loc) => loc.status === 'ACTIVE')
+  const assignedLocationMissing =
+    assignedLocationId != null &&
+    !activeLocationOptions.some((loc) => loc.id === assignedLocationId)
+  const assignedLocationName =
+    locationOptions.find((loc) => loc.id === assignedLocationId)?.name ?? null
+  const hasSelectableLocation = activeLocationOptions.length > 0 || assignedLocationMissing
 
   const {
     register,
@@ -195,6 +222,33 @@ export function VehicleForm({ vehicle, classOptions, onSaved, onCancel }: Vehicl
               </option>
             ))}
           </NativeSelect>
+        </div>
+      )}
+
+      {hasSelectableLocation ? (
+        <div>
+          <Label htmlFor="pickupLocationId">{t('pickupLocation')}</Label>
+          <NativeSelect
+            id="pickupLocationId"
+            {...register('pickupLocationId', { setValueAs: emptyToNull })}
+          >
+            <option value="">{t('pickupLocationNone')}</option>
+            {assignedLocationMissing && assignedLocationId != null && (
+              <option value={assignedLocationId}>
+                {assignedLocationName ?? t('pickupLocationCurrent')}
+              </option>
+            )}
+            {activeLocationOptions.map((loc) => (
+              <option key={loc.id} value={loc.id}>
+                {loc.name}
+              </option>
+            ))}
+          </NativeSelect>
+        </div>
+      ) : (
+        <div>
+          <div className="text-sm font-medium">{t('pickupLocation')}</div>
+          <p className="mt-1 text-sm text-muted-foreground">{t('pickupLocationEmptyHint')}</p>
         </div>
       )}
 

--- a/packages/web/src/vite/operator-fleet/api.ts
+++ b/packages/web/src/vite/operator-fleet/api.ts
@@ -14,6 +14,7 @@ import {
   type OperatorFleetVehicle,
   type PhotoDeleteResult,
   type PhotoUploadResult,
+  type PickupLocationOption,
   type VehicleClassOption,
   type VehicleDetailBookingDto,
   type VehicleDetailResponse,
@@ -22,6 +23,7 @@ import {
   operatorFleetListSchema,
   photoDeleteResultSchema,
   photoUploadResultSchema,
+  pickupLocationOptionsListSchema,
   vehicleClassOptionsListSchema,
   vehicleDetailResponseSchema,
   vehicleRowListSchema,
@@ -51,6 +53,7 @@ export type {
   OperatorFleetVehicle,
   PhotoDeleteResult,
   PhotoUploadResult,
+  PickupLocationOption,
   VehicleClassOption,
   VehicleDetailBookingDto,
   VehicleDetailResponse,
@@ -251,5 +254,29 @@ export function vehicleClassOptionsQueryOptions() {
   return queryOptions({
     queryKey: ['operator-fleet', 'class-options'],
     queryFn: fetchVehicleClassOptions,
+  })
+}
+
+// Minimal pickup-location list for the Add/Edit form's location dropdown (#1262).
+// Kept fleet-local (a direct fetch, not an `operator-locations` import) to stay
+// inside the web module boundary — mirrors fetchVehicleClassOptions above. The
+// session-authed `/locations` list is operator-scoped server-side; a UI-created
+// vehicle needs a pickupLocationId or it never surfaces in storefront search.
+export async function fetchPickupLocationOptions(): Promise<PickupLocationOption[]> {
+  // `includeArchived=true` keeps a since-archived *assigned* location resolvable
+  // for the edit fallback (the form filters to ACTIVE for selectable options).
+  // `includeAll=true` satisfies the private route's explicit cross-operator read
+  // contract for bypass roles (else they 400); OPERATOR_* callers stay scoped by
+  // the API and it ignores the flag. Fleet is not a picker route — no `?operator`.
+  const res = await fetch(`${getApiBaseUrl()}/locations?includeArchived=true&includeAll=true`, {
+    credentials: 'include',
+  })
+  return unwrap(res, pickupLocationOptionsListSchema)
+}
+
+export function pickupLocationOptionsQueryOptions() {
+  return queryOptions({
+    queryKey: ['operator-fleet', 'location-options'],
+    queryFn: fetchPickupLocationOptions,
   })
 }

--- a/packages/web/src/vite/operator-fleet/schema.ts
+++ b/packages/web/src/vite/operator-fleet/schema.ts
@@ -1,4 +1,9 @@
-import { BOOKING_SOURCES, TRANSMISSIONS, VEHICLE_STATUSES } from '@kuruma/shared/enums'
+import {
+  BOOKING_SOURCES,
+  LOCATION_STATUSES,
+  TRANSMISSIONS,
+  VEHICLE_STATUSES,
+} from '@kuruma/shared/enums'
 import { LUGGAGE_SIZES } from '@kuruma/shared/lib/luggage'
 import { z } from 'zod'
 
@@ -149,3 +154,19 @@ export const vehicleClassOptionSchema = z.object({
 export type VehicleClassOption = z.infer<typeof vehicleClassOptionSchema>
 
 export const vehicleClassOptionsListSchema = z.array(vehicleClassOptionSchema)
+
+/**
+ * Minimal pickup-location option for the Add/Edit form's location dropdown
+ * (#1262). Fed by the session-scoped `/locations` list; `status` is carried so
+ * the form can offer only ACTIVE locations while still preserving a
+ * since-archived assigned location as a labelled fallback (mirrors the archived
+ * "Current class" behaviour). Extra location fields are stripped by Zod.
+ */
+export const pickupLocationOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(LOCATION_STATUSES),
+})
+export type PickupLocationOption = z.infer<typeof pickupLocationOptionSchema>
+
+export const pickupLocationOptionsListSchema = z.array(pickupLocationOptionSchema)

--- a/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
@@ -400,6 +400,32 @@ describe('VehicleForm', () => {
     )
   })
 
+  it('edit mode: labels a preserved pickup location generically when it is absent from the fetched list (#1262)', async () => {
+    const user = userEvent.setup()
+    mockedUpdate.mockResolvedValue(existingVehicle())
+    // The assigned location is missing from the returned options entirely (a
+    // partial fetch or a stale link), so there is no name to show. The form
+    // still preserves the id and labels it with the generic "current" fallback
+    // rather than silently clearing the link on save.
+    const missingLocationId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    renderForm({ vehicle: existingVehicle({ pickupLocationId: missingLocationId }) })
+
+    const select = screen.getByLabelText(en.pickupLocation) as HTMLSelectElement
+    expect(select.value).toBe(missingLocationId)
+    expect(screen.getByRole('option', { name: en.pickupLocationCurrent })).toBeInTheDocument()
+
+    const nameInput = screen.getByLabelText(en.name)
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Toyota Aqua G')
+    await user.click(screen.getByRole('button', { name: en.save }))
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1))
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      'veh_1',
+      expect.objectContaining({ pickupLocationId: missingLocationId }),
+    )
+  })
+
   it('shows a hint instead of the picker when the operator has no locations (#1262)', () => {
     // Zero locations is the exact state that leaves a UI-created car invisible to
     // renters; surface a hint rather than silently hiding the field.

--- a/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
+++ b/packages/web/tests/vite/operator-fleet/VehicleForm.test.tsx
@@ -1,5 +1,9 @@
 import { VehicleForm } from '@/vite/operator-fleet/VehicleForm'
-import type { OperatorFleetVehicle, VehicleClassOption } from '@/vite/operator-fleet/api'
+import type {
+  OperatorFleetVehicle,
+  PickupLocationOption,
+  VehicleClassOption,
+} from '@/vite/operator-fleet/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -25,6 +29,13 @@ const en = enMessages.business.vehicles.form
 const classOptions: VehicleClassOption[] = [
   { id: '11111111-1111-4111-8111-111111111111', name: 'Compact' },
   { id: '22222222-2222-4222-8222-222222222222', name: 'SUV' },
+]
+
+const OSAKA_LOCATION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const KYOTO_LOCATION_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const locationOptions: PickupLocationOption[] = [
+  { id: OSAKA_LOCATION_ID, name: 'Osaka Namba', status: 'ACTIVE' },
+  { id: KYOTO_LOCATION_ID, name: 'Kyoto Station', status: 'ACTIVE' },
 ]
 
 function existingVehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVehicle {
@@ -67,11 +78,17 @@ function existingVehicle(overrides: Partial<OperatorFleetVehicle> = {}): Operato
 
 interface RenderOptions {
   vehicle?: OperatorFleetVehicle | null
+  locations?: readonly PickupLocationOption[]
   onSaved?: () => void
   onCancel?: () => void
 }
 
-function renderForm({ vehicle = null, onSaved = vi.fn(), onCancel = vi.fn() }: RenderOptions = {}) {
+function renderForm({
+  vehicle = null,
+  locations = locationOptions,
+  onSaved = vi.fn(),
+  onCancel = vi.fn(),
+}: RenderOptions = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
   })
@@ -82,6 +99,7 @@ function renderForm({ vehicle = null, onSaved = vi.fn(), onCancel = vi.fn() }: R
         <VehicleForm
           vehicle={vehicle}
           classOptions={classOptions}
+          locationOptions={locations}
           onSaved={onSaved}
           onCancel={onCancel}
         />
@@ -295,5 +313,99 @@ describe('VehicleForm', () => {
 
     await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1))
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: FLEET_QUERY_KEY })
+  })
+
+  it('create mode: submits the chosen pickup location (#1262)', async () => {
+    const user = userEvent.setup()
+    mockedCreate.mockResolvedValue(existingVehicle())
+    renderForm()
+
+    await user.type(screen.getByLabelText(en.name), 'Honda Fit')
+    await user.type(screen.getByLabelText(en.dailyRate), '7500')
+    await user.selectOptions(screen.getByLabelText(en.pickupLocation), OSAKA_LOCATION_ID)
+    await fillRequiredDocs(user)
+    await user.click(screen.getByRole('button', { name: en.save }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ pickupLocationId: OSAKA_LOCATION_ID }),
+    )
+  })
+
+  it('create mode: an unselected pickup location submits null (#1262)', async () => {
+    const user = userEvent.setup()
+    mockedCreate.mockResolvedValue(existingVehicle())
+    renderForm()
+
+    await user.type(screen.getByLabelText(en.name), 'Honda Fit')
+    await user.type(screen.getByLabelText(en.dailyRate), '7500')
+    await fillRequiredDocs(user)
+    await user.click(screen.getByRole('button', { name: en.save }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(expect.objectContaining({ pickupLocationId: null }))
+  })
+
+  it('offers only ACTIVE locations as selectable options (#1262)', () => {
+    renderForm({
+      locations: [
+        ...locationOptions,
+        { id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', name: 'Kobe (retired)', status: 'ARCHIVED' },
+      ],
+    })
+
+    const select = screen.getByLabelText(en.pickupLocation) as HTMLSelectElement
+    const optionNames = Array.from(select.options).map((o) => o.textContent)
+    expect(optionNames).toEqual([en.pickupLocationNone, 'Osaka Namba', 'Kyoto Station'])
+    expect(optionNames).not.toContain('Kobe (retired)')
+  })
+
+  it('edit mode: pre-fills the pickup location from the vehicle (#1262)', () => {
+    renderForm({ vehicle: existingVehicle({ pickupLocationId: KYOTO_LOCATION_ID }) })
+
+    expect((screen.getByLabelText(en.pickupLocation) as HTMLSelectElement).value).toBe(
+      KYOTO_LOCATION_ID,
+    )
+  })
+
+  it('edit mode: preserves a since-archived pickup location missing from active options (#1262)', async () => {
+    const user = userEvent.setup()
+    mockedUpdate.mockResolvedValue(existingVehicle())
+    const archivedLocationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    // The assigned location was archived: it is filtered out of the selectable
+    // ACTIVE list but still arrives (includeArchived=true) so the form can label
+    // and preserve it rather than silently clearing the link on save.
+    renderForm({
+      vehicle: existingVehicle({ pickupLocationId: archivedLocationId }),
+      locations: [
+        ...locationOptions,
+        { id: archivedLocationId, name: 'Sakai Depot', status: 'ARCHIVED' },
+      ],
+    })
+
+    const select = screen.getByLabelText(en.pickupLocation) as HTMLSelectElement
+    expect(select.value).toBe(archivedLocationId)
+    // The preserved option shows the real archived name, not a generic label.
+    expect(screen.getByRole('option', { name: 'Sakai Depot' })).toBeInTheDocument()
+
+    const nameInput = screen.getByLabelText(en.name)
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Toyota Aqua G')
+    await user.click(screen.getByRole('button', { name: en.save }))
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1))
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      'veh_1',
+      expect.objectContaining({ pickupLocationId: archivedLocationId }),
+    )
+  })
+
+  it('shows a hint instead of the picker when the operator has no locations (#1262)', () => {
+    // Zero locations is the exact state that leaves a UI-created car invisible to
+    // renters; surface a hint rather than silently hiding the field.
+    renderForm({ locations: [] })
+
+    expect(screen.queryByLabelText(en.pickupLocation)).not.toBeInTheDocument()
+    expect(screen.getByText(en.pickupLocationEmptyHint)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What

Adds a pickup-location `<select>` to the operator fleet vehicle form. Previously a UI-created vehicle always had `pickupLocationId = null` and therefore never surfaced in storefront search (which groups available cars by `pickupLocationId`) — only seeded cars were bookable by renters. This wires the missing form input; the backend already supported the column end to end (validator FK-seal, service, 422).

## How

- **Fleet-local `fetchPickupLocationOptions()`** in `operator-fleet/api.ts`, mirroring the existing `fetchVehicleClassOptions` — a direct `/locations` fetch kept in-feature rather than importing `operator-locations`, to respect the web module-boundary ratchet (a cross-feature import would fail `lint-module-boundaries` and force picker-scope semantics fleet does not want).
- **`VehicleForm`**: `pickupLocationId` select — ACTIVE-only selectable options, an archived-but-assigned "current location" fallback that preserves the real name so a save never silently clears the link, and an explicit empty-locations hint instead of silently hiding the field (that silent-hide would reproduce the exact invisibility bug this fixes).
- **`EditVehicleSheet`** self-fetches the options (create + edit share one sheet, used by both `OperatorFleetView` and `VehicleDetail`).
- **i18n** `pickupLocationEmptyHint` (en/ja/zh); the other pickup keys already existed at parity.

## Tests

- Web unit (`VehicleForm.test.tsx`, 18): ACTIVE filtering, archived real-name fallback, generic-label fallback when the id is absent from the fetched list, empty-locations hint, create defaults null, edit pre-fill, save preserves.
- API real-pg integration (`vehicle-pickup-location-storefront.test.ts`, 2): a UI-shaped create surfaces the vehicle in storefront search (id + name pinned against a positive-control baseline); a null-location create stays invisible (the pre-#1262 gap).

## Verification

web+api tsc, biome, i18n parity (1349x3), web suite 1635, module/size guards, web prod build — all green. Reviewed by code-reviewer (SHIP) and architect (no blockers); one flagged coverage gap folded (generic-label fallback test).

Closes #1262.