### PR TITLE
feat(#1315): renter reservation add-on i18n — thread ?locale= (catalog i18n sub-slice C)

### DIFF
--- a/packages/web/src/routes/$locale/_renter/bookings/new.tsx
+++ b/packages/web/src/routes/$locale/_renter/bookings/new.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE, isLocale } from '@/vite/i18n/locale'
 import { ReservationWizard } from '@/vite/reservation/ReservationWizard'
 import { fetchAddOns, fetchInsuranceOptions } from '@/vite/reservation/api'
 import { fetchStorefrontDetail } from '@/vite/storefronts/api'
@@ -73,8 +74,12 @@ export const Route = createFileRoute('/$locale/_renter/bookings/new')({
       })
     }
 
+    // The $locale layout already 404s an invalid param; narrow it to satisfy the
+    // typed client (fall back to the default defensively). Add-on names resolve to
+    // this locale server-side; a locale change re-runs the loader via the path.
+    const locale = isLocale(params.locale) ? params.locale : DEFAULT_LOCALE
     const [addOns, insuranceOptions] = await Promise.all([
-      fetchAddOns(deps.locationId),
+      fetchAddOns(deps.locationId, locale),
       fetchInsuranceOptions(deps.locationId),
     ])
     return {

--- a/packages/web/src/vite/reservation/api.ts
+++ b/packages/web/src/vite/reservation/api.ts
@@ -1,5 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
+import type { Locale } from '@kuruma/shared/i18n/locales'
 import type { StorefrontAddOnData, StorefrontInsuranceData } from '@kuruma/shared/types/storefront'
 import { z } from 'zod'
 
@@ -37,9 +38,18 @@ export type ReservationInsuranceOption = StorefrontInsuranceData
 // Public endpoints — no auth. ACTIVE-only, single-operator reads (the API seals
 // cross-tenant leaks). A 404 (unknown/archived storefront) surfaces as an
 // ApiError so the wizard loader can bounce the renter back to search.
-export async function fetchAddOns(locationId: string): Promise<ReservationAddOn[]> {
+//
+// Catalog i18n slice 2 (#1315): add-on name/description are templated + resolved
+// server-side to `?locale=`, so the renter read threads its route locale (absent
+// ⇒ server default EN). A bad locale is a 400 the server never caches, so the
+// wizard only ever passes a validated `Locale`. Insurance stays EN until slice 3.
+export async function fetchAddOns(
+  locationId: string,
+  locale?: Locale,
+): Promise<ReservationAddOn[]> {
+  const localeParam = locale ? `?locale=${locale}` : ''
   const res = await fetch(
-    `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/add-ons`,
+    `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/add-ons${localeParam}`,
     { credentials: 'include' },
   )
   return unwrap(res, reservationAddOnSchema.array())

--- a/packages/web/tests/vite/reservation/api.test.ts
+++ b/packages/web/tests/vite/reservation/api.test.ts
@@ -40,6 +40,21 @@ describe('fetchAddOns', () => {
     )
     await expect(fetchAddOns('gone')).rejects.toThrow('Storefront not found')
   })
+
+  // Catalog i18n slice 2 (#1315): the storefront add-ons endpoint resolves the
+  // picked template name/description to `?locale=`, so the renter wizard threads
+  // its route locale. (Absent locale ⇒ server default EN, asserted by the exact
+  // URL in the first case above.)
+  it('appends the caller locale so the server resolves add-on names to it', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchAddOns('loc-1', 'ja')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/storefronts/loc-1/add-ons?locale=ja', {
+      credentials: 'include',
+    })
+  })
 })
 
 describe('fetchInsuranceOptions', () => {

--- a/packages/web/tests/vite/reservation/new.route.test.ts
+++ b/packages/web/tests/vite/reservation/new.route.test.ts
@@ -1,0 +1,60 @@
+import { Route } from '@/routes/$locale/_renter/bookings/new'
+import { fetchAddOns } from '@/vite/reservation/api'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Catalog i18n slice 2 (#1315): the wizard loader threads its route locale into
+// the renter add-on read so a /ja booking shows JP-resolved add-on names. This
+// guards the wiring itself — the `fetchAddOns` URL contract is covered in
+// api.test.ts, and the availability re-check helpers in their own suites, so we
+// stub them and assert only the locale the loader forwards.
+vi.mock('@/vite/reservation/api', () => ({
+  fetchAddOns: vi.fn(async () => []),
+  fetchInsuranceOptions: vi.fn(async () => []),
+}))
+vi.mock('@/vite/storefronts/api', () => ({
+  fetchStorefrontDetail: vi.fn(async () => ({ vehicles: [{ id: 'veh-1' }] })),
+}))
+vi.mock('@/vite/storefronts/params', () => ({
+  parseSearchRange: () => ({
+    from: new Date('2026-08-01T00:00:00Z'),
+    to: new Date('2026-08-03T00:00:00Z'),
+  }),
+  carryForwardFilters: () => ({}),
+}))
+
+const loader = Route.options.loader as (args: {
+  params: { locale: string }
+  deps: {
+    locationId?: string
+    vehicleId?: string
+    from?: string
+    to?: string
+    class?: unknown
+    pickupLocationId?: string
+    region?: string
+  }
+}) => Promise<unknown>
+
+const deps = {
+  locationId: 'loc-1',
+  vehicleId: 'veh-1',
+  from: '2026-08-01',
+  to: '2026-08-03',
+  class: undefined,
+  pickupLocationId: undefined,
+  region: undefined,
+}
+
+describe('new booking route loader — add-on locale (#1315)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('forwards the route locale into the add-on read so /ja resolves JP names', async () => {
+    await loader({ params: { locale: 'ja' }, deps })
+    expect(vi.mocked(fetchAddOns)).toHaveBeenCalledWith('loc-1', 'ja')
+  })
+
+  it('falls back to the default locale when the route param is not a supported locale', async () => {
+    await loader({ params: { locale: 'xx' }, deps })
+    expect(vi.mocked(fetchAddOns)).toHaveBeenCalledWith('loc-1', 'en')
+  })
+})


### PR DESCRIPTION
## What

Final web slice of the catalog add-on i18n epic (#1315). The storefront add-ons endpoint already resolves templated add-on names/descriptions to a caller `?locale=` (shipped in sub-slice B, #1355). The renter **reservation wizard** was still reading add-ons locale-free, so a `/ja` or `/zh` booking showed English add-on names. This threads the renter's route locale into that read.

## Changes (web-only)

- `reservation/api.ts` — `fetchAddOns(locationId, locale?)` appends `?locale=` when a locale is passed, mirroring the sibling operator client (`operator-add-ons/api.ts`). Insurance is intentionally left EN-only (that's slice 3).
- `routes/$locale/_renter/bookings/new.tsx` — the loader narrows `params.locale` (`isLocale`/`DEFAULT_LOCALE`) and forwards it. `$locale` is a **path param**, so a language switch produces a distinct route match and re-runs the loader — no manual query-key needed (unlike the operator side's `useQuery`).
- No render change: `AddOnsStep`/`ConfirmStep` already render the server-resolved `name`/`description`. No new i18n keys.

## Why it's safe

- The `$locale` layout already 404s an invalid param; the loader still narrows defensively so a bad locale is coerced to `en` and **never reaches the server as a 400**.
- Public, ACTIVE-only storefront reads — no tenancy change.

## Tests

- `reservation/api.test.ts` — asserts the `?locale=ja` URL contract (absent locale ⇒ no param, covered by the existing exact-URL case).
- `reservation/new.route.test.ts` (new) — route-loader test asserting the forwarded locale **and** the default-locale fallback. Mutation-verified: reverting the loader's `locale` arg turns both red.

## Verification

- Full web suite: 269 files / 1853 tests green (post-merge with develop).
- web + api `tsc`, biome, `lint:modules`, `lint:size`, `vite build` all green.
- code-reviewer: SHIP (the flagged loader-test gap is closed by `new.route.test.ts`).

Part of epic #1315. Deferred follow-ups tracked in #1318-#1321.