### PR TITLE
fix(#1268): close residual deactivated-operator disclosure surfaces

### DIFF
--- a/packages/api/src/repositories/drizzle/availability.ts
+++ b/packages/api/src/repositories/drizzle/availability.ts
@@ -102,7 +102,20 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
     const [vehicle] = await this.db
       .select(vehicleColumns)
       .from(vehicles)
-      .where(eq(vehicles.id, vehicleId))
+      .where(
+        and(
+          eq(vehicles.id, vehicleId),
+          // #1268: a targeted lookup by a known vehicleId must not leak a
+          // soft-deactivated operator's car — same NOT EXISTS(operators …
+          // deactivatedAt) seam as findAvailableVehicles above. No row -> not_found.
+          // Orphan vehicles (no operators row) are kept, matching that predicate.
+          sql`NOT EXISTS (
+                SELECT 1 FROM ${operators} o
+                WHERE o.id = ${vehicles.operatorId}
+                AND o."deactivatedAt" IS NOT NULL
+              )`,
+        ),
+      )
 
     if (!vehicle) return undefined
 
@@ -162,6 +175,14 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
           eq(bookings.pickupLocationId, pickupLocationId),
           sql`status IN ('CONFIRMED', 'ACTIVE')`,
           sql`tstzrange("startAt", "effectiveEndAt") && tstzrange(${fromIso}::timestamptz, ${toIso}::timestamptz)`,
+          // #1268: keep the demand seam consistent with the capacity seam — a
+          // soft-deactivated operator contributes no demand either, so the pair
+          // stays symmetric and neither becomes a latent caller-dependent hole.
+          sql`NOT EXISTS (
+                SELECT 1 FROM ${operators} o
+                WHERE o.id = ${bookings.operatorId}
+                AND o."deactivatedAt" IS NOT NULL
+              )`,
         ),
       )
     return row?.count ?? 0
@@ -214,6 +235,16 @@ export class DrizzleAvailabilityRepository implements AvailabilityRepository {
           // class supply. Shares the predicate with findAvailableVehicles; the
           // in-memory path mirrors it.
           blockOverlapNotExists(fromIso, toIso),
+          // #1268: a soft-deactivated operator produces zero real class supply.
+          // Today the CLASS_COMBO producer only reaches here for operators the
+          // findActiveStorefronts seam already kept, but enforcing it in the data
+          // (not the caller) closes the latent hole a future caller would reopen.
+          // NOT EXISTS keeps orphan vehicles, matching findAvailableVehicles.
+          sql`NOT EXISTS (
+                SELECT 1 FROM ${operators} o
+                WHERE o.id = ${vehicles.operatorId}
+                AND o."deactivatedAt" IS NOT NULL
+              )`,
         ),
       )
     return row?.count ?? 0

--- a/packages/api/src/repositories/in-memory/availability.test.ts
+++ b/packages/api/src/repositories/in-memory/availability.test.ts
@@ -405,6 +405,20 @@ describe('InMemoryAvailabilityRepository.countClassDemand (#464)', () => {
     await makeBooking({ status: 'ACTIVE' })
     expect(await demand()).toBe(1)
   })
+
+  it('drops a soft-deactivated operator’s bookings from demand — guarantee in the data (#1268)', async () => {
+    const op = await operatorRepo.create({
+      name: 'Fade Cars',
+      slug: 'fade-demand',
+      preAuthHandoffUrl: null,
+    })
+    await makeBooking({ operatorId: op.id })
+    const forOp = () =>
+      availabilityRepo.countClassDemand(op.id, 'class_compact', 'loc_osaka', FROM, TO)
+    expect(await forOp()).toBe(1)
+    await operatorRepo.update(op.id, { deactivatedAt: new Date(), updatedAt: new Date() })
+    expect(await forOp()).toBe(0)
+  })
 })
 
 // #464 slice 2d.2: countClassCapacity is the road-legal supply side of the
@@ -489,6 +503,42 @@ describe('InMemoryAvailabilityRepository.countClassCapacity (#464 slice 2d.2)', 
     const v = await makeVehicle({})
     await makeBlock(v.id, new Date('2026-08-01T15:00:00Z'), new Date('2026-08-01T18:00:00Z'))
     expect(await capacity()).toBe(2)
+  })
+
+  it('drops a soft-deactivated operator’s cars from capacity — guarantee in the data (#1268)', async () => {
+    const op = await operatorRepo.create({
+      name: 'Fade Cars',
+      slug: 'fade-capacity',
+      preAuthHandoffUrl: null,
+    })
+    await makeVehicle({ operatorId: op.id })
+    const forOp = () =>
+      availabilityRepo.countClassCapacity(op.id, 'class_compact', 'loc_osaka', FROM, TO, TO)
+    expect(await forOp()).toBe(1)
+    await operatorRepo.update(op.id, { deactivatedAt: new Date(), updatedAt: new Date() })
+    expect(await forOp()).toBe(0)
+  })
+})
+
+// #1268: the targeted-lookup seam. A caller holding a known vehicleId must not
+// learn a deactivated operator's car is available; it reads as not_found, mirroring
+// the findAvailableVehicles NOT EXISTS(operators … deactivatedAt) exclusion.
+describe('InMemoryAvailabilityRepository.checkVehicleAvailability — operator deactivation (#1268)', () => {
+  it('returns undefined (not_found) for a soft-deactivated operator’s vehicle', async () => {
+    const op = await operatorRepo.create({
+      name: 'Fade Cars',
+      slug: 'fade-check',
+      preAuthHandoffUrl: null,
+    })
+    const v = await makeVehicle({ operatorId: op.id })
+    expect(await availabilityRepo.checkVehicleAvailability(v.id, FROM, TO)).toBeDefined()
+    await operatorRepo.update(op.id, { deactivatedAt: new Date(), updatedAt: new Date() })
+    expect(await availabilityRepo.checkVehicleAvailability(v.id, FROM, TO)).toBeUndefined()
+  })
+
+  it('keeps a vehicle whose operator record is absent (orphan — parity with the NOT EXISTS seam)', async () => {
+    const v = await makeVehicle({ operatorId: 'op_ghost' })
+    expect(await availabilityRepo.checkVehicleAvailability(v.id, FROM, TO)).toBeDefined()
   })
 })
 

--- a/packages/api/src/repositories/in-memory/availability.ts
+++ b/packages/api/src/repositories/in-memory/availability.ts
@@ -103,6 +103,11 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
   > {
     const vehicle = await this.vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
     if (!vehicle) return undefined
+    // #1268: a soft-deactivated operator's car reads as not_found even on a targeted
+    // lookup — mirrors the findAvailableVehicles NOT EXISTS(operators … deactivatedAt)
+    // seam. An absent operator record (orphan) is kept, matching that predicate.
+    const operator = await this.operatorRepo.findById(vehicle.operatorId)
+    if (operator?.deactivatedAt != null) return undefined
 
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
     const conflicts = getConflictingBookings(allBookings, vehicle.id, from, to)
@@ -124,6 +129,11 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
     from: Date,
     to: Date,
   ): Promise<number> {
+    // #1268: keep the demand seam symmetric with capacity — a soft-deactivated
+    // operator contributes no demand either, so neither becomes a caller-dependent
+    // hole. Orphan operator keeps counting (parity with the correlated NOT EXISTS).
+    const operator = await this.operatorRepo.findById(operatorId)
+    if (operator?.deactivatedAt != null) return 0
     const allBookings = await this.bookingRepo.findAll(SYSTEM_CONTEXT)
     // Same blocking-status + half-open overlap as getConflictingBookings, but
     // keyed on the (operator, class, location) triple instead of a single car —
@@ -174,6 +184,12 @@ export class InMemoryAvailabilityRepository implements AvailabilityRepository {
     to: Date,
     asOf: Date,
   ): Promise<number> {
+    // #1268: a soft-deactivated operator produces zero real class supply — mirrors
+    // the Drizzle NOT EXISTS(operators … deactivatedAt) on countClassCapacity so the
+    // guarantee lives in the data. An absent operator (orphan) keeps counting, parity
+    // with the correlated NOT EXISTS.
+    const operator = await this.operatorRepo.findById(operatorId)
+    if (operator?.deactivatedAt != null) return 0
     // #464 2d.2 / #1193: road-legal supply side of the combo guard. Counts only
     // status === 'AVAILABLE' — the exact predicate the assign gate enforces
     // (booking-lifecycle.ts rejects non-AVAILABLE). RETIRED (permanent exit) and

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -527,6 +527,34 @@ describe('DrizzleAvailabilityRepository', () => {
       expect(count).toBe(2)
     })
 
+    it('drops a soft-deactivated operator’s bookings from class demand — guarantee in the data (#1268)', async () => {
+      const { operatorId, classId, locationId } = await seedFreshOperatorWithVehicle()
+      // A car-less CLASS_COMBO float on the fresh operator's (class, location).
+      const float = await bookingRepo.create(
+        SYSTEM_CONTEXT,
+        bookingInput({
+          operatorId,
+          renterId: testUser.id,
+          classId,
+          requestedVehicleId: null,
+          assignedVehicleId: null,
+          fulfillmentMode: 'CLASS_COMBO',
+          pickupLocationId: locationId,
+          dropoffLocationId: locationId,
+          status: 'CONFIRMED',
+          ...window,
+        }),
+      )
+      createdBookingIds.push(float.id)
+      const forOp = () =>
+        availabilityRepo.countClassDemand(operatorId, classId, locationId, FROM, TO)
+      // Active: the booking counts as blocking demand for the class.
+      expect(await forOp()).toBe(1)
+      await deactivateOperator(operatorId)
+      // Deactivated: the demand seam counts zero, symmetric with the capacity seam.
+      expect(await forOp()).toBe(0)
+    })
+
     it('excludes CANCELLED bookings and windows that do not overlap', async () => {
       const car = await createTestVehicle({ name: 'Excluded Car' })
       createdVehicleIds.push(car.id)

--- a/packages/api/tests/integration/availability.test.ts
+++ b/packages/api/tests/integration/availability.test.ts
@@ -1,6 +1,6 @@
 import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
-import { users, vehicleBlocks } from '@kuruma/shared/db/schema'
-import { inArray } from 'drizzle-orm'
+import { operators, users, vehicleBlocks } from '@kuruma/shared/db/schema'
+import { eq, inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import {
@@ -40,6 +40,7 @@ const createdVehicleIds: string[] = []
 const createdBookingIds: string[] = []
 const createdClassIds: string[] = []
 const createdLocationIds: string[] = []
+const createdOperatorIds: string[] = []
 
 beforeAll(async () => {
   const [user] = await db
@@ -72,7 +73,45 @@ afterAll(async () => {
   await cleanupUsers([testUser.id])
   await cleanupVehicleClasses(createdClassIds)
   await cleanupLocations(createdLocationIds)
+  // Operators own the classes/locations above by composite FK, so drop them last.
+  for (const id of createdOperatorIds) {
+    await db.delete(operators).where(eq(operators.id, id))
+  }
 })
+
+// #1268: a fresh operator (that we can safely deactivate — unlike the shared
+// BEST_CAR_RENTAL seed) with its own class, location, and one AVAILABLE road-legal
+// car. Returns the ids so a test can flip the operator to deactivated and assert the
+// availability seams stop counting/disclosing its car.
+async function seedFreshOperatorWithVehicle(): Promise<{
+  operatorId: string
+  vehicleId: string
+  classId: string
+  locationId: string
+}> {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const [op] = await db
+    .insert(operators)
+    .values({ slug: `op1268-${uniq}`, name: `Op 1268 ${uniq}` })
+    .returning({ id: operators.id })
+  createdOperatorIds.push(op.id)
+  const klass = await seedVehicleClass('a1268', op.id)
+  createdClassIds.push(klass.id)
+  const location = await seedLocation('a1268', TURNAROUND_MINUTES, op.id)
+  createdLocationIds.push(location.id)
+  const vehicle = await createTestVehicle({
+    operatorId: op.id,
+    classId: klass.id,
+    pickupLocationId: location.id,
+    name: '1268 Car',
+  })
+  createdVehicleIds.push(vehicle.id)
+  return { operatorId: op.id, vehicleId: vehicle.id, classId: klass.id, locationId: location.id }
+}
+
+function deactivateOperator(operatorId: string): Promise<unknown> {
+  return db.update(operators).set({ deactivatedAt: new Date() }).where(eq(operators.id, operatorId))
+}
 
 function createTestVehicle(
   overrides: Partial<Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'>> = {},
@@ -425,6 +464,21 @@ describe('DrizzleAvailabilityRepository', () => {
 
       expect(result).toBeUndefined()
     })
+
+    it('returns undefined (not_found) for a soft-deactivated operator’s vehicle (#1268)', async () => {
+      const { operatorId, vehicleId } = await seedFreshOperatorWithVehicle()
+      const lookup = () =>
+        availabilityRepo.checkVehicleAvailability(
+          vehicleId,
+          new Date('2026-08-01T10:00:00Z'),
+          new Date('2026-08-01T14:00:00Z'),
+        )
+      // Active: a targeted lookup by the known id resolves the car.
+      expect(await lookup()).toBeDefined()
+      await deactivateOperator(operatorId)
+      // Deactivated: the same known id now reads as not_found — no disclosure.
+      expect(await lookup()).toBeUndefined()
+    })
   })
 
   // #464: countClassDemand backs slice 2's inventory guard — it sums BLOCKING
@@ -672,6 +726,19 @@ describe('DrizzleAvailabilityRepository', () => {
         ASOF,
       )
       expect(count).toBe(1)
+    })
+
+    it('drops a soft-deactivated operator’s cars from class capacity — guarantee in the data (#1268)', async () => {
+      const { operatorId, classId, locationId } = await seedFreshOperatorWithVehicle()
+      const from = new Date('2026-08-01T10:00:00Z')
+      const to = new Date('2026-08-01T14:00:00Z')
+      const forOp = () =>
+        availabilityRepo.countClassCapacity(operatorId, classId, locationId, from, to, to)
+      // Active: the road-legal AVAILABLE car counts as real class supply.
+      expect(await forOp()).toBe(1)
+      await deactivateOperator(operatorId)
+      // Deactivated: the seam counts zero even without the caller's storefront guard.
+      expect(await forOp()).toBe(0)
     })
   })
 })

--- a/packages/api/tests/routes/availability.test.ts
+++ b/packages/api/tests/routes/availability.test.ts
@@ -346,6 +346,39 @@ describe('Availability Routes', () => {
       expect((await res.json()).error).toBe('vehicleId must be a valid uuid')
     })
 
+    // #1268: a targeted lookup by a known vehicleId (e.g. cached before the operator
+    // was deactivated) must not leak a soft-deactivated operator's car — it reads as
+    // not_found, mirroring the #1224 exclusion at the findAvailableVehicles seam.
+    it('returns 404 for a vehicle whose operator is soft-deactivated (#1268)', async () => {
+      const gone = await operatorRepo.create({
+        name: 'Gone Rentals',
+        slug: 'gone-rentals',
+        preAuthHandoffUrl: null,
+      })
+      const vehicle = await createTestVehicle({ name: 'Hidden Car', operatorId: gone.id })
+      await operatorRepo.update(gone.id, { deactivatedAt: new Date(), updatedAt: new Date() })
+
+      const res = await app.request(
+        `/availability/${vehicle.id}?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z`,
+      )
+
+      expect(res.status).toBe(404)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Vehicle not found')
+    })
+
+    it('keeps a vehicle whose operator record is absent (orphan — parity with the NOT EXISTS seam)', async () => {
+      const vehicle = await createTestVehicle({ name: 'Orphan Car', operatorId: 'op_ghost' })
+
+      const res = await app.request(
+        `/availability/${vehicle.id}?from=2026-06-01T10:00:00Z&to=2026-06-01T14:00:00Z`,
+      )
+
+      expect(res.status).toBe(200)
+      expect((await res.json()).data.vehicle.id).toBe(vehicle.id)
+    })
+
     it('strips conflict details for RENTER role', async () => {
       const renterApp = new Hono()
       renterApp.use('*', testAuthMiddleware('renter-user', 'RENTER'))


### PR DESCRIPTION
Closes #1268. Follow-up to #1224 — closes the two residual information-disclosure surfaces its code review surfaced (both left out of #1224's enumeration-only scope). Moves the deactivated-operator guarantee into the data seam so no future caller can reopen it.

## Surfaces closed
**[MEDIUM] `GET /availability/:vehicleId`** — a targeted lookup by a known `vehicleId` (e.g. cached before the operator was deactivated) returned `available: true` + full vehicle details for a deactivated operator's car. `checkVehicleAvailability` now reads it as `not_found`:
- Drizzle: `NOT EXISTS(operators … deactivatedAt)` added to the vehicle `SELECT` (byte-identical to the `findAvailableVehicles` seam #1224 hardened).
- In-memory: resolves the operator and returns `undefined` when `deactivatedAt != null`.

**[LOW/MED] flat-search `CLASS_COMBO` capacity** — `countClassCapacity` still counted a deactivated operator's cars, protected only transitively by the `findActiveStorefronts` seam (#1206). The exclusion now lives in `countClassCapacity` (and, for seam symmetry, `countClassDemand`), so the guarantee is in the data, not the caller.

## Parity
Orphan vehicles (no `operators` row) stay visible/counted in every case — matching the correlated `NOT EXISTS` semantics of the #1224 seam.

## Tests (RED-verified in both repo layers)
- Route test: deactivated-operator `vehicleId` → 404; orphan → 200.
- In-memory repo: `checkVehicleAvailability` + `countClassCapacity` + `countClassDemand` deactivation cases (each asserts the active value, then 0/undefined after deactivation).
- Real-pg integration: `checkVehicleAvailability` + `countClassCapacity` deactivation cases (verified RED without the Drizzle fix, GREEN with it).

## Gates
- api tsc + boundaries green
- api unit suite: 2470 passed
- api integration suite (real pg): 452 passed (full suite, no regression)
- biome clean

Refs #1224, #1206.