### PR TITLE
fix(#1102): format today-panel row times in the active locale

### DIFF
--- a/packages/web/src/vite/operator-dashboard/TodayPanel.test.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.test.tsx
@@ -65,13 +65,17 @@ function buckets(over: Partial<TodayBuckets> = {}): TodayBuckets {
   return { pickups: [], returns: [], overdue: [], ...over }
 }
 
-function renderPanel(today: TodayBuckets, session: Session | null = OPERATOR_SESSION) {
+function renderPanel(
+  today: TodayBuckets,
+  session: Session | null = OPERATOR_SESSION,
+  locale = 'en',
+) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
   const view = render(
     <QueryClientProvider client={qc}>
       <IntlProvider locale="en" messages={en}>
-        <TodayPanel today={today} vehicles={VEHICLES} session={session} locale="en" />
+        <TodayPanel today={today} vehicles={VEHICLES} session={session} locale={locale} />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -108,6 +112,23 @@ describe('TodayPanel', () => {
   it('falls back to the walk-in label when the renter name is null', () => {
     renderPanel(buckets({ pickups: [row({ id: 'bk2', renterName: null })] }))
     expect(screen.getByText(M.walkIn)).toBeTruthy()
+  })
+
+  it('formats each row time in the active locale at the JST wall-clock (24h for ja, 12h for en)', () => {
+    // 05:30Z == 14:30 Asia/Tokyo — a PM instant that renders differently per locale,
+    // so it proves formatTime honours the passed locale rather than the ambient default.
+    const at = '2026-06-30T05:30:00.000Z'
+    const ja = renderPanel(
+      buckets({ pickups: [row({ id: 'bk1', startAt: at })] }),
+      OPERATOR_SESSION,
+      'ja',
+    )
+    expect(screen.getByText('14:30')).toBeTruthy()
+    expect(screen.queryByText(/PM/i)).toBeNull()
+    ja.unmount()
+
+    renderPanel(buckets({ pickups: [row({ id: 'bk2', startAt: at })] }), OPERATOR_SESSION, 'en')
+    expect(screen.getByText(/2:30\s?PM/i)).toBeTruthy()
   })
 
   it('shows the per-bucket empty-state copy for buckets with no rows', () => {

--- a/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
@@ -42,9 +42,11 @@ interface SectionSpec {
 
 // The buckets are JST-day-scoped server-side (a row lands in "today" by its JST
 // calendar day), so pin the time to Asia/Tokyo — otherwise an off-JST viewer sees
-// a time (and apparent day) that disagrees with the bucket it sits in.
-function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString([], {
+// a time (and apparent day) that disagrees with the bucket it sits in. Format in
+// the active locale so the clock convention (24h ja/zh vs 12h en) matches the rest
+// of the UI rather than following the viewer's browser default.
+function formatTime(iso: string, locale: string): string {
+  return new Date(iso).toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
     timeZone: 'Asia/Tokyo',
@@ -141,7 +143,9 @@ export function TodayPanel({ today, vehicles, session, locale }: TodayPanelProps
                       className="min-w-0 flex-1 text-sm hover:underline"
                     >
                       <span className="flex items-baseline gap-1.5">
-                        <span className="font-medium tabular-nums">{formatTime(r[timeField])}</span>
+                        <span className="font-medium tabular-nums">
+                          {formatTime(r[timeField], locale)}
+                        </span>
                         <span className="truncate">{r.renterName ?? t('walkIn')}</span>
                       </span>
                       <span className="block truncate text-xs text-muted-foreground">


### PR DESCRIPTION
## What

Post-merge fix-forward for a code-review LOW found on #1281 (the "Today" operations panel, epic #1099 slice 3).

`TodayPanel`'s `formatTime` called `toLocaleTimeString([], …)`, so the 12h-vs-24h clock convention followed the **viewer's browser default locale** instead of the app's active `$locale`. A ja/zh page could render `2:30 PM` for an operator whose browser was en-US. The instant was always correct (the `timeZone: 'Asia/Tokyo'` pin is untouched) — only the presentation drifted.

## Fix

Thread the `locale` prop (already present on the component and used for the row's deep-link params) into `formatTime`, passing it to `toLocaleTimeString`. One-line behavioural change; Asia/Tokyo pin unchanged.

## Test

TDD: added a differential test that renders the same 14:30-JST instant under `ja` and `en` and asserts 24h (`14:30`, no `PM`) vs 12h (`2:30 PM`). It fails against the old `[]` code regardless of the ambient default locale (proven RED before the fix), passes after.

## Verification

- `TodayPanel` suite 9/9 (was 8 + the new one)
- Full web suite 1670/1670 green
- web + api `tsc --noEmit` clean, biome clean, module-boundaries + file-size gates green (pre-commit)
- No message-file changes → i18n parity unaffected. No schema migration.

Refs #1102, #1099.