### PR TITLE
Bind picker-admin manual booking to the picked operator (#1260 slice 3)

### DIFF
--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -210,6 +210,11 @@ export function createBookingRoutes(service: BookingService, consentGate: Consen
         idempotencyKey: parsed.data.idempotencyKey ?? null,
         disclaimerAccepted: parsed.data.disclaimerAccepted ?? false,
       }
+      // #1260: a picker admin (PLATFORM_ADMIN) binds the manual booking to the
+      // operator it chose via ?operatorId=; tenant operators ignore it (their read
+      // scope clamps them). The service requires it for a bypass-admin create and
+      // scopes both the customer and the vehicle/inventory to that operator.
+      const actingOperatorId = c.req.query('operatorId')
       const createResult = await service.create(
         ctx,
         parsed.data.fulfillmentMode === 'CLASS_COMBO'
@@ -219,6 +224,8 @@ export function createBookingRoutes(service: BookingService, consentGate: Consen
               fulfillmentMode: 'SPECIFIC',
               requestedVehicleId: parsed.data.requestedVehicleId,
             },
+        undefined,
+        actingOperatorId,
       )
 
       if (!createResult.ok) {

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -60,7 +60,11 @@ export function createCustomerRoutes(service: CustomerService) {
       if (!q || q.length < 2) {
         return fail(c, 'Search query must be at least 2 characters', 400)
       }
-      const customers = await service.search(q, ctx)
+      // #1260: a picker admin (PLATFORM_ADMIN) scopes the manual-booking search to
+      // the operator it is acting as; without a pick it keeps the full-directory
+      // search. A tenant operator's own scope is unaffected (the service ignores it).
+      const actingOperatorId = c.req.query('operatorId')
+      const customers = await service.search(q, ctx, actingOperatorId)
       return ok(c, customers)
     })
     .post('/customers/quick-create', async (c) => {

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -275,9 +275,12 @@ export class BookingCreationService {
       }
     }
     const operatorId = vehicle.operatorId
-    // #1260: bind the booked vehicle to the picked operator, else a bypass admin
-    // could book ANY operator's car by raw id (the read is SYSTEM_CONTEXT). 404 = no
-    // oracle; tenant operators are unaffected (only the bypass `all` tier is bound).
+    // #1260: bind the booked vehicle to the picked operator — the read above is
+    // SYSTEM_CONTEXT (unscoped), so a bypass admin could otherwise book ANY
+    // operator's car by raw id. 404 (via fleetWriteDenialResult) reveals no more than
+    // the admin already sees. This binds ONLY the bypass `all` tier; the operator
+    // tier is deliberately left unbound here — a tenant operator booking a foreign
+    // operator's car is a separate, pre-existing gap tracked in #1417.
     const inventoryDenial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
     if (inventoryDenial) return fleetWriteDenialResult(inventoryDenial, 'Vehicle not found')
     const operatorBlock = await rejectIfOperatorDeactivated(repos, operatorId)
@@ -480,7 +483,8 @@ export class BookingCreationService {
       return { ok: false, status: 400, error: 'Pickup location is not available' }
     }
     const operatorId = pickup.operatorId
-    // #1260: bind the combo's pickup/inventory operator (mirrors the SPECIFIC path).
+    // #1260: bind the combo's pickup/inventory operator (mirrors the SPECIFIC path);
+    // bypass tier only, operator tier deferred to #1417.
     const inventoryDenial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
     if (inventoryDenial)
       return fleetWriteDenialResult(inventoryDenial, 'Pickup location is not available')

--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -2,17 +2,16 @@ import type { AddOnSnapshot, InsuranceSnapshot } from '@kuruma/shared/db/schema'
 import { isRoadLegal, jstDateString } from '@kuruma/shared/lib/compliance'
 import { calculateBookingPrice } from '@kuruma/shared/lib/pricing'
 import { checkRentalRules } from '@kuruma/shared/lib/rental-rules'
-import { isOperatorRole } from '../auth/roles'
 import { generateBookingCode } from '../lib/booking-code'
 import { type CallerContext, SYSTEM_CONTEXT } from '../middleware/auth'
 import { BOOKING_CODE_CONSTRAINT, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
-import type {
-  BookingRepository,
-  RunInTransaction,
-  TransactionRepos,
-  UserRepository,
-} from '../repositories/types'
+import type { BookingRepository, RunInTransaction, TransactionRepos } from '../repositories/types'
 import type { Location, Vehicle } from '../stores'
+import {
+  assertBookingWriteWithinOperator,
+  bookingReadScope,
+  fleetWriteDenialResult,
+} from '../tenancy'
 import { resolveBookingActor } from './booking-actor'
 import { rejectIfOperatorDeactivated } from './booking-creation-operator-guard'
 import type { BookingPostCommitDispatcher } from './booking-post-commit-dispatcher'
@@ -46,7 +45,6 @@ export class BookingCreationService {
   constructor(
     private readonly bookingRepo: BookingRepository,
     private readonly runInTransaction: RunInTransaction,
-    private readonly userRepo?: UserRepository,
     // Single post-commit seam (#393, TODO #300): ensureThread + notifications,
     // each caught-and-logged. Replaces the inline ensureThread calls.
     // Optional is a TEST-ONLY seam: prod always wires it (createApp/index.ts);
@@ -63,6 +61,9 @@ export class BookingCreationService {
     ctx: CallerContext,
     rawInput: CreateBookingRequest,
     now: Date = new Date(),
+    // #1260: the operator a bypass admin acts as (?operatorId=), binding both the
+    // customer scope (below) and the inventory (submitInTx). Operators ignore it.
+    actingOperatorId?: string,
   ): Promise<CreateBookingResult> {
     // #1108 (audit M4): resolve the actor (renter / source / walk-in) from the
     // caller's role HERE — the route forwards raw input and no longer rewrites it.
@@ -81,44 +82,19 @@ export class BookingCreationService {
         }
       : { ...rawRest, renterId: actor.renterId, source: actor.source }
 
-    // Resolve the booking's renter (#314, #589). Three cases:
-    //  - WALK-IN (1c): the operator registers a brand-new customer inline.
-    //    createWalkInRenter ALWAYS makes a fresh renter (never deduped by phone),
-    //    so a booking can't be attached to — nor the existence probed of — another
-    //    tenant's customer (#396/#475). The walk-in IS the authorization, so it
-    //    skips the scope check. renterId stays null here: submitInTx creates the
-    //    renter INSIDE the booking tx (#875), so a failed booking (409 double-book /
-    //    exhausted code-retries) rolls it back — no orphan customer — and the
-    //    idempotent replay below short-circuits before ever minting one.
-    //  - EXISTING renter (1b): operator authz is scope-FIRST — membership IS the
-    //    authorization + existence check; any out-of-scope id returns a uniform
-    //    403 WITHOUT touching the user table (no enumeration oracle). Staff/bypass
-    //    keep the exists+role probe (FK failures => friendly 400, not 500).
+    // Resolve the booking's renter (#314, #589):
+    //  - WALK-IN (1c): a fresh customer minted INSIDE the tx (#875) — the walk-in
+    //    IS the authorization, so it skips the customer scope check (its inventory
+    //    is still bound in submitInTx). renterId stays null; submitInTx mints it,
+    //    so a failed booking rolls it back and an idempotent replay never mints one.
+    //  - EXISTING renter (1b): scope-first membership (assertRenterWithinScope).
     //  - SELF: renterId === ctx.userId (renter self-serve).
     let renterId: string | null = null
     if (!input.walkInCustomer) {
       renterId = input.renterId
       if (renterId !== ctx.userId) {
-        if (isOperatorRole(ctx.role)) {
-          const scoped = ctx.operatorId
-            ? await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId)
-            : []
-          if (!scoped.includes(renterId)) {
-            return {
-              ok: false,
-              status: 403,
-              error: 'Cannot book for a renter outside your customers',
-            }
-          }
-        } else if (this.userRepo) {
-          const [renter] = await this.userRepo.findByIds([renterId])
-          if (!renter) {
-            return { ok: false, status: 400, error: 'Renter not found' }
-          }
-          if ((renter.role ?? 'RENTER') !== 'RENTER') {
-            return { ok: false, status: 400, error: 'Target user is not a renter' }
-          }
-        }
+        const denial = await this.assertRenterWithinScope(ctx, renterId, actingOperatorId)
+        if (denial) return denial
       }
     }
 
@@ -151,7 +127,7 @@ export class BookingCreationService {
     for (let attempt = 0; attempt < MAX_BOOKING_CODE_ATTEMPTS; attempt++) {
       try {
         const result = await this.runInTransaction((repos) =>
-          this.submitInTx(ctx, input, renterId, now, repos),
+          this.submitInTx(ctx, input, renterId, now, repos, actingOperatorId),
         )
         if (!result.ok) return result // domain validation failure — never retried
         // Post-commit side effects (#335 thread + #393 notifications) — never in
@@ -187,6 +163,44 @@ export class BookingCreationService {
     }
     // Exhausted the bounded retries — surface as a 500 at the route boundary.
     throw lastErr
+  }
+
+  // #1260: bind "book on behalf of an EXISTING renter" to an operator's customer
+  // set — membership (a prior booking with it) IS the authorization + existence
+  // check, so an out-of-scope id is a uniform 403 with no user-table probe
+  // (#396/#475). A tenant operator uses its own tenant (a stray actingOperatorId is
+  // ignored); a bypass admin (`all`, PLATFORM_ADMIN via the picker) must name the
+  // operator it acts as (422) and may attach only its customers. Keyed on
+  // bookingReadScope so only the true bypass tier is `all` (renters/partners never
+  // reach here — resolveBookingActor forces their renterId to self); `none` (an
+  // operator missing its operatorId) falls through to the empty-set 403 (fail closed).
+  private async assertRenterWithinScope(
+    ctx: CallerContext,
+    renterId: string,
+    actingOperatorId: string | undefined,
+  ): Promise<Extract<CreateBookingResult, { ok: false }> | null> {
+    const scope = bookingReadScope(ctx)
+    const customerOperatorId =
+      scope.kind === 'operator'
+        ? scope.operatorId
+        : scope.kind === 'all'
+          ? actingOperatorId
+          : undefined
+    if (scope.kind === 'all' && !customerOperatorId) {
+      return {
+        ok: false,
+        status: 422,
+        error: 'operatorId is required: specify the operator to act as',
+        code: 'OPERATOR_REQUIRED',
+      }
+    }
+    const customers = customerOperatorId
+      ? await this.bookingRepo.listRenterIdsForOperator(customerOperatorId)
+      : []
+    if (!customers.includes(renterId)) {
+      return { ok: false, status: 403, error: 'Cannot book for a renter outside your customers' }
+    }
+    return null
   }
 
   // Single seam for `effectiveEndAt`: both submit paths derive it from the DROPOFF
@@ -230,9 +244,12 @@ export class BookingCreationService {
     renterId: string | null,
     now: Date,
     repos: TransactionRepos,
+    // #1260: the operator a bypass admin is acting as; the booking's inventory is
+    // bound to it below. Undefined for tenant operators (already tenant-clamped).
+    actingOperatorId: string | undefined,
   ): Promise<CreateBookingResult> {
     if (input.fulfillmentMode === 'CLASS_COMBO') {
-      return this.submitComboInTx(ctx, input, renterId, now, repos)
+      return this.submitComboInTx(ctx, input, renterId, now, repos, actingOperatorId)
     }
     const vehicle = await repos.vehicleRepo.findById(SYSTEM_CONTEXT, input.requestedVehicleId)
     if (!vehicle) {
@@ -258,6 +275,11 @@ export class BookingCreationService {
       }
     }
     const operatorId = vehicle.operatorId
+    // #1260: bind the booked vehicle to the picked operator, else a bypass admin
+    // could book ANY operator's car by raw id (the read is SYSTEM_CONTEXT). 404 = no
+    // oracle; tenant operators are unaffected (only the bypass `all` tier is bound).
+    const inventoryDenial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
+    if (inventoryDenial) return fleetWriteDenialResult(inventoryDenial, 'Vehicle not found')
     const operatorBlock = await rejectIfOperatorDeactivated(repos, operatorId)
     if (operatorBlock) return operatorBlock
     const classId = vehicle.classId
@@ -447,6 +469,8 @@ export class BookingCreationService {
     renterId: string | null,
     now: Date,
     repos: TransactionRepos,
+    // #1260: the operator a bypass admin is acting as (bind the combo's inventory).
+    actingOperatorId: string | undefined,
   ): Promise<CreateBookingResult> {
     // The pickup location anchors the booking's operator + the (op, class, loc)
     // triple every other read keys off (a forged classId from another tenant
@@ -456,6 +480,10 @@ export class BookingCreationService {
       return { ok: false, status: 400, error: 'Pickup location is not available' }
     }
     const operatorId = pickup.operatorId
+    // #1260: bind the combo's pickup/inventory operator (mirrors the SPECIFIC path).
+    const inventoryDenial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
+    if (inventoryDenial)
+      return fleetWriteDenialResult(inventoryDenial, 'Pickup location is not available')
     const operatorBlock = await rejectIfOperatorDeactivated(repos, operatorId)
     if (operatorBlock) return operatorBlock
     const classId = input.classId

--- a/packages/api/src/services/booking-types.ts
+++ b/packages/api/src/services/booking-types.ts
@@ -63,7 +63,10 @@ export type CreateBookingResult =
   | { ok: true; booking: Booking; status?: 200 }
   | {
       ok: false
-      status: 400 | 403 | 409
+      // #1260 widened the union: 422 (a bypass admin named no operator to act as)
+      // and 404 (the picked operator does not own the booked vehicle — no oracle,
+      // via fleetWriteDenialResult) join the pre-existing create failures.
+      status: 400 | 403 | 404 | 409 | 422
       error: string | Record<string, string[]>
       code?: ErrorCode
       details?: { required: number; actual: number }

--- a/packages/api/src/services/booking.ts
+++ b/packages/api/src/services/booking.ts
@@ -91,7 +91,6 @@ export class BookingService {
     this.creation = new BookingCreationService(
       bookingRepo,
       runInTransaction,
-      userRepo,
       postCommit,
       generateCode,
       verificationGate,
@@ -165,8 +164,11 @@ export class BookingService {
     ctx: CallerContext,
     input: CreateBookingRequest,
     now: Date = new Date(),
+    // #1260: the operator a bypass admin is acting as (?operatorId=). Bound to the
+    // booking's customer + inventory in BookingCreationService; forwarded verbatim.
+    actingOperatorId?: string,
   ): Promise<CreateBookingResult> {
-    return this.creation.create(ctx, input, now)
+    return this.creation.create(ctx, input, now, actingOperatorId)
   }
 
   // --- lifecycle -----------------------------------------------------------

--- a/packages/api/src/services/customer.ts
+++ b/packages/api/src/services/customer.ts
@@ -56,23 +56,33 @@ export class CustomerService {
     return this.customerRepo.findByIdWithBookings(id)
   }
 
-  async search(query: string, ctx: CallerContext): Promise<User[]> {
+  async search(query: string, ctx: CallerContext, actingOperatorId?: string): Promise<User[]> {
     const matches = await this.userRepo.search(query)
     // Only the privileged platform tier searches the full user table. Gated on
     // PRIVILEGED_ROLES (PLATFORM_ADMIN-only since #1168), NOT the coarse
     // `bypassScope` flag — that also carries PARTNER, which must never enumerate
     // the cross-tenant directory. The route already 403s PARTNER (#1116); this is
     // the service-layer seal (defense-in-depth, mirrors #1119).
-    if (PRIVILEGED_ROLES.has(ctx.role)) return matches
+    // #1260: when that admin is acting through the operator picker (?operatorId=),
+    // its manual-booking search scopes to the picked operator's customers so it can
+    // only offer renters it can actually book (the create-time customer scope would
+    // otherwise 403 a foreign pick). No pick -> full directory (admin screen).
+    if (PRIVILEGED_ROLES.has(ctx.role)) {
+      return actingOperatorId ? this.scopeToOperatorCustomers(matches, actingOperatorId) : matches
+    }
     // An operator only resolves renters within its own tenant boundary — those
     // with a prior booking with it — so manual-booking can't enumerate the global
     // user table (#396/#475). Fail closed if somehow operator-less.
     if (!ctx.operatorId) return []
-    const allowed = new Set(await this.bookingRepo.listRenterIdsForOperator(ctx.operatorId))
-    // NOTE (MVP): userRepo.search caps at 20 by text first, so for an operator
-    // with a very large customer base an in-scope name past that cap could be
-    // missed. Fine for the picker at MVP scale; push the operator filter into the
-    // query if it ever bites.
+    return this.scopeToOperatorCustomers(matches, ctx.operatorId)
+  }
+
+  // Narrow a user-search result to an operator's own customers — those with a prior
+  // booking with it (listRenterIdsForOperator). NOTE (MVP): userRepo.search caps at
+  // 20 by text first, so an in-scope name past that cap could be missed for a very
+  // large customer base; fine for the picker at MVP scale.
+  private async scopeToOperatorCustomers(matches: User[], operatorId: string): Promise<User[]> {
+    const allowed = new Set(await this.bookingRepo.listRenterIdsForOperator(operatorId))
     return matches.filter((u) => allowed.has(u.id))
   }
 

--- a/packages/api/tests/integration/booking-class-combo.test.ts
+++ b/packages/api/tests/integration/booking-class-combo.test.ts
@@ -174,7 +174,9 @@ describe('CLASS_COMBO submit serialization (real pg, #464 slice 2d.5)', () => {
 
     const responses = await Promise.all(
       Array.from({ length: 3 }, () =>
-        app.request('/bookings', {
+        // #1260: the app is a PLATFORM_ADMIN, so the create binds to the operator
+        // it acts as via ?operatorId= (here the booking's own operator).
+        app.request(`/bookings?operatorId=${BEST_CAR_RENTAL_OPERATOR_ID}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -220,7 +222,8 @@ describe('CLASS_COMBO submit serialization (real pg, #464 slice 2d.5)', () => {
     const raceStart = new Date('2027-10-01T09:00:00Z')
     const raceEnd = new Date('2027-10-02T09:00:00Z')
     const post = (body: object) =>
-      app.request('/bookings', {
+      // #1260: PLATFORM_ADMIN app binds the create to the acting operator.
+      app.request(`/bookings?operatorId=${BEST_CAR_RENTAL_OPERATOR_ID}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -84,8 +84,11 @@ function validBookingInput(overrides: Record<string, unknown> = {}) {
   }
 }
 
+// The default app is a PLATFORM_ADMIN (bypassScope). #1260 binds every booking
+// write to the operator the admin acts as, so a create must name it via
+// ?operatorId= — exactly as the status/cancel calls in this file already do.
 async function createBooking(input: Record<string, unknown> = validBookingInput()) {
-  return app.request('/bookings', {
+  return app.request(`/bookings?operatorId=${OPERATOR}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
@@ -681,7 +684,7 @@ describe('Booking Routes', () => {
     async function createNBookings(n: number) {
       const ids: string[] = []
       for (let i = 0; i < n; i++) {
-        const res = await app.request('/bookings', {
+        const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(

--- a/packages/api/tests/routes/customers.test.ts
+++ b/packages/api/tests/routes/customers.test.ts
@@ -375,6 +375,24 @@ describe('GET /customers/search', () => {
     expect(body.data).toEqual([])
   })
 
+  it('#1260: a PLATFORM_ADMIN acting as an operator (?operatorId=) is scoped to that operator’s customers', async () => {
+    const OP = '00000000-0000-4000-8000-0000000000aa'
+    // u1 (Tanaka) has a prior booking with OP -> its customer; u3 (Chen) does not.
+    setup({
+      users: seed(),
+      bookings: [mkBooking({ id: 'b1', renterId: 'u1', operatorId: OP })],
+      asRole: 'PLATFORM_ADMIN',
+    })
+    // A non-customer match is filtered out — without the ?operatorId= wiring the
+    // admin would get the full-table hit here (mutation proof of the threading).
+    const foreign = await app.request(`/customers/search?q=chen&operatorId=${OP}`)
+    expect((await foreign.json()).data).toEqual([])
+    const own = await app.request(`/customers/search?q=tanaka&operatorId=${OP}`)
+    const body = await own.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].id).toBe('u1')
+  })
+
   it('rejects OPERATOR_OWNER on /customers list (403) — L7', async () => {
     setup({
       users: seed(),

--- a/packages/api/tests/routes/manual-booking.test.ts
+++ b/packages/api/tests/routes/manual-booking.test.ts
@@ -1,6 +1,7 @@
 import { SignJWT } from 'jose'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createApp } from '../../src/index'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryAvailabilityRepository } from '../../src/repositories/in-memory/availability'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { InMemoryLocationRepository } from '../../src/repositories/in-memory/location'
@@ -65,6 +66,43 @@ function makeRenter(id: string): User {
     phone: null,
     language: 'en',
     role: 'RENTER',
+  }
+}
+
+// #1260: a prior COMPLETED booking that makes `renterId` a customer of `operatorId`
+// (what the manual-booking scope check keys on). Far in the past so it can never
+// conflict with the CONFIRMED booking a test then creates.
+function priorBookingData(
+  operatorId: string,
+  renterId: string,
+  classId: string,
+  vehicleId: string,
+  locationId: string,
+) {
+  return {
+    operatorId,
+    renterId,
+    classId,
+    requestedVehicleId: vehicleId,
+    assignedVehicleId: vehicleId,
+    pickupLocationId: locationId,
+    dropoffLocationId: locationId,
+    startAt: new Date('2020-01-01T00:00:00Z'),
+    endAt: new Date('2020-01-02T00:00:00Z'),
+    effectiveEndAt: new Date('2020-01-04T00:00:00Z'),
+    status: 'COMPLETED' as const,
+    source: 'MANUAL' as const,
+    bookingCode: 'SEEDMB01',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 10000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
   }
 }
 
@@ -154,17 +192,24 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     })
   })
 
-  it('a platform admin can create a booking with a custom renterId', async () => {
+  it('a platform admin acting as the operator can create a booking for one of its customers', async () => {
     const staffId = crypto.randomUUID()
     const customerId = crypto.randomUUID()
     userStore.set(customerId, makeRenter(customerId))
+    // #1260: the renter must be a customer of the picked operator. Seed a prior
+    // booking so listRenterIdsForOperator(OPERATOR) includes them.
+    await bookingRepo.create(
+      SYSTEM_CONTEXT,
+      priorBookingData(OPERATOR, customerId, testClassId, vehicle.id, locationId),
+    )
     const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
 
     // Start 48 hours from now to satisfy advance booking rule
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
-    const res = await app.request('/bookings', {
+    // #1260: a picked admin binds the write to the operator via ?operatorId=.
+    const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -190,6 +235,35 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     // The booking should use the custom renterId, not the staff user's id
     expect(body.data.renterId).toBe(customerId)
     expect(body.data.renterId).not.toBe(staffId)
+  })
+
+  it('rejects a platform admin booking for a renter without ?operatorId= (422 OPERATOR_REQUIRED)', async () => {
+    const staffId = crypto.randomUUID()
+    const customerId = crypto.randomUUID()
+    userStore.set(customerId, makeRenter(customerId))
+    const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
+    const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
+    const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
+
+    // No ?operatorId= — a bypass admin must name the operator it acts as.
+    const res = await app.request('/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        requestedVehicleId: vehicle.id,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: customerId,
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        source: 'MANUAL',
+      }),
+    })
+
+    expect(res.status).toBe(422)
+    const body = (await res.json()) as { success: boolean; code: string }
+    expect(body.success).toBe(false)
+    expect(body.code).toBe('OPERATOR_REQUIRED')
   })
 
   it('renter cannot specify renterId — booking uses JWT user id', async () => {
@@ -234,7 +308,8 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     const startAt = new Date(Date.now() + 1 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
-    const res = await app.request('/bookings', {
+    // #1260: a self-booking admin still binds the write's inventory to its operator.
+    const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -265,7 +340,7 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     const startAt = new Date(Date.now() + 1 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 30 * 60 * 1000)
 
-    const res = await app.request('/bookings', {
+    const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -319,13 +394,17 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     expect(body.code).toBe('RENTAL_RULE_ADVANCE_BOOKING')
   })
 
-  it('rejects manual booking when target renterId does not exist', async () => {
+  it('rejects an unknown renterId as out-of-scope (403, no existence oracle)', async () => {
+    // #1260: scope-first — an id that is not the acting operator's customer returns
+    // a uniform 403 whether it is unknown or another operator's, so the manual
+    // booker can never probe the user table (#396/#475). This is the old
+    // 400 'Renter not found' path, now closed to the enumeration oracle.
     const staffId = crypto.randomUUID()
     const token = await createTestToken({ id: staffId, role: 'PLATFORM_ADMIN' })
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
-    const res = await app.request('/bookings', {
+    const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -342,13 +421,17 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
       }),
     })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(403)
     const body = (await res.json()) as { success: boolean; error: string }
     expect(body.success).toBe(false)
-    expect(body.error).toContain('Renter not found')
+    expect(body.error).toContain('outside your customers')
   })
 
-  it('rejects manual booking when target user is not a RENTER', async () => {
+  it('rejects a non-renter target as out-of-scope (403, no role oracle)', async () => {
+    // #1260: scope-first — a non-customer id (here a STAFF user) is refused with the
+    // same 403 as any other out-of-scope id. A STAFF user has no booking with the
+    // operator, so it is not in its customer set; the old 400 'not a renter' role
+    // probe is gone (it revealed the target's role to the manual booker).
     const staffId = crypto.randomUUID()
     const otherStaffId = crypto.randomUUID()
     userStore.set(otherStaffId, { ...makeRenter(otherStaffId), role: 'STAFF' })
@@ -356,7 +439,7 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
     const startAt = new Date(Date.now() + 48 * 60 * 60 * 1000)
     const endAt = new Date(startAt.getTime() + 4 * 60 * 60 * 1000)
 
-    const res = await app.request('/bookings', {
+    const res = await app.request(`/bookings?operatorId=${OPERATOR}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -373,9 +456,9 @@ describe('Manual booking (platform-admin renterId override + advance rule skip)'
       }),
     })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(403)
     const body = (await res.json()) as { success: boolean; error: string }
     expect(body.success).toBe(false)
-    expect(body.error).toContain('not a renter')
+    expect(body.error).toContain('outside your customers')
   })
 })

--- a/packages/api/tests/services/booking.test.ts
+++ b/packages/api/tests/services/booking.test.ts
@@ -298,6 +298,190 @@ async function seedReady(h: Harness) {
   return { vehicleId: h.vehicleId, locationId }
 }
 
+// #1260: register `renterId` as a customer of `operatorId` by seeding a prior
+// booking with it (that is what listRenterIdsForOperator keys on). Seeded far in
+// the past + COMPLETED so it never conflicts with the CONFIRMED booking under test.
+async function seedCustomerOf(
+  h: Harness,
+  operatorId: string,
+  renterId: string,
+  bookingCode = 'SEEDCUST',
+): Promise<void> {
+  await h.repos.bookingRepo.create(SYSTEM_CONTEXT, {
+    operatorId,
+    renterId,
+    classId: CLASS_COMPACT,
+    requestedVehicleId: h.vehicleId,
+    assignedVehicleId: h.vehicleId,
+    pickupLocationId: LOC_OSAKA,
+    dropoffLocationId: LOC_OSAKA,
+    startAt: new Date('2020-01-01T00:00:00Z'),
+    endAt: new Date('2020-01-02T00:00:00Z'),
+    effectiveEndAt: new Date('2020-01-04T00:00:00Z'),
+    status: 'COMPLETED',
+    source: 'MANUAL',
+    bookingCode,
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 10000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+  })
+}
+
+// #1260 slice 3: a bypass admin (PLATFORM_ADMIN) using the operator picker binds a
+// manual booking to the operator it acts as (?operatorId=) — for BOTH the customer
+// (an existing renter must be that operator's customer) and the inventory (the car
+// must belong to it). Before this a picked admin could attach ANY renter to ANY
+// operator's car by raw id. Tenant operators are unaffected (their read scope
+// already clamps them; a stray actingOperatorId is ignored).
+describe('BookingService.create — #1260 manual-booking operator binding', () => {
+  const adminCtx: CallerContext = { userId: 'admin-1', role: 'PLATFORM_ADMIN', bypassScope: true }
+  const opACtx: CallerContext = {
+    userId: 'op-a-owner',
+    role: 'OPERATOR_OWNER',
+    operatorId: OP_A,
+    bypassScope: false,
+  }
+  const walkIn = { name: 'Hanako Walk-In', phone: '+81-90-0000-0001' }
+
+  it('rejects a bypass admin booking for an existing renter with no acting operator (422 OPERATOR_REQUIRED)', async () => {
+    const h = await setup()
+    const { vehicleId, locationId } = await seedReady(h)
+    await seedCustomerOf(h, OP_A, RENTER)
+    const result = await h.service.create(
+      adminCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: RENTER,
+        source: 'MANUAL',
+      }),
+      NOW,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(422)
+    expect(result.code).toBe('OPERATOR_REQUIRED')
+  })
+
+  it('rejects a bypass admin (acting as OP_A) booking for a renter who is not OP_A’s customer (403, no oracle)', async () => {
+    const h = await setup()
+    const { vehicleId, locationId } = await seedReady(h)
+    // RENTER has no prior booking with OP_A -> not a customer.
+    const result = await h.service.create(
+      adminCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: RENTER,
+        source: 'MANUAL',
+      }),
+      NOW,
+      OP_A,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(403)
+    expect(result.error).toBe('Cannot book for a renter outside your customers')
+  })
+
+  it('lets a bypass admin (acting as OP_A) book for one of OP_A’s own customers (201)', async () => {
+    const h = await setup({ codes: ['ADMINOK1'] })
+    const { vehicleId, locationId } = await seedReady(h)
+    await seedCustomerOf(h, OP_A, RENTER)
+    const result = await h.service.create(
+      adminCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: RENTER,
+        source: 'MANUAL',
+      }),
+      NOW,
+      OP_A,
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.renterId).toBe(RENTER)
+    expect(result.booking.operatorId).toBe(OP_A)
+  })
+
+  it('binds the booked vehicle to the picked operator: acting as OP_B cannot book OP_A’s car (404, no oracle)', async () => {
+    const h = await setup()
+    const { vehicleId, locationId } = await seedReady(h)
+    // A walk-in isolates the INVENTORY bind (the customer scope check is skipped),
+    // so the 404 proves the vehicle-operator binding, not the customer one.
+    const result = await h.service.create(
+      adminCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        walkInCustomer: walkIn,
+        source: 'MANUAL',
+      }),
+      NOW,
+      OP_B,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(404)
+    expect(result.error).toBe('Vehicle not found')
+  })
+
+  it('lets a bypass admin (acting as OP_A) register a walk-in on OP_A’s car (201)', async () => {
+    const h = await setup({ codes: ['WALKADM1'] })
+    const { vehicleId, locationId } = await seedReady(h)
+    const result = await h.service.create(
+      adminCtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        walkInCustomer: walkIn,
+        source: 'MANUAL',
+      }),
+      NOW,
+      OP_A,
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.operatorId).toBe(OP_A)
+  })
+
+  it('a tenant operator ignores a stray ?operatorId= and books within its own tenant', async () => {
+    const h = await setup({ codes: ['OPOWN001'] })
+    const { vehicleId, locationId } = await seedReady(h)
+    await seedCustomerOf(h, OP_A, RENTER)
+    // OP_A owner passes a stray OP_B; it must be ignored in BOTH the customer and
+    // inventory checks (the booking still succeeds against its own tenant).
+    const result = await h.service.create(
+      opACtx,
+      createInput({
+        requestedVehicleId: vehicleId,
+        pickupLocationId: locationId,
+        dropoffLocationId: locationId,
+        renterId: RENTER,
+        source: 'MANUAL',
+      }),
+      NOW,
+      OP_B,
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.booking.renterId).toBe(RENTER)
+  })
+})
+
 describe('BookingService.create — past-start floor (#954)', () => {
   // The seeded vehicle has advanceBookingHours: null (the default + forced for
   // MANUAL), so the universal past-start floor in checkRentalRules is the only
@@ -610,6 +794,9 @@ describe('BookingService.create — single-transaction submit (#392 §4)', () =>
     const h = await setup({ codes: ['MANUAL12'] })
     const { vehicleId, locationId } = await seedReady(h)
     const staffCtx: CallerContext = { userId: 'staff-9', role: 'PLATFORM_ADMIN', bypassScope: true }
+    // #1260: a bypass admin binds the booking to the operator it acts as (OP_A) and
+    // may attach only that operator's customers, so seed RENTER as one.
+    await seedCustomerOf(h, OP_A, RENTER)
 
     const result = await h.service.create(
       staffCtx,
@@ -620,6 +807,7 @@ describe('BookingService.create — single-transaction submit (#392 §4)', () =>
         renterId: RENTER, // staff books on behalf of an existing renter
       }),
       NOW,
+      OP_A,
     )
 
     expect(result.ok).toBe(true)

--- a/packages/api/tests/services/customer.test.ts
+++ b/packages/api/tests/services/customer.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { CallerContext } from '../../src/auth/context'
+import { SYSTEM_CONTEXT } from '../../src/middleware/auth'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { InMemoryCustomerRepository } from '../../src/repositories/in-memory/customer'
 import { InMemoryUserRepository } from '../../src/repositories/in-memory/user'
 import { CustomerService } from '../../src/services/customer'
 import type { User } from '../../src/stores'
+
+const OPERATOR = '00000000-0000-4000-8000-0000000000f1'
 
 // #1168 — CustomerService.search() must scope "see the whole user table" to the
 // PLATFORM_ADMIN tier, NOT to the coarse `bypassScope` flag, which also carries
@@ -15,6 +18,7 @@ describe('CustomerService.search — privileged scope is PLATFORM_ADMIN, never P
   const RENTER_A = '00000000-0000-4000-8000-0000000000a1'
   const RENTER_B = '00000000-0000-4000-8000-0000000000b2'
   let service: CustomerService
+  let bookingRepo: InMemoryBookingRepository
 
   beforeEach(() => {
     const users = new Map<string, User>([
@@ -23,7 +27,7 @@ describe('CustomerService.search — privileged scope is PLATFORM_ADMIN, never P
     ])
     const userRepo = new InMemoryUserRepository(users)
     const customerRepo = new InMemoryCustomerRepository(users, new Map())
-    const bookingRepo = new InMemoryBookingRepository()
+    bookingRepo = new InMemoryBookingRepository()
     service = new CustomerService(customerRepo, userRepo, bookingRepo)
   })
 
@@ -40,6 +44,20 @@ describe('CustomerService.search — privileged scope is PLATFORM_ADMIN, never P
     const results = await service.search('Searchable', ctx)
     expect(results).toEqual([])
   })
+
+  it('#1260: a PLATFORM_ADMIN acting as an operator is scoped to that operator’s customers', async () => {
+    // Only RENTER_A has a prior booking with OPERATOR -> only they are a customer.
+    await seedCustomerBooking(bookingRepo, OPERATOR, RENTER_A)
+    const ctx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const results = await service.search('Searchable', ctx, OPERATOR)
+    expect(results.map((u) => u.id)).toEqual([RENTER_A])
+  })
+
+  it('#1260: a PLATFORM_ADMIN acting as an operator with no customers gets nothing (not the full table)', async () => {
+    const ctx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+    const results = await service.search('Searchable', ctx, OPERATOR)
+    expect(results).toEqual([])
+  })
 })
 
 function mkRenter(id: string, name: string): User {
@@ -52,4 +70,38 @@ function mkRenter(id: string, name: string): User {
     country: null,
     role: 'RENTER',
   }
+}
+
+// A prior booking making `renterId` a customer of `operatorId` — what
+// listRenterIdsForOperator (and thus the picked-operator search scope) keys on.
+async function seedCustomerBooking(
+  bookingRepo: InMemoryBookingRepository,
+  operatorId: string,
+  renterId: string,
+): Promise<void> {
+  await bookingRepo.create(SYSTEM_CONTEXT, {
+    operatorId,
+    renterId,
+    classId: 'class-x',
+    requestedVehicleId: 'veh-x',
+    assignedVehicleId: 'veh-x',
+    pickupLocationId: 'loc-x',
+    dropoffLocationId: 'loc-x',
+    startAt: new Date('2020-01-01T00:00:00Z'),
+    endAt: new Date('2020-01-02T00:00:00Z'),
+    effectiveEndAt: new Date('2020-01-04T00:00:00Z'),
+    status: 'COMPLETED',
+    source: 'MANUAL',
+    bookingCode: 'SEEDCS01',
+    insuranceOptionId: null,
+    insuranceSnapshot: null,
+    feeSnapshot: [],
+    addOnSnapshot: [],
+    externalId: null,
+    notes: null,
+    totalPrice: 10000,
+    cancellationFee: null,
+    cancelledAt: null,
+    idempotencyKey: null,
+  })
 }

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -385,6 +385,7 @@ export function OperatorBookingsRoute() {
           locations={manualBookingLocations}
           csrfToken={session?.csrfToken ?? ''}
           initialRange={slotRange ?? undefined}
+          pickedOperatorId={pickedOperatorId}
         />
       )}
       {canManageBlocks && (

--- a/packages/web/src/vite/operator-bookings/CustomerPicker.tsx
+++ b/packages/web/src/vite/operator-bookings/CustomerPicker.tsx
@@ -16,6 +16,9 @@ export interface CustomerPickerProps {
   readonly onSelect: (customer: CustomerSearchResult | null) => void
   /** Debounce before a keystroke fires a search; pass 0 in tests for determinism. */
   readonly debounceMs?: number
+  /** #1260: a picker admin's chosen operator — scopes the search to its customers
+   *  (undefined for a tenant operator, whose session cookie carries the scope). */
+  readonly pickedOperatorId?: string | undefined
 }
 
 // #589 1d (slice 3): search an EXISTING renter to attach to a manual booking. The
@@ -27,6 +30,7 @@ export function CustomerPicker({
   selected,
   onSelect,
   debounceMs = DEFAULT_DEBOUNCE_MS,
+  pickedOperatorId,
 }: CustomerPickerProps) {
   const t = useTranslations('bookings.operator.newBooking')
   const inputId = useId()
@@ -38,7 +42,7 @@ export function CustomerPicker({
     return () => clearTimeout(timer)
   }, [query, debounceMs])
 
-  const search = useQuery(customerSearchQueryOptions(debounced))
+  const search = useQuery(customerSearchQueryOptions(debounced, pickedOperatorId))
 
   if (selected) {
     return (

--- a/packages/web/src/vite/operator-bookings/ManualBookingDialog.test.tsx
+++ b/packages/web/src/vite/operator-bookings/ManualBookingDialog.test.tsx
@@ -1,0 +1,78 @@
+import type { BookingDto } from '@/vite/bookings/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+import { ManualBookingDialog } from './ManualBookingDialog'
+import type { CalendarVehicle } from './api'
+
+// Mock only createManualBooking so we can assert its args; keep the rest of the api
+// module real (invalidateBookingCaches runs in onSuccess).
+vi.mock('@/vite/operator-bookings/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/vite/operator-bookings/api')>()),
+  createManualBooking: vi.fn(),
+}))
+
+import { createManualBooking } from '@/vite/operator-bookings/api'
+
+function renderDialog(pickedOperatorId?: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  )
+  return render(
+    <ManualBookingDialog
+      open
+      onOpenChange={() => {}}
+      vehicles={[{ id: 'v1', name: 'Aqua' } as CalendarVehicle]}
+      locations={[{ id: 'l1', name: 'Namba' }]}
+      csrfToken="csrf-1"
+      pickedOperatorId={pickedOperatorId}
+    />,
+    { wrapper },
+  )
+}
+
+// The default customer mode is walk-in, so no CustomerPicker/search is needed.
+function fillWalkInAndSubmit() {
+  fireEvent.change(document.getElementById('manual-start') as HTMLInputElement, {
+    target: { value: '2026-08-01T10:00' },
+  })
+  fireEvent.change(document.getElementById('manual-end') as HTMLInputElement, {
+    target: { value: '2026-08-02T10:00' },
+  })
+  fireEvent.change(document.getElementById('manual-name') as HTMLInputElement, {
+    target: { value: 'Taro' },
+  })
+  fireEvent.change(document.getElementById('manual-phone') as HTMLInputElement, {
+    target: { value: '+81-90-1111-2222' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: en.bookings.operator.newBooking.submit }))
+}
+
+describe('ManualBookingDialog — #1260 picker-operator binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(createManualBooking).mockResolvedValue({ id: 'b1' } as BookingDto)
+  })
+
+  it('forwards pickedOperatorId to createManualBooking on submit', async () => {
+    renderDialog('op-7')
+    fillWalkInAndSubmit()
+    await waitFor(() => expect(createManualBooking).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(createManualBooking).mock.calls[0]?.[2]).toBe('op-7')
+  })
+
+  it('passes undefined for a tenant operator session (no pick)', async () => {
+    renderDialog(undefined)
+    fillWalkInAndSubmit()
+    await waitFor(() => expect(createManualBooking).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(createManualBooking).mock.calls[0]?.[2]).toBeUndefined()
+  })
+})

--- a/packages/web/src/vite/operator-bookings/ManualBookingDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/ManualBookingDialog.tsx
@@ -32,6 +32,9 @@ export interface ManualBookingDialogProps {
   readonly csrfToken: string
   /** A clicked calendar slot, to prefill the pickup/return range (wall-clock JST). */
   readonly initialRange?: { start: Date; end: Date } | undefined
+  /** #1260: the operator a picker admin is acting as. Binds the create + scopes the
+   *  customer search to that operator (undefined for a tenant operator session). */
+  readonly pickedOperatorId?: string | undefined
 }
 
 // #589 1d: the manual-booking form. A *controlled* dialog — the route lifts `open`
@@ -48,6 +51,7 @@ export function ManualBookingDialog({
   locations,
   csrfToken,
   initialRange,
+  pickedOperatorId,
 }: ManualBookingDialogProps) {
   const t = useTranslations('bookings.operator.newBooking')
   const queryClient = useQueryClient()
@@ -85,6 +89,7 @@ export function ManualBookingDialog({
           idempotencyKey,
         },
         csrfToken,
+        pickedOperatorId,
       ),
     onSuccess: () => {
       // A write invalidates the operator-bookings prefix + dashboard overview; the
@@ -252,7 +257,11 @@ export function ManualBookingDialog({
                   </div>
                 </>
               ) : (
-                <CustomerPicker selected={selectedCustomer} onSelect={setSelectedCustomer} />
+                <CustomerPicker
+                  selected={selectedCustomer}
+                  onSelect={setSelectedCustomer}
+                  pickedOperatorId={pickedOperatorId}
+                />
               )}
             </div>
 

--- a/packages/web/src/vite/operator-bookings/api.manual-booking-scope.test.ts
+++ b/packages/web/src/vite/operator-bookings/api.manual-booking-scope.test.ts
@@ -1,0 +1,79 @@
+import {
+  type CreateManualBookingInput,
+  createManualBooking,
+  customerSearchQueryOptions,
+  searchCustomers,
+} from '@/vite/operator-bookings/api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// #1260: the manual-booking write + its customer search must carry the picker
+// admin's chosen operator (?operatorId=) so the server binds/scopes to it. These
+// pin the URL wiring — without it a picker admin's create 422s and its search
+// offers un-bookable customers. We only assert the request URL, so the mocked
+// response is a failure body (unwrap rejects; the .catch swallows it).
+describe('operator-bookings api — #1260 picker-operator scoping', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function mockFetch() {
+    const res = { status: 500, json: async () => ({ success: false, error: 'boom' }) }
+    const fetchMock = vi.fn().mockResolvedValue(res)
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  function calledUrl(fetchMock: ReturnType<typeof vi.fn>): string {
+    return String(fetchMock.mock.calls[0]?.[0])
+  }
+
+  const manualInput: CreateManualBookingInput = {
+    requestedVehicleId: 'v1',
+    pickupLocationId: 'l1',
+    dropoffLocationId: 'l1',
+    startAt: '2026-07-10T00:00:00Z',
+    endAt: '2026-07-11T00:00:00Z',
+    customer: { kind: 'walk-in', name: 'A', phone: '+81-90-0000-0000' },
+    idempotencyKey: 'k1',
+  }
+
+  it('createManualBooking appends ?operatorId= when a picker admin acts as an operator', async () => {
+    const fetchMock = mockFetch()
+    await createManualBooking(manualInput, 'csrf', 'op-7').catch(() => {})
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(calledUrl(fetchMock)).toContain('/bookings?operatorId=op-7')
+  })
+
+  it('createManualBooking omits operatorId for a tenant operator (no pick)', async () => {
+    const fetchMock = mockFetch()
+    await createManualBooking(manualInput, 'csrf').catch(() => {})
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('/bookings')
+    expect(url).not.toContain('operatorId=')
+  })
+
+  it('searchCustomers scopes to the picked operator', async () => {
+    const fetchMock = mockFetch()
+    await searchCustomers('tanaka', 'op-7').catch(() => {})
+    const url = calledUrl(fetchMock)
+    expect(url).toContain('q=tanaka')
+    expect(url).toContain('operatorId=op-7')
+  })
+
+  it('searchCustomers omits operatorId when none is picked', async () => {
+    const fetchMock = mockFetch()
+    await searchCustomers('tanaka').catch(() => {})
+    expect(calledUrl(fetchMock)).not.toContain('operatorId=')
+  })
+
+  // CustomerPicker drives its search through customerSearchQueryOptions, so pinning
+  // that the picked operator lands in BOTH the query key (refetch on switch) and the
+  // queryFn's request covers the picker's wiring without a render.
+  it('customerSearchQueryOptions carries the picked operator in the key and the fetch', async () => {
+    const opts = customerSearchQueryOptions('tanaka', 'op-7')
+    expect(opts.queryKey).toContain('op-7')
+    const fetchMock = mockFetch()
+    await (opts.queryFn as () => Promise<unknown>)().catch(() => {})
+    expect(calledUrl(fetchMock)).toContain('operatorId=op-7')
+  })
+})

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -514,10 +514,16 @@ export function cancelBooking(id: string, csrfToken: string): Promise<BookingDto
 // The dialog can attach an EXISTING renter instead of creating a walk-in. This
 // reads the one operator-reachable customer route: CustomerService.search scopes
 // an OPERATOR_* caller to renters within its own tenant (prior-booking), so the
-// picker can't enumerate the global user table (#396/#475) — the client passes
-// only `q`, never an operatorId; the session cookie carries the tenant scope.
-export async function searchCustomers(q: string): Promise<CustomerSearchResult[]> {
+// picker can't enumerate the global user table (#396/#475). A tenant operator's
+// scope rides the session cookie; a picker admin (#1260) passes pickedOperatorId
+// so the search is scoped to the operator it acts as (else it would offer — then
+// 403 at booking — customers it cannot book).
+export async function searchCustomers(
+  q: string,
+  pickedOperatorId?: string,
+): Promise<CustomerSearchResult[]> {
   const sp = new URLSearchParams({ q })
+  if (pickedOperatorId) sp.set('operatorId', pickedOperatorId)
   const res = await fetch(`${getApiBaseUrl()}/customers/search?${sp.toString()}`, {
     credentials: 'include',
   })
@@ -526,11 +532,12 @@ export async function searchCustomers(q: string): Promise<CustomerSearchResult[]
 
 // The picker drives this with its debounced query. `enabled` mirrors the server's
 // 2-char minimum so an under-length term never fires a guaranteed-400 request.
+// pickedOperatorId is part of the query key so switching operators refetches.
 const CUSTOMER_SEARCH_MIN_CHARS = 2
-export function customerSearchQueryOptions(q: string) {
+export function customerSearchQueryOptions(q: string, pickedOperatorId?: string) {
   return queryOptions({
-    queryKey: ['operator-bookings', 'customer-search', q],
-    queryFn: () => searchCustomers(q),
+    queryKey: ['operator-bookings', 'customer-search', q, pickedOperatorId ?? null],
+    queryFn: () => searchCustomers(q, pickedOperatorId),
     enabled: q.trim().length >= CUSTOMER_SEARCH_MIN_CHARS,
   })
 }
@@ -572,6 +579,7 @@ export interface CreateManualBookingInput {
 export function createManualBooking(
   input: CreateManualBookingInput,
   csrfToken: string,
+  pickedOperatorId?: string,
 ): Promise<BookingDto> {
   // The customer source is XOR: an existing renter sends `renterId`, a walk-in
   // sends inline `walkInCustomer`. Building exactly one block keeps the wire body
@@ -581,9 +589,15 @@ export function createManualBooking(
     input.customer.kind === 'existing'
       ? { renterId: input.customer.renterId }
       : { walkInCustomer: { name: input.customer.name, phone: input.customer.phone } }
+  // #1260: a picker admin binds the write to the operator it acts as via
+  // ?operatorId=; a tenant operator omits it (the server drops it, never widening
+  // scope). Without it a picker admin's create would 422 (OPERATOR_REQUIRED).
+  const path = pickedOperatorId
+    ? `/bookings?operatorId=${encodeURIComponent(pickedOperatorId)}`
+    : '/bookings'
   // Composes the shared writeBooking helper (credentials + X-CSRF-Token + JSON +
   // unwrap in one auditable place). The body always exists, so JSON is sent.
-  return writeBooking('/bookings', 'POST', csrfToken, {
+  return writeBooking(path, 'POST', csrfToken, {
     requestedVehicleId: input.requestedVehicleId,
     pickupLocationId: input.pickupLocationId,
     dropoffLocationId: input.dropoffLocationId,

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -814,10 +814,17 @@ describe('searchCustomers', () => {
 })
 
 describe('customerSearchQueryOptions', () => {
-  it('keys by the query and is enabled only at >=2 non-space chars', () => {
+  it('keys by the query (+ picked operator) and is enabled only at >=2 non-space chars', () => {
     const opts = customerSearchQueryOptions('tan')
-    expect(opts.queryKey).toEqual(['operator-bookings', 'customer-search', 'tan'])
+    expect(opts.queryKey).toEqual(['operator-bookings', 'customer-search', 'tan', null])
     expect(opts.enabled).toBe(true)
+    // #1260: the picked operator joins the key so switching operators refetches.
+    expect(customerSearchQueryOptions('tan', 'op-7').queryKey).toEqual([
+      'operator-bookings',
+      'customer-search',
+      'tan',
+      'op-7',
+    ])
     expect(customerSearchQueryOptions(' a ').enabled).toBe(false)
     expect(customerSearchQueryOptions('').enabled).toBe(false)
   })


### PR DESCRIPTION
## What & why

Closes #1260 (slice 3 — the last unbound operator-portal write path).

A `PLATFORM_ADMIN` using the operator-context picker ("bypass admin") could create a manual booking (`POST /bookings`) attaching **any** renter to **any** operator's vehicle: `booking-creation.create()` gated its customer-scope check on `isOperatorRole` (false for `PLATFORM_ADMIN`), and the booking's operator was derived from the vehicle with no binding to the acting operator. The web manual-booking dialog is reachable by a picked admin (`canWriteAsOperator`), so this is a full API + web slice (like slice 4).

Owner-locked approach (AskUserQuestion): **bind both the renter and the inventory** to the picked operator, and **scope the customer search** to it.

## Changes

**API**
- `booking-creation.ts`: `create()` takes `actingOperatorId` (from `?operatorId=`). A bypass admin must name the operator it acts as (**422 OPERATOR_REQUIRED**) and may attach only that operator's customers (scope-first `listRenterIdsForOperator` → **403**, no user-table probe). `submitInTx`/`submitComboInTx` bind the booked vehicle/pickup operator to the acting operator via `assertBookingWriteWithinOperator` (→ **404**, no oracle). The dead user-table exists/role probe + `BookingCreationService.userRepo` are removed. Keyed on `bookingReadScope(ctx).kind === 'all'` (PLATFORM_ADMIN only) — not `bypassScope` (would bind PARTNER) nor `!isOperatorRole` (would 422 renters).
- `customer.ts`: `search()` scopes a privileged admin's manual-booking search to `?operatorId=` when present (else full directory, unchanged for the admin customer screen).
- Routes (`bookings` POST, `customers/search`) read `?operatorId=`.

**Web**
- `createManualBooking` + `searchCustomers`/`customerSearchQueryOptions` take `pickedOperatorId` and append `?operatorId=` (operator joins the search query key). `ManualBookingDialog` forwards it to the create + `CustomerPicker`; the `manage/bookings` route supplies it from `useOperatorContext`.

**Tenant operators are unaffected** — a stray `?operatorId=` is ignored (their read scope clamps them).

## Tests
- Service + route guard tests (422 / 403 / 404 / 201, walk-in inventory bind, tenant-operator-ignores-stray). The three `manual-booking.test.ts` tests that encoded the old unscoped behavior are converted (enumeration-oracle 400s → uniform 403s).
- Customer search scoping (service + route wiring, mutation-resistant).
- Web api URL/query-key wiring + a `ManualBookingDialog` submit test pinning the forwarded operatorId.

## Verification
- api unit **2699**, integration **493** (docker pg), web **1971**, tsc ×3, biome, boundaries, size, module-boundaries — all green. 0 behind develop at push (clean merge, no file overlap).

## Follow-ups
- **#1417** (new): a *tenant operator* can still book a foreign operator's vehicle (SYSTEM_CONTEXT vehicle read, operator tier deliberately deferred here) — pre-existing, needs an owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)