### PR TITLE
docs(#1330): deliberate react-calendar-timeline pin + a11y GA gate

### DIFF
--- a/docs/2026-07-02-fleet-timeline-lib-pin.md
+++ b/docs/2026-07-02-fleet-timeline-lib-pin.md
@@ -1,0 +1,40 @@
+# Fleet timeline: deliberate `react-calendar-timeline` pre-release pin
+
+Decision record for #1330. Date: 2026-07-02.
+
+## TL;DR
+
+The fleet planning board (`FleetTimeline`, #1100/#1204) is pinned to **`react-calendar-timeline@0.30.0-beta.18`** — a pre-release — **on purpose**.
+There is no stable release to move to, so #1330's "upgrade to a stable release" is not achievable today.
+Do not "fix" the pin to a `^`/`~` range or a `0.28.x` stable: `0.28.0` predates React 18/19 and will not run under our React 19.
+
+## What #1330 asked
+
+Before `VITE_FEATURE_FLEET_TIMELINE` is flipped ON in a paid/GA build, either (1) upgrade to a stable
+`react-calendar-timeline` release, or (2) pin deliberately and document the accessibility follow-up.
+
+## What the registry actually offers (checked 2026-07-02)
+
+- Our React: **19.2.4**.
+- `react-calendar-timeline` newest **stable**: **`0.28.0`** (React 16/17 era). Everything after is `0.30.0-beta.*` — the
+  React-18/19 compatibility line, which **never went stable**.
+- Newest published version of any kind: **`0.30.0-beta.18`** — which is exactly what we already run, and it is already an
+  **exact pin** (no range) in `packages/web/package.json`. Last upstream publish: 2026-03-04 (effectively stalled).
+- `interactjs@1.10.27` (drag/resize backend) is already the latest.
+
+So option 1 is impossible — we are already on the newest thing that exists, and React-19 compatibility is proven in
+practice (the board renders and its e2e passes; the lib is code-split into its own lazy chunk per the #1099 perf commit,
+so it ships to nobody until the flag turns on).
+
+## The decision (option 2)
+
+Keep the deliberate exact pin. The one real risk that remains is **accessibility**: the timeline bars are
+**mouse/pointer only** — no keyboard navigation and no ARIA labelling on the bars. That is tracked as **#1349** and
+**gates flipping `VITE_FEATURE_FLEET_TIMELINE` on for GA** (a paid build needs a keyboard-navigable, screen-reader-labelled
+path to the same information — either added to the bars, or satisfied by the existing accessible list/quick-view calendar
+as the fallback).
+
+The only path to a genuinely maintained upgrade would be swapping to a different timeline library or a maintained fork —
+out of scope for #1330; revisit if the accessibility work in #1349 turns out cheaper to get by replacing the lib.
+
+Refs: #1330 (this record), #1349 (a11y gate), #1099 (code-split), #1100 / #1204 (the board).

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -51,6 +51,9 @@ export const FEATURE_FLAGS = {
     runtimeControlled: true,
   },
   REVIEWS: { env: 'VITE_FEATURE_REVIEWS', label: 'Reviews & ratings', runtimeControlled: true },
+  // GA gate: the board is built on a pinned react-calendar-timeline pre-release whose bars are
+  // mouse-only (no keyboard/ARIA). Do not flip this on in a paid/GA build until #1349 lands an
+  // accessible path. Background: #1330 / docs/2026-07-02-fleet-timeline-lib-pin.md.
   FLEET_TIMELINE: {
     env: 'VITE_FEATURE_FLEET_TIMELINE',
     label: 'Fleet timeline board',

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -29,6 +29,12 @@ import './fleet-timeline-theme.css'
 // pure buildTimelineLayout; this shell only maps that shape to the lib's props and
 // owns its toolbar (FC/IS — the core decides, this renders). The booking-status
 // palette is applied via STATUS_CLASS on each bar (themed in fleet-timeline-theme.css).
+//
+// react-calendar-timeline is pinned to 0.30.0-beta.18 ON PURPOSE (#1330): no stable release
+// supports React 19 (0.28.0, the last stable, is React 16/17 era), so this pre-release is the
+// newest version that exists. Do NOT widen the exact pin or "downgrade to stable". Known a11y
+// gap: the bars are mouse-only (no keyboard/ARIA) — #1349 gates flipping VITE_FEATURE_FLEET_TIMELINE
+// on for GA. Full rationale: docs/2026-07-02-fleet-timeline-lib-pin.md.
 
 interface FleetTimelineProps {
   readonly rows: readonly CalendarBookingRow[]


### PR DESCRIPTION
## What & why

#1330 asked to upgrade `react-calendar-timeline` off the `0.30.0-beta.18` pre-release before the FLEET_TIMELINE flag flips on. Investigation (registry, 2026-07-02):

- Our React is **19.2.4**. The lib's newest **stable** is **0.28.0** (React 16/17 era). Everything after is `0.30.0-beta.*` — the React-18/19 line that **never went stable**.
- Newest published version of any kind is **`0.30.0-beta.18`** — exactly what we already **exact-pin**. `interactjs@1.10.27` is already latest.

So "upgrade to a stable release" is **impossible** — we're already on the newest thing that exists, and React-19 compat is proven (board renders, e2e green, code-split behind a lazy chunk). This resolves #1330 as **option 2: deliberate pin + documented a11y follow-up.**

## Changes (docs/comments only — no behavior change)

- `docs/2026-07-02-fleet-timeline-lib-pin.md` — decision record.
- `FleetTimeline.tsx` — import comment: don't widen/downgrade the pin; points to the gate.
- `registry.ts` — GA-gate comment on `FLEET_TIMELINE`: bars are mouse-only, blocked on the a11y follow-up.

## Follow-up

Filed **#1349** — the real risk is accessibility (timeline bars are mouse-only, no keyboard/ARIA); it **gates flipping `VITE_FEATURE_FLEET_TIMELINE` on for GA**.

## Verification

biome clean · registry parity 7/7 · shared + web typecheck pass · pre-commit hook (biome + size + module-boundaries + web/api tsc) green.

Closes #1330. Refs #1349 #1099 #1100.