### PR TITLE
feat(scripts): lint-csrf-on-writes — catch tokenless web cookie writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check global fetch is bound on runtime surfaces
         run: bun run lint:fetch-binding
 
+      - name: Check web cookie writes send the CSRF token
+        run: bun run lint:csrf-writes
+
       - name: Check unused deps and exports
         run: bun run lint:deps
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:i18n-parity": "bun run scripts/lint-i18n-parity.ts",
     "lint:unwrap-schema": "bun run scripts/lint-unwrap-schema.ts",
     "lint:fetch-binding": "bun run scripts/lint-fetch-binding.ts",
+    "lint:csrf-writes": "bun run scripts/lint-csrf-on-writes.ts",
     "lint:dist-size": "bun run scripts/lint-dist-size.ts",
     "lint:csp-hash": "bun run scripts/lint-csp-hash.ts",
     "lint:no-next-app": "bun run scripts/lint-no-next-app.ts",

--- a/scripts/lint-csrf-on-writes.test.ts
+++ b/scripts/lint-csrf-on-writes.test.ts
@@ -1,0 +1,184 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { findCsrfViolations, scanRoots } from './lint-csrf-on-writes'
+
+// A cookie write = `fetch(..., { method: <mutating>, credentials: 'include', ... })`.
+// The global CSRF guard 403s any such request whose headers omit `X-CSRF-Token`
+// (packages/api middleware/csrf.ts). This scanner catches the miss statically
+// (the class of bug #1304: operator-fleet/-classes shipped writes without it).
+const lines = (...ls: string[]): string => ls.join('\n')
+
+describe('findCsrfViolations', () => {
+  test('flags a literal POST cookie write missing X-CSRF-Token (the #1304 bug)', () => {
+    const src = lines(
+      'async function create(csrfToken: string) {',
+      '  const res = await fetch(`${base}/vehicles`, {',
+      "    method: 'POST',",
+      "    credentials: 'include',",
+      "    headers: { 'Content-Type': 'application/json' },",
+      '    body: JSON.stringify(data),',
+      '  })',
+      '}',
+    )
+    expect(findCsrfViolations(src)).toEqual([2])
+  })
+
+  test('does NOT flag when X-CSRF-Token is present', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}/vehicles`, {',
+      "    method: 'POST',",
+      "    credentials: 'include',",
+      "    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('does NOT flag a credentialed GET read (no method key)', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}/dashboard/overview`, {',
+      "    credentials: 'include',",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('flags the `method,` shorthand write helper missing the token (the fleet writeJson shape)', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}${path}`, {',
+      '    method,',
+      "    credentials: 'include',",
+      "    headers: { 'Content-Type': 'application/json' },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([1])
+  })
+
+  test('does NOT flag the `method,` shorthand helper when it threads the token', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}${path}`, {',
+      '    method,',
+      "    credentials: 'include',",
+      "    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('does NOT flag a write whose headers come from a helper threaded csrfToken', () => {
+    // admin/operators + messaging spell it `headers: jsonHeaders(csrfToken)` — the
+    // literal 'X-CSRF-Token' lives in the helper, but the token is demonstrably threaded.
+    const src = lines(
+      '  const res = await fetch(`${base}/admin/operators`, {',
+      "    method: 'POST',",
+      "    credentials: 'include',",
+      '    headers: jsonHeaders(csrfToken),',
+      '    body: JSON.stringify(body),',
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('does NOT flag a mutating fetch that is NOT a cookie write (no credentials: include)', () => {
+    const src =
+      "  await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' } })"
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('flags a DELETE cookie write missing the token', () => {
+    const src = lines(
+      '  const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(id)}`, {',
+      "    method: 'DELETE',",
+      "    credentials: 'include',",
+      "    headers: { 'X-Trace': traceId },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([1])
+  })
+
+  test('bracket-matching survives template-literal URLs with nested parens', () => {
+    const src = lines(
+      '  const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(id)}`, {',
+      "    method: 'DELETE',",
+      "    credentials: 'include',",
+      "    headers: { 'X-CSRF-Token': csrfToken },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('does NOT flag a write pattern that lives only inside a comment', () => {
+    const src = lines(
+      "// old bug: fetch(url, { method: 'POST', credentials: 'include' }) shipped no token",
+      'const ok = 1',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
+  test('reports every offending fetch in a multi-write module', () => {
+    const src = lines(
+      '  await fetch(a, {', // line 1 -> violation
+      "    method: 'POST',",
+      "    credentials: 'include',",
+      '  })',
+      '  await fetch(b, {', // line 5 -> clean (has token)
+      "    method: 'PATCH',",
+      "    credentials: 'include',",
+      "    headers: { 'X-CSRF-Token': t },",
+      '  })',
+      '  await fetch(c, {', // line 10 -> violation
+      "    method: 'DELETE',",
+      "    credentials: 'include',",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([1, 10])
+  })
+})
+
+describe('scanRoots', () => {
+  let cwd: string
+  const BAD = lines(
+    'export async function create(csrfToken: string) {',
+    '  return fetch(url, {',
+    "    method: 'POST',",
+    "    credentials: 'include',",
+    '  })',
+    '}',
+  )
+  const GOOD = lines(
+    'export async function read() {',
+    "  return fetch(url, { credentials: 'include' })",
+    '}',
+  )
+
+  beforeAll(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'lint-csrf-'))
+    const root = join(cwd, 'packages', 'web', 'src')
+    mkdirSync(join(root, 'tests'), { recursive: true })
+    writeFileSync(join(root, 'api.ts'), BAD) // scanned -> violation
+    writeFileSync(join(root, 'widget.tsx'), BAD) // .tsx scanned -> violation
+    writeFileSync(join(root, 'read.ts'), GOOD) // credentialed read -> clean
+    writeFileSync(join(root, 'api.test.ts'), BAD) // excluded (tests mock the client)
+    writeFileSync(join(root, 'tests', 'helper.ts'), BAD) // excluded (tests/ dir)
+  })
+
+  afterAll(() => rmSync(cwd, { recursive: true, force: true }))
+
+  test('reports prod .ts/.tsx violations and skips tests + credentialed reads', () => {
+    const files = scanRoots(['packages/web/src'], cwd)
+      .map((v) => v.file)
+      .sort()
+    expect(files).toEqual(['packages/web/src/api.ts', 'packages/web/src/widget.tsx'])
+  })
+
+  test('returns the offending fetch line number', () => {
+    const v = scanRoots(['packages/web/src'], cwd).find((x) => x.file.endsWith('api.ts'))
+    expect(v?.line).toBe(2)
+  })
+
+  test('silently skips a root that does not exist', () => {
+    expect(scanRoots(['nope'], cwd)).toEqual([])
+  })
+})

--- a/scripts/lint-csrf-on-writes.test.ts
+++ b/scripts/lint-csrf-on-writes.test.ts
@@ -67,6 +67,28 @@ describe('findCsrfViolations', () => {
     expect(findCsrfViolations(src)).toEqual([])
   })
 
+  test('flags a dynamic `method: verb` cookie write missing the token', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}${path}`, {',
+      '    method: verb,',
+      "    credentials: 'include',",
+      "    headers: { 'Content-Type': 'application/json' },",
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([1])
+  })
+
+  test('does NOT flag a dynamic `method: verb` write that threads the token', () => {
+    const src = lines(
+      '  const res = await fetch(`${base}${path}`, {',
+      '    method: verb,',
+      "    credentials: 'include',",
+      '    headers: jsonHeaders(csrfToken),',
+      '  })',
+    )
+    expect(findCsrfViolations(src)).toEqual([])
+  })
+
   test('does NOT flag a write whose headers come from a helper threaded csrfToken', () => {
     // admin/operators + messaging spell it `headers: jsonHeaders(csrfToken)` — the
     // literal 'X-CSRF-Token' lives in the helper, but the token is demonstrably threaded.
@@ -168,17 +190,24 @@ describe('scanRoots', () => {
 
   test('reports prod .ts/.tsx violations and skips tests + credentialed reads', () => {
     const files = scanRoots(['packages/web/src'], cwd)
-      .map((v) => v.file)
+      .violations.map((v) => v.file)
       .sort()
     expect(files).toEqual(['packages/web/src/api.ts', 'packages/web/src/widget.tsx'])
   })
 
   test('returns the offending fetch line number', () => {
-    const v = scanRoots(['packages/web/src'], cwd).find((x) => x.file.endsWith('api.ts'))
+    const v = scanRoots(['packages/web/src'], cwd).violations.find((x) => x.file.endsWith('api.ts'))
     expect(v?.line).toBe(2)
   })
 
-  test('silently skips a root that does not exist', () => {
-    expect(scanRoots(['nope'], cwd)).toEqual([])
+  test('counts every prod file scanned (fail-closed signal)', () => {
+    // BAD api.ts + BAD widget.tsx + GOOD read.ts = 3 prod files; tests excluded.
+    expect(scanRoots(['packages/web/src'], cwd).scanned).toBe(3)
+  })
+
+  test('a root that does not exist yields no violations AND zero scanned', () => {
+    const result = scanRoots(['nope'], cwd)
+    expect(result.violations).toEqual([])
+    expect(result.scanned).toBe(0)
   })
 })

--- a/scripts/lint-csrf-on-writes.ts
+++ b/scripts/lint-csrf-on-writes.ts
@@ -14,8 +14,10 @@
  * statically, in the spirit of `lint-fetch-binding.ts` (#887) and #1289.
  *
  * A "cookie write" here = a `fetch(...)` whose options object sets
- * `credentials: 'include'` AND a mutating `method` (a `'POST'|'PUT'|'PATCH'|'DELETE'`
- * literal, or the `method` shorthand a write helper forwards). Such a call must
+ * `credentials: 'include'` AND a mutating `method` — a `'POST'|'PUT'|'PATCH'|'DELETE'`
+ * literal, the `method` shorthand, or a `method` set to a variable (any form a write
+ * helper forwards the verb; only a literal `'GET'` and no-`method` reads are exempt).
+ * Such a call must
  * thread the token — either the literal `'X-CSRF-Token'` header inline, or the
  * canonical `csrfToken` identifier (some modules build headers with a
  * `jsonHeaders(csrfToken)` helper). Credentialed GET reads (no `method`) are
@@ -38,6 +40,12 @@ const CREDENTIALED = /credentials\s*:\s*['"]include['"]/
 const LITERAL_WRITE = /\bmethod\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/i
 // A write helper forwarding a `method` param as an object shorthand: `{ method, ... }`.
 const SHORTHAND_WRITE = /[{,]\s*method\s*[,}]/
+// A `method` set to an identifier (a variable/expression, not a quoted literal): a
+// generic `request(path, method, body)` helper forwards the verb this way. We can't
+// prove it isn't GET, so we treat it as write intent — over-approximating here only
+// risks flagging a (nonexistent) dynamic-method GET read, and every such call still
+// gets the token check. Reads in this codebase omit `method` entirely (default GET).
+const DYNAMIC_WRITE = /\bmethod\s*:\s*[A-Za-z_$]/
 const HAS_CSRF = /['"]x-csrf-token['"]/i
 // The canonical token identifier — covers `headers: jsonHeaders(csrfToken)`, where
 // the literal header name lives in the helper rather than the fetch call itself.
@@ -138,7 +146,8 @@ export function findCsrfViolations(source: string): number[] {
     if (close < 0) continue
     const segment = kept.slice(openParen, close + 1)
     if (!CREDENTIALED.test(segment)) continue
-    const isWrite = LITERAL_WRITE.test(segment) || SHORTHAND_WRITE.test(segment)
+    const isWrite =
+      LITERAL_WRITE.test(segment) || SHORTHAND_WRITE.test(segment) || DYNAMIC_WRITE.test(segment)
     if (!isWrite) continue
     if (HAS_CSRF.test(segment) || HAS_TOKEN_REF.test(segment)) continue
     offending.push(code.slice(0, start).split('\n').length)
@@ -166,8 +175,16 @@ export interface Violation {
   line: number
 }
 
-export function scanRoots(roots: readonly string[], cwd: string): Violation[] {
+export interface ScanResult {
+  violations: Violation[]
+  // How many prod source files were actually read. A regression guard that scans
+  // zero files (root moved/renamed) must fail closed, not report "all clean".
+  scanned: number
+}
+
+export function scanRoots(roots: readonly string[], cwd: string): ScanResult {
   const violations: Violation[] = []
+  let scanned = 0
   for (const root of roots) {
     const abs = join(cwd, root)
     let files: string[]
@@ -176,31 +193,39 @@ export function scanRoots(roots: readonly string[], cwd: string): Violation[] {
     } catch {
       continue // a root may not exist in every checkout — skip it
     }
+    scanned += files.length
     for (const file of files) {
       for (const line of findCsrfViolations(readFileSync(file, 'utf8'))) {
         violations.push({ file: relative(cwd, file), line })
       }
     }
   }
-  return violations
+  return { violations, scanned }
 }
 
 function main(): void {
   const cwd = new URL('..', import.meta.url).pathname
-  const violations = scanRoots(WRITE_ROOTS, cwd)
+  const { violations, scanned } = scanRoots(WRITE_ROOTS, cwd)
+  if (scanned === 0) {
+    console.error(
+      `[lint-csrf-on-writes] scanned 0 files under ${WRITE_ROOTS.join(', ')} — root moved or renamed?\nRefusing to pass: a guard that cannot reach its target must fail closed, not report clean.`,
+    )
+    process.exit(1)
+  }
   if (violations.length > 0) {
     console.error(
       `[lint-csrf-on-writes] ${violations.length} cookie write(s) missing X-CSRF-Token:`,
     )
     for (const v of violations) console.error(`  - ${v.file}:${v.line}`)
     console.error(
-      '\nThe API CSRF guard 403s any cookie write without a matching token.\n' +
-        "Thread the session token into the request headers: `'X-CSRF-Token': csrfToken`\n" +
-        '(csrfToken from `useSession().data?.csrfToken`), mirroring operator-fees/api.ts.',
+      '\nThe API CSRF guard 403s any cookie write without a matching token. Thread the session\n' +
+        'token (from `useSession().data?.csrfToken`) into the request headers — either inline\n' +
+        "(`'X-CSRF-Token': csrfToken`) or via a headers helper that names `csrfToken`, mirroring\n" +
+        'operator-fees/api.ts and admin/operators/api.ts.',
     )
     process.exit(1)
   }
-  console.log('[lint-csrf-on-writes] no cookie writes missing X-CSRF-Token')
+  console.log(`[lint-csrf-on-writes] no cookie writes missing X-CSRF-Token (${scanned} files)`)
 }
 
 if (import.meta.main) {

--- a/scripts/lint-csrf-on-writes.ts
+++ b/scripts/lint-csrf-on-writes.ts
@@ -1,0 +1,208 @@
+// ENFORCES: every web cookie WRITE echoes the session CSRF token (#1304, #1325).
+// SSOT: code-only — enforced by packages/api/src/middleware/csrf.ts; no written rule doc yet (#1325).
+/**
+ * Ban cookie writes that omit the `X-CSRF-Token` header (#1304).
+ *
+ * The API mounts a global CSRF guard (`app.use('*', csrf())`, `middleware/csrf.ts`):
+ * any state-changing, cookie-bearing request whose headers lack a matching
+ * `X-CSRF-Token` is rejected with 403 "CSRF token mismatch". The web SPA has no
+ * shared write helper — each `packages/web/src/vite/<feature>/api.ts` hand-rolls
+ * its `fetch(url, { method, credentials: 'include', headers: {...} })`, so a new
+ * module can (and did: operator-fleet + operator-classes, #1304) ship a write that
+ * forgets the header. `tsc` and the unit tests — which mock each module's `api.ts`
+ * — stay green; only a real-API/E2E request surfaces the 403. This guard catches it
+ * statically, in the spirit of `lint-fetch-binding.ts` (#887) and #1289.
+ *
+ * A "cookie write" here = a `fetch(...)` whose options object sets
+ * `credentials: 'include'` AND a mutating `method` (a `'POST'|'PUT'|'PATCH'|'DELETE'`
+ * literal, or the `method` shorthand a write helper forwards). Such a call must
+ * thread the token — either the literal `'X-CSRF-Token'` header inline, or the
+ * canonical `csrfToken` identifier (some modules build headers with a
+ * `jsonHeaders(csrfToken)` helper). Credentialed GET reads (no `method`) are
+ * untouched. The token variable is `csrfToken` everywhere (from
+ * `useSession().data?.csrfToken`); this is a regression guard on that convention,
+ * not an interprocedural proof — a write that stuffs the token somewhere other than
+ * the request headers would slip past, but nothing does that.
+ *
+ * Run: bun run scripts/lint-csrf-on-writes.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// The web SPA is the only cookie-write caller; the API guards, it does not call.
+const WRITE_ROOTS = ['packages/web/src']
+
+const FETCH_CALL = /\bfetch\s*\(/g
+const CREDENTIALED = /credentials\s*:\s*['"]include['"]/
+const LITERAL_WRITE = /\bmethod\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/i
+// A write helper forwarding a `method` param as an object shorthand: `{ method, ... }`.
+const SHORTHAND_WRITE = /[{,]\s*method\s*[,}]/
+const HAS_CSRF = /['"]x-csrf-token['"]/i
+// The canonical token identifier — covers `headers: jsonHeaders(csrfToken)`, where
+// the literal header name lives in the helper rather than the fetch call itself.
+const HAS_TOKEN_REF = /\bcsrfToken\b/
+
+/**
+ * Splits a source into two length-aligned views. `code` blanks comments AND string
+ * interiors (so brackets/`fetch(` inside strings never miscount); `kept` blanks only
+ * comments, leaving string literals intact so `'POST'` / `'X-CSRF-Token'` stay
+ * searchable. Newlines are preserved in both, so line numbers stay accurate.
+ */
+export function splitSource(source: string): { code: string; kept: string } {
+  const code: string[] = []
+  const kept: string[] = []
+  const push = (a: string, b: string): void => {
+    code.push(a)
+    kept.push(b)
+  }
+  let i = 0
+  const n = source.length
+  while (i < n) {
+    const c = source[i] ?? ''
+    const next = source[i + 1]
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') {
+        push(' ', ' ')
+        i++
+      }
+      continue
+    }
+    if (c === '/' && next === '*') {
+      push(' ', ' ')
+      push(' ', ' ')
+      i += 2
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) {
+        const ch = source[i] === '\n' ? '\n' : ' '
+        push(ch, ch)
+        i++
+      }
+      if (i < n) {
+        push(' ', ' ')
+        push(' ', ' ')
+        i += 2
+      }
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      push(c, c) // opening delimiter, kept in both
+      i++
+      while (i < n && source[i] !== c) {
+        if (source[i] === '\\') {
+          const a = source[i] ?? ''
+          const b = source[i + 1]
+          push(' ', a === '\n' ? '\n' : a)
+          if (b !== undefined) push(' ', b === '\n' ? '\n' : b)
+          i += 2
+          continue
+        }
+        const ch = source[i] ?? ''
+        const nl = ch === '\n'
+        push(nl ? '\n' : ' ', nl ? '\n' : ch)
+        i++
+      }
+      if (i < n) {
+        push(c, c) // closing delimiter
+        i++
+      }
+      continue
+    }
+    push(c, c)
+    i++
+  }
+  return { code: code.join(''), kept: kept.join('') }
+}
+
+/** Index of the `)` that closes the `(` at `openIdx`, or -1. Operates on `code`. */
+function matchParen(code: string, openIdx: number): number {
+  let depth = 0
+  for (let i = openIdx; i < code.length; i++) {
+    const c = code[i]
+    if (c === '(') depth++
+    else if (c === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/** 1-based line numbers of `fetch(` cookie writes that omit `X-CSRF-Token`. */
+export function findCsrfViolations(source: string): number[] {
+  const { code, kept } = splitSource(source)
+  const offending: number[] = []
+  for (const match of code.matchAll(FETCH_CALL)) {
+    const start = match.index
+    const openParen = start + match[0].length - 1
+    const close = matchParen(code, openParen)
+    if (close < 0) continue
+    const segment = kept.slice(openParen, close + 1)
+    if (!CREDENTIALED.test(segment)) continue
+    const isWrite = LITERAL_WRITE.test(segment) || SHORTHAND_WRITE.test(segment)
+    if (!isWrite) continue
+    if (HAS_CSRF.test(segment) || HAS_TOKEN_REF.test(segment)) continue
+    offending.push(code.slice(0, start).split('\n').length)
+  }
+  return offending
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.next') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === 'tests' || entry === '__tests__') continue
+      files.push(...collectSourceFiles(full))
+    } else if (/\.(c|m)?[jt]sx?$/.test(entry) && !/\.test\.(c|m)?[jt]sx?$/.test(entry)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+export interface Violation {
+  file: string
+  line: number
+}
+
+export function scanRoots(roots: readonly string[], cwd: string): Violation[] {
+  const violations: Violation[] = []
+  for (const root of roots) {
+    const abs = join(cwd, root)
+    let files: string[]
+    try {
+      files = collectSourceFiles(abs)
+    } catch {
+      continue // a root may not exist in every checkout — skip it
+    }
+    for (const file of files) {
+      for (const line of findCsrfViolations(readFileSync(file, 'utf8'))) {
+        violations.push({ file: relative(cwd, file), line })
+      }
+    }
+  }
+  return violations
+}
+
+function main(): void {
+  const cwd = new URL('..', import.meta.url).pathname
+  const violations = scanRoots(WRITE_ROOTS, cwd)
+  if (violations.length > 0) {
+    console.error(
+      `[lint-csrf-on-writes] ${violations.length} cookie write(s) missing X-CSRF-Token:`,
+    )
+    for (const v of violations) console.error(`  - ${v.file}:${v.line}`)
+    console.error(
+      '\nThe API CSRF guard 403s any cookie write without a matching token.\n' +
+        "Thread the session token into the request headers: `'X-CSRF-Token': csrfToken`\n" +
+        '(csrfToken from `useSession().data?.csrfToken`), mirroring operator-fees/api.ts.',
+    )
+    process.exit(1)
+  }
+  console.log('[lint-csrf-on-writes] no cookie writes missing X-CSRF-Token')
+}
+
+if (import.meta.main) {
+  main()
+}


### PR DESCRIPTION
## What

Adds `scripts/lint-csrf-on-writes.ts`, a deterministic governance linter that flags any web cookie **write** missing the CSRF token.

## Why

The API mounts a global CSRF guard (`app.use('*', csrf())`, `middleware/csrf.ts`) that 403s any cookie-bearing state-changing request whose headers lack a matching `X-CSRF-Token`. The web SPA has **no shared write helper** — each `packages/web/src/vite/<feature>/api.ts` hand-rolls its `fetch(url, { method, credentials: 'include', headers })`. So `operator-fleet` and `operator-classes` both shipped **tokenless writes** (#1304): `tsc` and the mocked unit tests stayed green, and only the #1257 real-DB E2E surfaced the 403. This is the class of bug a bespoke scanner should catch, in the spirit of `lint-fetch-binding` (#887) and #1289.

## How it detects

A "cookie write" = a `fetch(...)` whose options object sets `credentials: 'include'` **and** a mutating `method` (a `'POST'|'PUT'|'PATCH'|'DELETE'` literal, or the `method` shorthand a write helper forwards). Such a call must thread the token — either the literal `'X-CSRF-Token'` header inline, or the canonical `csrfToken` identifier (some modules build headers with a `jsonHeaders(csrfToken)` helper). Credentialed GET reads (no `method`) are untouched.

- Comment/string-aware source splitting so `fetch(` and brackets inside strings/comments never miscount; balanced-paren extraction survives template-literal URLs with nested parens.
- **Verified green on current `develop`** before wiring into CI (it gates regressions only — the two `jsonHeaders(csrfToken)` modules were the design's key edge case).
- **Mutation-proven** against real source: stripping the token from `operator-fees/api.ts` makes it flag `:73`.

## Wiring

- `package.json`: `lint:csrf-writes`
- `.github/workflows/ci.yml`: new lint step "Check web cookie writes send the CSRF token"
- co-located `scripts/lint-csrf-on-writes.test.ts` (14 cases) runs under the existing `bun test scripts/` CI job

Closes #1325. Follow-up from #1304 / #1311.