### PR TITLE
refactor(#1382): share 'from price' label via one seam

### DIFF
--- a/packages/web/src/vite/pricing-label.ts
+++ b/packages/web/src/vite/pricing-label.ts
@@ -1,0 +1,23 @@
+/** The use-intl translator shape used across the search + storefront price labels. */
+export type Translate = (key: string, values?: Record<string, string | number>) => string
+
+/** The JPY figure a "from price" note converts: the daily rate (preferred) else
+ *  hourly, or null for price-on-request. Shape-agnostic so every card and the map
+ *  popup derive it the same way. */
+export function preferredRateJpy(daily: number | null, hourly: number | null): number | null {
+  return daily ?? hourly ?? null
+}
+
+/** "From ¥X / day" (or hourly, or price-on-request) — the single seam every
+ *  "from price" label routes through (search rows, the map popup, storefront and
+ *  available-vehicle cards) so they never drift. `t` is the `search`-namespace
+ *  use-intl translator; daily is preferred, then hourly, then price-on-request. */
+export function formatFromPriceLabel(
+  daily: number | null,
+  hourly: number | null,
+  t: Translate,
+): string {
+  if (daily != null) return t('fromDaily', { price: daily.toLocaleString('en-US') })
+  if (hourly != null) return t('fromHourly', { price: hourly.toLocaleString('en-US') })
+  return t('noPrice')
+}

--- a/packages/web/src/vite/search/result.ts
+++ b/packages/web/src/vite/search/result.ts
@@ -1,3 +1,4 @@
+import { type Translate, formatFromPriceLabel, preferredRateJpy } from '@/vite/pricing-label'
 import { regionChain } from '@/vite/regions/region-lookup'
 import {
   type GeoPoint,
@@ -26,8 +27,6 @@ export function searchResultKey(item: SearchResultItem): string {
   }
 }
 
-type Translate = (key: string, values?: Record<string, string | number>) => string
-
 /** Human title of a result row: the car name (SPECIFIC) or class label (CLASS_COMBO).
  *  Switched (vs ternary) so a future `kind` is a tsc error here — see searchResultKey. */
 export function resultTitle(item: SearchResultItem): string {
@@ -47,17 +46,13 @@ export function resultTitle(item: SearchResultItem): string {
  *  `resultPriceLabel`'s daily-over-hourly preference so the `≈` note matches the
  *  label it sits beneath. */
 export function resultPriceJpy(item: SearchResultItem): number | null {
-  return item.dailyRateJpy ?? item.hourlyRateJpy ?? null
+  return preferredRateJpy(item.dailyRateJpy, item.hourlyRateJpy)
 }
 
 /** "From ¥X / day" (or hourly, or price-on-request) — shared by the list row and
  *  the map popup so they never drift. `t` is the use-intl translator. */
 export function resultPriceLabel(item: SearchResultItem, t: Translate): string {
-  if (item.dailyRateJpy != null)
-    return t('fromDaily', { price: item.dailyRateJpy.toLocaleString('en-US') })
-  if (item.hourlyRateJpy != null)
-    return t('fromHourly', { price: item.hourlyRateJpy.toLocaleString('en-US') })
-  return t('noPrice')
+  return formatFromPriceLabel(item.dailyRateJpy, item.hourlyRateJpy, t)
 }
 
 /** All results at one pickup location, in input order. The map plots one pin per

--- a/packages/web/src/vite/storefronts/AvailableVehicleCard.tsx
+++ b/packages/web/src/vite/storefronts/AvailableVehicleCard.tsx
@@ -1,6 +1,7 @@
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { IndicativeNote } from '@/vite/currency'
+import { formatFromPriceLabel, preferredRateJpy } from '@/vite/pricing-label'
 import { type AggregateEntry, RatingBadge } from '@/vite/reviews'
 import { PhotoGallery } from '@/vite/storefronts/PhotoGallery'
 import type { AvailableVehicleData } from '@/vite/storefronts/api'
@@ -48,13 +49,8 @@ export function AvailableVehicleCard({
   const locale = useLocale()
   const transmissionLabel = vehicle.transmission === 'AUTO' ? t('auto') : t('manual')
 
-  const priceLabel =
-    vehicle.dailyRateJpy != null
-      ? t('fromDaily', { price: vehicle.dailyRateJpy.toLocaleString('en-US') })
-      : vehicle.hourlyRateJpy != null
-        ? t('fromHourly', { price: vehicle.hourlyRateJpy.toLocaleString('en-US') })
-        : t('noPrice')
-  const fromPriceJpy = vehicle.dailyRateJpy ?? vehicle.hourlyRateJpy ?? null
+  const priceLabel = formatFromPriceLabel(vehicle.dailyRateJpy, vehicle.hourlyRateJpy, t)
+  const fromPriceJpy = preferredRateJpy(vehicle.dailyRateJpy, vehicle.hourlyRateJpy)
 
   return (
     <div className="flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm">

--- a/packages/web/src/vite/storefronts/StorefrontCard.tsx
+++ b/packages/web/src/vite/storefronts/StorefrontCard.tsx
@@ -1,4 +1,5 @@
 import { IndicativeNote } from '@/vite/currency'
+import { formatFromPriceLabel, preferredRateJpy } from '@/vite/pricing-label'
 import { type AggregateEntry, RatingBadge } from '@/vite/reviews'
 import { ClassSummaryBadges } from '@/vite/storefronts/ClassSummaryBadges'
 import { StoreMonogram } from '@/vite/storefronts/StoreMonogram'
@@ -45,14 +46,13 @@ export function StorefrontCard({
   const t = useTranslations('search')
   const locale = useLocale()
 
-  const priceLabel =
-    storefront.fromDailyPriceJpy != null
-      ? t('fromDaily', { price: storefront.fromDailyPriceJpy.toLocaleString('en-US') })
-      : storefront.fromHourlyPriceJpy != null
-        ? t('fromHourly', { price: storefront.fromHourlyPriceJpy.toLocaleString('en-US') })
-        : t('noPrice')
+  const priceLabel = formatFromPriceLabel(
+    storefront.fromDailyPriceJpy,
+    storefront.fromHourlyPriceJpy,
+    t,
+  )
   // The "from" JPY figure the indicative note converts (daily preferred, else hourly).
-  const fromPriceJpy = storefront.fromDailyPriceJpy ?? storefront.fromHourlyPriceJpy ?? null
+  const fromPriceJpy = preferredRateJpy(storefront.fromDailyPriceJpy, storefront.fromHourlyPriceJpy)
 
   return (
     <Link

--- a/packages/web/tests/vite/pricing-label.test.ts
+++ b/packages/web/tests/vite/pricing-label.test.ts
@@ -1,0 +1,34 @@
+import { formatFromPriceLabel, preferredRateJpy } from '@/vite/pricing-label'
+import { describe, expect, it } from 'vitest'
+
+// Fake translator mirroring tests/vite/search/result.test.ts: renders the key with
+// its interpolated price so we assert both template selection and value wiring.
+const t = (key: string, values?: Record<string, string | number>) =>
+  values ? `${key}:${values.price}` : key
+
+describe('preferredRateJpy', () => {
+  it('prefers the daily rate when both are present', () => {
+    expect(preferredRateJpy(8000, 500)).toBe(8000)
+  })
+  it('falls back to the hourly rate when there is no daily rate', () => {
+    expect(preferredRateJpy(null, 500)).toBe(500)
+  })
+  it('is null when neither rate is set (price on request)', () => {
+    expect(preferredRateJpy(null, null)).toBeNull()
+  })
+})
+
+describe('formatFromPriceLabel', () => {
+  it('formats a daily rate with thousands separators', () => {
+    expect(formatFromPriceLabel(8000, null, t)).toBe('fromDaily:8,000')
+  })
+  it('prefers the daily label even when an hourly rate is also set', () => {
+    expect(formatFromPriceLabel(12000, 500, t)).toBe('fromDaily:12,000')
+  })
+  it('falls back to the hourly label when there is no daily rate', () => {
+    expect(formatFromPriceLabel(null, 500, t)).toBe('fromHourly:500')
+  })
+  it('shows the no-price label when neither rate is set', () => {
+    expect(formatFromPriceLabel(null, null, t)).toBe('noPrice')
+  })
+})


### PR DESCRIPTION
Part of tracker #1369 (W3, P3). Closes #1382.

## Problem
`search/result.ts` already centralizes the "from price" label as `resultPriceLabel()` + `resultPriceJpy()` ("shared by the list row and the map popup so they never drift"). But `StorefrontCard` and `AvailableVehicleCard` each re-implemented the same daily-preferred ternary (`daily != null ? t('fromDaily', ...) : hourly != null ? t('fromHourly', ...) : t('noPrice')`) plus the `daily ?? hourly ?? null` derivation, differing only in field names — two call sites routing around the anti-drift seam that exists.

## Change
- New neutral `src/vite/pricing-label.ts` with shape-agnostic `formatFromPriceLabel(daily, hourly, t)` + `preferredRateJpy(daily, hourly)`, plus the shared `Translate` type.
- `resultPriceLabel` / `resultPriceJpy` now delegate to the helper (the existing seam becomes a thin wrapper).
- `StorefrontCard` and `AvailableVehicleCard` call the helper instead of their inline copies.

Placed at the vite root (not inside `search/`) so neither feature depends on the other — confirmed by `lint:modules` (no new cross-feature reach-in).

## Behavior
Byte-identical output. Same `search`-namespace keys (`fromDaily`/`fromHourly`/`noPrice`), same `.toLocaleString('en-US')`, same daily-over-hourly preference. No i18n keys touched (parity: all 3 locales still 1474 keys).

## Test plan
- [x] New `tests/vite/pricing-label.test.ts` — TDD, RED→GREEN (7 tests: daily-preferred, hourly fallback, no-price, thousands separators)
- [x] Existing `tests/vite/search/result.test.ts` unchanged and green (anchors the seam)
- [x] Full web suite: 282 files / 1944 tests pass
- [x] `tsc --noEmit` (web + api) clean
- [x] `lint:size`, `lint:modules`, i18n parity all exit 0