### PR TITLE
security(#1386): remove caller-facing POST /threads (arbitrary-counterparty spam vector)

### DIFF
--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,72 +1,68 @@
-import { createThreadSchema, sendMessageSchema } from '@kuruma/shared/validators/message'
+import { sendMessageSchema } from '@kuruma/shared/validators/message'
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageService } from '../services/message'
 import { fail, ok, parseBody, parseId, parsePagination } from './helpers'
 
 export function createMessageRoutes(service: MessageService) {
-  return new Hono()
-    .get('/threads', async (c) => {
-      const ctx = toCallerContext(requireUser(c))
+  return (
+    new Hono()
+      .get('/threads', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
 
-      const pg = parsePagination(c)
-      if (!pg.ok) return pg.response
-      const { limit, offset } = pg
+        const pg = parsePagination(c)
+        if (!pg.ok) return pg.response
+        const { limit, offset } = pg
 
-      const { threads, total } = await service.listThreads(ctx, limit, offset)
-      return ok(c, threads, 200, { total, limit, offset })
-    })
-    .get('/threads/:id', async (c) => {
-      const ctx = toCallerContext(requireUser(c))
+        const { threads, total } = await service.listThreads(ctx, limit, offset)
+        return ok(c, threads, 200, { total, limit, offset })
+      })
+      .get('/threads/:id', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
 
-      const idResult = parseId(c)
-      if (!idResult.ok) return idResult.response
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
 
-      const thread = await service.getThread(ctx, idResult.id)
-      if (!thread) return fail(c, 'Thread not found', 404)
+        const thread = await service.getThread(ctx, idResult.id)
+        if (!thread) return fail(c, 'Thread not found', 404)
 
-      return ok(c, thread)
-    })
-    .post('/threads', async (c) => {
-      const ctx = toCallerContext(requireUser(c))
+        return ok(c, thread)
+      })
+      // Threads are created server-side only, by ensureThread on booking commit
+      // (participants derived from the booking). The caller-facing POST /threads was
+      // removed (#1386): it was unused by the web and let any caller open a thread
+      // with arbitrary counterparties (a spam vector).
+      .post('/threads/:id/messages', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
 
-      const parsed = await parseBody(c, createThreadSchema)
-      if (!parsed.ok) return parsed.response
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
 
-      const result = await service.createThread(ctx, parsed.data)
-      if (result.kind === 'forbidden') return fail(c, 'Caller must be a participant', 400)
-      return ok(c, result.thread, result.status)
-    })
-    .post('/threads/:id/messages', async (c) => {
-      const ctx = toCallerContext(requireUser(c))
+        // Existence/scope (404) is checked BEFORE body validation (400) to preserve
+        // the original ordering; createMessage then reuses this confirmed thread id.
+        const thread = await service.getThread(ctx, idResult.id)
+        if (!thread) return fail(c, 'Thread not found', 404)
 
-      const idResult = parseId(c)
-      if (!idResult.ok) return idResult.response
+        const parsed = await parseBody(c, sendMessageSchema)
+        if (!parsed.ok) return parsed.response
 
-      // Existence/scope (404) is checked BEFORE body validation (400) to preserve
-      // the original ordering; createMessage then reuses this confirmed thread id.
-      const thread = await service.getThread(ctx, idResult.id)
-      if (!thread) return fail(c, 'Thread not found', 404)
+        const { message, status } = await service.createMessage(
+          ctx,
+          thread.id,
+          parsed.data.content,
+          parsed.data.idempotencyKey ?? null,
+        )
+        return ok(c, message, status)
+      })
+      .post('/threads/:id/read', async (c) => {
+        const ctx = toCallerContext(requireUser(c))
 
-      const parsed = await parseBody(c, sendMessageSchema)
-      if (!parsed.ok) return parsed.response
+        const idResult = parseId(c)
+        if (!idResult.ok) return idResult.response
 
-      const { message, status } = await service.createMessage(
-        ctx,
-        thread.id,
-        parsed.data.content,
-        parsed.data.idempotencyKey ?? null,
-      )
-      return ok(c, message, status)
-    })
-    .post('/threads/:id/read', async (c) => {
-      const ctx = toCallerContext(requireUser(c))
-
-      const idResult = parseId(c)
-      if (!idResult.ok) return idResult.response
-
-      const result = await service.markRead(ctx, idResult.id)
-      if (result.kind === 'thread_not_found') return fail(c, 'Thread not found', 404)
-      return ok(c, null)
-    })
+        const result = await service.markRead(ctx, idResult.id)
+        if (result.kind === 'thread_not_found') return fail(c, 'Thread not found', 404)
+        return ok(c, null)
+      })
+  )
 }

--- a/packages/api/src/services/message.ts
+++ b/packages/api/src/services/message.ts
@@ -1,22 +1,14 @@
-import type { CreateThreadInput } from '@kuruma/shared/validators/message'
 import type { CallerContext } from '../middleware/auth'
-import { PRIVILEGED_ROLES } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
   MessageCreateResult,
   MessageRepository,
   ThreadRepository,
 } from '../repositories/types'
-import type { Message, Thread } from '../stores'
+import type { Message } from '../stores'
 
 type ThreadListItem = Awaited<ReturnType<ThreadRepository['findAll']>>[number]
 type ThreadDetail = NonNullable<Awaited<ReturnType<ThreadRepository['findById']>>>
-
-/** A thread create either fails the participant gate or produces a record with
- *  its HTTP-meaningful status (201 fresh insert / 200 idempotent replay). */
-export type CreateThreadResult =
-  | { kind: 'forbidden' }
-  | { kind: 'created'; thread: Thread; status: 200 | 201 }
 
 export type MarkReadResult = { kind: 'thread_not_found' } | { kind: 'ok' }
 
@@ -37,8 +29,8 @@ export type NotifyOperatorNewMessage = (args: {
 }) => Promise<void>
 
 /**
- * Messaging business logic, Hono-free: thread/message creation with idempotent
- * replay handling and the participant-authz gate. The route stays a thin shell
+ * Messaging business logic, Hono-free: message creation with idempotent replay
+ * handling and the participant-authz gate. The route stays a thin shell
  * that parses input, maps these results to HTTP, and owns the 404-before-400
  * ordering by calling {@link MessageService.getThread} before parsing the body.
  */
@@ -60,29 +52,6 @@ export class MessageService {
 
   async getThread(ctx: CallerContext, id: string): Promise<ThreadDetail | undefined> {
     return this.threadRepo.findById(ctx, id)
-  }
-
-  async createThread(ctx: CallerContext, input: CreateThreadInput): Promise<CreateThreadResult> {
-    if (!PRIVILEGED_ROLES.has(ctx.role) && !input.participantIds.includes(ctx.userId)) {
-      return { kind: 'forbidden' }
-    }
-    const idempotencyKey = input.idempotencyKey ?? null
-    const { record, status } = await idempotentCreate(
-      idempotencyKey,
-      (k) => this.threadRepo.findByIdempotencyKey(ctx, k),
-      () =>
-        // operatorId is intentionally NOT passed (#1205, review finding 1): the
-        // caller-facing path must never derive tenant scope from a request body.
-        // It stays null here; only ensureThread stamps it, from the booking.
-        this.threadRepo.create(
-          ctx,
-          input.bookingId ?? null,
-          input.participantIds,
-          idempotencyKey,
-          null,
-        ),
-    )
-    return { kind: 'created', thread: record, status }
   }
 
   /**

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -28,6 +28,20 @@ function appAs(userId: string, role: TestRole = 'RENTER', operatorId?: string): 
   return a
 }
 
+/** Seed a thread straight through the repo. POST /threads (caller-facing thread
+ *  creation) was removed in #1386 as an unused arbitrary-counterparty spam vector;
+ *  every real thread is created server-side by ensureThread, so tests seed the same
+ *  way rather than through the API. SEED_CTX bypasses scope to stand in for that. */
+const SEED_CTX = { userId: 'system', role: 'PLATFORM_ADMIN', bypassScope: true } as const
+
+async function seedThread(
+  participantIds: string[],
+  opts: { operatorId?: string | null } = {},
+): Promise<string> {
+  const t = await threadRepo.create(SEED_CTX, null, participantIds, null, opts.operatorId ?? null)
+  return t.id
+}
+
 describe('Message Routes', () => {
   let app: Hono
 
@@ -49,12 +63,7 @@ describe('Message Routes', () => {
     })
 
     it('returns created thread with participant info', async () => {
-      // Create a thread with two participants
-      await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
+      await seedThread([U1, U2])
 
       const res = await app.request('/threads')
       const body = await res.json()
@@ -71,18 +80,9 @@ describe('Message Routes', () => {
 
     it('filters by userId and only shows threads user participates in', async () => {
       // Thread between user1 and user2
-      await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-
+      await seedThread([U1, U2])
       // Thread between user2 and user3 (user1 is NOT a participant)
-      await appAs(U2).request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U2, U3] }),
-      })
+      await seedThread([U2, U3])
 
       // user1 should only see 1 thread
       const res1 = await appAs(U1).request('/threads')
@@ -104,212 +104,35 @@ describe('Message Routes', () => {
     })
   })
 
-  describe('POST /threads', () => {
-    it('creates a thread with participants', async () => {
-      const res = await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          participantIds: [U1, U2],
-        }),
-      })
-
-      expect(res.status).toBe(201)
-
-      const body = await res.json()
-      expect(body.success).toBe(true)
-      expect(body.data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
-      expect(body.data.bookingId).toBeNull()
-      expect(body.data.createdAt).toBeDefined()
-      expect(body.data.updatedAt).toBeDefined()
-    })
-
-    describe('idempotency key', () => {
-      const KEY_A = '00000000-0000-4000-8000-aaaa00000001'
-      const KEY_B = '00000000-0000-4000-8000-aaaa00000002'
-
-      it('returns 200 with same thread when duplicate key is sent', async () => {
-        const first = await app.request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: KEY_A }),
-        })
-        expect(first.status).toBe(201)
-        const firstBody = await first.json()
-
-        const second = await app.request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: KEY_A }),
-        })
-        expect(second.status).toBe(200)
-        const secondBody = await second.json()
-
-        expect(secondBody.data.id).toBe(firstBody.data.id)
-        expect(secondBody.data.idempotencyKey).toBe(KEY_A)
-      })
-
-      it('creates distinct threads when different keys are sent', async () => {
-        const first = await app.request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: KEY_A }),
-        })
-        const second = await app.request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: KEY_B }),
-        })
-
-        expect(first.status).toBe(201)
-        expect(second.status).toBe(201)
-
-        const a = await first.json()
-        const b = await second.json()
-        expect(a.data.id).not.toBe(b.data.id)
-      })
-
-      it('creates thread without idempotency key for backward compatibility', async () => {
-        const res = await app.request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2] }),
-        })
-        expect(res.status).toBe(201)
-        const body = await res.json()
-        expect(body.data.idempotencyKey).toBeNull()
-      })
-
-      it('concurrent duplicate requests yield exactly one 201 and one 200', async () => {
-        const key = '00000000-0000-4000-8000-aaaa00000099'
-        const [r1, r2] = await Promise.all([
-          app.request('/threads', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
-          }),
-          app.request('/threads', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
-          }),
-        ])
-
-        const statuses = [r1.status, r2.status].sort()
-        expect(statuses).toEqual([200, 201])
-
-        const b1 = await r1.json()
-        const b2 = await r2.json()
-        expect(b1.data.id).toBe(b2.data.id)
-      })
-
-      // Issue #328: without caller scope on findByIdempotencyKey, a renter
-      // who guessed or observed another tenant's key would receive the
-      // other tenant's thread on replay. Lookup must filter by participant.
-      it('cross-tenant: U3 replaying U1/U2 thread key gets a fresh thread, not theirs', async () => {
-        const sharedKey = '00000000-0000-4000-8000-aaaa0f0f0f01'
-
-        // U1 creates a thread with U2 using the key.
-        const first = await appAs(U1).request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: sharedKey }),
-        })
-        expect(first.status).toBe(201)
-        const firstThreadId = (await first.json()).data.id
-
-        // U3 attempts to replay the same key (between themselves and some other user).
-        // Must NOT return U1/U2's thread. Because uniqueness is global on the
-        // idempotency key column, U3's insert will collide; the correct fix
-        // scopes the *lookup* so the post-race re-fetch also returns nothing
-        // for U3. This leaves U3 with a 500 from the collision OR a clean
-        // scope miss — either way, U3 must not see U1/U2's thread id.
-        const second = await appAs(U3).request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U3, U2], idempotencyKey: sharedKey }),
-        })
-        if (second.status === 200 || second.status === 201) {
-          const secondBody = await second.json()
-          expect(secondBody.data.id).not.toBe(firstThreadId)
-        }
-        // If status is 500, the collision was caught but not leaked — also acceptable.
-        expect([200, 201, 500]).toContain(second.status)
-      })
-
-      it('same caller replaying own key returns their existing thread', async () => {
-        const key = '00000000-0000-4000-8000-aaaa0f0f0f02'
-        const first = await appAs(U1).request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
-        })
-        expect(first.status).toBe(201)
-        const firstId = (await first.json()).data.id
-
-        const replay = await appAs(U1).request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2], idempotencyKey: key }),
-        })
-        expect(replay.status).toBe(200)
-        expect((await replay.json()).data.id).toBe(firstId)
-      })
-    })
-  })
-
   describe('access control', () => {
-    it('POST /threads rejects when caller is not in participantIds', async () => {
-      const res = await appAs(U1).request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U2, U3] }),
-      })
-      expect(res.status).toBe(400)
-      const body = await res.json()
-      expect(body.error).toBe('Caller must be a participant')
-    })
-
-    it('a platform admin can create a thread between arbitrary users', async () => {
-      const res = await appAs(U1, 'PLATFORM_ADMIN').request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U2, U3] }),
-      })
-      expect(res.status).toBe(201)
-    })
-
-    it('GET /threads/:id returns 404 for non-participant', async () => {
-      const createRes = await appAs(U1).request('/threads', {
+    // #1386: caller-facing thread creation was removed — it was unused by the web
+    // and let any caller open a thread with arbitrary counterparties (a spam
+    // vector). Threads are created server-side only, by ensureThread on a booking.
+    it('POST /threads is not a route (thread creation is server-side only)', async () => {
+      const res = await app.request('/threads', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participantIds: [U1, U2] }),
       })
-      const threadId = (await createRes.json()).data.id
+      expect(res.status).toBe(404)
+    })
+
+    it('GET /threads/:id returns 404 for non-participant', async () => {
+      const threadId = await seedThread([U1, U2])
 
       const res = await appAs(U3).request(`/threads/${threadId}`)
       expect(res.status).toBe(404)
     })
 
     it('a platform admin can read any thread regardless of participation', async () => {
-      const createRes = await appAs(U1).request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const threadId = (await createRes.json()).data.id
+      const threadId = await seedThread([U1, U2])
 
       const res = await appAs(U3, 'PLATFORM_ADMIN').request(`/threads/${threadId}`)
       expect(res.status).toBe(200)
     })
 
     it('non-participant cannot send messages to thread', async () => {
-      const createRes = await appAs(U1).request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const threadId = (await createRes.json()).data.id
+      const threadId = await seedThread([U1, U2])
 
       const res = await appAs(U3).request(`/threads/${threadId}/messages`, {
         method: 'POST',
@@ -320,12 +143,7 @@ describe('Message Routes', () => {
     })
 
     it('non-participant cannot mark thread as read', async () => {
-      const createRes = await appAs(U1).request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const threadId = (await createRes.json()).data.id
+      const threadId = await seedThread([U1, U2])
 
       const res = await appAs(U3).request(`/threads/${threadId}/read`, {
         method: 'POST',
@@ -340,8 +158,8 @@ describe('Message Routes', () => {
   // operatorId (set by ensureThread, never the request body); an OPERATOR_*
   // caller may read/reply only its own tenant's threads. Exploit path under
   // test: operator B must get a 404 — never a 200 read or a 201 reply — on
-  // operator A's thread. Threads are seeded via the repo directly because the
-  // caller-facing POST /threads always leaves operatorId null.
+  // operator A's thread. Threads are seeded via the repo directly with an
+  // operatorId, which only ensureThread sets (from the booking) in production.
   describe('operator tenant scoping (#1205)', () => {
     const OP_A = 'op-aaaa'
     const OP_B = 'op-bbbb'
@@ -402,25 +220,13 @@ describe('Message Routes', () => {
     const MSG_KEY_A = '00000000-0000-4000-8000-bbbb00000001'
     const MSG_KEY_B = '00000000-0000-4000-8000-bbbb00000002'
 
-    /** Helper: create a thread and return its id. */
+    /** Helper: seed a thread and return its id (POST /threads was removed in #1386). */
     async function createThread(): Promise<string> {
-      const res = await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      return (await res.json()).data.id
+      return seedThread([U1, U2])
     }
 
     it('sends a message to a thread', async () => {
-      // Create thread first
-      const createRes = await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const created = await createRes.json()
-      const threadId = created.data.id
+      const threadId = await createThread()
 
       // senderId derived from JWT (U1)
       const res = await app.request(`/threads/${threadId}/messages`, {
@@ -528,13 +334,8 @@ describe('Message Routes', () => {
       // participants in the same thread replaying the same key must
       // not see each other's messages.
       it('cross-tenant: U2 replaying U1 message key does not leak U1 message', async () => {
-        // U1 creates thread and sends a message with idempotency key.
-        const createRes = await appAs(U1).request('/threads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantIds: [U1, U2] }),
-        })
-        const threadId = (await createRes.json()).data.id
+        // U1's thread with U2.
+        const threadId = await seedThread([U1, U2])
 
         const sharedKey = '00000000-0000-4000-8000-bbbb0f0f0f01'
         const u1Msg = await appAs(U1).request(`/threads/${threadId}/messages`, {
@@ -584,14 +385,7 @@ describe('Message Routes', () => {
 
   describe('GET /threads/:id', () => {
     it('returns thread with messages', async () => {
-      // Create thread
-      const createRes = await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const created = await createRes.json()
-      const threadId = created.data.id
+      const threadId = await seedThread([U1, U2])
 
       // U1 sends a message
       await appAs(U1).request(`/threads/${threadId}/messages`, {
@@ -644,14 +438,7 @@ describe('Message Routes', () => {
 
   describe('POST /threads/:id/read', () => {
     it('resets unread count for user after messages are sent', async () => {
-      // Create thread
-      const createRes = await app.request('/threads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantIds: [U1, U2] }),
-      })
-      const created = await createRes.json()
-      const threadId = created.data.id
+      const threadId = await seedThread([U1, U2])
 
       // user1 sends two messages (user2 gets unread incremented)
       await appAs(U1).request(`/threads/${threadId}/messages`, {

--- a/packages/api/tests/services/message.test.ts
+++ b/packages/api/tests/services/message.test.ts
@@ -23,8 +23,7 @@ function ctxFor(userId: string, role: AuthUser['role'] = 'RENTER', operatorId?: 
 }
 
 // Seed a booking+operator thread directly: the booking flow's ensureThread stamps
-// operatorId from the booking, which we shortcut here to exercise the alert trigger
-// (the caller-facing createThread path intentionally leaves operatorId null).
+// operatorId from the booking, which we shortcut here to exercise the alert trigger.
 async function seedBookingThread(): Promise<string> {
   const thread = await threadRepo.create(
     ctxFor(U1, 'RENTER'),
@@ -43,49 +42,11 @@ beforeEach(() => {
   service = new MessageService(threadRepo, messageRepo, notifyOperatorNewMessage)
 })
 
-describe('MessageService.createThread', () => {
-  it('forbids a non-privileged caller from creating a thread they are not in', async () => {
-    const result = await service.createThread(ctxFor(U1, 'RENTER'), { participantIds: [U2, U3] })
-
-    expect(result).toEqual({ kind: 'forbidden' })
-  })
-
-  it('lets a privileged caller create a thread between other users (status 201)', async () => {
-    const result = await service.createThread(ctxFor(U1, 'PLATFORM_ADMIN'), {
-      participantIds: [U2, U3],
-    })
-
-    expect(result.kind).toBe('created')
-    if (result.kind !== 'created') throw new Error('expected created')
-    expect(result.status).toBe(201)
-  })
-
-  it('forbids a legacy STAFF caller from creating a thread between other users — revoked by #487', async () => {
-    const result = await service.createThread(ctxFor(U1, 'STAFF'), { participantIds: [U2, U3] })
-
-    expect(result).toEqual({ kind: 'forbidden' })
-  })
-
-  it('replays an idempotency key: second create returns status 200 and the same thread', async () => {
-    const ctx = ctxFor(U1, 'RENTER')
-    const input = { participantIds: [U1, U2], idempotencyKey: 'key-thread-1' }
-
-    const first = await service.createThread(ctx, input)
-    const second = await service.createThread(ctx, input)
-
-    if (first.kind !== 'created' || second.kind !== 'created') throw new Error('expected created')
-    expect(first.status).toBe(201)
-    expect(second.status).toBe(200)
-    expect(second.thread.id).toBe(first.thread.id)
-  })
-})
-
 describe('MessageService.createMessage', () => {
   it('replays an idempotency key: second send returns status 200 and the same message', async () => {
     const ctx = ctxFor(U1, 'RENTER')
-    const created = await service.createThread(ctx, { participantIds: [U1, U2] })
-    if (created.kind !== 'created') throw new Error('expected created')
-    const threadId = created.thread.id
+    const thread = await threadRepo.create(ctx, null, [U1, U2], null, null)
+    const threadId = thread.id
 
     const first = await service.createMessage(ctx, threadId, 'hi', 'key-msg-1')
     const second = await service.createMessage(ctx, threadId, 'hi', 'key-msg-1')

--- a/packages/shared/src/validators/message.ts
+++ b/packages/shared/src/validators/message.ts
@@ -1,17 +1,8 @@
 import { z } from 'zod'
 
-export const createThreadSchema = z.object({
-  bookingId: z.string().uuid('Must be a valid UUID').optional(),
-  participantIds: z
-    .array(z.string().uuid('Each participant ID must be a valid UUID'))
-    .min(1, 'At least one participant required'),
-  idempotencyKey: z.string().uuid('Must be a valid UUID').optional(),
-})
-
 export const sendMessageSchema = z.object({
   content: z.string().trim().min(1, 'Message cannot be empty').max(5000),
   idempotencyKey: z.string().uuid('Must be a valid UUID').optional(),
 })
 
-export type CreateThreadInput = z.infer<typeof createThreadSchema>
 export type SendMessageInput = z.infer<typeof sendMessageSchema>

--- a/packages/shared/tests/validators/message.test.ts
+++ b/packages/shared/tests/validators/message.test.ts
@@ -1,54 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createThreadSchema, sendMessageSchema } from '../../src/validators/message'
-
-const UUID1 = '550e8400-e29b-41d4-a716-446655440001'
-const UUID2 = '550e8400-e29b-41d4-a716-446655440002'
-const UUID_BOOKING = '550e8400-e29b-41d4-a716-446655440099'
-
-describe('createThreadSchema', () => {
-  const validInput = { participantIds: [UUID1, UUID2] }
-
-  it('accepts valid input with participantIds only', () => {
-    const result = createThreadSchema.safeParse(validInput)
-    expect(result.success).toBe(true)
-  })
-
-  it('accepts valid input with bookingId', () => {
-    const result = createThreadSchema.safeParse({ ...validInput, bookingId: UUID_BOOKING })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.bookingId).toBe(UUID_BOOKING)
-    }
-  })
-
-  it('rejects non-UUID bookingId', () => {
-    const result = createThreadSchema.safeParse({ ...validInput, bookingId: 'booking-1' })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects non-UUID participantIds', () => {
-    const result = createThreadSchema.safeParse({ participantIds: ['not-a-uuid'] })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects missing participantIds', () => {
-    const result = createThreadSchema.safeParse({})
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects empty participantIds array', () => {
-    const result = createThreadSchema.safeParse({ participantIds: [] })
-    expect(result.success).toBe(false)
-  })
-
-  it('allows bookingId to be omitted', () => {
-    const result = createThreadSchema.safeParse(validInput)
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.bookingId).toBeUndefined()
-    }
-  })
-})
+import { sendMessageSchema } from '../../src/validators/message'
 
 describe('sendMessageSchema', () => {
   it('accepts valid content', () => {


### PR DESCRIPTION
## Summary

`POST /threads` (`createThread`) let any authenticated caller open a message thread naming **arbitrary** `participantIds`. It only checked the *caller* was among the participants — never that the counterparties had any relationship to them — so a caller could spam a thread at any user id they knew or guessed. Not a data leak (thread reads stay per-participant scoped), but an unbounded spam/harassment surface.

Investigation showed the endpoint is also **redundant and dead**:
- The web has **zero** callers of `POST /threads` (it only reads threads and sends messages).
- Every real thread is created server-side by `ensureThread` on booking commit, with participants derived from the booking — including Trip.com/PARTNER bookings.
- `MessageService.createThread` was called only by that one route.

## Change

Rather than harden an unused endpoint, remove it:
- Drop the `POST /threads` route handler.
- Drop `MessageService.createThread` + `CreateThreadResult` and the now-unused `PRIVILEGED_ROLES`/`CreateThreadInput`/`Thread` imports.
- Drop `createThreadSchema` + `CreateThreadInput` from `@kuruma/shared` (no web references).
- Route tests now seed threads through the repo (the way `ensureThread` does) instead of the removed endpoint; a guard test pins `POST /threads` → 404.

Message send/read/list and the operator tenant-scoping (#1205) paths are unaffected.

## Test plan

- [x] New guard test: `POST /threads` → 404.
- [x] Full api suite — 2600 pass; full shared suite — 887 pass.
- [x] `tsc --noEmit` on shared/api/web, `lint:boundaries`, pre-commit hook — all green.
- [x] Net −345 lines (removed dead surface).

Closes #1386