### PR TITLE
feat(web): gate operator Today panel (#1102) + calendar quick-view (#1282) behind per-feature flags

### DIFF
--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -61,6 +61,16 @@ export const FEATURE_FLAGS = {
     label: 'Multi-currency display',
     runtimeControlled: true,
   },
+  OPERATOR_TODAY: {
+    env: 'VITE_FEATURE_OPERATOR_TODAY',
+    label: 'Operator today panel',
+    runtimeControlled: false,
+  },
+  CALENDAR_QUICKVIEW: {
+    env: 'VITE_FEATURE_CALENDAR_QUICKVIEW',
+    label: 'Calendar quick-view',
+    runtimeControlled: false,
+  },
 } as const
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import {
   featureFlagsQueryOptions,
+  isCalendarQuickViewEnabled,
   isOperatorBlocksEnabled,
   isOperatorManualBookingEnabled,
   isVisibleToViewer,
@@ -141,6 +142,11 @@ export function OperatorBookingsRoute() {
   const canViewBlocks = isVisibleToViewer(isOperatorBlocksEnabled(), session?.user.role)
   const canManageBlocks = canViewBlocks && isOperatorSession(session ?? null)
 
+  // The booking quick-view chip (#1282) is gated OFF for the beta MVP (#1329). When
+  // off, a booking band is a plain link-less span, so booking navigation moves back
+  // to the rbc event-click (handleSelectEvent) — the pre-#1282 baseline.
+  const quickViewEnabled = isCalendarQuickViewEnabled()
+
   // Block dialogs: a schedule (create) form and a click-to-view detail. The schedule
   // slot prefill carries the clicked vehicle + range; the detail dialog is keyed on
   // the selected block.
@@ -253,15 +259,22 @@ export function OperatorBookingsRoute() {
     [navigate, locale],
   )
 
-  const handleSelectEvent = useCallback((item: CalendarItem) => {
-    // #1101: dispatch by the discriminant. A block opens its detail dialog (view +
-    // delete). A booking is handled by the CalendarEventChip's own popover
-    // (hover-peek / click-pin), whose inner <Link> owns navigation — so an rbc
-    // event-click is a no-op for bookings here; navigating would defeat the pin.
-    if (item.type === 'block') {
-      setSelectedBlock(item)
-    }
-  }, [])
+  const handleSelectEvent = useCallback(
+    (item: CalendarItem) => {
+      // #1101: dispatch by the discriminant. A block opens its detail dialog (view +
+      // delete).
+      if (item.type === 'block') {
+        setSelectedBlock(item)
+        return
+      }
+      // Booking: with the quick-view chip ON (#1282), its inner <Link> owns
+      // navigation and an rbc event-click must stay a no-op (navigating would defeat
+      // the pin). With the chip gated OFF (#1329) the band is link-less, so restore
+      // the pre-#1282 baseline — the click navigates to the booking detail.
+      if (!quickViewEnabled) navigateToBooking(item.id)
+    },
+    [quickViewEnabled, navigateToBooking],
+  )
 
   // Both the header button and a calendar slot-click open the dialog; a slot also
   // prefills the pickup/return range (the button opens an empty range).

--- a/packages/web/src/vite/config/feature-flags-runtime.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.ts
@@ -28,6 +28,8 @@ const BUILD_TIME_READERS: Record<FeatureFlagKey, () => boolean> = {
   REVIEWS: () => isEnvTrue(import.meta.env.VITE_FEATURE_REVIEWS),
   FLEET_TIMELINE: () => isEnvTrue(import.meta.env.VITE_FEATURE_FLEET_TIMELINE),
   MULTI_CURRENCY: () => isEnvTrue(import.meta.env.VITE_FEATURE_MULTI_CURRENCY),
+  OPERATOR_TODAY: () => isEnvTrue(import.meta.env.VITE_FEATURE_OPERATOR_TODAY),
+  CALENDAR_QUICKVIEW: () => isEnvTrue(import.meta.env.VITE_FEATURE_CALENDAR_QUICKVIEW),
 }
 
 export function isBuildTimeEnabled(key: FeatureFlagKey): boolean {

--- a/packages/web/src/vite/config/features.ts
+++ b/packages/web/src/vite/config/features.ts
@@ -81,3 +81,25 @@ export function isFleetTimelineEnabled(): boolean {
 export function isMultiCurrencyEnabled(): boolean {
   return isEnvTrue(import.meta.env.VITE_FEATURE_MULTI_CURRENCY)
 }
+
+/**
+ * Operator "Today" dispatch panel (#1102): the dashboard's pickups / returns /
+ * overdue board with one-click status advances. Shipped un-gated in #1099; gated
+ * OFF here for the beta MVP so the demo dashboard mirrors the contracted scope.
+ * Operator-only surface, so it is uniformly on/off. Build-time only for now
+ * (runtime migration tracked by #1322).
+ */
+export function isOperatorTodayEnabled(): boolean {
+  return isEnvTrue(import.meta.env.VITE_FEATURE_OPERATOR_TODAY)
+}
+
+/**
+ * Calendar booking quick-view chip (#1282): the hover-peek / click-pin popover on
+ * each operator booking band. Shipped un-gated in #1099; gated OFF here for the
+ * beta MVP — the calendar falls back to a plain, non-interactive booking band.
+ * Operator-only surface, so it is uniformly on/off. Build-time only for now
+ * (runtime migration tracked by #1322).
+ */
+export function isCalendarQuickViewEnabled(): boolean {
+  return isEnvTrue(import.meta.env.VITE_FEATURE_CALENDAR_QUICKVIEW)
+}

--- a/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
@@ -1,5 +1,5 @@
 import { localizer } from '@/lib/rbc-localizer'
-import { useFeatureFlag } from '@/vite/config'
+import { isCalendarQuickViewEnabled, useFeatureFlag } from '@/vite/config'
 import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
 import { CalendarToolbar } from '@/vite/operator-bookings/CalendarToolbar'
 import {
@@ -62,6 +62,10 @@ export function BookingsCalendar({
   // The Timeline option in the switcher follows the runtime-toggleable flag (#1322):
   // a dashboard override flips it live, falling back to the build-time default.
   const timelineEnabled = useFeatureFlag('FLEET_TIMELINE')
+  // The booking quick-view chip (#1282) is gated OFF for the beta MVP (#1329);
+  // when off, a booking renders as a plain band like a block. Build-time flag for
+  // now (runtime migration tracked by #1322).
+  const quickViewEnabled = isCalendarQuickViewEnabled()
 
   const toolbarLabel = useMemo(() => {
     const fmt = (opts: Intl.DateTimeFormatOptions) =>
@@ -132,13 +136,13 @@ export function BookingsCalendar({
     () => ({
       toolbar: () => null,
       event: (props: EventProps<CalendarItem>) =>
-        props.event.type === 'booking' ? (
+        props.event.type === 'booking' && quickViewEnabled ? (
           <CalendarEventChip event={props.event} locale={locale} />
         ) : (
           <span className="truncate">{props.event.title}</span>
         ),
     }),
-    [locale],
+    [locale, quickViewEnabled],
   )
 
   const messages = useMemo(

--- a/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
+++ b/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
@@ -1,3 +1,4 @@
+import { isOperatorTodayEnabled } from '@/vite/config'
 import { TodayPanel } from '@/vite/operator-dashboard/TodayPanel'
 import { ComplianceBanner } from '@/vite/operator-fleet/ComplianceBanner'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
@@ -45,7 +46,16 @@ export function OperatorDashboardView({
 
         <ComplianceBanner vehicles={vehicles} locale={locale} />
 
-        <TodayPanel today={overview.today} vehicles={vehicles} session={session} locale={locale} />
+        {/* #1102 Today panel, gated OFF for the beta MVP (#1329). The panel also
+            self-gates to an operator session; this flag hides it entirely otherwise. */}
+        {isOperatorTodayEnabled() && (
+          <TodayPanel
+            today={overview.today}
+            vehicles={vehicles}
+            session={session}
+            locale={locale}
+          />
+        )}
 
         <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {tiles.map(({ label, icon: Icon, value }) => (

--- a/packages/web/src/vite/vite-env.d.ts
+++ b/packages/web/src/vite/vite-env.d.ts
@@ -20,6 +20,8 @@ interface ImportMetaEnv {
   readonly VITE_FEATURE_REVIEWS?: string
   readonly VITE_FEATURE_FLEET_TIMELINE?: string
   readonly VITE_FEATURE_MULTI_CURRENCY?: string
+  readonly VITE_FEATURE_OPERATOR_TODAY?: string
+  readonly VITE_FEATURE_CALENDAR_QUICKVIEW?: string
   // Browser Sentry (#765). DSN absent → instrumentation is a no-op. Release is
   // injected by CI at build time; environment defaults to 'production'.
   readonly VITE_SENTRY_DSN?: string

--- a/packages/web/tests/vite/config/features.test.ts
+++ b/packages/web/tests/vite/config/features.test.ts
@@ -1,10 +1,12 @@
 import {
+  isCalendarQuickViewEnabled,
   isCancellationEnabled,
   isFleetTimelineEnabled,
   isMultiCurrencyEnabled,
   isOperatorManualBookingEnabled,
   isOperatorSettingsEnabled,
   isOperatorTeamEnabled,
+  isOperatorTodayEnabled,
   isRenterDocumentsEnabled,
   isReviewsEnabled,
 } from '@/vite/config/features'
@@ -22,6 +24,8 @@ const FLAGS = [
   { name: 'VITE_FEATURE_REVIEWS', read: isReviewsEnabled },
   { name: 'VITE_FEATURE_FLEET_TIMELINE', read: isFleetTimelineEnabled },
   { name: 'VITE_FEATURE_MULTI_CURRENCY', read: isMultiCurrencyEnabled },
+  { name: 'VITE_FEATURE_OPERATOR_TODAY', read: isOperatorTodayEnabled },
+  { name: 'VITE_FEATURE_CALENDAR_QUICKVIEW', read: isCalendarQuickViewEnabled },
 ] as const
 
 describe('post-MVP feature flags', () => {

--- a/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
@@ -9,7 +9,7 @@ import { render, within } from '@testing-library/react'
 import type { ComponentType } from 'react'
 import type { EventProps, SlotInfo } from 'react-big-calendar'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 // Capture the props handed to react-big-calendar's <Calendar> so the slot-selection
@@ -73,6 +73,13 @@ describe('BookingsCalendar slot-selection seam (#589 1d)', () => {
 // A booking becomes the interactive chip; a block stays a plain, non-interactive band
 // whose click still flows through onSelectEvent to the block-detail dialog.
 describe('BookingsCalendar event rendering (quick-view chip vs block band)', () => {
+  // The quick-view chip (#1282) is gated by VITE_FEATURE_CALENDAR_QUICKVIEW; the
+  // chip tests below opt it on, and one asserts the flag-OFF fallback. Reset per test
+  // so a stub never leaks into the next.
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   const bookingItem: BookingCalendarEvent = {
     type: 'booking',
     id: 'bk-1',
@@ -120,7 +127,8 @@ describe('BookingsCalendar event rendering (quick-view chip vs block band)', () 
     expect(typeof (calendarProps.components as { event?: unknown }).event).toBe('function')
   })
 
-  it('renders a booking as the interactive quick-view chip (a button)', () => {
+  it('renders a booking as the interactive quick-view chip (a button) when the flag is ON', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', 'true')
     const { container } = renderEvent(bookingItem)
     expect(within(container).getByRole('button', { name: /Jane Doe/ })).toBeInTheDocument()
   })
@@ -129,6 +137,13 @@ describe('BookingsCalendar event rendering (quick-view chip vs block band)', () 
     const { container } = renderEvent(blockItem)
     expect(within(container).queryByRole('button')).toBeNull()
     expect(within(container).getByText('Oil change')).toBeInTheDocument()
+  })
+
+  it('renders a booking as a plain band (no chip) when the quick-view flag is OFF (#1329)', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', undefined)
+    const { container } = renderEvent(bookingItem)
+    expect(within(container).queryByRole('button')).toBeNull()
+    expect(within(container).getByText('Jane Doe')).toBeInTheDocument()
   })
 
   it('keeps onSelectEvent wired so a block click still reaches the detail dialog', () => {

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -320,6 +320,9 @@ describe('OperatorBookingsRoute blocks layer (#1101)', () => {
   })
 
   it('does not navigate on a calendar booking click (its chip Link owns it) but opens the detail dialog for a block', () => {
+    // Chip ON is the precondition for "its Link owns navigation" (#1282); with it OFF
+    // the band click navigates instead — asserted by the #1329 sibling test below.
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', 'true')
     vi.stubEnv('VITE_FEATURE_OPERATOR_BLOCKS', 'true')
     renderRoute(operatorSession, blocksFleet, [], {
       bookings: [calendarBooking],
@@ -338,6 +341,24 @@ describe('OperatorBookingsRoute blocks layer (#1101)', () => {
     // A block still routes through the shared handler to open its detail dialog.
     act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(block))
     expect(screen.getByText(B.detail.dialogTitle)).toBeInTheDocument()
+  })
+
+  it('navigates to the booking detail on a calendar booking click when the quick-view chip is gated OFF (#1329)', () => {
+    // With the chip flag OFF the band is a plain, link-less span, so the pre-#1282
+    // baseline must be restored: the rbc event-click navigates to the detail page.
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', undefined)
+    renderRoute(operatorSession, blocksFleet, [], { bookings: [calendarBooking] })
+
+    const booking = (calendarProps.events as { type: string; id: string }[]).find(
+      (e) => e.type === 'booking',
+    )
+    act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(booking))
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/$locale/manage/bookings/$bookingId',
+        params: expect.objectContaining({ bookingId: 'bk-1' }),
+      }),
+    )
   })
 
   it('prefills the schedule dialog with the slot vehicle for a managing operator', async () => {

--- a/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
@@ -1,11 +1,12 @@
 import { OperatorDashboardView } from '@/vite/operator-dashboard/OperatorDashboardView'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
+import type { Session } from '@/vite/session'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
 // The view mounts the compliance banner (#916 §5.5), which links to the fleet via
@@ -63,22 +64,40 @@ function vehicle(overrides: Partial<OperatorFleetVehicle> = {}): OperatorFleetVe
   }
 }
 
-// session=null: the #1102 Today panel gates itself off for a non-operator viewer,
-// so it renders nothing and stays clear of these tiles/compliance assertions. The
+const OPERATOR_SESSION: Session = {
+  user: { id: 'u_op', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'osaka' },
+  csrfToken: 'test-csrf',
+}
+
+const TODAY_PANEL_TITLE = enMessages.business.today.title
+
+// session defaults to null: the #1102 Today panel gates itself off for a non-operator
+// viewer, so it renders nothing and stays clear of these tiles/compliance assertions.
+// It is ALSO gated behind VITE_FEATURE_OPERATOR_TODAY (#1329, default OFF), so the
+// panel-visibility tests pass an operator session AND stub the flag. The
 // QueryClientProvider is still required — TodayPanel calls useQueryClient/useMutation
 // before its early return (rules of hooks).
-function renderDashboard(vehicles: OperatorFleetVehicle[]) {
+function renderDashboard(vehicles: OperatorFleetVehicle[], session: Session | null = null) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
-        <OperatorDashboardView overview={overview} vehicles={vehicles} session={null} locale="en" />
+        <OperatorDashboardView
+          overview={overview}
+          vehicles={vehicles}
+          session={session}
+          locale="en"
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
 }
 
 describe('OperatorDashboardView', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('renders the three operator stat tiles', () => {
     renderDashboard([vehicle()])
     expect(screen.getByText('12')).toBeInTheDocument()
@@ -94,5 +113,17 @@ describe('OperatorDashboardView', () => {
   it('omits the compliance banner when the whole fleet is compliant', () => {
     renderDashboard([vehicle()])
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('mounts the Today panel for an operator session when the flag is ON (#1329)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', 'true')
+    renderDashboard([vehicle()], OPERATOR_SESSION)
+    expect(screen.getByRole('region', { name: TODAY_PANEL_TITLE })).toBeInTheDocument()
+  })
+
+  it('omits the Today panel for an operator session when the flag is OFF (#1329)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', undefined)
+    renderDashboard([vehicle()], OPERATOR_SESSION)
+    expect(screen.queryByRole('region', { name: TODAY_PANEL_TITLE })).not.toBeInTheDocument()
   })
 })

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -75,10 +75,11 @@ export default defineConfig({
         VITE_DEV_API_PROXY: API_URL,
         // These real-DB specs exercise features the beta demo gates OFF —
         // cancellation (#868), operator manual booking (#589), team (#904),
-        // settings (#903), reviews (#1083-1086), the fleet timeline (#1100) and
-        // multi-currency indicative display (#1070). Enable them here so e2e covers
-        // the FULL product; the beta Pages build (deploy.yml) sets none of these, so
-        // the demo still hides them. Fail-safe-OFF default lives in
+        // settings (#903), reviews (#1083-1086), the fleet timeline (#1100),
+        // multi-currency indicative display (#1070), the operator Today panel
+        // (#1102) and the calendar booking quick-view (#1282). Enable them here so
+        // e2e covers the FULL product; the beta Pages build (deploy.yml) sets none
+        // of these, so the demo still hides them. Fail-safe-OFF default lives in
         // vite/config/features.ts.
         VITE_FEATURE_CANCELLATION: 'true',
         VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
@@ -88,6 +89,8 @@ export default defineConfig({
         VITE_FEATURE_REVIEWS: 'true',
         VITE_FEATURE_FLEET_TIMELINE: 'true',
         VITE_FEATURE_MULTI_CURRENCY: 'true',
+        VITE_FEATURE_OPERATOR_TODAY: 'true',
+        VITE_FEATURE_CALENDAR_QUICKVIEW: 'true',
       },
     },
   ],


### PR DESCRIPTION
## What

Two features from epic #1099 shipped **reachable whenever the session was an operator session, with no build-time gate** — contrary to the beta-MVP convention that every post-MVP feature ships behind its own `VITE_FEATURE_*` flag, fail-safe OFF (the beta demo bakes none).

This adds two flags and gates the features:

| Flag | Gates | Gate site |
|------|-------|-----------|
| `VITE_FEATURE_OPERATOR_TODAY` (`OPERATOR_TODAY`) | Operator Today dispatch panel (#1102) | parent `OperatorDashboardView` |
| `VITE_FEATURE_CALENDAR_QUICKVIEW` (`CALENDAR_QUICKVIEW`) | Calendar booking quick-view chip (#1282) | consumer `BookingsCalendar` |

Both are `runtimeControlled: false` (build-time only); the runtime-toggle migration is deliberately deferred to #1322, matching how the other un-migrated flags are registered. Registration spans the four points the parity test enforces: `features.ts` accessor, `vite-env.d.ts` decl, shared `feature-flags/registry.ts`, `feature-flags-runtime.ts` build-time reader.

## Fail-safe restores the pre-#1282 baseline (not a dead click)

When the quick-view chip is OFF a booking band is a plain, link-less `<span>`. #1282 had moved booking navigation into the chip's inner `<Link>` and made the calendar's `onSelectEvent` a no-op for bookings. Left as-is, gating the chip OFF would make a booking band a **dead click** — worse than the pre-#1282 behavior. So `handleSelectEvent` now navigates to the booking detail when the chip is OFF, restoring the exact pre-feature baseline. (Caught in review.)

## Test plan

- TDD, RED→GREEN per cycle. New/updated tests:
  - `features.test.ts` — both flags join the fail-safe FLAGS table (OFF-when-unset / ON-only-for-`'true'` / typo-stays-OFF).
  - `OperatorDashboardView.test.tsx` — Today panel present for an operator session with the flag ON, absent with it OFF.
  - `BookingsCalendar.test.tsx` — booking renders as the chip (button) with the flag ON, as a plain band with it OFF.
  - `OperatorBookingsRoute.test.tsx` — booking band click navigates to detail when the chip is OFF; existing "chip Link owns navigation" test now stubs the flag ON (its precondition).
- `playwright.real-db.config.ts` bakes both flags ON so E2E still covers the full product; the beta Pages build sets none, so the demo stays gated.
- Gates green: full web suite (260 files / 1763 tests), shared (875), tsc ×3, biome lint, module/size/csrf/tenant-anchor scanners, `vite build`.

Closes #1329