### PR TITLE
test(#1099): deflake operator-bookings default-view test (mock lazy FleetTimeline)

### DIFF
--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -57,6 +57,16 @@ vi.mock('react-big-calendar', async (importOriginal) => ({
   },
 }))
 
+// #1331 fallout: FleetTimeline statically imports react-calendar-timeline + interactjs
+// (~460KB) and is lazy()-loaded by the route (#1099 code-split). Loading the real module
+// through Suspense races findByRole's poll on a cold CI runner -> an intermittent timeout.
+// Mock it to a light marker so the lazy import resolves deterministically; the default-view
+// test only needs to prove FleetTimeline (not the rbc week grid) mounted. FleetTimeline's
+// own toolbar/behavior stays covered by FleetTimeline.test.tsx.
+vi.mock('@/vite/operator-bookings/FleetTimeline', () => ({
+  FleetTimeline: () => <div data-testid="fleet-timeline" />,
+}))
+
 const ANCHOR = '2026-07-01'
 // Seed both the week range (the explicit-view tests) and the timeline range (the
 // default landing view) for the same anchor day, so whichever view the component
@@ -252,14 +262,10 @@ describe('OperatorBookingsRoute default view (#1100)', () => {
   it('lands on the fleet timeline board when no view param is present', async () => {
     searchState.value = { date: ANCHOR } // view omitted -> DEFAULT_VIEW = 'timeline'
     renderRoute(operatorSession)
-    // FleetTimeline is lazy-loaded (code-split, #1099), so it resolves through a
-    // Suspense fallback — await its toolbar. That toolbar (rendered outside the mocked
-    // rbc Calendar) proves the timeline board mounted, not the week grid.
-    expect(
-      await screen.findByRole('button', {
-        name: enMessages.business.bookings.calendar.views.timeline,
-      }),
-    ).toBeInTheDocument()
+    // FleetTimeline is lazy-loaded (code-split, #1099) and mocked here to a marker
+    // (the real react-calendar-timeline lib makes the dynamic import flaky). Finding the
+    // marker proves the default view resolved to the timeline board, not the week grid.
+    expect(await screen.findByTestId('fleet-timeline')).toBeInTheDocument()
     // The rbc <Calendar> (day/week/month) never mounted, so it captured no props.
     expect(calendarProps).toEqual({})
   })


### PR DESCRIPTION
## Problem
`OperatorBookingsRoute.test.tsx` (#1100 "lands on the fleet timeline board") is **flaky on develop** and has been intermittently red-flagging `test-and-build` across the swarm (seen on #1328, #1316; passed by luck on #1331's own CI and #1334).

## Root cause
#1331 (already merged) code-split `FleetTimeline` behind `lazy()`/`<Suspense>` and updated this test to `await` the toolbar — but never added a `vi.mock` for the component (the file mocks `react-big-calendar` but not this). So the test dynamically imports the **real** `react-calendar-timeline` + `interactjs` (~460KB) and races `findByRole`'s 1000ms poll:
- warm runner → import resolves in time → pass
- cold runner → the `h-[600px] animate-pulse` Suspense fallback is still mounted → `findByRole` times out → fail

## Fix
Mock `FleetTimeline` to a light marker (`<div data-testid="fleet-timeline" />`) so the lazy import resolves deterministically. The default-view test only needs to prove the route resolved to the timeline board (not the rbc week grid) — the marker plus `calendarProps === {}` asserts exactly that. `FleetTimeline`'s own toolbar/behavior stays covered by `FleetTimeline.test.tsx`. This mirrors the file's existing `react-big-calendar` mock.

Scope: only `OperatorBookingsRoute.test.tsx:252` rendered the real lazy `FleetTimeline`, so this is the sole flake site.

## Verification
- Target test: 3/3 deterministic green at ~310ms (was ~163s heavy-lib load).
- Full web suite: **260 files / 1747 tests pass** (was `1 failed | 1746 passed`).
- `bun run --filter @kuruma/web typecheck`: clean.
- biome + lint:size + lint:modules (pre-commit hook): clean.

Follow-up to #1331 · unblocks #1328, #1316.