### PR TITLE
refactor(#1376): failResult() envelope helper + type-accurate stripUndefined

### DIFF
--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -11,11 +11,12 @@ import {
   requireUser,
   toCallerContext,
 } from '../middleware/auth'
-import type { AddOnService, AddOnUpdate } from '../services/add-on'
+import type { AddOnService } from '../services/add-on'
 import type { AddOnFilters } from '../services/filters'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import {
   fail,
+  failResult,
   ok,
   parseArchivableFilters,
   parseBody,
@@ -94,7 +95,7 @@ export function createAddOnRoutes(
         },
         locale.locale,
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option, 201)
     })
     .patch('/add-ons/:id', async (c) => {
@@ -113,10 +114,10 @@ export function createAddOnRoutes(
       const result = await service.update(
         toCallerContext(user),
         idResult.id,
-        stripUndefined(parsed.data) as AddOnUpdate,
+        stripUndefined(parsed.data),
         locale.locale,
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
     })
     .delete('/add-ons/:id', async (c) => {
@@ -130,7 +131,7 @@ export function createAddOnRoutes(
       if (!locale.ok) return locale.response
 
       const result = await service.archive(toCallerContext(user), idResult.id, locale.locale)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
     })
 }

--- a/packages/api/src/routes/consent.ts
+++ b/packages/api/src/routes/consent.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { ConsentService } from '../services/consent'
-import { fail, ok, parseBody } from './helpers'
+import { failResult, ok, parseBody } from './helpers'
 
 // Document ids are deterministic slugs (e.g. `doc_renter_tos_v1_en`), not UUIDs,
 // so this is a presence check — the service is the authority on whether the id
@@ -50,7 +50,7 @@ export function createConsentRoutes(service: ConsentService) {
           userAgent: c.req.header('user-agent') ?? null,
         },
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.acceptance)
     })
 }

--- a/packages/api/src/routes/documents.ts
+++ b/packages/api/src/routes/documents.ts
@@ -9,6 +9,7 @@ import type { RenterDocumentService } from '../services/renter-document'
 import {
   MULTIPART_OVERHEAD_BYTES,
   fail,
+  failResult,
   ok,
   parseBody,
   parseId,
@@ -45,7 +46,7 @@ export function createDocumentRoutes(service: RenterDocumentService) {
         STAFF_ROLES.has(user.role) && typeof body.renterId === 'string' ? body.renterId : ctx.userId
 
       const result = await service.upload(ctx, { renterId, type: parsed.data.type }, file)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { document: result.document }, 201)
     })
     .get('/documents/me', async (c) => {
@@ -100,7 +101,7 @@ export function createDocumentRoutes(service: RenterDocumentService) {
         expiryDate: parsed.data.expiryDate ?? null,
         rejectionReason: parsed.data.rejectionReason ?? null,
       })
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { document: result.document })
     })
 }

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -11,11 +11,12 @@ import {
   requireUser,
   toCallerContext,
 } from '../middleware/auth'
-import type { FeeScheduleService, FeeScheduleUpdate } from '../services/fee-schedule'
+import type { FeeScheduleService } from '../services/fee-schedule'
 import type { FeeScheduleFilters } from '../services/filters'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import {
   fail,
+  failResult,
   ok,
   parseArchivableFilters,
   parseBody,
@@ -90,8 +91,7 @@ export function createFeeScheduleRoutes(
         amountJpy: d.amountJpy,
         status: 'ACTIVE',
       })
-      if (!result.ok)
-        return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.feeSchedule, 201)
     })
     .patch('/fee-schedules/:id', async (c) => {
@@ -107,10 +107,9 @@ export function createFeeScheduleRoutes(
       const result = await service.update(
         toCallerContext(user),
         idResult.id,
-        stripUndefined(parsed.data) as FeeScheduleUpdate,
+        stripUndefined(parsed.data),
       )
-      if (!result.ok)
-        return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.feeSchedule)
     })
     .delete('/fee-schedules/:id', async (c) => {
@@ -121,8 +120,7 @@ export function createFeeScheduleRoutes(
       if (!idResult.ok) return idResult.response
 
       const result = await service.archive(toCallerContext(user), idResult.id)
-      if (!result.ok)
-        return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.feeSchedule)
     })
 }

--- a/packages/api/src/routes/helpers.ts
+++ b/packages/api/src/routes/helpers.ts
@@ -24,16 +24,53 @@ export function fail(
   return c.json({ success: false, error, ...extras }, status as 400)
 }
 
+/** The failure half every service `Result` shares once narrowed on `!result.ok`:
+ *  an HTTP `status` + a human `error`, plus the optional machine-readable
+ *  discriminants a route must forward so a client can branch — a `code`, and the
+ *  `activeBookingsCount` an archive conflict surfaces (#412). */
+export interface FailureResult {
+  status: number
+  error: string | Record<string, unknown>
+  code?: string
+  activeBookingsCount?: number
+}
+
+/**
+ * Translate a narrowed service failure into a `fail()` envelope, forwarding the
+ * known optional discriminants when present (never as truthiness — `activeBookingsCount: 0`
+ * is a real value). Prefer over hand-spreading extras, so a route can't silently
+ * swallow a `code` a service later adds (#1376):
+ *
+ *   if (!result.ok) return failResult(c, result)
+ *
+ * A discriminant beyond `code`/`activeBookingsCount` (e.g. bookings' `details`) keeps
+ * a bespoke `fail(c, ...)` until it is shared by 2+ routes.
+ */
+export function failResult(c: Context, result: FailureResult): Response {
+  const extras: Record<string, unknown> = {}
+  if (result.code !== undefined) extras.code = result.code
+  if (result.activeBookingsCount !== undefined) {
+    extras.activeBookingsCount = result.activeBookingsCount
+  }
+  return fail(c, result.error, result.status, extras)
+}
+
 // --- Object helpers ---
 
-/** Remove entries with `undefined` values. Isolates the single type assertion
- *  needed for exactOptionalPropertyTypes compliance so call sites stay clean. */
-export function stripUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+/** Remove entries with `undefined` values. The return type strips `undefined` from
+ *  every property (`Exclude<T[K], undefined>`) — matching the runtime, which drops
+ *  those keys — so the result is directly assignable to the exactOptionalPropertyTypes
+ *  `*Update` types WITHOUT a call-site `as` cast (#1376). The one assertion this needs
+ *  lives here, isolated. Still a subtype of `Partial<T>`, so any `Partial<T>` caller is
+ *  unaffected. */
+export function stripUndefined<T extends Record<string, unknown>>(
+  obj: T,
+): { [K in keyof T]?: Exclude<T[K], undefined> } {
   const result: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(obj)) {
     if (v !== undefined) result[k] = v
   }
-  return result as Partial<T>
+  return result as { [K in keyof T]?: Exclude<T[K], undefined> }
 }
 
 // --- Pagination helpers ---

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -12,10 +12,11 @@ import {
   toCallerContext,
 } from '../middleware/auth'
 import type { InsuranceOptionFilters } from '../services/filters'
-import type { InsuranceOptionService, InsuranceOptionUpdate } from '../services/insurance-option'
+import type { InsuranceOptionService } from '../services/insurance-option'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import {
   fail,
+  failResult,
   ok,
   parseArchivableFilters,
   parseBody,
@@ -82,7 +83,7 @@ export function createInsuranceOptionRoutes(
         deductibleJpy: d.deductibleJpy ?? null,
         status: 'ACTIVE',
       })
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option, 201)
     })
     .patch('/insurance-options/:id', async (c) => {
@@ -98,9 +99,9 @@ export function createInsuranceOptionRoutes(
       const result = await service.update(
         toCallerContext(user),
         idResult.id,
-        stripUndefined(parsed.data) as InsuranceOptionUpdate,
+        stripUndefined(parsed.data),
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
     })
     .delete('/insurance-options/:id', async (c) => {
@@ -111,7 +112,7 @@ export function createInsuranceOptionRoutes(
       if (!idResult.ok) return idResult.response
 
       const result = await service.archive(toCallerContext(user), idResult.id)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
     })
 }

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -7,9 +7,17 @@ import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { LocationFilters } from '../services/filters'
-import type { LocationService, LocationUpdateData } from '../services/location'
+import type { LocationService } from '../services/location'
 import type { ResolveWriteOperatorId } from '../tenancy'
-import { fail, ok, parseBody, parseId, parseScopedCreate, stripUndefined } from './helpers'
+import {
+  fail,
+  failResult,
+  ok,
+  parseBody,
+  parseId,
+  parseScopedCreate,
+  stripUndefined,
+} from './helpers'
 
 export function createLocationRoutes(
   service: LocationService,
@@ -84,7 +92,7 @@ export function createLocationRoutes(
           regionId: d.regionId,
           status: 'ACTIVE',
         })
-        if (!result.ok) return fail(c, result.error, result.status)
+        if (!result.ok) return failResult(c, result)
         return ok(c, result.location, 201)
       } catch (err) {
         // Two client-supplied FKs now: operatorId -> operators and regionId ->
@@ -114,9 +122,9 @@ export function createLocationRoutes(
         const result = await service.update(
           toCallerContext(user),
           idResult.id,
-          stripUndefined(parsed.data) as LocationUpdateData,
+          stripUndefined(parsed.data),
         )
-        if (!result.ok) return fail(c, result.error, result.status)
+        if (!result.ok) return failResult(c, result)
         return ok(c, result.location)
       } catch (err) {
         // regionId is the only client-supplied FK on update (#394) — operatorId
@@ -135,16 +143,10 @@ export function createLocationRoutes(
       if (!idResult.ok) return idResult.response
 
       const result = await service.archive(toCallerContext(user), idResult.id)
-      if (!result.ok) {
-        // Surface the active-bookings discriminator so the portal can prompt the
-        // owner to reassign/cancel first instead of showing a generic 409 (#412).
-        const extras: Record<string, unknown> = {}
-        if (result.code) extras.code = result.code
-        if (result.activeBookingsCount !== undefined) {
-          extras.activeBookingsCount = result.activeBookingsCount
-        }
-        return fail(c, result.error, result.status, extras)
-      }
+      // The active-bookings discriminator (code + activeBookingsCount) rides through
+      // failResult so the portal can prompt the owner to reassign/cancel first
+      // instead of showing a generic 409 (#412).
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.location)
     })
 }

--- a/packages/api/src/routes/notifications.ts
+++ b/packages/api/src/routes/notifications.ts
@@ -7,7 +7,7 @@ import {
 } from '../middleware/auth'
 import type { NotificationLogFilters } from '../services/filters'
 import type { NotificationService } from '../services/notification'
-import { fail, ok, parseCrossOperatorRead, parseId } from './helpers'
+import { fail, failResult, ok, parseCrossOperatorRead, parseId } from './helpers'
 
 /**
  * Operator-portal surface for the outbound-notification ledger (#393): a scoped
@@ -44,7 +44,7 @@ export function createNotificationRoutes(service: NotificationService) {
       // A cross-operator id resolves to 404 (not 403) in the service — no
       // tenant-existence leak. The atomic claim makes a double-click send once.
       const result = await service.resend(toCallerContext(user), idResult.id)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       // `outcome` lets the portal distinguish a real re-send from a no-op
       // ("already in progress" / "already sent") instead of a blanket green (#485).
       return ok(c, { status: result.status, outcome: result.outcome })

--- a/packages/api/src/routes/payments.ts
+++ b/packages/api/src/routes/payments.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { PaymentService } from '../services/payment/payment'
-import { fail, ok, parseId } from './helpers'
+import { fail, failResult, ok, parseId } from './helpers'
 
 const STRIPE_SIGNATURE_HEADER = 'stripe-signature'
 
@@ -24,7 +24,7 @@ export function createPaymentRoutes(service: PaymentService) {
       const idResult = parseId(c, 'bookingId')
       if (!idResult.ok) return idResult.response
       const result = await service.createCheckoutSession(ctx, idResult.id)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { url: result.url })
     })
     .get('/bookings/:bookingId/payment', async (c) => {

--- a/packages/api/src/routes/reviews.ts
+++ b/packages/api/src/routes/reviews.ts
@@ -2,7 +2,7 @@ import { editReviewSchema, submitReviewSchema } from '@kuruma/shared/validators/
 import { Hono } from 'hono'
 import { requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import type { ReviewService } from '../services/review'
-import { fail, ok, parseBody, parseId } from './helpers'
+import { failResult, ok, parseBody, parseId } from './helpers'
 
 /**
  * Mutual-review surface (#1067 slice 2): submit, edit-until-published, and the
@@ -28,7 +28,7 @@ export function createReviewRoutes(service: ReviewService) {
       if (!body.ok) return body.response
 
       const result = await service.submit(ctx, body.data, new Date())
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { review: result.review }, 201)
     })
     .patch('/reviews/:id', async (c) => {
@@ -40,7 +40,7 @@ export function createReviewRoutes(service: ReviewService) {
       if (!body.ok) return body.response
 
       const result = await service.edit(ctx, idResult.id, body.data, new Date())
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { review: result.review })
     })
     .get('/bookings/:bookingId/reviews', async (c) => {
@@ -49,7 +49,7 @@ export function createReviewRoutes(service: ReviewService) {
       if (!idResult.ok) return idResult.response
 
       const result = await service.getForBooking(ctx, idResult.id, new Date())
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { reviews: result.reviews })
     })
 }

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -2,7 +2,7 @@ import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
 import { Hono } from 'hono'
 import { PUBLIC_CONTEXT } from '../middleware/auth'
 import type { FlatSearchService } from '../services/flat-search'
-import { cachePublic, fail, ok, parseDateRange, parseLimit } from './helpers'
+import { cachePublic, failResult, ok, parseDateRange, parseLimit } from './helpers'
 import { rateLimitByIp } from './rate-limit'
 
 const DEFAULT_LIMIT = 25
@@ -53,7 +53,7 @@ export function createFlatSearchRoutes(
       ...(classes && classes.length > 0 ? { classes } : {}),
       ...(cursor ? { cursor } : {}),
     })
-    if (!result.ok) return fail(c, result.error, result.status)
+    if (!result.ok) return failResult(c, result)
     cachePublic(c, CACHE_SECONDS)
     return ok(c, result.data)
   })

--- a/packages/api/src/routes/storefronts.ts
+++ b/packages/api/src/routes/storefronts.ts
@@ -3,7 +3,15 @@ import { Hono } from 'hono'
 import { PUBLIC_CONTEXT } from '../middleware/auth'
 import type { StorefrontDetailService } from '../services/storefront-detail'
 import type { StorefrontSearchService } from '../services/storefront-search'
-import { cachePublic, fail, ok, parseDateRange, parseId, parseLimit, parseLocale } from './helpers'
+import {
+  cachePublic,
+  failResult,
+  ok,
+  parseDateRange,
+  parseId,
+  parseLimit,
+  parseLocale,
+} from './helpers'
 import { rateLimitByIp } from './rate-limit'
 
 const DEFAULT_LIMIT = 25
@@ -55,7 +63,7 @@ export function createStorefrontRoutes(
         ...(classes && classes.length > 0 ? { classes } : {}),
         ...(cursor ? { cursor } : {}),
       })
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)
     })
@@ -80,7 +88,7 @@ export function createStorefrontRoutes(
       })
       // Unknown/archived location -> 404, never edge-cached: a cached 404 would
       // pin the miss until TTL, hiding a store that just went ACTIVE.
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)
     })
@@ -92,7 +100,7 @@ export function createStorefrontRoutes(
       // (#392). Public + active-only + single-operator — see the service for the
       // [P0] seal rationale. 404 mirrors the vehicles route (unknown/archived).
       const result = await detailService.getInsuranceOptions(PUBLIC_CONTEXT, idResult.id)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)
     })
@@ -110,7 +118,7 @@ export function createStorefrontRoutes(
       // (#460). Public + active-only + single-operator — see the service for the
       // [P0] seal rationale. 404 mirrors the vehicles route (unknown/archived).
       const result = await detailService.getAddOns(PUBLIC_CONTEXT, idResult.id, locale.locale)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)
     })

--- a/packages/api/src/routes/translate.ts
+++ b/packages/api/src/routes/translate.ts
@@ -2,7 +2,7 @@ import { translateMessageSchema } from '@kuruma/shared/validators/translation'
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageTranslationService } from '../services/message-translation'
-import { fail, ok, parseBody, parseId } from './helpers'
+import { failResult, ok, parseBody, parseId } from './helpers'
 
 export function createTranslateRoutes(service: MessageTranslationService) {
   return new Hono().post('/messages/:id/translate', async (c) => {
@@ -15,7 +15,7 @@ export function createTranslateRoutes(service: MessageTranslationService) {
     if (!parsed.ok) return parsed.response
 
     const result = await service.translate(ctx, idResult.id, parsed.data.targetLanguage)
-    if (!result.ok) return fail(c, result.error, result.status)
+    if (!result.ok) return failResult(c, result)
 
     return ok(c, {
       translatedText: result.translatedText,

--- a/packages/api/src/routes/vehicle-blocks.ts
+++ b/packages/api/src/routes/vehicle-blocks.ts
@@ -8,7 +8,7 @@ import {
   toCallerContext,
 } from '../middleware/auth'
 import type { VehicleBlockService } from '../services/vehicle-block'
-import { fail, ok, parseBody, parseDateRange, parseId } from './helpers'
+import { fail, failResult, ok, parseBody, parseDateRange, parseId } from './helpers'
 
 export function createVehicleBlockRoutes(service: VehicleBlockService) {
   const app = new Hono()
@@ -65,8 +65,7 @@ export function createVehicleBlockRoutes(service: VehicleBlockService) {
         parsed.data,
         actingOperatorId,
       )
-      if (!result.ok)
-        return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.block, 201)
     })
     .delete('/vehicles/:vehicleId/blocks/:blockId', async (c) => {
@@ -86,8 +85,7 @@ export function createVehicleBlockRoutes(service: VehicleBlockService) {
         blockIdResult.id,
         actingOperatorId,
       )
-      if (!result.ok)
-        return fail(c, result.error, result.status, result.code ? { code: result.code } : undefined)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.block)
     })
 }

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -14,12 +14,13 @@ import {
 } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type { VehicleClassFilters } from '../services/filters'
-import type { VehicleClassService, VehicleClassUpdate } from '../services/vehicle-class'
+import type { VehicleClassService } from '../services/vehicle-class'
 import type { VehicleClassAvailabilityService } from '../services/vehicle-class-availability'
 import type { ResolveWriteOperatorId } from '../tenancy'
 import {
   cachePublic,
   fail,
+  failResult,
   ok,
   parseArchivableFilters,
   parseBody,
@@ -83,7 +84,7 @@ export function createVehicleClassRoutes(
           range.from,
           range.to,
         )
-        if (!result.ok) return fail(c, result.error, result.status)
+        if (!result.ok) return failResult(c, result)
         // Short TTL — availability is time-sensitive (bookings land, vehicles
         // go under maintenance). 10s absorbs a renter's click-to-confirm
         // round trip without keeping a stale view for long. The DB exclusion
@@ -150,7 +151,7 @@ export function createVehicleClassRoutes(
             status: 'ACTIVE',
           })
 
-          if (!result.ok) return fail(c, result.error, result.status)
+          if (!result.ok) return failResult(c, result)
           return ok(c, result.vehicleClass, 201)
         } catch (err) {
           // #400: vehicleClasses.operatorId -> operators is the only FK a create
@@ -175,9 +176,9 @@ export function createVehicleClassRoutes(
         const result = await service.update(
           toCallerContext(user),
           idResult.id,
-          stripUndefined(parsed.data) as VehicleClassUpdate,
+          stripUndefined(parsed.data),
         )
-        if (!result.ok) return fail(c, result.error, result.status)
+        if (!result.ok) return failResult(c, result)
         return ok(c, result.vehicleClass)
       })
       .delete('/vehicle-classes/:id', async (c) => {
@@ -188,14 +189,9 @@ export function createVehicleClassRoutes(
         if (!idResult.ok) return idResult.response
 
         const result = await service.archive(toCallerContext(user), idResult.id)
-        if (!result.ok) {
-          const extras: Record<string, unknown> = {}
-          if (result.code) extras.code = result.code
-          if (result.activeBookingsCount !== undefined) {
-            extras.activeBookingsCount = result.activeBookingsCount
-          }
-          return fail(c, result.error, result.status, extras)
-        }
+        // code + activeBookingsCount ride through failResult so the portal can
+        // prompt the owner to reassign/cancel before archiving (#412).
+        if (!result.ok) return failResult(c, result)
         return ok(c, result.vehicleClass)
       })
   )

--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -6,7 +6,14 @@ import {
   MAX_PHOTOS_PER_VEHICLE,
   type VehiclePhotoService,
 } from '../services/vehicle-photo'
-import { MULTIPART_OVERHEAD_BYTES, fail, ok, parseId, rejectOversizedBody } from './helpers'
+import {
+  MULTIPART_OVERHEAD_BYTES,
+  fail,
+  failResult,
+  ok,
+  parseId,
+  rejectOversizedBody,
+} from './helpers'
 
 // Up to MAX_PHOTOS_PER_VEHICLE files per request; cap the whole multipart body
 // at that many max-sized files plus framing slack.
@@ -50,7 +57,7 @@ export function createVehiclePhotoRoutes(
       )
 
       const result = await service.uploadPhotos(ctx, idResult.id, files)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { uploaded: result.uploaded, total: result.total }, 201)
     })
     .delete('/vehicles/:id/photos', async (c) => {
@@ -65,7 +72,7 @@ export function createVehiclePhotoRoutes(
       if (!url) return fail(c, 'url query parameter required', 400)
 
       const result = await service.deletePhoto(ctx, idResult.id, url)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, { deleted: url, remaining: result.remaining })
     })
 }

--- a/packages/api/src/routes/vehicles.ts
+++ b/packages/api/src/routes/vehicles.ts
@@ -8,7 +8,7 @@ import { Hono } from 'hono'
 import { FLEET_WRITE_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import type { MaintenanceService } from '../services/maintenance'
 import type { VehicleService } from '../services/vehicle'
-import { fail, ok, parseBody, parseId, parsePagination } from './helpers'
+import { fail, failResult, ok, parseBody, parseId, parsePagination } from './helpers'
 
 export function createVehicleRoutes(
   service: VehicleService,
@@ -48,7 +48,7 @@ export function createVehicleRoutes(
       if (!parsed.ok) return parsed.response
 
       const result = await service.create(toCallerContext(user), parsed.data)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.vehicle, 201)
     })
     .patch('/vehicles/bulk-status', async (c) => {
@@ -63,7 +63,7 @@ export function createVehicleRoutes(
         parsed.data.vehicleIds,
         parsed.data.status,
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.vehicles)
     })
     .patch('/vehicles/:id', async (c) => {
@@ -77,7 +77,7 @@ export function createVehicleRoutes(
       if (!parsed.ok) return parsed.response
 
       const result = await service.update(toCallerContext(user), idResult.id, parsed.data)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.vehicle)
     })
     .patch('/vehicles/:id/status', async (c) => {
@@ -97,7 +97,7 @@ export function createVehicleRoutes(
         parsed.data.status,
         parsed.data.reason,
       )
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.vehicle)
     })
     .delete('/vehicles/:id', async (c) => {
@@ -108,7 +108,7 @@ export function createVehicleRoutes(
       if (!idResult.ok) return idResult.response
 
       const result = await service.softDelete(toCallerContext(user), idResult.id)
-      if (!result.ok) return fail(c, result.error, result.status)
+      if (!result.ok) return failResult(c, result)
       return ok(c, result.vehicle)
     })
 }

--- a/packages/api/tests/routes/helpers.test.ts
+++ b/packages/api/tests/routes/helpers.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import {
   exceedsContentLength,
   fail,
+  failResult,
   ok,
   parseArchivableFilters,
   parseBody,
@@ -27,6 +28,22 @@ function createTestApp() {
   app.get('/fail-404', (c) => fail(c, 'not found', 404))
   app.get('/fail-extras', (c) =>
     fail(c, 'rule violated', 400, { code: 'RULE_X', details: { required: 6 } }),
+  )
+
+  app.get('/fail-result-bare', (c) => failResult(c, { status: 404, error: 'not found' }))
+  app.get('/fail-result-code', (c) =>
+    failResult(c, { status: 409, error: 'conflict', code: 'RULE_X' }),
+  )
+  app.get('/fail-result-count', (c) =>
+    failResult(c, {
+      status: 409,
+      error: 'reassign first',
+      code: 'HAS_ACTIVE_BOOKINGS',
+      activeBookingsCount: 2,
+    }),
+  )
+  app.get('/fail-result-zero-count', (c) =>
+    failResult(c, { status: 409, error: 'edge', code: 'X', activeBookingsCount: 0 }),
   )
 
   const testSchema = z.object({
@@ -197,6 +214,54 @@ describe('fail()', () => {
       code: 'RULE_X',
       details: { required: 6 },
     })
+  })
+})
+
+describe('failResult()', () => {
+  const app = createTestApp()
+
+  it('returns the bare { success: false, error } envelope when the result carries no discriminants', async () => {
+    const res = await app.request('/fail-result-bare')
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ success: false, error: 'not found' })
+  })
+
+  it('forwards the machine-readable code discriminant', async () => {
+    const res = await app.request('/fail-result-code')
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ success: false, error: 'conflict', code: 'RULE_X' })
+  })
+
+  it('forwards both code and activeBookingsCount', async () => {
+    const res = await app.request('/fail-result-count')
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({
+      success: false,
+      error: 'reassign first',
+      code: 'HAS_ACTIVE_BOOKINGS',
+      activeBookingsCount: 2,
+    })
+  })
+
+  it('forwards activeBookingsCount === 0 (guard is a defined-check, not a truthiness check)', async () => {
+    const res = await app.request('/fail-result-zero-count')
+
+    expect(await res.json()).toEqual({
+      success: false,
+      error: 'edge',
+      code: 'X',
+      activeBookingsCount: 0,
+    })
+  })
+
+  it('never leaks the internal status/ok fields into the response body', async () => {
+    const body = await (await app.request('/fail-result-code')).json()
+
+    expect(body.status).toBeUndefined()
+    expect(body.ok).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## What

Two related route-layer cleanups from the maintainability tracker (#1369):

1. **`failResult(c, result)` helper** (`routes/helpers.ts`) — collapses the boilerplate `if (!result.ok) return fail(c, result.error, result.status)` narrowing every service caller repeats. It forwards the known optional discriminants (`code`, `activeBookingsCount`) only when defined — never as truthiness, so `activeBookingsCount: 0` (a real archive-conflict value) is not dropped. Prevents a route from silently swallowing a `code` a service later adds.

2. **Type-accurate `stripUndefined`** — its return type now strips `undefined` from every property (`{ [K in keyof T]?: Exclude<T[K], undefined> }`), matching the runtime. The result is directly assignable to the `exactOptionalPropertyTypes` `*Update` types, so the five config-catalog `stripUndefined(...) as *Update` call-site casts are gone. The one isolated assertion lives in the helper.

## Scope

Migrated **16 route files** to `failResult`:
add-ons, consent, documents, fee-schedules, insurance-options, locations, notifications, payments, reviews, search, storefronts, translate, vehicle-blocks, vehicle-classes, vehicle-photos, vehicles.

vehicle-blocks' two `result.code ? { code } : undefined` extras forms collapse into `failResult` (code is in its allowlist).

## Left on raw `fail()` by design

`bookings.ts` — its four failure sites forward a bespoke `details` extra outside the `code`/`activeBookingsCount` allowlist. Folding a one-caller discriminant into the shared helper would be the wrong DRY; it stays on `fail()` until a second route needs `details`.

## Verification

- `bunx tsc --noEmit` (api) clean
- Full API unit suite: **2617 passed** (236 files)
- Per-batch affected route tests green; biome + lint:size + lint:boundaries pass via pre-commit
- Behaviour-preserving: no service contract changed, so the integration suite is not required

Closes #1376. Part of #1369.