### PR TITLE
test(#1232): pin tstzrange [) block-vs-booking adjacency on real pg

### DIFF
--- a/packages/api/tests/integration/booking-vehicle-block.test.ts
+++ b/packages/api/tests/integration/booking-vehicle-block.test.ts
@@ -257,4 +257,26 @@ describe('block-vs-booking guard (real pg, #1196)', () => {
     expect(res.ok).toBe(true)
     if (res.ok) createdBlockIds.push(res.block.id)
   })
+
+  it('allows a block whose start touches the booking effectiveEndAt exactly (half-open [), no overlap)', async () => {
+    const vehicleId = await seedVehicle('Block Over Booking Car 4')
+    const booked = await bookVehicle(vehicleId)
+    expect(booked.ok).toBe(true)
+    if (booked.ok) createdBookingIds.push(booked.booking.id)
+
+    // Booking endAt 09:00 + 60-min turnaround => effectiveEndAt 2027-10-02T10:00:00Z.
+    // A block starting at that exact instant shares only the closed-open boundary, so
+    // under `tstzrange [)` bounds the ranges do NOT overlap. Pins the boundary on real
+    // pg (the in-memory unit test covers it; #1232) so a switch to inclusive `[]` bounds
+    // would fail the e2e-real-db job, not slip through.
+    const res = await vehicleBlockService.createBlock(opCtx, vehicleId, {
+      kind: 'MAINTENANCE',
+      reason: 'adjacent',
+      startAt: '2027-10-02T10:00:00.000Z',
+      endAt: '2027-10-02T16:00:00.000Z',
+    })
+
+    expect(res.ok).toBe(true)
+    if (res.ok) createdBlockIds.push(res.block.id)
+  })
 })


### PR DESCRIPTION
## Summary

Low-severity test-hardening follow-up from the #1196 maintainability review. The exact half-open `tstzrange [)` boundary — a block whose `startAt` equals the booking's `effectiveEndAt` is **allowed** (no overlap) — was pinned only in the in-memory unit test (`services/vehicle-block.test.ts`), not on real pg. A mutation to inclusive `[]` bounds in `booking.ts` `findActiveOverlappingForVehicle` would slip past the e2e-real-db job.

Adds one case to the `block-vs-booking guard (real pg, #1196)` describe in `packages/api/tests/integration/booking-vehicle-block.test.ts`. Booking `endAt 2027-10-02T09:00Z` + 60-min turnaround → `effectiveEndAt 2027-10-02T10:00:00Z`; a block starting at that exact instant is asserted allowed.

Test-only. No source change.

Closes #1232.

## Verification

- Real-pg run (docker postgres:16): the `booking-vehicle-block` suite passes 7/7 (was 6).
- **RED-verified**: flipping `booking.ts:250` to `tstzrange("startAt", "effectiveEndAt", '[]')` makes ONLY the new adjacency case fail (`expected false to be true`); the other 6 pass. Restoring passes. The test catches exactly the mutation it guards against.