### PR TITLE
feat(#1322): migrate nav+route flags (OPERATOR_SETTINGS/TEAM/RENTER_DOCUMENTS/MESSAGING) to the runtime hook

### DIFF
--- a/packages/shared/src/feature-flags/registry.test.ts
+++ b/packages/shared/src/feature-flags/registry.test.ts
@@ -30,6 +30,8 @@ describe('feature flag registry', () => {
     // so a dashboard toggle actually takes effect. Flip this to true in the same
     // slice that migrates the flag (#1322) — the admin page badges the difference.
     const controlled = FEATURE_FLAG_KEYS.filter((k) => FEATURE_FLAGS[k].runtimeControlled)
+    // Every flag is migrated as of #1322 (PR3 finished the batch). A newly added,
+    // not-yet-migrated flag would be absent here and must be added on migration.
     expect(new Set(controlled)).toEqual(
       new Set([
         'MULTI_CURRENCY',
@@ -38,6 +40,10 @@ describe('feature flag registry', () => {
         'FLEET_TIMELINE',
         'OPERATOR_MANUAL_BOOKING',
         'OPERATOR_BLOCKS',
+        'OPERATOR_TEAM',
+        'OPERATOR_SETTINGS',
+        'RENTER_DOCUMENTS',
+        'MESSAGING',
       ]),
     )
   })

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -28,22 +28,22 @@ export const FEATURE_FLAGS = {
   OPERATOR_TEAM: {
     env: 'VITE_FEATURE_OPERATOR_TEAM',
     label: 'Operator team management',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   OPERATOR_SETTINGS: {
     env: 'VITE_FEATURE_OPERATOR_SETTINGS',
     label: 'Operator settings',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   RENTER_DOCUMENTS: {
     env: 'VITE_FEATURE_RENTER_DOCUMENTS',
     label: 'Renter document upload',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   MESSAGING: {
     env: 'VITE_FEATURE_MESSAGING',
     label: 'Renter–operator messaging',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   OPERATOR_BLOCKS: {
     env: 'VITE_FEATURE_OPERATOR_BLOCKS',

--- a/packages/web/src/routes/$locale/_business/manage/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_business/manage/messages.guard.test.ts
@@ -1,0 +1,47 @@
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { isRedirect } from '@tanstack/react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './messages'
+
+// The operator inbox mirrors the renter messages guard: the `_business` role check is
+// the parent's job; this adds the post-MVP visibility gate. It reads the session + the
+// runtime flag overrides (#1322) and redirects home when messaging is hidden, EXCEPT
+// for the platform admin (owner preview via the admin bypass). The stub branches on the
+// query key so the overrides query and the session query return the right shapes.
+function runGuard(
+  role: string | undefined,
+  overrides: FeatureFlagOverrides = {},
+): Promise<unknown> {
+  const session = role ? { user: { role } } : null
+  const ensureQueryData = async (opts: { queryKey: readonly unknown[] }) =>
+    opts.queryKey[0] === 'feature-flags' ? overrides : session
+  const context = { queryClient: { ensureQueryData } }
+  return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
+    context,
+    params: { locale: 'en' },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('business messages route guard (admin bypass)', () => {
+  it('redirects an operator home when messaging is hidden in beta', async () => {
+    try {
+      await runGuard('OPERATOR_OWNER')
+      expect.unreachable('guard should have redirected the operator')
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true)
+    }
+  })
+
+  it('admits the platform admin so the owner can preview the inbox on beta', async () => {
+    await expect(runGuard('PLATFORM_ADMIN')).resolves.toBeUndefined()
+  })
+
+  it('admits an operator when a runtime override turns messaging on even though the build default is off', async () => {
+    vi.stubEnv('VITE_FEATURE_MESSAGING', undefined)
+    await expect(runGuard('OPERATOR_OWNER', { MESSAGING: true })).resolves.toBeUndefined()
+  })
+})

--- a/packages/web/src/routes/$locale/_business/manage/messages.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/messages.tsx
@@ -1,4 +1,4 @@
-import { isMessagingEnabled, isVisibleToViewer } from '@/vite/config'
+import { featureFlagsQueryOptions, isVisibleToViewer, resolveFeatureFlag } from '@/vite/config'
 import { sessionQueryOptions } from '@/vite/session'
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
@@ -11,9 +11,14 @@ import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 // `_renter/messages.tsx` gate. Visibility only — the messaging API still enforces
 // its own operator tenant scoping (#1205 slice 2).
 export const Route = createFileRoute('/$locale/_business/manage/messages')({
+  // #1322: the messaging flag now reads the runtime override (a dashboard toggle
+  // opens/closes the route live); the admin-bypass visibility rule is unchanged.
   beforeLoad: async ({ context, params }) => {
-    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
-    if (!isVisibleToViewer(isMessagingEnabled(), session?.user?.role)) {
+    const [session, overrides] = await Promise.all([
+      context.queryClient.ensureQueryData(sessionQueryOptions()),
+      context.queryClient.ensureQueryData(featureFlagsQueryOptions()),
+    ])
+    if (!isVisibleToViewer(resolveFeatureFlag(overrides, 'MESSAGING'), session?.user?.role)) {
       throw redirect({ to: '/$locale', params: { locale: params.locale } })
     }
   },

--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -1,5 +1,5 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
-import { isOperatorSettingsEnabled } from '@/vite/config/features'
+import { featureFlagsQueryOptions, resolveFeatureFlag } from '@/vite/config'
 import { canPickOperatorContext, canWriteAsOperatorOwner } from '@/vite/guards'
 import { useOperatorContext } from '@/vite/operator-context'
 import { SettingsForm } from '@/vite/operator-settings/SettingsForm'
@@ -29,8 +29,11 @@ import { useTranslations } from 'use-intl'
 export const Route = createFileRoute('/$locale/_business/manage/settings')({
   // Post-MVP feature (#903), hidden in the beta demo. The nav link is already
   // filtered out; this blocks a direct URL too, falling back to the bookings page.
-  beforeLoad: ({ params }) => {
-    if (!isOperatorSettingsEnabled()) {
+  // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes the
+  // route live. resolveFeatureFlag = override ?? build-time env ?? false.
+  beforeLoad: async ({ context, params }) => {
+    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    if (!resolveFeatureFlag(overrides, 'OPERATOR_SETTINGS')) {
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }
   },

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
-import { isOperatorTeamEnabled } from '@/vite/config/features'
+import { featureFlagsQueryOptions, resolveFeatureFlag } from '@/vite/config'
 import { isOperatorOwnerSession, isOperatorSession } from '@/vite/guards'
 import { DeactivateMemberDialog } from '@/vite/operator-team/DeactivateMemberDialog'
 import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
@@ -29,8 +29,11 @@ import { useTranslations } from 'use-intl'
 export const Route = createFileRoute('/$locale/_business/manage/team')({
   // Post-MVP feature (#904), hidden in the beta demo. The nav link is already
   // filtered out; this blocks a direct URL too, falling back to the bookings page.
-  beforeLoad: ({ params }) => {
-    if (!isOperatorTeamEnabled()) {
+  // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes the
+  // route live. resolveFeatureFlag = override ?? build-time env ?? false.
+  beforeLoad: async ({ context, params }) => {
+    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    if (!resolveFeatureFlag(overrides, 'OPERATOR_TEAM')) {
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }
   },

--- a/packages/web/src/routes/$locale/_renter/documents.tsx
+++ b/packages/web/src/routes/$locale/_renter/documents.tsx
@@ -1,4 +1,4 @@
-import { isRenterDocumentsEnabled } from '@/vite/config/features'
+import { featureFlagsQueryOptions, resolveFeatureFlag } from '@/vite/config'
 import { DocumentUploadCard } from '@/vite/documents/DocumentUploadCard'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
@@ -8,8 +8,11 @@ export const Route = createFileRoute('/$locale/_renter/documents')({
   // Post-MVP feature, hidden in the beta demo: the instant-book flow doesn't
   // gate on uploaded documents, so this page is orphaned. The nav link is
   // filtered out; this blocks a direct URL too, falling back to search.
-  beforeLoad: ({ params }) => {
-    if (!isRenterDocumentsEnabled()) {
+  // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes
+  // the route live. resolveFeatureFlag = override ?? build-time env ?? false.
+  beforeLoad: async ({ context, params }) => {
+    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    if (!resolveFeatureFlag(overrides, 'RENTER_DOCUMENTS')) {
       throw redirect({ to: '/$locale/search', params: { locale: params.locale } })
     }
   },

--- a/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
@@ -1,14 +1,22 @@
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import { isRedirect } from '@tanstack/react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Route } from './messages'
 
 // Invoke the route's beforeLoad directly with a minimal stubbed context to prove the
-// wiring (design §4.1 / §8): the guard reads the session, runs the admin-bypass rule,
-// and redirects home when messaging is hidden. The decision itself is unit-tested in
-// feature-visibility.test.ts; this asserts the route is wired to it correctly.
-function runGuard(role: string | undefined): Promise<unknown> {
+// wiring (design §4.1 / §8): the guard reads the session + the runtime flag overrides,
+// runs the admin-bypass rule, and redirects home when messaging is hidden. The decision
+// itself is unit-tested in feature-visibility.test.ts; this asserts the route is wired
+// to it correctly. Since #1322 the flag reads the ['feature-flags'] override map, so the
+// stub branches on the query key: the session query vs. the overrides query.
+function runGuard(
+  role: string | undefined,
+  overrides: FeatureFlagOverrides = {},
+): Promise<unknown> {
   const session = role ? { user: { role } } : null
-  const context = { queryClient: { ensureQueryData: async () => session } }
+  const ensureQueryData = async (opts: { queryKey: readonly unknown[] }) =>
+    opts.queryKey[0] === 'feature-flags' ? overrides : session
+  const context = { queryClient: { ensureQueryData } }
   // Minimal stub — the real beforeLoad arg carries more, but the guard only touches these.
   return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
     context,
@@ -43,8 +51,13 @@ describe('messages route guard (admin bypass)', () => {
     await expect(runGuard('PLATFORM_ADMIN')).resolves.toBeUndefined()
   })
 
-  it('admits a renter once the messaging flag is on', async () => {
+  it('admits a renter once the messaging flag is on (build default)', async () => {
     vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
     await expect(runGuard('RENTER')).resolves.toBeUndefined()
+  })
+
+  it('admits a renter when a runtime override turns messaging on even though the build default is off', async () => {
+    vi.stubEnv('VITE_FEATURE_MESSAGING', undefined)
+    await expect(runGuard('RENTER', { MESSAGING: true })).resolves.toBeUndefined()
   })
 })

--- a/packages/web/src/routes/$locale/_renter/messages.tsx
+++ b/packages/web/src/routes/$locale/_renter/messages.tsx
@@ -1,4 +1,4 @@
-import { isMessagingEnabled, isVisibleToViewer } from '@/vite/config'
+import { featureFlagsQueryOptions, isVisibleToViewer, resolveFeatureFlag } from '@/vite/config'
 import { sessionQueryOptions } from '@/vite/session'
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 
@@ -10,9 +10,14 @@ import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 // redirect pattern in `_admin.tsx`. Visibility only — the messaging API still enforces
 // its own per-participant access (design §2.1).
 export const Route = createFileRoute('/$locale/_renter/messages')({
+  // #1322: the messaging flag now reads the runtime override (a dashboard toggle
+  // opens/closes the route live); the admin-bypass visibility rule is unchanged.
   beforeLoad: async ({ context, params }) => {
-    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
-    if (!isVisibleToViewer(isMessagingEnabled(), session?.user?.role)) {
+    const [session, overrides] = await Promise.all([
+      context.queryClient.ensureQueryData(sessionQueryOptions()),
+      context.queryClient.ensureQueryData(featureFlagsQueryOptions()),
+    ])
+    if (!isVisibleToViewer(resolveFeatureFlag(overrides, 'MESSAGING'), session?.user?.role)) {
       throw redirect({ to: '/$locale', params: { locale: params.locale } })
     }
   },

--- a/packages/web/src/vite/nav/BusinessLayout.test.tsx
+++ b/packages/web/src/vite/nav/BusinessLayout.test.tsx
@@ -8,8 +8,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 // Drive the signed-in role through the session hook; the sidebar's own seams
-// (router Link, feature flags, badge query) are mocked so this exercises the
-// layout's wiring — preference + view-cookie → render/omit the sidebar.
+// (router Link, badge query) are mocked so this exercises the layout's wiring —
+// preference + view-cookie → render/omit the sidebar. Feature flags are left at
+// their build-time default (no provider -> useFeatureFlag reads the empty context),
+// which hides the gated nav items; these tests assert sidebar/picker, not those.
 // Typed as UserRole | undefined (not string) so a typo'd literal here fails to
 // compile — that's the whole point of #1111's narrowing (audit M6).
 const h = vi.hoisted(() => ({
@@ -39,11 +41,6 @@ vi.mock('@tanstack/react-router', () => ({
   // current route honors ?operator; feed it the route id under test.
   useRouterState: ({ select }: { select: (s: { matches: { routeId: string }[] }) => unknown }) =>
     select({ matches: [{ routeId: '/$locale/_business' }, { routeId: h.routeId }] }),
-}))
-vi.mock('@/vite/config/features', () => ({
-  isOperatorTeamEnabled: () => true,
-  isOperatorSettingsEnabled: () => true,
-  isMessagingEnabled: () => false,
 }))
 vi.mock('@/vite/operator-bookings/useNewBookingsBadge', () => ({
   useNewBookingsBadge: () => ({ count: 0 }),

--- a/packages/web/src/vite/nav/BusinessSidebar.test.tsx
+++ b/packages/web/src/vite/nav/BusinessSidebar.test.tsx
@@ -1,3 +1,6 @@
+import { FeatureFlagsProvider } from '@/vite/config'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
@@ -5,11 +8,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 
 // Hoisted so the (hoisted) vi.mock factories below can read them; tests mutate
-// these to drive the feature flags and the new-bookings count.
+// these to drive the new-bookings count and the viewer role. The feature flags are
+// driven per-render by a seeded ['feature-flags'] override map (#1322), not a mock
+// of the config barrel — the sidebar now reads them live via useFeatureFlag.
 const h = vi.hoisted(() => ({
-  flags: { team: true, settings: true },
   badge: { count: 0 },
-  messaging: { enabled: false },
   unread: { count: 0 },
   role: 'OPERATOR_OWNER' as string | undefined,
 }))
@@ -21,16 +24,6 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, to }: { children: ReactNode; to: unknown }) => (
     <a href={String(to)}>{children}</a>
   ),
-}))
-
-vi.mock('@/vite/config/features', () => ({
-  isOperatorTeamEnabled: () => h.flags.team,
-  isOperatorSettingsEnabled: () => h.flags.settings,
-}))
-
-vi.mock('@/vite/config', () => ({
-  isMessagingEnabled: () => h.messaging.enabled,
-  isVisibleToViewer: (flag: boolean, role: string | undefined) => flag || role === 'PLATFORM_ADMIN',
 }))
 
 vi.mock('@/vite/session', () => ({
@@ -47,20 +40,26 @@ vi.mock('@/vite/messaging', () => ({
 
 import { BusinessSidebar } from './BusinessSidebar'
 
-function renderSidebar() {
+// Seed the runtime override map so FeatureFlagsProvider reads it from cache (no
+// network). This drives the effective flag values end-to-end: override -> hook ->
+// pure nav filter -> rendered links, proving the dashboard toggle reaches the UI.
+function renderSidebar(overrides: FeatureFlagOverrides = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['feature-flags'], overrides)
   return render(
-    <IntlProvider locale="en" messages={en}>
-      <BusinessSidebar />
-    </IntlProvider>,
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        <FeatureFlagsProvider>
+          <BusinessSidebar />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
   )
 }
 
 describe('BusinessSidebar', () => {
   beforeEach(() => {
-    h.flags.team = true
-    h.flags.settings = true
     h.badge.count = 0
-    h.messaging.enabled = false
     h.unread.count = 0
     h.role = 'OPERATOR_OWNER'
   })
@@ -71,7 +70,7 @@ describe('BusinessSidebar', () => {
   })
 
   it('renders a link with the translated label for every visible business nav item, in order', () => {
-    renderSidebar()
+    renderSidebar({ OPERATOR_TEAM: true, OPERATOR_SETTINGS: true })
     const labels = within(screen.getByRole('navigation'))
       .getAllByRole('link')
       .map((link) => link.textContent)
@@ -90,12 +89,16 @@ describe('BusinessSidebar', () => {
   })
 
   it('hides Team and Settings when their operator feature flags are off', () => {
-    h.flags.team = false
-    h.flags.settings = false
     renderSidebar()
     expect(screen.queryByRole('link', { name: 'Team' })).toBeNull()
     expect(screen.queryByRole('link', { name: 'Settings' })).toBeNull()
     expect(screen.queryByRole('link', { name: 'Dashboard' })).not.toBeNull()
+  })
+
+  it('reveals Team and Settings live when a runtime override turns their flags on', () => {
+    renderSidebar({ OPERATOR_TEAM: true, OPERATOR_SETTINGS: true })
+    expect(screen.queryByRole('link', { name: 'Team' })).not.toBeNull()
+    expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeNull()
   })
 
   it('shows the new-bookings badge on the Bookings item when the count is positive', () => {
@@ -117,9 +120,8 @@ describe('BusinessSidebar', () => {
     expect(screen.queryByRole('link', { name: 'Messages' })).toBeNull()
   })
 
-  it('shows Messages when the messaging flag is on', () => {
-    h.messaging.enabled = true
-    renderSidebar()
+  it('shows Messages when a runtime override turns the messaging flag on', () => {
+    renderSidebar({ MESSAGING: true })
     expect(screen.queryByRole('link', { name: 'Messages' })).not.toBeNull()
   })
 
@@ -130,9 +132,8 @@ describe('BusinessSidebar', () => {
   })
 
   it('shows the operator unread badge on Messages when positive', () => {
-    h.messaging.enabled = true
     h.unread.count = 4
-    renderSidebar()
+    renderSidebar({ MESSAGING: true })
     const badge = screen.getByRole('status')
     expect(badge.textContent).toBe('4')
     expect(badge.getAttribute('aria-label')).toBe('4 unread messages')

--- a/packages/web/src/vite/nav/BusinessSidebar.tsx
+++ b/packages/web/src/vite/nav/BusinessSidebar.tsx
@@ -1,6 +1,7 @@
 import { useOperatorUnreadBadge } from '@/vite/messaging'
 import { NavBadge } from '@/vite/nav/NavBadge'
 import { visibleBusinessNavItems } from '@/vite/nav/business-nav-items'
+import { useBusinessNavFlags } from '@/vite/nav/useNavFlags'
 import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import { useSession } from '@/vite/session'
 import { Link } from '@tanstack/react-router'
@@ -29,6 +30,8 @@ export function BusinessSidebar() {
   // so the operator-scoped badge scans are safe to enable unconditionally.
   const { count: newBookingsCount } = useNewBookingsBadge({ enabled: true })
   const { count: operatorUnread } = useOperatorUnreadBadge({ enabled: true })
+  // #1322: read the runtime-toggleable nav flags so a dashboard override reflects live.
+  const businessNavFlags = useBusinessNavFlags()
 
   return (
     <aside
@@ -38,7 +41,7 @@ export function BusinessSidebar() {
       className="hidden md:flex md:flex-col w-56 shrink-0 border-r border-sidebar-border bg-sidebar"
     >
       <nav className="flex flex-col gap-1 p-3">
-        {visibleBusinessNavItems(session?.user?.role).map(({ to, labelKey }) => (
+        {visibleBusinessNavItems(session?.user?.role, businessNavFlags).map(({ to, labelKey }) => (
           <Link
             key={to}
             to={to}

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -8,6 +8,7 @@ import { NavBadge } from '@/vite/nav/NavBadge'
 import { NavbarClient } from '@/vite/nav/NavbarClient'
 import { visibleBusinessNavItems } from '@/vite/nav/business-nav-items'
 import { visibleRenterNavItems } from '@/vite/nav/renter-nav-items'
+import { useBusinessNavFlags, useRenterNavFlags } from '@/vite/nav/useNavFlags'
 import { useNewBookingsBadge } from '@/vite/operator-bookings/useNewBookingsBadge'
 import { useSession } from '@/vite/session'
 import { getViewMode, isBusiness } from '@/vite/view-mode'
@@ -42,8 +43,13 @@ export function Navbar() {
   // #1205: operator unread-message badge — tenant-level, only scanned in business view.
   const { count: operatorUnread } = useOperatorUnreadBadge({ enabled: isBusinessView })
 
+  // #1322: nav visibility now reads the runtime-toggleable flags via useFeatureFlag,
+  // so a dashboard override hides/shows an item live (the routes still redirect too).
+  const businessNavFlags = useBusinessNavFlags()
+  const renterNavFlags = useRenterNavFlags()
+
   const navItems: readonly NavItem[] = isBusinessView
-    ? visibleBusinessNavItems(role).map((item) => ({
+    ? visibleBusinessNavItems(role, businessNavFlags).map((item) => ({
         to: item.to,
         label: t(item.labelKey),
         // exactOptionalPropertyTypes: only attach `badge` when there is one.
@@ -56,7 +62,7 @@ export function Navbar() {
     : session?.user
       ? [
           { to: '/$locale/search', label: t('browse') },
-          ...visibleRenterNavItems(role).map((item) => ({
+          ...visibleRenterNavItems(role, renterNavFlags).map((item) => ({
             to: item.to,
             label: t(item.labelKey),
             // exactOptionalPropertyTypes: only attach the badge when there is one.

--- a/packages/web/src/vite/nav/business-nav-items.ts
+++ b/packages/web/src/vite/nav/business-nav-items.ts
@@ -1,5 +1,4 @@
-import { isMessagingEnabled, isVisibleToViewer } from '@/vite/config'
-import { isOperatorSettingsEnabled, isOperatorTeamEnabled } from '@/vite/config/features'
+import { isVisibleToViewer } from '@/vite/config'
 import type { UserRole } from '@kuruma/shared/auth/roles'
 
 // Single source of truth for the business-view (operator) nav (#603). Both
@@ -29,6 +28,15 @@ export const businessNavItems = [
 // Derived so the union can never drift from the array above.
 export type BusinessNavTo = (typeof businessNavItems)[number]['to']
 
+// The effective (runtime-toggleable) values of the flags this nav gates on. The
+// component reads them with useFeatureFlag and passes them in, so this stays a pure
+// function — unit-testable without a provider and free of the build-time reader.
+export interface BusinessNavFlags {
+  readonly messaging: boolean
+  readonly operatorTeam: boolean
+  readonly operatorSettings: boolean
+}
+
 // Post-MVP routes the beta demo hides behind a feature flag (billable add-ons).
 // The array above stays the full source of truth so the `BusinessNavTo` union and
 // the nav-count test never drift; only the RENDERED list is filtered. The routes
@@ -36,14 +44,14 @@ export type BusinessNavTo = (typeof businessNavItems)[number]['to']
 // Messages is the post-MVP messaging feature: hidden in beta but shown to the
 // platform admin (owner preview via admin bypass), mirroring the renter side — so
 // its gate is role-aware (isVisibleToViewer), unlike the flag-only team/settings.
-const navItemGates: Partial<Record<BusinessNavTo, (role: UserRole | undefined) => boolean>> = {
-  '/$locale/manage/messages': (role) => isVisibleToViewer(isMessagingEnabled(), role),
-  '/$locale/manage/team': () => isOperatorTeamEnabled(),
-  '/$locale/manage/settings': () => isOperatorSettingsEnabled(),
-}
-
 export function visibleBusinessNavItems(
   role: UserRole | undefined,
+  flags: BusinessNavFlags,
 ): readonly (typeof businessNavItems)[number][] {
+  const navItemGates: Partial<Record<BusinessNavTo, (role: UserRole | undefined) => boolean>> = {
+    '/$locale/manage/messages': (r) => isVisibleToViewer(flags.messaging, r),
+    '/$locale/manage/team': () => flags.operatorTeam,
+    '/$locale/manage/settings': () => flags.operatorSettings,
+  }
   return businessNavItems.filter((item) => navItemGates[item.to]?.(role) ?? true)
 }

--- a/packages/web/src/vite/nav/renter-nav-items.test.ts
+++ b/packages/web/src/vite/nav/renter-nav-items.test.ts
@@ -1,14 +1,13 @@
 import type { UserRole } from '@kuruma/shared/auth/roles'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { visibleRenterNavItems } from './renter-nav-items'
+import { describe, expect, it } from 'vitest'
+import { type RenterNavFlags, visibleRenterNavItems } from './renter-nav-items'
 
-// `to` literals in render order, for compact truth-table assertions.
-const tos = (role: UserRole | undefined): readonly string[] =>
-  visibleRenterNavItems(role).map((item) => item.to)
-
-afterEach(() => {
-  vi.unstubAllEnvs()
-})
+// The gate is a pure function now (#1322): the effective flags are injected, so the
+// runtime-override wiring is proven at the component/route layer while this stays a
+// fast, provider-free truth table. Beta default = both flags off.
+const OFF: RenterNavFlags = { messaging: false, renterDocuments: false }
+const tos = (role: UserRole | undefined, flags: RenterNavFlags = OFF): readonly string[] =>
+  visibleRenterNavItems(role, flags).map((item) => item.to)
 
 describe('visibleRenterNavItems', () => {
   it('shows a renter only My Bookings in beta (messaging + documents flags off)', () => {
@@ -28,17 +27,22 @@ describe('visibleRenterNavItems', () => {
   })
 
   it('shows a renter Messages once the messaging flag is on', () => {
-    vi.stubEnv('VITE_FEATURE_MESSAGING', 'true')
-    expect(tos('RENTER')).toEqual(['/$locale/bookings', '/$locale/messages'])
+    expect(tos('RENTER', { messaging: true, renterDocuments: false })).toEqual([
+      '/$locale/bookings',
+      '/$locale/messages',
+    ])
   })
 
   it('shows a renter Documents once the documents flag is on (gated on the real renter role)', () => {
-    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
-    expect(tos('RENTER')).toEqual(['/$locale/bookings', '/$locale/documents'])
+    expect(tos('RENTER', { messaging: false, renterDocuments: true })).toEqual([
+      '/$locale/bookings',
+      '/$locale/documents',
+    ])
   })
 
   it('keeps Documents hidden from the admin even with the flag on — no bypass, it is renter-only "my data" (Messages still shows via bypass)', () => {
-    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
-    expect(tos('PLATFORM_ADMIN')).toEqual(['/$locale/messages'])
+    expect(tos('PLATFORM_ADMIN', { messaging: false, renterDocuments: true })).toEqual([
+      '/$locale/messages',
+    ])
   })
 })

--- a/packages/web/src/vite/nav/renter-nav-items.ts
+++ b/packages/web/src/vite/nav/renter-nav-items.ts
@@ -1,4 +1,4 @@
-import { isMessagingEnabled, isRenterDocumentsEnabled, isVisibleToViewer } from '@/vite/config'
+import { isVisibleToViewer } from '@/vite/config'
 import type { UserRole } from '@kuruma/shared/auth/roles'
 
 // Single source of truth for the renter-view nav (#543), mirroring
@@ -16,6 +16,14 @@ export const renterNavItems = [
 // Derived so the union can never drift from the array above.
 export type RenterNavTo = (typeof renterNavItems)[number]['to']
 
+// The effective (runtime-toggleable) values of the flags this nav gates on. The
+// component reads them with useFeatureFlag and passes them in, keeping this a pure
+// function — unit-testable without a provider and free of the build-time reader.
+export interface RenterNavFlags {
+  readonly messaging: boolean
+  readonly renterDocuments: boolean
+}
+
 // Per-item visibility (design: docs/plans/2026-06-26-mvp-feature-gating-design.md §4.1).
 // My Bookings and Documents are personal "my data" pages, gated on the REAL renter
 // role — an operator/admin in renter view must not see them (view state is not
@@ -25,12 +33,13 @@ export type RenterNavTo = (typeof renterNavItems)[number]['to']
 // its own build-time flag (#459, OFF in beta).
 export function visibleRenterNavItems(
   role: UserRole | undefined,
+  flags: RenterNavFlags,
 ): readonly (typeof renterNavItems)[number][] {
   const isRenter = role === 'RENTER'
   const gates: Record<RenterNavTo, boolean> = {
     '/$locale/bookings': isRenter,
-    '/$locale/messages': isVisibleToViewer(isMessagingEnabled(), role),
-    '/$locale/documents': isRenter && isRenterDocumentsEnabled(),
+    '/$locale/messages': isVisibleToViewer(flags.messaging, role),
+    '/$locale/documents': isRenter && flags.renterDocuments,
   }
   return renterNavItems.filter((item) => gates[item.to])
 }

--- a/packages/web/src/vite/nav/useNavFlags.ts
+++ b/packages/web/src/vite/nav/useNavFlags.ts
@@ -1,0 +1,23 @@
+import { useFeatureFlag } from '@/vite/config'
+import type { BusinessNavFlags } from './business-nav-items'
+import type { RenterNavFlags } from './renter-nav-items'
+
+// Read the effective (runtime-toggleable) nav flags via useFeatureFlag so a
+// dashboard override takes effect live, then hand them to the pure
+// visible*NavItems() filters. Kept as hooks (not inline in each component) so
+// Navbar and BusinessSidebar share one wiring and can't drift on which flags gate
+// which items (#1322).
+export function useBusinessNavFlags(): BusinessNavFlags {
+  return {
+    messaging: useFeatureFlag('MESSAGING'),
+    operatorTeam: useFeatureFlag('OPERATOR_TEAM'),
+    operatorSettings: useFeatureFlag('OPERATOR_SETTINGS'),
+  }
+}
+
+export function useRenterNavFlags(): RenterNavFlags {
+  return {
+    messaging: useFeatureFlag('MESSAGING'),
+    renterDocuments: useFeatureFlag('RENTER_DOCUMENTS'),
+  }
+}

--- a/packages/web/tests/vite/config/features.test.ts
+++ b/packages/web/tests/vite/config/features.test.ts
@@ -1,6 +1,7 @@
 import {
   isCancellationEnabled,
   isFleetTimelineEnabled,
+  isMessagingEnabled,
   isMultiCurrencyEnabled,
   isOperatorBlocksEnabled,
   isOperatorManualBookingEnabled,
@@ -21,6 +22,7 @@ const FLAGS = [
   { name: 'VITE_FEATURE_OPERATOR_TEAM', read: isOperatorTeamEnabled },
   { name: 'VITE_FEATURE_OPERATOR_SETTINGS', read: isOperatorSettingsEnabled },
   { name: 'VITE_FEATURE_RENTER_DOCUMENTS', read: isRenterDocumentsEnabled },
+  { name: 'VITE_FEATURE_MESSAGING', read: isMessagingEnabled },
   { name: 'VITE_FEATURE_REVIEWS', read: isReviewsEnabled },
   { name: 'VITE_FEATURE_FLEET_TIMELINE', read: isFleetTimelineEnabled },
   { name: 'VITE_FEATURE_MULTI_CURRENCY', read: isMultiCurrencyEnabled },

--- a/packages/web/tests/vite/documents/documents.route.test.ts
+++ b/packages/web/tests/vite/documents/documents.route.test.ts
@@ -1,34 +1,50 @@
 import { Route } from '@/routes/$locale/_renter/documents'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The beta MVP demo hides the renter document-upload page (#459) behind a build
-// flag — the instant-book flow no longer gates on it. The nav link is filtered
-// out elsewhere; the load-bearing block against a direct URL / bookmark is THIS
-// beforeLoad redirect, so it gets its own test.
-const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+// The beta MVP demo hides the renter document-upload page (#459) behind a flag —
+// the instant-book flow no longer gates on it. The nav link is filtered out
+// elsewhere; the load-bearing block against a direct URL / bookmark is THIS
+// beforeLoad redirect, so it gets its own test. Since #1322 the guard reads the
+// runtime override (effective = override ?? build-time env ?? false).
+const beforeLoad = Route.options.beforeLoad as (input: {
+  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  params: { locale: string }
+}) => Promise<void>
+
+function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
+  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+}
 
 describe('/documents feature-flag guard', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
   })
 
-  it('redirects a direct URL to /search when the documents flag is off (beta default)', () => {
+  it('redirects a direct URL to /search when the flag is off (no override, beta env default)', async () => {
     vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', undefined)
-    let thrown: unknown
-    try {
-      beforeLoad({ params: { locale: 'en' } })
-    } catch (err) {
-      thrown = err
-    }
-    // TanStack's redirect() throws a Response-like object carrying the target
-    // under `.options` — assert the destination, not just that something threw.
-    expect(thrown).toMatchObject({
+    // TanStack's redirect() throws a Response-like object carrying the target under
+    // `.options` — assert the destination, not just that something threw.
+    await expect(runGuard({})).rejects.toMatchObject({
       options: { to: '/$locale/search', params: { locale: 'en' } },
     })
   })
 
-  it('does not redirect when the documents flag is enabled (full build)', () => {
+  it('lets a direct URL through when a runtime override enables documents even if the build default is off', async () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', undefined)
+    await expect(runGuard({ RENTER_DOCUMENTS: true })).resolves.toBeUndefined()
+  })
+
+  it('does not redirect when the build default is on and no override is set (full build)', async () => {
     vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
-    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+    await expect(runGuard({})).resolves.toBeUndefined()
+  })
+
+  it('a runtime override OFF still redirects even when the build default is on', async () => {
+    vi.stubEnv('VITE_FEATURE_RENTER_DOCUMENTS', 'true')
+    await expect(runGuard({ RENTER_DOCUMENTS: false })).rejects.toMatchObject({
+      options: { to: '/$locale/search', params: { locale: 'en' } },
+    })
   })
 })

--- a/packages/web/tests/vite/nav/business-nav-items.test.ts
+++ b/packages/web/tests/vite/nav/business-nav-items.test.ts
@@ -1,4 +1,9 @@
-import { businessNavItems } from '@/vite/nav/business-nav-items'
+import {
+  type BusinessNavFlags,
+  businessNavItems,
+  visibleBusinessNavItems,
+} from '@/vite/nav/business-nav-items'
+import type { UserRole } from '@kuruma/shared/auth/roles'
 import { describe, expect, it } from 'vitest'
 import en from '../../../messages/en.json'
 
@@ -28,5 +33,64 @@ describe('businessNavItems', () => {
     for (const item of businessNavItems) {
       expect(en.nav[item.labelKey as keyof typeof en.nav]).toBeTruthy()
     }
+  })
+})
+
+// The visibility filter is a pure function (#1322): effective flags are injected, so
+// this is a provider-free truth table; the runtime-override wiring is proven at the
+// component/route layer. Beta default = every gated flag off.
+const ALL_OFF: BusinessNavFlags = { messaging: false, operatorTeam: false, operatorSettings: false }
+
+// The eight always-on operator items, in render order (dashboard through add-ons).
+const BASE = [
+  '/$locale/dashboard',
+  '/$locale/manage/bookings',
+  '/$locale/manage/fleet',
+  '/$locale/manage/classes',
+  '/$locale/manage/locations',
+  '/$locale/manage/insurance',
+  '/$locale/manage/fees',
+  '/$locale/manage/add-ons',
+]
+
+const tos = (role: UserRole | undefined, flags: BusinessNavFlags = ALL_OFF): readonly string[] =>
+  visibleBusinessNavItems(role, flags).map((item) => item.to)
+
+describe('visibleBusinessNavItems', () => {
+  it('shows an operator only the always-on items in beta (messages/team/settings flags off)', () => {
+    expect(tos('OPERATOR_OWNER')).toEqual(BASE)
+  })
+
+  it('adds all three gated items for an operator once every flag is on', () => {
+    expect(
+      tos('OPERATOR_OWNER', { messaging: true, operatorTeam: true, operatorSettings: true }),
+    ).toEqual([
+      ...BASE,
+      '/$locale/manage/messages',
+      '/$locale/manage/team',
+      '/$locale/manage/settings',
+    ])
+  })
+
+  it('shows the platform admin Messages via the bypass but NOT team/settings (flag-only, no bypass)', () => {
+    expect(tos('PLATFORM_ADMIN')).toEqual([...BASE, '/$locale/manage/messages'])
+  })
+
+  it('reveals only Team when just the team flag is on', () => {
+    expect(
+      tos('OPERATOR_OWNER', { messaging: false, operatorTeam: true, operatorSettings: false }),
+    ).toEqual([...BASE, '/$locale/manage/team'])
+  })
+
+  it('reveals only Settings when just the settings flag is on', () => {
+    expect(
+      tos('OPERATOR_OWNER', { messaging: false, operatorTeam: false, operatorSettings: true }),
+    ).toEqual([...BASE, '/$locale/manage/settings'])
+  })
+
+  it('reveals Messages to an operator once the messaging flag is on', () => {
+    expect(
+      tos('OPERATOR_OWNER', { messaging: true, operatorTeam: false, operatorSettings: false }),
+    ).toEqual([...BASE, '/$locale/manage/messages'])
   })
 })

--- a/packages/web/tests/vite/operator-settings/settings.route.test.ts
+++ b/packages/web/tests/vite/operator-settings/settings.route.test.ts
@@ -1,35 +1,54 @@
 import { Route } from '@/routes/$locale/_business/manage/settings'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The beta MVP demo hides operator settings (#903) behind a build flag. The nav
-// link is filtered out elsewhere, but the load-bearing block against a direct URL /
-// bookmark is THIS beforeLoad redirect — so it gets its own test: hiding the link
-// is not the same guarantee as blocking the route.
-const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+// The beta MVP demo hides operator settings (#903) behind a flag. The nav link is
+// filtered out elsewhere, but the load-bearing block against a direct URL / bookmark
+// is THIS beforeLoad redirect — so it gets its own test: hiding the link is not the
+// same guarantee as blocking the route. Since #1322 the guard reads the runtime
+// override (effective = override ?? build-time env ?? false), so these drive both.
+const beforeLoad = Route.options.beforeLoad as (input: {
+  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  params: { locale: string }
+}) => Promise<void>
+
+// The guard resolves the flag from the ['feature-flags'] override map; the mock
+// returns it regardless of the query-options arg, and vi.stubEnv controls the
+// build-time fallback so both precedence directions can be asserted.
+function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
+  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+}
 
 describe('/manage/settings feature-flag guard', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
   })
 
-  it('redirects a direct URL to /manage/bookings when the settings flag is off (beta default)', () => {
+  it('redirects a direct URL to /manage/bookings when the flag is off (no override, beta env default)', async () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', undefined)
-    let thrown: unknown
-    try {
-      beforeLoad({ params: { locale: 'en' } })
-    } catch (err) {
-      thrown = err
-    }
-    // TanStack's redirect() throws a Response-like object carrying the target
-    // under `.options` — assert the destination, not just that something threw.
-    expect(thrown).toMatchObject({
+    // TanStack's redirect() throws a Response-like object carrying the target under
+    // `.options` — assert the destination, not just that something threw.
+    await expect(runGuard({})).rejects.toMatchObject({
       options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
     })
   })
 
-  it('does not redirect when the settings flag is enabled (full build)', () => {
+  it('lets a direct URL through when a runtime override enables settings even if the build default is off', async () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', undefined)
+    await expect(runGuard({ OPERATOR_SETTINGS: true })).resolves.toBeUndefined()
+  })
+
+  it('does not redirect when the build default is on and no override is set (full build)', async () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', 'true')
-    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+    await expect(runGuard({})).resolves.toBeUndefined()
+  })
+
+  it('a runtime override OFF still redirects even when the build default is on', async () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_SETTINGS', 'true')
+    await expect(runGuard({ OPERATOR_SETTINGS: false })).rejects.toMatchObject({
+      options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
+    })
   })
 })
 

--- a/packages/web/tests/vite/operator-team/team.route.test.ts
+++ b/packages/web/tests/vite/operator-team/team.route.test.ts
@@ -1,34 +1,50 @@
 import { Route } from '@/routes/$locale/_business/manage/team'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The beta MVP demo hides operator team management (#904) behind a build flag. The
-// nav link is filtered out elsewhere, but the load-bearing block against a direct
-// URL / bookmark is THIS beforeLoad redirect — so it gets its own test: hiding the
-// link is not the same guarantee as blocking the route.
-const beforeLoad = Route.options.beforeLoad as (input: { params: { locale: string } }) => void
+// The beta MVP demo hides operator team management (#904) behind a flag. The nav
+// link is filtered out elsewhere, but the load-bearing block against a direct URL /
+// bookmark is THIS beforeLoad redirect — so it gets its own test: hiding the link is
+// not the same guarantee as blocking the route. Since #1322 the guard reads the
+// runtime override (effective = override ?? build-time env ?? false).
+const beforeLoad = Route.options.beforeLoad as (input: {
+  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  params: { locale: string }
+}) => Promise<void>
+
+function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
+  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+}
 
 describe('/manage/team feature-flag guard', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
   })
 
-  it('redirects a direct URL to /manage/bookings when the team flag is off (beta default)', () => {
+  it('redirects a direct URL to /manage/bookings when the flag is off (no override, beta env default)', async () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', undefined)
-    let thrown: unknown
-    try {
-      beforeLoad({ params: { locale: 'en' } })
-    } catch (err) {
-      thrown = err
-    }
-    // TanStack's redirect() throws a Response-like object carrying the target
-    // under `.options` — assert the destination, not just that something threw.
-    expect(thrown).toMatchObject({
+    // TanStack's redirect() throws a Response-like object carrying the target under
+    // `.options` — assert the destination, not just that something threw.
+    await expect(runGuard({})).rejects.toMatchObject({
       options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
     })
   })
 
-  it('does not redirect when the team flag is enabled (full build)', () => {
+  it('lets a direct URL through when a runtime override enables team even if the build default is off', async () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', undefined)
+    await expect(runGuard({ OPERATOR_TEAM: true })).resolves.toBeUndefined()
+  })
+
+  it('does not redirect when the build default is on and no override is set (full build)', async () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', 'true')
-    expect(() => beforeLoad({ params: { locale: 'en' } })).not.toThrow()
+    await expect(runGuard({})).resolves.toBeUndefined()
+  })
+
+  it('a runtime override OFF still redirects even when the build default is on', async () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TEAM', 'true')
+    await expect(runGuard({ OPERATOR_TEAM: false })).rejects.toMatchObject({
+      options: { to: '/$locale/manage/bookings', params: { locale: 'en' } },
+    })
   })
 })


### PR DESCRIPTION
Refs #1322 — finishes the batch. Migrates the last four build-time flags to `useFeatureFlag` / `resolveFeatureFlag`, so the `/admin/feature-flags` dashboard toggles them live. Every registry flag is now `runtimeControlled`.

## What
**Nav visibility (pure funcs + injected flags):**
- `visibleBusinessNavItems` / `visibleRenterNavItems` gain `BusinessNavFlags` / `RenterNavFlags` params instead of reading the build-time module — they stay provider-free unit tests.
- New `useNavFlags` hooks (`useBusinessNavFlags` / `useRenterNavFlags`) read the flags via `useFeatureFlag`; `Navbar` + `BusinessSidebar` share that one wiring.

**Route direct-URL guards (`beforeLoad`):**
- `settings` / `team` / `documents` become async and resolve the flag from `ensureQueryData(featureFlagsQueryOptions())` + `resolveFeatureFlag`; the two `messages` layouts add the overrides read alongside their existing session read.
- `effective = override ?? build-time env ?? false` — half-migrated stays correct; beta bakes no env so every add-on stays OFF until an admin flips it.

## Safety
Visibility only — the messaging admin-bypass (`isVisibleToViewer`) and the API's own per-role/per-participant authz are untouched. Moving the flag read to runtime changes only the *source* of the value, not any gate.

## Tests
- Registry marker-set now lists all ten flags; features parity table gains the `MESSAGING` reader (keeps every `features.ts` reader referenced post-migration).
- Nav filter truth tables pass injected flags. `BusinessSidebar` rewritten to the provider+override pattern (dead config mock removed) with runtime-toggle proofs; `BusinessLayout`'s dead mock dropped; `Navbar`'s env-stub tests unchanged (hook falls back to env with no provider).
- Route guard tests seed the override map and assert override-beats-env **both directions**; added a business-messages guard test (its load-bearing redirect was previously untested).

## Gates
- tsc: web + shared + api green
- tests: web 1788, shared 875, api 2464 green
- lint (biome + size + modules) exit 0; `vite build` green

Follows the FLEET_TIMELINE (#1340) and OPERATOR_MANUAL_BOOKING+OPERATOR_BLOCKS (#1341) precedent. Closes the #1322 migration batch.