### PR TITLE
feat(#1302): branded store monogram fallback for search cards

### DIFF
--- a/e2e/mobile/store-cards.spec.ts
+++ b/e2e/mobile/store-cards.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+// Mobile UX hardening, Search store cards (#1302, epic #1294 Wave 2). Runs ONLY on
+// the mobile-safari project (real iPhone 13 / WebKit, 390px wide) — the #1294 gate.
+// The flag-default search surface is the store grid, and a store has no image
+// field, so each card renders the store's own initials as a branded fallback tile
+// rather than the earlier generic glyph, which read as empty/unfinished on mobile.
+// Store name + card come from the e2e/mock-api.ts storefront fixture.
+const STORE_NAME = 'Best Car Rental Osaka'
+
+test.describe('mobile search store cards (#1302)', () => {
+  test('renders a branded monogram tile, not a bare glyph, and fits the 390px card', async ({
+    page,
+  }) => {
+    await page.goto('/en/search')
+
+    // No range in the URL -> beforeLoad seeds a default JST range and redirects,
+    // so results auto-run (mirrors storefront-search.spec.ts).
+    await expect(page).toHaveURL(/\/en\/search\?from=.+&to=.+/)
+
+    const card = page.getByRole('link', { name: new RegExp(STORE_NAME) })
+    await expect(card).toHaveCount(1)
+
+    // The fallback hero is the store's own initials on a labelled tile — a
+    // deliberate visual (#1302), not a bare placeholder glyph.
+    const tile = card.getByRole('img', { name: 'Store location' })
+    await expect(tile).toBeVisible()
+    await expect(tile).toHaveText('BC')
+
+    // No vehicle photo masquerades as the store hero (#955), and the card stays
+    // within the phone's viewport width.
+    await expect(card.locator('img')).toHaveCount(0)
+    const box = await card.boundingBox()
+    const viewport = page.viewportSize()
+    expect(box).not.toBeNull()
+    expect(viewport).not.toBeNull()
+    expect(box?.width ?? 0).toBeLessThanOrEqual(viewport?.width ?? 0)
+  })
+})

--- a/packages/web/src/vite/storefronts/StoreMonogram.tsx
+++ b/packages/web/src/vite/storefronts/StoreMonogram.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils'
+import { storeInitials } from '@/vite/storefronts/monogram'
+
+interface StoreMonogramProps {
+  /** Store display name the monogram initials are derived from. */
+  readonly name: string
+  /** Accessible label for the tile (the initials themselves are decorative). */
+  readonly label: string
+  readonly className?: string
+}
+
+/**
+ * Branded fallback for a storefront card that has no image (#1302). A store is a
+ * rental location, not a car, so a vehicle photo would mislead (#955) and the
+ * old generic glyph read as "empty/unfinished". The store's own initials on the
+ * placeholder-background token (DESIGN.md) give each card a deliberate identity
+ * while staying on-brand (the palette is intentionally monochrome).
+ */
+export function StoreMonogram({ name, label, className }: StoreMonogramProps) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={cn('flex h-full w-full items-center justify-center bg-muted', className)}
+    >
+      <span
+        aria-hidden="true"
+        className="select-none text-4xl font-semibold tracking-wide text-muted-foreground"
+      >
+        {storeInitials(name)}
+      </span>
+    </div>
+  )
+}

--- a/packages/web/src/vite/storefronts/StorefrontCard.tsx
+++ b/packages/web/src/vite/storefronts/StorefrontCard.tsx
@@ -1,11 +1,12 @@
 import { IndicativeNote } from '@/vite/currency'
 import { type AggregateEntry, RatingBadge } from '@/vite/reviews'
 import { ClassSummaryBadges } from '@/vite/storefronts/ClassSummaryBadges'
+import { StoreMonogram } from '@/vite/storefronts/StoreMonogram'
 import type { StorefrontCardData } from '@/vite/storefronts/api'
 import { carryForwardFilters } from '@/vite/storefronts/params'
 import { turnaroundHours } from '@/vite/storefronts/turnaround'
 import { Link } from '@tanstack/react-router'
-import { Clock, MapPin, Store } from 'lucide-react'
+import { Clock, MapPin } from 'lucide-react'
 import { useLocale, useTranslations } from 'use-intl'
 
 interface StorefrontCardProps {
@@ -64,20 +65,14 @@ export function StorefrontCard({
       }}
       className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-shadow hover:shadow-md"
     >
-      <div className="aspect-[4/3] overflow-hidden bg-muted">
+      <div className="aspect-[4/3] overflow-hidden">
         {/*
           A storefront is a rental location, not a car: showing a vehicle photo here
           read as "this is the store" (#955). Until a real store image field exists,
-          show a location placeholder — a Store glyph, distinct from the PhotoGallery
-          Car fallback so it unambiguously signals "location".
+          show the store's own initials (#1302) — a deliberate branded tile rather
+          than the earlier generic glyph, which read as empty/unfinished on mobile.
         */}
-        <div
-          role="img"
-          aria-label={t('storeImagePlaceholder')}
-          className="flex h-full w-full items-center justify-center"
-        >
-          <Store className="size-12 text-muted-foreground/30" aria-hidden="true" />
-        </div>
+        <StoreMonogram name={storefront.name} label={t('storeImagePlaceholder')} />
       </div>
       <div className="flex flex-1 flex-col gap-3 p-5">
         <div>

--- a/packages/web/src/vite/storefronts/monogram.ts
+++ b/packages/web/src/vite/storefronts/monogram.ts
@@ -1,0 +1,25 @@
+/**
+ * Derive a 1-2 character monogram from a store name for the branded fallback
+ * tile (#1302). There is no store image field, so the initials stand in as the
+ * store's visual identity on the search grid.
+ *
+ * Rule: for a multi-word name, take the first character of the first two words
+ * ("Best Car Rental Osaka" -> "BC"); for a single token (including space-less
+ * CJK names) take its first two characters ("Toyota" -> "TO", "大阪レンタカー"
+ * -> "大阪"). Latin output is uppercased; a blank name yields "".
+ */
+export function storeInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return ''
+
+  const chars =
+    words.length >= 2
+      ? [firstChar(words[0]), firstChar(words[1])]
+      : Array.from(words[0] ?? '').slice(0, 2)
+
+  return chars.join('').toUpperCase()
+}
+
+function firstChar(word: string | undefined): string {
+  return Array.from(word ?? '')[0] ?? ''
+}

--- a/packages/web/tests/vite/storefronts/StoreMonogram.test.tsx
+++ b/packages/web/tests/vite/storefronts/StoreMonogram.test.tsx
@@ -1,0 +1,25 @@
+import { StoreMonogram } from '@/vite/storefronts/StoreMonogram'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+describe('StoreMonogram', () => {
+  it('renders the store initials as the visual identity', () => {
+    render(<StoreMonogram name="Best Car Rental Osaka" label="Store location" />)
+    expect(screen.getByText('BC')).toBeInTheDocument()
+  })
+
+  it('exposes an image role carrying the accessible label', () => {
+    render(<StoreMonogram name="Best Car Rental Osaka" label="Store location" />)
+    expect(screen.getByRole('img', { name: 'Store location' })).toBeInTheDocument()
+  })
+
+  it('hides the decorative initials from assistive tech so the label is announced instead', () => {
+    render(<StoreMonogram name="Best Car Rental Osaka" label="Store location" />)
+    expect(screen.getByText('BC')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('renders text only, never an <img> element', () => {
+    const { container } = render(<StoreMonogram name="Sakura Rentals" label="Store location" />)
+    expect(container.querySelector('img')).toBeNull()
+  })
+})

--- a/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
+++ b/packages/web/tests/vite/storefronts/StorefrontCard.test.tsx
@@ -132,6 +132,12 @@ describe('StorefrontCard', () => {
     expect(screen.getByRole('img', { name: 'Store location' })).toBeInTheDocument()
   })
 
+  it('renders the store initials as a branded fallback tile instead of a generic glyph (#1302)', () => {
+    renderCard(makeStorefront({ name: 'Best Car Rental Osaka' }))
+    const tile = screen.getByRole('img', { name: 'Store location' })
+    expect(tile).toHaveTextContent('BC')
+  })
+
   it('converts the from-price for the indicative note', async () => {
     renderWithUsdIndicative(
       <StorefrontCard

--- a/packages/web/tests/vite/storefronts/monogram.test.ts
+++ b/packages/web/tests/vite/storefronts/monogram.test.ts
@@ -1,0 +1,32 @@
+import { storeInitials } from '@/vite/storefronts/monogram'
+import { describe, expect, it } from 'vitest'
+
+describe('storeInitials', () => {
+  it('takes the first letter of the first two words for a multi-word name', () => {
+    expect(storeInitials('Best Car Rental Osaka')).toBe('BC')
+  })
+
+  it('takes both leading initials for a two-word name', () => {
+    expect(storeInitials('Sakura Rentals')).toBe('SR')
+  })
+
+  it('uses the first two characters of a single-word name', () => {
+    expect(storeInitials('Toyota')).toBe('TO')
+  })
+
+  it('collapses surrounding and interior whitespace', () => {
+    expect(storeInitials('  Best   Car  ')).toBe('BC')
+  })
+
+  it('uppercases lowercased latin names', () => {
+    expect(storeInitials('toyota rent')).toBe('TR')
+  })
+
+  it('uses the first two characters for a space-less CJK name', () => {
+    expect(storeInitials('大阪レンタカー')).toBe('大阪')
+  })
+
+  it('returns an empty string for a blank name', () => {
+    expect(storeInitials('   ')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Mobile UX epic #1294, Wave 2 (E). The flag-default search surface is the **store grid**, and a store has **no image field** — so `StorefrontCard` rendered a faint generic `Store` glyph that read as empty/unfinished on mobile (a data/product gap, not a CSS bug).

This ships the **branded-fallback** option scoped in the issue: the store's own **initials** (a monogram) on the `bg-muted` placeholder-background token. Distinctness comes from the letters — the design system (`packages/web/DESIGN.md`) is intentionally **monochrome** (every color token is `oklch(x 0 0)`, zero chroma; the `red-600` brand accent is banned in app chrome), so a colorful per-store palette was deliberately not used.

Pure web slice: **no migration, no new i18n keys** (reuses the existing `storeImagePlaceholder` = "Store location" aria-label).

## Changes

- `monogram.ts` — pure `storeInitials(name)`: first-two-word initials for multi-word names, first-two-chars for a single token (handles space-less CJK, e.g. `大阪レンタカー` → `大阪`), uppercased; blank → `""`.
- `StoreMonogram.tsx` — presentational `role="img"` tile with the accessible label; the initials themselves are decorative (`aria-hidden`) so the store's real identity (adjacent `<h2>`) isn't double-announced.
- `StorefrontCard.tsx` — wires in `StoreMonogram`, drops the `Store` glyph.

## Test Plan

- [x] Unit: `monogram.test.ts` (7) — multi-word, single-word, CJK, whitespace, casing, blank
- [x] Component: `StoreMonogram.test.tsx` (4) — initials render, labelled img role, decorative initials, text-only (no `<img>`)
- [x] `StorefrontCard.test.tsx` — asserts the branded tile shows initials; existing #955 no-photo / labelled-placeholder tests stay green
- [x] Mobile e2e `e2e/mobile/store-cards.spec.ts` (mobile-safari, iPhone 13 / 390px — the #1294 gate): the card renders the `BC` tile, no `<img>`, fits the viewport
- [x] Full web suite 266 files / 1815 tests · web `tsc` clean · `bun run lint` exit 0
- [x] Desktop chromium `storefront-search.spec.ts` 2/2 (card change didn't regress the grid)

## Notes

- Real store photos (schema + upload + moderation) remain a separate, larger follow-up — this fallback doesn't preclude it.
- code-reviewer: SHIP, no CRITICAL/HIGH/MEDIUM.

Closes #1302