### PR TITLE
feat(#1230): team picker (slice 6) — platform-admin manages a picked operator's team

### DIFF
--- a/packages/api/src/auth/guards.ts
+++ b/packages/api/src/auth/guards.ts
@@ -53,7 +53,10 @@ export class ScopeRequiredError extends Error {
  * this doubles as the cross-tenant seal (no existence oracle).
  */
 export class NotFoundError extends Error {
-  readonly name = 'NotFoundError'
+  // Typed `string`, not the literal, so subclasses (e.g. OperatorNotFoundError,
+  // #1230 c1) can override with a distinct name; the global handler + local
+  // catches match by `instanceof`, never on this literal.
+  readonly name: string = 'NotFoundError'
   constructor(message = 'Not found') {
     super(message)
   }

--- a/packages/api/src/routes/operator-team.ts
+++ b/packages/api/src/routes/operator-team.ts
@@ -5,11 +5,13 @@ import type { OperatorTeamService } from '../services/operator-team'
 import { ok, parseBody } from './helpers'
 
 /**
- * #904: operator self-service team management. The tenant is ALWAYS the caller's
- * own operator — these are `/operators/me/*` paths with no id segment, so there
- * is no foreign-id surface to scope-check or leak. Owner-vs-member gating and the
- * absent-tenant seal live in `OperatorTeamService`; a denied write surfaces as a
- * 403 via the global `ForbiddenError` handler, so the routes stay HTTP-only.
+ * #904 / #1230: operator self-service team management. An operator always acts on
+ * its OWN tenant — a foreign `?operatorId=` is ignored. A PLATFORM_ADMIN using the
+ * operator-context picker names the target tenant via `?operatorId=` on the reads
+ * (`resolveTeamOperatorId` honors it only for that privileged tier). Owner-vs-member
+ * gating, the picker allowlist, and the absent-tenant seal live in
+ * `OperatorTeamService`; denials surface as 403/422 via the global handlers, so the
+ * routes stay HTTP-only.
  */
 export function createOperatorTeamRoutes(service: OperatorTeamService) {
   const app = new Hono()
@@ -29,7 +31,10 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       return ok(c, { inviteUrl: created.inviteUrl, expiresAt: created.expiresAt }, 201)
     })
     .get('/operators/me/invites', async (c) => {
-      const invites = await service.listInvites(toCallerContext(requireUser(c)))
+      const invites = await service.listInvites(
+        toCallerContext(requireUser(c)),
+        c.req.query('operatorId'),
+      )
       return ok(c, invites)
     })
     .post('/operators/me/invites/:id/revoke', async (c) => {
@@ -40,7 +45,10 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       return ok(c, { id })
     })
     .get('/operators/me/members', async (c) => {
-      const members = await service.listMembers(toCallerContext(requireUser(c)))
+      const members = await service.listMembers(
+        toCallerContext(requireUser(c)),
+        c.req.query('operatorId'),
+      )
       return ok(c, members)
     })
     .post('/operators/me/members/:id/deactivate', async (c) => {

--- a/packages/api/src/routes/operator-team.ts
+++ b/packages/api/src/routes/operator-team.ts
@@ -7,9 +7,9 @@ import { ok, parseBody } from './helpers'
 /**
  * #904 / #1230: operator self-service team management. An operator always acts on
  * its OWN tenant — a foreign `?operatorId=` is ignored. A PLATFORM_ADMIN using the
- * operator-context picker names the target tenant via `?operatorId=` on the reads
- * (`resolveTeamOperatorId` honors it only for that privileged tier). Owner-vs-member
- * gating, the picker allowlist, and the absent-tenant seal live in
+ * operator-context picker names the target tenant via `?operatorId=` on every read
+ * AND write (`resolveTeamOperatorId` honors it only for that privileged tier).
+ * Owner-vs-member gating, the picker allowlist, and the absent-tenant seal live in
  * `OperatorTeamService`; denials surface as 403/422 via the global handlers, so the
  * routes stay HTTP-only.
  */
@@ -24,7 +24,11 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       const parsed = await parseBody(c, inviteStaffSchema)
       if (!parsed.ok) return parsed.response
 
-      const created = await service.inviteStaff(toCallerContext(user), parsed.data)
+      const created = await service.inviteStaff(
+        toCallerContext(user),
+        parsed.data,
+        c.req.query('operatorId'),
+      )
       // The URL embeds the one-time token (never persisted in cleartext); the
       // owner copies it to share. We omit the bare `token` field — the URL is the
       // only form the page needs.
@@ -41,7 +45,7 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       const id = c.req.param('id')
       // Owner-only + tenant scope live in the service; an unknown/foreign id
       // throws NotFoundError (-> 404) via the global handler, so no id is leaked.
-      await service.revokeInvite(toCallerContext(requireUser(c)), id)
+      await service.revokeInvite(toCallerContext(requireUser(c)), id, c.req.query('operatorId'))
       return ok(c, { id })
     })
     .get('/operators/me/members', async (c) => {
@@ -56,7 +60,7 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       // Owner-only + tenant scope + last-owner lockout live in the service: an
       // unknown/foreign id throws NotFoundError (-> 404) and the last owner throws
       // ConflictError (-> 409), both via the global handler, so no id is leaked.
-      await service.deactivateMember(toCallerContext(requireUser(c)), id)
+      await service.deactivateMember(toCallerContext(requireUser(c)), id, c.req.query('operatorId'))
       return ok(c, { id })
     })
 }

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -1,11 +1,6 @@
 import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
 import type { CallerContext } from '../auth/context'
-import {
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-  requireOperatorOwnerWrite,
-} from '../auth/guards'
+import { ConflictError, NotFoundError, requireOperatorOwnerWrite } from '../auth/guards'
 import type {
   OperatorMembershipRepository,
   ProviderInviteRepository,
@@ -35,11 +30,14 @@ export type RecordOperatorMemberDeactivatedAudit = (
 ) => void
 
 /**
- * #904: operator self-service staff management. Every method derives the tenant
- * from the caller's session (`ctx.operatorId`) — there is no foreign-id surface,
- * so a tenant can only ever see or mutate its own team. Writes are owner-only;
- * reads admit any operator member. The minted role is hard-coded OPERATOR_STAFF:
- * an owner can never escalate an invitee to OPERATOR_OWNER through this path.
+ * #904 + #1230 slice 6: operator self-service staff management, plus a
+ * platform-admin picker surface. Every method derives the tenant through
+ * {@link resolveTeamOperatorId}: an operator role is pinned to its own
+ * `ctx.operatorId` (a foreign input is IGNORED — no cross-tenant), while a
+ * PLATFORM_ADMIN supplies the target via `inputOperatorId` and a no-pick admin
+ * is refused (422). Writes are owner-tier (`requireOperatorOwnerWrite`); reads
+ * admit any operator member. The minted role is hard-coded OPERATOR_STAFF: an
+ * owner can never escalate an invitee to OPERATOR_OWNER through this path.
  */
 export class OperatorTeamService {
   constructor(
@@ -50,9 +48,13 @@ export class OperatorTeamService {
     private readonly recordAudit: RecordOperatorMemberDeactivatedAudit,
   ) {}
 
-  async inviteStaff(ctx: CallerContext, input: { email: string }): Promise<CreatedInvite> {
+  async inviteStaff(
+    ctx: CallerContext,
+    input: { email: string },
+    inputOperatorId?: string,
+  ): Promise<CreatedInvite> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     return this.inviteService.createInvite(
       { email: input.email, operatorId, role: 'OPERATOR_STAFF' },
       ctx.userId,
@@ -82,9 +84,9 @@ export class OperatorTeamService {
    * unknown id reads as `undefined` from the scoped repo and surfaces as a 404 —
    * never a 403 that would confirm the invite exists elsewhere.
    */
-  async revokeInvite(ctx: CallerContext, id: string): Promise<void> {
+  async revokeInvite(ctx: CallerContext, id: string, inputOperatorId?: string): Promise<void> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const revoked = await this.invites.revoke(id, operatorId)
     if (!revoked) throw new NotFoundError('invite not found')
   }
@@ -105,9 +107,9 @@ export class OperatorTeamService {
    * member keeps access until their token expires; see the #904 session-revocation
    * follow-up.
    */
-  async deactivateMember(ctx: CallerContext, id: string): Promise<void> {
+  async deactivateMember(ctx: CallerContext, id: string, inputOperatorId?: string): Promise<void> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const members = await this.memberships.findActiveByOperator(operatorId)
     const target = members.find((m) => m.id === id)
     if (!target) throw new NotFoundError('member not found')
@@ -129,17 +131,6 @@ export class OperatorTeamService {
         targetUserId: target.userId,
       })
     }
-  }
-
-  /**
-   * `requireOperatorScope` only fails OPERATOR_* roles missing an operatorId; a
-   * PLATFORM_ADMIN (not an OPERATOR_* role) slips through with no tenant. The
-   * `/me` surface is operator-only, so seal the absent tenant here rather than
-   * letting it reach the repo as `listByOperator(undefined)`.
-   */
-  private requireOwnOperator(ctx: CallerContext): string {
-    if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
-    return ctx.operatorId
   }
 }
 

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -61,6 +61,9 @@ export class OperatorTeamService {
     )
   }
 
+  // Reads intentionally return an empty list (never 404) for an unknown/foreign
+  // operatorId — unlike the writes. An empty roster is not an existence oracle, and
+  // only a PLATFORM_ADMIN can even reach a foreign id here; do NOT "fix" this to 404.
   async listInvites(ctx: CallerContext, inputOperatorId?: string): Promise<OperatorInviteData[]> {
     const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const rows = await this.invites.listByOperator(operatorId)

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -5,7 +5,6 @@ import {
   ForbiddenError,
   NotFoundError,
   requireOperatorOwnerWrite,
-  requireOperatorScope,
 } from '../auth/guards'
 import type {
   OperatorMembershipRepository,
@@ -13,6 +12,7 @@ import type {
   UserRepository,
 } from '../repositories/types'
 import type { OperatorMembership, ProviderInvite, User } from '../stores'
+import { resolveTeamOperatorId } from '../tenancy'
 import type { CreatedInvite, ProviderInviteService } from './provider-invite'
 
 /**
@@ -59,16 +59,14 @@ export class OperatorTeamService {
     )
   }
 
-  async listInvites(ctx: CallerContext): Promise<OperatorInviteData[]> {
-    requireOperatorScope(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+  async listInvites(ctx: CallerContext, inputOperatorId?: string): Promise<OperatorInviteData[]> {
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const rows = await this.invites.listByOperator(operatorId)
     return rows.map(toOperatorInviteData)
   }
 
-  async listMembers(ctx: CallerContext): Promise<OperatorMemberData[]> {
-    requireOperatorScope(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+  async listMembers(ctx: CallerContext, inputOperatorId?: string): Promise<OperatorMemberData[]> {
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const memberships = await this.memberships.findActiveByOperator(operatorId)
     // One batched read, not a per-member query — the team is small but an N+1
     // loop is still the wrong shape. `findActiveByOperator` already orders the rows.

--- a/packages/api/src/services/provider-invite.ts
+++ b/packages/api/src/services/provider-invite.ts
@@ -1,5 +1,5 @@
 import type { CreateProviderInviteInput } from '@kuruma/shared/validators/provider-invite'
-import { ConflictError } from '../auth/guards'
+import { ConflictError, NotFoundError } from '../auth/guards'
 import { sha256Hex } from '../auth/token-hash'
 import {
   PG_ERROR,
@@ -15,12 +15,14 @@ export { INVITE_TTL_MS } from './invite-mint'
 export type { ProviderInviteAuditEvent }
 
 /** Raised when an invite is minted against an operatorId with no matching row.
- *  The route maps this to a 404 so a bad target reads as a client error, not a
- *  500 from the FK violation (#563). */
-export class OperatorNotFoundError extends Error {
+ *  Extends NotFoundError so the global handler maps it to 404 (#563, #1230 c1);
+ *  the platform-admin team path can now supply an arbitrary operatorId, so this
+ *  is reachable for the first time. The admin.ts:47 local catch is KEPT — it pins
+ *  the suffix-free 'Operator not found' message provider-invites.test.ts asserts. */
+export class OperatorNotFoundError extends NotFoundError {
+  override readonly name = 'OperatorNotFoundError'
   constructor(readonly operatorId: string) {
     super(`Operator not found: ${operatorId}`)
-    this.name = 'OperatorNotFoundError'
   }
 }
 

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -319,3 +319,27 @@ export async function resolveOperatorIdForWrite(
   if (inputOperatorId) return inputOperatorId
   throw new OperatorRequiredError('operatorId is required: specify a target operator')
 }
+
+/**
+ * Resolve the operator whose TEAM the caller may read/manage (#1230 slice 6).
+ *
+ * Deliberately STRICTER than {@link resolveOperatorIdForWrite}: team data is
+ * operator-internal, owner-tier, so a foreign operatorId is honored ONLY for
+ * PRIVILEGED_ROLES (PLATFORM_ADMIN). It is an allowlist, not a bypass-first
+ * denylist — operator role OR PRIVILEGED_ROLES pass; everyone else (renter,
+ * PARTNER, legacy STAFF/ADMIN) falls into `else` and is denied, which is why no
+ * explicit PARTNER branch is needed. Do NOT collapse this onto the write
+ * resolver: it keys on `!isOperatorRole` and would honor legacy STAFF/ADMIN,
+ * silently opening a cross-tenant team write (pinned by a route test).
+ */
+export function resolveTeamOperatorId(ctx: CallerContext, inputOperatorId?: string): string {
+  if (isOperatorRole(ctx.role)) {
+    if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
+    return ctx.operatorId // input IGNORED — an operator cannot act cross-tenant
+  }
+  if (PRIVILEGED_ROLES.has(ctx.role)) {
+    if (inputOperatorId) return inputOperatorId // the `all` tier — honored ONLY here
+    throw new OperatorRequiredError('operatorId is required: specify a target operator')
+  }
+  throw new ForbiddenError('operator scope required') // renter / partner / legacy
+}

--- a/packages/api/tests/integration/operator-team-picker.test.ts
+++ b/packages/api/tests/integration/operator-team-picker.test.ts
@@ -1,0 +1,164 @@
+import { operatorMemberships, operators, providerInvites, users } from '@kuruma/shared/db/schema'
+import { inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { ConflictError, NotFoundError } from '../../src/auth/guards'
+import type { CallerContext } from '../../src/middleware/auth'
+import {
+  DrizzleOperatorMembershipRepository,
+  DrizzleOperatorRepository,
+  DrizzleProviderInviteRepository,
+  DrizzleUserRepository,
+} from '../../src/repositories/drizzle'
+import {
+  type OperatorMemberDeactivatedAuditEvent,
+  OperatorTeamService,
+} from '../../src/services/operator-team'
+import { ProviderInviteService } from '../../src/services/provider-invite'
+import { db } from './setup'
+
+// #1230 slice 6: a PLATFORM_ADMIN drives the operator team surface via
+// `?operatorId=`. The picker path resolves the target tenant through
+// resolveTeamOperatorId, so the write lands on the PICKED operator (X), never the
+// admin's absent tenant — and the scope + last-owner + audit invariants hold
+// against real Postgres, not just the in-memory twin.
+describe('operator team writes as a picked operator (Drizzle, real Postgres) (#1230)', () => {
+  const inviteRepo = new DrizzleProviderInviteRepository(db)
+  const membershipRepo = new DrizzleOperatorMembershipRepository(db)
+  const userRepo = new DrizzleUserRepository(db)
+  const operatorRepo = new DrizzleOperatorRepository(db)
+  const inviteService = new ProviderInviteService(
+    inviteRepo,
+    operatorRepo,
+    { webBaseUrl: 'https://app.example.com' },
+    () => {},
+  )
+  const recordedAudits: OperatorMemberDeactivatedAuditEvent[] = []
+  const service = new OperatorTeamService(
+    inviteRepo,
+    membershipRepo,
+    userRepo,
+    inviteService,
+    (e) => recordedAudits.push(e),
+  )
+
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const opXId = `op_team_x_${uniq}`
+  const opYId = `op_team_y_${uniq}`
+  const adminId = crypto.randomUUID()
+  const ownerXId = crypto.randomUUID()
+  const staffXId = crypto.randomUUID()
+  const memberYId = crypto.randomUUID()
+  let ownerXMembershipId: string
+  let staffXMembershipId: string
+  let memberYMembershipId: string
+
+  // A PLATFORM_ADMIN carries NO operatorId — the target tenant rides in via the pick.
+  const ADMIN_CTX: CallerContext = { userId: adminId, role: 'PLATFORM_ADMIN', bypassScope: true }
+
+  beforeAll(async () => {
+    await db.insert(operators).values([
+      { id: opXId, slug: `team-x-${uniq}`, name: 'Team Operator X' },
+      { id: opYId, slug: `team-y-${uniq}`, name: 'Team Operator Y' },
+    ])
+    await db.insert(users).values([
+      {
+        id: adminId,
+        email: `admin-${uniq}@kuruma-test.com`,
+        role: 'PLATFORM_ADMIN',
+        language: 'en',
+      },
+      {
+        id: ownerXId,
+        email: `ownerx-${uniq}@kuruma-test.com`,
+        role: 'OPERATOR_OWNER',
+        language: 'en',
+        operatorId: opXId,
+      },
+      {
+        id: staffXId,
+        email: `staffx-${uniq}@kuruma-test.com`,
+        role: 'OPERATOR_STAFF',
+        language: 'en',
+        operatorId: opXId,
+      },
+      {
+        id: memberYId,
+        email: `membery-${uniq}@kuruma-test.com`,
+        role: 'OPERATOR_OWNER',
+        language: 'en',
+        operatorId: opYId,
+      },
+    ])
+    ownerXMembershipId = (
+      await membershipRepo.create({
+        userId: ownerXId,
+        operatorId: opXId,
+        role: 'OPERATOR_OWNER',
+        status: 'ACTIVE',
+      })
+    ).id
+    staffXMembershipId = (
+      await membershipRepo.create({
+        userId: staffXId,
+        operatorId: opXId,
+        role: 'OPERATOR_STAFF',
+        status: 'ACTIVE',
+      })
+    ).id
+    memberYMembershipId = (
+      await membershipRepo.create({
+        userId: memberYId,
+        operatorId: opYId,
+        role: 'OPERATOR_OWNER',
+        status: 'ACTIVE',
+      })
+    ).id
+  })
+
+  afterAll(async () => {
+    await db.delete(providerInvites).where(inArray(providerInvites.operatorId, [opXId, opYId]))
+    await db
+      .delete(operatorMemberships)
+      .where(inArray(operatorMemberships.operatorId, [opXId, opYId]))
+    await db.delete(users).where(inArray(users.id, [adminId, ownerXId, staffXId, memberYId]))
+    await db.delete(operators).where(inArray(operators.id, [opXId, opYId]))
+  })
+
+  it('(a) mints the invite under the PICKED operator X, stamping the admin as inviter — not its absent tenant', async () => {
+    await service.inviteStaff(ADMIN_CTX, { email: `newstaff-${uniq}@op-x.com` }, opXId)
+    const rows = await inviteRepo.listByOperator(opXId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.operatorId).toBe(opXId)
+    expect(rows[0]?.invitedByUserId).toBe(adminId)
+    expect(rows[0]?.status).toBe('PENDING')
+  })
+
+  it('(b) deactivating a member of Y via ?operatorId=X is 404 — the id is resolved within the PICKED tenant', async () => {
+    await expect(service.deactivateMember(ADMIN_CTX, memberYMembershipId, opXId)).rejects.toThrow(
+      NotFoundError,
+    )
+    // The Y member is untouched — the cross-tenant id never matched X's roster.
+    expect((await membershipRepo.findActiveByOperator(opYId)).map((m) => m.id)).toContain(
+      memberYMembershipId,
+    )
+  })
+
+  it('(c) deactivating X’s last active owner is 409, even for the admin', async () => {
+    await expect(service.deactivateMember(ADMIN_CTX, ownerXMembershipId, opXId)).rejects.toThrow(
+      ConflictError,
+    )
+  })
+
+  it('(d) deactivating X’s staff succeeds and the audit names the PICKED operator + admin actor', async () => {
+    await service.deactivateMember(ADMIN_CTX, staffXMembershipId, opXId)
+    expect((await membershipRepo.findActiveByOperator(opXId)).map((m) => m.id)).not.toContain(
+      staffXMembershipId,
+    )
+    expect(recordedAudits).toContainEqual({
+      type: 'OPERATOR_MEMBER_DEACTIVATED',
+      operatorId: opXId,
+      actorUserId: adminId,
+      targetUserId: staffXId,
+    })
+  })
+})

--- a/packages/api/tests/routes/operator-team.test.ts
+++ b/packages/api/tests/routes/operator-team.test.ts
@@ -279,3 +279,48 @@ describe('POST /operators/me/members/:id/deactivate', () => {
     expect(await membershipRepo.findActiveByOperator('op_2')).toHaveLength(1)
   })
 })
+
+describe('read routes thread ?operatorId= for a picker-admin', () => {
+  it('GET /operators/me/members?operatorId=op_2 returns op_2 members for a PLATFORM_ADMIN', async () => {
+    await membershipRepo.create({
+      userId: 'u_b',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/members?operatorId=op_2')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    expect(data.map((m: { userId: string }) => m.userId)).toEqual(['u_b'])
+  })
+
+  it('GET /operators/me/members with NO pick is 422 for a PLATFORM_ADMIN (no merged view)', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/members')
+    expect(res.status).toBe(422)
+  })
+
+  it('a RENTER is 403 even with ?operatorId= (team is owner-tier internal)', async () => {
+    const res = await mountFor('RENTER').request('/operators/me/members?operatorId=op_1')
+    expect(res.status).toBe(403)
+  })
+
+  it('an operator IGNORES a foreign ?operatorId= and reads its own tenant', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_b',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const res = await mountFor('OPERATOR_OWNER', 'op_1').request(
+      '/operators/me/members?operatorId=op_2',
+    )
+    const { data } = await res.json()
+    expect(data.map((m: { userId: string }) => m.userId)).toEqual(['u_owner'])
+  })
+})

--- a/packages/api/tests/routes/operator-team.test.ts
+++ b/packages/api/tests/routes/operator-team.test.ts
@@ -324,3 +324,62 @@ describe('read routes thread ?operatorId= for a picker-admin', () => {
     expect(data.map((m: { userId: string }) => m.userId)).toEqual(['u_owner'])
   })
 })
+
+describe('write routes as a picked operator (#1230)', () => {
+  it('POST /operators/me/invites?operatorId=op_2 mints under op_2 for a PLATFORM_ADMIN (201)', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/invites?operatorId=op_2', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'new@op2.com' }),
+    })
+    expect(res.status).toBe(201)
+    expect(await inviteRepo.listByOperator('op_2')).toHaveLength(1)
+  })
+
+  it('POST invite with NO pick is 422 for a PLATFORM_ADMIN', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/invites', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'x@x.com' }),
+    })
+    expect(res.status).toBe(422)
+  })
+
+  it('a bogus ?operatorId= on invite is 404 (c1), not 500', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request(
+      '/operators/me/invites?operatorId=op_ghost',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'x@x.com' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // G6a: a legacy STAFF/ADMIN passes requireOperatorOwnerWrite but the RESOLVER
+  // denies it (403). This pins that the resolver, not the gate, is the deny point —
+  // collapsing team onto resolveOperatorIdForWrite (which honors legacy admins)
+  // would flip this to a cross-tenant 201 and fail here.
+  it('denies a legacy STAFF write-with-?operatorId= at the resolver (403)', async () => {
+    const res = await mountFor('STAFF').request('/operators/me/invites?operatorId=op_2', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'x@op2.com' }),
+    })
+    expect(res.status).toBe(403)
+    expect(await inviteRepo.listByOperator('op_2')).toHaveLength(0)
+  })
+
+  it('still forbids an OPERATOR_STAFF write even with a valid ?operatorId= (owner-tier gate)', async () => {
+    const res = await mountFor('OPERATOR_STAFF', 'op_1').request(
+      '/operators/me/invites?operatorId=op_1',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'x@op1.com' }),
+      },
+    )
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/api/tests/services/operator-team.test.ts
+++ b/packages/api/tests/services/operator-team.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { CallerContext } from '../../src/auth/context'
-import { ConflictError, ForbiddenError, NotFoundError } from '../../src/auth/guards'
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  OperatorRequiredError,
+} from '../../src/auth/guards'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
 import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
 import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
@@ -136,8 +141,8 @@ describe('OperatorTeamService.listInvites', () => {
     expect(invites[0]).not.toHaveProperty('invitedByUserId')
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
-    await expect(service.listInvites(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  it('refuses a no-pick PLATFORM_ADMIN (422) — no merged team view', async () => {
+    await expect(service.listInvites(ADMIN_CTX)).rejects.toThrow(OperatorRequiredError)
   })
 })
 
@@ -166,8 +171,8 @@ describe('OperatorTeamService.listMembers', () => {
     expect(members[0]?.joinedAt).toMatch(ISO_RE)
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
-    await expect(service.listMembers(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  it('refuses a no-pick PLATFORM_ADMIN (422) — no merged team view', async () => {
+    await expect(service.listMembers(ADMIN_CTX)).rejects.toThrow(OperatorRequiredError)
   })
 })
 
@@ -310,5 +315,40 @@ describe('OperatorTeamService.deactivateMember', () => {
 
     expect((await service.listMembers(OWNER_CTX)).map((m) => m.userId)).toEqual(['u_owner'])
     expect(await projectionOf('u_owner2')).toEqual({ role: 'RENTER', operatorId: null })
+  })
+})
+
+describe('OperatorTeamService reads as a picked operator (#1230)', () => {
+  it('listInvites: a PLATFORM_ADMIN with a picked operatorId reads THAT tenant', async () => {
+    await inviteRepo.create({
+      email: 'theirs@x.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_2',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_other',
+      acceptedByUserId: null,
+    })
+    const invites = await service.listInvites(ADMIN_CTX, 'op_2')
+    expect(invites).toHaveLength(1)
+    expect(invites[0]?.email).toBe('theirs@x.com')
+  })
+
+  it('listMembers: an operator IGNORES a foreign picked id and reads its own tenant', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_other',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const members = await service.listMembers(OWNER_CTX, 'op_2')
+    expect(members.map((m) => m.userId)).toEqual(['u_owner'])
   })
 })

--- a/packages/api/tests/services/operator-team.test.ts
+++ b/packages/api/tests/services/operator-team.test.ts
@@ -108,9 +108,9 @@ describe('OperatorTeamService.inviteStaff', () => {
     expect(await inviteRepo.listByOperator('op_1')).toHaveLength(0)
   })
 
-  it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) — never mints against undefined', async () => {
+  it('refuses a no-pick PLATFORM_ADMIN (422) — never mints against undefined', async () => {
     await expect(service.inviteStaff(ADMIN_CTX, { email: 'new@x.com' })).rejects.toThrow(
-      ForbiddenError,
+      OperatorRequiredError,
     )
   })
 })
@@ -203,9 +203,9 @@ describe('OperatorTeamService.revokeInvite', () => {
     expect(await service.listInvites(OWNER_CTX)).toHaveLength(1)
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
+  it('refuses a no-pick PLATFORM_ADMIN (422)', async () => {
     const id = await seedInvite('op_1', 'h_mine')
-    await expect(service.revokeInvite(ADMIN_CTX, id)).rejects.toThrow(ForbiddenError)
+    await expect(service.revokeInvite(ADMIN_CTX, id)).rejects.toThrow(OperatorRequiredError)
   })
 
   it('cannot revoke another tenant invite (404) — the target stays pending', async () => {
@@ -282,9 +282,11 @@ describe('OperatorTeamService.deactivateMember', () => {
     expect(await projectionOf('u_staffm')).toEqual({ role: 'OPERATOR_STAFF', operatorId: 'op_1' })
   })
 
-  it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) (403)', async () => {
+  it('refuses a no-pick PLATFORM_ADMIN (422)', async () => {
     const staffId = await seedMember('u_staffm', 'OPERATOR_STAFF')
-    await expect(service.deactivateMember(ADMIN_CTX, staffId)).rejects.toThrow(ForbiddenError)
+    await expect(service.deactivateMember(ADMIN_CTX, staffId)).rejects.toThrow(
+      OperatorRequiredError,
+    )
   })
 
   it('cannot deactivate another tenant member (404) — target stays active', async () => {
@@ -350,5 +352,39 @@ describe('OperatorTeamService reads as a picked operator (#1230)', () => {
     })
     const members = await service.listMembers(OWNER_CTX, 'op_2')
     expect(members.map((m) => m.userId)).toEqual(['u_owner'])
+  })
+})
+
+describe('OperatorTeamService writes as a picked operator (#1230)', () => {
+  it('inviteStaff: a PLATFORM_ADMIN mints under the PICKED operator, stamping the admin as inviter', async () => {
+    await service.inviteStaff(ADMIN_CTX, { email: 'new@op2.com' }, 'op_2')
+    const stored = await inviteRepo.listByOperator('op_2')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.operatorId).toBe('op_2')
+    expect(stored[0]?.invitedByUserId).toBe('u_admin')
+  })
+
+  it('deactivateMember: a PLATFORM_ADMIN deactivates within the picked tenant and the audit names the picked operator + admin actor', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const staff = await membershipRepo.create({
+      userId: 'u_staffm',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      status: 'ACTIVE',
+    })
+    await service.deactivateMember(ADMIN_CTX, staff.id, 'op_2')
+    expect(recordedAudits).toEqual([
+      {
+        type: 'OPERATOR_MEMBER_DEACTIVATED',
+        operatorId: 'op_2',
+        actorUserId: 'u_admin',
+        targetUserId: 'u_staffm',
+      },
+    ])
   })
 })

--- a/packages/api/tests/services/provider-invite.test.ts
+++ b/packages/api/tests/services/provider-invite.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ConflictError } from '../../src/auth/guards'
+import { ConflictError, NotFoundError } from '../../src/auth/guards'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
 import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
 import {
@@ -79,6 +79,12 @@ describe('ProviderInviteService.createInvite', () => {
     ).rejects.toThrow(OperatorNotFoundError)
     // The guard runs before the insert + audit — no partial side effects leak out.
     expect(audits).toEqual([])
+  })
+
+  it('OperatorNotFoundError is a NotFoundError so the global handler maps it to 404, not 500 (c1)', () => {
+    const err = new OperatorNotFoundError('op_missing')
+    expect(err).toBeInstanceOf(NotFoundError)
+    expect(err.operatorId).toBe('op_missing')
   })
 
   it('emits a privilege-grant audit event that does not leak the token', async () => {

--- a/packages/api/tests/tenancy.test.ts
+++ b/packages/api/tests/tenancy.test.ts
@@ -9,6 +9,7 @@ import {
   applyCrossOperatorReadScope,
   operatorReadScope,
   resolveOperatorIdForWrite,
+  resolveTeamOperatorId,
 } from '../src/tenancy'
 
 const operatorCtx = (operatorId?: string): CallerContext =>
@@ -119,5 +120,39 @@ describe('applyCrossOperatorReadScope', () => {
     expect(
       applyCrossOperatorReadScope(adminCtx, { operatorId: 'op_9', includeAll: true }, {}),
     ).toEqual({ operatorId: 'op_9' })
+  })
+})
+
+describe('resolveTeamOperatorId (#1230 slice 6)', () => {
+  const owner: CallerContext = { userId: 'u', role: 'OPERATOR_OWNER', operatorId: 'op-self' }
+  const admin: CallerContext = { userId: 'a', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+  test('returns an operator its own id and IGNORES a foreign input (no cross-tenant)', () => {
+    expect(resolveTeamOperatorId(owner)).toBe('op-self')
+    expect(resolveTeamOperatorId(owner, 'op-other')).toBe('op-self')
+  })
+
+  test('fails closed for an operator that lost its operatorId claim', () => {
+    const noOp: CallerContext = { userId: 'u', role: 'OPERATOR_STAFF' }
+    expect(() => resolveTeamOperatorId(noOp, 'op-x')).toThrow(ForbiddenError)
+  })
+
+  test('returns the input id for a PLATFORM_ADMIN (honored ONLY here)', () => {
+    expect(resolveTeamOperatorId(admin, 'op-target')).toBe('op-target')
+  })
+
+  test('throws OperatorRequiredError (422) for a PLATFORM_ADMIN with no pick — no merged team view', () => {
+    expect(() => resolveTeamOperatorId(admin)).toThrow(OperatorRequiredError)
+    expect(() => resolveTeamOperatorId(admin, '')).toThrow(OperatorRequiredError)
+  })
+
+  test('denies renter / partner / legacy STAFF·ADMIN outright (403) — team is owner-tier internal', () => {
+    const renter: CallerContext = { userId: 'r', role: 'RENTER' }
+    const partner: CallerContext = { userId: 't', role: 'PARTNER', bypassScope: true }
+    const legacyStaff: CallerContext = { userId: 's', role: 'STAFF', bypassScope: false }
+    const legacyAdmin: CallerContext = { userId: 'a2', role: 'ADMIN', bypassScope: false }
+    for (const ctx of [renter, partner, legacyStaff, legacyAdmin]) {
+      expect(() => resolveTeamOperatorId(ctx, 'op-target')).toThrow(ForbiddenError)
+    }
   })
 })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -877,6 +877,7 @@
       "deactivating": "Deactivating...",
       "staffNotice": "Only an owner can invite staff.",
       "noOperatorContext": "This page manages a single operator's team. Use the admin portal to manage operators.",
+      "pickOperatorPrompt": "Select an operator from the picker above to view and manage its team.",
       "unknownName": "Unnamed",
       "roleOwner": "Owner",
       "roleStaff": "Staff",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -877,6 +877,7 @@
       "deactivating": "無効化中...",
       "staffNotice": "スタッフを招待できるのはオーナーのみです。",
       "noOperatorContext": "このページは単一の事業者のチームを管理します。事業者の管理は管理ポータルを使用してください。",
+      "pickOperatorPrompt": "上部の選択メニューから事業者を選ぶと、そのチームを表示・管理できます。",
       "unknownName": "名前未設定",
       "roleOwner": "オーナー",
       "roleStaff": "スタッフ",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -877,6 +877,7 @@
       "deactivating": "停用中...",
       "staffNotice": "只有所有者才能邀请员工。",
       "noOperatorContext": "此页面管理单个运营商的团队。请使用管理门户来管理运营商。",
+      "pickOperatorPrompt": "请从上方的选择器中选择一个运营商，以查看并管理其团队。",
       "unknownName": "未命名",
       "roleOwner": "所有者",
       "roleStaff": "员工",

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -2,7 +2,8 @@ import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { RouteRetryError } from '@/vite/RouteRetryError'
 import { featureFlagsQueryOptions, resolveFeatureFlag } from '@/vite/config'
-import { isOperatorOwnerSession, isOperatorSession } from '@/vite/guards'
+import { canPickOperatorContext, canWriteAsOperatorOwner } from '@/vite/guards'
+import { OperatorBadge, operatorsQueryOptions, useOperatorContext } from '@/vite/operator-context'
 import { DeactivateMemberDialog } from '@/vite/operator-team/DeactivateMemberDialog'
 import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
 import { RevokeInviteDialog } from '@/vite/operator-team/RevokeInviteDialog'
@@ -10,18 +11,19 @@ import { TeamView } from '@/vite/operator-team/TeamView'
 import { teamInvitesQueryOptions, teamMembersQueryOptions } from '@/vite/operator-team/api'
 import { sessionQueryOptions } from '@/vite/session'
 import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, redirect } from '@tanstack/react-router'
 import { UserPlus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 
-// Operator self-service team management (#904). URL `/<locale>/manage/team` —
-// behind the `_business` guard. The loader prefetches the session + members +
-// pending invites (no FOUC); the component reads the same options via
-// useSuspenseQuery. Tenant scoping is server-side (the client names no
-// operatorId). Inviting is owner-only (isOperatorOwnerSession), mirroring the
-// API's requireOperatorOwnerWrite gate; staff and bypass roles see read-only.
+// Operator self-service team management (#904) + platform-admin picker (#1230
+// slice 6). URL `/<locale>/manage/team` — behind the `_business` guard. An
+// operator manages its own tenant; a PLATFORM_ADMIN manages the PICKED operator's
+// team (the API resolves the tenant through `resolveTeamOperatorId`). All-mode (no
+// pick) fires NO team read and shows a pick-prompt — the operatorId-gated child
+// never mounts. Inviting/revoking/deactivating is owner-tier (canWriteAsOperatorOwner),
+// mirroring the API's requireOperatorOwnerWrite gate; staff see read-only.
 export const Route = createFileRoute('/$locale/_business/manage/team')({
   // Post-MVP feature (#904), hidden in the beta demo. The nav link is already
   // filtered out; this blocks a direct URL too, falling back to the bookings page.
@@ -33,12 +35,22 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }
   },
-  loader: async ({ context }) => {
-    await Promise.all([
-      context.queryClient.ensureQueryData(sessionQueryOptions()),
-      context.queryClient.ensureQueryData(teamMembersQueryOptions()),
-      context.queryClient.ensureQueryData(teamInvitesQueryOptions()),
-    ])
+  loaderDeps: ({ search }: { search: { operator?: string | undefined } }) => ({
+    operator: search.operator,
+  }),
+  loader: async ({ context, deps }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
+    // Capability-gated: a retained ?operator= is honored only for a picker-admin,
+    // never a legacy STAFF/ADMIN (whose team read would 403). Search params are
+    // input, not permission — derive from session capability first.
+    const picked = canPickOperatorContext(session ?? null) ? deps.operator : undefined
+    const operatorId = session?.user.operatorId ?? picked
+    if (operatorId) {
+      await Promise.all([
+        context.queryClient.ensureQueryData(teamMembersQueryOptions(operatorId)),
+        context.queryClient.ensureQueryData(teamInvitesQueryOptions(operatorId)),
+      ])
+    }
   },
   pendingComponent: PageSkeleton,
   errorComponent: OperatorTeamError,
@@ -48,18 +60,21 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
 export function OperatorTeamRoute() {
   const t = useTranslations('business.team')
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
-  const { data: members } = useSuspenseQuery(teamMembersQueryOptions())
-  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions())
-  const [inviteOpen, setInviteOpen] = useState(false)
-  const [selectedInvite, setSelectedInvite] = useState<OperatorInviteData | null>(null)
-  const [selectedMember, setSelectedMember] = useState<OperatorMemberData | null>(null)
+  const { pickedOperatorId } = useOperatorContext()
+  const canPick = canPickOperatorContext(session ?? null)
+  // Mirror the loader — must stay in lockstep. A legacy admin's retained param drops.
+  const picked = canPick ? pickedOperatorId : undefined
+  const operatorId = session?.user.operatorId ?? picked
+  const canManage = canWriteAsOperatorOwner(session ?? null, pickedOperatorId)
 
-  // A bypass role (PLATFORM_ADMIN / legacy STAFF·ADMIN) carries no operatorId and
-  // has no single team to manage — it onboards operators via the admin portal.
-  const hasOperator = isOperatorSession(session)
-  // Managing (invite / revoke / deactivate) is owner-only; staff see the team
-  // read-only (the API's requireOperatorOwnerWrite gate is the real enforcement).
-  const canManage = isOperatorOwnerSession(session)
+  // Badge label: team reads carry only the user's name, so source the operator name
+  // from the operators list (already cached by BusinessLayout's picker on this route).
+  // operatorNameById from useOperatorScope is empty when a pick is active — do not use it.
+  const { data: operators } = useQuery({
+    ...operatorsQueryOptions(),
+    enabled: canPick && Boolean(pickedOperatorId),
+  })
+  const pickedName = operators?.find((o) => o.id === pickedOperatorId)?.name
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -69,50 +84,89 @@ export function OperatorTeamRoute() {
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
             <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
           </div>
-          {canManage && (
-            <Button onClick={() => setInviteOpen(true)} className="shrink-0">
-              <UserPlus className="size-4" />
-              {t('invite')}
-            </Button>
-          )}
+          {canPick && Boolean(pickedOperatorId) && <OperatorBadge name={pickedName} />}
         </header>
 
-        {hasOperator ? (
-          <>
-            {!canManage && <p className="mb-6 text-sm text-muted-foreground">{t('staffNotice')}</p>}
-            <TeamView
-              members={members}
-              invites={invites}
-              canManage={canManage}
-              onRevokeInvite={setSelectedInvite}
-              onDeactivateMember={setSelectedMember}
-            />
-          </>
+        {session && operatorId ? (
+          <OperatorTeamData
+            key={operatorId}
+            operatorId={operatorId}
+            canManage={canManage}
+            csrfToken={session.csrfToken}
+          />
         ) : (
-          <p className="text-muted-foreground">{t('noOperatorContext')}</p>
-        )}
-
-        {canManage && session && (
-          <>
-            <InviteStaffDialog
-              open={inviteOpen}
-              onOpenChange={setInviteOpen}
-              csrfToken={session.csrfToken}
-            />
-            <RevokeInviteDialog
-              invite={selectedInvite}
-              onOpenChange={(open) => !open && setSelectedInvite(null)}
-              csrfToken={session.csrfToken}
-            />
-            <DeactivateMemberDialog
-              member={selectedMember}
-              onOpenChange={(open) => !open && setSelectedMember(null)}
-              csrfToken={session.csrfToken}
-            />
-          </>
+          <p className="text-muted-foreground">
+            {canPick ? t('pickOperatorPrompt') : t('noOperatorContext')}
+          </p>
         )}
       </div>
     </main>
+  )
+}
+
+function OperatorTeamData({
+  operatorId,
+  canManage,
+  csrfToken,
+}: {
+  operatorId: string
+  canManage: boolean
+  csrfToken: string
+}) {
+  const t = useTranslations('business.team')
+  const { data: members } = useSuspenseQuery(teamMembersQueryOptions(operatorId))
+  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions(operatorId))
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [selectedInvite, setSelectedInvite] = useState<OperatorInviteData | null>(null)
+  const [selectedMember, setSelectedMember] = useState<OperatorMemberData | null>(null)
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        {!canManage ? (
+          <p className="text-sm text-muted-foreground">{t('staffNotice')}</p>
+        ) : (
+          <span />
+        )}
+        {canManage && (
+          <Button onClick={() => setInviteOpen(true)} className="shrink-0">
+            <UserPlus className="size-4" />
+            {t('invite')}
+          </Button>
+        )}
+      </div>
+
+      <TeamView
+        members={members}
+        invites={invites}
+        canManage={canManage}
+        onRevokeInvite={setSelectedInvite}
+        onDeactivateMember={setSelectedMember}
+      />
+
+      {canManage && (
+        <>
+          <InviteStaffDialog
+            open={inviteOpen}
+            onOpenChange={setInviteOpen}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+          <RevokeInviteDialog
+            invite={selectedInvite}
+            onOpenChange={(open) => !open && setSelectedInvite(null)}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+          <DeactivateMemberDialog
+            member={selectedMember}
+            onOpenChange={(open) => !open && setSelectedMember(null)}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+        </>
+      )}
+    </>
   )
 }
 

--- a/packages/web/src/vite/nav/BusinessLayout.test.tsx
+++ b/packages/web/src/vite/nav/BusinessLayout.test.tsx
@@ -121,7 +121,9 @@ describe('BusinessLayout', () => {
   })
 
   it('hides the operator picker for a PLATFORM_ADMIN on a route that does not honor ?operator', () => {
-    h.routeId = '/$locale/_business/manage/team'
+    // The fleet by-id detail is intentionally NOT a picker route (#1264); team is
+    // now registered (#1230), so use the detail as the stable non-honoring example.
+    h.routeId = '/$locale/_business/manage/fleet/$vehicleId'
     renderBusinessLayout({ role: 'PLATFORM_ADMIN' })
     expect(screen.queryByLabelText('Operator')).toBeNull()
   })

--- a/packages/web/src/vite/operator-context/operator-context.test.ts
+++ b/packages/web/src/vite/operator-context/operator-context.test.ts
@@ -96,7 +96,12 @@ describe('useIsOperatorContextRoute', () => {
   })
 
   it('is false on an unscoped business route that does not honor ?operator', () => {
-    h.matches = [{ routeId: '/$locale/_business' }, { routeId: '/$locale/_business/manage/team' }]
+    // The fleet by-id detail is intentionally NOT registered (#1264) — a stable
+    // example of a business route the picker does not honor.
+    h.matches = [
+      { routeId: '/$locale/_business' },
+      { routeId: '/$locale/_business/manage/fleet/$vehicleId' },
+    ]
     const { result } = renderHook(() => useIsOperatorContextRoute())
     expect(result.current).toBe(false)
   })
@@ -106,6 +111,12 @@ describe('useIsOperatorContextRoute', () => {
       { routeId: '/$locale/_business' },
       { routeId: '/$locale/_business/manage/settings' },
     ]
+    const { result } = renderHook(() => useIsOperatorContextRoute())
+    expect(result.current).toBe(true)
+  })
+
+  it('is true on the team route (slice 6 honors ?operator, #1230)', () => {
+    h.matches = [{ routeId: '/$locale/_business' }, { routeId: '/$locale/_business/manage/team' }]
     const { result } = renderHook(() => useIsOperatorContextRoute())
     expect(result.current).toBe(true)
   })

--- a/packages/web/src/vite/operator-context/operator-context.ts
+++ b/packages/web/src/vite/operator-context/operator-context.ts
@@ -104,6 +104,7 @@ export const OPERATOR_CONTEXT_ROUTE_IDS: ReadonlySet<string> = new Set([
   '/$locale/_business/manage/insurance',
   '/$locale/_business/manage/locations',
   '/$locale/_business/manage/settings', // slice 2 — picker honored on settings
+  '/$locale/_business/manage/team', // slice 6 (#1230) — picker honored on team management
 ])
 
 // True when the active route is one that honors `?operator` (a descendant match

--- a/packages/web/src/vite/operator-team/DeactivateMemberDialog.tsx
+++ b/packages/web/src/vite/operator-team/DeactivateMemberDialog.tsx
@@ -16,6 +16,9 @@ interface DeactivateMemberDialogProps {
   member: OperatorMemberData | null
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  // Picked tenant (picker-admin) or the operator's own id — ignored server-side
+  // for a self-scoped operator.
+  operatorId: string
 }
 
 // #904 slice 2: owner-only deactivation of a staff member. The API refuses the
@@ -26,11 +29,12 @@ export function DeactivateMemberDialog({
   member,
   onOpenChange,
   csrfToken,
+  operatorId,
 }: DeactivateMemberDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: (id: string) => deactivateMember(id, csrfToken),
+    mutationFn: (id: string) => deactivateMember(id, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_MEMBERS_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
+++ b/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
@@ -17,6 +17,9 @@ interface InviteStaffDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  // The tenant the invite is minted under: the picker-admin's picked operator, or
+  // the operator's own id (ignored server-side for a self-scoped operator).
+  operatorId: string
 }
 
 // #904: owner-only staff invite. On success the dialog does NOT close — it
@@ -24,14 +27,19 @@ interface InviteStaffDialogProps {
 // no email is sent yet), so the owner copies it to share. The new pending row is
 // pulled in by invalidating the invites query. Closing resets both the mutation
 // and the local form/copy state so a prior reveal never lingers on reopen.
-export function InviteStaffDialog({ open, onOpenChange, csrfToken }: InviteStaffDialogProps) {
+export function InviteStaffDialog({
+  open,
+  onOpenChange,
+  csrfToken,
+  operatorId,
+}: InviteStaffDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const [email, setEmail] = useState('')
   const [copied, setCopied] = useState(false)
 
   const mutation = useMutation({
-    mutationFn: (value: string) => inviteStaff({ email: value }, csrfToken),
+    mutationFn: (value: string) => inviteStaff({ email: value }, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_INVITES_QUERY_KEY })
     },

--- a/packages/web/src/vite/operator-team/RevokeInviteDialog.tsx
+++ b/packages/web/src/vite/operator-team/RevokeInviteDialog.tsx
@@ -16,17 +16,25 @@ interface RevokeInviteDialogProps {
   invite: OperatorInviteData | null
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  // Picked tenant (picker-admin) or the operator's own id — ignored server-side
+  // for a self-scoped operator.
+  operatorId: string
 }
 
 // #904 slice 2: owner-only revoke of a pending staff invite. The API returns 404
 // for an unknown/foreign id (tenant is session-derived), surfaced inline via the
 // thrown ApiError message. Success invalidates the invites query and closes;
 // closing resets the mutation so a prior refusal never lingers on reopen.
-export function RevokeInviteDialog({ invite, onOpenChange, csrfToken }: RevokeInviteDialogProps) {
+export function RevokeInviteDialog({
+  invite,
+  onOpenChange,
+  csrfToken,
+  operatorId,
+}: RevokeInviteDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: (id: string) => revokeInvite(id, csrfToken),
+    mutationFn: (id: string) => revokeInvite(id, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_INVITES_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-team/api.ts
+++ b/packages/web/src/vite/operator-team/api.ts
@@ -10,10 +10,13 @@ import type { InviteStaffInput } from '@kuruma/shared/validators/provider-invite
 import { queryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-// #904: operator self-service team page. Cookie-based and operator-scoped
-// server-side — the client names NO operatorId, so a cross-tenant read/write is
-// impossible by construction (the API derives the tenant from the session). The
-// invite POST threads the session CSRF token (global double-submit guard).
+// #904 + #1230 slice 6: operator self-service team page, plus a platform-admin
+// picker surface. Cookie-based; the API resolves the tenant through
+// `resolveTeamOperatorId`, so an operator's own reads/writes stay self-scoped (a
+// foreign `operatorId` is ignored server-side) while a PLATFORM_ADMIN names the
+// picked tenant via `?operatorId=`. The reads fold that id into the query key so a
+// tenant switch refetches; the invite POST threads the session CSRF token (global
+// double-submit guard).
 
 // Network-seam validators pinned to the shared DTOs with `satisfies` so a field
 // drift fails to compile here, not silently at render.
@@ -39,22 +42,34 @@ const memberSchema = z.object({
 export const TEAM_INVITES_QUERY_KEY = ['operator-team', 'invites'] as const
 export const TEAM_MEMBERS_QUERY_KEY = ['operator-team', 'members'] as const
 
-export async function fetchTeamInvites(): Promise<OperatorInviteData[]> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, { credentials: 'include' })
+export async function fetchTeamInvites(operatorId: string): Promise<OperatorInviteData[]> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/invites?operatorId=${encodeURIComponent(operatorId)}`,
+    { credentials: 'include' },
+  )
   return unwrap(res, inviteSchema.array())
 }
 
-export async function fetchTeamMembers(): Promise<OperatorMemberData[]> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/members`, { credentials: 'include' })
+export async function fetchTeamMembers(operatorId: string): Promise<OperatorMemberData[]> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/members?operatorId=${encodeURIComponent(operatorId)}`,
+    { credentials: 'include' },
+  )
   return unwrap(res, memberSchema.array())
 }
 
-export function teamInvitesQueryOptions() {
-  return queryOptions({ queryKey: TEAM_INVITES_QUERY_KEY, queryFn: fetchTeamInvites })
+export function teamInvitesQueryOptions(operatorId: string) {
+  return queryOptions({
+    queryKey: [...TEAM_INVITES_QUERY_KEY, operatorId],
+    queryFn: () => fetchTeamInvites(operatorId),
+  })
 }
 
-export function teamMembersQueryOptions() {
-  return queryOptions({ queryKey: TEAM_MEMBERS_QUERY_KEY, queryFn: fetchTeamMembers })
+export function teamMembersQueryOptions(operatorId: string) {
+  return queryOptions({
+    queryKey: [...TEAM_MEMBERS_QUERY_KEY, operatorId],
+    queryFn: () => fetchTeamMembers(operatorId),
+  })
 }
 
 /** The one-time invite reveal: the URL embeds the token (never persisted in
@@ -69,17 +84,23 @@ const createdInviteSchema = z.object({
   expiresAt: z.string(),
 }) satisfies z.ZodType<CreatedInviteResult>
 
-// Cookie-authed POST — CSRF-gated, so the session token rides in the header.
+// Cookie-authed POST — CSRF-gated, so the session token rides in the header. The
+// `operatorId` names the picked tenant for a platform-admin; it is IGNORED for an
+// operator (self-scoped server-side) and can never mask an absent CSRF token.
 export async function inviteStaff(
   input: InviteStaffInput,
   csrfToken: string,
+  operatorId: string,
 ): Promise<CreatedInviteResult> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
-    body: JSON.stringify(input),
-  })
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/invites?operatorId=${encodeURIComponent(operatorId)}`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+      body: JSON.stringify(input),
+    },
+  )
   return unwrap(res, createdInviteSchema)
 }
 
@@ -89,24 +110,30 @@ export async function inviteStaff(
 const mutatedEntitySchema = z.object({ id: z.string() })
 
 // Owner-only writes. Both are cookie-authed POSTs (CSRF double-submit) to
-// `/operators/me/*` id paths — the API derives the tenant from the session, so
-// the client never names an operatorId. unwrap throws an ApiError carrying the
-// server message (404 for an unknown/foreign id, 409 for the last owner) so the
-// confirm dialog can render it.
-export async function revokeInvite(id: string, csrfToken: string): Promise<void> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites/${id}/revoke`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'X-CSRF-Token': csrfToken },
-  })
+// `/operators/me/*` id paths carrying the picked `?operatorId=` (ignored for a
+// self-scoped operator). unwrap throws an ApiError carrying the server message
+// (404 for an unknown/foreign id, 409 for the last owner) so the confirm dialog
+// can render it.
+export async function revokeInvite(
+  id: string,
+  csrfToken: string,
+  operatorId: string,
+): Promise<void> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/invites/${id}/revoke?operatorId=${encodeURIComponent(operatorId)}`,
+    { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
+  )
   await unwrap(res, mutatedEntitySchema)
 }
 
-export async function deactivateMember(id: string, csrfToken: string): Promise<void> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/members/${id}/deactivate`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'X-CSRF-Token': csrfToken },
-  })
+export async function deactivateMember(
+  id: string,
+  csrfToken: string,
+  operatorId: string,
+): Promise<void> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/members/${id}/deactivate?operatorId=${encodeURIComponent(operatorId)}`,
+    { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
+  )
   await unwrap(res, mutatedEntitySchema)
 }

--- a/packages/web/src/vite/operator-team/api.ts
+++ b/packages/web/src/vite/operator-team/api.ts
@@ -120,7 +120,7 @@ export async function revokeInvite(
   operatorId: string,
 ): Promise<void> {
   const res = await fetch(
-    `${getApiBaseUrl()}/operators/me/invites/${id}/revoke?operatorId=${encodeURIComponent(operatorId)}`,
+    `${getApiBaseUrl()}/operators/me/invites/${encodeURIComponent(id)}/revoke?operatorId=${encodeURIComponent(operatorId)}`,
     { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
   )
   await unwrap(res, mutatedEntitySchema)
@@ -132,7 +132,7 @@ export async function deactivateMember(
   operatorId: string,
 ): Promise<void> {
   const res = await fetch(
-    `${getApiBaseUrl()}/operators/me/members/${id}/deactivate?operatorId=${encodeURIComponent(operatorId)}`,
+    `${getApiBaseUrl()}/operators/me/members/${encodeURIComponent(id)}/deactivate?operatorId=${encodeURIComponent(operatorId)}`,
     { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
   )
   await unwrap(res, mutatedEntitySchema)

--- a/packages/web/tests/vite/operator-team-api.test.ts
+++ b/packages/web/tests/vite/operator-team-api.test.ts
@@ -4,6 +4,8 @@ import {
   fetchTeamMembers,
   inviteStaff,
   revokeInvite,
+  teamInvitesQueryOptions,
+  teamMembersQueryOptions,
 } from '@/vite/operator-team/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -29,7 +31,7 @@ describe('inviteStaff', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await inviteStaff({ email: 'new@x.com' }, 'csrf-1')
+    const result = await inviteStaff({ email: 'new@x.com' }, 'csrf-1', 'op_1')
     expect(result).toEqual({
       inviteUrl: 'https://app/provider/invite/tok',
       expiresAt: '2099-01-01T00:00:00.000Z',
@@ -37,18 +39,21 @@ describe('inviteStaff', () => {
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/invites')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
     expect(JSON.parse(opts.body as string)).toEqual({ email: 'new@x.com' })
   })
 
+  // G6b pin: the query param cannot mask an absent/stale CSRF token — a 403 still
+  // throws, so passing an operatorId never turns a rejected write into a silent pass.
   it('throws on a CSRF rejection (403) so the dialog surfaces it', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => jsonResponse({ success: false, error: 'CSRF token mismatch' }, 403)),
     )
-    await expect(inviteStaff({ email: 'x@x.com' }, 'stale')).rejects.toThrow()
+    await expect(inviteStaff({ email: 'x@x.com' }, 'stale', 'op_1')).rejects.toThrow()
   })
 })
 
@@ -57,10 +62,11 @@ describe('revokeInvite', () => {
     const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: { id: 'i1' } }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await revokeInvite('i1', 'csrf-1')
+    await revokeInvite('i1', 'csrf-1', 'op_1')
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/invites/i1/revoke')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
@@ -71,7 +77,7 @@ describe('revokeInvite', () => {
       'fetch',
       vi.fn(async () => jsonResponse({ success: false, error: 'invite not found' }, 404)),
     )
-    await expect(revokeInvite('nope', 'csrf-1')).rejects.toThrow('invite not found')
+    await expect(revokeInvite('nope', 'csrf-1', 'op_1')).rejects.toThrow('invite not found')
   })
 })
 
@@ -80,10 +86,11 @@ describe('deactivateMember', () => {
     const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: { id: 'm1' } }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await deactivateMember('m1', 'csrf-1')
+    await deactivateMember('m1', 'csrf-1', 'op_1')
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/members/m1/deactivate')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
@@ -96,7 +103,7 @@ describe('deactivateMember', () => {
         jsonResponse({ success: false, error: 'cannot deactivate the last operator owner' }, 409),
       ),
     )
-    await expect(deactivateMember('m1', 'csrf-1')).rejects.toThrow(
+    await expect(deactivateMember('m1', 'csrf-1', 'op_1')).rejects.toThrow(
       'cannot deactivate the last operator owner',
     )
   })
@@ -123,9 +130,11 @@ describe('fetchTeamMembers', () => {
         }),
       ),
     )
-    const members = await fetchTeamMembers()
+    const fetchMock = vi.mocked(fetch)
+    const members = await fetchTeamMembers('op_1')
     expect(members).toHaveLength(1)
     expect(members[0]).toMatchObject({ userId: 'u1', name: 'Olive Owner', role: 'OPERATOR_OWNER' })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/operators/me/members?operatorId=op_1')
   })
 
   it('tolerates a null name/email (walk-in-style user) without throwing', async () => {
@@ -173,7 +182,16 @@ describe('fetchTeamInvites', () => {
         }),
       ),
     )
-    const invites = await fetchTeamInvites()
+    const fetchMock = vi.mocked(fetch)
+    const invites = await fetchTeamInvites('op_1')
     expect(invites[0]).toMatchObject({ email: 'pending@x.com', status: 'PENDING' })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/operators/me/invites?operatorId=op_1')
+  })
+})
+
+describe('query keys fold in the operatorId', () => {
+  it('keys team reads on the operator so a tenant switch refetches', () => {
+    expect(teamMembersQueryOptions('op_1').queryKey).toEqual(['operator-team', 'members', 'op_1'])
+    expect(teamInvitesQueryOptions('op_2').queryKey).toEqual(['operator-team', 'invites', 'op_2'])
   })
 })

--- a/packages/web/tests/vite/operator-team/DeactivateMemberDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/DeactivateMemberDialog.test.tsx
@@ -40,7 +40,12 @@ function renderDialog(mem: OperatorMemberData | null) {
   render(
     <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <DeactivateMemberDialog member={mem} onOpenChange={onOpenChange} csrfToken="csrf-token" />
+        <DeactivateMemberDialog
+          member={mem}
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId="op_1"
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -63,6 +68,7 @@ describe('DeactivateMemberDialog', () => {
     await waitFor(() => expect(deactivateMember).toHaveBeenCalledTimes(1))
     expect(deactivateMember.mock.calls[0][0]).toBe('mem_1')
     expect(deactivateMember.mock.calls[0][1]).toBe('csrf-token')
+    expect(deactivateMember.mock.calls[0][2]).toBe('op_1')
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: TEAM_MEMBERS_QUERY_KEY })
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })

--- a/packages/web/tests/vite/operator-team/InviteStaffDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/InviteStaffDialog.test.tsx
@@ -1,0 +1,58 @@
+import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
+import * as api from '@/vite/operator-team/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+vi.mock('@/vite/operator-team/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/vite/operator-team/api')>()
+  return { ...actual, inviteStaff: vi.fn() }
+})
+
+const inviteStaff = vi.mocked(api.inviteStaff)
+const en = enMessages.business.team
+
+function renderDialog() {
+  const onOpenChange = vi.fn()
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <InviteStaffDialog
+          open
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId="op_1"
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+  return { onOpenChange }
+}
+
+describe('InviteStaffDialog', () => {
+  afterEach(() => {
+    cleanup()
+    inviteStaff.mockReset()
+  })
+
+  it('mints the invite with the email, csrf token, AND the operatorId (picker path)', async () => {
+    inviteStaff.mockResolvedValue({
+      inviteUrl: 'https://app/provider/invite/tok',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    })
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(en.form.email), 'new@op1.com')
+    await user.click(screen.getByRole('button', { name: en.form.submit }))
+
+    await waitFor(() => expect(inviteStaff).toHaveBeenCalledTimes(1))
+    expect(inviteStaff.mock.calls[0]).toEqual([{ email: 'new@op1.com' }, 'csrf-token', 'op_1'])
+  })
+})

--- a/packages/web/tests/vite/operator-team/RevokeInviteDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/RevokeInviteDialog.test.tsx
@@ -39,7 +39,12 @@ function renderDialog(inv: OperatorInviteData | null) {
   render(
     <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <RevokeInviteDialog invite={inv} onOpenChange={onOpenChange} csrfToken="csrf-token" />
+        <RevokeInviteDialog
+          invite={inv}
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId="op_1"
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -62,6 +67,7 @@ describe('RevokeInviteDialog', () => {
     await waitFor(() => expect(revokeInvite).toHaveBeenCalledTimes(1))
     expect(revokeInvite.mock.calls[0][0]).toBe('inv_1')
     expect(revokeInvite.mock.calls[0][1]).toBe('csrf-token')
+    expect(revokeInvite.mock.calls[0][2]).toBe('op_1')
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: TEAM_INVITES_QUERY_KEY })
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })

--- a/packages/web/tests/vite/operator-team/TeamRoute.test.tsx
+++ b/packages/web/tests/vite/operator-team/TeamRoute.test.tsx
@@ -1,0 +1,130 @@
+import { OperatorTeamRoute } from '@/routes/$locale/_business/manage/team'
+import { teamInvitesQueryOptions, teamMembersQueryOptions } from '@/vite/operator-team/api'
+import { type Session, sessionQueryOptions } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type ReactNode, Suspense } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+// The picker context is the ONE input that decides all-mode vs picked; mock it so
+// each test drives it directly. Session comes through the query cache (seeded),
+// and `fetch` is stubbed — NOT useSuspenseQuery — so the P1 "no team read fires"
+// assertion observes real network behavior, not a stubbed-away query.
+const useOperatorContextMock = vi.fn<() => { pickedOperatorId: string | undefined }>()
+
+vi.mock('@/vite/operator-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/vite/operator-context')>()
+  return { ...actual, useOperatorContext: () => useOperatorContextMock() }
+})
+
+const en = enMessages.business.team
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderRoute(session: Session | null, seedTeams: readonly string[] = []) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  client.setQueryData(sessionQueryOptions().queryKey, session)
+  // Pre-seed named tenants so their team reads resolve without suspense/fetch —
+  // used only where a test switches tenants and must not race the network.
+  for (const id of seedTeams) {
+    client.setQueryData(teamMembersQueryOptions(id).queryKey, [])
+    client.setQueryData(teamInvitesQueryOptions(id).queryKey, [])
+  }
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <IntlProvider locale="en" messages={enMessages}>
+          <Suspense fallback={<div>loading</div>}>{children}</Suspense>
+        </IntlProvider>
+      </QueryClientProvider>
+    )
+  }
+  return render(<OperatorTeamRoute />, { wrapper })
+}
+
+const calledTeamRead = (m: ReturnType<typeof vi.fn>): boolean =>
+  m.mock.calls.some(([u]) => String(u).includes('/operators/me/'))
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('OperatorTeamRoute picker gating (#1230)', () => {
+  // P1 — all-mode fires NO team read (the operatorId-gated child never mounts).
+  it('a PLATFORM_ADMIN with no pick shows the pick-prompt and issues no /operators/me/* read', () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: undefined })
+
+    renderRoute({ user: { id: 'a', role: 'PLATFORM_ADMIN' }, csrfToken: 'c' })
+
+    expect(screen.getByText(en.pickOperatorPrompt)).toBeInTheDocument()
+    expect(calledTeamRead(fetchMock)).toBe(false)
+  })
+
+  // P2a — a legacy STAFF/ADMIN with a retained ?operator= is NOT a picker: it sees
+  // the no-context prompt (its team read would 403) and fires no team read.
+  it('a legacy STAFF session with a retained pickedOperatorId shows the no-context prompt and fires no team read', () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+
+    renderRoute({ user: { id: 's', role: 'STAFF' }, csrfToken: 'c' })
+
+    expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
+    expect(calledTeamRead(fetchMock)).toBe(false)
+  })
+
+  // Picked mode — the scoped read fires with the picked id.
+  it('a PLATFORM_ADMIN with a pick fires the scoped team read with ?operatorId=', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+
+    renderRoute({ user: { id: 'a', role: 'PLATFORM_ADMIN' }, csrfToken: 'c' })
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) =>
+          String(u).includes('/operators/me/members?operatorId=op_2'),
+        ),
+      ).toBe(true),
+    )
+  })
+
+  // P2b — a tenant switch remounts the keyed child, resetting dialog state: an
+  // invite dialog opened under op_2 is gone after switching to op_3.
+  it('resets open dialog state when the picked tenant switches (key remount)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: true, data: [] })),
+    )
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+    const user = userEvent.setup()
+
+    const { rerender } = renderRoute(
+      { user: { id: 'a', role: 'PLATFORM_ADMIN' }, csrfToken: 'c' },
+      ['op_2', 'op_3'],
+    )
+
+    await user.click(await screen.findByRole('button', { name: en.invite }))
+    expect(screen.getByText(en.inviteTitle)).toBeInTheDocument()
+
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_3' })
+    rerender(<OperatorTeamRoute />)
+
+    await waitFor(() => expect(screen.queryByText(en.inviteTitle)).not.toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary

Closes the last gap in the operator-context picker (epic #1230, **slice 6**): a `PLATFORM_ADMIN` can now read and manage a **picked** operator's team (invite / revoke / deactivate) as that operator. `/operators/me/*` was self-scoped with no foreign-id surface; this threads an optional `?operatorId=` through the five routes and the web, honored **only** for the platform tier.

Implements the design + plan in #1412 (`docs/superpowers/specs|plans/2026-07-02-team-picker*`). **Refs #1230 — does not close the epic.**

## Architecture (one seam)

- Replace the service's private `requireOwnOperator(ctx)` with a pure **`resolveTeamOperatorId(ctx, inputOperatorId?)`** in `tenancy.ts` — an **allowlist**: operator role → own id (foreign input **ignored**, no cross-tenant); `PRIVILEGED_ROLES` (`PLATFORM_ADMIN`) → the input id (honored only here), no-pick → 422; everyone else (renter, PARTNER, legacy STAFF/ADMIN) → 403.
- Deliberately **stricter** than `resolveOperatorIdForWrite` (which keys on `!isOperatorRole` and would honor legacy STAFF/ADMIN) — pinned by a route test (G6a).
- No schema, no migration, no new authz gate.

## Slices / commits (TDD throughout)

**API**
- `resolveTeamOperatorId` resolver + reads thread `?operatorId=` (slice 1, pre-existing).
- `OperatorNotFoundError extends NotFoundError` → global handler maps a bogus picked id to **404, not 500** (c1). Base `NotFoundError.name` widened to `string` so the subclass can override (matching is by `instanceof`).
- Service writes accept a picked `operatorId` via the resolver; `requireOwnOperator` deleted. No-pick admin now **422** (was 403).
- Write routes thread `?operatorId=` + **real-pg integration test** (mint under picked X; cross-tenant deactivate → 404; last-owner → 409; audit names picked operator + admin actor).

**Web**
- `api.ts` threads `operatorId` into the 3 mutations + 2 reads; folds it into the query keys so a tenant switch refetches.
- The 3 dialogs take an `operatorId` prop.
- Team route registered in the picker; `business.team.pickOperatorPrompt` (en/ja/zh).
- `team.tsx`: capability-gated resolution + a **keyed `OperatorTeamData` child** — all-mode fires **no team read** (prompt only), and a tenant switch remounts (resets dialog/selection state). A retained `?operator=` is honored only for a picker-admin (a legacy STAFF/ADMIN's team read would 403).
- Ripple: `team` is now a picker route, so the "does not honor ?operator" fixtures in `operator-context.test.ts` / `BusinessLayout.test.tsx` move to the fleet by-id detail.

## Test plan

- [x] `bun run --filter @kuruma/api test` — 242 files / 2705 pass
- [x] `bun run --filter @kuruma/api test:integration` — 75 files / 497 pass (incl. new `operator-team-picker`)
- [x] `bun run --filter @kuruma/web test` — 285 files / 1955 pass
- [x] `bunx tsc --noEmit` clean in api / web / shared
- [x] `lint:boundaries` + `lint:modules` + `lint:size` exit 0; biome clean
- [x] i18n key parity (en/ja/zh)

## Security pins

- `resolveTeamOperatorId` is the deny point (not the owner-write gate): a legacy STAFF write-with-`?operatorId=` is **403** (G6a), proving team is not collapsed onto the looser write resolver.
- An `OPERATOR_STAFF` is still 403 even with a valid `?operatorId=` (owner-tier gate).
- CSRF pin (G6b): the query param cannot mask an absent/stale token — a 403 still throws.
- A bogus picked id is 404 (no existence oracle beyond the operator FK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)