### PR TITLE
feat(#1300): mobile header/nav — fill logged-out drawer, 44px touch targets, Kuruma naming

### DIFF
--- a/e2e/mobile/header-nav.spec.ts
+++ b/e2e/mobile/header-nav.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+// Mobile UX hardening, Header/nav (#1300, epic #1294 Wave 2). Runs ONLY on the
+// mobile-safari project (real iPhone 13 / WebKit, 390px wide) — the #1294 gate.
+// Covers the three ACs from the end-user path: the logged-out drawer now carries a
+// public Browse link (not just "Log in"); the header's icon-only menu + language
+// controls meet the 44px WCAG 2.5.5 touch floor; and the product brand is "Kuruma"
+// everywhere (no leaked seed-operator name on the sign-in screen).
+const TOUCH_TARGET_MIN = 44
+
+test.describe('mobile header/nav (#1300)', () => {
+  test('menu and language controls meet the 44px touch floor', async ({ page }) => {
+    await page.goto('/en/search')
+    await expect(page).toHaveURL(/\/en\/search\?from=.+&to=.+/)
+
+    for (const name of ['Menu', 'Language']) {
+      const control = page.getByRole('button', { name })
+      await expect(control).toBeVisible()
+      const box = await control.boundingBox()
+      expect(box, `${name} control has a box`).not.toBeNull()
+      expect(box?.width ?? 0).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN)
+      expect(box?.height ?? 0).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN)
+    }
+  })
+
+  test('logged-out drawer exposes the public Browse link, not just Log in', async ({ page }) => {
+    await page.goto('/en/search')
+    await expect(page).toHaveURL(/\/en\/search\?from=.+&to=.+/)
+
+    await page.getByRole('button', { name: 'Menu' }).click()
+
+    // The drawer is no longer empty: a signed-out visitor gets the Browse funnel
+    // link (-> /en/search) alongside the existing Log in action.
+    const browse = page.getByRole('link', { name: 'Browse' })
+    await expect(browse).toBeVisible()
+    await expect(browse).toHaveAttribute('href', /\/en\/search$/)
+    await expect(page.getByRole('link', { name: /log in/i })).toBeVisible()
+  })
+
+  test('sign-in screen uses the Kuruma product brand, not the seed operator name', async ({
+    page,
+  }) => {
+    await page.goto('/en/login')
+    await expect(page.getByText('Continue to Kuruma Rental')).toBeVisible()
+    await expect(page.getByText('Best Car Rental')).toHaveCount(0)
+  })
+})

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Best Car Rental</title>
+    <title>Kuruma Rental</title>
     <!--
       Pre-paint locale bootstrap (spec §6.2): set <html lang> before React mounts
       for a11y/font correctness. Mirrors detectLocale() (the tested canonical path

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -51,7 +51,7 @@
     "google": "Google",
     "apple": "Apple",
     "signInTitle": "Sign in",
-    "signInSubtitle": "Continue to Best Car Rental",
+    "signInSubtitle": "Continue to Kuruma Rental",
     "continueWithGoogle": "Continue with Google",
     "inAppBrowser": {
       "title": "Open this page in your browser",
@@ -91,6 +91,7 @@
     "fees": "Fees",
     "addOns": "Add-ons",
     "menu": "Menu",
+    "language": "Language",
     "close": "Close menu",
     "switchToRenter": "Switch to renter view",
     "switchToBusiness": "Switch to business view",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -51,7 +51,7 @@
     "google": "Google",
     "apple": "Apple",
     "signInTitle": "ログイン",
-    "signInSubtitle": "Best Car Rental に続行",
+    "signInSubtitle": "クルマレンタルに続行",
     "continueWithGoogle": "Googleで続行",
     "inAppBrowser": {
       "title": "このページをブラウザで開いてください",
@@ -91,6 +91,7 @@
     "fees": "料金",
     "addOns": "オプション",
     "menu": "メニュー",
+    "language": "言語",
     "close": "メニューを閉じる",
     "switchToRenter": "利用者ビューに切替",
     "switchToBusiness": "管理者ビューに切替",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -51,7 +51,7 @@
     "google": "Google",
     "apple": "Apple",
     "signInTitle": "登录",
-    "signInSubtitle": "继续使用 Best Car Rental",
+    "signInSubtitle": "继续使用库鲁马租车",
     "continueWithGoogle": "使用 Google 继续",
     "inAppBrowser": {
       "title": "请在浏览器中打开此页面",
@@ -91,6 +91,7 @@
     "fees": "费用",
     "addOns": "附加项目",
     "menu": "菜单",
+    "language": "语言",
     "close": "关闭菜单",
     "switchToRenter": "切换到租客视图",
     "switchToBusiness": "切换到管理视图",

--- a/packages/web/src/vite/nav/LocaleSwitcher.tsx
+++ b/packages/web/src/vite/nav/LocaleSwitcher.tsx
@@ -39,16 +39,13 @@ export function LocaleSwitcher() {
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          /* #1300: the label is hidden on mobile, leaving an icon-only trigger; pin
-             the width to the 44px touch floor (the base already pins the height) and
-             give it an aria-label so the control still has a name without the text. */
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5 pointer-coarse:min-w-11"
-            aria-label={t('language')}
-          >
+          /* #1300: pin the width to the 44px touch floor (the base already pins the
+             height). On mobile the visible label is hidden, so an sr-only span names
+             the control; on sm+ the visible locale label is the name (an aria-label
+             would override "English" with "Language" — WCAG 2.5.3 Label in Name). */
+          <Button variant="ghost" size="sm" className="gap-1.5 pointer-coarse:min-w-11">
             <Globe className="size-4" />
+            <span className="sr-only sm:hidden">{t('language')}</span>
             <span className="hidden sm:inline">{LOCALE_LABELS[locale]}</span>
           </Button>
         }

--- a/packages/web/src/vite/nav/LocaleSwitcher.tsx
+++ b/packages/web/src/vite/nav/LocaleSwitcher.tsx
@@ -8,7 +8,7 @@ import {
 import type { Locale } from '@/vite/i18n/locale'
 import { useNavigate } from '@tanstack/react-router'
 import { Globe } from 'lucide-react'
-import { useLocale } from 'use-intl'
+import { useLocale, useTranslations } from 'use-intl'
 
 const LOCALE_LABELS: Record<Locale, string> = {
   en: 'English',
@@ -33,12 +33,21 @@ export function localeSwapNav(next: Locale) {
 export function LocaleSwitcher() {
   const locale = useLocale() as Locale
   const navigate = useNavigate()
+  const t = useTranslations('nav')
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button variant="ghost" size="sm" className="gap-1.5">
+          /* #1300: the label is hidden on mobile, leaving an icon-only trigger; pin
+             the width to the 44px touch floor (the base already pins the height) and
+             give it an aria-label so the control still has a name without the text. */
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 pointer-coarse:min-w-11"
+            aria-label={t('language')}
+          >
             <Globe className="size-4" />
             <span className="hidden sm:inline">{LOCALE_LABELS[locale]}</span>
           </Button>

--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -59,7 +59,14 @@ export function MobileMenu({ session, navItems }: MobileMenuProps) {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger
         render={
-          <Button variant="ghost" size="sm" className="md:hidden" data-mobile-menu="">
+          /* #1300: icon-only on touch (label is sr-only) — the base gives the 44px
+             height floor, so pin the width to 44px too for a full WCAG 2.5.5 target. */
+          <Button
+            variant="ghost"
+            size="sm"
+            className="md:hidden pointer-coarse:min-w-11"
+            data-mobile-menu=""
+          >
             <Menu className="size-5" />
             <span className="sr-only">{t('nav.menu')}</span>
           </Button>

--- a/packages/web/src/vite/nav/MobileMenu.tsx
+++ b/packages/web/src/vite/nav/MobileMenu.tsx
@@ -59,14 +59,10 @@ export function MobileMenu({ session, navItems }: MobileMenuProps) {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger
         render={
-          /* #1300: icon-only on touch (label is sr-only) — the base gives the 44px
-             height floor, so pin the width to 44px too for a full WCAG 2.5.5 target. */
-          <Button
-            variant="ghost"
-            size="sm"
-            className="md:hidden pointer-coarse:min-w-11"
-            data-mobile-menu=""
-          >
+          /* #1300: `icon-sm` is the square icon primitive — it bundles the 44px
+             touch floor (min-w-11 + base min-h-11), so the always-icon-only menu
+             trigger meets WCAG 2.5.5 without a hand-rolled width. */
+          <Button variant="ghost" size="icon-sm" className="md:hidden" data-mobile-menu="">
             <Menu className="size-5" />
             <span className="sr-only">{t('nav.menu')}</span>
           </Button>

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -75,7 +75,9 @@ export function Navbar() {
               : {}),
           })),
         ]
-      : []
+      : // #1300: a logged-out visitor still gets the public Browse funnel link so
+        // the mobile drawer isn't empty (desktop nav shares the same array).
+        [{ to: '/$locale/search', label: t('browse') }]
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">

--- a/packages/web/src/vite/nav/Navbar.tsx
+++ b/packages/web/src/vite/nav/Navbar.tsx
@@ -49,6 +49,10 @@ export function Navbar() {
   const businessNavFlags = useBusinessNavFlags()
   const renterNavFlags = useRenterNavFlags()
 
+  // #1300: Browse (-> /search) leads every non-business nav — the public funnel
+  // link a logged-out visitor sees and the renter's first item.
+  const browseItem: NavItem = { to: '/$locale/search', label: t('browse') }
+
   const navItems: readonly NavItem[] = isBusinessView
     ? visibleBusinessNavItems(role, businessNavFlags).map((item) => ({
         to: item.to,
@@ -60,24 +64,24 @@ export function Navbar() {
             ? { badge: operatorUnread, badgeLabel: t('unreadMessages', { count: operatorUnread }) }
             : {}),
       }))
-    : session?.user
-      ? [
-          { to: '/$locale/search', label: t('browse') },
-          ...visibleRenterNavItems(role, renterNavFlags).map((item) => ({
-            to: item.to,
-            label: t(item.labelKey),
-            // exactOptionalPropertyTypes: only attach the badge when there is one.
-            ...(item.to === '/$locale/messages' && unreadMessages > 0
-              ? {
-                  badge: unreadMessages,
-                  badgeLabel: t('unreadMessages', { count: unreadMessages }),
-                }
-              : {}),
-          })),
-        ]
-      : // #1300: a logged-out visitor still gets the public Browse funnel link so
-        // the mobile drawer isn't empty (desktop nav shares the same array).
-        [{ to: '/$locale/search', label: t('browse') }]
+    : // Browse leads for renter and logged-out alike; the same array feeds the
+      // desktop nav and the mobile drawer, so neither is ever empty (#1300).
+      [
+        browseItem,
+        ...(session?.user
+          ? visibleRenterNavItems(role, renterNavFlags).map((item) => ({
+              to: item.to,
+              label: t(item.labelKey),
+              // exactOptionalPropertyTypes: only attach the badge when there is one.
+              ...(item.to === '/$locale/messages' && unreadMessages > 0
+                ? {
+                    badge: unreadMessages,
+                    badgeLabel: t('unreadMessages', { count: unreadMessages }),
+                  }
+                : {}),
+            }))
+          : []),
+      ]
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">

--- a/packages/web/tests/vite/auth/LoginCard.test.tsx
+++ b/packages/web/tests/vite/auth/LoginCard.test.tsx
@@ -5,7 +5,7 @@ vi.mock('use-intl', () => ({
   useTranslations: () => (key: string) => {
     const messages: Record<string, string> = {
       signInTitle: 'Sign in',
-      signInSubtitle: 'Continue to Best Car Rental',
+      signInSubtitle: 'Continue to Kuruma Rental',
       continueWithGoogle: 'Continue with Google',
     }
     return messages[key] ?? key
@@ -20,7 +20,7 @@ describe('LoginCard', () => {
   it('renders the title and subtitle', () => {
     render(<LoginCard />)
     expect(screen.getByRole('heading', { name: 'Sign in' })).toBeInTheDocument()
-    expect(screen.getByText('Continue to Best Car Rental')).toBeInTheDocument()
+    expect(screen.getByText('Continue to Kuruma Rental')).toBeInTheDocument()
   })
 
   it('submits a POST form to /auth/google/start (no returnTo)', () => {

--- a/packages/web/tests/vite/nav/Navbar.test.tsx
+++ b/packages/web/tests/vite/nav/Navbar.test.tsx
@@ -105,13 +105,18 @@ afterEach(() => {
 })
 
 describe('Navbar', () => {
-  it('links the logo to the locale home and shows no nav links when signed out', () => {
+  it('exposes the public Browse (search) link when signed out (#1300)', () => {
     renderNavbar(undefined)
     expect(screen.getByText('Kuruma').closest('a')).toHaveAttribute('data-to', '/$locale')
+    // A logged-out visitor gets one public funnel link, Browse -> /search, so the
+    // mobile drawer is no longer empty. The same navItems array feeds desktop + drawer.
+    expect(screen.getByText('Browse').closest('a')).toHaveAttribute('data-to', '/$locale/search')
+    // No authenticated nav leaks in for an anonymous session.
     expect(screen.queryByText('Dashboard')).toBeNull()
     expect(screen.queryByText('Bookings')).toBeNull()
+    expect(screen.queryByText('My Bookings')).toBeNull()
     expect(screen.getByTestId('navbar-client')).toHaveAttribute('data-signed-in', 'false')
-    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '0')
+    expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-nav-count', '1')
   })
 
   it('shows the dashboard, operator bookings + fleet + classes + insurance links and business markers for a business user', () => {


### PR DESCRIPTION
Closes #1300.
Closes #1294 (this is the epic's last open child — Wave 1 + #1299/#1301/#1302 already shipped).

## What & why
Mobile UX C, the final child of the mobile-hardening epic. Three fixes to the logged-out header/nav on touch:

1. **Logged-out nav was empty.** An anonymous session's `navItems` was `[]`, so the mobile drawer showed only "Log in". It now leads with the public **Browse → /search** funnel link, shared by the desktop nav and the drawer (the derivation collapsed to a two-way branch with a single hoisted `browseItem`, so the route+label lives in one place).
2. **Icon-only controls under the 44px touch floor.** The base Button already pins *height* on coarse pointers (`pointer-coarse:min-h-11`, #1298); the menu + language triggers were still narrow. The menu trigger now uses the `icon-sm` primitive (bundles `min-w-11`); the language trigger gets `pointer-coarse:min-w-11`. The language trigger also gained a mobile accessible name via an `sr-only sm:hidden` span (it was an unnamed icon-only control on mobile) — deliberately *not* an `aria-label`, which would clobber the visible "English" label on desktop (WCAG 2.5.3).
3. **Brand divergence.** `auth.signInSubtitle` leaked the seed operator name "Best Car Rental"; it now reads the Kuruma product brand in all three locales, and `index.html`'s `<title>` matches. New `nav.language` key added to en/ja/zh.

Owner confirmed scope: drawer exposes only the Browse link (no Locations/Help pages exist); product brand everywhere.

## Test plan
- [x] `Navbar.test.tsx` signed-out case rewritten: asserts the Browse link → `/$locale/search` and `data-nav-count='1'`.
- [x] `LoginCard.test.tsx` subtitle updated to the product brand.
- [x] New `e2e/mobile/header-nav.spec.ts` (mobile-safari / iPhone 13): drawer shows Browse + Log in; menu & language boxes ≥44×44; sign-in shows "Continue to Kuruma Rental" and no "Best Car Rental". 3/3 pass.
- [x] Full web unit suite (266 files / 1822 tests), tsc ×3, biome, lint:size, lint:modules, i18n parity (1389 keys ×3 locales), vite build — all green.
- [x] code-reviewer + architect reviews: no CRITICAL/HIGH; 1 MEDIUM (a11y) + 2 LOW folded in.