### PR TITLE
feat(#1319): create template — POST /admin/templates + New template dialog (slice 3a of 3)

### DIFF
--- a/packages/api/src/repositories/drizzle/add-on-template.ts
+++ b/packages/api/src/repositories/drizzle/add-on-template.ts
@@ -2,7 +2,7 @@ import { addOnTemplates } from '@kuruma/shared/db/schema'
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import { asc, eq } from 'drizzle-orm'
 import type { AddOnTemplate } from '../../stores'
-import type { AddOnTemplateRepository } from '../types'
+import type { AddOnTemplateRepository, TemplateCreateInput } from '../types'
 import type { Db } from './shared'
 import { templatePatchColumns } from './template-patch-columns'
 
@@ -44,6 +44,14 @@ export class DrizzleAddOnTemplateRepository implements AddOnTemplateRepository {
       .set({ ...templatePatchColumns(patch), updatedAt: new Date() })
       .where(eq(addOnTemplates.id, id))
       .returning(TEMPLATE_COLUMNS)
+    return row
+  }
+
+  async create(input: TemplateCreateInput): Promise<AddOnTemplate> {
+    // id + createdAt/updatedAt are DB-defaulted (crypto.randomUUID / now()). A
+    // duplicate key trips add_on_templates_key_unique (23505) -> service 409.
+    const [row] = await this.db.insert(addOnTemplates).values(input).returning(TEMPLATE_COLUMNS)
+    if (!row) throw new Error('Failed to insert add-on template')
     return row
   }
 }

--- a/packages/api/src/repositories/drizzle/insurance-template.ts
+++ b/packages/api/src/repositories/drizzle/insurance-template.ts
@@ -2,7 +2,7 @@ import { insuranceTemplates } from '@kuruma/shared/db/schema'
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import { asc, eq } from 'drizzle-orm'
 import type { InsuranceTemplate } from '../../stores'
-import type { InsuranceTemplateRepository } from '../types'
+import type { InsuranceTemplateRepository, TemplateCreateInput } from '../types'
 import type { Db } from './shared'
 import { templatePatchColumns } from './template-patch-columns'
 
@@ -39,6 +39,14 @@ export class DrizzleInsuranceTemplateRepository implements InsuranceTemplateRepo
       .set({ ...templatePatchColumns(patch), updatedAt: new Date() })
       .where(eq(insuranceTemplates.id, id))
       .returning(TEMPLATE_COLUMNS)
+    return row
+  }
+
+  async create(input: TemplateCreateInput): Promise<InsuranceTemplate> {
+    // id + timestamps DB-defaulted; a duplicate key trips
+    // insurance_templates_key_unique (23505) -> service 409.
+    const [row] = await this.db.insert(insuranceTemplates).values(input).returning(TEMPLATE_COLUMNS)
+    if (!row) throw new Error('Failed to insert insurance template')
     return row
   }
 }

--- a/packages/api/src/repositories/in-memory/add-on-template.ts
+++ b/packages/api/src/repositories/in-memory/add-on-template.ts
@@ -1,8 +1,10 @@
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { AddOnTemplate } from '../../stores'
-import type { AddOnTemplateRepository } from '../types'
+import type { AddOnTemplateRepository, TemplateCreateInput } from '../types'
 import { seedDemoAddOnTemplates } from './add-on-template-seed'
-import { mergeTemplatePatch } from './template-patch'
+import { insertTemplate, mergeTemplatePatch } from './template-patch'
+
+const KEY_CONSTRAINT = 'add_on_templates_key_unique'
 
 /**
  * Local-dev / route-suite double for the global add-on template catalog. An
@@ -37,5 +39,9 @@ export class InMemoryAddOnTemplateRepository implements AddOnTemplateRepository 
     const updated = mergeTemplatePatch(current, patch)
     this.store.set(id, updated)
     return updated
+  }
+
+  async create(input: TemplateCreateInput): Promise<AddOnTemplate> {
+    return insertTemplate(this.store, input, KEY_CONSTRAINT)
   }
 }

--- a/packages/api/src/repositories/in-memory/insurance-template.ts
+++ b/packages/api/src/repositories/in-memory/insurance-template.ts
@@ -1,8 +1,10 @@
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { InsuranceTemplate } from '../../stores'
-import type { InsuranceTemplateRepository } from '../types'
+import type { InsuranceTemplateRepository, TemplateCreateInput } from '../types'
 import { seedDemoInsuranceTemplates } from './insurance-template-seed'
-import { mergeTemplatePatch } from './template-patch'
+import { insertTemplate, mergeTemplatePatch } from './template-patch'
+
+const KEY_CONSTRAINT = 'insurance_templates_key_unique'
 
 /**
  * Local-dev / route-suite double for the global insurance template catalog.
@@ -32,5 +34,9 @@ export class InMemoryInsuranceTemplateRepository implements InsuranceTemplateRep
     const updated = mergeTemplatePatch(current, patch)
     this.store.set(id, updated)
     return updated
+  }
+
+  async create(input: TemplateCreateInput): Promise<InsuranceTemplate> {
+    return insertTemplate(this.store, input, KEY_CONSTRAINT)
   }
 }

--- a/packages/api/src/repositories/in-memory/template-patch.ts
+++ b/packages/api/src/repositories/in-memory/template-patch.ts
@@ -1,5 +1,7 @@
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
+import { PG_ERROR } from '../../pg-errors'
 import type { AddOnTemplate, InsuranceTemplate } from '../../stores'
+import type { TemplateCreateInput } from '../types'
 
 /**
  * Pure in-memory application of a #1319 admin template patch: return a NEW row
@@ -19,4 +21,38 @@ export function mergeTemplatePatch<T extends AddOnTemplate | InsuranceTemplate>(
     ...(patch.status !== undefined ? { status: patch.status } : {}),
     updatedAt: new Date(),
   }
+}
+
+// Mirror postgres-js's PostgresError shape (top-level `code` + `constraint_name`)
+// so the create service's 23505 key-clash catch behaves identically against the
+// in-memory and Drizzle repos (driver parity, #1362). Same pattern as consent.ts.
+function uniqueViolation(
+  constraintName: string,
+): Error & { code: string; constraint_name: string } {
+  return Object.assign(new Error(`duplicate key violates unique constraint "${constraintName}"`), {
+    code: PG_ERROR.UNIQUE_VIOLATION,
+    constraint_name: constraintName,
+  })
+}
+
+/**
+ * In-memory template insert (#1319 slice 3): mint the id + timestamps the real DB
+ * defaults, and enforce the per-catalog key-unique seal by throwing a 23505-shaped
+ * error the service maps to 409 — the same path Postgres takes on `*_key_unique`.
+ * Mutates `store`. `keyConstraint` is the real index name for a faithful error.
+ */
+export function insertTemplate<T extends AddOnTemplate | InsuranceTemplate>(
+  store: Map<string, T>,
+  input: TemplateCreateInput,
+  keyConstraint: string,
+): T {
+  for (const existing of store.values()) {
+    if (existing.key === input.key) throw uniqueViolation(keyConstraint)
+  }
+  const now = new Date()
+  // The constructed object carries exactly the AddOnTemplate/InsuranceTemplate
+  // fields; the cast reconciles the generic T (both are structurally identical).
+  const row = { id: crypto.randomUUID(), ...input, createdAt: now, updatedAt: now } as T
+  store.set(row.id, row)
+  return row
 }

--- a/packages/api/src/repositories/types-catalog-templates.ts
+++ b/packages/api/src/repositories/types-catalog-templates.ts
@@ -1,9 +1,24 @@
+import type { CatalogTemplateStatus } from '@kuruma/shared/enums'
+import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
 import type { TemplatePatch } from '@kuruma/shared/types/template-admin'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
 
 // Platform-owned catalog TEMPLATE repositories (catalog i18n, epic #385 / #1319).
 // Split into their own module to keep the repositories/types barrel under the
 // file-size cap; re-exported there so callers' imports don't change.
+
+/**
+ * New-template columns the admin create supplies (#1319 slice 3). The service
+ * derives `key` (`slugify(name.en)`) and defaults `description`/`status`, then
+ * hands the repo this fully-resolved row minus the DB-generated id + timestamps.
+ * Shared by both catalogs (add-on and insurance templates are identical shapes).
+ */
+export interface TemplateCreateInput {
+  key: string
+  name: LocalizedText
+  description: LocalizedText | null
+  status: CatalogTemplateStatus
+}
 
 /**
  * The platform-owned add-on TEMPLATE catalog (catalog i18n, epic #385). Global,
@@ -36,6 +51,12 @@ export interface AddOnTemplateRepository {
    * row, or undefined when no row matches (a 404 for the service, never a throw).
    */
   update(id: string, patch: TemplatePatch): Promise<AddOnTemplate | undefined>
+  /**
+   * Add a new template to the catalog (#1319 slice 3). `key` is unique
+   * (`add_on_templates_key_unique`); a clash throws a 23505 the service maps to a
+   * 409 (a template with that name already exists). Returns the inserted row.
+   */
+  create(input: TemplateCreateInput): Promise<AddOnTemplate>
 }
 
 /**
@@ -53,4 +74,7 @@ export interface InsuranceTemplateRepository {
   /** Curate ONE template — the admin write (#1319 slice 2). Same partial + bump
    *  as the add-on catalog; undefined when no row matches. */
   update(id: string, patch: TemplatePatch): Promise<InsuranceTemplate | undefined>
+  /** Add a new insurance template (#1319 slice 3). Same contract as the add-on
+   *  catalog's `create`; a duplicate `key` throws a 23505 (-> 409). */
+  create(input: TemplateCreateInput): Promise<InsuranceTemplate>
 }

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -270,6 +270,7 @@ export interface AddOnRepository {
 export type {
   AddOnTemplateRepository,
   InsuranceTemplateRepository,
+  TemplateCreateInput,
 } from './types-catalog-templates'
 
 // #521 provider authorization. Not ctx-scoped: the admin endpoint

--- a/packages/api/src/routes/admin-templates.ts
+++ b/packages/api/src/routes/admin-templates.ts
@@ -1,4 +1,9 @@
-import { type TemplatePatch, templatePatchSchema } from '@kuruma/shared/types/template-admin'
+import {
+  type TemplateCreate,
+  type TemplatePatch,
+  templateCreateSchema,
+  templatePatchSchema,
+} from '@kuruma/shared/types/template-admin'
 import { type Context, Hono } from 'hono'
 import {
   type CallerContext,
@@ -28,15 +33,31 @@ async function parsePatch(c: Context): Promise<PatchInput> {
   return { ok: true, id: idResult.id, patch: parsed.data, ctx: toCallerContext(requireUser(c)) }
 }
 
+type CreateInput =
+  | { ok: true; data: TemplateCreate; ctx: CallerContext }
+  | { ok: false; response: Response }
+
+/**
+ * Parse + validate a template POST at the HTTP boundary: the create body (`name`
+ * required; `key` is NOT accepted — the service derives it) and the caller
+ * context. A malformed body is a 400 here; the service applies the
+ * `requirePlatformAdmin` write gate (403) and the duplicate-key (409).
+ */
+async function parseCreate(c: Context): Promise<CreateInput> {
+  const parsed = await parseBody(c, templateCreateSchema)
+  if (!parsed.ok) return parsed
+  return { ok: true, data: parsed.data, ctx: toCallerContext(requireUser(c)) }
+}
+
 /**
  * Platform-admin template library (#1319). Mounts under `/admin/*`, so the
  * structural platform read-floor already gates the path; per-handler guards are
  * defence in depth (AGENTS.md). Slice 1 read (`GET`) exposes every status; slice
  * 2 adds the curation WRITES (`PATCH`) — translate/edit the localized bundles and
- * promote an ARCHIVED backfill-minted row to ACTIVE — each gated by the stricter
- * `requirePlatformAdmin` in the service. Add-on and insurance catalogs are
- * distinct paths (`/add-ons/:id`, `/insurance/:id`) over structurally identical
- * rows.
+ * promote an ARCHIVED backfill-minted row to ACTIVE; slice 3 adds `POST` to mint a
+ * new template — each gated by the stricter `requirePlatformAdmin` in the service.
+ * Add-on and insurance catalogs are distinct paths (`/add-ons`, `/insurance`) over
+ * structurally identical rows.
  */
 export function createAdminTemplateRoutes(service: TemplateLibraryService) {
   const app = new Hono()
@@ -48,6 +69,16 @@ export function createAdminTemplateRoutes(service: TemplateLibraryService) {
       const ctx = toCallerContext(requireUser(c))
       requirePlatformRead(ctx)
       return ok(c, await service.listAll(ctx))
+    })
+    .post('/admin/templates/add-ons', async (c) => {
+      const input = await parseCreate(c)
+      if (!input.ok) return input.response
+      return ok(c, await service.createAddOn(input.ctx, input.data), 201)
+    })
+    .post('/admin/templates/insurance', async (c) => {
+      const input = await parseCreate(c)
+      if (!input.ok) return input.response
+      return ok(c, await service.createInsurance(input.ctx, input.data), 201)
     })
     .patch('/admin/templates/add-ons/:id', async (c) => {
       const input = await parsePatch(c)

--- a/packages/api/src/services/template-library.test.ts
+++ b/packages/api/src/services/template-library.test.ts
@@ -1,5 +1,12 @@
+import { slugify } from '@kuruma/shared/i18n/slugify'
+import type { TemplateCreate } from '@kuruma/shared/types/template-admin'
 import { describe, expect, it } from 'vitest'
-import { type CallerContext, ForbiddenError, NotFoundError } from '../middleware/auth'
+import {
+  type CallerContext,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from '../middleware/auth'
 import { InMemoryAddOnTemplateRepository } from '../repositories/in-memory/add-on-template'
 import { InMemoryInsuranceTemplateRepository } from '../repositories/in-memory/insurance-template'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
@@ -139,5 +146,74 @@ describe('TemplateLibraryService.updateInsurance', () => {
     await expect(service.updateInsurance(ADMIN, 'nope', { status: 'ARCHIVED' })).rejects.toThrow(
       NotFoundError,
     )
+  })
+})
+
+const skiRack: TemplateCreate = {
+  name: { en: 'Ski rack', ja: 'スキーラック' },
+  description: null,
+  status: 'ACTIVE',
+}
+
+describe('TemplateLibraryService.createAddOn', () => {
+  it('mints a template, deriving key from slugify(name.en), and persists it', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([]))
+
+    const row = await service.createAddOn(ADMIN, skiRack)
+
+    expect(row).toEqual({
+      id: expect.any(String),
+      key: slugify('Ski rack'),
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+      description: null,
+      status: 'ACTIVE',
+    })
+    const all = await service.listAll(ADMIN)
+    expect(all.addOns.map((t) => t.key)).toContain(slugify('Ski rack'))
+  })
+
+  it('rejects a duplicate key (same slugified name) with ConflictError', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([]))
+    await service.createAddOn(ADMIN, skiRack)
+
+    await expect(service.createAddOn(ADMIN, skiRack)).rejects.toThrow(ConflictError)
+  })
+
+  it('rejects an operator caller with ForbiddenError before any write', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([]))
+
+    await expect(service.createAddOn(OPERATOR, skiRack)).rejects.toThrow(ForbiddenError)
+  })
+})
+
+describe('TemplateLibraryService.createInsurance', () => {
+  it('mints an insurance template with the derived key and provided description', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([]))
+
+    const row = await service.createInsurance(ADMIN, {
+      name: { en: 'Premium cover' },
+      description: { en: 'Zero deductible' },
+      status: 'ACTIVE',
+    })
+
+    expect(row).toEqual({
+      id: expect.any(String),
+      key: slugify('Premium cover'),
+      name: { en: 'Premium cover' },
+      description: { en: 'Zero deductible' },
+      status: 'ACTIVE',
+    })
+  })
+
+  it('rejects a duplicate key with ConflictError', async () => {
+    const service = new TemplateLibraryService(addOnStore([]), insuranceStore([]))
+    const input: TemplateCreate = {
+      name: { en: 'Premium cover' },
+      description: null,
+      status: 'ACTIVE',
+    }
+    await service.createInsurance(ADMIN, input)
+
+    await expect(service.createInsurance(ADMIN, input)).rejects.toThrow(ConflictError)
   })
 })

--- a/packages/api/src/services/template-library.ts
+++ b/packages/api/src/services/template-library.ts
@@ -1,16 +1,29 @@
+import { slugify } from '@kuruma/shared/i18n/slugify'
 import type {
   TemplateAdminRow,
+  TemplateCreate,
   TemplateLibraryResponse,
   TemplatePatch,
 } from '@kuruma/shared/types/template-admin'
 import {
   type CallerContext,
+  ConflictError,
   NotFoundError,
   requirePlatformAdmin,
   requirePlatformRead,
 } from '../middleware/auth'
-import type { AddOnTemplateRepository, InsuranceTemplateRepository } from '../repositories/types'
+import { PG_ERROR, pgErrorCode } from '../pg-errors'
+import type {
+  AddOnTemplateRepository,
+  InsuranceTemplateRepository,
+  TemplateCreateInput,
+} from '../repositories/types'
 import type { AddOnTemplate, InsuranceTemplate } from '../stores'
+
+/** A template repo viewed as just its create seam — both catalogs share it. */
+type TemplateCreator = {
+  create(input: TemplateCreateInput): Promise<AddOnTemplate | InsuranceTemplate>
+}
 
 /**
  * Project a persisted template onto the admin wire row (@kuruma/shared): the
@@ -75,5 +88,49 @@ export class TemplateLibraryService {
     const updated = await this.insuranceTemplateRepo.update(id, patch)
     if (!updated) throw new NotFoundError('insurance template not found')
     return toRow(updated)
+  }
+
+  /**
+   * Add a new add-on template to the catalog (#1319 slice 3). A WRITE, so gated
+   * by `requirePlatformAdmin` first. The client never sends `key` — it is derived
+   * from `slugify(name.en)` so a hand-created template keys the same way a seed or
+   * backfill one does; a clash on the DB's `*_key_unique` (23505) surfaces as a
+   * 409 (a template with that name already exists) rather than a 500.
+   */
+  async createAddOn(ctx: CallerContext, data: TemplateCreate): Promise<TemplateAdminRow> {
+    requirePlatformAdmin(ctx)
+    return insertTemplate(this.addOnTemplateRepo, data)
+  }
+
+  /** Add a new insurance template — same contract as {@link createAddOn}. */
+  async createInsurance(ctx: CallerContext, data: TemplateCreate): Promise<TemplateAdminRow> {
+    requirePlatformAdmin(ctx)
+    return insertTemplate(this.insuranceTemplateRepo, data)
+  }
+}
+
+/**
+ * Derive the `key` and insert, mapping the key-unique 23505 to a 409. Shared by
+ * both catalogs (the create seam is identical); the caller applies the write gate
+ * before this runs. A concurrent insert can also lose the key race, so the same
+ * ConflictError covers both the pre-existing row and the lost race — no 500.
+ */
+async function insertTemplate(
+  repo: TemplateCreator,
+  data: TemplateCreate,
+): Promise<TemplateAdminRow> {
+  const input: TemplateCreateInput = {
+    key: slugify(data.name.en),
+    name: data.name,
+    description: data.description,
+    status: data.status,
+  }
+  try {
+    return toRow(await repo.create(input))
+  } catch (err) {
+    if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION) {
+      throw new ConflictError(`a template with key "${input.key}" already exists`)
+    }
+    throw err
   }
 }

--- a/packages/api/tests/integration/insurance-template-repo.test.ts
+++ b/packages/api/tests/integration/insurance-template-repo.test.ts
@@ -1,6 +1,7 @@
 import { insuranceTemplates } from '@kuruma/shared/db/schema'
 import { inArray } from 'drizzle-orm'
 import { afterAll, describe, expect, it } from 'vitest'
+import { PG_ERROR, pgErrorCode } from '../../src/pg-errors'
 import { DrizzleInsuranceTemplateRepository } from '../../src/repositories/drizzle'
 import { db } from './setup'
 
@@ -116,5 +117,48 @@ describe('DrizzleInsuranceTemplateRepository.update', () => {
   it('returns undefined for an unknown id, writing nothing', async () => {
     const repo = new DrizzleInsuranceTemplateRepository(db)
     expect(await repo.update(crypto.randomUUID(), { status: 'ACTIVE' })).toBeUndefined()
+  })
+})
+
+describe('DrizzleInsuranceTemplateRepository.create', () => {
+  const CREATE_KEY = `test_ins_create_${uniq}`
+  afterAll(async () => {
+    await db.delete(insuranceTemplates).where(inArray(insuranceTemplates.key, [CREATE_KEY]))
+  })
+
+  it('inserts a template with DB-defaulted id + timestamps, persisting the bundles', async () => {
+    const repo = new DrizzleInsuranceTemplateRepository(db)
+
+    const created = await repo.create({
+      key: CREATE_KEY,
+      name: { en: 'Premium cover', ja: 'プレミアム' },
+      description: { en: 'Zero deductible.' },
+      status: 'ACTIVE',
+    })
+
+    expect(created.id).toMatch(/[0-9a-f-]{36}/)
+    expect(created.name).toEqual({ en: 'Premium cover', ja: 'プレミアム' })
+    // Re-read proves the row landed, not just the returning() projection.
+    const reread = await repo.findById(created.id)
+    expect(reread?.key).toBe(CREATE_KEY)
+    expect(reread?.description).toEqual({ en: 'Zero deductible.' })
+  })
+
+  it('rejects a duplicate key with a real-PG 23505 that pgErrorCode reads (driver parity)', async () => {
+    const repo = new DrizzleInsuranceTemplateRepository(db)
+    const input = {
+      key: CREATE_KEY,
+      name: { en: 'Premium cover' },
+      description: null,
+      status: 'ACTIVE' as const,
+    }
+    await repo.create(input).catch(() => {}) // ensure the row exists (idempotent w/ prior test)
+
+    const err = await repo.create(input).then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).not.toBeNull()
+    expect(pgErrorCode(err)).toBe(PG_ERROR.UNIQUE_VIOLATION)
   })
 })

--- a/packages/api/tests/routes/admin-templates.test.ts
+++ b/packages/api/tests/routes/admin-templates.test.ts
@@ -198,3 +198,74 @@ describe('PATCH /admin/templates/insurance/:id', () => {
     expect(res.status).toBe(403)
   })
 })
+
+function post(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /admin/templates/add-ons', () => {
+  it('mints a template for a platform admin (201), deriving key + defaulting status/description', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await post(app, '/admin/templates/add-ons', {
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      key: 'ski_rack',
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+      description: null,
+      status: 'ACTIVE',
+    })
+    expect(body.data.id).toEqual(expect.any(String))
+  })
+
+  it('rejects an operator owner with 403 (requirePlatformAdmin)', async () => {
+    const app = mountWrite('OPERATOR_OWNER', 'op_1')
+    const res = await post(app, '/admin/templates/add-ons', { name: { en: 'Ski rack' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('409s a duplicate name (same derived key)', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    await post(app, '/admin/templates/add-ons', { name: { en: 'Ski rack' } })
+
+    const res = await post(app, '/admin/templates/add-ons', { name: { en: 'Ski rack' } })
+    expect(res.status).toBe(409)
+  })
+
+  it('400s a body with no name', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await post(app, '/admin/templates/add-ons', { description: { en: 'orphan' } })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('POST /admin/templates/insurance', () => {
+  it('mints an insurance template for a platform admin (201)', async () => {
+    const app = mountWrite('PLATFORM_ADMIN')
+    const res = await post(app, '/admin/templates/insurance', {
+      name: { en: 'Premium cover' },
+      description: { en: 'Zero deductible' },
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      key: 'premium_cover',
+      description: { en: 'Zero deductible' },
+      status: 'ACTIVE',
+    })
+  })
+
+  it('rejects a renter with 403', async () => {
+    const app = mountWrite('RENTER')
+    const res = await post(app, '/admin/templates/insurance', { name: { en: 'Premium cover' } })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/shared/src/types/template-admin.test.ts
+++ b/packages/shared/src/types/template-admin.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { templateCreateSchema } from './template-admin'
+
+describe('templateCreateSchema', () => {
+  it('defaults description to null and status to ACTIVE when omitted', () => {
+    const parsed = templateCreateSchema.parse({ name: { en: 'Baby seat' } })
+
+    expect(parsed).toEqual({
+      name: { en: 'Baby seat' },
+      description: null,
+      status: 'ACTIVE',
+    })
+  })
+
+  it('keeps a provided description bundle and status', () => {
+    const parsed = templateCreateSchema.parse({
+      name: { en: 'Full cover', ja: '全補償' },
+      description: { en: 'Zero deductible' },
+      status: 'ARCHIVED',
+    })
+
+    expect(parsed.description).toEqual({ en: 'Zero deductible' })
+    expect(parsed.status).toBe('ARCHIVED')
+  })
+
+  it('rejects a name without the en fallback', () => {
+    const result = templateCreateSchema.safeParse({ name: { ja: 'ベビーシート' } })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/shared/src/types/template-admin.ts
+++ b/packages/shared/src/types/template-admin.ts
@@ -56,3 +56,20 @@ export const templatePatchSchema = z
   })
 
 export type TemplatePatch = z.infer<typeof templatePatchSchema>
+
+/**
+ * `POST /admin/templates/{add-ons,insurance}` body (#1319 slice 3). Unlike the
+ * patch, `name` is REQUIRED (a new template must carry its en fallback) and the
+ * client never sends `key` — the service derives it from `slugify(name.en)` so a
+ * seed key and an admin-created key follow the same rule (a duplicate key is a
+ * 409, the same seal the DB's `*_templates_key_unique` enforces). `description`
+ * defaults to null (no description) and `status` to ACTIVE (an admin curates
+ * intentionally; the ARCHIVED rows come from the backfill, not this path).
+ */
+export const templateCreateSchema = z.object({
+  name: localizedTextSchema,
+  description: localizedTextSchema.nullable().default(null),
+  status: z.enum(CATALOG_TEMPLATE_STATUSES).default('ACTIVE'),
+})
+
+export type TemplateCreate = z.infer<typeof templateCreateSchema>

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1445,7 +1445,8 @@
       "retry": "Retry",
       "action": {
         "edit": "Edit",
-        "editNamed": "Edit {name}"
+        "editNamed": "Edit {name}",
+        "create": "New template"
       },
       "edit": {
         "title": "Edit template",
@@ -1457,6 +1458,12 @@
         "save": "Save",
         "saving": "Saving…",
         "cancel": "Cancel"
+      },
+      "create": {
+        "title": "New template",
+        "description": "Add a template to the catalog. The English name is required; the key is generated from it.",
+        "submit": "Create",
+        "submitting": "Creating…"
       }
     },
     "featureFlags": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1445,7 +1445,8 @@
       "retry": "再試行",
       "action": {
         "edit": "編集",
-        "editNamed": "{name}を編集"
+        "editNamed": "{name}を編集",
+        "create": "新規テンプレート"
       },
       "edit": {
         "title": "テンプレートを編集",
@@ -1457,6 +1458,12 @@
         "save": "保存",
         "saving": "保存中…",
         "cancel": "キャンセル"
+      },
+      "create": {
+        "title": "新規テンプレート",
+        "description": "カタログにテンプレートを追加します。英語名は必須で、キーはそこから生成されます。",
+        "submit": "作成",
+        "submitting": "作成中…"
       }
     },
     "featureFlags": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1445,7 +1445,8 @@
       "retry": "重试",
       "action": {
         "edit": "编辑",
-        "editNamed": "编辑{name}"
+        "editNamed": "编辑{name}",
+        "create": "新建模板"
       },
       "edit": {
         "title": "编辑模板",
@@ -1457,6 +1458,12 @@
         "save": "保存",
         "saving": "保存中…",
         "cancel": "取消"
+      },
+      "create": {
+        "title": "新建模板",
+        "description": "向目录添加模板。英文名称为必填项，键将据此生成。",
+        "submit": "创建",
+        "submitting": "创建中…"
       }
     },
     "featureFlags": {

--- a/packages/web/src/vite/admin/template-library/TemplateCreateDialog.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateCreateDialog.tsx
@@ -8,34 +8,33 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { useSession } from '@/vite/session'
-import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 import { TemplateFormFields } from './TemplateFormFields'
-import { TEMPLATE_LIBRARY_QUERY_KEY, type TemplateCatalog, updateTemplate } from './api'
-import { type TemplateForm, buildTemplatePatch, formFromRow } from './patch-form'
+import { TEMPLATE_LIBRARY_QUERY_KEY, type TemplateCatalog, createTemplate } from './api'
+import { type TemplateForm, buildTemplateCreate, emptyTemplateForm } from './patch-form'
 
-interface TemplateEditDialogProps {
+interface TemplateCreateDialogProps {
   readonly catalog: TemplateCatalog
-  readonly row: TemplateAdminRow | null
+  readonly open: boolean
   readonly onOpenChange: (open: boolean) => void
 }
 
 /**
- * Curate one template (#1319 slice 2). Self-contained like the operator dialogs:
- * owns the CSRF token, the mutation, and the cache invalidation. A single Save
- * both translates the name/description bundles AND promotes/archives via the
- * status select — promoting a backfill-minted ARCHIVED, en-only row is: add ja/zh,
- * switch status to Active, Save. Keyed by row so the form resets per template.
+ * Mint a new template into the active catalog (#1319 slice 3). Self-contained
+ * like {@link TemplateEditDialog}: owns the CSRF token, the mutation, and the
+ * cache invalidation. Reuses {@link TemplateFormFields} so create + edit share
+ * one field layout. `key`ing the inner form by catalog + open resets it between
+ * opens; the server derives the `key` and 409s a duplicate (surfaced inline).
  */
-export function TemplateEditDialog({ catalog, row, onOpenChange }: TemplateEditDialogProps) {
+export function TemplateCreateDialog({ catalog, open, onOpenChange }: TemplateCreateDialogProps) {
   const t = useTranslations('admin.templateLibrary')
   const queryClient = useQueryClient()
   const csrfToken = useSession().data?.csrfToken ?? ''
 
   const { mutate, isPending, error } = useMutation({
-    mutationFn: updateTemplate,
+    mutationFn: createTemplate,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEMPLATE_LIBRARY_QUERY_KEY })
       onOpenChange(false)
@@ -43,27 +42,27 @@ export function TemplateEditDialog({ catalog, row, onOpenChange }: TemplateEditD
   })
 
   return (
-    <Dialog open={row !== null} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('edit.title')}</DialogTitle>
-          <DialogDescription>{t('edit.description')}</DialogDescription>
+          <DialogTitle>{t('create.title')}</DialogTitle>
+          <DialogDescription>{t('create.description')}</DialogDescription>
         </DialogHeader>
         {error && (
           <p className="px-1 text-destructive text-sm">
             {error instanceof Error ? error.message : String(error)}
           </p>
         )}
-        {row && (
-          <EditForm
-            key={row.id}
+        {open && (
+          <CreateForm
+            key={catalog}
             t={t}
-            row={row}
             isSubmitting={isPending}
             onCancel={() => onOpenChange(false)}
-            onSubmit={(form) =>
-              mutate({ catalog, id: row.id, patch: buildTemplatePatch(form), csrfToken })
-            }
+            onSubmit={(form) => {
+              const body = buildTemplateCreate(form)
+              if (body) mutate({ catalog, body, csrfToken })
+            }}
           />
         )}
       </DialogContent>
@@ -71,20 +70,18 @@ export function TemplateEditDialog({ catalog, row, onOpenChange }: TemplateEditD
   )
 }
 
-function EditForm({
+function CreateForm({
   t,
-  row,
   isSubmitting,
   onCancel,
   onSubmit,
 }: {
   readonly t: (key: string) => string
-  readonly row: TemplateAdminRow
   readonly isSubmitting: boolean
   readonly onCancel: () => void
   readonly onSubmit: (form: TemplateForm) => void
 }) {
-  const [form, setForm] = useState<TemplateForm>(() => formFromRow(row))
+  const [form, setForm] = useState<TemplateForm>(() => emptyTemplateForm())
   const nameMissing = form.name.en.trim() === ''
 
   return (
@@ -104,7 +101,7 @@ function EditForm({
           {t('edit.cancel')}
         </Button>
         <Button type="submit" disabled={isSubmitting || nameMissing}>
-          {isSubmitting ? t('edit.saving') : t('edit.save')}
+          {isSubmitting ? t('create.submitting') : t('create.submit')}
         </Button>
       </DialogFooter>
     </form>

--- a/packages/web/src/vite/admin/template-library/TemplateEditDialog.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateEditDialog.tsx
@@ -18,7 +18,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
 import { TEMPLATE_LIBRARY_QUERY_KEY, type TemplateCatalog, updateTemplate } from './api'
-import { type TemplateForm, buildTemplatePatch, formFromRow } from './patch-form'
+import {
+  type TemplateForm,
+  buildTemplatePatch,
+  formFromRow,
+  isCatalogTemplateStatus,
+} from './patch-form'
 
 interface TemplateEditDialogProps {
   readonly catalog: TemplateCatalog
@@ -118,12 +123,12 @@ function EditForm({
         <NativeSelect
           id="template-status"
           value={form.status}
-          onChange={(e) =>
-            setForm((prev) => ({
-              ...prev,
-              status: e.target.value as TemplateForm['status'],
-            }))
-          }
+          onChange={(e) => {
+            const { value } = e.target
+            if (isCatalogTemplateStatus(value)) {
+              setForm((prev) => ({ ...prev, status: value }))
+            }
+          }}
         >
           {CATALOG_TEMPLATE_STATUSES.map((status) => (
             <option key={status} value={status}>

--- a/packages/web/src/vite/admin/template-library/TemplateFormFields.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateFormFields.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/components/ui/label'
 import { NativeSelect } from '@/components/ui/native-select'
 import { CATALOG_TEMPLATE_STATUSES } from '@kuruma/shared/enums'
 import { SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import { useId } from 'react'
 import { type TemplateForm, isCatalogTemplateStatus } from './patch-form'
 
 type SetForm = (updater: (prev: TemplateForm) => TemplateForm) => void
@@ -23,6 +24,9 @@ export function TemplateFormFields({
   readonly form: TemplateForm
   readonly setForm: SetForm
 }) {
+  // Unique per mounted instance so the create + edit dialogs never collide on a
+  // shared DOM id / label binding (they render the same component).
+  const statusId = useId()
   return (
     <>
       <BundleFields
@@ -40,9 +44,9 @@ export function TemplateFormFields({
       />
 
       <div className="space-y-1.5">
-        <Label htmlFor="template-status">{t('edit.statusLabel')}</Label>
+        <Label htmlFor={statusId}>{t('edit.statusLabel')}</Label>
         <NativeSelect
-          id="template-status"
+          id={statusId}
           value={form.status}
           onChange={(e) => {
             const { value } = e.target

--- a/packages/web/src/vite/admin/template-library/TemplateFormFields.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateFormFields.tsx
@@ -1,0 +1,107 @@
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { NativeSelect } from '@/components/ui/native-select'
+import { CATALOG_TEMPLATE_STATUSES } from '@kuruma/shared/enums'
+import { SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import { type TemplateForm, isCatalogTemplateStatus } from './patch-form'
+
+type SetForm = (updater: (prev: TemplateForm) => TemplateForm) => void
+
+/**
+ * The shared body of the template create + edit forms (#1319): the two localized
+ * bundle field-groups (name / description) plus the status select. Both dialogs
+ * render this over their own `form`/`setForm` state and supply their own footer,
+ * so the field markup and a11y wiring live in one place. `t` is scoped to
+ * `admin.templateLibrary`; the labels reuse the slice-2 `edit.*` keys.
+ */
+export function TemplateFormFields({
+  t,
+  form,
+  setForm,
+}: {
+  readonly t: (key: string) => string
+  readonly form: TemplateForm
+  readonly setForm: SetForm
+}) {
+  return (
+    <>
+      <BundleFields
+        legend={t('edit.nameSection')}
+        field="name"
+        form={form}
+        setForm={setForm}
+        requireEn
+      />
+      <BundleFields
+        legend={t('edit.descriptionSection')}
+        field="description"
+        form={form}
+        setForm={setForm}
+      />
+
+      <div className="space-y-1.5">
+        <Label htmlFor="template-status">{t('edit.statusLabel')}</Label>
+        <NativeSelect
+          id="template-status"
+          value={form.status}
+          onChange={(e) => {
+            const { value } = e.target
+            if (isCatalogTemplateStatus(value)) {
+              setForm((prev) => ({ ...prev, status: value }))
+            }
+          }}
+        >
+          {CATALOG_TEMPLATE_STATUSES.map((status) => (
+            <option key={status} value={status}>
+              {status === 'ACTIVE' ? t('active') : t('archived')}
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
+    </>
+  )
+}
+
+/** Three locale inputs for one bundle field (`name` | `description`), each with
+ *  its own label so screen readers announce "Name (JA)" etc. */
+function BundleFields({
+  legend,
+  field,
+  form,
+  setForm,
+  requireEn = false,
+}: {
+  readonly legend: string
+  readonly field: 'name' | 'description'
+  readonly form: TemplateForm
+  readonly setForm: SetForm
+  readonly requireEn?: boolean
+}) {
+  return (
+    <fieldset className="space-y-1.5">
+      <legend className="font-medium text-sm">{legend}</legend>
+      <div className="grid gap-2 sm:grid-cols-3">
+        {SUPPORTED_LOCALES.map((locale) => (
+          <div key={locale} className="space-y-1">
+            <span aria-hidden className="block text-muted-foreground text-xs uppercase">
+              {locale}
+            </span>
+            <Input
+              // Unique accessible name per field+locale (e.g. "Name JA"); the
+              // visible locale chip above is aria-hidden to avoid a duplicate.
+              aria-label={`${legend} ${locale.toUpperCase()}`}
+              value={form[field][locale]}
+              required={requireEn && locale === 'en'}
+              onChange={(e) =>
+                setForm((prev) => ({
+                  ...prev,
+                  [field]: { ...prev[field], [locale]: e.target.value },
+                }))
+              }
+            />
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/packages/web/src/vite/admin/template-library/TemplateLibraryView.test.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateLibraryView.test.tsx
@@ -1,8 +1,8 @@
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../../messages/en.json'
 import { TemplateLibraryView } from './TemplateLibraryView'
 
@@ -101,5 +101,57 @@ describe('TemplateLibraryView edit dialog', () => {
 
     expect(screen.getByRole('heading', { name: 'Edit template' })).toBeInTheDocument()
     expect(screen.getByLabelText('Name EN')).toHaveValue('Baby seat')
+  })
+})
+
+describe('TemplateLibraryView create dialog', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('opens a blank create dialog and keeps Create disabled until the en name is filled', () => {
+    renderViewWithProviders()
+    expect(screen.queryByRole('heading', { name: 'New template' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New template' }))
+
+    expect(screen.getByRole('heading', { name: 'New template' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Name EN')).toHaveValue('')
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+  })
+
+  it('POSTs a new template to the active catalog when the form is submitted', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            id: 'n1',
+            key: 'ski_rack',
+            name: { en: 'Ski rack' },
+            description: null,
+            status: 'ACTIVE',
+          },
+        }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    renderViewWithProviders()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New template' }))
+    fireEvent.change(screen.getByLabelText('Name EN'), { target: { value: 'Ski rack' } })
+    const submit = screen.getByRole('button', { name: 'Create' })
+    expect(submit).not.toBeDisabled()
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    // Default tab is add-ons, so the create targets that catalog's collection.
+    expect(url).toContain('/admin/templates/add-ons')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf_1')
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      name: { en: 'Ski rack' },
+      description: null,
+      status: 'ACTIVE',
+    })
   })
 })

--- a/packages/web/src/vite/admin/template-library/TemplateLibraryView.tsx
+++ b/packages/web/src/vite/admin/template-library/TemplateLibraryView.tsx
@@ -1,7 +1,9 @@
+import { Button } from '@/components/ui/button'
 import { SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { useState } from 'react'
 import { useTranslations } from 'use-intl'
+import { TemplateCreateDialog } from './TemplateCreateDialog'
 import { TemplateEditDialog } from './TemplateEditDialog'
 import type { TemplateCatalog } from './api'
 
@@ -29,6 +31,7 @@ interface TemplateLibraryViewProps {
 export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewProps) {
   const t = useTranslations('admin.templateLibrary')
   const [tab, setTab] = useState<CatalogKey>('addOns')
+  const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<{
     catalog: TemplateCatalog
     row: TemplateAdminRow
@@ -44,18 +47,23 @@ export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewPr
         <p className="mt-1 text-muted-foreground text-sm">{t('subtitle')}</p>
       </div>
 
-      <div className="flex gap-1 rounded-lg border border-border p-1 w-fit">
-        {CATALOGS.map((c) => (
-          <button
-            key={c}
-            type="button"
-            onClick={() => setTab(c)}
-            aria-pressed={tab === c}
-            className="rounded-md px-3 py-1.5 font-medium text-sm transition-colors aria-pressed:bg-muted aria-[pressed=false]:text-muted-foreground aria-[pressed=false]:hover:bg-muted/50"
-          >
-            {t(`tab.${c}`, { count: rowsByTab[c].length })}
-          </button>
-        ))}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-1 rounded-lg border border-border p-1 w-fit">
+          {CATALOGS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setTab(c)}
+              aria-pressed={tab === c}
+              className="rounded-md px-3 py-1.5 font-medium text-sm transition-colors aria-pressed:bg-muted aria-[pressed=false]:text-muted-foreground aria-[pressed=false]:hover:bg-muted/50"
+            >
+              {t(`tab.${c}`, { count: rowsByTab[c].length })}
+            </button>
+          ))}
+        </div>
+        <Button type="button" size="sm" onClick={() => setCreating(true)}>
+          {t('action.create')}
+        </Button>
       </div>
 
       <div className="overflow-x-auto rounded-xl border border-border">
@@ -117,6 +125,10 @@ export function TemplateLibraryView({ addOns, insurance }: TemplateLibraryViewPr
           </tbody>
         </table>
       </div>
+
+      {creating && (
+        <TemplateCreateDialog catalog={CATALOG_PATH[tab]} open onOpenChange={setCreating} />
+      )}
 
       {editing && (
         <TemplateEditDialog

--- a/packages/web/src/vite/admin/template-library/api.test.ts
+++ b/packages/web/src/vite/admin/template-library/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchTemplateLibrary, updateTemplate } from './api'
+import { createTemplate, fetchTemplateLibrary, updateTemplate } from './api'
 
 const BODY = {
   success: true,
@@ -105,6 +105,65 @@ describe('updateTemplate', () => {
         catalog: 'insurance',
         id: 'i1',
         patch: { status: 'ARCHIVED' },
+        csrfToken: 'x',
+      }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('createTemplate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs the catalog collection with the CSRF header and returns the minted row', async () => {
+    const mintedRow = {
+      id: 'new1',
+      key: 'ski_rack',
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+      description: null,
+      status: 'ACTIVE',
+    }
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: mintedRow }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await createTemplate({
+      catalog: 'add-ons',
+      body: { name: { en: 'Ski rack', ja: 'スキーラック' }, description: null, status: 'ACTIVE' },
+      csrfToken: 'csrf_1',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/admin/templates/add-ons')
+    expect(url.endsWith('/add-ons')).toBe(true)
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect((init.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf_1')
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+      description: null,
+      status: 'ACTIVE',
+    })
+    expect(result).toEqual(mintedRow)
+  })
+
+  it('rejects when the API 409s a duplicate key', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ success: false, error: 'a template with key "ski_rack" already exists' }),
+        {
+          status: 409,
+        },
+      ),
+    )
+    await expect(
+      createTemplate({
+        catalog: 'add-ons',
+        body: { name: { en: 'Ski rack' }, description: null, status: 'ACTIVE' },
         csrfToken: 'x',
       }),
     ).rejects.toThrow()

--- a/packages/web/src/vite/admin/template-library/api.ts
+++ b/packages/web/src/vite/admin/template-library/api.ts
@@ -2,6 +2,7 @@ import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import {
   type TemplateAdminRow,
+  type TemplateCreate,
   type TemplateLibraryResponse,
   type TemplatePatch,
   templateAdminRowSchema,
@@ -51,5 +52,24 @@ export async function updateTemplate(params: {
       body: JSON.stringify(patch),
     },
   )
+  return unwrap(res, templateAdminRowSchema)
+}
+
+// Platform-admin template CREATE (#1319 slice 3). Cookie-authenticated + CSRF-gated
+// like the PATCH. The client never sends `key` — the server derives it from
+// slugify(name.en) and 409s a duplicate. Returns the minted raw row; the caller
+// invalidates TEMPLATE_LIBRARY_QUERY_KEY to refetch the table.
+export async function createTemplate(params: {
+  catalog: TemplateCatalog
+  body: TemplateCreate
+  csrfToken: string
+}): Promise<TemplateAdminRow> {
+  const { catalog, body, csrfToken } = params
+  const res = await fetch(`${getApiBaseUrl()}/admin/templates/${catalog}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify(body),
+  })
   return unwrap(res, templateAdminRowSchema)
 }

--- a/packages/web/src/vite/admin/template-library/patch-form.test.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.test.ts
@@ -1,6 +1,12 @@
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { describe, expect, it } from 'vitest'
-import { buildTemplatePatch, formFromRow, isCatalogTemplateStatus } from './patch-form'
+import {
+  buildTemplateCreate,
+  buildTemplatePatch,
+  emptyTemplateForm,
+  formFromRow,
+  isCatalogTemplateStatus,
+} from './patch-form'
 
 describe('isCatalogTemplateStatus', () => {
   it('accepts the catalog statuses and rejects anything else', () => {
@@ -59,5 +65,52 @@ describe('buildTemplatePatch', () => {
     })
 
     expect(patch.description).toEqual({ en: 'Zero deductible', zh: '全额' })
+  })
+})
+
+describe('emptyTemplateForm', () => {
+  it('seeds every locale blank and defaults status to ACTIVE', () => {
+    expect(emptyTemplateForm()).toEqual({
+      name: { en: '', ja: '', zh: '' },
+      description: { en: '', ja: '', zh: '' },
+      status: 'ACTIVE',
+    })
+  })
+})
+
+describe('buildTemplateCreate', () => {
+  it('assembles the required name bundle, description, and status, trimming', () => {
+    const body = buildTemplateCreate({
+      name: { en: '  Ski rack ', ja: 'スキーラック', zh: '' },
+      description: { en: 'Roof-mounted', ja: '', zh: '' },
+      status: 'ACTIVE',
+    })
+
+    expect(body).toEqual({
+      name: { en: 'Ski rack', ja: 'スキーラック' },
+      description: { en: 'Roof-mounted' },
+      status: 'ACTIVE',
+    })
+  })
+
+  it('sends a null description when its en field is blank', () => {
+    const body = buildTemplateCreate({
+      name: { en: 'Ski rack', ja: '', zh: '' },
+      description: { en: '', ja: 'ignored', zh: '' },
+      status: 'ARCHIVED',
+    })
+
+    expect(body?.description).toBeNull()
+    expect(body?.status).toBe('ARCHIVED')
+  })
+
+  it('returns null when the required en name is blank (submit stays disabled)', () => {
+    const body = buildTemplateCreate({
+      name: { en: '   ', ja: 'スキーラック', zh: '' },
+      description: { en: '', ja: '', zh: '' },
+      status: 'ACTIVE',
+    })
+
+    expect(body).toBeNull()
   })
 })

--- a/packages/web/src/vite/admin/template-library/patch-form.test.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.test.ts
@@ -1,6 +1,15 @@
 import type { TemplateAdminRow } from '@kuruma/shared/types/template-admin'
 import { describe, expect, it } from 'vitest'
-import { buildTemplatePatch, formFromRow } from './patch-form'
+import { buildTemplatePatch, formFromRow, isCatalogTemplateStatus } from './patch-form'
+
+describe('isCatalogTemplateStatus', () => {
+  it('accepts the catalog statuses and rejects anything else', () => {
+    expect(isCatalogTemplateStatus('ACTIVE')).toBe(true)
+    expect(isCatalogTemplateStatus('ARCHIVED')).toBe(true)
+    expect(isCatalogTemplateStatus('DRAFT')).toBe(false)
+    expect(isCatalogTemplateStatus('')).toBe(false)
+  })
+})
 
 describe('formFromRow', () => {
   it('spreads each locale into its own field, blanking absent locales and a null description', () => {

--- a/packages/web/src/vite/admin/template-library/patch-form.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.ts
@@ -1,4 +1,4 @@
-import type { CatalogTemplateStatus } from '@kuruma/shared/enums'
+import { CATALOG_TEMPLATE_STATUSES, type CatalogTemplateStatus } from '@kuruma/shared/enums'
 import type { Locale } from '@kuruma/shared/i18n/locales'
 import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
 import type { TemplateAdminRow, TemplatePatch } from '@kuruma/shared/types/template-admin'
@@ -11,6 +11,13 @@ export interface TemplateForm {
   name: BundleForm
   description: BundleForm
   status: CatalogTemplateStatus
+}
+
+/** Narrow a raw `<select>` value to a catalog status. The options are exactly
+ *  CATALOG_TEMPLATE_STATUSES so an unknown value never arises in practice — this
+ *  keeps the onChange handler assertion-free (type guard over `as`). */
+export function isCatalogTemplateStatus(value: string): value is CatalogTemplateStatus {
+  return (CATALOG_TEMPLATE_STATUSES as readonly string[]).includes(value)
 }
 
 function bundleToForm(bundle: LocalizedText | null): BundleForm {

--- a/packages/web/src/vite/admin/template-library/patch-form.ts
+++ b/packages/web/src/vite/admin/template-library/patch-form.ts
@@ -1,7 +1,11 @@
 import { CATALOG_TEMPLATE_STATUSES, type CatalogTemplateStatus } from '@kuruma/shared/enums'
 import type { Locale } from '@kuruma/shared/i18n/locales'
 import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
-import type { TemplateAdminRow, TemplatePatch } from '@kuruma/shared/types/template-admin'
+import type {
+  TemplateAdminRow,
+  TemplateCreate,
+  TemplatePatch,
+} from '@kuruma/shared/types/template-admin'
 
 /** One text field per supported locale (always a string, never undefined — a
  *  controlled input's value). Absent bundle locales render as empty strings. */
@@ -34,6 +38,17 @@ export function formFromRow(row: TemplateAdminRow): TemplateForm {
   }
 }
 
+/** Seed a blank create form (#1319 slice 3): every locale empty, status ACTIVE
+ *  (an admin-created template is intentionally live; the ARCHIVED rows come from
+ *  the backfill). Pure; the create dialog owns the mutable copy. */
+export function emptyTemplateForm(): TemplateForm {
+  return {
+    name: { en: '', ja: '', zh: '' },
+    description: { en: '', ja: '', zh: '' },
+    status: 'ACTIVE',
+  }
+}
+
 /**
  * Collapse a bundle form into a `LocalizedText`, or null when en is blank.
  * `en` is the required fallback (`localizedTextSchema`): with no en there is no
@@ -63,4 +78,17 @@ export function buildTemplatePatch(form: TemplateForm): TemplatePatch {
     description: toBundle(form.description),
     status: form.status,
   }
+}
+
+/**
+ * Build the `POST` body from the create form (#1319 slice 3). Unlike the patch,
+ * `name` is REQUIRED — so this returns null when the en name is blank (the Create
+ * button stays disabled in that state; null is the defensive belt). `description`
+ * rides as its bundle or explicit null (a blank en clears it), and `status` is
+ * whatever the form selected (defaults ACTIVE via {@link emptyTemplateForm}).
+ */
+export function buildTemplateCreate(form: TemplateForm): TemplateCreate | null {
+  const name = toBundle(form.name)
+  if (!name) return null
+  return { name, description: toBundle(form.description), status: form.status }
 }


### PR DESCRIPTION
## What

Slice 3a of the platform-admin template library (#1319): **create** a new add-on or insurance template from the admin UI. Splits the issue's "create + merge synonyms" scope — merge synonyms is the heavier follow-up (slice 3b) because it needs the insurance-`templateId` FK wired through the API layer plus a transactional per-operator repoint.

Also folds two LOW findings from review (a slice-2 carry-over + one introduced here).

## Changes

**API**
- `templateCreateSchema` (`@kuruma/shared`): `name` required (en-enforced `localizedTextSchema`); the client never sends `key` — the service derives it from `slugify(name.en)` so an admin-created key follows the same rule as a seed/backfill key; `description` defaults null, `status` defaults ACTIVE.
- `create()` on both template repo interfaces + drizzle (`INSERT ... RETURNING`) + in-memory (23505-parity double).
- `TemplateLibraryService.createAddOn/createInsurance`, gated `requirePlatformAdmin` **before** any write, mapping the key-unique `23505` to a **409 ConflictError** (never a 500; concurrent-insert race collapses into the same 409).
- `POST /admin/templates/{add-ons,insurance}` → 201.

**Web**
- A "New template" action on the library tab bar opens a catalog-aware `TemplateCreateDialog`.
- Extracted the shared name/description/status form body into `TemplateFormFields` (reused by the edit + create dialogs); pure `emptyTemplateForm` / `buildTemplateCreate` helpers; `createTemplate` client (POST, CSRF).
- `create.*` + `action.create` i18n keys with en/ja/zh parity.

**Folded LOWs**
- Replaced an `as TemplateForm['status']` cast with an `isCatalogTemplateStatus` type guard.
- `useId()` for the shared status-select id so create + edit dialogs can't collide on a DOM id.

## Testing

- TDD throughout: shared schema, service (create + conflict + authz), route (201/403/409/400), real-PG integration (`insert` + duplicate-key 23505 driver parity), pure web helpers, api client, and view create-flow (blank → disabled → POST).
- Full suites green: **api 2697, web 1957, shared 904**; api + web `tsc` clean; boundaries / size / module lints exit 0; i18n 34-key parity verified.
- No DB migration (create uses existing columns).

## Review

code-reviewer: **SHIP** — no CRITICAL/HIGH/MEDIUM. The two remaining LOWs (untranslated 409 message, `t` prop typing) are pre-existing slice-2 patterns kept for cross-dialog consistency.

Refs #1319. (Merge synonyms = slice 3b will `Closes #1319`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)