### PR TITLE
feat(web): badge not-yet-migrated feature flags as build-time only

### DIFF
--- a/packages/shared/src/feature-flags/registry.test.ts
+++ b/packages/shared/src/feature-flags/registry.test.ts
@@ -25,6 +25,20 @@ describe('feature flag registry', () => {
     expect(new Set(envs).size).toBe(envs.length)
   })
 
+  it('marks exactly the runtime-migrated flags as runtimeControlled', () => {
+    // A flag is runtimeControlled once a consumer reads it via useFeatureFlag(),
+    // so a dashboard toggle actually takes effect. Flip this to true in the same
+    // slice that migrates the flag (#1322) — the admin page badges the difference.
+    const controlled = FEATURE_FLAG_KEYS.filter((k) => FEATURE_FLAGS[k].runtimeControlled)
+    expect(new Set(controlled)).toEqual(new Set(['MULTI_CURRENCY', 'REVIEWS', 'CANCELLATION']))
+  })
+
+  it('gives every flag an explicit boolean runtimeControlled (no accidental undefined)', () => {
+    for (const key of FEATURE_FLAG_KEYS) {
+      expect(typeof FEATURE_FLAGS[key].runtimeControlled).toBe('boolean')
+    }
+  })
+
   it('isFeatureFlagKey accepts a registered key and rejects anything else', () => {
     expect(isFeatureFlagKey('MULTI_CURRENCY')).toBe(true)
     expect(isFeatureFlagKey('DEFINITELY_NOT_A_FLAG')).toBe(false)

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -8,20 +8,59 @@
 // One row per existing VITE_FEATURE_* flag. VITE_SEARCH_MAP_ENABLED is not a
 // VITE_FEATURE_ flag and stays out of the runtime control plane.
 // See docs/plans/2026-06-30-runtime-feature-flags.md.
+//
+// `runtimeControlled` = at least one consumer reads the flag via useFeatureFlag(),
+// so a dashboard toggle takes effect live. Flip it to true in the same slice that
+// migrates the flag off the build-time isXEnabled() reader (#1322); the admin page
+// badges a not-yet-migrated flag as "build-time only" so its toggle isn't mistaken
+// for a no-op.
 export const FEATURE_FLAGS = {
-  CANCELLATION: { env: 'VITE_FEATURE_CANCELLATION', label: 'Self-service cancellation' },
+  CANCELLATION: {
+    env: 'VITE_FEATURE_CANCELLATION',
+    label: 'Self-service cancellation',
+    runtimeControlled: true,
+  },
   OPERATOR_MANUAL_BOOKING: {
     env: 'VITE_FEATURE_OPERATOR_MANUAL_BOOKING',
     label: 'Operator manual booking',
+    runtimeControlled: false,
   },
-  OPERATOR_TEAM: { env: 'VITE_FEATURE_OPERATOR_TEAM', label: 'Operator team management' },
-  OPERATOR_SETTINGS: { env: 'VITE_FEATURE_OPERATOR_SETTINGS', label: 'Operator settings' },
-  RENTER_DOCUMENTS: { env: 'VITE_FEATURE_RENTER_DOCUMENTS', label: 'Renter document upload' },
-  MESSAGING: { env: 'VITE_FEATURE_MESSAGING', label: 'Renter–operator messaging' },
-  OPERATOR_BLOCKS: { env: 'VITE_FEATURE_OPERATOR_BLOCKS', label: 'Maintenance blocks' },
-  REVIEWS: { env: 'VITE_FEATURE_REVIEWS', label: 'Reviews & ratings' },
-  FLEET_TIMELINE: { env: 'VITE_FEATURE_FLEET_TIMELINE', label: 'Fleet timeline board' },
-  MULTI_CURRENCY: { env: 'VITE_FEATURE_MULTI_CURRENCY', label: 'Multi-currency display' },
+  OPERATOR_TEAM: {
+    env: 'VITE_FEATURE_OPERATOR_TEAM',
+    label: 'Operator team management',
+    runtimeControlled: false,
+  },
+  OPERATOR_SETTINGS: {
+    env: 'VITE_FEATURE_OPERATOR_SETTINGS',
+    label: 'Operator settings',
+    runtimeControlled: false,
+  },
+  RENTER_DOCUMENTS: {
+    env: 'VITE_FEATURE_RENTER_DOCUMENTS',
+    label: 'Renter document upload',
+    runtimeControlled: false,
+  },
+  MESSAGING: {
+    env: 'VITE_FEATURE_MESSAGING',
+    label: 'Renter–operator messaging',
+    runtimeControlled: false,
+  },
+  OPERATOR_BLOCKS: {
+    env: 'VITE_FEATURE_OPERATOR_BLOCKS',
+    label: 'Maintenance blocks',
+    runtimeControlled: false,
+  },
+  REVIEWS: { env: 'VITE_FEATURE_REVIEWS', label: 'Reviews & ratings', runtimeControlled: true },
+  FLEET_TIMELINE: {
+    env: 'VITE_FEATURE_FLEET_TIMELINE',
+    label: 'Fleet timeline board',
+    runtimeControlled: false,
+  },
+  MULTI_CURRENCY: {
+    env: 'VITE_FEATURE_MULTI_CURRENCY',
+    label: 'Multi-currency display',
+    runtimeControlled: true,
+  },
 } as const
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1344,6 +1344,9 @@
       "colState": "State",
       "overridden": "Overridden",
       "default": "Default",
+      "runtimeLive": "Live",
+      "runtimeBuildOnly": "Build-time only",
+      "buildOnlyHint": "This flag isn't wired to the runtime layer yet; toggling persists but has no effect until its migration ships.",
       "toggleLabel": "Toggle {feature}",
       "loadError": "Couldn't load feature flags.",
       "retry": "Retry"

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1344,6 +1344,9 @@
       "colState": "状態",
       "overridden": "上書き中",
       "default": "デフォルト",
+      "runtimeLive": "即時反映",
+      "runtimeBuildOnly": "ビルド時のみ",
+      "buildOnlyHint": "このフラグはまだランタイム制御に接続されていません。切り替えは保存されますが、移行が完了するまで反映されません。",
       "toggleLabel": "{feature}を切り替え",
       "loadError": "機能フラグを読み込めませんでした。",
       "retry": "再試行"

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1344,6 +1344,9 @@
       "colState": "状态",
       "overridden": "已覆盖",
       "default": "默认",
+      "runtimeLive": "实时生效",
+      "runtimeBuildOnly": "仅构建时",
+      "buildOnlyHint": "此开关尚未接入运行时控制层，切换会保存但在其迁移上线前不会生效。",
       "toggleLabel": "切换{feature}",
       "loadError": "无法加载功能开关。",
       "retry": "重试"

--- a/packages/web/src/routes/$locale/_admin/admin/feature-flags/index.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/feature-flags/index.tsx
@@ -41,6 +41,7 @@ function FeatureFlagsRoute() {
     label: FEATURE_FLAGS[key].label,
     effective: map[key] ?? isBuildTimeEnabled(key),
     overridden: map[key] !== undefined,
+    runtimeControlled: FEATURE_FLAGS[key].runtimeControlled,
   }))
 
   const pendingKey = mutation.isPending ? (mutation.variables?.key ?? null) : null

--- a/packages/web/src/vite/admin/feature-flags/FeatureFlagsView.test.tsx
+++ b/packages/web/src/vite/admin/feature-flags/FeatureFlagsView.test.tsx
@@ -6,8 +6,20 @@ import { type FeatureFlagRow, FeatureFlagsView } from './FeatureFlagsView'
 
 function sampleRows(): FeatureFlagRow[] {
   return [
-    { key: 'MULTI_CURRENCY', label: 'Multi-currency display', effective: true, overridden: true },
-    { key: 'REVIEWS', label: 'Reviews & ratings', effective: false, overridden: false },
+    {
+      key: 'MULTI_CURRENCY',
+      label: 'Multi-currency display',
+      effective: true,
+      overridden: true,
+      runtimeControlled: true,
+    },
+    {
+      key: 'REVIEWS',
+      label: 'Reviews & ratings',
+      effective: false,
+      overridden: false,
+      runtimeControlled: true,
+    },
   ]
 }
 
@@ -39,6 +51,29 @@ describe('FeatureFlagsView', () => {
     renderView()
     expect(screen.getByText('Overridden')).toBeInTheDocument()
     expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('badges a runtime-controlled flag as live and a not-yet-migrated one as build-time only', () => {
+    renderView({
+      rows: [
+        {
+          key: 'MULTI_CURRENCY',
+          label: 'Multi-currency display',
+          effective: true,
+          overridden: true,
+          runtimeControlled: true,
+        },
+        {
+          key: 'OPERATOR_TEAM',
+          label: 'Operator team management',
+          effective: false,
+          overridden: false,
+          runtimeControlled: false,
+        },
+      ],
+    })
+    expect(screen.getByText('Live')).toBeInTheDocument()
+    expect(screen.getByText('Build-time only')).toBeInTheDocument()
   })
 
   it('toggling a flag calls onToggle with the negated value', () => {

--- a/packages/web/src/vite/admin/feature-flags/FeatureFlagsView.tsx
+++ b/packages/web/src/vite/admin/feature-flags/FeatureFlagsView.tsx
@@ -9,6 +9,10 @@ export interface FeatureFlagRow {
   readonly effective: boolean
   /** True when a DB override is set (vs. following the build-time default). */
   readonly overridden: boolean
+  /** True once a consumer reads the flag via useFeatureFlag(), so its toggle takes
+   *  effect live; false = build-time only (the toggle persists but is inert until
+   *  that flag's runtime migration ships). Surfaced so a no-op toggle is honest. */
+  readonly runtimeControlled: boolean
 }
 
 interface FeatureFlagsViewProps {
@@ -54,8 +58,20 @@ export function FeatureFlagsView({ rows, pendingKey, onToggle }: FeatureFlagsVie
             {rows.map((row) => (
               <tr key={row.key} className="border-border border-b last:border-0">
                 <td className="px-3 py-3">
-                  <span className="font-medium">{row.label}</span>
-                  <span className="ml-2 text-muted-foreground text-xs">{row.key}</span>
+                  <div>
+                    <span className="font-medium">{row.label}</span>
+                    <span className="ml-2 text-muted-foreground text-xs">{row.key}</span>
+                  </div>
+                  <span
+                    className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs ${
+                      row.runtimeControlled
+                        ? 'bg-emerald-500/10 text-emerald-600'
+                        : 'bg-amber-500/10 text-amber-600'
+                    }`}
+                    title={row.runtimeControlled ? undefined : t('buildOnlyHint')}
+                  >
+                    {row.runtimeControlled ? t('runtimeLive') : t('runtimeBuildOnly')}
+                  </span>
                 </td>
                 <td className="px-3 py-3">
                   <span


### PR DESCRIPTION
## Badge not-yet-migrated feature flags as "build-time only"

The admin `/admin/feature-flags` page lists every registry flag with a working toggle, but only flags whose consumers read `useFeatureFlag()` actually respond to a DB override. Toggling a not-yet-migrated flag (7 of 10 today) persisted a row but silently did nothing — a real footgun on the platform-owner surface.

This closes that gap for **all** remaining flags in one small change (an alternative to migrating each flag before the UI is honest).

### What changed
- **shared registry** — new `runtimeControlled: boolean` per flag: `true` for the migrated `MULTI_CURRENCY` / `REVIEWS` / `CANCELLATION`, `false` for the other 7. Two registry tests pin the set + that every flag carries an explicit boolean.
- **admin view** — each row now badges **Live** (emerald) vs **Build-time only** (amber, with a `title` hint: "toggling persists but has no effect until its migration ships"). Route threads the field into the rows.
- **i18n** — `runtimeLive` / `runtimeBuildOnly` / `buildOnlyHint` in en/ja/zh.

### Self-documenting
`runtimeControlled` is flipped to `true` in the same slice that migrates each remaining flag (#1322) — the registry comment says so, so the badge can never drift from reality without someone editing the same file they're already touching.

### Verification (local, off develop `be6def1f`)
- shared **847** · api unit **2452** · full web **1742** · web tsc 0 · vite build 0 (no route drift) · i18n parity green · biome/boundaries/file-size clean (pre-commit).
- TDD: registry field (RED→GREEN) and the view badge (RED→GREEN), both mutation-resistant.

Refs #1322.
