### PR TITLE
feat(#1319): platform-admin template curation — edit + promote (slice 2 of 3)

### DIFF
--- a/packages/api/src/repositories/drizzle/add-on-template.ts
+++ b/packages/api/src/repositories/drizzle/add-on-template.ts
@@ -1,8 +1,10 @@
 import { addOnTemplates } from '@kuruma/shared/db/schema'
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import { asc, eq } from 'drizzle-orm'
 import type { AddOnTemplate } from '../../stores'
 import type { AddOnTemplateRepository } from '../types'
 import type { Db } from './shared'
+import { templatePatchColumns } from './template-patch-columns'
 
 /**
  * The platform-owned add-on template catalog (catalog i18n, epic #385). Global,
@@ -33,6 +35,15 @@ export class DrizzleAddOnTemplateRepository implements AddOnTemplateRepository {
       .from(addOnTemplates)
       .where(eq(addOnTemplates.id, id))
       .limit(1)
+    return row
+  }
+
+  async update(id: string, patch: TemplatePatch): Promise<AddOnTemplate | undefined> {
+    const [row] = await this.db
+      .update(addOnTemplates)
+      .set({ ...templatePatchColumns(patch), updatedAt: new Date() })
+      .where(eq(addOnTemplates.id, id))
+      .returning(TEMPLATE_COLUMNS)
     return row
   }
 }

--- a/packages/api/src/repositories/drizzle/insurance-template.ts
+++ b/packages/api/src/repositories/drizzle/insurance-template.ts
@@ -1,8 +1,10 @@
 import { insuranceTemplates } from '@kuruma/shared/db/schema'
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import { asc, eq } from 'drizzle-orm'
 import type { InsuranceTemplate } from '../../stores'
 import type { InsuranceTemplateRepository } from '../types'
 import type { Db } from './shared'
+import { templatePatchColumns } from './template-patch-columns'
 
 /**
  * The platform-owned insurance template catalog (catalog i18n, slice 3). Global,
@@ -28,6 +30,15 @@ export class DrizzleInsuranceTemplateRepository implements InsuranceTemplateRepo
       .from(insuranceTemplates)
       .where(eq(insuranceTemplates.id, id))
       .limit(1)
+    return row
+  }
+
+  async update(id: string, patch: TemplatePatch): Promise<InsuranceTemplate | undefined> {
+    const [row] = await this.db
+      .update(insuranceTemplates)
+      .set({ ...templatePatchColumns(patch), updatedAt: new Date() })
+      .where(eq(insuranceTemplates.id, id))
+      .returning(TEMPLATE_COLUMNS)
     return row
   }
 }

--- a/packages/api/src/repositories/drizzle/template-patch-columns.ts
+++ b/packages/api/src/repositories/drizzle/template-patch-columns.ts
@@ -1,0 +1,24 @@
+import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
+import type { CatalogTemplateStatus } from '@kuruma/shared/enums'
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
+
+type TemplateSetColumns = {
+  name?: LocalizedText
+  description?: LocalizedText | null
+  status?: CatalogTemplateStatus
+}
+
+/**
+ * Build the drizzle `.set()` column subset for a #1319 admin template patch,
+ * copying ONLY the fields the caller supplied. An absent field is left out
+ * entirely (leaving the column untouched); `description: null` is a real clear,
+ * so each field is gated on `!== undefined`, never truthiness. The caller adds
+ * `updatedAt`. Shared by the add-on and insurance drizzle repos.
+ */
+export function templatePatchColumns(patch: TemplatePatch): TemplateSetColumns {
+  const cols: TemplateSetColumns = {}
+  if (patch.name !== undefined) cols.name = patch.name
+  if (patch.description !== undefined) cols.description = patch.description
+  if (patch.status !== undefined) cols.status = patch.status
+  return cols
+}

--- a/packages/api/src/repositories/in-memory/add-on-template.ts
+++ b/packages/api/src/repositories/in-memory/add-on-template.ts
@@ -1,6 +1,8 @@
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { AddOnTemplate } from '../../stores'
 import type { AddOnTemplateRepository } from '../types'
 import { seedDemoAddOnTemplates } from './add-on-template-seed'
+import { mergeTemplatePatch } from './template-patch'
 
 /**
  * Local-dev / route-suite double for the global add-on template catalog. An
@@ -27,5 +29,13 @@ export class InMemoryAddOnTemplateRepository implements AddOnTemplateRepository 
 
   async findById(id: string): Promise<AddOnTemplate | undefined> {
     return this.store.get(id)
+  }
+
+  async update(id: string, patch: TemplatePatch): Promise<AddOnTemplate | undefined> {
+    const current = this.store.get(id)
+    if (!current) return undefined
+    const updated = mergeTemplatePatch(current, patch)
+    this.store.set(id, updated)
+    return updated
   }
 }

--- a/packages/api/src/repositories/in-memory/insurance-template.test.ts
+++ b/packages/api/src/repositories/in-memory/insurance-template.test.ts
@@ -43,4 +43,70 @@ describe('InMemoryInsuranceTemplateRepository', () => {
     expect(await repo.findById(id ?? '')).toEqual(seeded)
     expect(await repo.findById('nope')).toBeUndefined()
   })
+
+  describe('update', () => {
+    const OLD = new Date('2020-01-01T00:00:00Z')
+    function archivedStore(): Map<string, InsuranceTemplate> {
+      return new Map([
+        [
+          'ins_1',
+          {
+            id: 'ins_1',
+            key: 'legacy-tier',
+            name: { en: 'Legacy tier' },
+            description: null,
+            status: 'ARCHIVED',
+            createdAt: OLD,
+            updatedAt: OLD,
+          },
+        ],
+      ])
+    }
+
+    it('merges the localized bundles and bumps updatedAt, leaving id/key/createdAt intact', async () => {
+      const repo = new InMemoryInsuranceTemplateRepository(archivedStore())
+
+      const updated = await repo.update('ins_1', {
+        name: { en: 'Legacy tier', ja: 'レガシー', zh: '旧版' },
+        description: { en: 'Older coverage tier' },
+      })
+
+      expect(updated?.name).toEqual({ en: 'Legacy tier', ja: 'レガシー', zh: '旧版' })
+      expect(updated?.description).toEqual({ en: 'Older coverage tier' })
+      expect(updated?.id).toBe('ins_1')
+      expect(updated?.key).toBe('legacy-tier')
+      expect(updated?.createdAt).toEqual(OLD)
+      expect(updated?.updatedAt.getTime()).toBeGreaterThan(OLD.getTime())
+      // status untouched when the patch omits it
+      expect(updated?.status).toBe('ARCHIVED')
+    })
+
+    it('promotes an ARCHIVED row to ACTIVE via a status-only patch', async () => {
+      const repo = new InMemoryInsuranceTemplateRepository(archivedStore())
+
+      const updated = await repo.update('ins_1', { status: 'ACTIVE' })
+
+      expect(updated?.status).toBe('ACTIVE')
+      expect(updated?.name).toEqual({ en: 'Legacy tier' })
+      expect((await repo.findById('ins_1'))?.status).toBe('ACTIVE')
+    })
+
+    it('clears the description when the patch sets it null', async () => {
+      const store = archivedStore()
+      const row = store.get('ins_1')
+      if (row) store.set('ins_1', { ...row, description: { en: 'has one' } })
+      const repo = new InMemoryInsuranceTemplateRepository(store)
+
+      const updated = await repo.update('ins_1', { description: null })
+
+      expect(updated?.description).toBeNull()
+    })
+
+    it('returns undefined for an unknown id and writes nothing', async () => {
+      const repo = new InMemoryInsuranceTemplateRepository(archivedStore())
+
+      expect(await repo.update('nope', { status: 'ACTIVE' })).toBeUndefined()
+      expect((await repo.findById('ins_1'))?.status).toBe('ARCHIVED')
+    })
+  })
 })

--- a/packages/api/src/repositories/in-memory/insurance-template.ts
+++ b/packages/api/src/repositories/in-memory/insurance-template.ts
@@ -1,6 +1,8 @@
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { InsuranceTemplate } from '../../stores'
 import type { InsuranceTemplateRepository } from '../types'
 import { seedDemoInsuranceTemplates } from './insurance-template-seed'
+import { mergeTemplatePatch } from './template-patch'
 
 /**
  * Local-dev / route-suite double for the global insurance template catalog.
@@ -22,5 +24,13 @@ export class InMemoryInsuranceTemplateRepository implements InsuranceTemplateRep
 
   async findById(id: string): Promise<InsuranceTemplate | undefined> {
     return this.store.get(id)
+  }
+
+  async update(id: string, patch: TemplatePatch): Promise<InsuranceTemplate | undefined> {
+    const current = this.store.get(id)
+    if (!current) return undefined
+    const updated = mergeTemplatePatch(current, patch)
+    this.store.set(id, updated)
+    return updated
   }
 }

--- a/packages/api/src/repositories/in-memory/template-patch.ts
+++ b/packages/api/src/repositories/in-memory/template-patch.ts
@@ -1,0 +1,22 @@
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
+import type { AddOnTemplate, InsuranceTemplate } from '../../stores'
+
+/**
+ * Pure in-memory application of a #1319 admin template patch: return a NEW row
+ * with only the present fields overwritten (an absent key leaves the current
+ * value; `description: null` is a real clear, so `!== undefined` — never a
+ * truthiness check — decides each field) and `updatedAt` bumped. Shared by the
+ * add-on and insurance in-memory repos, whose rows are structurally identical.
+ */
+export function mergeTemplatePatch<T extends AddOnTemplate | InsuranceTemplate>(
+  row: T,
+  patch: TemplatePatch,
+): T {
+  return {
+    ...row,
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+    ...(patch.description !== undefined ? { description: patch.description } : {}),
+    ...(patch.status !== undefined ? { status: patch.status } : {}),
+    updatedAt: new Date(),
+  }
+}

--- a/packages/api/src/repositories/types-catalog-templates.ts
+++ b/packages/api/src/repositories/types-catalog-templates.ts
@@ -1,3 +1,4 @@
+import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
 
 // Platform-owned catalog TEMPLATE repositories (catalog i18n, epic #385 / #1319).
@@ -27,6 +28,14 @@ export interface AddOnTemplateRepository {
    * the ACTIVE-only policy. Undefined when no row matches.
    */
   findById(id: string): Promise<AddOnTemplate | undefined>
+  /**
+   * Curate ONE template — the platform-admin write (#1319 slice 2). A single
+   * partial serves both intents: translate/edit the `name` / `description`
+   * bundles and promote/archive via `status` (promote = `{ status: 'ACTIVE' }`
+   * on a backfill-minted ARCHIVED row). Bumps `updatedAt`. Returns the updated
+   * row, or undefined when no row matches (a 404 for the service, never a throw).
+   */
+  update(id: string, patch: TemplatePatch): Promise<AddOnTemplate | undefined>
 }
 
 /**
@@ -41,4 +50,7 @@ export interface InsuranceTemplateRepository {
   findAll(): Promise<InsuranceTemplate[]>
   /** One template by id, any status; undefined when no row matches. */
   findById(id: string): Promise<InsuranceTemplate | undefined>
+  /** Curate ONE template — the admin write (#1319 slice 2). Same partial + bump
+   *  as the add-on catalog; undefined when no row matches. */
+  update(id: string, patch: TemplatePatch): Promise<InsuranceTemplate | undefined>
 }

--- a/packages/api/src/routes/admin-templates.ts
+++ b/packages/api/src/routes/admin-templates.ts
@@ -1,23 +1,62 @@
-import { Hono } from 'hono'
-import { requireAuth, requirePlatformRead, requireUser, toCallerContext } from '../middleware/auth'
+import { type TemplatePatch, templatePatchSchema } from '@kuruma/shared/types/template-admin'
+import { type Context, Hono } from 'hono'
+import {
+  type CallerContext,
+  requireAuth,
+  requirePlatformRead,
+  requireUser,
+  toCallerContext,
+} from '../middleware/auth'
 import type { TemplateLibraryService } from '../services/template-library'
-import { ok } from './helpers'
+import { ok, parseBody, parseId } from './helpers'
+
+type PatchInput =
+  | { ok: true; id: string; patch: TemplatePatch; ctx: CallerContext }
+  | { ok: false; response: Response }
+
+/**
+ * Parse + validate a template PATCH at the HTTP boundary: a uuid `:id`, a
+ * non-empty patch body, and the caller context. Returns a short-circuit response
+ * on a bad id (400) or body (400); the service applies the `requirePlatformAdmin`
+ * write gate (403) and the not-found (404), so those stay out of the route.
+ */
+async function parsePatch(c: Context): Promise<PatchInput> {
+  const idResult = parseId(c)
+  if (!idResult.ok) return idResult
+  const parsed = await parseBody(c, templatePatchSchema)
+  if (!parsed.ok) return parsed
+  return { ok: true, id: idResult.id, patch: parsed.data, ctx: toCallerContext(requireUser(c)) }
+}
 
 /**
  * Platform-admin template library (#1319). Mounts under `/admin/*`, so the
- * structural platform read-floor (`requirePlatformMember`) already gates the
- * path; the per-handler `requirePlatformRead` is defence in depth (AGENTS.md) and
- * the service re-asserts it. Read-only in slice 1 — the admin sees every add-on
- * and insurance template, ALL statuses, so it can later translate + promote the
- * ARCHIVED, en-only rows the slice-2/3 backfills mint.
+ * structural platform read-floor already gates the path; per-handler guards are
+ * defence in depth (AGENTS.md). Slice 1 read (`GET`) exposes every status; slice
+ * 2 adds the curation WRITES (`PATCH`) — translate/edit the localized bundles and
+ * promote an ARCHIVED backfill-minted row to ACTIVE — each gated by the stricter
+ * `requirePlatformAdmin` in the service. Add-on and insurance catalogs are
+ * distinct paths (`/add-ons/:id`, `/insurance/:id`) over structurally identical
+ * rows.
  */
 export function createAdminTemplateRoutes(service: TemplateLibraryService) {
   const app = new Hono()
   app.use('/admin/templates', requireAuth())
+  app.use('/admin/templates/*', requireAuth())
 
-  return app.get('/admin/templates', async (c) => {
-    const ctx = toCallerContext(requireUser(c))
-    requirePlatformRead(ctx)
-    return ok(c, await service.listAll(ctx))
-  })
+  return app
+    .get('/admin/templates', async (c) => {
+      const ctx = toCallerContext(requireUser(c))
+      requirePlatformRead(ctx)
+      return ok(c, await service.listAll(ctx))
+    })
+    .patch('/admin/templates/add-ons/:id', async (c) => {
+      const input = await parsePatch(c)
+      if (!input.ok) return input.response
+      return ok(c, await service.updateAddOn(input.ctx, input.id, input.patch))
+    })
+    .patch('/admin/templates/insurance/:id', async (c) => {
+      const input = await parsePatch(c)
+      if (!input.ok) return input.response
+      return ok(c, await service.updateInsurance(input.ctx, input.id, input.patch))
+    })
 }

--- a/packages/api/src/services/template-library.test.ts
+++ b/packages/api/src/services/template-library.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { type CallerContext, ForbiddenError } from '../middleware/auth'
+import { type CallerContext, ForbiddenError, NotFoundError } from '../middleware/auth'
 import { InMemoryAddOnTemplateRepository } from '../repositories/in-memory/add-on-template'
 import { InMemoryInsuranceTemplateRepository } from '../repositories/in-memory/insurance-template'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
@@ -68,5 +68,76 @@ describe('TemplateLibraryService.listAll', () => {
     const operator: CallerContext = { userId: 'op', role: 'OPERATOR_OWNER', operatorId: 'op_1' }
 
     await expect(service.listAll(operator)).rejects.toThrow(ForbiddenError)
+  })
+})
+
+const OPERATOR: CallerContext = { userId: 'op', role: 'OPERATOR_OWNER', operatorId: 'op_1' }
+
+describe('TemplateLibraryService.updateAddOn', () => {
+  it('translates + promotes a backfill-minted row, returning the raw admin row (no timestamps)', async () => {
+    const service = new TemplateLibraryService(addOnStore([archivedAddOn]), insuranceStore([]))
+
+    const row = await service.updateAddOn(ADMIN, 'a1', {
+      name: { en: 'Baby seat', ja: 'ベビーシート', zh: '婴儿座椅' },
+      status: 'ACTIVE',
+    })
+
+    expect(row).toEqual({
+      id: 'a1',
+      key: 'baby-seat',
+      name: { en: 'Baby seat', ja: 'ベビーシート', zh: '婴儿座椅' },
+      description: null,
+      status: 'ACTIVE',
+    })
+  })
+
+  it('rejects an operator caller with ForbiddenError (requirePlatformAdmin)', async () => {
+    const service = new TemplateLibraryService(addOnStore([archivedAddOn]), insuranceStore([]))
+
+    await expect(service.updateAddOn(OPERATOR, 'a1', { status: 'ACTIVE' })).rejects.toThrow(
+      ForbiddenError,
+    )
+  })
+
+  it('throws NotFoundError for an unknown id', async () => {
+    const service = new TemplateLibraryService(addOnStore([archivedAddOn]), insuranceStore([]))
+
+    await expect(service.updateAddOn(ADMIN, 'nope', { status: 'ACTIVE' })).rejects.toThrow(
+      NotFoundError,
+    )
+  })
+})
+
+describe('TemplateLibraryService.updateInsurance', () => {
+  it('edits the insurance bundle, returning the raw admin row', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([activeInsurance]))
+
+    const row = await service.updateInsurance(ADMIN, 'i1', {
+      description: { en: 'Updated cover.' },
+    })
+
+    expect(row).toEqual({
+      id: 'i1',
+      key: 'normal',
+      name: { en: 'Normal', ja: 'ノーマル', zh: '标准' },
+      description: { en: 'Updated cover.' },
+      status: 'ACTIVE',
+    })
+  })
+
+  it('rejects an operator caller with ForbiddenError', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([activeInsurance]))
+
+    await expect(service.updateInsurance(OPERATOR, 'i1', { status: 'ARCHIVED' })).rejects.toThrow(
+      ForbiddenError,
+    )
+  })
+
+  it('throws NotFoundError for an unknown id', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([activeInsurance]))
+
+    await expect(service.updateInsurance(ADMIN, 'nope', { status: 'ARCHIVED' })).rejects.toThrow(
+      NotFoundError,
+    )
   })
 })

--- a/packages/api/src/services/template-library.ts
+++ b/packages/api/src/services/template-library.ts
@@ -1,5 +1,14 @@
-import type { TemplateAdminRow, TemplateLibraryResponse } from '@kuruma/shared/types/template-admin'
-import { type CallerContext, requirePlatformRead } from '../middleware/auth'
+import type {
+  TemplateAdminRow,
+  TemplateLibraryResponse,
+  TemplatePatch,
+} from '@kuruma/shared/types/template-admin'
+import {
+  type CallerContext,
+  NotFoundError,
+  requirePlatformAdmin,
+  requirePlatformRead,
+} from '../middleware/auth'
 import type { AddOnTemplateRepository, InsuranceTemplateRepository } from '../repositories/types'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
 
@@ -34,5 +43,37 @@ export class TemplateLibraryService {
       this.insuranceTemplateRepo.findAll(),
     ])
     return { addOns: addOns.map(toRow), insurance: insurance.map(toRow) }
+  }
+
+  /**
+   * Curate one add-on template — translate/edit its bundles and/or promote an
+   * ARCHIVED backfill-minted row to ACTIVE (#1319 slice 2). A WRITE, so gated by
+   * the stricter `requirePlatformAdmin` (read-floor `requirePlatformRead` admits
+   * the whole platform tier; a write must not). The 403 is asserted BEFORE the
+   * lookup so a missing id never leaks existence to a non-admin. Returns the raw
+   * admin row; throws `NotFoundError` (-> 404) when no row matches.
+   */
+  async updateAddOn(
+    ctx: CallerContext,
+    id: string,
+    patch: TemplatePatch,
+  ): Promise<TemplateAdminRow> {
+    requirePlatformAdmin(ctx)
+    const updated = await this.addOnTemplateRepo.update(id, patch)
+    if (!updated) throw new NotFoundError('add-on template not found')
+    return toRow(updated)
+  }
+
+  /** Curate one insurance template — same contract as {@link updateAddOn} over
+   *  the insurance catalog. */
+  async updateInsurance(
+    ctx: CallerContext,
+    id: string,
+    patch: TemplatePatch,
+  ): Promise<TemplateAdminRow> {
+    requirePlatformAdmin(ctx)
+    const updated = await this.insuranceTemplateRepo.update(id, patch)
+    if (!updated) throw new NotFoundError('insurance template not found')
+    return toRow(updated)
   }
 }

--- a/packages/api/tests/integration/insurance-template-repo.test.ts
+++ b/packages/api/tests/integration/insurance-template-repo.test.ts
@@ -60,3 +60,61 @@ describe('DrizzleInsuranceTemplateRepository.findAll', () => {
     await db.delete(insuranceTemplates).where(inArray(insuranceTemplates.key, [key]))
   })
 })
+
+describe('DrizzleInsuranceTemplateRepository.update', () => {
+  const OLD = new Date('2020-01-01T00:00:00Z')
+
+  it('translates + promotes an ARCHIVED row, persisting bundles and bumping updatedAt', async () => {
+    const id = crypto.randomUUID()
+    const key = `test_ins_promote_${uniq}`
+    await db.insert(insuranceTemplates).values({
+      id,
+      key,
+      name: { en: 'Retired tier' },
+      description: null,
+      status: 'ARCHIVED',
+      updatedAt: OLD,
+    })
+    const repo = new DrizzleInsuranceTemplateRepository(db)
+
+    const updated = await repo.update(id, {
+      name: { en: 'Retired tier', ja: '旧プラン', zh: '旧套餐' },
+      status: 'ACTIVE',
+    })
+
+    expect(updated?.name).toEqual({ en: 'Retired tier', ja: '旧プラン', zh: '旧套餐' })
+    expect(updated?.status).toBe('ACTIVE')
+    expect(updated?.updatedAt.getTime()).toBeGreaterThan(OLD.getTime())
+    // Re-read proves the write hit the row, not just the returning() projection.
+    const reread = await repo.findById(id)
+    expect(reread?.status).toBe('ACTIVE')
+    expect(reread?.name).toEqual({ en: 'Retired tier', ja: '旧プラン', zh: '旧套餐' })
+
+    await db.delete(insuranceTemplates).where(inArray(insuranceTemplates.key, [key]))
+  })
+
+  it('clears the description when the patch sets it null, leaving name untouched', async () => {
+    const id = crypto.randomUUID()
+    const key = `test_ins_clear_${uniq}`
+    await db.insert(insuranceTemplates).values({
+      id,
+      key,
+      name: { en: 'Has desc' },
+      description: { en: 'Remove me.' },
+      status: 'ACTIVE',
+    })
+    const repo = new DrizzleInsuranceTemplateRepository(db)
+
+    const updated = await repo.update(id, { description: null })
+
+    expect(updated?.description).toBeNull()
+    expect(updated?.name).toEqual({ en: 'Has desc' })
+
+    await db.delete(insuranceTemplates).where(inArray(insuranceTemplates.key, [key]))
+  })
+
+  it('returns undefined for an unknown id, writing nothing', async () => {
+    const repo = new DrizzleInsuranceTemplateRepository(db)
+    expect(await repo.update(crypto.randomUUID(), { status: 'ACTIVE' })).toBeUndefined()
+  })
+})

--- a/packages/api/tests/routes/admin-templates.test.ts
+++ b/packages/api/tests/routes/admin-templates.test.ts
@@ -164,10 +164,12 @@ describe('PATCH /admin/templates/add-ons/:id', () => {
     expect(res.status).toBe(404)
   })
 
-  it('400s an empty patch body (no-op guard)', async () => {
+  it('400s an empty patch body (no-op guard) with a surfaced message', async () => {
     const app = mountWrite('PLATFORM_ADMIN')
     const res = await patch(app, `/admin/templates/add-ons/${ADDON_UUID}`, {})
     expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.status).toContain('at least one of name, description, status is required')
   })
 
   it('400s a malformed (non-uuid) id', async () => {

--- a/packages/api/tests/routes/admin-templates.test.ts
+++ b/packages/api/tests/routes/admin-templates.test.ts
@@ -84,3 +84,115 @@ describe('GET /admin/templates', () => {
     expect(res.status).toBe(403)
   })
 })
+
+// parseId validates a uuid path param, so the write fixtures use uuid-shaped ids
+// (seedId derives v4-shaped uuids in production).
+const ADDON_UUID = '11111111-1111-4111-8111-111111111111'
+const INS_UUID = '22222222-2222-4222-8222-222222222222'
+
+function writeService() {
+  const addOn: AddOnTemplate = {
+    id: ADDON_UUID,
+    key: 'baby-seat',
+    name: { en: 'Baby seat' },
+    description: null,
+    status: 'ARCHIVED',
+    createdAt: now,
+    updatedAt: now,
+  }
+  const insurance: InsuranceTemplate = {
+    id: INS_UUID,
+    key: 'normal',
+    name: { en: 'Normal', ja: 'ノーマル', zh: '标准' },
+    description: { en: 'Standard cover.' },
+    status: 'ACTIVE',
+    createdAt: now,
+    updatedAt: now,
+  }
+  return new TemplateLibraryService(
+    new InMemoryAddOnTemplateRepository(new Map([[addOn.id, addOn]])),
+    new InMemoryInsuranceTemplateRepository(new Map([[insurance.id, insurance]])),
+  )
+}
+
+function mountWrite(role: UserRole, operatorId?: string) {
+  const app = new Hono()
+  setupGlobalHandlers(app)
+  app.use('*', testAuthMiddleware(`${role}-user`, role, operatorId))
+  app.route('/', createAdminTemplateRoutes(writeService()))
+  return app
+}
+
+function patch(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /admin/templates/add-ons/:id', () => {
+  it('translates + promotes an ARCHIVED add-on for a platform admin', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await patch(app, `/admin/templates/add-ons/${ADDON_UUID}`, {
+      name: { en: 'Baby seat', ja: 'ベビーシート', zh: '婴儿座椅' },
+      status: 'ACTIVE',
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual({
+      id: ADDON_UUID,
+      key: 'baby-seat',
+      name: { en: 'Baby seat', ja: 'ベビーシート', zh: '婴儿座椅' },
+      description: null,
+      status: 'ACTIVE',
+    })
+  })
+
+  it('rejects an operator owner with 403', async () => {
+    const app = mountWrite('OPERATOR_OWNER', 'op_1')
+    const res = await patch(app, `/admin/templates/add-ons/${ADDON_UUID}`, { status: 'ACTIVE' })
+    expect(res.status).toBe(403)
+  })
+
+  it('404s for a valid-uuid id with no matching row', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await patch(app, '/admin/templates/add-ons/33333333-3333-4333-8333-333333333333', {
+      status: 'ACTIVE',
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('400s an empty patch body (no-op guard)', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await patch(app, `/admin/templates/add-ons/${ADDON_UUID}`, {})
+    expect(res.status).toBe(400)
+  })
+
+  it('400s a malformed (non-uuid) id', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await patch(app, '/admin/templates/add-ons/not-a-uuid', { status: 'ACTIVE' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('PATCH /admin/templates/insurance/:id', () => {
+  it('edits the insurance bundle for a platform admin', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await patch(app, `/admin/templates/insurance/${INS_UUID}`, {
+      description: { en: 'Updated cover.' },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.description).toEqual({ en: 'Updated cover.' })
+    expect(body.data.status).toBe('ACTIVE')
+  })
+
+  it('rejects a renter with 403', async () => {
+    const app = mountWrite('RENTER')
+    const res = await patch(app, `/admin/templates/insurance/${INS_UUID}`, { status: 'ARCHIVED' })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/shared/src/types/template-admin.ts
+++ b/packages/shared/src/types/template-admin.ts
@@ -32,3 +32,24 @@ export const templateLibraryResponseSchema = z.object({
 })
 
 export type TemplateLibraryResponse = z.infer<typeof templateLibraryResponseSchema>
+
+/**
+ * `PATCH /admin/templates/{add-ons,insurance}/:id` body (#1319 slice 2). One
+ * partial covers BOTH admin write intents: translate/curate (`name` /
+ * `description` bundles) and promote/archive (`status`) — promote is just
+ * `{ status: 'ACTIVE' }` on a backfill-minted ARCHIVED row. Every field optional,
+ * but `.refine` rejects an empty body so a no-op PATCH is a 400, not a silent
+ * write. `name` keeps the en-required `localizedTextSchema` invariant (a template
+ * must always carry its fallback); `description` is nullable to clear it.
+ */
+export const templatePatchSchema = z
+  .object({
+    name: localizedTextSchema.optional(),
+    description: localizedTextSchema.nullable().optional(),
+    status: z.enum(CATALOG_TEMPLATE_STATUSES).optional(),
+  })
+  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    message: 'at least one of name, description, status is required',
+  })
+
+export type TemplatePatch = z.infer<typeof templatePatchSchema>

--- a/packages/shared/src/types/template-admin.ts
+++ b/packages/shared/src/types/template-admin.ts
@@ -49,6 +49,9 @@ export const templatePatchSchema = z
     status: z.enum(CATALOG_TEMPLATE_STATUSES).optional(),
   })
   .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    // Pin to a field path so the message lands in zod's `fieldErrors` (which the
+    // API's parseBody forwards) rather than the dropped top-level `formErrors`.
+    path: ['status'],
     message: 'at least one of name, description, status is required',
   })
 

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1409,11 +1409,27 @@
       "colKey": "Key",
       "colStatus": "Status",
       "colTranslations": "Translations",
+      "colActions": "Actions",
       "active": "Active",
       "archived": "Archived",
       "empty": "No templates in this catalog yet.",
       "loadError": "Couldn't load the template library.",
-      "retry": "Retry"
+      "retry": "Retry",
+      "action": {
+        "edit": "Edit",
+        "editNamed": "Edit {name}"
+      },
+      "edit": {
+        "title": "Edit template",
+        "description": "Translate each locale, then set the status. Promote a backfill-minted template by switching it to Active.",
+        "nameSection": "Name",
+        "descriptionSection": "Description",
+        "statusLabel": "Status",
+        "nameEnRequired": "An English name is required.",
+        "save": "Save",
+        "saving": "Saving…",
+        "cancel": "Cancel"
+      }
     },
     "featureFlags": {
       "title": "Feature flags",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1409,11 +1409,27 @@
       "colKey": "キー",
       "colStatus": "ステータス",
       "colTranslations": "翻訳",
+      "colActions": "操作",
       "active": "有効",
       "archived": "アーカイブ済み",
       "empty": "このカタログにはまだテンプレートがありません。",
       "loadError": "テンプレートライブラリを読み込めませんでした。",
-      "retry": "再試行"
+      "retry": "再試行",
+      "action": {
+        "edit": "編集",
+        "editNamed": "{name}を編集"
+      },
+      "edit": {
+        "title": "テンプレートを編集",
+        "description": "各言語を翻訳してからステータスを設定します。バックフィルで作成されたテンプレートは、有効に切り替えると公開されます。",
+        "nameSection": "名称",
+        "descriptionSection": "説明",
+        "statusLabel": "ステータス",
+        "nameEnRequired": "英語名は必須です。",
+        "save": "保存",
+        "saving": "保存中…",
+        "cancel": "キャンセル"
+      }
     },
     "featureFlags": {
       "title": "機能フラグ",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1409,11 +1409,27 @@
       "colKey": "键",
       "colStatus": "状态",
       "colTranslations": "翻译",
+      "colActions": "操作",
       "active": "启用",
       "archived": "已归档",
       "empty": "此目录中暂无模板。",
       "loadError": "无法加载模板库。",
-      "retry": "重试"
+      "retry": "重试",
+      "action": {
+        "edit": "编辑",
+        "editNamed": "编辑{name}"
+      },
+      "edit": {
+        "title": "编辑模板",
+        "description": "先翻译各语言，再设置状态。将回填生成的模板切换为启用即可发布。",
+        "nameSection": "名称",
+        "descriptionSection": "说明",
+        "statusLabel": "状态",
+        "nameEnRequired": "英文名称为必填项。",
+        "save": "保存",
+        "saving": "保存中…",
+        "cancel": "取消"
+      }
     },
     "featureFlags": {
       "title": "功能开关",

--- a/packages/web/src/routes/$locale/_admin/admin/templates.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/templates.tsx
@@ -4,10 +4,10 @@ import { useQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
 
-// Platform-admin template library (#1319), slice 1: read-only. The `_admin` parent
-// layout already gates on platform-admin membership, so this owns only the data —
-// prefetch both catalogs and render the tabbed table. Curation (translate, promote,
-// merge) lands in later slices.
+// Platform-admin template library (#1319). The `_admin` parent layout already
+// gates on platform-admin membership, so this owns only the data — prefetch both
+// catalogs and render the tabbed table. Slice 2 adds per-row translate + promote
+// (via the view's edit dialog); create + merge synonyms lands in slice 3.
 export const Route = createFileRoute('/$locale/_admin/admin/templates')({
   loader: ({ context }) => context.queryClient.ensureQueryData(templateLibraryQueryOptions()),
   pendingComponent: PageSkeleton,

--- a/packages/web/src/vite/admin/template-library/TemplateEditDialog.test.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateEditDialog.test.tsx
@@ -1,0 +1,88 @@
+import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../../messages/en.json'
+import { TemplateEditDialog } from './TemplateEditDialog'
+import { updateTemplate } from './api'
+
+// The dialog reads the CSRF token from the session and PATCHes via updateTemplate;
+// both are stubbed so the test asserts the wiring (what patch is sent), not I/O.
+vi.mock('@/vite/session', () => ({
+  useSession: () => ({ data: { csrfToken: 'csrf_1' } }),
+}))
+vi.mock('./api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api')>()
+  return { ...actual, updateTemplate: vi.fn() }
+})
+
+const ARCHIVED_ADD_ON: TemplateAdminRow = {
+  id: 'a1',
+  key: 'baby-seat',
+  name: { en: 'Baby seat' },
+  description: null,
+  status: 'ARCHIVED',
+}
+
+function renderDialog(over?: { row?: TemplateAdminRow; onOpenChange?: (open: boolean) => void }) {
+  const onOpenChange = over?.onOpenChange ?? vi.fn()
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <IntlProvider locale="en" messages={en}>
+        <TemplateEditDialog
+          catalog="add-ons"
+          row={over?.row ?? ARCHIVED_ADD_ON}
+          onOpenChange={onOpenChange}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+  return { onOpenChange }
+}
+
+describe('TemplateEditDialog', () => {
+  afterEach(() => {
+    vi.mocked(updateTemplate).mockReset()
+  })
+
+  it('pre-fills the form from the row', () => {
+    renderDialog()
+    expect(screen.getByLabelText('Name EN')).toHaveValue('Baby seat')
+    expect(screen.getByLabelText('Name JA')).toHaveValue('')
+  })
+
+  it('translates and promotes in one Save, sending the merged patch with the CSRF token', async () => {
+    vi.mocked(updateTemplate).mockResolvedValue({ ...ARCHIVED_ADD_ON, status: 'ACTIVE' })
+    const { onOpenChange } = renderDialog()
+
+    fireEvent.change(screen.getByLabelText('Name JA'), { target: { value: 'ベビーシート' } })
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'ACTIVE' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    // TanStack passes a context object as a 2nd arg; assert the variables only.
+    expect(vi.mocked(updateTemplate).mock.calls[0]?.[0]).toEqual({
+      catalog: 'add-ons',
+      id: 'a1',
+      patch: {
+        name: { en: 'Baby seat', ja: 'ベビーシート' },
+        description: null,
+        status: 'ACTIVE',
+      },
+      csrfToken: 'csrf_1',
+    })
+  })
+
+  it('blocks Save (and never calls the API) while the English name is empty', () => {
+    renderDialog()
+    fireEvent.change(screen.getByLabelText('Name EN'), { target: { value: '   ' } })
+
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeDisabled()
+    fireEvent.click(save)
+    expect(updateTemplate).not.toHaveBeenCalled()
+    expect(screen.getByText('An English name is required.')).toBeInTheDocument()
+  })
+})

--- a/packages/web/src/vite/admin/template-library/TemplateEditDialog.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateEditDialog.tsx
@@ -1,0 +1,192 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { NativeSelect } from '@/components/ui/native-select'
+import { useSession } from '@/vite/session'
+import { CATALOG_TEMPLATE_STATUSES } from '@kuruma/shared/enums'
+import { SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useTranslations } from 'use-intl'
+import { TEMPLATE_LIBRARY_QUERY_KEY, type TemplateCatalog, updateTemplate } from './api'
+import { type TemplateForm, buildTemplatePatch, formFromRow } from './patch-form'
+
+interface TemplateEditDialogProps {
+  readonly catalog: TemplateCatalog
+  readonly row: TemplateAdminRow | null
+  readonly onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Curate one template (#1319 slice 2). Self-contained like the operator dialogs:
+ * owns the CSRF token, the mutation, and the cache invalidation. A single Save
+ * both translates the name/description bundles AND promotes/archives via the
+ * status select — promoting a backfill-minted ARCHIVED, en-only row is: add ja/zh,
+ * switch status to Active, Save. Keyed by row so the form resets per template.
+ */
+export function TemplateEditDialog({ catalog, row, onOpenChange }: TemplateEditDialogProps) {
+  const t = useTranslations('admin.templateLibrary')
+  const queryClient = useQueryClient()
+  const csrfToken = useSession().data?.csrfToken ?? ''
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: updateTemplate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TEMPLATE_LIBRARY_QUERY_KEY })
+      onOpenChange(false)
+    },
+  })
+
+  return (
+    <Dialog open={row !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('edit.title')}</DialogTitle>
+          <DialogDescription>{t('edit.description')}</DialogDescription>
+        </DialogHeader>
+        {error && (
+          <p className="px-1 text-destructive text-sm">
+            {error instanceof Error ? error.message : String(error)}
+          </p>
+        )}
+        {row && (
+          <EditForm
+            key={row.id}
+            t={t}
+            row={row}
+            isSubmitting={isPending}
+            onCancel={() => onOpenChange(false)}
+            onSubmit={(form) =>
+              mutate({ catalog, id: row.id, patch: buildTemplatePatch(form), csrfToken })
+            }
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EditForm({
+  t,
+  row,
+  isSubmitting,
+  onCancel,
+  onSubmit,
+}: {
+  readonly t: (key: string) => string
+  readonly row: TemplateAdminRow
+  readonly isSubmitting: boolean
+  readonly onCancel: () => void
+  readonly onSubmit: (form: TemplateForm) => void
+}) {
+  const [form, setForm] = useState<TemplateForm>(() => formFromRow(row))
+  const nameMissing = form.name.en.trim() === ''
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (!nameMissing) onSubmit(form)
+      }}
+      className="space-y-4"
+    >
+      <BundleFields
+        legend={t('edit.nameSection')}
+        field="name"
+        form={form}
+        setForm={setForm}
+        requireEn
+      />
+      <BundleFields
+        legend={t('edit.descriptionSection')}
+        field="description"
+        form={form}
+        setForm={setForm}
+      />
+
+      <div className="space-y-1.5">
+        <Label htmlFor="template-status">{t('edit.statusLabel')}</Label>
+        <NativeSelect
+          id="template-status"
+          value={form.status}
+          onChange={(e) =>
+            setForm((prev) => ({
+              ...prev,
+              status: e.target.value as TemplateForm['status'],
+            }))
+          }
+        >
+          {CATALOG_TEMPLATE_STATUSES.map((status) => (
+            <option key={status} value={status}>
+              {status === 'ACTIVE' ? t('active') : t('archived')}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+
+      {nameMissing && <p className="text-destructive text-sm">{t('edit.nameEnRequired')}</p>}
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+          {t('edit.cancel')}
+        </Button>
+        <Button type="submit" disabled={isSubmitting || nameMissing}>
+          {isSubmitting ? t('edit.saving') : t('edit.save')}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}
+
+/** Three locale inputs for one bundle field (`name` | `description`), each with
+ *  its own label so screen readers announce "Name (JA)" etc. */
+function BundleFields({
+  legend,
+  field,
+  form,
+  setForm,
+  requireEn = false,
+}: {
+  readonly legend: string
+  readonly field: 'name' | 'description'
+  readonly form: TemplateForm
+  readonly setForm: (updater: (prev: TemplateForm) => TemplateForm) => void
+  readonly requireEn?: boolean
+}) {
+  return (
+    <fieldset className="space-y-1.5">
+      <legend className="font-medium text-sm">{legend}</legend>
+      <div className="grid gap-2 sm:grid-cols-3">
+        {SUPPORTED_LOCALES.map((locale) => (
+          <div key={locale} className="space-y-1">
+            <span aria-hidden className="block text-muted-foreground text-xs uppercase">
+              {locale}
+            </span>
+            <Input
+              // Unique accessible name per field+locale (e.g. "Name JA"); the
+              // visible locale chip above is aria-hidden to avoid a duplicate.
+              aria-label={`${legend} ${locale.toUpperCase()}`}
+              value={form[field][locale]}
+              required={requireEn && locale === 'en'}
+              onChange={(e) =>
+                setForm((prev) => ({
+                  ...prev,
+                  [field]: { ...prev[field], [locale]: e.target.value },
+                }))
+              }
+            />
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/packages/web/src/vite/admin/template-library/TemplateLibraryView.test.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateLibraryView.test.tsx
@@ -1,9 +1,15 @@
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import en from '../../../../messages/en.json'
 import { TemplateLibraryView } from './TemplateLibraryView'
+
+// Opening the edit dialog mounts a component that reads the session; stub it.
+vi.mock('@/vite/session', () => ({
+  useSession: () => ({ data: { csrfToken: 'csrf_1' } }),
+}))
 
 const ARCHIVED_ADD_ON: TemplateAdminRow = {
   id: 'a1',
@@ -64,5 +70,36 @@ describe('TemplateLibraryView', () => {
   it('renders an empty message when a catalog has no templates', () => {
     renderView({ addOns: [] })
     expect(screen.getByText('No templates in this catalog yet.')).toBeInTheDocument()
+  })
+
+  it('renders a per-row Edit button keyed by the template name', () => {
+    renderView()
+    const row = screen.getByText('Baby seat').closest('tr') as HTMLElement
+    expect(within(row).getByRole('button', { name: 'Edit Baby seat' })).toBeInTheDocument()
+  })
+})
+
+// The edit dialog mounts on click, so it needs a QueryClient (mutation) provider.
+function renderViewWithProviders() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <IntlProvider locale="en" messages={en}>
+        <TemplateLibraryView addOns={[ARCHIVED_ADD_ON]} insurance={[ACTIVE_INSURANCE]} />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('TemplateLibraryView edit dialog', () => {
+  it('opens the edit dialog seeded with the clicked row when Edit is pressed', () => {
+    renderViewWithProviders()
+    // No dialog until a row's Edit is clicked.
+    expect(screen.queryByRole('heading', { name: 'Edit template' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Baby seat' }))
+
+    expect(screen.getByRole('heading', { name: 'Edit template' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Name EN')).toHaveValue('Baby seat')
   })
 })

--- a/packages/web/src/vite/admin/template-library/TemplateLibraryView.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateLibraryView.tsx
@@ -2,9 +2,16 @@ import { SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
+import { TemplateEditDialog } from './TemplateEditDialog'
+import type { TemplateCatalog } from './api'
 
 const CATALOGS = ['addOns', 'insurance'] as const
 type CatalogKey = (typeof CATALOGS)[number]
+// Tab key -> the URL path segment the write endpoint uses.
+const CATALOG_PATH: Record<CatalogKey, TemplateCatalog> = {
+  addOns: 'add-ons',
+  insurance: 'insurance',
+}
 
 interface TemplateLibraryViewProps {
   readonly addOns: readonly TemplateAdminRow[]
@@ -12,16 +19,20 @@ interface TemplateLibraryViewProps {
 }
 
 /**
- * Platform-admin template library (#1319), slice 1: read-only. Two catalogs
- * (add-ons / insurance) behind a tab, each a table of RAW rows — every status,
- * including the ARCHIVED en-only rows the backfill mints. The per-locale
- * translation chips make an untranslated (en-only) row visible at a glance, which
- * is what a later slice will let the admin fix + promote. Pure props (FC/IS — the
- * route owns the query).
+ * Platform-admin template library (#1319). Two catalogs (add-ons / insurance)
+ * behind a tab, each a table of RAW rows — every status, including the ARCHIVED
+ * en-only rows the backfill mints. The per-locale translation chips flag an
+ * untranslated row at a glance; slice 2's per-row Edit opens {@link TemplateEditDialog}
+ * to fix + promote it. Rows arrive as props (the route owns the query); the only
+ * local state is the active tab and the row being edited.
  */
 export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewProps) {
   const t = useTranslations('admin.templateLibrary')
   const [tab, setTab] = useState<CatalogKey>('addOns')
+  const [editing, setEditing] = useState<{
+    catalog: TemplateCatalog
+    row: TemplateAdminRow
+  } | null>(null)
   const rowsByTab: Record<CatalogKey, readonly TemplateAdminRow[]> = { addOns, insurance }
   const rows = rowsByTab[tab]
   const head = 'px-3 py-2 text-left font-medium text-muted-foreground'
@@ -63,12 +74,15 @@ export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewPr
               <th scope="col" className={head}>
                 {t('colTranslations')}
               </th>
+              <th scope="col" className={head}>
+                {t('colActions')}
+              </th>
             </tr>
           </thead>
           <tbody>
             {rows.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-3 py-8 text-center text-muted-foreground">
+                <td colSpan={5} className="px-3 py-8 text-center text-muted-foreground">
                   {t('empty')}
                 </td>
               </tr>
@@ -87,12 +101,32 @@ export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewPr
                   <td className="px-3 py-3">
                     <TranslationChips row={row} />
                   </td>
+                  <td className="px-3 py-3">
+                    <button
+                      type="button"
+                      onClick={() => setEditing({ catalog: CATALOG_PATH[tab], row })}
+                      aria-label={t('action.editNamed', { name: row.name.en })}
+                      className="rounded-md border border-border px-2.5 py-1 font-medium text-xs hover:bg-muted/50"
+                    >
+                      {t('action.edit')}
+                    </button>
+                  </td>
                 </tr>
               ))
             )}
           </tbody>
         </table>
       </div>
+
+      {editing && (
+        <TemplateEditDialog
+          catalog={editing.catalog}
+          row={editing.row}
+          onOpenChange={(open) => {
+            if (!open) setEditing(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/packages/web/src/vite/admin/template-library/api.test.ts
+++ b/packages/web/src/vite/admin/template-library/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchTemplateLibrary } from './api'
+import { fetchTemplateLibrary, updateTemplate } from './api'
 
 const BODY = {
   success: true,
@@ -52,5 +52,61 @@ describe('fetchTemplateLibrary', () => {
       new Response(JSON.stringify({ success: false, error: 'Forbidden' }), { status: 403 }),
     )
     await expect(fetchTemplateLibrary()).rejects.toThrow()
+  })
+})
+
+describe('updateTemplate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('PATCHes the catalog-scoped path with the CSRF header and returns the updated row', async () => {
+    const updatedRow = {
+      id: 'a1',
+      key: 'baby-seat',
+      name: { en: 'Baby seat', ja: 'ベビーシート' },
+      description: null,
+      status: 'ACTIVE',
+    }
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: updatedRow }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await updateTemplate({
+      catalog: 'add-ons',
+      id: 'a1',
+      patch: { name: { en: 'Baby seat', ja: 'ベビーシート' }, status: 'ACTIVE' },
+      csrfToken: 'csrf_1',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/admin/templates/add-ons/a1')
+    expect(init.method).toBe('PATCH')
+    expect(init.credentials).toBe('include')
+    expect((init.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf_1')
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: { en: 'Baby seat', ja: 'ベビーシート' },
+      status: 'ACTIVE',
+    })
+    expect(result).toEqual(updatedRow)
+  })
+
+  it('rejects when the API returns a non-ok status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: false, error: 'PLATFORM_ADMIN role required' }), {
+        status: 403,
+      }),
+    )
+    await expect(
+      updateTemplate({
+        catalog: 'insurance',
+        id: 'i1',
+        patch: { status: 'ARCHIVED' },
+        csrfToken: 'x',
+      }),
+    ).rejects.toThrow()
   })
 })

--- a/packages/web/src/vite/admin/template-library/api.ts
+++ b/packages/web/src/vite/admin/template-library/api.ts
@@ -1,10 +1,16 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import {
+  type TemplateAdminRow,
   type TemplateLibraryResponse,
+  type TemplatePatch,
+  templateAdminRowSchema,
   templateLibraryResponseSchema,
 } from '@kuruma/shared/types/template-admin'
 import { queryOptions } from '@tanstack/react-query'
+
+/** URL path segment per catalog (the tabbed view keys them `addOns`/`insurance`). */
+export type TemplateCatalog = 'add-ons' | 'insurance'
 
 // Platform-admin template library (#1319). Cookie-based (credentials: 'include')
 // so the API gates on the session role server-side (requirePlatformRead). The
@@ -22,4 +28,28 @@ export function templateLibraryQueryOptions() {
     queryKey: TEMPLATE_LIBRARY_QUERY_KEY,
     queryFn: fetchTemplateLibrary,
   })
+}
+
+// Platform-admin template WRITE (#1319 slice 2). Cookie-authenticated, so it is
+// CSRF-gated: the caller echoes the session's token in `X-CSRF-Token`. One PATCH
+// both translates (name/description bundles) and promotes/archives (status) — the
+// server (requirePlatformAdmin) rejects a non-admin. Returns the updated raw row;
+// the caller invalidates TEMPLATE_LIBRARY_QUERY_KEY to refetch the table.
+export async function updateTemplate(params: {
+  catalog: TemplateCatalog
+  id: string
+  patch: TemplatePatch
+  csrfToken: string
+}): Promise<TemplateAdminRow> {
+  const { catalog, id, patch, csrfToken } = params
+  const res = await fetch(
+    `${getApiBaseUrl()}/admin/templates/${catalog}/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify(patch),
+    },
+  )
+  return unwrap(res, templateAdminRowSchema)
 }

--- a/packages/web/src/vite/admin/template-library/patch-form.test.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.test.ts
@@ -1,0 +1,54 @@
+import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
+import { describe, expect, it } from 'vitest'
+import { buildTemplatePatch, formFromRow } from './patch-form'
+
+describe('formFromRow', () => {
+  it('spreads each locale into its own field, blanking absent locales and a null description', () => {
+    const row: TemplateAdminRow = {
+      id: 'a1',
+      key: 'baby-seat',
+      name: { en: 'Baby seat', ja: 'ベビーシート' },
+      description: null,
+      status: 'ARCHIVED',
+    }
+
+    expect(formFromRow(row)).toEqual({
+      name: { en: 'Baby seat', ja: 'ベビーシート', zh: '' },
+      description: { en: '', ja: '', zh: '' },
+      status: 'ARCHIVED',
+    })
+  })
+})
+
+describe('buildTemplatePatch', () => {
+  it('assembles the name bundle, drops empty locales, and trims', () => {
+    const patch = buildTemplatePatch({
+      name: { en: '  Baby seat ', ja: 'ベビーシート', zh: '' },
+      description: { en: '', ja: '', zh: '' },
+      status: 'ACTIVE',
+    })
+
+    expect(patch.name).toEqual({ en: 'Baby seat', ja: 'ベビーシート' })
+    expect(patch.status).toBe('ACTIVE')
+  })
+
+  it('clears the description (null) when its en field is empty', () => {
+    const patch = buildTemplatePatch({
+      name: { en: 'Baby seat', ja: '', zh: '' },
+      description: { en: '', ja: 'ignored', zh: '' },
+      status: 'ACTIVE',
+    })
+
+    expect(patch.description).toBeNull()
+  })
+
+  it('includes description locales only when en is present', () => {
+    const patch = buildTemplatePatch({
+      name: { en: 'Full cover', ja: '', zh: '' },
+      description: { en: 'Zero deductible', ja: '', zh: '全额' },
+      status: 'ACTIVE',
+    })
+
+    expect(patch.description).toEqual({ en: 'Zero deductible', zh: '全额' })
+  })
+})

--- a/packages/web/src/vite/admin/template-library/patch-form.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.ts
@@ -1,0 +1,59 @@
+import type { CatalogTemplateStatus } from '@kuruma/shared/enums'
+import type { Locale } from '@kuruma/shared/i18n/locales'
+import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
+import type { TemplateAdminRow, TemplatePatch } from '@kuruma/shared/types/template-admin'
+
+/** One text field per supported locale (always a string, never undefined — a
+ *  controlled input's value). Absent bundle locales render as empty strings. */
+export type BundleForm = Record<Locale, string>
+
+export interface TemplateForm {
+  name: BundleForm
+  description: BundleForm
+  status: CatalogTemplateStatus
+}
+
+function bundleToForm(bundle: LocalizedText | null): BundleForm {
+  return { en: bundle?.en ?? '', ja: bundle?.ja ?? '', zh: bundle?.zh ?? '' }
+}
+
+/** Seed the edit form from a persisted row — each locale to its own field, a
+ *  null description to blank fields. Pure; the dialog owns the mutable copy. */
+export function formFromRow(row: TemplateAdminRow): TemplateForm {
+  return {
+    name: bundleToForm(row.name),
+    description: bundleToForm(row.description),
+    status: row.status,
+  }
+}
+
+/**
+ * Collapse a bundle form into a `LocalizedText`, or null when en is blank.
+ * `en` is the required fallback (`localizedTextSchema`): with no en there is no
+ * bundle, so a description whose en is empty CLEARS to null. ja/zh are included
+ * only when non-empty. Trims every value so a whitespace-only field never
+ * persists a blank slot.
+ */
+function toBundle(form: BundleForm): LocalizedText | null {
+  const en = form.en.trim()
+  if (!en) return null
+  const ja = form.ja.trim()
+  const zh = form.zh.trim()
+  return { en, ...(ja ? { ja } : {}), ...(zh ? { zh } : {}) }
+}
+
+/**
+ * Build the `PATCH` body from the edit form. `name` requires en (the Save button
+ * stays disabled while it is blank, so a null name never reaches here — but it is
+ * omitted defensively rather than sent as an invalid bundle); `description` is
+ * sent as its bundle or explicit null (a real clear); `status` always rides along
+ * so a single Save both translates and promotes/archives.
+ */
+export function buildTemplatePatch(form: TemplateForm): TemplatePatch {
+  const name = toBundle(form.name)
+  return {
+    ...(name ? { name } : {}),
+    description: toBundle(form.description),
+    status: form.status,
+  }
+}


### PR DESCRIPTION
## What

Slice 2 of #1319 — the **write** half of the platform-admin template library, on top of slice 1's read-only page (#1397). A platform admin can now **translate/edit** a template's name + description bundles and **promote** a backfill-minted `ARCHIVED`, en-only row to `ACTIVE` — in a single PATCH.

Refs #1319 (slice 3 = create + merge synonyms will close it).

## API

- `templatePatchSchema` (shared): partial `name` / `description` / `status`; `.refine` rejects an empty body so a no-op PATCH is a 400.
- `update(id, patch)` on both template repo interfaces + drizzle and in-memory impls. Shared pure `mergeTemplatePatch` / `templatePatchColumns` helpers keep the add-on and insurance catalogs in step. `description: null` is a real clear (gated on `!== undefined`, never truthiness); `updatedAt` bumped.
- `TemplateLibraryService.updateAddOn` / `updateInsurance`: gated by the stricter `requirePlatformAdmin`, **asserted before the lookup** so a miss never leaks existence to a non-admin; throws `NotFoundError` → 404.
- `PATCH /admin/templates/{add-ons,insurance}/:id` under the existing `/admin/*` structural floor; uuid + non-empty body parsed at the boundary.

## Web

- `updateTemplate` client (cookie + `X-CSRF-Token`).
- Per-row **Edit** opens `TemplateEditDialog` (self-contained mutation, mirrors `AnomalyResolveDialog`): per-locale name/description inputs + a status select; one **Save** both translates and promotes/archives. Pure `buildTemplatePatch` assembles the body (drops empty locales, clears description when en is blank).
- i18n keys en/ja/zh (25 keys each, parity verified).

## Test plan

- [x] in-memory repo update (merge, promote, null-clear, unknown-id, immutability + `updatedAt` bump)
- [x] real-pg integration (SQL round-trip, null-clear, `updatedAt` bump, unknown-id → undefined)
- [x] service (platform-admin edit/promote, operator 403, unknown-id 404)
- [x] route (200 promote+translate, 403 operator/renter, 404 missing, 400 empty body, 400 non-uuid id)
- [x] web: pure patch-builder, client (URL/CSRF/body), dialog (pre-fill, translate+promote patch, name-required guard), view (per-row Edit button, opens dialog seeded with the row)
- [x] API 2642 unit + 5 integration green; web slice tests green; tsc ×3, boundaries, size, modules, biome clean

_Note: 6 unrelated operator route-placement + deploy-config tests fail locally (stale `routeTree.gen.ts` artifact, identical to develop, outside this diff); they pass in CI._

🤖 Generated with [Claude Code](https://claude.com/claude-code)