### PR TITLE
fix(#1260): bind vehicle block writes to the picked operator (slice 1)

### DIFF
--- a/packages/api/src/routes/vehicle-blocks.ts
+++ b/packages/api/src/routes/vehicle-blocks.ts
@@ -56,7 +56,15 @@ export function createVehicleBlockRoutes(service: VehicleBlockService) {
       const parsed = await parseBody(c, createVehicleBlockSchema)
       if (!parsed.ok) return parsed.response
 
-      const result = await service.createBlock(toCallerContext(user), idResult.id, parsed.data)
+      // #1260: a picker admin binds the write to the operator it is acting as; the
+      // service drops the id for a tenant operator, so it can never widen scope.
+      const actingOperatorId = c.req.query('operatorId')
+      const result = await service.createBlock(
+        toCallerContext(user),
+        idResult.id,
+        parsed.data,
+        actingOperatorId,
+      )
       if (!result.ok)
         return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
       return ok(c, result.block, 201)
@@ -70,10 +78,13 @@ export function createVehicleBlockRoutes(service: VehicleBlockService) {
       const blockIdResult = parseId(c, 'blockId')
       if (!blockIdResult.ok) return blockIdResult.response
 
+      // #1260: bind an admin delete to the operator it is acting as (see POST).
+      const actingOperatorId = c.req.query('operatorId')
       const result = await service.deleteBlock(
         toCallerContext(user),
         vehicleIdResult.id,
         blockIdResult.id,
+        actingOperatorId,
       )
       if (!result.ok)
         return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)

--- a/packages/api/src/services/vehicle-block.ts
+++ b/packages/api/src/services/vehicle-block.ts
@@ -8,17 +8,38 @@ import type {
   VehicleBlockRepository,
   VehicleRepository,
 } from '../repositories/types'
-import { narrowReadToOperator, vehicleBlockReadScope } from '../tenancy'
+import {
+  assertFleetWriteWithinOperator,
+  narrowReadToOperator,
+  vehicleBlockReadScope,
+} from '../tenancy'
 
 export type VehicleBlockResult =
   | { ok: true; block: VehicleBlock }
   | { ok: false; error: string; status: number; code?: ErrorCode }
 
 const VEHICLE_NOT_FOUND_MESSAGE = 'Vehicle not found'
+const OPERATOR_REQUIRED_MESSAGE = 'operatorId is required: specify the operator to act as'
 const BLOCK_NOT_FOUND_MESSAGE = 'Block not found'
 const OVERLAP_MESSAGE = 'This vehicle is already blocked for an overlapping window'
 const BOOKING_CONFLICT_MESSAGE =
   'This vehicle has a confirmed or active booking in the requested window'
+
+// #1260: map the acting-operator-binding denial to the service result. A missing
+// pick is a 422 carrying the same OPERATOR_REQUIRED code the global
+// OperatorRequiredError emits (so the web can discriminate it); a mismatch is a
+// 404 — from the acting operator's fleet the vehicle does not exist (no oracle).
+function denyFleetWrite(
+  ctx: CallerContext,
+  targetOperatorId: string,
+  actingOperatorId: string | undefined,
+): VehicleBlockResult | undefined {
+  const denial = assertFleetWriteWithinOperator(ctx, targetOperatorId, actingOperatorId)
+  if (!denial) return undefined
+  return denial.kind === 'operator-required'
+    ? { ok: false, error: OPERATOR_REQUIRED_MESSAGE, status: 422, code: 'OPERATOR_REQUIRED' }
+    : { ok: false, error: VEHICLE_NOT_FOUND_MESSAGE, status: 404 }
+}
 
 // The GiST EXCLUDE is named `vehicle_blocks_no_overlap`; match the name (not the
 // bare 23P01) so a block-vs-block clash is told apart from any other exclusion.
@@ -52,11 +73,17 @@ export class VehicleBlockService {
     ctx: CallerContext,
     vehicleId: string,
     input: CreateVehicleBlockInput,
+    actingOperatorId?: string,
   ): Promise<VehicleBlockResult> {
     requireFleetWriteScope(ctx)
 
     const vehicle = await this.vehicleRepo.findById(ctx, vehicleId)
     if (!vehicle) return { ok: false, error: VEHICLE_NOT_FOUND_MESSAGE, status: 404 }
+
+    // #1260: an admin/legacy caller resolves vehicles across all operators, so bind
+    // the write to the operator it picked before deriving operatorId from the vehicle.
+    const denied = denyFleetWrite(ctx, vehicle.operatorId, actingOperatorId)
+    if (denied) return denied
 
     // #1196: reject a block that would silently take a car off the calendar while
     // a CONFIRMED/ACTIVE booking still holds it — the reverse of the booking→block
@@ -112,6 +139,7 @@ export class VehicleBlockService {
     ctx: CallerContext,
     vehicleId: string,
     blockId: string,
+    actingOperatorId?: string,
   ): Promise<VehicleBlockResult> {
     requireFleetWriteScope(ctx)
 
@@ -120,6 +148,10 @@ export class VehicleBlockService {
     // unknown vehicleId → 404 before any write is attempted.
     const vehicle = await this.vehicleRepo.findById(ctx, vehicleId)
     if (!vehicle) return { ok: false, error: VEHICLE_NOT_FOUND_MESSAGE, status: 404 }
+
+    // #1260: bind an admin/legacy delete to the operator it picked (see createBlock).
+    const denied = denyFleetWrite(ctx, vehicle.operatorId, actingOperatorId)
+    if (denied) return denied
 
     const removed = await this.vehicleBlockRepo.delete(blockId, vehicle.operatorId)
     if (!removed) return { ok: false, error: BLOCK_NOT_FOUND_MESSAGE, status: 404 }

--- a/packages/api/src/tenancy.test.ts
+++ b/packages/api/src/tenancy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { CallerContext } from './middleware/auth'
 import {
+  assertFleetWriteWithinOperator,
   bookingReadScope,
   narrowReadToOperator,
   operatorReadScope,
@@ -124,6 +125,50 @@ describe('narrowReadToOperator', () => {
     // reads pass bookingReadScope precisely so renter/partner ids drop.
     const renter: CallerContext = { userId: 'r1', role: 'RENTER' }
     expect(narrowReadToOperator(renter, 'op-target', operatorReadScope)).toBe('op-target')
+  })
+})
+
+describe('assertFleetWriteWithinOperator (#1260)', () => {
+  // A tenant operator is already clamped to its own tenant by the repo read
+  // scope (findById returns undefined for a foreign vehicle), so a fleet write
+  // needs no acting-operator binding — a stray acting id is simply ignored.
+  it('allows a tenant operator regardless of the acting operatorId', () => {
+    const op: CallerContext = { userId: 'u1', role: 'OPERATOR_OWNER', operatorId: 'op-self' }
+    expect(assertFleetWriteWithinOperator(op, 'op-self', undefined)).toBeNull()
+    expect(assertFleetWriteWithinOperator(op, 'op-self', 'op-other')).toBeNull()
+    expect(assertFleetWriteWithinOperator(op, 'op-self', 'op-self')).toBeNull()
+  })
+
+  it('requires a bypass admin to name the operator it is acting as', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(assertFleetWriteWithinOperator(admin, 'op-A', undefined)).toEqual({
+      kind: 'operator-required',
+    })
+  })
+
+  it('rejects an admin whose acting operator does not own the target (no existence oracle)', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(assertFleetWriteWithinOperator(admin, 'op-A', 'op-B')).toEqual({ kind: 'not-in-scope' })
+  })
+
+  it('allows an admin acting as the operator that owns the target', () => {
+    const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    expect(assertFleetWriteWithinOperator(admin, 'op-A', 'op-A')).toBeNull()
+  })
+
+  it('guards legacy STAFF/ADMIN identically — the hole is !isOperatorRole, not bypassScope', () => {
+    // #487 dropped legacy STAFF/ADMIN from SCOPE_BYPASS_ROLES, but operatorReadScope
+    // still maps them to `all`, so findById resolves ANY vehicle for them too. Keying
+    // this guard on bypassScope would leave them able to write cross-tenant.
+    const staff: CallerContext = { userId: 's1', role: 'STAFF', bypassScope: false }
+    const legacyAdmin: CallerContext = { userId: 'a1', role: 'ADMIN', bypassScope: false }
+    expect(assertFleetWriteWithinOperator(staff, 'op-A', undefined)).toEqual({
+      kind: 'operator-required',
+    })
+    expect(assertFleetWriteWithinOperator(legacyAdmin, 'op-A', 'op-B')).toEqual({
+      kind: 'not-in-scope',
+    })
+    expect(assertFleetWriteWithinOperator(staff, 'op-A', 'op-A')).toBeNull()
   })
 })
 

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -198,6 +198,41 @@ export function threadReadScope(ctx: CallerContext): ThreadReadScope {
 }
 
 /**
+ * Why a fleet WRITE is refused when a non-tenant caller has not bound itself to
+ * the operator that owns the target (#1260):
+ * - `operator-required` — no acting operatorId was supplied (mapped to 422).
+ * - `not-in-scope`      — the acting operator does not own the target vehicle,
+ *                         so from that context the target does not exist (404).
+ */
+export type FleetWriteDenial = { kind: 'operator-required' } | { kind: 'not-in-scope' }
+
+/**
+ * Bind a fleet WRITE to the operator the caller is acting as (#1260).
+ *
+ * A tenant operator (OPERATOR_*) is already clamped to its own tenant by the
+ * repository read scope — `findById` returns undefined for a foreign vehicle —
+ * so its write needs no acting-operator id and a stray one is ignored.
+ *
+ * Every other admitted caller (PLATFORM_ADMIN, and legacy STAFF/ADMIN) resolves
+ * `all` under `operatorReadScope`, so `findById` hands them ANY operator's
+ * vehicle by raw id. Keyed on `!isOperatorRole` (NOT `ctx.bypassScope`) because
+ * #487 dropped legacy STAFF/ADMIN from the bypass set yet left them `all`-scoped
+ * — bypass-keying would leave that pair able to write cross-tenant. Such a caller
+ * must name the operator it picked, and that operator must own the target;
+ * otherwise the client-side "read-only preview" would be its only protection.
+ */
+export function assertFleetWriteWithinOperator(
+  ctx: CallerContext,
+  targetOperatorId: string,
+  actingOperatorId: string | undefined,
+): FleetWriteDenial | null {
+  if (isOperatorRole(ctx.role)) return null
+  if (!actingOperatorId) return { kind: 'operator-required' }
+  if (actingOperatorId !== targetOperatorId) return { kind: 'not-in-scope' }
+  return null
+}
+
+/**
  * Resolve the operatorId to stamp on a write (#401, #407):
  * - OPERATOR_OWNER / OPERATOR_STAFF write under their own tenant; missing
  *   operatorId fails closed. They cannot write for another operator, so an

--- a/packages/api/tests/integration/vehicle-block-write-scope.test.ts
+++ b/packages/api/tests/integration/vehicle-block-write-scope.test.ts
@@ -1,0 +1,115 @@
+import { operators, vehicleBlocks, vehicles } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  DrizzleVehicleBlockRepository,
+  DrizzleVehicleRepository,
+} from '../../src/repositories/drizzle'
+import { VehicleBlockService } from '../../src/services/vehicle-block'
+import { DEFAULT_DAILY_RATE_JPY, db } from './setup'
+
+// #1260: proven against real Postgres — a platform-admin resolves ANY operator's
+// vehicle by raw id (operatorReadScope → all), so the block-write service must bind
+// the write to the operator the admin is acting as. Without the guard the admin
+// could create/remove a block on any operator's car despite the read-only web UI.
+describe('VehicleBlockService write acting-operator binding (#1260, Drizzle)', () => {
+  const vehicleRepo = new DrizzleVehicleRepository(db)
+  const blockRepo = new DrizzleVehicleBlockRepository(db)
+  // The reverse block→booking conflict lookup is orthogonal here; no bookings exist.
+  const service = new VehicleBlockService(vehicleRepo, blockRepo, {
+    findActiveOverlappingForVehicle: async () => [],
+  })
+
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opAId = `blk_write_a_${uniq}`
+  const opBId = `blk_write_b_${uniq}`
+  const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+  const input = {
+    kind: 'MAINTENANCE' as const,
+    reason: 'shaken',
+    startAt: '2027-11-01T09:00:00.000Z',
+    endAt: '2027-11-01T17:00:00.000Z',
+  }
+
+  let vehicleAId: string
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opAId, slug: `blk-write-a-${uniq}`, name: 'Blk Write A' },
+      { id: opBId, slug: `blk-write-b-${uniq}`, name: 'Blk Write B' },
+    ])
+    const v = await vehicleRepo.create(SYSTEM_CONTEXT, {
+      operatorId: opAId,
+      classId: null,
+      name: 'Blk Car',
+      description: null,
+      photos: [],
+      seats: 5,
+      transmission: 'AUTO',
+      fuelType: null,
+      licensePlate: null,
+      status: 'AVAILABLE',
+      minRentalHours: null,
+      maxRentalHours: null,
+      advanceBookingHours: null,
+      make: null,
+      model: null,
+      year: null,
+      color: null,
+      dailyRateJpy: DEFAULT_DAILY_RATE_JPY,
+      hourlyRateJpy: null,
+      shakenExpiryDate: null,
+      insuranceExpiryDate: null,
+    })
+    vehicleAId = v.id
+  })
+
+  afterAll(async () => {
+    await db.delete(vehicleBlocks).where(inArray(vehicleBlocks.operatorId, [opAId, opBId]))
+    await db.delete(vehicles).where(inArray(vehicles.operatorId, [opAId, opBId]))
+    await db.delete(operators).where(inArray(operators.id, [opAId, opBId]))
+  })
+
+  it('confirms the precondition: an admin resolves the foreign vehicle by raw id (the hole)', async () => {
+    const resolved = await vehicleRepo.findById(admin, vehicleAId)
+    expect(resolved?.operatorId).toBe(opAId)
+  })
+
+  it('rejects an admin creating a block with no acting operator (422)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input)
+    expect(result).toMatchObject({ ok: false, status: 422 })
+  })
+
+  it('rejects an admin whose acting operator does not own the vehicle (404)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input, opBId)
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('creates the block when the admin acts as the owning operator (op-A)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input, opAId)
+    expect(result).toMatchObject({ ok: true, block: { operatorId: opAId, vehicleId: vehicleAId } })
+  })
+
+  it('rejects an admin deleting a block with no acting operator, then removes it when acting as op-A', async () => {
+    const created = await blockRepo.create({
+      operatorId: opAId,
+      vehicleId: vehicleAId,
+      startAt: new Date('2027-12-01T09:00:00Z'),
+      endAt: new Date('2027-12-01T17:00:00Z'),
+      kind: 'MAINTENANCE',
+      reason: 'to-remove',
+      notes: null,
+      createdBy: 'seed',
+    })
+
+    const denied = await service.deleteBlock(admin, vehicleAId, created.id)
+    expect(denied).toMatchObject({ ok: false, status: 422 })
+    expect(await blockRepo.findById(created.id)).toBeDefined()
+
+    const removed = await service.deleteBlock(admin, vehicleAId, created.id, opAId)
+    expect(removed).toMatchObject({ ok: true })
+    expect(await blockRepo.findById(created.id)).toBeUndefined()
+  })
+})

--- a/packages/api/tests/integration/vehicle-blocks.test.ts
+++ b/packages/api/tests/integration/vehicle-blocks.test.ts
@@ -302,10 +302,13 @@ describe('VehicleBlockService against Postgres', () => {
   }
 
   it('persists a block with operatorId derived from the vehicle', async () => {
+    // #1260: an admin/bypass caller (SYSTEM_CONTEXT is PLATFORM_ADMIN) must name the
+    // operator it is acting as; here it acts as the vehicle's owning operator.
     const result = await service.createBlock(
       SYSTEM_CONTEXT,
       vehicleA,
       input(hours(200), hours(208)),
+      BEST_CAR_RENTAL_OPERATOR_ID,
     )
 
     expect(result.ok).toBe(true)
@@ -317,7 +320,12 @@ describe('VehicleBlockService against Postgres', () => {
   })
 
   it('maps the GiST 23P01 to 409 VEHICLE_BLOCK_OVERLAP on an overlapping window', async () => {
-    const first = await service.createBlock(SYSTEM_CONTEXT, vehicleA, input(hours(300), hours(320)))
+    const first = await service.createBlock(
+      SYSTEM_CONTEXT,
+      vehicleA,
+      input(hours(300), hours(320)),
+      BEST_CAR_RENTAL_OPERATOR_ID,
+    )
     if (!first.ok) throw new Error('setup block should have been created')
     createdBlockIds.push(first.block.id)
 
@@ -325,6 +333,7 @@ describe('VehicleBlockService against Postgres', () => {
       SYSTEM_CONTEXT,
       vehicleA,
       input(hours(310), hours(330)),
+      BEST_CAR_RENTAL_OPERATOR_ID,
     )
 
     expect(overlap).toMatchObject({ ok: false, status: 409, code: 'VEHICLE_BLOCK_OVERLAP' })

--- a/packages/api/tests/routes/vehicle-blocks-write-scope.test.ts
+++ b/packages/api/tests/routes/vehicle-blocks-write-scope.test.ts
@@ -1,0 +1,156 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SYSTEM_CONTEXT, type UserRole } from '../../src/middleware/auth'
+import {
+  InMemoryBookingRepository,
+  InMemoryVehicleBlockRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { createVehicleBlockRoutes } from '../../src/routes/vehicle-blocks'
+import { VehicleBlockService } from '../../src/services/vehicle-block'
+import type { Vehicle } from '../../src/stores'
+import { testAuthMiddleware } from '../helpers/auth'
+
+// #1260: the "admin gets a read-only preview" property was enforced client-side
+// only; the write API let a platform-admin mutate any operator's blocks by raw
+// vehicleId. Writes now require the picked ?operatorId= and bind to it.
+
+function vehicleInput(operatorId: string): Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    operatorId,
+    name: 'Car',
+    classId: null,
+    pickupLocationId: null,
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: null,
+    luggageSize: null,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-06-15',
+    insuranceExpiryDate: '2099-01-01',
+  }
+}
+
+const validBody = {
+  kind: 'MAINTENANCE',
+  reason: 'Annual shaken',
+  startAt: '2026-07-01T09:00:00.000Z',
+  endAt: '2026-07-01T17:00:00.000Z',
+}
+
+let vehicleRepo: InMemoryVehicleRepository
+let blockRepo: InMemoryVehicleBlockRepository
+let bookingRepo: InMemoryBookingRepository
+
+function appAs(role: UserRole, operatorId?: string): Hono {
+  const a = new Hono()
+  a.use('*', testAuthMiddleware('caller', role, operatorId))
+  a.route(
+    '/',
+    createVehicleBlockRoutes(new VehicleBlockService(vehicleRepo, blockRepo, bookingRepo)),
+  )
+  return a
+}
+
+function postBlock(app: Hono, vehicleId: string, query = '') {
+  return app.request(`/vehicles/${vehicleId}/blocks${query}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(validBody),
+  })
+}
+
+beforeEach(() => {
+  vehicleRepo = new InMemoryVehicleRepository()
+  blockRepo = new InMemoryVehicleBlockRepository()
+  bookingRepo = new InMemoryBookingRepository()
+})
+
+describe('POST /vehicles/:vehicleId/blocks — admin acting-operator (#1260)', () => {
+  it('rejects a platform-admin with no ?operatorId= (422)', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    const res = await postBlock(appAs('PLATFORM_ADMIN'), vehicle.id)
+    expect(res.status).toBe(422)
+  })
+
+  it('rejects a platform-admin whose ?operatorId= does not own the vehicle (404)', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    const res = await postBlock(appAs('PLATFORM_ADMIN'), vehicle.id, '?operatorId=op-b')
+    expect(res.status).toBe(404)
+  })
+
+  it('creates the block when the admin acts as the owning operator (201)', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    const res = await postBlock(appAs('PLATFORM_ADMIN'), vehicle.id, '?operatorId=op-a')
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { data: { operatorId: string } }
+    expect(body.data.operatorId).toBe('op-a')
+  })
+
+  it('ignores ?operatorId= for a tenant operator — it stays clamped to its own tenant', async () => {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-a'))
+    // A tenant operator passing a foreign ?operatorId= must not be able to widen
+    // scope; its own read scope still binds it, so this simply succeeds on its car.
+    const res = await postBlock(appAs('OPERATOR_OWNER', 'op-a'), vehicle.id, '?operatorId=op-b')
+    expect(res.status).toBe(201)
+  })
+})
+
+describe('DELETE /vehicles/:vehicleId/blocks/:blockId — admin acting-operator (#1260)', () => {
+  async function seedBlock(operatorId: string): Promise<{ vehicleId: string; blockId: string }> {
+    const vehicle = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput(operatorId))
+    const block = await blockRepo.create({
+      operatorId,
+      vehicleId: vehicle.id,
+      startAt: new Date(validBody.startAt),
+      endAt: new Date(validBody.endAt),
+      kind: 'MAINTENANCE',
+      reason: 'seed',
+      notes: null,
+      createdBy: 'seed',
+    })
+    return { vehicleId: vehicle.id, blockId: block.id }
+  }
+
+  it('rejects a platform-admin with no ?operatorId= (422)', async () => {
+    const { vehicleId, blockId } = await seedBlock('op-a')
+    const res = await appAs('PLATFORM_ADMIN').request(`/vehicles/${vehicleId}/blocks/${blockId}`, {
+      method: 'DELETE',
+    })
+    expect(res.status).toBe(422)
+    expect(await blockRepo.findById(blockId)).toBeDefined()
+  })
+
+  it('rejects a platform-admin whose ?operatorId= does not own the vehicle (404)', async () => {
+    const { vehicleId, blockId } = await seedBlock('op-a')
+    const res = await appAs('PLATFORM_ADMIN').request(
+      `/vehicles/${vehicleId}/blocks/${blockId}?operatorId=op-b`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(404)
+    expect(await blockRepo.findById(blockId)).toBeDefined()
+  })
+
+  it('removes the block when the admin acts as the owning operator (200)', async () => {
+    const { vehicleId, blockId } = await seedBlock('op-a')
+    const res = await appAs('PLATFORM_ADMIN').request(
+      `/vehicles/${vehicleId}/blocks/${blockId}?operatorId=op-a`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(200)
+    expect(await blockRepo.findById(blockId)).toBeUndefined()
+  })
+})

--- a/packages/api/tests/services/vehicle-block-write-scope.test.ts
+++ b/packages/api/tests/services/vehicle-block-write-scope.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'
+import {
+  InMemoryBookingRepository,
+  InMemoryVehicleBlockRepository,
+  InMemoryVehicleRepository,
+} from '../../src/repositories/in-memory'
+import { VehicleBlockService } from '../../src/services/vehicle-block'
+import type { Vehicle } from '../../src/stores'
+
+// #1260: a platform-admin (or legacy STAFF/ADMIN) resolves `all` under
+// operatorReadScope, so findById hands them ANY operator's vehicle by raw id.
+// Block writes must therefore be bound to the operator the admin is acting as,
+// or the "read-only preview" is enforced client-side only.
+const admin: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+const opA: CallerContext = { userId: 'ua', role: 'OPERATOR_OWNER', operatorId: 'op-A' }
+
+const input = {
+  kind: 'MAINTENANCE' as const,
+  reason: 'Annual shaken',
+  startAt: '2026-07-01T09:00:00.000Z',
+  endAt: '2026-07-01T17:00:00.000Z',
+}
+
+function vehicleInput(operatorId: string): Omit<Vehicle, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    operatorId,
+    name: 'Car',
+    classId: null,
+    pickupLocationId: null,
+    description: null,
+    photos: [],
+    seats: 5,
+    luggageCapacity: null,
+    luggageSize: null,
+    transmission: 'AUTO',
+    fuelType: null,
+    licensePlate: null,
+    status: 'AVAILABLE',
+    minRentalHours: null,
+    maxRentalHours: null,
+    advanceBookingHours: null,
+    make: null,
+    model: null,
+    year: null,
+    color: null,
+    dailyRateJpy: 8000,
+    hourlyRateJpy: null,
+    shakenExpiryDate: '2099-06-15',
+    insuranceExpiryDate: '2099-01-01',
+  }
+}
+
+let vehicleRepo: InMemoryVehicleRepository
+let blockRepo: InMemoryVehicleBlockRepository
+let service: VehicleBlockService
+let vehicleAId: string
+
+beforeEach(async () => {
+  vehicleRepo = new InMemoryVehicleRepository()
+  blockRepo = new InMemoryVehicleBlockRepository()
+  service = new VehicleBlockService(vehicleRepo, blockRepo, new InMemoryBookingRepository())
+  const veh = await vehicleRepo.create(SYSTEM_CONTEXT, vehicleInput('op-A'))
+  vehicleAId = veh.id
+})
+
+describe('VehicleBlockService.createBlock — acting-operator binding (#1260)', () => {
+  it('rejects an admin who names no acting operator (422)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input, undefined)
+    expect(result).toMatchObject({ ok: false, status: 422 })
+  })
+
+  it('rejects an admin whose acting operator does not own the vehicle (404, no oracle)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input, 'op-B')
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('creates the block when the admin acts as the owning operator (201)', async () => {
+    const result = await service.createBlock(admin, vehicleAId, input, 'op-A')
+    expect(result).toMatchObject({ ok: true, block: { operatorId: 'op-A', vehicleId: vehicleAId } })
+  })
+
+  it('still lets a tenant operator write without an acting id (regression)', async () => {
+    const result = await service.createBlock(opA, vehicleAId, input)
+    expect(result).toMatchObject({ ok: true, block: { operatorId: 'op-A' } })
+  })
+})
+
+describe('VehicleBlockService.deleteBlock — acting-operator binding (#1260)', () => {
+  async function seedBlock(): Promise<string> {
+    const block = await blockRepo.create({
+      operatorId: 'op-A',
+      vehicleId: vehicleAId,
+      startAt: new Date(input.startAt),
+      endAt: new Date(input.endAt),
+      kind: 'MAINTENANCE',
+      reason: 'seed',
+      notes: null,
+      createdBy: 'seed',
+    })
+    return block.id
+  }
+
+  it('rejects an admin who names no acting operator (422)', async () => {
+    const blockId = await seedBlock()
+    const result = await service.deleteBlock(admin, vehicleAId, blockId, undefined)
+    expect(result).toMatchObject({ ok: false, status: 422 })
+    expect(await blockRepo.findById(blockId)).toBeDefined()
+  })
+
+  it('rejects an admin whose acting operator does not own the vehicle (404)', async () => {
+    const blockId = await seedBlock()
+    const result = await service.deleteBlock(admin, vehicleAId, blockId, 'op-B')
+    expect(result).toMatchObject({ ok: false, status: 404 })
+    expect(await blockRepo.findById(blockId)).toBeDefined()
+  })
+
+  it('removes the block when the admin acts as the owning operator', async () => {
+    const blockId = await seedBlock()
+    const result = await service.deleteBlock(admin, vehicleAId, blockId, 'op-A')
+    expect(result).toMatchObject({ ok: true })
+    expect(await blockRepo.findById(blockId)).toBeUndefined()
+  })
+})

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -393,6 +393,7 @@ export function OperatorBookingsRoute() {
           csrfToken={session?.csrfToken ?? ''}
           initialVehicleId={blockSlotVehicleId}
           initialRange={blockSlotRange ?? undefined}
+          pickedOperatorId={pickedOperatorId}
         />
       )}
       {canViewBlocks && (
@@ -405,6 +406,7 @@ export function OperatorBookingsRoute() {
           }
           canManage={canManageBlocks}
           csrfToken={session?.csrfToken ?? ''}
+          pickedOperatorId={pickedOperatorId}
           locale={locale}
         />
       )}

--- a/packages/web/src/vite/operator-bookings/BlockDetailDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/BlockDetailDialog.tsx
@@ -20,10 +20,13 @@ export interface BlockDetailDialogProps {
   /** Resolved by the route from the block's `resourceId` (the calendar item carries
    *  only the vehicle id, never an enriched name). */
   readonly vehicleName: string | null
-  /** Operator-session viewers manage blocks; a platform-admin preview is read-only
-   *  (the API admits an admin write, so this affordance gate is the boundary). */
+  /** Operator-session viewers manage blocks; a platform-admin manages blocks only
+   *  within the operator it has picked (canManage folds that in). */
   readonly canManage: boolean
   readonly csrfToken: string
+  /** #1260: the picked operator a platform-admin is acting as; the delete binds to
+   *  it server-side. Undefined for a tenant operator (its own scope binds it). */
+  readonly pickedOperatorId?: string | undefined
   readonly locale: string
 }
 
@@ -38,6 +41,7 @@ export function BlockDetailDialog({
   vehicleName,
   canManage,
   csrfToken,
+  pickedOperatorId,
   locale,
 }: BlockDetailDialogProps) {
   const t = useTranslations('bookings.operator.blocks')
@@ -47,7 +51,7 @@ export function BlockDetailDialog({
   const mutation = useMutation({
     mutationFn: () => {
       if (!block) throw new Error('no block selected')
-      return deleteBlock(block.resourceId, block.id, csrfToken)
+      return deleteBlock(block.resourceId, block.id, csrfToken, pickedOperatorId)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })

--- a/packages/web/src/vite/operator-bookings/ScheduleBlockDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/ScheduleBlockDialog.tsx
@@ -34,6 +34,9 @@ export interface ScheduleBlockDialogProps {
   readonly initialVehicleId?: string | undefined
   /** A clicked slot's range, to prefill start/end (wall-clock JST). */
   readonly initialRange?: { start: Date; end: Date } | undefined
+  /** #1260: the picked operator a platform-admin is acting as; the write binds to
+   *  it server-side. Undefined for a tenant operator (its own scope binds it). */
+  readonly pickedOperatorId?: string | undefined
 }
 
 const HTTP_CONFLICT = 409
@@ -51,6 +54,7 @@ export function ScheduleBlockDialog({
   csrfToken,
   initialVehicleId,
   initialRange,
+  pickedOperatorId,
 }: ScheduleBlockDialogProps) {
   const t = useTranslations('bookings.operator.blocks')
   const queryClient = useQueryClient()
@@ -73,7 +77,7 @@ export function ScheduleBlockDialog({
         // optional notes; sending '' would be a needless empty string.
         ...(notes.trim() ? { notes: notes.trim() } : {}),
       }
-      return createBlock(vehicleId, input, csrfToken)
+      return createBlock(vehicleId, input, csrfToken, pickedOperatorId)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: OPERATOR_BOOKINGS_KEY })

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -186,9 +186,11 @@ export function operatorCalendarVehiclesQueryOptions(pickedOperatorId?: string) 
 
 // --- #1101 Slice B: scheduled vehicle blocks ---------------------------------
 // The operator calendar reads fleet-wide blocks over a range (GET /vehicle-blocks,
-// gated MANAGEMENT_READ_ROLES, row-scoped in the repo — the client passes no
-// operatorId) and writes per-vehicle (POST/DELETE /vehicles/:id/blocks, operatorId
-// server-derived from the vehicle). The block DTO + its schema live in ./schema.
+// gated MANAGEMENT_READ_ROLES, row-scoped in the repo) and writes per-vehicle
+// (POST/DELETE /vehicles/:id/blocks). A picker admin passes the picked operatorId
+// on both reads and writes; the API binds the write to it (#1260) so an admin can
+// only mutate the operator it is acting as, not any operator by raw vehicleId. The
+// block operatorId is still server-derived from the vehicle. DTO + schema: ./schema.
 export type { CalendarBlockRow }
 /** Create-block body — the shared validator's input (kind, reason, startAt, endAt, notes?). */
 export type CreateBlockInput = CreateVehicleBlockInput
@@ -226,13 +228,20 @@ export async function createBlock(
   vehicleId: string,
   input: CreateBlockInput,
   csrfToken: string,
+  pickedOperatorId?: string,
 ): Promise<CalendarBlockRow> {
-  const res = await fetch(`${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/blocks`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
-    body: JSON.stringify(input),
-  })
+  // #1260: a picker admin binds the write to the operator it is acting as; a tenant
+  // operator omits it (the server drops it, so it can never widen scope).
+  const suffix = pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
+  const res = await fetch(
+    `${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/blocks${suffix}`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify(input),
+    },
+  )
   return unwrap(res, calendarBlockSchema)
 }
 
@@ -240,9 +249,12 @@ export async function deleteBlock(
   vehicleId: string,
   blockId: string,
   csrfToken: string,
+  pickedOperatorId?: string,
 ): Promise<CalendarBlockRow> {
+  // #1260: bind an admin delete to the picked operator (see createBlock).
+  const suffix = pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
   const res = await fetch(
-    `${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/blocks/${encodeURIComponent(blockId)}`,
+    `${getApiBaseUrl()}/vehicles/${encodeURIComponent(vehicleId)}/blocks/${encodeURIComponent(blockId)}${suffix}`,
     {
       method: 'DELETE',
       credentials: 'include',

--- a/packages/web/tests/vite/operator-bookings/BlockDetailDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BlockDetailDialog.test.tsx
@@ -71,9 +71,10 @@ describe('BlockDetailDialog', () => {
     expect(screen.getByText('Bay 3 lift')).not.toBeNull()
   })
 
-  it('requires a confirm click, then deletes, invalidates the cache, and closes', async () => {
+  it('requires a confirm click, then deletes (forwarding the picked operator), invalidates the cache, and closes', async () => {
     deleteBlockMock.mockResolvedValue(BLOCK)
-    const { onClose, invalidate } = setup()
+    // #1260: a picker admin's delete binds to the operator it is acting as.
+    const { onClose, invalidate } = setup({ pickedOperatorId: 'op-7' })
 
     // First click arms the confirm — no API call yet.
     fireEvent.click(screen.getByRole('button', { name: T.deleteAction }))
@@ -83,7 +84,7 @@ describe('BlockDetailDialog', () => {
     // Second click performs the hard delete against the block's vehicle + id.
     fireEvent.click(screen.getByRole('button', { name: T.deleteAction }))
     await waitFor(() => expect(onClose).toHaveBeenCalled())
-    expect(deleteBlockMock).toHaveBeenCalledWith('veh-2', 'blk-1', 'csrf-1')
+    expect(deleteBlockMock).toHaveBeenCalledWith('veh-2', 'blk-1', 'csrf-1', 'op-7')
     expect(invalidate).toHaveBeenCalledWith({ queryKey: OPERATOR_BOOKINGS_KEY })
   })
 

--- a/packages/web/tests/vite/operator-bookings/ScheduleBlockDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/ScheduleBlockDialog.test.tsx
@@ -75,9 +75,13 @@ describe('ScheduleBlockDialog', () => {
     expect((screen.getByLabelText(T.vehicleLabel) as HTMLSelectElement).value).toBe('veh-1')
   })
 
-  it('creates the block (JST→ISO), invalidates the operator-bookings cache, and closes on success', async () => {
+  it('creates the block (JST→ISO), forwards the picked operator, invalidates the cache, and closes on success', async () => {
     createBlockMock.mockResolvedValue(CREATED)
-    const { onOpenChange, invalidate } = setup({ initialVehicleId: 'veh-2' })
+    // #1260: a picker admin's write binds to the operator it is acting as.
+    const { onOpenChange, invalidate } = setup({
+      initialVehicleId: 'veh-2',
+      pickedOperatorId: 'op-7',
+    })
 
     fillRequiredFields()
     fireEvent.click(screen.getByRole('button', { name: T.submit }))
@@ -93,6 +97,7 @@ describe('ScheduleBlockDialog', () => {
         endAt: '2026-07-02T00:00:00.000Z',
       },
       'csrf-1',
+      'op-7',
     )
     expect(invalidate).toHaveBeenCalledWith({ queryKey: OPERATOR_BOOKINGS_KEY })
   })

--- a/packages/web/tests/vite/operator-bookings/blocks-api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/blocks-api.test.ts
@@ -85,6 +85,21 @@ describe('createBlock', () => {
     expect(JSON.parse(init.body as string)).toEqual(input)
     expect(result).toEqual(blockRow)
   })
+
+  it('binds the write to the picked operator via ?operatorId= (#1260)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: blockRow }, 201))
+    const input: CreateBlockInput = {
+      kind: 'MAINTENANCE',
+      reason: 'Oil change',
+      startAt: blockRow.startAt,
+      endAt: blockRow.endAt,
+    }
+
+    await createBlock(blockRow.vehicleId, input, 'csrf-tok', 'op-a')
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`/api/vehicles/${blockRow.vehicleId}/blocks?operatorId=op-a`)
+  })
 })
 
 describe('deleteBlock', () => {
@@ -97,6 +112,15 @@ describe('deleteBlock', () => {
     expect(url).toBe(`/api/vehicles/${blockRow.vehicleId}/blocks/${blockRow.id}`)
     expect(init.method).toBe('DELETE')
     expect((init.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-tok')
+  })
+
+  it('binds the delete to the picked operator via ?operatorId= (#1260)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: blockRow }))
+
+    await deleteBlock(blockRow.vehicleId, blockRow.id, 'csrf-tok', 'op-a')
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe(`/api/vehicles/${blockRow.vehicleId}/blocks/${blockRow.id}?operatorId=op-a`)
   })
 })
 


### PR DESCRIPTION
## Slice 1 of #1260 (blocks) — keeps #1260 open for the booking-write paths

### The gap
`POST/DELETE /vehicles/:id/blocks` admitted **platform-admin (and legacy STAFF/ADMIN) cross-tenant writes**. Those roles resolve `all` under `operatorReadScope`, so `vehicleRepo.findById(ctx, id)` hands them **any** operator's vehicle by raw id, and the block `operatorId` was derived from it. The "admin gets a read-only preview" property was enforced **client-side only** (`canManageBlocks = … && isOperatorSession`), so a direct API call could create/remove a block on any operator's car.

### The fix (Enforce, per the #1260/#1099 decision)
New pure guard `assertFleetWriteWithinOperator(ctx, targetOperatorId, actingOperatorId)` in `tenancy.ts` binds a fleet write to the operator the caller is acting as:
- **Keyed on `!isOperatorRole`, not `bypassScope`** — legacy STAFF/ADMIN lost bypass in #487 but are still `all`-scoped by the repo, so a `bypassScope`-keyed guard would leave them able to write cross-tenant. This is the crux; a unit test pins it.
- Non-tenant caller with no picked operator → **422 `OPERATOR_REQUIRED`** (matches the global `OperatorRequiredError` convention).
- Picked operator that doesn't own the target → **404** (no existence oracle — same message as a genuinely missing vehicle).
- Tenant operators pass through, already clamped by the repo read scope; a stray `?operatorId=` can never widen them.

Wired into `VehicleBlockService.createBlock/deleteBlock` (read from `?operatorId=`), and the web threads the picked operator through `createBlock`/`deleteBlock` and both block dialogs so a picked admin can still manage that operator's blocks.

### Tests (TDD, red-verified each layer)
- Pure-guard units incl. legacy STAFF/ADMIN (would fail if simplified to `bypassScope`).
- InMemory service tests + full-stack Hono route tests (incl. tenant-ignores-stray-`?operatorId=`, delete side-effects).
- **Real-pg integration proof**: a precondition test confirms the repo hole is real (admin resolves the foreign vehicle), then asserts 422 / 404 / 201 against Postgres.
- Web api (`?operatorId=` URL) + both dialog tests (`toHaveBeenCalledWith(..., 'op-7')`).

Full suites green: api 2513, web 1824, +5 real-pg. tsc ×3, biome, boundaries, modules, size, csrf-writes all clean. No migration.

### Follow-up (slice 2, same #1260)
The owner's scope-extension comment (from the #1099 cross-slice review) covers the same client-only gap on the resource-id-keyed **booking** writes — status-advance (`PATCH /bookings/:id/status`), manual booking, and substitute/assign — plus (found in review) `VehicleService` writes (edit / retire / bulk-status / append-photos). Slice 2 will reuse `assertFleetWriteWithinOperator` across those.

Refs #1260, #1099