### PR TITLE
refactor(#1375): derive types/* unions from enums.ts SSoT

### DIFF
--- a/packages/shared/src/enums.test.ts
+++ b/packages/shared/src/enums.test.ts
@@ -7,6 +7,7 @@ import {
   OPERATOR_APPLICATION_BUSINESS_TYPES,
   OPERATOR_APPLICATION_FLEET_SIZES,
   OPERATOR_APPLICATION_STATUSES,
+  REVIEW_DIMENSIONS,
 } from './enums'
 
 describe('consent enums', () => {
@@ -44,5 +45,17 @@ describe('operator application enums', () => {
   })
   it('pins business types', () => {
     expect(OPERATOR_APPLICATION_BUSINESS_TYPES).toEqual(['INDIVIDUAL', 'COMPANY'])
+  })
+})
+
+describe('review enums', () => {
+  it('pins the named sub-dimension key set (folded from validators/review.ts)', () => {
+    expect(REVIEW_DIMENSIONS).toEqual([
+      'cleanliness',
+      'accuracy',
+      'communication',
+      'value',
+      'ruleAdherence',
+    ])
   })
 })

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -219,3 +219,16 @@ export type ReviewSubject = (typeof REVIEW_SUBJECTS)[number]
  *  public reads; VISIBLE is the default. */
 export const REVIEW_MODERATION_STATUSES = ['VISIBLE', 'HIDDEN'] as const
 export type ReviewModerationStatus = (typeof REVIEW_MODERATION_STATUSES)[number]
+
+/** Named sub-dimensions a review may carry (epic #1067): renter->operator uses
+ *  cleanliness/accuracy/communication/value; operator->renter uses communication/
+ *  cleanliness/ruleAdherence. The union is the accepted key set; the precise
+ *  per-direction subset is enforced in the submission service (slice 2). */
+export const REVIEW_DIMENSIONS = [
+  'cleanliness',
+  'accuracy',
+  'communication',
+  'value',
+  'ruleAdherence',
+] as const
+export type ReviewDimension = (typeof REVIEW_DIMENSIONS)[number]

--- a/packages/shared/src/types/customer.ts
+++ b/packages/shared/src/types/customer.ts
@@ -2,6 +2,8 @@
 // surface for the /manage/customers owner workflow. Computed per-request; not
 // denormalized. See issue #43.
 
+import type { BookingStatus } from '../enums'
+
 export interface Customer {
   id: string
   name: string | null
@@ -21,7 +23,7 @@ export interface CustomerBookingSummary {
   vehicleName: string | null
   startAt: string
   endAt: string
-  status: 'CONFIRMED' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+  status: BookingStatus
   totalPrice: number | null
 }
 

--- a/packages/shared/src/types/search-result.ts
+++ b/packages/shared/src/types/search-result.ts
@@ -8,8 +8,11 @@
 // — there is no types/index barrel). Import as
 // `@kuruma/shared/types/search-result`, NOT from the `@kuruma/shared` root.
 
-/** Discriminator — mirrors #463 `fulfillment_mode` (SPECIFIC | CLASS_COMBO). */
-export type SearchResultKind = 'SPECIFIC' | 'CLASS_COMBO'
+import type { BookingFulfillmentMode, Transmission } from '../enums'
+
+/** Discriminator — mirrors #463 `fulfillment_mode` (SPECIFIC | CLASS_COMBO). Aliased
+ *  to the enums SSoT (#1375) so the two never drift. */
+export type SearchResultKind = BookingFulfillmentMode
 
 /** Location identity + map coordinates, embedded on every result row. */
 export interface ResultLocation {
@@ -44,7 +47,7 @@ export interface SpecificSearchResult extends SearchResultBase {
   make: string | null
   model: string | null
   year: number | null
-  transmission: 'AUTO' | 'MANUAL'
+  transmission: Transmission
 }
 
 /** FAST-FOLLOW (#464): a class with an inventory count, exact car assigned on

--- a/packages/shared/src/types/vehicle-detail.ts
+++ b/packages/shared/src/types/vehicle-detail.ts
@@ -2,6 +2,7 @@
 // utilization data for the owner-facing /manage/vehicles/[id] page.
 // Computed per-request by the repository. See issue #53.
 
+import type { BookingSource, BookingStatus } from '../enums'
 import type { MaintenanceLogSummary } from './maintenance-log'
 import type { VehicleBase } from './vehicle'
 
@@ -10,8 +11,9 @@ export interface VehicleDetailBooking {
   startAt: Date
   endAt: Date
   renterName: string | null
-  source: 'DIRECT' | 'TRIP_COM' | 'MANUAL' | 'OTHER'
-  status: 'CONFIRMED' | 'ACTIVE'
+  source: BookingSource
+  // Deliberate subset of BookingStatus: only in-flight bookings surface as "upcoming".
+  status: Extract<BookingStatus, 'CONFIRMED' | 'ACTIVE'>
 }
 
 export interface DailyUtilization {

--- a/packages/shared/src/types/vehicle.ts
+++ b/packages/shared/src/types/vehicle.ts
@@ -1,7 +1,9 @@
+import type { Transmission, VehicleStatus } from '../enums'
 import type { LuggageSize } from '../lib/luggage'
 
-export type VehicleStatus = 'AVAILABLE' | 'MAINTENANCE' | 'RETIRED'
-export type Transmission = 'AUTO' | 'MANUAL'
+// Re-exported from the enums SSoT (#1375) so existing `types/vehicle` importers of
+// these names are unaffected; the members are identical, derivation just kills drift.
+export type { Transmission, VehicleStatus }
 
 export interface VehicleBase {
   id: string

--- a/packages/shared/src/validators/review.ts
+++ b/packages/shared/src/validators/review.ts
@@ -1,18 +1,10 @@
 import { z } from 'zod'
 import { REVIEW_SUBJECTS } from '../enums'
 
-/** Named sub-dimensions a review may carry (epic #1067): renter->operator uses
- *  cleanliness/accuracy/communication/value; operator->renter uses communication/
- *  cleanliness/ruleAdherence. The union is the accepted key set; the precise
- *  per-direction subset is enforced in the submission service (slice 2). */
-export const REVIEW_DIMENSIONS = [
-  'cleanliness',
-  'accuracy',
-  'communication',
-  'value',
-  'ruleAdherence',
-] as const
-export type ReviewDimension = (typeof REVIEW_DIMENSIONS)[number]
+// REVIEW_DIMENSIONS lives in enums.ts beside its sibling review enums (the closed-set
+// SSoT); re-exported here so existing `@kuruma/shared/validators/review` importers are
+// unaffected.
+export { REVIEW_DIMENSIONS, type ReviewDimension } from '../enums'
 
 // 1-5 whole stars — mirrors the DB reviews_overall_range_chk.
 const starRating = z.number().int().min(1).max(5)


### PR DESCRIPTION
Part of #1369 (maintainability tracker). Closes #1375.

## Problem
`types/*` re-spelled closed sets as inline literal unions, bypassing the `enums.ts` SSoT. Renaming an enum member compiled green while shipping a runtime mismatch (22P02 on insert).

## Change (type-only, no migration)
- `types/vehicle.ts` — import + re-export `Transmission`/`VehicleStatus` from `../enums`
- `types/search-result.ts` — `SearchResultKind = BookingFulfillmentMode`; `transmission: Transmission`
- `types/customer.ts` — `status: BookingStatus`
- `types/vehicle-detail.ts` — `source: BookingSource`; `status: Extract<BookingStatus, 'CONFIRMED' | 'ACTIVE'>` (deliberate subset kept linked, not raw)
- fold `REVIEW_DIMENSIONS` into `enums.ts` beside its sibling review enums; re-export from `validators/review.ts`

Members are identical, so every consumer is unaffected (types erase at build).

## Verification
- New RED→GREEN test in `enums.test.ts` pinning `REVIEW_DIMENSIONS` membership (imported from `./enums`)
- `tsc --noEmit` green across **all three** packages (proves api + web consumers unchanged)
- Full shared suite: 888 passed
- biome check clean