### PR TITLE
refactor(#1245): split calendar-events.ts into calendar-view + events

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -24,16 +24,18 @@ import {
 import {
   type BlockCalendarEvent,
   type CalendarItem,
-  type CalendarView,
   blocksToCalendarEvents,
-  calendarRange,
   fleetToResources,
+  toCalendarEvents,
+} from '@/vite/operator-bookings/calendar-events'
+import {
+  type CalendarView,
+  calendarRange,
   formatCalendarDate,
   normalizeViewParam,
   parseCalendarDate,
   parseCalendarView,
-  toCalendarEvents,
-} from '@/vite/operator-bookings/calendar-events'
+} from '@/vite/operator-bookings/calendar-view'
 import { markBookingsSeen } from '@/vite/operator-bookings/new-bookings'
 import { useCalendarFilters } from '@/vite/operator-bookings/useCalendarFilters'
 import { useOperatorContext } from '@/vite/operator-context'

--- a/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
@@ -6,10 +6,9 @@ import { CalendarToolbar } from '@/vite/operator-bookings/CalendarToolbar'
 import {
   type CalendarItem,
   type CalendarResource,
-  type CalendarView,
   calendarItemClassName,
-  operatorViews,
 } from '@/vite/operator-bookings/calendar-events'
+import { type CalendarView, operatorViews } from '@/vite/operator-bookings/calendar-view'
 import { endOfWeek, startOfWeek } from 'date-fns'
 import { useCallback, useMemo } from 'react'
 import { Calendar, type EventProps, type SlotInfo, type View } from 'react-big-calendar'

--- a/packages/web/src/vite/operator-bookings/CalendarToolbar.tsx
+++ b/packages/web/src/vite/operator-bookings/CalendarToolbar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import type { CalendarView } from '@/vite/operator-bookings/calendar-events'
+import type { CalendarView } from '@/vite/operator-bookings/calendar-view'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslations } from 'use-intl'
 

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -9,7 +9,7 @@ import {
   calendarRange,
   operatorViews,
   shiftCalendarDate,
-} from '@/vite/operator-bookings/calendar-events'
+} from '@/vite/operator-bookings/calendar-view'
 import {
   bookingIdFromTimelineItem,
   buildTimelineLayout,

--- a/packages/web/src/vite/operator-bookings/calendar-events.ts
+++ b/packages/web/src/vite/operator-bookings/calendar-events.ts
@@ -1,54 +1,13 @@
-import { jstWallClockToInstant, todayInJst } from '@/lib/datetime'
 import { BLOCK_KIND_CLASS, STATUS_CLASS } from '@/lib/event-colors'
 import type { CalendarBookingRow, OperatorBookingStatus } from '@/vite/operator-bookings/api'
 import type { CalendarBlockRow } from '@/vite/operator-bookings/schema'
 import type { VehicleBlockKind } from '@kuruma/shared/enums'
-import {
-  addDays,
-  endOfDay,
-  endOfMonth,
-  endOfWeek,
-  format,
-  isValid,
-  parse,
-  startOfDay,
-  startOfMonth,
-  startOfWeek,
-} from 'date-fns'
 
 // #525 Slice B: pure transforms feeding the operator booking calendar. Kept free
 // of React/rbc so they stay unit-testable (FC/IS — the BookingsCalendar shell
 // renders; these decide the data shape). The component is framework code we don't
-// unit-test; these functions carry the logic that can actually break.
-
-/** The operator calendar views. `timeline` is the fleet planning board (#1100),
- *  its own component; the other three are rbc views (a subset of rbc's `View`). */
-export type CalendarView = 'timeline' | 'day' | 'week' | 'month'
-
-/** The full view-switcher order. `timeline` leads — the operator default when the
- *  fleet-timeline feature is enabled (#1100). */
-export const OPERATOR_VIEWS = ['timeline', 'day', 'week', 'month'] as const
-
-/** The view set when the fleet timeline is gated off (#1100): the plain rbc grids. */
-const CALENDAR_VIEWS_NO_TIMELINE = ['day', 'week', 'month'] as const
-
-/** The views offered in the switcher, gated by the fleet-timeline flag. Off → the
- *  timeline view drops out and only the day/week/month grids remain. Pure in the
- *  flag: the caller (a component via useFeatureFlag, the loader via the runtime
- *  overrides map) supplies the effective value so a dashboard toggle takes effect
- *  live (#1322). */
-export function operatorViews(timelineEnabled: boolean): readonly CalendarView[] {
-  return timelineEnabled ? OPERATOR_VIEWS : CALENDAR_VIEWS_NO_TIMELINE
-}
-
-/** The landing view: the fleet timeline board when enabled (#1100), else the week
- *  grid — the natural default once the planning board is gated off. */
-export function defaultCalendarView(timelineEnabled: boolean): CalendarView {
-  return timelineEnabled ? 'timeline' : 'week'
-}
-
-/** How many days the fleet timeline spans from its anchor day (#1100 AC: 14). */
-export const TIMELINE_SPAN_DAYS = 14
+// unit-test; these functions carry the logic that can actually break. The
+// view/range/param plumbing lives in calendar-view.ts (#1245).
 
 /** One booking as react-big-calendar consumes it (events bind to columns by id). */
 export interface CalendarEvent {
@@ -149,92 +108,4 @@ export function fleetToResources(
   vehicles: readonly { id: string; name: string }[],
 ): CalendarResource[] {
   return vehicles.map((v) => ({ resourceId: v.id, resourceTitle: v.name }))
-}
-
-// rbc's localizer starts weeks on Monday (see lib/rbc-localizer); match it so the
-// fetched range lines up exactly with the grid the user sees.
-const WEEK_OPTS = { weekStartsOn: 1 } as const
-
-/**
- * The [from, to] window (ISO) to fetch for a given view + anchor date. Month view
- * covers the full visible grid (the weeks overlapping the month), so events in the
- * leading/trailing days of adjacent months still render.
- */
-export function calendarRange(view: CalendarView, date: Date): { from: string; to: string } {
-  // The timeline shows a fixed multi-day span from the anchor day (a planning
-  // board, not a calendar grid): [startOfDay(date), startOfDay(date)+14d).
-  if (view === 'timeline')
-    return iso(startOfDay(date), startOfDay(addDays(date, TIMELINE_SPAN_DAYS)))
-  if (view === 'day') return iso(startOfDay(date), endOfDay(date))
-  if (view === 'week') return iso(startOfWeek(date, WEEK_OPTS), endOfWeek(date, WEEK_OPTS))
-  return iso(startOfWeek(startOfMonth(date), WEEK_OPTS), endOfWeek(endOfMonth(date), WEEK_OPTS))
-}
-
-/** Shift the anchor day one view-span back (`-1`) or forward (`+1`) — the unit is
- *  the view's natural step (a day, a week, a month, or the timeline's 14 days). */
-export function shiftCalendarDate(view: CalendarView, date: Date, dir: -1 | 1): Date {
-  const next = new Date(date)
-  if (view === 'month') next.setMonth(next.getMonth() + dir)
-  else if (view === 'week') next.setDate(next.getDate() + dir * 7)
-  else if (view === 'timeline') next.setDate(next.getDate() + dir * TIMELINE_SPAN_DAYS)
-  else next.setDate(next.getDate() + dir)
-  return next
-}
-
-function iso(from: Date, to: Date): { from: string; to: string } {
-  // #1250: the date-fns boundaries above are computed on the anchor's LOCAL calendar
-  // day; reinterpret that wall clock as JST so the fetched window is the Tokyo day/
-  // week/month, not the browser-local one. Off-JST the two diverge, and a browser-local
-  // window straddles two JST days — dropping bookings near JST-midnight from the query.
-  return {
-    from: jstWallClockToInstant(from).toISOString(),
-    to: jstWallClockToInstant(to).toISOString(),
-  }
-}
-
-// --- URL <-> calendar state (the route stores view/date as search params) ------
-
-/** Narrow an untrusted `?view=` param to a KNOWN view string (or undefined),
- *  without applying the feature flag. The flag-blind pass runs in the route's
- *  `validateSearch`, which has no access to the runtime overrides; the flag-aware
- *  resolution below decides whether `timeline` is actually offered (#1322). */
-export function normalizeViewParam(value: unknown): CalendarView | undefined {
-  return typeof value === 'string' && (OPERATOR_VIEWS as readonly string[]).includes(value)
-    ? (value as CalendarView)
-    : undefined
-}
-
-/** Resolve a `?view=` value to a currently-offered view, defaulting to the landing
- *  view. Validates against the flag-gated set, so a hand-typed `?view=timeline`
- *  falls back to the week grid while the timeline is gated off (#1322: the caller
- *  passes the effective flag). */
-export function parseCalendarView(
-  value: string | undefined,
-  timelineEnabled: boolean,
-): CalendarView {
-  const views = operatorViews(timelineEnabled)
-  return value && (views as readonly string[]).includes(value)
-    ? (value as CalendarView)
-    : defaultCalendarView(timelineEnabled)
-}
-
-const DATE_FMT = 'yyyy-MM-dd'
-
-/** The `?date=` param value — a local calendar day, time-of-day discarded. */
-export function formatCalendarDate(date: Date): string {
-  return format(date, DATE_FMT)
-}
-
-/**
- * Parse a `?date=` param to a *local* day. Anything missing, malformed, or
- * overflowed (`2026-13-99`) falls back to today. The round-trip check rejects
- * values date-fns would silently normalize into a different day.
- */
-export function parseCalendarDate(value?: string | undefined): Date {
-  // #1250: an absent/malformed param falls back to the JST calendar day, not the
-  // browser-local one — off-JST near midnight they differ, and TODAY must land on the
-  // Tokyo day the operator works in. An explicit valid day is used as given.
-  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return todayInJst()
-  const parsed = parse(value, DATE_FMT, new Date())
-  return isValid(parsed) && format(parsed, DATE_FMT) === value ? parsed : todayInJst()
 }

--- a/packages/web/src/vite/operator-bookings/calendar-view.ts
+++ b/packages/web/src/vite/operator-bookings/calendar-view.ts
@@ -1,0 +1,135 @@
+import { jstWallClockToInstant, todayInJst } from '@/lib/datetime'
+import {
+  addDays,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isValid,
+  parse,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns'
+
+// #1245: the operator calendar's view/range/param plumbing, split out of
+// calendar-events.ts so the booking/block transform module stays focused on the
+// data shape. Pure and React/rbc-free (FC/IS — the shells render; this decides which
+// view is offered and which instant window to fetch).
+
+/** The operator calendar views. `timeline` is the fleet planning board (#1100),
+ *  its own component; the other three are rbc views (a subset of rbc's `View`). */
+export type CalendarView = 'timeline' | 'day' | 'week' | 'month'
+
+/** The full view-switcher order. `timeline` leads — the operator default when the
+ *  fleet-timeline feature is enabled (#1100). */
+export const OPERATOR_VIEWS = ['timeline', 'day', 'week', 'month'] as const
+
+/** The view set when the fleet timeline is gated off (#1100): the plain rbc grids. */
+const CALENDAR_VIEWS_NO_TIMELINE = ['day', 'week', 'month'] as const
+
+/** The views offered in the switcher, gated by the fleet-timeline flag. Off → the
+ *  timeline view drops out and only the day/week/month grids remain. Pure in the
+ *  flag: the caller (a component via useFeatureFlag, the loader via the runtime
+ *  overrides map) supplies the effective value so a dashboard toggle takes effect
+ *  live (#1322). */
+export function operatorViews(timelineEnabled: boolean): readonly CalendarView[] {
+  return timelineEnabled ? OPERATOR_VIEWS : CALENDAR_VIEWS_NO_TIMELINE
+}
+
+/** The landing view: the fleet timeline board when enabled (#1100), else the week
+ *  grid — the natural default once the planning board is gated off. */
+export function defaultCalendarView(timelineEnabled: boolean): CalendarView {
+  return timelineEnabled ? 'timeline' : 'week'
+}
+
+/** How many days the fleet timeline spans from its anchor day (#1100 AC: 14). */
+export const TIMELINE_SPAN_DAYS = 14
+
+// rbc's localizer starts weeks on Monday (see lib/rbc-localizer); match it so the
+// fetched range lines up exactly with the grid the user sees.
+const WEEK_OPTS = { weekStartsOn: 1 } as const
+
+/**
+ * The [from, to] window (ISO) to fetch for a given view + anchor date. Month view
+ * covers the full visible grid (the weeks overlapping the month), so events in the
+ * leading/trailing days of adjacent months still render.
+ */
+export function calendarRange(view: CalendarView, date: Date): { from: string; to: string } {
+  // The timeline shows a fixed multi-day span from the anchor day (a planning
+  // board, not a calendar grid): [startOfDay(date), startOfDay(date)+14d).
+  if (view === 'timeline')
+    return iso(startOfDay(date), startOfDay(addDays(date, TIMELINE_SPAN_DAYS)))
+  if (view === 'day') return iso(startOfDay(date), endOfDay(date))
+  if (view === 'week') return iso(startOfWeek(date, WEEK_OPTS), endOfWeek(date, WEEK_OPTS))
+  return iso(startOfWeek(startOfMonth(date), WEEK_OPTS), endOfWeek(endOfMonth(date), WEEK_OPTS))
+}
+
+/** Shift the anchor day one view-span back (`-1`) or forward (`+1`) — the unit is
+ *  the view's natural step (a day, a week, a month, or the timeline's 14 days). */
+export function shiftCalendarDate(view: CalendarView, date: Date, dir: -1 | 1): Date {
+  const next = new Date(date)
+  if (view === 'month') next.setMonth(next.getMonth() + dir)
+  else if (view === 'week') next.setDate(next.getDate() + dir * 7)
+  else if (view === 'timeline') next.setDate(next.getDate() + dir * TIMELINE_SPAN_DAYS)
+  else next.setDate(next.getDate() + dir)
+  return next
+}
+
+function iso(from: Date, to: Date): { from: string; to: string } {
+  // #1250: the date-fns boundaries above are computed on the anchor's LOCAL calendar
+  // day; reinterpret that wall clock as JST so the fetched window is the Tokyo day/
+  // week/month, not the browser-local one. Off-JST the two diverge, and a browser-local
+  // window straddles two JST days — dropping bookings near JST-midnight from the query.
+  return {
+    from: jstWallClockToInstant(from).toISOString(),
+    to: jstWallClockToInstant(to).toISOString(),
+  }
+}
+
+// --- URL <-> calendar state (the route stores view/date as search params) ------
+
+/** Narrow an untrusted `?view=` param to a KNOWN view string (or undefined),
+ *  without applying the feature flag. The flag-blind pass runs in the route's
+ *  `validateSearch`, which has no access to the runtime overrides; the flag-aware
+ *  resolution below decides whether `timeline` is actually offered (#1322). */
+export function normalizeViewParam(value: unknown): CalendarView | undefined {
+  return typeof value === 'string' && (OPERATOR_VIEWS as readonly string[]).includes(value)
+    ? (value as CalendarView)
+    : undefined
+}
+
+/** Resolve a `?view=` value to a currently-offered view, defaulting to the landing
+ *  view. Validates against the flag-gated set, so a hand-typed `?view=timeline`
+ *  falls back to the week grid while the timeline is gated off (#1322: the caller
+ *  passes the effective flag). */
+export function parseCalendarView(
+  value: string | undefined,
+  timelineEnabled: boolean,
+): CalendarView {
+  const views = operatorViews(timelineEnabled)
+  return value && (views as readonly string[]).includes(value)
+    ? (value as CalendarView)
+    : defaultCalendarView(timelineEnabled)
+}
+
+const DATE_FMT = 'yyyy-MM-dd'
+
+/** The `?date=` param value — a local calendar day, time-of-day discarded. */
+export function formatCalendarDate(date: Date): string {
+  return format(date, DATE_FMT)
+}
+
+/**
+ * Parse a `?date=` param to a *local* day. Anything missing, malformed, or
+ * overflowed (`2026-13-99`) falls back to today. The round-trip check rejects
+ * values date-fns would silently normalize into a different day.
+ */
+export function parseCalendarDate(value?: string | undefined): Date {
+  // #1250: an absent/malformed param falls back to the JST calendar day, not the
+  // browser-local one — off-JST near midnight they differ, and TODAY must land on the
+  // Tokyo day the operator works in. An explicit valid day is used as given.
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return todayInJst()
+  const parsed = parse(value, DATE_FMT, new Date())
+  return isValid(parsed) && format(parsed, DATE_FMT) === value ? parsed : todayInJst()
+}

--- a/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
+++ b/packages/web/src/vite/operator-bookings/useCalendarFilters.ts
@@ -52,9 +52,13 @@ export interface CalendarFiltersApi {
   clearAllVehicles: () => void
   // #1101: items are the booking|block union. Both are filtered by vehicle
   // (resourceId); the STATUS filter applies to bookings only — a block carries no
-  // status, so a status toggle never hides it. Generic so a caller passing a
-  // narrower array (bookings only) gets that narrower element type back.
-  filterEvents: <T extends { resourceId: string }>(events: readonly T[]) => T[]
+  // status, so a status toggle never hides it. The constraint admits an optional
+  // `status` (a block omits it, which is assignable), so the implementation reads it
+  // without a cast. Generic so a caller passing a narrower array (bookings only) gets
+  // that narrower element type back.
+  filterEvents: <T extends { resourceId: string; status?: OperatorBookingStatus }>(
+    events: readonly T[],
+  ) => T[]
   filterResources: <T extends { resourceId: string }>(resources: readonly T[]) => T[]
 }
 
@@ -134,15 +138,13 @@ export function useCalendarFilters(knownVehicleIds: readonly string[]): Calendar
   const clearAllVehicles = useCallback(() => setUncheckedVehicles(new Set(knownIdsRef.current)), [])
 
   const filterEvents = useCallback(
-    <T extends { resourceId: string }>(events: readonly T[]): T[] =>
+    <T extends { resourceId: string; status?: OperatorBookingStatus }>(events: readonly T[]): T[] =>
       events.filter((e) => {
         if (uncheckedVehicles.has(e.resourceId)) return false
-        // The generic `<T extends { resourceId }>` erases the CalendarItem
-        // discriminant (this filter is shared with filterResources), so we probe
-        // `status` structurally rather than switching on `type`. Safe because the
-        // union guarantees only bookings carry a status — a block reads `undefined`
-        // and bypasses the status filter entirely (`status === undefined` passes).
-        const status = (e as { status?: OperatorBookingStatus }).status
+        // #1245: the constraint admits an optional `status`, so we read it directly —
+        // no cast needed. Only bookings carry a status; a block's is `undefined` and
+        // bypasses the status filter entirely (`status === undefined` passes).
+        const status = e.status
         return status === undefined || !uncheckedStatuses.has(status)
       }),
     [uncheckedVehicles, uncheckedStatuses],

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -1,7 +1,7 @@
 import { OperatorBookingsRoute } from '@/routes/$locale/_business/manage/bookings/index'
 import { FeatureFlagsProvider } from '@/vite/config'
 import * as api from '@/vite/operator-bookings/api'
-import { calendarRange, parseCalendarDate } from '@/vite/operator-bookings/calendar-events'
+import { calendarRange, parseCalendarDate } from '@/vite/operator-bookings/calendar-view'
 import { type OperatorLocation, operatorLocationsQueryOptions } from '@/vite/operator-locations/api'
 import type { Session } from '@/vite/session'
 import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'

--- a/packages/web/tests/vite/operator-bookings/calendar-events.test.ts
+++ b/packages/web/tests/vite/operator-bookings/calendar-events.test.ts
@@ -1,25 +1,14 @@
-import { todayInJst } from '@/lib/datetime'
 import type { CalendarBookingRow } from '@/vite/operator-bookings/api'
 import {
   type BlockCalendarEvent,
   type CalendarItem,
   blocksToCalendarEvents,
   calendarItemClassName,
-  calendarRange,
-  defaultCalendarView,
   fleetToResources,
-  formatCalendarDate,
-  normalizeViewParam,
-  operatorViews,
-  parseCalendarDate,
-  parseCalendarView,
   toCalendarEvents,
 } from '@/vite/operator-bookings/calendar-events'
 import type { CalendarBlockRow } from '@/vite/operator-bookings/schema'
 import { describe, expect, it } from 'vitest'
-
-const HOUR_MS = 60 * 60 * 1000
-const DAY_MS = 24 * HOUR_MS
 
 const row = (over: Partial<CalendarBookingRow> = {}): CalendarBookingRow => ({
   id: 'bk-1',
@@ -96,110 +85,6 @@ describe('fleetToResources', () => {
 
   it('returns an empty list for an empty fleet', () => {
     expect(fleetToResources([])).toEqual([])
-  })
-})
-
-describe('calendarRange (JST-anchored, #1250)', () => {
-  // 2026-07-15 is a Wednesday. Built from LOCAL fields so the anchor's calendar day is
-  // July 15 in ANY runner TZ. The bounds are anchored to the JST day/week/month, not
-  // the browser-local one, so an off-JST viewer's fetch window is the SAME instants a
-  // Tokyo viewer gets — no booking near JST-midnight drops out of the query. Asserted
-  // as exact UTC ISO (a JST wall clock is `wall - 9h`), so these hold under any TZ.
-  const anchor = new Date(2026, 6, 15, 12)
-
-  it('spans the JST day in day view (00:00–23:59:59.999 JST)', () => {
-    expect(calendarRange('day', anchor)).toEqual({
-      from: '2026-07-14T15:00:00.000Z', // JST 2026-07-15 00:00
-      to: '2026-07-15T14:59:59.999Z', // JST 2026-07-15 23:59:59.999
-    })
-  })
-
-  it('spans a fixed 14-day JST planning window from the anchor day in timeline view', () => {
-    const { from, to } = calendarRange('timeline', anchor)
-    expect(from).toBe('2026-07-14T15:00:00.000Z') // JST 2026-07-15 00:00
-    expect(to).toBe('2026-07-28T15:00:00.000Z') // JST 2026-07-29 00:00 — exactly 14 days
-    expect(new Date(to).getTime() - new Date(from).getTime()).toBe(14 * DAY_MS)
-  })
-
-  it('spans the Monday-start JST week in week view', () => {
-    expect(calendarRange('week', anchor)).toEqual({
-      from: '2026-07-12T15:00:00.000Z', // JST Mon 2026-07-13 00:00
-      to: '2026-07-19T14:59:59.999Z', // JST Sun 2026-07-19 23:59:59.999
-    })
-  })
-
-  it('covers the whole month grid in month view (Monday-aligned JST weeks enclosing July)', () => {
-    expect(calendarRange('month', anchor)).toEqual({
-      from: '2026-06-28T15:00:00.000Z', // JST Mon 2026-06-29 00:00 (grid start)
-      to: '2026-08-02T14:59:59.999Z', // JST Sun 2026-08-02 23:59:59.999 (grid end)
-    })
-  })
-})
-
-describe('parseCalendarView (fleet timeline enabled)', () => {
-  // The timeline board (#1100) is the operator default only while its flag is on; the
-  // caller passes the effective value (#1322), so this is pure of the runtime env.
-  it('keeps a valid view and defaults anything else to the timeline board', () => {
-    expect(parseCalendarView('timeline', true)).toBe('timeline')
-    expect(parseCalendarView('day', true)).toBe('day')
-    expect(parseCalendarView('week', true)).toBe('week')
-    expect(parseCalendarView('month', true)).toBe('month')
-    expect(parseCalendarView('agenda', true)).toBe('timeline') // a real rbc view we do not offer
-    expect(parseCalendarView(undefined, true)).toBe('timeline')
-  })
-})
-
-describe('fleet-timeline view gating (#1100)', () => {
-  it('enabled → timeline leads the switcher and is the landing default', () => {
-    expect(operatorViews(true)).toEqual(['timeline', 'day', 'week', 'month'])
-    expect(defaultCalendarView(true)).toBe('timeline')
-  })
-
-  it('gated off → the timeline view drops out and week becomes the default', () => {
-    expect(operatorViews(false)).toEqual(['day', 'week', 'month'])
-    expect(defaultCalendarView(false)).toBe('week')
-  })
-
-  it('gated off → a hand-typed ?view=timeline falls back to the week grid', () => {
-    expect(parseCalendarView('timeline', false)).toBe('week')
-    expect(parseCalendarView(undefined, false)).toBe('week')
-    // The remaining grids still parse through untouched.
-    expect(parseCalendarView('day', false)).toBe('day')
-    expect(parseCalendarView('month', false)).toBe('month')
-  })
-})
-
-describe('normalizeViewParam (flag-blind URL narrowing for validateSearch)', () => {
-  it('keeps any KNOWN view string, including timeline (the flag decides later)', () => {
-    expect(normalizeViewParam('timeline')).toBe('timeline')
-    expect(normalizeViewParam('day')).toBe('day')
-    expect(normalizeViewParam('week')).toBe('week')
-    expect(normalizeViewParam('month')).toBe('month')
-  })
-
-  it('drops an unknown or non-string value to undefined', () => {
-    expect(normalizeViewParam('agenda')).toBeUndefined()
-    expect(normalizeViewParam(undefined)).toBeUndefined()
-    expect(normalizeViewParam(42)).toBeUndefined()
-  })
-})
-
-describe('formatCalendarDate / parseCalendarDate', () => {
-  it('round-trips a local calendar day regardless of time of day', () => {
-    const s = formatCalendarDate(new Date(2026, 6, 15, 9, 30)) // local Jul 15 2026
-    expect(s).toBe('2026-07-15')
-    const back = parseCalendarDate(s)
-    expect([back.getFullYear(), back.getMonth(), back.getDate()]).toEqual([2026, 6, 15])
-  })
-
-  it('falls back to the JST calendar day (not the browser-local day) when missing/malformed', () => {
-    // #1250: near midnight an off-JST browser's local day can differ from the Tokyo
-    // day the operator works in; the fallback must anchor to JST so TODAY lands right.
-    const jstToday = todayInJst()
-    const ymd = (d: Date) => [d.getFullYear(), d.getMonth(), d.getDate()]
-    for (const bad of [undefined, '', 'not-a-date', '2026-13-99', '2026-7-1']) {
-      expect(ymd(parseCalendarDate(bad))).toEqual(ymd(jstToday))
-    }
   })
 })
 

--- a/packages/web/tests/vite/operator-bookings/calendar-view.test.ts
+++ b/packages/web/tests/vite/operator-bookings/calendar-view.test.ts
@@ -1,0 +1,118 @@
+import { todayInJst } from '@/lib/datetime'
+import {
+  calendarRange,
+  defaultCalendarView,
+  formatCalendarDate,
+  normalizeViewParam,
+  operatorViews,
+  parseCalendarDate,
+  parseCalendarView,
+} from '@/vite/operator-bookings/calendar-view'
+import { describe, expect, it } from 'vitest'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+describe('calendarRange (JST-anchored, #1250)', () => {
+  // 2026-07-15 is a Wednesday. Built from LOCAL fields so the anchor's calendar day is
+  // July 15 in ANY runner TZ. The bounds are anchored to the JST day/week/month, not
+  // the browser-local one, so an off-JST viewer's fetch window is the SAME instants a
+  // Tokyo viewer gets — no booking near JST-midnight drops out of the query. Asserted
+  // as exact UTC ISO (a JST wall clock is `wall - 9h`), so these hold under any TZ.
+  const anchor = new Date(2026, 6, 15, 12)
+
+  it('spans the JST day in day view (00:00–23:59:59.999 JST)', () => {
+    expect(calendarRange('day', anchor)).toEqual({
+      from: '2026-07-14T15:00:00.000Z', // JST 2026-07-15 00:00
+      to: '2026-07-15T14:59:59.999Z', // JST 2026-07-15 23:59:59.999
+    })
+  })
+
+  it('spans a fixed 14-day JST planning window from the anchor day in timeline view', () => {
+    const { from, to } = calendarRange('timeline', anchor)
+    expect(from).toBe('2026-07-14T15:00:00.000Z') // JST 2026-07-15 00:00
+    expect(to).toBe('2026-07-28T15:00:00.000Z') // JST 2026-07-29 00:00 — exactly 14 days
+    expect(new Date(to).getTime() - new Date(from).getTime()).toBe(14 * DAY_MS)
+  })
+
+  it('spans the Monday-start JST week in week view', () => {
+    expect(calendarRange('week', anchor)).toEqual({
+      from: '2026-07-12T15:00:00.000Z', // JST Mon 2026-07-13 00:00
+      to: '2026-07-19T14:59:59.999Z', // JST Sun 2026-07-19 23:59:59.999
+    })
+  })
+
+  it('covers the whole month grid in month view (Monday-aligned JST weeks enclosing July)', () => {
+    expect(calendarRange('month', anchor)).toEqual({
+      from: '2026-06-28T15:00:00.000Z', // JST Mon 2026-06-29 00:00 (grid start)
+      to: '2026-08-02T14:59:59.999Z', // JST Sun 2026-08-02 23:59:59.999 (grid end)
+    })
+  })
+})
+
+describe('parseCalendarView (fleet timeline enabled)', () => {
+  // The timeline board (#1100) is the operator default only while its flag is on; the
+  // caller passes the effective value (#1322), so this is pure of the runtime env.
+  it('keeps a valid view and defaults anything else to the timeline board', () => {
+    expect(parseCalendarView('timeline', true)).toBe('timeline')
+    expect(parseCalendarView('day', true)).toBe('day')
+    expect(parseCalendarView('week', true)).toBe('week')
+    expect(parseCalendarView('month', true)).toBe('month')
+    expect(parseCalendarView('agenda', true)).toBe('timeline') // a real rbc view we do not offer
+    expect(parseCalendarView(undefined, true)).toBe('timeline')
+  })
+})
+
+describe('fleet-timeline view gating (#1100)', () => {
+  it('enabled → timeline leads the switcher and is the landing default', () => {
+    expect(operatorViews(true)).toEqual(['timeline', 'day', 'week', 'month'])
+    expect(defaultCalendarView(true)).toBe('timeline')
+  })
+
+  it('gated off → the timeline view drops out and week becomes the default', () => {
+    expect(operatorViews(false)).toEqual(['day', 'week', 'month'])
+    expect(defaultCalendarView(false)).toBe('week')
+  })
+
+  it('gated off → a hand-typed ?view=timeline falls back to the week grid', () => {
+    expect(parseCalendarView('timeline', false)).toBe('week')
+    expect(parseCalendarView(undefined, false)).toBe('week')
+    // The remaining grids still parse through untouched.
+    expect(parseCalendarView('day', false)).toBe('day')
+    expect(parseCalendarView('month', false)).toBe('month')
+  })
+})
+
+describe('normalizeViewParam (flag-blind URL narrowing for validateSearch)', () => {
+  it('keeps any KNOWN view string, including timeline (the flag decides later)', () => {
+    expect(normalizeViewParam('timeline')).toBe('timeline')
+    expect(normalizeViewParam('day')).toBe('day')
+    expect(normalizeViewParam('week')).toBe('week')
+    expect(normalizeViewParam('month')).toBe('month')
+  })
+
+  it('drops an unknown or non-string value to undefined', () => {
+    expect(normalizeViewParam('agenda')).toBeUndefined()
+    expect(normalizeViewParam(undefined)).toBeUndefined()
+    expect(normalizeViewParam(42)).toBeUndefined()
+  })
+})
+
+describe('formatCalendarDate / parseCalendarDate', () => {
+  it('round-trips a local calendar day regardless of time of day', () => {
+    const s = formatCalendarDate(new Date(2026, 6, 15, 9, 30)) // local Jul 15 2026
+    expect(s).toBe('2026-07-15')
+    const back = parseCalendarDate(s)
+    expect([back.getFullYear(), back.getMonth(), back.getDate()]).toEqual([2026, 6, 15])
+  })
+
+  it('falls back to the JST calendar day (not the browser-local day) when missing/malformed', () => {
+    // #1250: near midnight an off-JST browser's local day can differ from the Tokyo
+    // day the operator works in; the fallback must anchor to JST so TODAY lands right.
+    const jstToday = todayInJst()
+    const ymd = (d: Date) => [d.getFullYear(), d.getMonth(), d.getDate()]
+    for (const bad of [undefined, '', 'not-a-date', '2026-13-99', '2026-7-1']) {
+      expect(ymd(parseCalendarDate(bad))).toEqual(ymd(jstToday))
+    }
+  })
+})


### PR DESCRIPTION
## What

Behavior-preserving split of `packages/web/src/vite/operator-bookings/calendar-events.ts` into two single-concern modules with **zero cross-import**, per #1245 (tech-debt under the calendar-hardening epic).

- **`calendar-view.ts` (new)** — view + range concern: `CalendarView`, view gating (`operatorViews`/`defaultCalendarView`), `calendarRange`/`shiftCalendarDate`, and the URL⇄state param helpers (`normalizeViewParam`/`parseCalendarView`/`formatCalendarDate`/`parseCalendarDate`).
- **`calendar-events.ts` (trimmed)** — event/resource concern: the `CalendarItem` union + `toCalendarEvents`/`blocksToCalendarEvents`/`fleetToResources`/`calendarItemClassName`.

Consumers (`BookingsCalendar`, `FleetTimeline`, `CalendarToolbar`, the bookings route, and the route test) were re-pointed per-symbol; type-only importers were left untouched. The co-located test file was split alongside into `calendar-view.test.ts` + `calendar-events.test.ts`.

Folded in the issue's LOW cleanup: `useCalendarFilters.filterEvents` is now generic over `<T extends { resourceId: string; status?: OperatorBookingStatus }>`, dropping the `as`-cast.

## Why

`calendar-events.ts` mixed two concerns (view/range gating vs. event shaping). Splitting them shrinks the surface each consumer imports and removes an unnecessary coupling. Web-only; no migration, API, or i18n changes.

## Test plan

- [x] `tsc --noEmit` (web) clean
- [x] Full web suite green (1853/1853, 270 files)
- [x] `biome` clean
- [x] `lint:size` + `lint:modules` exit 0 (reach-in ratchet shrank to 150 < 162 baseline)
- [x] Pre-commit hook (biome + size + modules + web/api tsc) passed

Closes #1245