### PR TITLE
feat(web): migrate REVIEWS + CANCELLATION to the runtime feature-flag hook

### DIFF
--- a/packages/web/src/vite/bookings/BookingConfirmationView.tsx
+++ b/packages/web/src/vite/bookings/BookingConfirmationView.tsx
@@ -6,7 +6,7 @@ import { CancelBookingDialog } from '@/vite/bookings/CancelBookingDialog'
 import { PreAuthHandoffCard } from '@/vite/bookings/PreAuthHandoffCard'
 import type { BookingDto } from '@/vite/bookings/api'
 import { buildStorefrontSearch } from '@/vite/bookings/storefront-link'
-import { isCancellationEnabled } from '@/vite/config/features'
+import { useFeatureFlag } from '@/vite/config'
 import { IndicativeNote, useIndicative } from '@/vite/currency'
 import { MessageHostLink } from '@/vite/messaging'
 import type { VehicleClassData } from '@/vite/vehicles/classes'
@@ -41,6 +41,7 @@ export function BookingConfirmationView({
   const tCurrency = useTranslations('currency')
   const locale = useLocale()
   const { format: indicativeOf } = useIndicative()
+  const cancellationEnabled = useFeatureFlag('CANCELLATION')
 
   // The base (vehicle-rental) charge is never stored — only composed into
   // totalPrice — so recover it via the documented inverse for the itemised
@@ -204,7 +205,7 @@ export function BookingConfirmationView({
       {/* #856: self-cancel is offered only for a CONFIRMED booking (an ACTIVE/
           COMPLETED/CANCELLED one is past the renter's reach) and only when a CSRF
           token is present to authorize the write. */}
-      {isCancellationEnabled() && booking.status === 'CONFIRMED' && csrfToken && (
+      {cancellationEnabled && booking.status === 'CONFIRMED' && csrfToken && (
         <div className="mt-8 flex justify-center border-t border-border pt-6">
           <CancelBookingDialog
             bookingId={booking.id}

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { isCancellationEnabled } from '@/vite/config/features'
+import { useFeatureFlag } from '@/vite/config'
 import { isOperatorSession } from '@/vite/guards'
 import { CancelBookingDialog } from '@/vite/operator-bookings/CancelBookingDialog'
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
@@ -55,6 +55,7 @@ export function BookingActionsPanel({
   candidatesError = false,
 }: BookingActionsPanelProps) {
   const t = useTranslations('bookings.operator.detail')
+  const cancellationEnabled = useFeatureFlag('CANCELLATION')
   const queryClient = useQueryClient()
   const csrfToken = session?.csrfToken ?? ''
 
@@ -92,7 +93,7 @@ export function BookingActionsPanel({
           {/* Only CONFIRMED bookings can be cancelled — the server 409s any other
               status. An ACTIVE (picked-up) trip is past the cancellation window, so
               we hide the button rather than offer a dead-end action. */}
-          {isCancellationEnabled() && detail.status === 'CONFIRMED' && (
+          {cancellationEnabled && detail.status === 'CONFIRMED' && (
             <CancelBookingDialog bookingId={detail.id} csrfToken={csrfToken} />
           )}
         </div>

--- a/packages/web/src/vite/reservation/ConfirmStep.tsx
+++ b/packages/web/src/vite/reservation/ConfirmStep.tsx
@@ -1,5 +1,5 @@
 import { formatJpy } from '@/lib/format'
-import { isCancellationEnabled } from '@/vite/config/features'
+import { useFeatureFlag } from '@/vite/config'
 import { IndicativeNote, useIndicative } from '@/vite/currency'
 import { useTranslations } from 'use-intl'
 import { CancellationPolicy } from './CancellationPolicy'
@@ -29,6 +29,7 @@ export function ConfirmStep({
 }: ConfirmStepProps) {
   const t = useTranslations('reservation')
   const tCurrency = useTranslations('currency')
+  const cancellationEnabled = useFeatureFlag('CANCELLATION')
   const { format: indicativeOf } = useIndicative()
   // The charge is always JPY; only flag that when a converted figure is on screen.
   const showCurrencyDisclaimer = indicativeOf(estimate.totalJpy) !== null
@@ -74,7 +75,7 @@ export function ConfirmStep({
       {/* #937: self-cancel is gated for the beta demo (#868), so don't advertise the
           tiered policy at checkout when the feature is OFF — it would promise a flow
           the booking confirmation then hides. */}
-      {isCancellationEnabled() && <CancellationPolicy pickupAt={pickupAt} />}
+      {cancellationEnabled && <CancellationPolicy pickupAt={pickupAt} />}
     </section>
   )
 }

--- a/packages/web/src/vite/reservation/cancellation-runtime-toggle.test.tsx
+++ b/packages/web/src/vite/reservation/cancellation-runtime-toggle.test.tsx
@@ -1,0 +1,54 @@
+import { FeatureFlagsProvider } from '@/vite/config'
+import { ConfirmStep } from '@/vite/reservation/ConfirmStep'
+import type { ReservationAddOn } from '@/vite/reservation/api'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+const addOns: ReservationAddOn[] = [
+  { id: 'a1', name: 'Baby seat', description: null, priceJpy: 2000 },
+]
+
+// Proves CANCELLATION is driven by the runtime override layer, not just the
+// build-time env: a DB override wins over the baked-in default at the live UI.
+// ConfirmStep renders the cancellation-policy schedule only when the flag is
+// effectively ON, so the heading's presence is a clean signal for the flag value.
+function renderStep(overrides: FeatureFlagOverrides) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['feature-flags'], overrides)
+  return render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        <FeatureFlagsProvider>
+          <ConfirmStep
+            estimate={{ baseJpy: 16000, insuranceJpy: 3000, totalJpy: 21000 }}
+            selectedAddOns={addOns}
+            insuranceName="Full coverage"
+            pickupAt={new Date('2026-12-01T10:00:00Z')}
+          />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('CANCELLATION runtime override reaches the live UI', () => {
+  it('a server override ON shows the cancellation policy even when the build default is OFF', () => {
+    vi.stubEnv('VITE_FEATURE_CANCELLATION', 'false')
+    renderStep({ CANCELLATION: true })
+    expect(screen.getByRole('heading', { name: 'Cancellation policy' })).toBeInTheDocument()
+  })
+
+  it('a server override OFF hides the cancellation policy even when the build default is ON', () => {
+    vi.stubEnv('VITE_FEATURE_CANCELLATION', 'true')
+    renderStep({ CANCELLATION: false })
+    expect(screen.queryByRole('heading', { name: 'Cancellation policy' })).toBeNull()
+  })
+})

--- a/packages/web/src/vite/reviews/RateRenterPanel.tsx
+++ b/packages/web/src/vite/reviews/RateRenterPanel.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
-import { isReviewsEnabled } from '@/vite/config'
+import { useFeatureFlag } from '@/vite/config'
 import { StarRating } from '@/vite/reviews/StarRating'
 import {
   OPERATOR_RENTER_DIMENSIONS,
@@ -39,6 +39,7 @@ interface RateRenterPanelProps {
 // operator staff), the panel shows a "reviewed" line instead of the form.
 export function RateRenterPanel({ bookingId, bookingCode, csrfToken }: RateRenterPanelProps) {
   const t = useTranslations('reviews.operatorPanel')
+  const reviewsEnabled = useFeatureFlag('REVIEWS')
   const queryClient = useQueryClient()
   const { data: reviews = [] } = useQuery(reviewsForBookingQueryOptions(bookingId))
   const [open, setOpen] = useState(false)
@@ -81,8 +82,8 @@ export function RateRenterPanel({ bookingId, bookingCode, csrfToken }: RateRente
   if (!mutation.isPending && inFlightRef.current) inFlightRef.current = false
 
   // Reviews gated off (#1083-1086) → operators can't rate renters. After all hooks
-  // so rules-of-hooks stays satisfied.
-  if (!isReviewsEnabled()) return null
+  // so rules-of-hooks stays satisfied. Runtime-toggleable.
+  if (!reviewsEnabled) return null
 
   const ready = overall >= 1
   function handleSubmit() {

--- a/packages/web/src/vite/reviews/RatingBadge.tsx
+++ b/packages/web/src/vite/reviews/RatingBadge.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils'
-import { isReviewsEnabled } from '@/vite/config'
+import { useFeatureFlag } from '@/vite/config'
 import type { AggregateEntry } from '@/vite/reviews/api'
 import { useTranslations } from 'use-intl'
 
@@ -16,11 +16,12 @@ interface RatingBadgeProps {
 // each branch by exact text/role.
 export function RatingBadge({ entry, size = 'sm' }: RatingBadgeProps) {
   const t = useTranslations('reviews.aggregate')
+  const reviewsEnabled = useFeatureFlag('REVIEWS')
   const textClass = cn('text-muted-foreground', size === 'sm' ? 'text-xs' : 'text-sm')
 
   // Reviews gated off (#1083-1086): render nothing so no rating surfaces anywhere the
-  // badge is used (storefront + vehicle cards, storefront detail).
-  if (!isReviewsEnabled()) return null
+  // badge is used (storefront + vehicle cards, storefront detail). Runtime-toggleable.
+  if (!reviewsEnabled) return null
 
   if (entry === undefined) {
     return (

--- a/packages/web/src/vite/reviews/ReviewPrompt.tsx
+++ b/packages/web/src/vite/reviews/ReviewPrompt.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { isReviewsEnabled } from '@/vite/config'
+import { useFeatureFlag } from '@/vite/config'
 import { ReviewForm } from '@/vite/reviews/ReviewForm'
 import { pendingReviewSubjects } from '@/vite/reviews/api'
 import { useSession } from '@/vite/session'
@@ -28,13 +28,14 @@ interface ReviewPromptProps {
 // ReviewForm for exactly the pending subjects.
 export function ReviewPrompt({ bookingId, bookingCode, reviewedSubjects }: ReviewPromptProps) {
   const t = useTranslations('reviews.prompt')
+  const reviewsEnabled = useFeatureFlag('REVIEWS')
   const { data: session } = useSession()
   const [open, setOpen] = useState(false)
   const pending = pendingReviewSubjects(reviewedSubjects)
 
   // Reviews gated off (#1083-1086) → no post-trip prompt. Placed with the other
-  // post-hooks guards so rules-of-hooks stays satisfied.
-  if (!isReviewsEnabled() || pending.length === 0 || !session) return null
+  // post-hooks guards so rules-of-hooks stays satisfied. Runtime-toggleable.
+  if (!reviewsEnabled || pending.length === 0 || !session) return null
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/packages/web/src/vite/reviews/reviews-runtime-toggle.test.tsx
+++ b/packages/web/src/vite/reviews/reviews-runtime-toggle.test.tsx
@@ -1,0 +1,44 @@
+import { FeatureFlagsProvider } from '@/vite/config'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+import { RatingBadge } from './RatingBadge'
+
+// Proves REVIEWS is driven by the runtime override layer, not just the build-time
+// env: a DB override wins over the baked-in default at the live UI. RatingBadge is
+// the simplest consumer -- it renders the ★ badge only when the flag is effectively
+// ON, so its presence/absence is a clean signal for the effective flag value.
+function renderBadge(overrides: FeatureFlagOverrides) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['feature-flags'], overrides)
+  return render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        <FeatureFlagsProvider>
+          <RatingBadge entry={{ avg: 4.5, count: 12 }} />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('REVIEWS runtime override reaches the live UI', () => {
+  it('a server override ON renders the badge even when the build default is OFF', () => {
+    vi.stubEnv('VITE_FEATURE_REVIEWS', '')
+    renderBadge({ REVIEWS: true })
+    expect(screen.getByText('★ 4.5 (12)')).toBeInTheDocument()
+  })
+
+  it('a server override OFF hides the badge even when the build default is ON', () => {
+    vi.stubEnv('VITE_FEATURE_REVIEWS', 'true')
+    renderBadge({ REVIEWS: false })
+    expect(screen.queryByText('★ 4.5 (12)')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Runtime feature flags — migrate REVIEWS + CANCELLATION to the hook

Two vertical slices of #1322: swap `isXEnabled()` → `useFeatureFlag('X')` at each consumer so these flags are **live-toggleable** from `/admin/feature-flags`, no rebuild. Follows the `MULTI_CURRENCY` proof shipped in #1314.

Web-only. No schema/API/migration change — the control plane already exists.

### REVIEWS (3 consumers)
- `RatingBadge`, `ReviewPrompt`, `RateRenterPanel` — each already guarded its render after its hooks, so `useFeatureFlag('REVIEWS')` drops in with no rules-of-hooks change.

### CANCELLATION (3 consumers)
- `ConfirmStep`, `BookingActionsPanel`, `BookingConfirmationView` — inline JSX guards become a hook read at the top of each component. Also moves the import from the internal `./config/features` to the `@/vite/config` barrel (module-boundary compliance).

### Why this is safe / incremental
- `effective = override ?? build-time default ?? false`. The build-time `isXEnabled()` functions stay in `features.ts` as the fail-safe env readers (guarded by `features.test.ts`); only the consumers moved.
- Existing env-stub component tests pass **unchanged** — `useFeatureFlag` falls back to the build default when there's no override, so `vi.stubEnv('VITE_FEATURE_*', ...)` still drives them.
- Each flag adds a **runtime-override proof test** (RED before the swap, GREEN after): a DB override wins over the baked-in env default at the live UI, both ON-over-OFF and OFF-over-ON.

### Verification (local, off develop `d1027e4c`)
- Full web suite **1733** (257 files) green · web tsc 0 · vite build 0 (no route drift) · biome + module-boundaries + file-size clean (pre-commit).
- Migration completeness: `isReviewsEnabled`/`isCancellationEnabled` now referenced only by their `features.ts` definition + the `features.test.ts` parity table — no stray consumers.

### Checklist items closed in #1322
- [x] `REVIEWS`
- [x] `CANCELLATION`

Remaining flags (FLEET_TIMELINE, OPERATOR_SETTINGS/TEAM, RENTER_DOCUMENTS, OPERATOR_MANUAL_BOOKING; MESSAGING + OPERATOR_BLOCKS last) stay tracked in #1322 — each is its own slice because they read the flag in plain `.ts` nav modules / route guards, which need a different (non-hook) treatment.

Refs #1322.
