### PR TITLE
chore(ci): add GOOGLE_TRANSLATE_API_KEY to deploy secret presence check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,11 +93,13 @@ jobs:
       # (#378 Phase 2). AUTH_URL is the public Pages origin used to build the
       # google redirect_uri; set it once Pages is live (#304). Missing any of
       # these ships /auth/google/* as a silent 503 — see resolveGoogleOAuthConfig.
+      # GOOGLE_TRANSLATE_API_KEY added once the secret was rotated on (#1290);
+      # missing it ships POST /messages/:id/translate as a throwing sentinel.
       - name: Verify API Worker secrets present
         working-directory: packages/api
         run: |
           secrets_json=$(npx wrangler secret list)
-          for key in DATABASE_URL AUTH_SECRET AUTH_GOOGLE_ID AUTH_GOOGLE_SECRET AUTH_URL; do
+          for key in DATABASE_URL AUTH_SECRET AUTH_GOOGLE_ID AUTH_GOOGLE_SECRET AUTH_URL GOOGLE_TRANSLATE_API_KEY; do
             echo "$secrets_json" | jq -e --arg k "$key" 'any(.[]; .name == $k)' > /dev/null \
               || { echo "::error::Missing required secret on API Worker: $key (rotate via rotate-secrets.yml)"; exit 1; }
           done


### PR DESCRIPTION
## What

Adds `GOOGLE_TRANSLATE_API_KEY` to the read-only secret presence check in `deploy.yml` (the `wrangler secret list` drift detector).

## Why

The secret was rotated onto the API Worker in #1290 / via `rotate-secrets.yml`. The presence check was deliberately deferred until the secret existed — adding it earlier would have failed every deploy before the key was set up. The key is now confirmed present on `kuruma-api`, so it is safe to guard.

Effect: a future deploy fails loudly if the translate secret is ever deleted or never rotated. Missing it ships `POST /messages/:id/translate` as a throwing sentinel.

## Notes

- Read-only check — lists secret **names** only; no key value is read or needed (CF never returns secret values).
- No runtime/schema change; CI-only.

Refs #1290.