### PR TITLE
refactor(#1381): jpyAmount(label) money validator helper

### DIFF
--- a/packages/shared/src/validators/fee-schedule.ts
+++ b/packages/shared/src/validators/fee-schedule.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { FEE_TYPES, FEE_UNITS, type FeeType, type FeeUnit } from '../enums'
+import { jpyAmount } from './money'
 
 // Re-exported from the enum SSoT (#688) under their original names so the
 // `fee_type`/`fee_unit` pgEnums, this validator, and every existing consumer all
@@ -32,10 +33,7 @@ export function feeUnitCoherenceMessage(feeType: FeeType): string {
   return `${feeType} fees must use the ${REQUIRED_UNIT_BY_FEE_TYPE[feeType]} unit`
 }
 
-const amountSchema = z
-  .number()
-  .int('Amount must be a whole yen amount')
-  .min(0, 'Amount cannot be negative')
+const amountSchema = jpyAmount('Amount')
 
 const feeScheduleObjectSchema = z.object({
   feeType: z.enum(FEE_TYPES),

--- a/packages/shared/src/validators/money.ts
+++ b/packages/shared/src/validators/money.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+/**
+ * The whole-yen, non-negative money rule shared by every JPY amount field
+ * (vehicle rates, fee amounts, add-on prices, insurance deductibles). Zero is a
+ * valid value — a free promo or a waived fee — while fractional yen and
+ * negatives are not. `label` names the field so the error reads naturally where
+ * a form renders it ("Rate must be a whole yen amount"), replacing the four
+ * hand-written copies that had drifted to four different error strings (#1381).
+ *
+ * JPY is zero-decimal, so amounts are whole integers end to end (no ×100). The
+ * inferred type stays `number` — this is deliberately NOT branded, so every
+ * existing api/web consumer is unaffected. The full `.brand<'Jpy'>()` (which
+ * would ripple into every consumer's types) is out of scope for this dedupe.
+ */
+export function jpyAmount(label: string): z.ZodNumber {
+  return z.number().int(`${label} must be a whole yen amount`).min(0, `${label} cannot be negative`)
+}

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { TRANSMISSIONS, VEHICLE_STATUSES } from '../enums'
 import { LUGGAGE_SIZES } from '../lib/luggage'
+import { jpyAmount } from './money'
 import { httpUrl } from './url'
 
 const MIN_VEHICLE_YEAR = 1900
@@ -11,7 +12,7 @@ const MAX_VEHICLE_YEAR = 2100
 // with no price is not rentable. Mirrored in the `vehicles_pricing_at_
 // least_one` CHECK constraint on the vehicles table (see schema.ts and
 // issue #48).
-const jpyRate = z.number().int('Rate must be a whole yen amount').min(0, 'Rate cannot be negative')
+const jpyRate = jpyAmount('Rate')
 
 // photos carries a .default() only on create. Kept off the base because Zod
 // .partial() does NOT strip .default(), so a partial PATCH would re-inject

--- a/packages/shared/tests/validators/money.test.ts
+++ b/packages/shared/tests/validators/money.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { jpyAmount } from '../../src/validators/money'
+
+// The message helper: pull the first issue's message off a failed safeParse so
+// assertions pin the exact copy a form renders, not just success/failure.
+function firstError(schema: ReturnType<typeof jpyAmount>, value: unknown): string {
+  const result = schema.safeParse(value)
+  if (result.success) throw new Error('expected a validation failure')
+  return result.error.issues[0]?.message ?? ''
+}
+
+describe('jpyAmount(label)', () => {
+  it('accepts zero — a free promo / waived fee is a valid whole-yen amount', () => {
+    expect(jpyAmount('Rate').safeParse(0)).toMatchObject({ success: true, data: 0 })
+  })
+
+  it('accepts a positive whole-yen amount', () => {
+    expect(jpyAmount('Amount').safeParse(5000)).toMatchObject({ success: true, data: 5000 })
+  })
+
+  it('rejects a negative amount with the label-scoped message', () => {
+    expect(firstError(jpyAmount('Rate'), -1)).toBe('Rate cannot be negative')
+  })
+
+  it('rejects a fractional yen with the label-scoped whole-yen message', () => {
+    expect(firstError(jpyAmount('Rate'), 1500.5)).toBe('Rate must be a whole yen amount')
+  })
+
+  it('rejects a non-number', () => {
+    expect(jpyAmount('Amount').safeParse('5000').success).toBe(false)
+  })
+
+  it('interpolates the label so each field reads naturally', () => {
+    expect(firstError(jpyAmount('Amount'), -1)).toBe('Amount cannot be negative')
+    expect(firstError(jpyAmount('Deductible'), 0.5)).toBe('Deductible must be a whole yen amount')
+  })
+})


### PR DESCRIPTION
## What

Extract the whole-yen, non-negative JPY money rule that was hand-written across 4+ validators with 4 divergent error strings into one shared helper.

New `packages/shared/src/validators/money.ts`:

```ts
export function jpyAmount(label: string): z.ZodNumber {
  return z.number().int(`${label} must be a whole yen amount`).min(0, `${label} cannot be negative`)
}
```

Adopted in the two validators the issue scoped for now:
- `vehicle.ts` — `jpyRate` → `jpyAmount('Rate')`
- `fee-schedule.ts` — `amountSchema` → `jpyAmount('Amount')`

Both keep their **exact** prior per-field messages (`Rate must be a whole yen amount` / `Rate cannot be negative`, and the `Amount` variants), so this is byte-for-byte behaviour-preserving.

## Deliberately out of scope

- **Brand** — the full `.brand<'Jpy'>()` changes the inferred type and ripples into every consumer (higher risk). Left as a separate decision per the issue.
- **`add-on.ts` / `insurance-option.ts`** — both catalog-i18n / insurance-i18n hot; they adopt `jpyAmount` when next touched, per the issue plan.

## Why safe

The inferred type stays `number`, so no api/web consumer's types change.

## Verification

- New `tests/validators/money.test.ts` — 6 mutation-resistant cases (zero accepted, positive accepted, negative/fractional rejected with the exact label-scoped message, non-number rejected, label interpolation). Written test-first (RED on missing module → GREEN).
- Full shared suite: **894 passed** (60 files)
- `packages/api` and `packages/web` typecheck clean (consumers unaffected)
- biome + lint:size + lint:boundaries + tsc×2 pass via pre-commit

Closes #1381. Part of #1369.