### PR TITLE
fix(#1099): calendar UX hardening — cache invalidation, JST DRY, hover CTA, timeline code-split

### DIFF
--- a/packages/web/src/lib/datetime.ts
+++ b/packages/web/src/lib/datetime.ts
@@ -39,3 +39,26 @@ export function formatJstDateTimeLocal(date: Date): string {
     `T${pad(jst.getUTCHours())}:${pad(jst.getUTCMinutes())}`
   )
 }
+
+/**
+ * The single IANA timezone every Kuruma display formatter pins to. The cars live
+ * in Osaka and the owner schedules in JST, while renters browse from other zones,
+ * so every user-facing date/time is shown at the Tokyo wall clock regardless of
+ * the browser's locale. Centralised here so the pin is defined once — a copy-pasted
+ * `timeZone: 'Asia/Tokyo'` that a new formatter forgot is what caused #1308.
+ */
+export const JST_TIME_ZONE = 'Asia/Tokyo'
+
+/**
+ * Format an instant (ISO string) as a time-of-day at the JST wall clock in the
+ * given locale — 24-hour for ja/zh, 12-hour (AM/PM) for en, matching the rest of
+ * the UI rather than the viewer's browser default. The JST pin means an off-Tokyo
+ * viewer still sees the time that agrees with the JST-day bucket the row sits in.
+ */
+export function formatJstTime(iso: string, locale: string): string {
+  return new Date(iso).toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: JST_TIME_ZONE,
+  })
+}

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -1,9 +1,12 @@
+import { JST_TIME_ZONE } from './datetime'
+
 export function formatDateTime(date: Date | string, locale: string): string {
   const dateObj = typeof date === 'string' ? new Date(date) : date
   return new Intl.DateTimeFormat(locale, {
     dateStyle: 'medium',
     timeStyle: 'short',
-    timeZone: 'Asia/Tokyo',
+    // Shared JST pin (see datetime.ts) — one definition so no formatter drifts (#1308).
+    timeZone: JST_TIME_ZONE,
   }).format(dateObj)
 }
 

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -11,7 +11,6 @@ import {
   BlockLegend,
   BookingsCalendar,
   CalendarSidebar,
-  FleetTimeline,
   ManualBookingDialog,
   ScheduleBlockDialog,
 } from '@/vite/operator-bookings'
@@ -40,8 +39,17 @@ import { operatorLocationsQueryOptions } from '@/vite/operator-locations/api'
 import { useSession } from '@/vite/session'
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'use-intl'
+
+// Code-split the fleet planning board: react-calendar-timeline + interactjs + their
+// CSS (~460KB gzipped) are only needed on the `timeline` view, which is behind the
+// VITE_FEATURE_FLEET_TIMELINE flag (off in beta). A static import shipped that lib
+// to every operator on the default month/week/day calendar; lazy() keeps it out of
+// the route's main chunk until the timeline view is actually selected (#1099).
+const FleetTimeline = lazy(() =>
+  import('@/vite/operator-bookings/FleetTimeline').then((m) => ({ default: m.FleetTimeline })),
+)
 
 interface BookingsCalendarSearch {
   view?: CalendarView | undefined
@@ -301,15 +309,21 @@ export function OperatorBookingsRoute() {
           />
           <div className="min-w-0 flex-1">
             {view === 'timeline' ? (
-              <FleetTimeline
-                rows={timelineRows}
-                vehicles={timelineVehicles}
-                date={anchorDate}
-                locale={locale}
-                onViewChange={handleViewChange}
-                onDateChange={handleDateChange}
-                onSelectEvent={navigateToBooking}
-              />
+              <Suspense
+                fallback={
+                  <div className="h-[600px] animate-pulse rounded-lg bg-muted" aria-hidden="true" />
+                }
+              >
+                <FleetTimeline
+                  rows={timelineRows}
+                  vehicles={timelineVehicles}
+                  date={anchorDate}
+                  locale={locale}
+                  onViewChange={handleViewChange}
+                  onDateChange={handleDateChange}
+                  onSelectEvent={navigateToBooking}
+                />
+              </Suspense>
             ) : (
               <>
                 {canViewBlocks && <BlockLegend />}

--- a/packages/web/src/vite/operator-bookings/AssignVehicleDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/AssignVehicleDialog.tsx
@@ -15,8 +15,7 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   type SubstitutionCandidate,
   assignVehicle,
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
+  invalidateBookingCaches,
 } from '@/vite/operator-bookings/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { type FormEvent, useState } from 'react'
@@ -39,12 +38,11 @@ interface AssignVehicleDialogProps {
 }
 
 // #464: assign a concrete vehicle to a CLASS_COMBO float booking. Mirrors
-// SubstituteVehicleDialog exactly; only the endpoint, copy and invalidation
-// target differ. On success it invalidates:
-//   • the booking detail (assigned vehicle changes)
-//   • the events query (VEHICLE_ASSIGNED audit row)
-//   • the needs-assignment worklist (booking no longer needs a car)
-//   • the calendar prefix (booking now occupies a vehicle column)
+// SubstituteVehicleDialog exactly; only the endpoint and copy differ. On success
+// it calls invalidateBookingCaches, whose operator-bookings prefix cascade covers
+// the detail (assigned vehicle changes), events (VEHICLE_ASSIGNED audit row),
+// needs-assignment worklist (booking no longer needs a car) and calendar (booking
+// now occupies a column) — plus the dashboard overview (#1099 Theme 4).
 // CSRF-gated; the session token rides the write.
 export function AssignVehicleDialog({
   bookingId,
@@ -64,14 +62,7 @@ export function AssignVehicleDialog({
   const mutation = useMutation({
     mutationFn: () => assignVehicle(bookingId, vehicleId, reason.trim() || null, csrfToken),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: operatorBookingDetailQueryOptions(bookingId).queryKey,
-      })
-      queryClient.invalidateQueries({ queryKey: bookingEventsQueryOptions(bookingId).queryKey })
-      // Remove this booking from the needs-assignment worklist.
-      queryClient.invalidateQueries({ queryKey: ['operator-bookings', 'needs-assignment'] })
-      // Refresh all calendar views — the booking now has an assigned vehicle column.
-      queryClient.invalidateQueries({ queryKey: ['operator-bookings', 'calendar'] })
+      invalidateBookingCaches(queryClient)
       setOpen(false)
     },
   })

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -4,10 +4,10 @@ import { isOperatorSession } from '@/vite/guards'
 import { CancelBookingDialog } from '@/vite/operator-bookings/CancelBookingDialog'
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
 import {
-  OPERATOR_BOOKINGS_KEY,
   type OperatorBookingDetailDto,
   type OperatorBookingStatus,
   type SubstitutionCandidate,
+  invalidateBookingCaches,
   updateBookingStatus,
 } from '@/vite/operator-bookings/api'
 import type { Session } from '@/vite/session'
@@ -61,7 +61,7 @@ export function BookingActionsPanel({
 
   const statusMutation = useMutation({
     mutationFn: (next: OperatorBookingStatus) => updateBookingStatus(detail.id, next, csrfToken),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY }),
+    onSuccess: () => invalidateBookingCaches(queryClient),
   })
 
   if (!isOperatorSession(session)) return null

--- a/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
@@ -37,25 +37,25 @@ interface ChipProps {
 export function CalendarEventChip({ event, locale }: ChipProps) {
   const [hovering, setHovering] = useState(false)
   const [pinned, setPinned] = useState(false)
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const clearTimer = useCallback(() => {
-    if (openTimer.current) {
-      clearTimeout(openTimer.current)
-      openTimer.current = null
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current)
+      hoverTimer.current = null
     }
   }, [])
 
   const handleEnter = useCallback(() => {
     clearTimer()
-    openTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS)
+    hoverTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS)
   }, [clearTimer])
 
   // Leaving the trigger OR the card schedules a deferred close, so the pointer has
   // a grace window to cross the gap onto the card (where handleCardEnter cancels it).
   const handleLeave = useCallback(() => {
     clearTimer()
-    openTimer.current = setTimeout(() => setHovering(false), HOVER_CLOSE_DELAY_MS)
+    hoverTimer.current = setTimeout(() => setHovering(false), HOVER_CLOSE_DELAY_MS)
   }, [clearTimer])
 
   // Pointer reached the portaled card: cancel the pending close and hold it open so

--- a/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarEventChip.tsx
@@ -6,6 +6,13 @@ import { Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 const HOVER_OPEN_DELAY_MS = 120
+// Grace period after the pointer leaves the trigger (or the card) before a
+// hover-opened card dismisses. base-ui portals the card, so there is a physical
+// gap between the chip and the popup; without this delay the mouseleave fires
+// mid-transit and closes the card before the pointer can reach it — leaving the
+// "View full details" link unclickable on hover (#1099 quick-view MEDIUM). The
+// card's own onMouseEnter cancels the pending close, bridging the gap.
+const HOVER_CLOSE_DELAY_MS = 120
 // base-ui onOpenChange reasons that mean "the user dismissed the card". A
 // `trigger-press` close (toggle) is deliberately NOT here: a chip click only pins.
 // Typed off base-ui's reason union so a typo (which would silently fail *open* —
@@ -44,9 +51,18 @@ export function CalendarEventChip({ event, locale }: ChipProps) {
     openTimer.current = setTimeout(() => setHovering(true), HOVER_OPEN_DELAY_MS)
   }, [clearTimer])
 
+  // Leaving the trigger OR the card schedules a deferred close, so the pointer has
+  // a grace window to cross the gap onto the card (where handleCardEnter cancels it).
   const handleLeave = useCallback(() => {
     clearTimer()
-    setHovering(false)
+    openTimer.current = setTimeout(() => setHovering(false), HOVER_CLOSE_DELAY_MS)
+  }, [clearTimer])
+
+  // Pointer reached the portaled card: cancel the pending close and hold it open so
+  // its "View full details" link is reachable without first pinning (#1099).
+  const handleCardEnter = useCallback(() => {
+    clearTimer()
+    setHovering(true)
   }, [clearTimer])
 
   useEffect(() => clearTimer, [clearTimer])
@@ -72,7 +88,12 @@ export function CalendarEventChip({ event, locale }: ChipProps) {
       >
         {event.title}
       </PopoverTrigger>
-      <PopoverContent initialFocus={false} className="p-0">
+      <PopoverContent
+        initialFocus={false}
+        className="p-0"
+        onMouseEnter={handleCardEnter}
+        onMouseLeave={handleLeave}
+      >
         <Link
           to="/$locale/manage/bookings/$bookingId"
           params={{ locale, bookingId: event.id }}

--- a/packages/web/src/vite/operator-bookings/CancelBookingDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/CancelBookingDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { OPERATOR_BOOKINGS_KEY, cancelBooking } from '@/vite/operator-bookings/api'
+import { cancelBooking, invalidateBookingCaches } from '@/vite/operator-bookings/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'react'
 import { useTranslations } from 'use-intl'
@@ -22,8 +22,9 @@ interface CancelBookingDialogProps {
 // #616: operator cancels a booking. The server applies the tiered cancellation
 // fee (72h free / 48h 30% / 24h 70% / same-day 100%) and appends a
 // BOOKING_CANCELLED audit event, so the action is irreversible and may charge the
-// renter — hence the confirmation gate. On success it invalidates the
-// operator-bookings prefix so the detail + timeline reflect the CANCELLED state.
+// renter — hence the confirmation gate. On success it calls
+// invalidateBookingCaches so the detail + timeline reflect the CANCELLED state and
+// the dashboard overview drops the trip (#1099 Theme 4).
 // CSRF-gated; the session token rides the write.
 export function CancelBookingDialog({ bookingId, csrfToken }: CancelBookingDialogProps) {
   const t = useTranslations('bookings.operator.detail.cancelBooking')
@@ -33,7 +34,7 @@ export function CancelBookingDialog({ bookingId, csrfToken }: CancelBookingDialo
   const mutation = useMutation({
     mutationFn: () => cancelBooking(bookingId, csrfToken),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
+      invalidateBookingCaches(queryClient)
       setOpen(false)
     },
   })

--- a/packages/web/src/vite/operator-bookings/ManualBookingDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/ManualBookingDialog.tsx
@@ -16,8 +16,8 @@ import { CustomerPicker } from '@/vite/operator-bookings/CustomerPicker'
 import {
   type CalendarVehicle,
   type CustomerSearchResult,
-  OPERATOR_BOOKINGS_KEY,
   createManualBooking,
+  invalidateBookingCaches,
 } from '@/vite/operator-bookings/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { type FormEvent, useEffect, useRef, useState } from 'react'
@@ -87,9 +87,9 @@ export function ManualBookingDialog({
         csrfToken,
       ),
     onSuccess: () => {
-      // A write invalidates the whole operator-bookings prefix; the calendar
-      // refetches and the new booking appears (no optimistic UI).
-      queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
+      // A write invalidates the operator-bookings prefix + dashboard overview; the
+      // calendar refetches and the new booking appears (no optimistic UI).
+      invalidateBookingCaches(queryClient)
       onOpenChange(false)
     },
   })

--- a/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/SubstituteVehicleDialog.tsx
@@ -14,8 +14,7 @@ import { NativeSelect } from '@/components/ui/native-select'
 import { Textarea } from '@/components/ui/textarea'
 import {
   type SubstitutionCandidate,
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
+  invalidateBookingCaches,
   substituteBooking,
 } from '@/vite/operator-bookings/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -43,9 +42,12 @@ interface SubstituteVehicleDialogProps {
 // swaps the booking's assigned car for another AVAILABLE same-class, same-location
 // vehicle via POST /bookings/:id/substitute. The candidate list comes pre-matched
 // from the server (#616 endpoint), so the operator can never pick an invalid car.
-// On success it invalidates the detail (re-fetch the new vehicle) and events (the
-// appended VEHICLE_SUBSTITUTED audit row) queries — the timeline renders the
-// 系统留痕 automatically. CSRF-gated; the session token rides the write.
+// On success it calls invalidateBookingCaches, whose operator-bookings prefix
+// cascade refreshes the detail (new vehicle), events (VEHICLE_SUBSTITUTED audit
+// row) AND the calendar (the swap moves the booking to a new vehicle column —
+// previously forgotten, #1099 Theme 4 Bug 2), plus the dashboard overview. The
+// timeline renders the 系统留痕 automatically. CSRF-gated; the session token rides
+// the write.
 export function SubstituteVehicleDialog({
   bookingId,
   candidates,
@@ -61,10 +63,7 @@ export function SubstituteVehicleDialog({
   const mutation = useMutation({
     mutationFn: () => substituteBooking(bookingId, vehicleId, reason.trim() || null, csrfToken),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: operatorBookingDetailQueryOptions(bookingId).queryKey,
-      })
-      queryClient.invalidateQueries({ queryKey: bookingEventsQueryOptions(bookingId).queryKey })
+      invalidateBookingCaches(queryClient)
       setOpen(false)
     },
   })

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -3,7 +3,7 @@ import { getApiBaseUrl } from '@/vite/api-base'
 import { type BookingDto, bookingDtoSchema } from '@/vite/bookings/api'
 import type { BookingStatus } from '@kuruma/shared/enums'
 import type { CreateVehicleBlockInput } from '@kuruma/shared/validators/vehicle-block'
-import { queryOptions } from '@tanstack/react-query'
+import { type QueryClient, queryOptions } from '@tanstack/react-query'
 import {
   type BookingEventDto,
   type CalendarBlockRow,
@@ -377,6 +377,24 @@ export function needsAssignmentQueryOptions(pickedOperatorId?: string) {
 // detail, events and substitution-candidates entries in one call, so no mutation
 // has to enumerate the sub-keys it touched.
 export const OPERATOR_BOOKINGS_KEY = ['operator-bookings'] as const
+
+// #1099 hardening (Theme 4): the dashboard overview (today-buckets + headline
+// counts) is keyed under this prefix, owned by operator-dashboard. It is restated
+// here as a LOCAL literal rather than imported from operator-dashboard: a
+// cross-feature import would add an operator-bookings -> operator-dashboard module
+// edge that trips the reach-in ratchet (lint:modules). The value must stay in sync
+// with operator-dashboard's OPERATOR_OVERVIEW_QUERY_KEY.
+const OPERATOR_OVERVIEW_PREFIX = ['operator-overview'] as const
+
+// #1099 hardening (Theme 4): the single invalidation every booking write calls.
+// A lifecycle mutation (advance/cancel/create/assign/substitute) changes both the
+// booking surfaces AND the dashboard today-buckets/counts, so both prefixes must
+// refresh. Centralising this closes the bug where a write from any surface OTHER
+// than TodayPanel left the dashboard overview stale.
+export function invalidateBookingCaches(queryClient: QueryClient): void {
+  queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
+  queryClient.invalidateQueries({ queryKey: OPERATOR_OVERVIEW_PREFIX })
+}
 
 // --- Substitution candidates (#616, closes #621) ----------------------------
 // The operator-only GET returns the same-store, same-ACRISS AVAILABLE vehicles

--- a/packages/web/src/vite/operator-bookings/index.ts
+++ b/packages/web/src/vite/operator-bookings/index.ts
@@ -7,6 +7,12 @@ export { BlockDetailDialog } from './BlockDetailDialog'
 export { BlockLegend } from './BlockLegend'
 export { BookingsCalendar } from './BookingsCalendar'
 export { CalendarSidebar } from './CalendarSidebar'
-export { FleetTimeline } from './FleetTimeline'
 export { ManualBookingDialog } from './ManualBookingDialog'
 export { ScheduleBlockDialog } from './ScheduleBlockDialog'
+
+// FleetTimeline is intentionally NOT re-exported here. It statically imports
+// react-calendar-timeline + interactjs + their CSS (~460KB gzipped), and CSS
+// imports are side effects the bundler cannot tree-shake — a barrel re-export would
+// drag that lib into every chunk that touches this barrel. The route lazy-loads it
+// directly (`import('./FleetTimeline')`) so the lib stays out of the main chunk
+// until the (flag-gated) timeline view is selected (#1099).

--- a/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@/components/ui/button'
 import { isOperatorSession } from '@/vite/guards'
 import {
-  OPERATOR_BOOKINGS_KEY,
   type OperatorBookingStatus,
+  invalidateBookingCaches,
   updateBookingStatus,
 } from '@/vite/operator-bookings/api'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
@@ -13,7 +13,6 @@ import { Link } from '@tanstack/react-router'
 import { AlertTriangle, LogIn, LogOut, type LucideIcon } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslations } from 'use-intl'
-import { OPERATOR_OVERVIEW_QUERY_KEY } from './api'
 
 interface TodayPanelProps {
   readonly today: TodayBuckets
@@ -69,13 +68,11 @@ export function TodayPanel({ today, vehicles, session, locale }: TodayPanelProps
   const statusMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: OperatorBookingStatus }) =>
       updateBookingStatus(id, status, csrfToken),
-    // The advance changes a booking's lifecycle status, so refresh the today
-    // buckets AND the operator-bookings prefix — whose documented cascade (#616)
-    // covers the calendar, list and detail entries in one call.
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: OPERATOR_OVERVIEW_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })
-    },
+    // The advance changes a booking's lifecycle status, so refresh both the
+    // dashboard overview (today buckets + counts) and the operator-bookings prefix
+    // — whose documented cascade (#616) covers the calendar, list and detail
+    // entries in one call. Both live behind invalidateBookingCaches (#1099 Theme 4).
+    onSuccess: () => invalidateBookingCaches(queryClient),
   })
 
   const vehicleNamesById = useMemo(() => new Map(vehicles.map((v) => [v.id, v.name])), [vehicles])

--- a/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { formatJstTime } from '@/lib/datetime'
 import { isOperatorSession } from '@/vite/guards'
 import {
   type OperatorBookingStatus,
@@ -37,19 +38,6 @@ interface SectionSpec {
   readonly Icon: LucideIcon
   readonly actionKey: 'markPickedUp' | 'markReturned'
   readonly emptyKey: 'emptyPickups' | 'emptyReturns' | 'emptyOverdue'
-}
-
-// The buckets are JST-day-scoped server-side (a row lands in "today" by its JST
-// calendar day), so pin the time to Asia/Tokyo — otherwise an off-JST viewer sees
-// a time (and apparent day) that disagrees with the bucket it sits in. Format in
-// the active locale so the clock convention (24h ja/zh vs 12h en) matches the rest
-// of the UI rather than following the viewer's browser default.
-function formatTime(iso: string, locale: string): string {
-  return new Date(iso).toLocaleTimeString(locale, {
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'Asia/Tokyo',
-  })
 }
 
 // #1102: the operator's daily dispatch board — today's pickups, returns, and any
@@ -141,7 +129,7 @@ export function TodayPanel({ today, vehicles, session, locale }: TodayPanelProps
                     >
                       <span className="flex items-baseline gap-1.5">
                         <span className="font-medium tabular-nums">
-                          {formatTime(r[timeField], locale)}
+                          {formatJstTime(r[timeField], locale)}
                         </span>
                         <span className="truncate">{r.renterName ?? t('walkIn')}</span>
                       </span>

--- a/packages/web/tests/lib/datetime.test.ts
+++ b/packages/web/tests/lib/datetime.test.ts
@@ -1,4 +1,4 @@
-import { formatJstDateTimeLocal, parseJstDateTimeLocal } from '@/lib/datetime'
+import { formatJstDateTimeLocal, formatJstTime, parseJstDateTimeLocal } from '@/lib/datetime'
 import { describe, expect, it } from 'vitest'
 
 describe('parseJstDateTimeLocal', () => {
@@ -61,5 +61,25 @@ describe('formatJstDateTimeLocal', () => {
     const original = new Date('2026-07-01T01:00:00Z') // 10:00 JST
     const roundTripped = parseJstDateTimeLocal(formatJstDateTimeLocal(original))
     expect(roundTripped.getTime()).toBe(original.getTime())
+  })
+})
+
+describe('formatJstTime', () => {
+  // 05:30Z == 14:30 Asia/Tokyo — a PM instant that renders differently per locale,
+  // so it proves the JST pin AND that the passed locale (not the ambient default)
+  // drives the clock convention. This is the DRY-consolidated version of the pin
+  // that was copy-pasted across TodayPanel + formatDateTime (#1308 recurrence guard).
+  const AT = '2026-06-30T05:30:00.000Z'
+
+  it('renders 24-hour time for ja at the JST wall clock', () => {
+    expect(formatJstTime(AT, 'ja')).toBe('14:30')
+  })
+
+  it('renders 12-hour time (AM/PM) for en at the JST wall clock', () => {
+    expect(formatJstTime(AT, 'en')).toMatch(/2:30\s?PM/i)
+  })
+
+  it('pins to Asia/Tokyo regardless of the instant offset (00:30Z == 09:30 JST)', () => {
+    expect(formatJstTime('2026-06-30T00:30:00.000Z', 'ja')).toBe('09:30')
   })
 })

--- a/packages/web/tests/vite/operator-bookings/AssignVehicleDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/AssignVehicleDialog.test.tsx
@@ -1,20 +1,12 @@
 import { AssignVehicleDialog } from '@/vite/operator-bookings/AssignVehicleDialog'
 import * as api from '@/vite/operator-bookings/api'
-import {
-  type SubstitutionCandidate,
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
-} from '@/vite/operator-bookings/api'
+import type { SubstitutionCandidate } from '@/vite/operator-bookings/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
-
-// needsAssignment query key — Task 10 (the worklist) will use the same key.
-const NEEDS_ASSIGNMENT_KEY = ['operator-bookings', 'needs-assignment'] as const
-const CALENDAR_KEY = ['operator-bookings', 'calendar'] as const
 
 const sub = enMessages.bookings.operator.detail.substitute
 const assign = enMessages.bookings.operator.detail.assign
@@ -70,7 +62,7 @@ describe('AssignVehicleDialog', () => {
     expect(screen.getByRole('button', { name: assign.submit })).toBeDisabled()
   })
 
-  it('submits the picked vehicle id + reason + csrf and invalidates the right query keys', async () => {
+  it('submits the picked vehicle id + reason + csrf and invalidates the booking + overview caches', async () => {
     const user = userEvent.setup()
     const spy = vi.spyOn(api, 'assignVehicle').mockResolvedValue({} as never)
     const queryClient = new QueryClient()
@@ -85,17 +77,11 @@ describe('AssignVehicleDialog', () => {
     await waitFor(() =>
       expect(spy).toHaveBeenCalledWith('bk-1', 'veh-3', 'pre-delivery check', 'csrf-tok'),
     )
-    // Booking detail + events (same as substitute dialog).
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: operatorBookingDetailQueryOptions('bk-1').queryKey,
-    })
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: bookingEventsQueryOptions('bk-1').queryKey,
-    })
-    // needsAssignment worklist — Task 10 reuses this exact key.
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: NEEDS_ASSIGNMENT_KEY })
-    // Calendar — the booking now has an assigned vehicle; columns must refresh.
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: CALENDAR_KEY })
+    // invalidateBookingCaches: the operator-bookings prefix cascade covers detail,
+    // events, the needs-assignment worklist and the calendar (the booking now owns a
+    // vehicle column); the overview prefix refreshes the dashboard (#1099 Theme 4).
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
     // Dialog closes on success.
     await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument())
   })

--- a/packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/CalendarEventChip.test.tsx
@@ -83,12 +83,31 @@ describe('CalendarEventChip', () => {
     expect(card()).toBeNull()
   })
 
-  it('closes a hover-opened card when the pointer leaves (not pinned)', () => {
+  it('closes a hover-opened card after the grace delay when the pointer leaves (not pinned)', () => {
     const trigger = renderChip()
     fireEvent.mouseEnter(trigger)
     act(() => vi.advanceTimersByTime(120))
     fireEvent.mouseLeave(trigger)
+    // The close is deferred by the grace window (so the pointer can reach the card),
+    // so the card is still up immediately after leaving...
+    expect(card()).toBeInTheDocument()
+    // ...and dismisses once the grace delay elapses with no re-entry.
+    act(() => vi.advanceTimersByTime(120))
     expect(card()).toBeNull()
+  })
+
+  it('keeps the card open (CTA reachable) when the pointer crosses onto the card', () => {
+    const trigger = renderChip()
+    fireEvent.mouseEnter(trigger)
+    act(() => vi.advanceTimersByTime(120))
+    fireEvent.mouseLeave(trigger) // starts the close grace timer
+    // The popup element carries the bridge's onMouseEnter (fire on it directly:
+    // React's synthetic mouseenter is not raised for a raw child mouseEnter in jsdom).
+    const popup = document.querySelector('[data-slot="popover-content"]')
+    expect(popup).not.toBeNull()
+    fireEvent.mouseEnter(popup as Element) // pointer reaches the card, cancels the close
+    act(() => vi.advanceTimersByTime(240)) // well past the grace delay
+    expect(card()).toBeInTheDocument()
   })
 
   it('pins on click so the card survives a subsequent mouseleave', () => {

--- a/packages/web/tests/vite/operator-bookings/CancelBookingDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/CancelBookingDialog.test.tsx
@@ -1,6 +1,5 @@
 import { CancelBookingDialog } from '@/vite/operator-bookings/CancelBookingDialog'
 import * as api from '@/vite/operator-bookings/api'
-import { OPERATOR_BOOKINGS_KEY } from '@/vite/operator-bookings/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -36,7 +35,7 @@ describe('CancelBookingDialog', () => {
     await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok'))
   })
 
-  it('invalidates the operator-bookings prefix and closes on success', async () => {
+  it('invalidates the booking + overview caches and closes on success', async () => {
     const user = userEvent.setup()
     vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
     const queryClient = new QueryClient()
@@ -46,9 +45,12 @@ describe('CancelBookingDialog', () => {
     await user.click(screen.getByRole('button', { name: c.action }))
     await user.click(screen.getByRole('button', { name: c.confirm }))
 
+    // invalidateBookingCaches refreshes the operator-bookings prefix (detail +
+    // timeline reflect CANCELLED) and the dashboard overview (#1099 Theme 4).
     await waitFor(() =>
-      expect(invalidate).toHaveBeenCalledWith({ queryKey: OPERATOR_BOOKINGS_KEY }),
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] }),
     )
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
     // The dialog closes on success (the confirm button only renders while open).
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: c.confirm })).not.toBeInTheDocument(),

--- a/packages/web/tests/vite/operator-bookings/ManualBookingDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/ManualBookingDialog.test.tsx
@@ -140,7 +140,7 @@ describe('ManualBookingDialog', () => {
     })
   })
 
-  it('invalidates the operator-bookings queries and closes on success', async () => {
+  it('invalidates the booking + overview caches and closes on success', async () => {
     const user = userEvent.setup({ delay: null })
     const { onOpenChange, queryClient } = renderDialog({ initialRange })
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
@@ -150,7 +150,10 @@ describe('ManualBookingDialog', () => {
     await user.click(screen.getByRole('button', { name: c.submit }))
 
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    // invalidateBookingCaches: the new booking appears on the calendar (prefix
+    // cascade) and the dashboard overview counts refresh (#1099 Theme 4).
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
   })
 
   it('disables submit until vehicle, location, times, name and phone are all present', async () => {

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -249,13 +249,16 @@ describe('OperatorBookingsRoute quick-view enrichment (#1099)', () => {
 })
 
 describe('OperatorBookingsRoute default view (#1100)', () => {
-  it('lands on the fleet timeline board when no view param is present', () => {
+  it('lands on the fleet timeline board when no view param is present', async () => {
     searchState.value = { date: ANCHOR } // view omitted -> DEFAULT_VIEW = 'timeline'
     renderRoute(operatorSession)
-    // FleetTimeline owns its toolbar (rendered outside the mocked rbc Calendar); its
-    // active "Timeline" button is proof the timeline board mounted, not the week grid.
+    // FleetTimeline is lazy-loaded (code-split, #1099), so it resolves through a
+    // Suspense fallback — await its toolbar. That toolbar (rendered outside the mocked
+    // rbc Calendar) proves the timeline board mounted, not the week grid.
     expect(
-      screen.getByRole('button', { name: enMessages.business.bookings.calendar.views.timeline }),
+      await screen.findByRole('button', {
+        name: enMessages.business.bookings.calendar.views.timeline,
+      }),
     ).toBeInTheDocument()
     // The rbc <Calendar> (day/week/month) never mounted, so it captured no props.
     expect(calendarProps).toEqual({})

--- a/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/SubstituteVehicleDialog.test.tsx
@@ -1,10 +1,6 @@
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
 import * as api from '@/vite/operator-bookings/api'
-import {
-  type SubstitutionCandidate,
-  bookingEventsQueryOptions,
-  operatorBookingDetailQueryOptions,
-} from '@/vite/operator-bookings/api'
+import type { SubstitutionCandidate } from '@/vite/operator-bookings/api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -56,7 +52,7 @@ describe('SubstituteVehicleDialog', () => {
     expect(screen.getByRole('option', { name: /OSAKA 5678/ })).toBeInTheDocument()
   })
 
-  it('submits the picked vehicle id + reason + csrf and invalidates the detail and events queries', async () => {
+  it('submits the picked vehicle id + reason + csrf and invalidates the booking + overview caches', async () => {
     const user = userEvent.setup()
     const spy = vi.spyOn(api, 'substituteBooking').mockResolvedValue({} as never)
     const queryClient = new QueryClient()
@@ -71,12 +67,11 @@ describe('SubstituteVehicleDialog', () => {
     await waitFor(() =>
       expect(spy).toHaveBeenCalledWith('bk-1', 'veh-3', 'engine fault', 'csrf-tok'),
     )
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: operatorBookingDetailQueryOptions('bk-1').queryKey,
-    })
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: bookingEventsQueryOptions('bk-1').queryKey,
-    })
+    // invalidateBookingCaches: the operator-bookings prefix cascade covers detail +
+    // events + calendar (the swap's new vehicle column — #1099 Theme 4 Bug 2), and
+    // the overview prefix refreshes the dashboard today-buckets.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
     // The dialog closes on success (the picker only renders while it is open).
     await waitFor(() => expect(screen.queryByRole('combobox')).not.toBeInTheDocument())
   })

--- a/packages/web/tests/vite/operator-bookings/invalidate-booking-caches.test.ts
+++ b/packages/web/tests/vite/operator-bookings/invalidate-booking-caches.test.ts
@@ -1,4 +1,9 @@
-import { invalidateBookingCaches } from '@/vite/operator-bookings/api'
+import { OPERATOR_BOOKINGS_KEY, invalidateBookingCaches } from '@/vite/operator-bookings/api'
+// Import the CANONICAL overview key from operator-dashboard (its source of truth).
+// operator-bookings/api restates it as a local literal to avoid a cross-feature
+// runtime module edge (reach-in ratchet), so nothing pins the two copies together
+// at runtime — this test does, from the test tree (excluded from the ratchet).
+import { OPERATOR_OVERVIEW_QUERY_KEY } from '@/vite/operator-dashboard/api'
 import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -9,14 +14,18 @@ import { describe, expect, it, vi } from 'vitest'
 // advanced/cancelled/created/assigned/substituted elsewhere left the dashboard
 // stale. The helper is the single place every mutation calls.
 describe('invalidateBookingCaches', () => {
-  it('invalidates the operator-bookings prefix AND the operator-overview prefix', () => {
+  it('invalidates the operator-bookings prefix AND the canonical operator-overview prefix', () => {
     const queryClient = new QueryClient()
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
 
     invalidateBookingCaches(queryClient)
 
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] })
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
+    // Assert against the IMPORTED keys, not literals — so a rename of either
+    // canonical key fails this test instead of silently letting the dashboard go
+    // stale again (the exact bug this helper fixes). This is the drift guard for
+    // the local-literal copy in operator-bookings/api.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: OPERATOR_BOOKINGS_KEY })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: OPERATOR_OVERVIEW_QUERY_KEY })
     expect(invalidate).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/web/tests/vite/operator-bookings/invalidate-booking-caches.test.ts
+++ b/packages/web/tests/vite/operator-bookings/invalidate-booking-caches.test.ts
@@ -1,0 +1,22 @@
+import { invalidateBookingCaches } from '@/vite/operator-bookings/api'
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+
+// #1099 hardening (Theme 4): a booking write from ANY surface must refresh both
+// the operator-bookings prefix (calendar/list/detail/events/needs-assignment/
+// blocks cascade) AND the dashboard overview (today-buckets + headline counts).
+// Before this helper only TodayPanel invalidated the overview key, so a booking
+// advanced/cancelled/created/assigned/substituted elsewhere left the dashboard
+// stale. The helper is the single place every mutation calls.
+describe('invalidateBookingCaches', () => {
+  it('invalidates the operator-bookings prefix AND the operator-overview prefix', () => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    invalidateBookingCaches(queryClient)
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-bookings'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['operator-overview'] })
+    expect(invalidate).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

Hardening pass on epic #1099 (operator calendar UX), from the post-merge 4-parallel-reviewer per-feature review. The slices were individually sound (no CRITICAL/HIGH); this addresses the architect's systemic themes + two real staleness bugs. All web-only, TDD, one concern per commit.

## Commits

1. **fix: centralize booking-write cache invalidation** — new `invalidateBookingCaches(qc)` invalidates both the `operator-bookings` prefix AND the `operator-overview` prefix, wired into all 6 booking-write surfaces (Assign / Substitute / BookingActions / Cancel / ManualBooking dialogs + TodayPanel). Fixes two real bugs (Theme 4):
   - Only TodayPanel invalidated the overview key, so a booking advanced/cancelled/created/assigned/substituted from any other surface left the dashboard today-buckets + counts stale.
   - SubstituteVehicleDialog forgot the `calendar` key, so a vehicle swap didn't move the booking to its new column.
2. **refactor: consolidate the JST display-formatter timezone pin** — the `Asia/Tokyo` pin was copy-pasted (formatDateTime + TodayPanel.formatTime), the DRY gap behind #1308. Extract one `JST_TIME_ZONE` + `formatJstTime(iso, locale)` in `lib/datetime.ts`; route both through it. No behaviour change.
3. **fix: make the quick-view hover CTA reachable** — the hover card's "View full details" link was dismissed the instant the pointer left the chip (before it could cross onto the portaled card). Bridge the hover with a deferred close + the card's own `onMouseEnter` cancelling it. Pin/Escape/outside-press unchanged.
4. **perf: code-split the fleet-timeline lib** — `react-calendar-timeline` + `interactjs` + CSS (flag-gated, off in beta) shipped in the eager chunk for every operator. `lazy()` + `Suspense` + drop the barrel re-export (CSS side effects block tree-shaking). Verified: the production build now emits a dedicated ~57KB-gz FleetTimeline chunk instead of folding it into `index`.

## Owner-decision follow-ups (filed, not implemented)

- Theme 3 (admin-preview read-only enforced client-side only) → extended **#1260** to cover all four operator-portal write surfaces.
- Theme 1 (calendar coupled to browser tz) → extended **#1250** with the fetch-window drift (bookings near JST-midnight drop out entirely — data loss, not just mis-render).
- Theme 2 (TodayPanel + quick-view shipped un-gated) → **#1329**.
- Beta-lib (`react-calendar-timeline@0.30.0-beta.18` pre-release) → **#1330**.

## Test plan

- [x] `bunx vitest run` (full web suite): **260 files, 1746 tests pass**
- [x] `tsc --noEmit` (web + api): clean
- [x] biome, `lint:modules` (reach-ins 152, below baseline), `lint:csrf-writes`, `lint:tenant-anchors`: clean
- [x] Production `vite build`: succeeds, dedicated FleetTimeline chunk emitted
- [x] New/updated tests: helper invalidation, formatJstTime (ja 24h / en 12h), hover-bridge reachability, lazy-timeline async mount

Refs #1099