### PR TITLE
refactor(#1384): httpUrlMax(len) helper to dedupe the http(s)-only URL guard

### DIFF
--- a/packages/shared/src/validators/url.ts
+++ b/packages/shared/src/validators/url.ts
@@ -20,8 +20,19 @@ export function isHttpUrl(value: string): boolean {
 
 /**
  * A URL string constrained to the http(s) schemes. Reused by operator handoff
- * URLs and vehicle/vehicle-class photo arrays. When a length cap is also needed
- * (e.g. class photos' `.max(2048)`), compose `z.string().url().max(n).refine(
- * isHttpUrl, ...)` directly — `.max()` is unavailable on this ZodEffects.
+ * URLs and vehicle/vehicle-class photo arrays. When a length cap is also needed,
+ * use `httpUrlMax(n)` — `.max()` is a ZodString method, gone once `.refine()`
+ * turns this into a ZodEffects, so it can't chain onto `httpUrl`.
  */
 export const httpUrl = z.string().url().refine(isHttpUrl, { message: HTTP_URL_MESSAGE })
+
+/**
+ * `httpUrl` with a maximum length applied BEFORE the refine (so both the length
+ * cap and the http(s)-only guard hold). The single home for the capped shape the
+ * photo arrays need — previously re-inlined in vehicle-class.ts, which split the
+ * security-critical #967 refine into two copies a future tightening could miss
+ * (#1384). Returns the same `string`-output schema, so consumers are unaffected.
+ */
+export function httpUrlMax(maxLen: number): z.ZodType<string> {
+  return z.string().url().max(maxLen).refine(isHttpUrl, { message: HTTP_URL_MESSAGE })
+}

--- a/packages/shared/src/validators/vehicle-class.ts
+++ b/packages/shared/src/validators/vehicle-class.ts
@@ -2,16 +2,13 @@ import { z } from 'zod'
 import { ACRISS_PATTERN } from '../acriss'
 import { TRANSMISSIONS } from '../enums'
 import { LUGGAGE_SIZES } from '../lib/luggage'
-import { HTTP_URL_MESSAGE, isHttpUrl } from './url'
+import { httpUrlMax } from './url'
 
 // photos/sortOrder carry .default()s only on create. Kept off the base because
 // Zod .partial() does NOT strip .default(), so a partial PATCH would re-inject
 // { photos: [], sortOrder: 0 } and wipe those columns on write (issue #430).
-// Entries are http(s) URLs (#967, see validators/url.ts) — the refine rides
-// after .max(2048) since .max() is a ZodString method, gone once refined.
-const photosSchema = z
-  .array(z.string().url().max(2048).refine(isHttpUrl, { message: HTTP_URL_MESSAGE }))
-  .max(20)
+// Entries are length-capped http(s) URLs (#967, see validators/url.ts).
+const photosSchema = z.array(httpUrlMax(2048)).max(20)
 const sortOrderSchema = z.number().int().min(0)
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/

--- a/packages/shared/src/validators/vehicle.ts
+++ b/packages/shared/src/validators/vehicle.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { TRANSMISSIONS, VEHICLE_STATUSES } from '../enums'
 import { LUGGAGE_SIZES } from '../lib/luggage'
 import { jpyAmount } from './money'
-import { httpUrl } from './url'
+import { httpUrlMax } from './url'
 
 const MIN_VEHICLE_YEAR = 1900
 const MAX_VEHICLE_YEAR = 2100
@@ -17,9 +17,10 @@ const jpyRate = jpyAmount('Rate')
 // photos carries a .default() only on create. Kept off the base because Zod
 // .partial() does NOT strip .default(), so a partial PATCH would re-inject
 // { photos: [] } and wipe that column on write (issue #432, same root cause
-// as #430). Entries are http(s) URLs (#967): bare .url() admits `r2:`/`data:`/
-// `javascript:`, which stored then rendered are spoof/injection vectors.
-const photosSchema = z.array(httpUrl)
+// as #430). Entries are length-capped http(s) URLs (#967): bare .url() admits
+// `r2:`/`data:`/`javascript:`, which stored then rendered are spoof/injection
+// vectors. The 2048 cap matches class photos (validators/url.ts httpUrlMax).
+const photosSchema = z.array(httpUrlMax(2048))
 
 // Shaken/insurance expiry — a real YYYY-MM-DD calendar date that is not in the
 // past (§5.0 / #916). The runtime road-legal gate treats a certificate as valid

--- a/packages/shared/tests/validators/url.test.ts
+++ b/packages/shared/tests/validators/url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { HTTP_URL_MESSAGE, httpUrlMax } from '../../src/validators/url'
+
+function firstError(schema: ReturnType<typeof httpUrlMax>, value: unknown): string {
+  const result = schema.safeParse(value)
+  if (result.success) throw new Error('expected a validation failure')
+  return result.error.issues[0]?.message ?? ''
+}
+
+describe('httpUrlMax(maxLen)', () => {
+  it('accepts an https URL within the length cap', () => {
+    expect(httpUrlMax(2048).safeParse('https://cdn.example.com/car.jpg')).toMatchObject({
+      success: true,
+    })
+  })
+
+  it('accepts a plain http URL', () => {
+    expect(httpUrlMax(2048).safeParse('http://example.com/x').success).toBe(true)
+  })
+
+  it('rejects a non-http(s) scheme with the shared http(s) message (the #967 refine rides)', () => {
+    // r2:/data:/javascript: are the photo-spoof / XSS vectors bare .url() admits.
+    expect(firstError(httpUrlMax(2048), 'r2://bucket/key')).toBe(HTTP_URL_MESSAGE)
+    expect(firstError(httpUrlMax(2048), 'javascript:alert(1)')).toBe(HTTP_URL_MESSAGE)
+  })
+
+  it('rejects a URL longer than the cap — the .max() applies before the refine', () => {
+    const tooLong = `https://example.com/${'a'.repeat(2100)}`
+    expect(tooLong.length).toBeGreaterThan(2048)
+    expect(httpUrlMax(2048).safeParse(tooLong).success).toBe(false)
+  })
+
+  it('honours a custom cap independent of the refine', () => {
+    expect(httpUrlMax(10).safeParse('https://example.com/still-valid-url').success).toBe(false)
+  })
+
+  it('rejects a non-URL string', () => {
+    expect(httpUrlMax(2048).safeParse('not a url').success).toBe(false)
+  })
+})

--- a/packages/shared/tests/validators/vehicle.test.ts
+++ b/packages/shared/tests/validators/vehicle.test.ts
@@ -94,6 +94,15 @@ describe('createVehicleSchema', () => {
     },
   )
 
+  // #1384: photo URLs are length-capped at 2048 (matches class photos) — an
+  // absurdly long URL is a stored-payload / DoS vector. A real photo URL is
+  // never close to the cap, so legitimate consumers are unaffected.
+  it('rejects a photo URL longer than the 2048 cap', () => {
+    const tooLong = `https://example.com/${'a'.repeat(2100)}`
+    const result = createVehicleSchema.safeParse({ ...validInput, photos: [tooLong] })
+    expect(result.success).toBe(false)
+  })
+
   // Issue #48: pricing rules.
   describe('pricing (dailyRateJpy / hourlyRateJpy)', () => {
     // Strip the rate from validInput so we can add rates per-test.


### PR DESCRIPTION
## What

Adds `httpUrlMax(maxLen)` to `validators/url.ts` and adopts it in the two photo-array validators, so the security-critical #967 http(s)-only refine lives in **one** place.

- **`validators/url.ts`** — new `httpUrlMax(maxLen): z.ZodType<string>` = `z.string().url().max(maxLen).refine(isHttpUrl, ...)`. The `.max()` must be applied **before** the refine (it is a `ZodString` method, gone once `httpUrl` becomes a `ZodEffects`). Doc comment on `httpUrl` now points at it.
- **`vehicle-class.ts`** — replaced the re-inlined `z.string().url().max(2048).refine(...)` (a duplicate copy of the #967 refine a future tightening could miss) with `httpUrlMax(2048)`. Byte-identical behavior; dropped the now-unused `HTTP_URL_MESSAGE`/`isHttpUrl` imports.
- **`vehicle.ts`** — `photos: z.array(httpUrl)` → `z.array(httpUrlMax(2048))`.

## Why the vehicle photo cap is new (intentional)

`vehicle.ts` photos previously had no length cap; adopting `httpUrlMax(2048)` adds one — matching what class photos already enforce. This is an **inert hardening** the issue plan calls for: no real photo URL nears 2048, and an unbounded URL is a stored-payload/DoS vector. Consumers' inferred type stays `string`, so nothing downstream changes. `operator.ts`/`operator-application.ts` single-URL fields keep bare `httpUrl` (out of scope).

## Verification

- New `tests/validators/url.test.ts` (6 cases: http/https accepted, non-http scheme → `HTTP_URL_MESSAGE`, over-cap rejected, custom cap, non-URL) + a mutation-resistant vehicle photo-cap test.
- `url` + `vehicle` + `vehicle-class` suites: 103 pass.
- Full shared suite: 900 pass. `shared`/`api`/`web` tsc clean. Pre-commit (biome, lint:size, lint:boundaries, tsc×2) green.

Closes #1384. Part of #1369.