### PR TITLE
fix(#1378): auto-refund amount-mismatched Stripe charges + alert on stranded funds

### DIFF
--- a/packages/api/src/routes/payments.ts
+++ b/packages/api/src/routes/payments.ts
@@ -43,14 +43,24 @@ export function createPaymentRoutes(service: PaymentService) {
       const rawBody = await c.req.text()
       const result = await service.handleWebhook(rawBody, signature)
 
-      // A double charge or an amount mismatch needs an operator's eyes. The
-      // service now PERSISTS these to payment_anomalies (#508 P2, idempotent on
-      // stripeEventId); this log is supplementary real-time signal carrying the
-      // FULL context (event/session/paymentIntent/booking/amounts). NOTE: because
-      // persistence happens before the 200 ack, a transient insert failure rejects
-      // here → 500 → Stripe retry, which re-converges (the insert is idempotent) —
-      // an intentional trade-off favouring durable capture over a silent log-only ack.
-      if (result.outcome === 'double_payment' || result.outcome === 'amount_mismatch') {
+      // A double charge or an amount mismatch needs attention. The service PERSISTS
+      // these to payment_anomalies (#508 P2, idempotent on stripeEventId); this log is
+      // the real-time signal carrying FULL context (event/session/paymentIntent/booking/
+      // amounts). NOTE: persistence happens before the 200 ack, so a transient failure
+      // rejects here → 500 → Stripe retry, which re-converges (idempotent) — favouring
+      // durable capture over a silent log-only ack.
+      if (result.outcome === 'amount_mismatch') {
+        // #1378: the mismatched charge is AUTO-REFUNDED. Alert LOUD only when the refund
+        // did not go through ('failed'/'unrefundable') — captured funds may still be
+        // stranded and need a human. A completed/pending refund is a warning-level record.
+        const stranded = result.refund === 'failed' || result.refund === 'unrefundable'
+        const emit = stranded ? console.error : console.warn
+        emit('[payment:webhook] amount mismatch', {
+          refund: result.refund,
+          stranded,
+          ...result.context,
+        })
+      } else if (result.outcome === 'double_payment') {
         console.error('[payment:webhook] anomaly', {
           outcome: result.outcome,
           ...result.context,

--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -373,6 +373,22 @@ describe('PaymentService.handleWebhook', () => {
     expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'failed' })
   })
 
+  it('flags the refund as failed when Stripe RETURNS a failed status (not thrown)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999, status: 'failed' })
+    const result = await service.handleWebhook('raw', 'sig')
+    // A non-thrown 'failed'/'canceled' refund must NOT be softened to 'pending':
+    // captured funds did not move, so the route has to alert LOUD, not warn.
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'failed' })
+  })
+
+  it('flags the refund as failed when Stripe RETURNS a canceled status', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999, status: 'canceled' })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'failed' })
+  })
+
   it('propagates a TRANSIENT refund error so the webhook 500s and Stripe retries (never a silent strand)', async () => {
     gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
     gateway.nextRefund = () => {
@@ -398,8 +414,23 @@ describe('PaymentService.handleWebhook', () => {
   it('rejects a null amount even against a booking with no total (no null===null match)', async () => {
     bookings.set('bk-1', makeBooking({ totalPrice: null }))
     gateway.nextEvent = completedEvent({ amountTotal: null })
-    expect(await service.handleWebhook('raw', 'sig')).toMatchObject({ outcome: 'amount_mismatch' })
+    // A null amount has nothing to refund against → 'unrefundable' (the anomaly is the
+    // human surface), and Stripe is never called.
+    expect(await service.handleWebhook('raw', 'sig')).toMatchObject({
+      outcome: 'amount_mismatch',
+      refund: 'unrefundable',
+    })
+    expect(gateway.refundCalls).toEqual([])
     expect(await paymentRepo.findSucceededByBookingId('bk-1')).toBeNull()
+  })
+
+  it('flags a zero-amount mismatch as unrefundable (nothing to refund, never calls Stripe)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 0 })
+    expect(await service.handleWebhook('raw', 'sig')).toMatchObject({
+      outcome: 'amount_mismatch',
+      refund: 'unrefundable',
+    })
+    expect(gateway.refundCalls).toEqual([])
   })
 
   it('is idempotent on a redelivered event (no duplicate row)', async () => {

--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -6,11 +6,14 @@ import { InMemoryPaymentEventRepository } from '../../repositories/in-memory/pay
 import { InMemoryPaymentRefundRepository } from '../../repositories/in-memory/payment-refund'
 import type { Booking } from '../../stores'
 import { PaymentService } from './payment'
-import type {
-  CheckoutSession,
-  CreateCheckoutParams,
-  PaymentGateway,
-  VerifiedPaymentEvent,
+import {
+  type CheckoutSession,
+  type CreateCheckoutParams,
+  type PaymentGateway,
+  type RefundParams,
+  RefundRejectedError,
+  type StripeRefund,
+  type VerifiedPaymentEvent,
 } from './payment-gateway'
 
 const RENTER: CallerContext = { userId: 'renter-1', role: 'RENTER', bypassScope: false }
@@ -72,10 +75,18 @@ class FakeGateway implements PaymentGateway {
     return ev
   }
 
-  // Refund surface (#851) is exercised in payment-refund.test.ts; these checkout/
-  // webhook tests never refund, so the stubs throw if unexpectedly reached.
-  async refundPayment(): Promise<never> {
+  // Refund surface: refundPayment is programmable so the #1378 amount-mismatch
+  // auto-refund path can be driven and asserted. retrieve/list stay throwing —
+  // the mismatch path refunds DIRECTLY (no receipt ledger, no adopt), so they're
+  // never reached from these webhook tests.
+  refundCalls: RefundParams[] = []
+  nextRefund: StripeRefund | (() => never) = () => {
     throw new Error('no refund programmed')
+  }
+  async refundPayment(p: RefundParams): Promise<StripeRefund> {
+    this.refundCalls.push(p)
+    const r = this.nextRefund
+    return typeof r === 'function' ? r() : r
   }
   async retrieveRefund(): Promise<never> {
     throw new Error('no refund programmed')
@@ -98,6 +109,20 @@ function completedEvent(overrides: Partial<VerifiedPaymentEvent> = {}): Verified
     refundId: null,
     metadata: { bookingId: 'bk-1', operatorId: 'spoofed-operator' },
     ...overrides,
+  }
+}
+
+// A narrowed Stripe Refund the fake hands back from refundPayment (#1378 mismatch
+// auto-refund). Defaults to a succeeded full refund of the mismatched charge.
+function stripeRefund(o: Partial<StripeRefund> = {}): StripeRefund {
+  return {
+    id: 're_mismatch_1',
+    amount: 99_999,
+    currency: 'jpy',
+    status: 'succeeded',
+    paymentIntentId: 'pi_1',
+    metadata: { bookingId: 'bk-1' },
+    ...o,
   }
 }
 
@@ -284,6 +309,7 @@ describe('PaymentService.handleWebhook', () => {
 
   it('rejects an amount that does not match the booking total, carrying reconciliation context', async () => {
     gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999 })
     const result = await service.handleWebhook('raw', 'sig')
     expect(result.status).toBe(200)
     expect(result.outcome).toBe('amount_mismatch')
@@ -299,9 +325,65 @@ describe('PaymentService.handleWebhook', () => {
     expect(await paymentRepo.findSucceededByBookingId('bk-1')).toBeNull()
   })
 
-  it('rejects a non-JPY currency', async () => {
+  it('auto-refunds the captured charge on an amount mismatch, never stranding funds (#1378)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999 })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result.outcome).toBe('amount_mismatch')
+    // The disposition is surfaced so the route can alert on an UNRESOLVED refund.
+    expect(result.refund).toBe('refunded')
+    // The FULL captured (wrong) amount is refunded against the charge's paymentIntent.
+    expect(gateway.refundCalls).toEqual([
+      expect.objectContaining({
+        paymentIntentId: 'pi_1',
+        amountJpy: 99_999,
+        metadata: { bookingId: 'bk-1' },
+      }),
+    ])
+    // Booking legitimately stays UNPAID — we refused a wrong amount, we didn't book it.
+    expect(await paymentRepo.findSucceededByBookingId('bk-1')).toBeNull()
+  })
+
+  it('rejects a non-JPY currency and refunds the foreign-currency charge', async () => {
     gateway.nextEvent = completedEvent({ currency: 'usd' })
-    expect(await service.handleWebhook('raw', 'sig')).toMatchObject({ outcome: 'amount_mismatch' })
+    gateway.nextRefund = stripeRefund({ amount: 100_000 })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'refunded' })
+    expect(gateway.refundCalls).toHaveLength(1)
+  })
+
+  it('flags a mismatch as unrefundable when Stripe reported no PaymentIntent (nothing to refund)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999, paymentIntentId: null })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'unrefundable' })
+    // Never call Stripe when there's no PI to refund against; the anomaly is the surface.
+    expect(gateway.refundCalls).toEqual([])
+  })
+
+  it('flags the refund as failed when Stripe TERMINALLY rejects it (funds may still be stranded)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = () => {
+      throw new RefundRejectedError('charge already refunded', 'charge_already_refunded')
+    }
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'failed' })
+  })
+
+  it('propagates a TRANSIENT refund error so the webhook 500s and Stripe retries (never a silent strand)', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = () => {
+      throw new Error('stripe 503 timeout')
+    }
+    await expect(service.handleWebhook('raw', 'sig')).rejects.toThrow('stripe 503 timeout')
+    // The anomaly was still captured before the refund attempt threw.
+    expect(await anomalyRepo.listUnresolved()).toHaveLength(1)
+  })
+
+  it('surfaces a pending refund (async settlement) so the route does not alert as stranded', async () => {
+    gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999, status: 'pending' })
+    const result = await service.handleWebhook('raw', 'sig')
+    expect(result).toMatchObject({ outcome: 'amount_mismatch', refund: 'pending' })
   })
 
   it('rejects a null amount even against a booking with no total (no null===null match)', async () => {
@@ -368,6 +450,7 @@ describe('PaymentService.handleWebhook', () => {
   // can list duplicate charges to refund instead of scraping logs.
   it('persists an AMOUNT_MISMATCH anomaly carrying received + expected amounts', async () => {
     gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999 })
     await service.handleWebhook('raw', 'sig')
 
     const anomalies = await anomalyRepo.listUnresolved()
@@ -411,6 +494,7 @@ describe('PaymentService.handleWebhook', () => {
 
   it('records a single anomaly when an amount_mismatch webhook is redelivered (idempotent)', async () => {
     gateway.nextEvent = completedEvent({ amountTotal: 99_999 })
+    gateway.nextRefund = stripeRefund({ amount: 99_999 })
     await service.handleWebhook('raw', 'sig')
     await service.handleWebhook('raw', 'sig') // same evt_1 redelivered
     expect(await anomalyRepo.listUnresolved()).toHaveLength(1)

--- a/packages/api/src/services/payment/payment.test.ts
+++ b/packages/api/src/services/payment/payment.test.ts
@@ -337,6 +337,10 @@ describe('PaymentService.handleWebhook', () => {
       expect.objectContaining({
         paymentIntentId: 'pi_1',
         amountJpy: 99_999,
+        // The dedup key MUST be namespaced away from #851's `refund:${bookingId}`:
+        // a collision would cross-fire the cancellation refund's idempotency (same
+        // booking, different params → Stripe reuse error). This assertion pins it.
+        idempotencyKey: 'refund:mismatch:evt_1',
         metadata: { bookingId: 'bk-1' },
       }),
     ])
@@ -376,6 +380,11 @@ describe('PaymentService.handleWebhook', () => {
     }
     await expect(service.handleWebhook('raw', 'sig')).rejects.toThrow('stripe 503 timeout')
     // The anomaly was still captured before the refund attempt threw.
+    expect(await anomalyRepo.listUnresolved()).toHaveLength(1)
+    // Stripe retries the same event; the refund now succeeds and the anomaly stays
+    // single (recordAnomaly is idempotent on stripeEventId) — the retry converges.
+    gateway.nextRefund = stripeRefund({ amount: 99_999 })
+    expect(await service.handleWebhook('raw', 'sig')).toMatchObject({ refund: 'refunded' })
     expect(await anomalyRepo.listUnresolved()).toHaveLength(1)
   })
 

--- a/packages/api/src/services/payment/payment.ts
+++ b/packages/api/src/services/payment/payment.ts
@@ -70,11 +70,20 @@ export interface WebhookLogContext {
   currency: string | null
 }
 
+/** What happened to the auto-refund of an amount-mismatched charge (#1378). The
+ *  route alerts LOUD on 'failed'/'unrefundable' (captured funds may still be
+ *  stranded — a human must act) and softly on 'refunded'/'pending' (money is on
+ *  its way back to the renter, nothing owed). */
+export type MismatchRefundDisposition = 'refunded' | 'pending' | 'failed' | 'unrefundable'
+
 export interface WebhookResult {
   status: 200 | 400
   outcome: WebhookOutcome
   /** Present for anomaly/duplicate outcomes so the route can log identifiers. */
   context?: WebhookLogContext
+  /** Present only on `amount_mismatch`: the disposition of the #1378 auto-refund,
+   *  so the route can alert loudly when captured funds still need a human. */
+  refund?: MismatchRefundDisposition
 }
 
 export interface BookingPaymentStatus {
@@ -115,6 +124,50 @@ export class PaymentService {
       expectedAmountJpy: booking.totalPrice,
       currency: event.currency,
     })
+  }
+
+  /**
+   * Auto-refund a charge Stripe captured for the WRONG amount (#1378). The mismatch
+   * guard refuses to RECORD a wrong-amount payment, but the card was already charged —
+   * so return the money instead of stranding it in the anomaly queue. Refunds the FULL
+   * captured amount against its PaymentIntent; the booking legitimately stays UNPAID
+   * (we refused the amount, we never fulfilled it).
+   *
+   * Deliberately does NOT use the cancellation `payment_refunds` receipt ledger: that
+   * table is one-row-per-booking for the REFUND_DUE settlement flow, so reusing it here
+   * would let a later real cancellation adopt this stale receipt and skip its own
+   * refund. Idempotency instead rides Stripe's key (`refund:mismatch:${eventId}`): a
+   * redelivery dedupes at Stripe, and a terminal "already refunded" surfaces as
+   * 'failed' (a conservative human-check alert, never a double refund). Transient
+   * gateway errors PROPAGATE so the 500 → Stripe retry re-drives — captured funds can
+   * never silently strand.
+   */
+  private async refundMismatchedCharge(
+    booking: Booking,
+    event: VerifiedPaymentEvent,
+  ): Promise<MismatchRefundDisposition> {
+    const { paymentIntentId, amountTotal } = event
+    // No PaymentIntent or non-positive amount → nothing we can refund from here; the
+    // recorded anomaly stays the human surface (the route alerts on 'unrefundable').
+    if (paymentIntentId === null || amountTotal === null || amountTotal <= 0) {
+      return 'unrefundable'
+    }
+    try {
+      const refund = await this.gateway.refundPayment({
+        paymentIntentId,
+        amountJpy: amountTotal,
+        idempotencyKey: `refund:mismatch:${event.eventId}`,
+        metadata: { bookingId: booking.id },
+      })
+      if (refund.status === 'succeeded') return 'refunded'
+      if (refund.status === 'failed' || refund.status === 'canceled') return 'failed'
+      return 'pending' // pending / requires_action — money is moving, no booking state to advance
+    } catch (err) {
+      // Terminal rejection (already-refunded / insufficient balance) → the charge may
+      // still be stranded, so flag for a human. Transient errors propagate (→ retry).
+      if (err instanceof RefundRejectedError) return 'failed'
+      throw err
+    }
   }
 
   async createCheckoutSession(
@@ -212,7 +265,8 @@ export class PaymentService {
       event.currency !== CURRENCY
     ) {
       await this.recordAnomaly('AMOUNT_MISMATCH', booking, event)
-      return { status: 200, outcome: 'amount_mismatch', context }
+      const refund = await this.refundMismatchedCharge(booking, event)
+      return { status: 200, outcome: 'amount_mismatch', context, refund }
     }
 
     const grossJpy = event.amountTotal

--- a/packages/api/tests/routes/payments.test.ts
+++ b/packages/api/tests/routes/payments.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
 import { type UserRole, requireAuth } from '../../src/middleware/auth'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
@@ -8,11 +8,14 @@ import { InMemoryPaymentEventRepository } from '../../src/repositories/in-memory
 import { InMemoryPaymentRefundRepository } from '../../src/repositories/in-memory/payment-refund'
 import { createPaymentRoutes } from '../../src/routes/payments'
 import { PaymentService } from '../../src/services/payment/payment'
-import type {
-  CheckoutSession,
-  CreateCheckoutParams,
-  PaymentGateway,
-  VerifiedPaymentEvent,
+import {
+  type CheckoutSession,
+  type CreateCheckoutParams,
+  type PaymentGateway,
+  type RefundParams,
+  RefundRejectedError,
+  type StripeRefund,
+  type VerifiedPaymentEvent,
 } from '../../src/services/payment/payment-gateway'
 import type { Booking } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
@@ -46,9 +49,16 @@ class StubGateway implements PaymentGateway {
     if (!this.event) throw new Error('bad signature')
     return this.event
   }
-  // Refund surface (#851) is unused by these checkout/webhook route tests.
-  async refundPayment(): Promise<never> {
+  // Refund surface: programmable so the #1378 amount-mismatch auto-refund + alert
+  // path can be driven at the route boundary. retrieve/list stay unused here.
+  refundCalls: RefundParams[] = []
+  nextRefund: StripeRefund | (() => never) = () => {
     throw new Error('no refund programmed')
+  }
+  async refundPayment(p: RefundParams): Promise<StripeRefund> {
+    this.refundCalls.push(p)
+    const r = this.nextRefund
+    return typeof r === 'function' ? r() : r
   }
   async retrieveRefund(): Promise<never> {
     throw new Error('no refund programmed')
@@ -105,8 +115,26 @@ const completed = (): VerifiedPaymentEvent => ({
   amountTotal: 100_000,
   currency: 'jpy',
   paymentStatus: 'paid',
+  refundStatus: null,
+  refundId: null,
   metadata: { bookingId: BOOKING_ID },
 })
+
+// A charge captured for the WRONG amount (99_999 vs the booking's 100_000) → #1378.
+const mismatch = (): VerifiedPaymentEvent => ({
+  ...completed(),
+  eventId: 'evt_mm',
+  amountTotal: 99_999,
+})
+
+const succeededRefund: StripeRefund = {
+  id: 're_1',
+  amount: 99_999,
+  currency: 'jpy',
+  status: 'succeeded',
+  paymentIntentId: 'pi_1',
+  metadata: { bookingId: BOOKING_ID },
+}
 
 describe('POST /bookings/:id/checkout-session', () => {
   it('401 when unauthenticated (relies on the app-level /bookings/* guard)', async () => {
@@ -177,6 +205,50 @@ describe('POST /webhooks/stripe (public)', () => {
     expect(await paymentRepo.findSucceededByBookingId(BOOKING_ID)).toMatchObject({
       grossJpy: 100_000,
     })
+  })
+
+  it('auto-refunds a mismatched charge and logs at WARNING level, not an alert (#1378)', async () => {
+    const { app, gateway } = publicApp()
+    gateway.event = mismatch()
+    gateway.nextRefund = succeededRefund
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await app.request('/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 't=1,v1=good' },
+      body: 'raw',
+    })
+    expect(res.status).toBe(200)
+    expect(gateway.refundCalls).toHaveLength(1)
+    // A clean auto-refund is NOT an alert.
+    expect(error).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[payment:webhook] amount mismatch',
+      expect.objectContaining({ refund: 'refunded', stranded: false, bookingId: BOOKING_ID }),
+    )
+    warn.mockRestore()
+    error.mockRestore()
+  })
+
+  it('ALERTS via console.error when the mismatch refund is rejected — funds may be stranded (#1378)', async () => {
+    const { app, gateway } = publicApp()
+    gateway.event = mismatch()
+    gateway.nextRefund = () => {
+      throw new RefundRejectedError('charge already refunded', 'charge_already_refunded')
+    }
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await app.request('/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 't=1,v1=good' },
+      body: 'raw',
+    })
+    // Still a 200 ack (the anomaly + failed disposition are recorded, not re-driven here).
+    expect(res.status).toBe(200)
+    expect(error).toHaveBeenCalledWith(
+      '[payment:webhook] amount mismatch',
+      expect.objectContaining({ refund: 'failed', stranded: true, bookingId: BOOKING_ID }),
+    )
+    error.mockRestore()
   })
 })
 

--- a/packages/api/tests/routes/payments.test.ts
+++ b/packages/api/tests/routes/payments.test.ts
@@ -236,6 +236,7 @@ describe('POST /webhooks/stripe (public)', () => {
     gateway.nextRefund = () => {
       throw new RefundRejectedError('charge already refunded', 'charge_already_refunded')
     }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const res = await app.request('/webhooks/stripe', {
       method: 'POST',
@@ -247,6 +248,28 @@ describe('POST /webhooks/stripe (public)', () => {
     expect(error).toHaveBeenCalledWith(
       '[payment:webhook] amount mismatch',
       expect.objectContaining({ refund: 'failed', stranded: true, bookingId: BOOKING_ID }),
+    )
+    // A stranded alert must be an ALERT, not a soft warning.
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+    error.mockRestore()
+  })
+
+  it('ALERTS when a mismatch is unrefundable (no PaymentIntent to reverse) (#1378)', async () => {
+    const { app, gateway } = publicApp()
+    gateway.event = { ...mismatch(), paymentIntentId: null }
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await app.request('/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 't=1,v1=good' },
+      body: 'raw',
+    })
+    expect(res.status).toBe(200)
+    // No PI → we never call Stripe, but the funds are unaccounted → alert.
+    expect(gateway.refundCalls).toEqual([])
+    expect(error).toHaveBeenCalledWith(
+      '[payment:webhook] amount mismatch',
+      expect.objectContaining({ refund: 'unrefundable', stranded: true }),
     )
     error.mockRestore()
   })


### PR DESCRIPTION
Closes #1378

## Problem

`handleWebhook`'s `AMOUNT_MISMATCH` branch recorded a `payment_anomaly` and returned `200` **without refunding** — but Stripe had already captured the card. The money sat stranded while the booking stayed `UNPAID`, recoverable only by a human watching the `/admin` anomaly queue.

## Fix

In the mismatch branch, after `recordAnomaly`, call a new `refundMismatchedCharge(booking, event)` that:
- refunds the **full captured amount** against its PaymentIntent via `gateway.refundPayment` (idempotency key `refund:mismatch:${eventId}`);
- returns a `MismatchRefundDisposition` (`refunded` | `pending` | `failed` | `unrefundable`), surfaced in `WebhookResult.refund`.

The route alerts on it: `console.error` when funds may still be stranded (`failed`/`unrefundable`), `console.warn` on a clean refund. Terminal `RefundRejectedError` → `failed`; **transient errors propagate** so the webhook 500s and Stripe retries (`recordAnomaly` is idempotent on `stripeEventId`, so the retry converges). The booking legitimately stays `UNPAID` — a wrong amount is refused, not booked.

### Key design decision
Deliberately does **not** reuse the #851 `payment_refunds` receipt ledger. That table is one-row-per-booking and keyed to the cancellation `REFUND_DUE → REFUNDED` flow; reusing it would let a later real cancellation `claim()` adopt a stale `SUCCEEDED` mismatch receipt and **skip its own refund** (a renter-loses-money hole). Idempotency instead rides Stripe's key.

## Test plan
- Service (`payment.test.ts`): auto-refund of the captured amount; disposition for `pending` / terminal-reject (`failed`) / no-PaymentIntent (`unrefundable`); transient error propagates then a retry converges with a single anomaly; idempotency-key value pinned (namespaced away from #851's `refund:${bookingId}`).
- Route (`payments.test.ts`): clean refund logs at WARN (not an alert); `failed` and `unrefundable` alert via `console.error` and do not also warn.
- Gates: full api unit suite **2633 passed**, `tsc --noEmit` clean, biome clean.

## Residual risk / follow-up
A `pending` async refund (konbini/bank) that later flips to `failed` at Stripe is not re-observed — the mismatch path writes no durable receipt and has no reconciler, and `handleRefundWebhook` ignores refunds without a receipt. Tracked as a follow-up: persist the disposition on the `payment_anomalies` row (per-event, idempotent — no adoption hazard) + a reconciler for `pending → failed`, which also de-ambiguates the admin queue and enables an `EmailSender` alert over `console.error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)