### PR TITLE
fix(#1362): read the Neon driver's `.constraint` in pgConstraintName (silent double-charge misclassification)

### DIFF
--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -121,18 +121,23 @@ export function pgErrorCode(err: unknown): string | null {
 }
 
 /** Extract the violated constraint name from a thrown PG error, or null.
- * Like the code, postgres-js exposes `constraint_name`; drizzle wraps the
- * PostgresError under `err.cause`, so we check both paths. */
+ * Driver parity (#1362): production runs the Neon drivers
+ * (`@neondatabase/serverless` HTTP + WebSocket), which — like node-postgres —
+ * expose the name on `.constraint`. The integration test client + the in-memory
+ * repos use postgres-js, which exposes `.constraint_name`. Reading only the
+ * latter left this dead in prod (silent double-charge misclassification), so we
+ * accept every driver's convention. Drizzle wraps the PG error under `err.cause`,
+ * so we check that path too. */
 export function pgConstraintName(err: unknown): string | null {
   return extractConstraint(err) ?? extractConstraint(getCause(err))
 }
 
 function extractConstraint(val: unknown): string | null {
-  if (val && typeof val === 'object' && 'constraint_name' in val) {
-    const name = (val as { constraint_name: unknown }).constraint_name
-    return typeof name === 'string' ? name : null
-  }
-  return null
+  if (!val || typeof val !== 'object') return null
+  const rec = val as Record<string, unknown>
+  // Neon / node-postgres → `constraint`; postgres-js / in-memory → `constraint_name`.
+  const name = rec.constraint ?? rec.constraint_name ?? rec.constraintName
+  return typeof name === 'string' ? name : null
 }
 
 function extractCode(val: unknown): string | null {

--- a/packages/api/tests/pg-errors.test.ts
+++ b/packages/api/tests/pg-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { pgErrorCode } from '../src/pg-errors'
+import { pgConstraintName, pgErrorCode } from '../src/pg-errors'
 
 describe('pgErrorCode', () => {
   it('extracts code from a raw PG error (in-memory repo style)', () => {
@@ -42,5 +42,51 @@ describe('pgErrorCode', () => {
   it('returns null when neither err.code nor err.cause.code exist', () => {
     const err = new Error('plain error')
     expect(pgErrorCode(err)).toBeNull()
+  })
+})
+
+describe('pgConstraintName (#1362 driver parity)', () => {
+  // postgres-js (the integration test driver) + the in-memory repos expose the
+  // violated constraint as `constraint_name`. This is what the suite has always
+  // exercised; it must stay green.
+  it('extracts constraint_name (postgres-js / in-memory repo style)', () => {
+    const err = Object.assign(new Error('duplicate'), {
+      code: '23505',
+      constraint_name: 'payment_events_one_success_per_booking',
+    })
+    expect(pgConstraintName(err)).toBe('payment_events_one_success_per_booking')
+  })
+
+  // PRODUCTION runs the Neon drivers (@neondatabase/serverless HTTP + WebSocket),
+  // which — like node-postgres — expose the name on `.constraint`, NOT
+  // `.constraint_name`. This is the shape that silently returned null in prod.
+  it('extracts constraint from a Neon-driver error (.constraint)', () => {
+    const err = Object.assign(new Error('duplicate'), {
+      code: '23505',
+      constraint: 'payment_events_one_success_per_booking',
+    })
+    expect(pgConstraintName(err)).toBe('payment_events_one_success_per_booking')
+  })
+
+  it('extracts constraint from a drizzle-wrapped Neon error (err.cause.constraint)', () => {
+    const cause = Object.assign(new Error('inner'), {
+      code: '23505',
+      constraint: 'bookings_no_overlap',
+    })
+    const err = new Error('Failed query')
+    ;(err as unknown as { cause: Error }).cause = cause
+    expect(pgConstraintName(err)).toBe('bookings_no_overlap')
+  })
+
+  it('extracts a camelCase constraintName defensively', () => {
+    const err = Object.assign(new Error('dup'), { constraintName: 'vehicle_blocks_no_overlap' })
+    expect(pgConstraintName(err)).toBe('vehicle_blocks_no_overlap')
+  })
+
+  it('returns null when no constraint field exists or input is not an object', () => {
+    expect(pgConstraintName(new Error('plain'))).toBeNull()
+    expect(pgConstraintName(null)).toBeNull()
+    expect(pgConstraintName('nope')).toBeNull()
+    expect(pgConstraintName(Object.assign(new Error('x'), { constraint: 123 }))).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

`extractConstraint` in `packages/api/src/pg-errors.ts` read only `constraint_name` — the **postgres-js** convention used by the integration-test client and the in-memory repos. Production runs the **Neon drivers** (`@neondatabase/serverless` HTTP + WebSocket), which — like node-postgres — expose the violated constraint on `.constraint` (`constraint_name` appears **zero times** in the Neon bundle). So `pgConstraintName()` returned `null` for every real Postgres error in prod, while the postgres-js-backed suite stayed green — a driver-parity blind spot.

**Money impact (GA-blocking):** the payment `one_success_per_booking` check (`services/payment/payment.ts:240`) was always false in prod, so a genuine **second** Stripe session paying the same booking was misclassified as a benign webhook redelivery — no `DOUBLE_PAYMENT` anomaly raised, an invisible double-charge. Several constraint-mapped 409/422 paths (bookings overlap, vehicle blocks, reviews, fee schedules, locations region FK, provider invites) also degraded to 500.

## Fix

- `extractConstraint` now accepts every driver convention — `.constraint ?? .constraint_name ?? .constraintName` — behind a non-object guard, keeping the drizzle `.cause` fallback.
- Adds the **first direct unit tests** for `pgConstraintName`, pinning each driver's error shape against regression.
- Strictly additive: every existing caller (all `constraint_name` readers) keeps its behavior; no signature change.

## Test plan

- [x] `bunx vitest run tests/pg-errors.test.ts` — 13/13 pass (new: postgres-js shape, Neon `.constraint` shape, drizzle-wrapped `err.cause.constraint`, camelCase defensive, null/non-object/non-string guards)
- [x] `tsc --noEmit` on `packages/api` — clean
- [x] `lint:boundaries` + pre-commit hook — green
- [ ] Post-merge: confirm a real 23505 in prod now maps to its 409/422 (was 500)

Closes #1362