### PR TITLE
fix(#1324): key the new-order last-seen watermark by picked operator

### DIFF
--- a/packages/web/src/vite/operator-bookings/new-bookings.ts
+++ b/packages/web/src/vite/operator-bookings/new-bookings.ts
@@ -11,7 +11,20 @@ import { z } from 'zod'
 // cache so the Navbar badge and the orders-route clear-on-visit stay in sync.
 
 export const LAST_SEEN_STORAGE_KEY = 'kuruma_bookings_last_seen_at'
-export const LAST_SEEN_QUERY_KEY = ['operator-bookings', 'last-seen-at'] as const
+
+// #1230 slice 5a keyed the scan per operator; #1324 keys the watermark to match, so a
+// picker admin switching operators measures each operator's badge against ITS OWN
+// last-seen instant instead of whichever operator's was advanced last. No-pick (tenant
+// sessions) keeps the bare base storage key and a `null` query slot — a single stable
+// watermark, no migration/reset. markBookingsSeen and lastSeenQueryOptions both derive
+// from these, so clear-on-visit and the badge read always share one key per pick.
+export function lastSeenStorageKey(pickedOperatorId?: string): string {
+  return pickedOperatorId ? `${LAST_SEEN_STORAGE_KEY}:${pickedOperatorId}` : LAST_SEEN_STORAGE_KEY
+}
+
+export function lastSeenQueryKey(pickedOperatorId?: string) {
+  return ['operator-bookings', 'last-seen-at', pickedOperatorId ?? null] as const
+}
 
 // #1230 slice 5a: the scan is keyed by the picked operator (null = no pick) so a
 // picker admin switching operators gets that operator's own count instead of a
@@ -78,18 +91,19 @@ export function newOrderBookingsQueryOptions(enabled: boolean, pickedOperatorId?
  * than the epoch — otherwise the badge would light up with the entire existing
  * backlog, which is not "new".
  */
-export function getStoredLastSeenAt(): string {
-  const stored = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY)
+export function getStoredLastSeenAt(pickedOperatorId?: string): string {
+  const storageKey = lastSeenStorageKey(pickedOperatorId)
+  const stored = window.localStorage.getItem(storageKey)
   if (stored) return stored
   const now = new Date().toISOString()
-  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, now)
+  window.localStorage.setItem(storageKey, now)
   return now
 }
 
-export function lastSeenQueryOptions() {
+export function lastSeenQueryOptions(pickedOperatorId?: string) {
   return queryOptions({
-    queryKey: LAST_SEEN_QUERY_KEY,
-    queryFn: () => getStoredLastSeenAt(),
+    queryKey: lastSeenQueryKey(pickedOperatorId),
+    queryFn: () => getStoredLastSeenAt(pickedOperatorId),
     staleTime: Number.POSITIVE_INFINITY,
   })
 }
@@ -110,6 +124,6 @@ export function markBookingsSeen(queryClient: QueryClient, pickedOperatorId?: st
     newOrderScanQueryKey(pickedOperatorId),
   )
   const seenAt = scanned?.[0]?.createdAt ?? new Date().toISOString()
-  window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, seenAt)
-  queryClient.setQueryData(LAST_SEEN_QUERY_KEY, seenAt)
+  window.localStorage.setItem(lastSeenStorageKey(pickedOperatorId), seenAt)
+  queryClient.setQueryData(lastSeenQueryKey(pickedOperatorId), seenAt)
 }

--- a/packages/web/src/vite/operator-bookings/useNewBookingsBadge.ts
+++ b/packages/web/src/vite/operator-bookings/useNewBookingsBadge.ts
@@ -18,7 +18,7 @@ import { useMemo } from 'react'
 // BusinessSidebar) get the narrowed count with no caller changes.
 export function useNewBookingsBadge({ enabled }: { enabled: boolean }): { count: number } {
   const pickedOperatorId = useOptionalPickedOperatorId()
-  const { data: lastSeenAt } = useQuery(lastSeenQueryOptions())
+  const { data: lastSeenAt } = useQuery(lastSeenQueryOptions(pickedOperatorId))
   const { data: bookings } = useQuery(newOrderBookingsQueryOptions(enabled, pickedOperatorId))
 
   const count = useMemo(

--- a/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
+++ b/packages/web/tests/vite/operator-bookings/new-bookings.test.ts
@@ -4,6 +4,8 @@ import {
   countNewBookings,
   fetchNewOrderBookings,
   getStoredLastSeenAt,
+  lastSeenQueryKey,
+  lastSeenStorageKey,
   markBookingsSeen,
   newOrderScanQueryKey,
 } from '@/vite/operator-bookings/new-bookings'
@@ -76,7 +78,7 @@ describe('markBookingsSeen', () => {
     // Exactly the newest scanned createdAt — NOT the client clock.
     expect(stored).toBe('2026-06-13T05:00:00.000Z')
     // Same value mirrored into the cache so subscribers (the nav badge) re-derive.
-    expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
+    expect(qc.getQueryData(lastSeenQueryKey())).toBe(stored)
   })
 
   it('falls back to now when no orders have been scanned yet', () => {
@@ -88,7 +90,43 @@ describe('markBookingsSeen', () => {
     expect(new Date(stored).getTime()).toBeGreaterThan(
       new Date('2020-01-01T00:00:00.000Z').getTime(),
     )
-    expect(qc.getQueryData(['operator-bookings', 'last-seen-at'])).toBe(stored)
+    expect(qc.getQueryData(lastSeenQueryKey())).toBe(stored)
+  })
+})
+
+describe('per-operator watermark (#1324)', () => {
+  it('namespaces keys by picked operator; no-pick keeps the stable base slot', () => {
+    // No-pick (tenant sessions) must keep the exact legacy key so their existing
+    // watermark is not reset (no migration); a pick is namespaced by operator id.
+    expect(lastSeenStorageKey(undefined)).toBe(LAST_SEEN_STORAGE_KEY)
+    expect(lastSeenStorageKey('op_a')).toBe(`${LAST_SEEN_STORAGE_KEY}:op_a`)
+    // Mirrors newOrderScanQueryKey's `?? null` no-pick slot.
+    expect(lastSeenQueryKey(undefined)).toEqual(['operator-bookings', 'last-seen-at', null])
+    expect(lastSeenQueryKey('op_a')).toEqual(['operator-bookings', 'last-seen-at', 'op_a'])
+  })
+
+  it("does not measure one operator against another operator's watermark (the slice-5a gap)", () => {
+    // Operator A opened its orders at T; that must NOT become operator B's baseline.
+    window.localStorage.setItem(lastSeenStorageKey('op_a'), '2026-06-13T05:00:00.000Z')
+    const bSeen = getStoredLastSeenAt('op_b')
+    expect(bSeen).not.toBe('2026-06-13T05:00:00.000Z')
+    // Reading B does not disturb A's slot.
+    expect(window.localStorage.getItem(lastSeenStorageKey('op_a'))).toBe('2026-06-13T05:00:00.000Z')
+  })
+
+  it("markBookingsSeen advances only the picked operator's slot", () => {
+    const qc = new QueryClient()
+    window.localStorage.setItem(lastSeenStorageKey('op_a'), '2020-01-01T00:00:00.000Z')
+    window.localStorage.setItem(lastSeenStorageKey('op_b'), '2020-01-01T00:00:00.000Z')
+    qc.setQueryData(newOrderScanQueryKey('op_a'), [{ createdAt: '2026-06-13T05:00:00.000Z' }])
+
+    markBookingsSeen(qc, 'op_a')
+
+    expect(window.localStorage.getItem(lastSeenStorageKey('op_a'))).toBe('2026-06-13T05:00:00.000Z')
+    // Operator B's watermark is untouched by advancing A.
+    expect(window.localStorage.getItem(lastSeenStorageKey('op_b'))).toBe('2020-01-01T00:00:00.000Z')
+    expect(qc.getQueryData(lastSeenQueryKey('op_a'))).toBe('2026-06-13T05:00:00.000Z')
+    expect(qc.getQueryData(lastSeenQueryKey('op_b'))).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Problem

Picker slice 5a (#1317) made the operator new-order badge **scan** per picked operator (`newOrderScanQueryKey(pickedOperatorId)`), but the **last-seen watermark stayed global** (`kuruma_bookings_last_seen_at` / `['operator-bookings','last-seen-at']`). So when a picker admin switches operators, operator B's count is measured against whatever watermark operator A last advanced — transiently wrong until B's orders list re-syncs it. Normal operator sessions never pick, so they're unaffected.

## Fix

Mirror the scan key. New `lastSeenStorageKey(pickedOperatorId)` / `lastSeenQueryKey(pickedOperatorId)` namespace the watermark by picked operator, with the **bare base key / a `null` query slot** for no-pick (tenant) sessions so their single stable watermark is unchanged — **no migration, no reset**. The pick is threaded through `getStoredLastSeenAt`, `lastSeenQueryOptions` (consumed by `useNewBookingsBadge`) and `markBookingsSeen` (the bookings route already passed `pickedOperatorId`).

## Tests (TDD, RED→GREEN)

New `per-operator watermark (#1324)` suite: key namespacing + no-pick stability, cross-operator non-leak, and `markBookingsSeen` advancing only the picked slot. Existing no-pick assertions updated to the mirrored key shape.

## Verification

new-bookings + hook + operator-narrow **20/20** · full operator-bookings dir **250/250** · biome clean · web + api tsc (pre-commit hook) green.

Closes #1324. Refs #1230 #1317.