### PR TITLE
feat(#1230): team picker — manage a picked operator's team as that operator (slice 6)

### DIFF
--- a/packages/api/src/routes/operator-team.ts
+++ b/packages/api/src/routes/operator-team.ts
@@ -22,7 +22,11 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       const parsed = await parseBody(c, inviteStaffSchema)
       if (!parsed.ok) return parsed.response
 
-      const created = await service.inviteStaff(toCallerContext(user), parsed.data)
+      const created = await service.inviteStaff(
+        toCallerContext(user),
+        parsed.data,
+        c.req.query('operatorId'),
+      )
       // The URL embeds the one-time token (never persisted in cleartext); the
       // owner copies it to share. We omit the bare `token` field — the URL is the
       // only form the page needs.
@@ -39,7 +43,7 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       const id = c.req.param('id')
       // Owner-only + tenant scope live in the service; an unknown/foreign id
       // throws NotFoundError (-> 404) via the global handler, so no id is leaked.
-      await service.revokeInvite(toCallerContext(requireUser(c)), id)
+      await service.revokeInvite(toCallerContext(requireUser(c)), id, c.req.query('operatorId'))
       return ok(c, { id })
     })
     .get('/operators/me/members', async (c) => {
@@ -54,7 +58,7 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       // Owner-only + tenant scope + last-owner lockout live in the service: an
       // unknown/foreign id throws NotFoundError (-> 404) and the last owner throws
       // ConflictError (-> 409), both via the global handler, so no id is leaked.
-      await service.deactivateMember(toCallerContext(requireUser(c)), id)
+      await service.deactivateMember(toCallerContext(requireUser(c)), id, c.req.query('operatorId'))
       return ok(c, { id })
     })
 }

--- a/packages/api/src/routes/operator-team.ts
+++ b/packages/api/src/routes/operator-team.ts
@@ -29,7 +29,10 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       return ok(c, { inviteUrl: created.inviteUrl, expiresAt: created.expiresAt }, 201)
     })
     .get('/operators/me/invites', async (c) => {
-      const invites = await service.listInvites(toCallerContext(requireUser(c)))
+      const invites = await service.listInvites(
+        toCallerContext(requireUser(c)),
+        c.req.query('operatorId'),
+      )
       return ok(c, invites)
     })
     .post('/operators/me/invites/:id/revoke', async (c) => {
@@ -40,7 +43,10 @@ export function createOperatorTeamRoutes(service: OperatorTeamService) {
       return ok(c, { id })
     })
     .get('/operators/me/members', async (c) => {
-      const members = await service.listMembers(toCallerContext(requireUser(c)))
+      const members = await service.listMembers(
+        toCallerContext(requireUser(c)),
+        c.req.query('operatorId'),
+      )
       return ok(c, members)
     })
     .post('/operators/me/members/:id/deactivate', async (c) => {

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -1,11 +1,6 @@
 import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
 import type { CallerContext } from '../auth/context'
-import {
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-  requireOperatorOwnerWrite,
-} from '../auth/guards'
+import { ConflictError, NotFoundError, requireOperatorOwnerWrite } from '../auth/guards'
 import type {
   OperatorMembershipRepository,
   ProviderInviteRepository,
@@ -50,9 +45,13 @@ export class OperatorTeamService {
     private readonly recordAudit: RecordOperatorMemberDeactivatedAudit,
   ) {}
 
-  async inviteStaff(ctx: CallerContext, input: { email: string }): Promise<CreatedInvite> {
+  async inviteStaff(
+    ctx: CallerContext,
+    input: { email: string },
+    inputOperatorId?: string,
+  ): Promise<CreatedInvite> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     return this.inviteService.createInvite(
       { email: input.email, operatorId, role: 'OPERATOR_STAFF' },
       ctx.userId,
@@ -82,9 +81,9 @@ export class OperatorTeamService {
    * unknown id reads as `undefined` from the scoped repo and surfaces as a 404 —
    * never a 403 that would confirm the invite exists elsewhere.
    */
-  async revokeInvite(ctx: CallerContext, id: string): Promise<void> {
+  async revokeInvite(ctx: CallerContext, id: string, inputOperatorId?: string): Promise<void> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const revoked = await this.invites.revoke(id, operatorId)
     if (!revoked) throw new NotFoundError('invite not found')
   }
@@ -105,9 +104,9 @@ export class OperatorTeamService {
    * member keeps access until their token expires; see the #904 session-revocation
    * follow-up.
    */
-  async deactivateMember(ctx: CallerContext, id: string): Promise<void> {
+  async deactivateMember(ctx: CallerContext, id: string, inputOperatorId?: string): Promise<void> {
     requireOperatorOwnerWrite(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const members = await this.memberships.findActiveByOperator(operatorId)
     const target = members.find((m) => m.id === id)
     if (!target) throw new NotFoundError('member not found')
@@ -129,17 +128,6 @@ export class OperatorTeamService {
         targetUserId: target.userId,
       })
     }
-  }
-
-  /**
-   * `requireOperatorScope` only fails OPERATOR_* roles missing an operatorId; a
-   * PLATFORM_ADMIN (not an OPERATOR_* role) slips through with no tenant. The
-   * `/me` surface is operator-only, so seal the absent tenant here rather than
-   * letting it reach the repo as `listByOperator(undefined)`.
-   */
-  private requireOwnOperator(ctx: CallerContext): string {
-    if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
-    return ctx.operatorId
   }
 }
 

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -5,7 +5,6 @@ import {
   ForbiddenError,
   NotFoundError,
   requireOperatorOwnerWrite,
-  requireOperatorScope,
 } from '../auth/guards'
 import type {
   OperatorMembershipRepository,
@@ -13,6 +12,7 @@ import type {
   UserRepository,
 } from '../repositories/types'
 import type { OperatorMembership, ProviderInvite, User } from '../stores'
+import { resolveTeamOperatorId } from '../tenancy'
 import type { CreatedInvite, ProviderInviteService } from './provider-invite'
 
 /**
@@ -59,16 +59,14 @@ export class OperatorTeamService {
     )
   }
 
-  async listInvites(ctx: CallerContext): Promise<OperatorInviteData[]> {
-    requireOperatorScope(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+  async listInvites(ctx: CallerContext, inputOperatorId?: string): Promise<OperatorInviteData[]> {
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const rows = await this.invites.listByOperator(operatorId)
     return rows.map(toOperatorInviteData)
   }
 
-  async listMembers(ctx: CallerContext): Promise<OperatorMemberData[]> {
-    requireOperatorScope(ctx)
-    const operatorId = this.requireOwnOperator(ctx)
+  async listMembers(ctx: CallerContext, inputOperatorId?: string): Promise<OperatorMemberData[]> {
+    const operatorId = resolveTeamOperatorId(ctx, inputOperatorId)
     const memberships = await this.memberships.findActiveByOperator(operatorId)
     // One batched read, not a per-member query — the team is small but an N+1
     // loop is still the wrong shape. `findActiveByOperator` already orders the rows.

--- a/packages/api/src/services/operator-team.ts
+++ b/packages/api/src/services/operator-team.ts
@@ -30,9 +30,11 @@ export type RecordOperatorMemberDeactivatedAudit = (
 ) => void
 
 /**
- * #904: operator self-service staff management. Every method derives the tenant
- * from the caller's session (`ctx.operatorId`) — there is no foreign-id surface,
- * so a tenant can only ever see or mutate its own team. Writes are owner-only;
+ * #904: operator self-service staff management. Every method resolves the tenant
+ * through `resolveTeamOperatorId` (#1230 slice 6): for operator roles `ctx.operatorId`
+ * is the ceiling (any client-supplied id is ignored), so a tenant can only ever see
+ * or mutate its OWN team; a PLATFORM_ADMIN may supply a foreign `operatorId` to act
+ * as a picked operator, and that is the ONLY foreign-id surface. Writes are owner-only;
  * reads admit any operator member. The minted role is hard-coded OPERATOR_STAFF:
  * an owner can never escalate an invitee to OPERATOR_OWNER through this path.
  */

--- a/packages/api/src/services/provider-invite.ts
+++ b/packages/api/src/services/provider-invite.ts
@@ -1,5 +1,5 @@
 import type { CreateProviderInviteInput } from '@kuruma/shared/validators/provider-invite'
-import { ConflictError } from '../auth/guards'
+import { ConflictError, NotFoundError } from '../auth/guards'
 import { sha256Hex } from '../auth/token-hash'
 import {
   PG_ERROR,
@@ -15,12 +15,17 @@ export { INVITE_TTL_MS } from './invite-mint'
 export type { ProviderInviteAuditEvent }
 
 /** Raised when an invite is minted against an operatorId with no matching row.
- *  The route maps this to a 404 so a bad target reads as a client error, not a
- *  500 from the FK violation (#563). */
-export class OperatorNotFoundError extends Error {
+ *  Extends NotFoundError so the global handler maps it to 404 (#563, #1230 c1);
+ *  the platform-admin team path can now supply an arbitrary operatorId, so this
+ *  is reachable for the first time. The admin.ts:47 local catch is KEPT — it pins
+ *  the suffix-free 'Operator not found' message provider-invites.test.ts asserts.
+ *  Note: `name` is not overridden here because NotFoundError declares it as the
+ *  literal type 'NotFoundError'; a subclass override would be a TS2416 type error.
+ *  Identity is preserved via `instanceof OperatorNotFoundError` (the admin.ts catch)
+ *  and `instanceof NotFoundError` (the global handler's 404 branch). */
+export class OperatorNotFoundError extends NotFoundError {
   constructor(readonly operatorId: string) {
     super(`Operator not found: ${operatorId}`)
-    this.name = 'OperatorNotFoundError'
   }
 }
 

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -319,3 +319,27 @@ export async function resolveOperatorIdForWrite(
   if (inputOperatorId) return inputOperatorId
   throw new OperatorRequiredError('operatorId is required: specify a target operator')
 }
+
+/**
+ * Resolve the operator whose TEAM the caller may read/manage (#1230 slice 6).
+ *
+ * Deliberately STRICTER than {@link resolveOperatorIdForWrite}: team data is
+ * operator-internal, owner-tier, so a foreign operatorId is honored ONLY for
+ * PRIVILEGED_ROLES (PLATFORM_ADMIN). It is an allowlist, not a bypass-first
+ * denylist — operator role OR PRIVILEGED_ROLES pass; everyone else (renter,
+ * PARTNER, legacy STAFF/ADMIN) falls into `else` and is denied, which is why no
+ * explicit PARTNER branch is needed. Do NOT collapse this onto the write
+ * resolver: it keys on `!isOperatorRole` and would honor legacy STAFF/ADMIN,
+ * silently opening a cross-tenant team write (pinned by a route test).
+ */
+export function resolveTeamOperatorId(ctx: CallerContext, inputOperatorId?: string): string {
+  if (isOperatorRole(ctx.role)) {
+    if (!ctx.operatorId) throw new ForbiddenError('operator scope required')
+    return ctx.operatorId // input IGNORED — an operator cannot act cross-tenant
+  }
+  if (PRIVILEGED_ROLES.has(ctx.role)) {
+    if (inputOperatorId) return inputOperatorId // the `all` tier — honored ONLY here
+    throw new OperatorRequiredError('operatorId is required: specify a target operator')
+  }
+  throw new ForbiddenError('operator scope required') // renter / partner / legacy
+}

--- a/packages/api/tests/integration/operator-team-picker.test.ts
+++ b/packages/api/tests/integration/operator-team-picker.test.ts
@@ -1,0 +1,231 @@
+import { BEST_CAR_RENTAL_OPERATOR_ID, SECOND_OPERATOR_ID } from '@kuruma/shared/db/constants'
+import { operatorMemberships, providerInvites, users } from '@kuruma/shared/db/schema'
+import { and, eq, inArray } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
+import type { Db } from '../../src/repositories/drizzle'
+import {
+  DrizzleOperatorMembershipRepository,
+  DrizzleOperatorRepository,
+  DrizzleProviderInviteRepository,
+  DrizzleUserRepository,
+} from '../../src/repositories/drizzle'
+import { createOperatorTeamRoutes } from '../../src/routes/operator-team'
+import type { OperatorMemberDeactivatedAuditEvent } from '../../src/services/operator-team'
+import { OperatorTeamService } from '../../src/services/operator-team'
+import { ProviderInviteService } from '../../src/services/provider-invite'
+import { testAuthMiddleware } from '../helpers/auth'
+import { db } from './setup'
+
+// Alias for the repo constructors: postgres-js drizzle and neon-http drizzle
+// share the same query API surface but differ in driver type. Integration tests
+// cast once (same pattern as user-projection.test.ts and renter-documents.test.ts).
+const typedDb = db as unknown as Db
+
+// #1230 slice 6: the picker-admin's write routes proven against real Postgres.
+// A PLATFORM_ADMIN with ?operatorId=X writes under X (not a phantom admin tenant);
+// a member-id belonging to Y is 404 when X is picked; the last-owner lockout
+// fires at 409; and the audit event carries the picked operatorId.
+describe('operator-team write routes — picker-admin (?operatorId=) (real Postgres)', () => {
+  const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const adminId = `tm_admin_${uniq}`
+  const ownerXId = `tm_owner_x_${uniq}`
+  const staffXId = `tm_staff_x_${uniq}`
+  const ownerYId = `tm_owner_y_${uniq}`
+
+  // Picked operator is X (BEST_CAR_RENTAL_OPERATOR_ID), Y is the other tenant.
+  const opXId = BEST_CAR_RENTAL_OPERATOR_ID
+  const opYId = SECOND_OPERATOR_ID
+
+  let ownerXMembershipId: string
+  let staffXMembershipId: string
+  let ownerYMembershipId: string
+  const auditEvents: OperatorMemberDeactivatedAuditEvent[] = []
+
+  let app: Hono
+
+  function buildApp(): Hono {
+    const inviteRepo = new DrizzleProviderInviteRepository(typedDb)
+    const membershipRepo = new DrizzleOperatorMembershipRepository(typedDb)
+    const userRepo = new DrizzleUserRepository(typedDb)
+    const operatorRepo = new DrizzleOperatorRepository(typedDb)
+    const inviteService = new ProviderInviteService(
+      inviteRepo,
+      operatorRepo,
+      { webBaseUrl: 'https://app.example.com' },
+      () => {},
+    )
+    const service = new OperatorTeamService(
+      inviteRepo,
+      membershipRepo,
+      userRepo,
+      inviteService,
+      (event) => {
+        auditEvents.push(event)
+      },
+    )
+    const hono = new Hono()
+    setupGlobalHandlers(hono)
+    // PLATFORM_ADMIN with no operatorId — must pick via ?operatorId=
+    hono.use('*', testAuthMiddleware(adminId, 'PLATFORM_ADMIN'))
+    hono.route('/', createOperatorTeamRoutes(service))
+    return hono
+  }
+
+  beforeAll(async () => {
+    await db.insert(users).values([
+      {
+        id: adminId,
+        email: `tm-admin-${uniq}@test.com`,
+        role: 'PLATFORM_ADMIN',
+        language: 'en',
+      },
+      {
+        id: ownerXId,
+        email: `tm-owner-x-${uniq}@test.com`,
+        role: 'OPERATOR_OWNER',
+        language: 'en',
+      },
+      {
+        id: staffXId,
+        email: `tm-staff-x-${uniq}@test.com`,
+        role: 'OPERATOR_STAFF',
+        language: 'en',
+      },
+      {
+        id: ownerYId,
+        email: `tm-owner-y-${uniq}@test.com`,
+        role: 'OPERATOR_OWNER',
+        language: 'en',
+      },
+    ])
+    const membershipRepo = new DrizzleOperatorMembershipRepository(typedDb)
+    const mOwnerX = await membershipRepo.create({
+      userId: ownerXId,
+      operatorId: opXId,
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const mStaffX = await membershipRepo.create({
+      userId: staffXId,
+      operatorId: opXId,
+      role: 'OPERATOR_STAFF',
+      status: 'ACTIVE',
+    })
+    const mOwnerY = await membershipRepo.create({
+      userId: ownerYId,
+      operatorId: opYId,
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    ownerXMembershipId = mOwnerX.id
+    staffXMembershipId = mStaffX.id
+    ownerYMembershipId = mOwnerY.id
+    app = buildApp()
+  })
+
+  afterAll(async () => {
+    // Remove the invite seeded in (a), scoped tightly by email to avoid
+    // touching other tests' rows.
+    await db
+      .delete(providerInvites)
+      .where(
+        and(
+          eq(providerInvites.operatorId, opXId),
+          eq(providerInvites.email, `picker-invite-${uniq}@test.com`),
+        ),
+      )
+    // Memberships are keyed on userId — these IDs are unique to this run.
+    await db
+      .delete(operatorMemberships)
+      .where(inArray(operatorMemberships.userId, [ownerXId, staffXId, ownerYId]))
+    await db.delete(users).where(inArray(users.id, [adminId, ownerXId, staffXId, ownerYId]))
+  })
+
+  it('(a) POST invite with ?operatorId=X creates a PENDING invite under X', async () => {
+    const email = `picker-invite-${uniq}@test.com`
+    const res = await app.request(`/operators/me/invites?operatorId=${opXId}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.inviteUrl).toContain('/provider/invite/')
+
+    // Confirm the row is stored under opX, not a phantom admin tenant.
+    const [row] = await db
+      .select()
+      .from(providerInvites)
+      .where(and(eq(providerInvites.operatorId, opXId), eq(providerInvites.email, email)))
+    expect(row).toBeDefined()
+    expect(row?.operatorId).toBe(opXId)
+    expect(row?.status).toBe('PENDING')
+  })
+
+  it('(b) deactivating a member of Y via ?operatorId=X is 404 — cross-tenant id invisible', async () => {
+    // ownerYMembershipId belongs to Y; the admin picked X.
+    const res = await app.request(
+      `/operators/me/members/${ownerYMembershipId}/deactivate?operatorId=${opXId}`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(404)
+
+    // Y's owner is still ACTIVE — no cross-tenant mutation occurred.
+    const [stillActive] = await db
+      .select()
+      .from(operatorMemberships)
+      .where(
+        and(
+          eq(operatorMemberships.id, ownerYMembershipId),
+          eq(operatorMemberships.status, 'ACTIVE'),
+        ),
+      )
+    expect(stillActive).toBeDefined()
+  })
+
+  it('(c) deactivating X last owner via ?operatorId=X is 409 — lockout enforced', async () => {
+    // ownerX is X's only OPERATOR_OWNER; the lockout counts owners (not total
+    // members), so this 409 holds independently of the staff-deactivation in (d).
+    const res = await app.request(
+      `/operators/me/members/${ownerXMembershipId}/deactivate?operatorId=${opXId}`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(409)
+
+    // Owner is still ACTIVE — a rejected deactivate mutates nothing.
+    const [stillActive] = await db
+      .select()
+      .from(operatorMemberships)
+      .where(
+        and(
+          eq(operatorMemberships.id, ownerXMembershipId),
+          eq(operatorMemberships.status, 'ACTIVE'),
+        ),
+      )
+    expect(stillActive).toBeDefined()
+  })
+
+  it('(d) deactivating X staff via ?operatorId=X is 200 and audit event carries operatorId=X', async () => {
+    const res = await app.request(
+      `/operators/me/members/${staffXMembershipId}/deactivate?operatorId=${opXId}`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+    expect((await res.json()).data).toEqual({ id: staffXMembershipId })
+
+    // The staff membership row is now REVOKED.
+    const [deactivated] = await db
+      .select()
+      .from(operatorMemberships)
+      .where(eq(operatorMemberships.id, staffXMembershipId))
+    expect(deactivated?.status).toBe('REVOKED')
+
+    // The audit event names the PICKED operator, not a phantom admin tenant.
+    const event = auditEvents.find((e) => e.targetUserId === staffXId)
+    expect(event).toBeDefined()
+    expect(event?.operatorId).toBe(opXId)
+    expect(event?.type).toBe('OPERATOR_MEMBER_DEACTIVATED')
+  })
+})

--- a/packages/api/tests/routes/operator-team.test.ts
+++ b/packages/api/tests/routes/operator-team.test.ts
@@ -223,6 +223,68 @@ describe('GET /operators/me/members', () => {
   })
 })
 
+describe('read routes thread ?operatorId= for a picker-admin', () => {
+  it('GET /operators/me/members?operatorId=op_2 returns op_2 members for a PLATFORM_ADMIN', async () => {
+    await membershipRepo.create({
+      userId: 'u_b',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/members?operatorId=op_2')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    expect(data.map((m: { userId: string }) => m.userId)).toEqual(['u_b'])
+  })
+
+  it('GET /operators/me/invites?operatorId=op_2 returns op_2 invites for a PLATFORM_ADMIN', async () => {
+    await inviteRepo.create({
+      email: 'theirs@op2.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_op2',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_b',
+      acceptedByUserId: null,
+    })
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/invites?operatorId=op_2')
+    expect(res.status).toBe(200)
+    const { data } = await res.json()
+    expect(data.map((i: { email: string }) => i.email)).toEqual(['theirs@op2.com'])
+  })
+
+  it('GET /operators/me/members with NO pick is 422 for a PLATFORM_ADMIN (no merged view)', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/members')
+    expect(res.status).toBe(422)
+  })
+
+  it('a RENTER is 403 even with ?operatorId= (team is owner-tier internal)', async () => {
+    const res = await mountFor('RENTER').request('/operators/me/members?operatorId=op_1')
+    expect(res.status).toBe(403)
+  })
+
+  it('an operator IGNORES a foreign ?operatorId= and reads its own tenant', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_b',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const res = await mountFor('OPERATOR_OWNER', 'op_1').request(
+      '/operators/me/members?operatorId=op_2',
+    )
+    const { data } = await res.json()
+    expect(data.map((m: { userId: string }) => m.userId)).toEqual(['u_owner'])
+  })
+})
+
 describe('POST /operators/me/members/:id/deactivate', () => {
   async function seedMember(
     userId: string,

--- a/packages/api/tests/routes/operator-team.test.ts
+++ b/packages/api/tests/routes/operator-team.test.ts
@@ -285,6 +285,66 @@ describe('read routes thread ?operatorId= for a picker-admin', () => {
   })
 })
 
+describe('write routes thread ?operatorId= for a picker-admin (#1230)', () => {
+  it('POST /operators/me/invites?operatorId=op_2 mints under op_2 for a PLATFORM_ADMIN (201)', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/invites?operatorId=op_2', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'new@op2.com' }),
+    })
+    expect(res.status).toBe(201)
+    expect(await inviteRepo.listByOperator('op_2')).toHaveLength(1)
+  })
+
+  it('POST invite with NO pick is 422 for a PLATFORM_ADMIN', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request('/operators/me/invites', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'x@x.com' }),
+    })
+    expect(res.status).toBe(422)
+  })
+
+  it('a bogus ?operatorId= on invite is 404 (c1), not 500', async () => {
+    const res = await mountFor('PLATFORM_ADMIN').request(
+      '/operators/me/invites?operatorId=op_ghost',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'x@x.com' }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  // G6a: a legacy STAFF/ADMIN passes requireOperatorOwnerWrite but the RESOLVER
+  // denies it (403). This pins that the resolver, not the gate, is the deny point —
+  // collapsing team onto resolveOperatorIdForWrite (which honors legacy admins)
+  // would flip this to a cross-tenant 201 and fail here.
+  it('denies a legacy STAFF write-with-?operatorId= at the resolver (403)', async () => {
+    const res = await mountFor('STAFF').request('/operators/me/invites?operatorId=op_2', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'x@op2.com' }),
+    })
+    expect(res.status).toBe(403)
+    expect(await inviteRepo.listByOperator('op_2')).toHaveLength(0)
+  })
+
+  it('still forbids an OPERATOR_STAFF write even with a valid ?operatorId= (owner-tier gate)', async () => {
+    const res = await mountFor('OPERATOR_STAFF', 'op_1').request(
+      '/operators/me/invites?operatorId=op_1',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'x@op1.com' }),
+      },
+    )
+    expect(res.status).toBe(403)
+    expect(await inviteRepo.listByOperator('op_1')).toHaveLength(0)
+  })
+})
+
 describe('POST /operators/me/members/:id/deactivate', () => {
   async function seedMember(
     userId: string,

--- a/packages/api/tests/services/operator-team.test.ts
+++ b/packages/api/tests/services/operator-team.test.ts
@@ -110,7 +110,7 @@ describe('OperatorTeamService.inviteStaff', () => {
 
   it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) — never mints against undefined', async () => {
     await expect(service.inviteStaff(ADMIN_CTX, { email: 'new@x.com' })).rejects.toThrow(
-      ForbiddenError,
+      OperatorRequiredError,
     )
   })
 })
@@ -238,9 +238,9 @@ describe('OperatorTeamService.revokeInvite', () => {
     expect(await service.listInvites(OWNER_CTX)).toHaveLength(1)
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
+  it('refuses a caller with no operatorId (422)', async () => {
     const id = await seedInvite('op_1', 'h_mine')
-    await expect(service.revokeInvite(ADMIN_CTX, id)).rejects.toThrow(ForbiddenError)
+    await expect(service.revokeInvite(ADMIN_CTX, id)).rejects.toThrow(OperatorRequiredError)
   })
 
   it('cannot revoke another tenant invite (404) — the target stays pending', async () => {
@@ -317,9 +317,11 @@ describe('OperatorTeamService.deactivateMember', () => {
     expect(await projectionOf('u_staffm')).toEqual({ role: 'OPERATOR_STAFF', operatorId: 'op_1' })
   })
 
-  it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) (403)', async () => {
+  it('refuses a caller with no operatorId (e.g. PLATFORM_ADMIN) (422)', async () => {
     const staffId = await seedMember('u_staffm', 'OPERATOR_STAFF')
-    await expect(service.deactivateMember(ADMIN_CTX, staffId)).rejects.toThrow(ForbiddenError)
+    await expect(service.deactivateMember(ADMIN_CTX, staffId)).rejects.toThrow(
+      OperatorRequiredError,
+    )
   })
 
   it('cannot deactivate another tenant member (404) — target stays active', async () => {
@@ -350,5 +352,66 @@ describe('OperatorTeamService.deactivateMember', () => {
 
     expect((await service.listMembers(OWNER_CTX)).map((m) => m.userId)).toEqual(['u_owner'])
     expect(await projectionOf('u_owner2')).toEqual({ role: 'RENTER', operatorId: null })
+  })
+})
+
+describe('OperatorTeamService writes as a picked operator (#1230)', () => {
+  it('inviteStaff: a PLATFORM_ADMIN mints under the PICKED operator, stamping the admin as inviter', async () => {
+    await service.inviteStaff(ADMIN_CTX, { email: 'new@op2.com' }, 'op_2')
+    const stored = await inviteRepo.listByOperator('op_2')
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.operatorId).toBe('op_2')
+    expect(stored[0]?.invitedByUserId).toBe('u_admin')
+  })
+
+  it('revokeInvite: a PLATFORM_ADMIN revokes within the picked tenant and cannot touch another', async () => {
+    const mine = await inviteRepo.create({
+      email: 'target@op2.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_op2',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_owner',
+      acceptedByUserId: null,
+    })
+    await inviteRepo.create({
+      email: 'safe@op1.com',
+      operatorId: 'op_1',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_op1',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_owner',
+      acceptedByUserId: null,
+    })
+    await service.revokeInvite(ADMIN_CTX, mine.id, 'op_2')
+    expect(await inviteRepo.listByOperator('op_2')).toHaveLength(0)
+    // the picked scope cannot reach op_1 — its invite stays pending
+    expect(await inviteRepo.listByOperator('op_1')).toHaveLength(1)
+  })
+
+  it('deactivateMember: a PLATFORM_ADMIN deactivates within the picked tenant and the audit names the picked operator + admin actor', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const staff = await membershipRepo.create({
+      userId: 'u_staffm',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      status: 'ACTIVE',
+    })
+    await service.deactivateMember(ADMIN_CTX, staff.id, 'op_2')
+    expect(recordedAudits).toEqual([
+      {
+        type: 'OPERATOR_MEMBER_DEACTIVATED',
+        operatorId: 'op_2',
+        actorUserId: 'u_admin',
+        targetUserId: 'u_staffm',
+      },
+    ])
   })
 })

--- a/packages/api/tests/services/operator-team.test.ts
+++ b/packages/api/tests/services/operator-team.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { CallerContext } from '../../src/auth/context'
-import { ConflictError, ForbiddenError, NotFoundError } from '../../src/auth/guards'
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  OperatorRequiredError,
+} from '../../src/auth/guards'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
 import { InMemoryOperatorMembershipRepository } from '../../src/repositories/in-memory/operator-membership'
 import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
@@ -136,8 +141,8 @@ describe('OperatorTeamService.listInvites', () => {
     expect(invites[0]).not.toHaveProperty('invitedByUserId')
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
-    await expect(service.listInvites(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  it('refuses a caller with no operatorId (422)', async () => {
+    await expect(service.listInvites(ADMIN_CTX)).rejects.toThrow(OperatorRequiredError)
   })
 })
 
@@ -166,8 +171,43 @@ describe('OperatorTeamService.listMembers', () => {
     expect(members[0]?.joinedAt).toMatch(ISO_RE)
   })
 
-  it('refuses a caller with no operatorId (403)', async () => {
-    await expect(service.listMembers(ADMIN_CTX)).rejects.toThrow(ForbiddenError)
+  it('refuses a caller with no operatorId (422)', async () => {
+    await expect(service.listMembers(ADMIN_CTX)).rejects.toThrow(OperatorRequiredError)
+  })
+})
+
+describe('OperatorTeamService reads as a picked operator (#1230)', () => {
+  it('listInvites: a PLATFORM_ADMIN with a picked operatorId reads THAT tenant', async () => {
+    await inviteRepo.create({
+      email: 'theirs@x.com',
+      operatorId: 'op_2',
+      role: 'OPERATOR_STAFF',
+      tokenHash: 'h_2',
+      status: 'PENDING',
+      expiresAt: FUTURE,
+      invitedByUserId: 'u_other',
+      acceptedByUserId: null,
+    })
+    const invites = await service.listInvites(ADMIN_CTX, 'op_2')
+    expect(invites).toHaveLength(1)
+    expect(invites[0]?.email).toBe('theirs@x.com')
+  })
+
+  it('listMembers: an operator IGNORES a foreign picked id and reads its own tenant', async () => {
+    await membershipRepo.create({
+      userId: 'u_owner',
+      operatorId: 'op_1',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    await membershipRepo.create({
+      userId: 'u_other',
+      operatorId: 'op_2',
+      role: 'OPERATOR_OWNER',
+      status: 'ACTIVE',
+    })
+    const members = await service.listMembers(OWNER_CTX, 'op_2')
+    expect(members.map((m) => m.userId)).toEqual(['u_owner'])
   })
 })
 

--- a/packages/api/tests/services/provider-invite.test.ts
+++ b/packages/api/tests/services/provider-invite.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ConflictError } from '../../src/auth/guards'
+import { ConflictError, NotFoundError } from '../../src/auth/guards'
 import { InMemoryOperatorRepository } from '../../src/repositories/in-memory/operator'
 import { InMemoryProviderInviteRepository } from '../../src/repositories/in-memory/provider-invite'
 import {
@@ -103,6 +103,12 @@ describe('ProviderInviteService.createInvite', () => {
     // The failed mint adds no second row and emits no audit for the rejected attempt.
     expect(await repo.listByOperator('op_1')).toHaveLength(1)
     expect(audits).toHaveLength(1)
+  })
+
+  it('OperatorNotFoundError is a NotFoundError so the global handler maps it to 404, not 500 (c1)', () => {
+    const err = new OperatorNotFoundError('op_missing')
+    expect(err).toBeInstanceOf(NotFoundError)
+    expect(err.operatorId).toBe('op_missing')
   })
 
   it('lets the same email be re-invited once the prior invite is revoked', async () => {

--- a/packages/api/tests/tenancy.test.ts
+++ b/packages/api/tests/tenancy.test.ts
@@ -9,6 +9,7 @@ import {
   applyCrossOperatorReadScope,
   operatorReadScope,
   resolveOperatorIdForWrite,
+  resolveTeamOperatorId,
 } from '../src/tenancy'
 
 const operatorCtx = (operatorId?: string): CallerContext =>
@@ -119,5 +120,44 @@ describe('applyCrossOperatorReadScope', () => {
     expect(
       applyCrossOperatorReadScope(adminCtx, { operatorId: 'op_9', includeAll: true }, {}),
     ).toEqual({ operatorId: 'op_9' })
+  })
+})
+
+describe('resolveTeamOperatorId (#1230 slice 6)', () => {
+  const owner: CallerContext = { userId: 'u', role: 'OPERATOR_OWNER', operatorId: 'op-self' }
+  const admin: CallerContext = { userId: 'a', role: 'PLATFORM_ADMIN', bypassScope: true }
+
+  test('returns an operator its own id and IGNORES a foreign input (no cross-tenant)', () => {
+    expect(resolveTeamOperatorId(owner)).toBe('op-self')
+    expect(resolveTeamOperatorId(owner, 'op-other')).toBe('op-self')
+    // OPERATOR_STAFF follows the identical operator branch — pin it so removing
+    // OPERATOR_STAFF from OPERATOR_ROLES would fail here, not silently pass.
+    const staff: CallerContext = { userId: 'u', role: 'OPERATOR_STAFF', operatorId: 'op-self' }
+    expect(resolveTeamOperatorId(staff)).toBe('op-self')
+    expect(resolveTeamOperatorId(staff, 'op-other')).toBe('op-self')
+  })
+
+  test('fails closed for an operator that lost its operatorId claim', () => {
+    const noOp: CallerContext = { userId: 'u', role: 'OPERATOR_STAFF' }
+    expect(() => resolveTeamOperatorId(noOp, 'op-x')).toThrow(ForbiddenError)
+  })
+
+  test('returns the input id for a PLATFORM_ADMIN (honored ONLY here)', () => {
+    expect(resolveTeamOperatorId(admin, 'op-target')).toBe('op-target')
+  })
+
+  test('throws OperatorRequiredError (422) for a PLATFORM_ADMIN with no pick — no merged team view', () => {
+    expect(() => resolveTeamOperatorId(admin)).toThrow(OperatorRequiredError)
+    expect(() => resolveTeamOperatorId(admin, '')).toThrow(OperatorRequiredError)
+  })
+
+  test('denies renter / partner / legacy STAFF·ADMIN outright (403) — team is owner-tier internal', () => {
+    const renter: CallerContext = { userId: 'r', role: 'RENTER' }
+    const partner: CallerContext = { userId: 't', role: 'PARTNER', bypassScope: true }
+    const legacyStaff: CallerContext = { userId: 's', role: 'STAFF', bypassScope: false }
+    const legacyAdmin: CallerContext = { userId: 'a2', role: 'ADMIN', bypassScope: false }
+    for (const ctx of [renter, partner, legacyStaff, legacyAdmin]) {
+      expect(() => resolveTeamOperatorId(ctx, 'op-target')).toThrow(ForbiddenError)
+    }
   })
 })

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -877,6 +877,7 @@
       "deactivating": "Deactivating...",
       "staffNotice": "Only an owner can invite staff.",
       "noOperatorContext": "This page manages a single operator's team. Use the admin portal to manage operators.",
+      "pickOperatorPrompt": "Select an operator from the picker above to view and manage its team.",
       "unknownName": "Unnamed",
       "roleOwner": "Owner",
       "roleStaff": "Staff",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -877,6 +877,7 @@
       "deactivating": "無効化中...",
       "staffNotice": "スタッフを招待できるのはオーナーのみです。",
       "noOperatorContext": "このページは単一の事業者のチームを管理します。事業者の管理は管理ポータルを使用してください。",
+      "pickOperatorPrompt": "上部の選択メニューから事業者を選ぶと、そのチームを表示・管理できます。",
       "unknownName": "名前未設定",
       "roleOwner": "オーナー",
       "roleStaff": "スタッフ",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -877,6 +877,7 @@
       "deactivating": "停用中...",
       "staffNotice": "只有所有者才能邀请员工。",
       "noOperatorContext": "此页面管理单个运营商的团队。请使用管理门户来管理运营商。",
+      "pickOperatorPrompt": "请从上方的选择器中选择一个运营商，以查看并管理其团队。",
       "unknownName": "未命名",
       "roleOwner": "所有者",
       "roleStaff": "员工",

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -2,7 +2,8 @@ import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { RouteRetryError } from '@/vite/RouteRetryError'
 import { featureFlagsQueryOptions, resolveFeatureFlag } from '@/vite/config'
-import { isOperatorOwnerSession, isOperatorSession } from '@/vite/guards'
+import { canPickOperatorContext, canWriteAsOperatorOwner } from '@/vite/guards'
+import { OperatorBadge, operatorsQueryOptions, useOperatorContext } from '@/vite/operator-context'
 import { DeactivateMemberDialog } from '@/vite/operator-team/DeactivateMemberDialog'
 import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
 import { RevokeInviteDialog } from '@/vite/operator-team/RevokeInviteDialog'
@@ -10,7 +11,7 @@ import { TeamView } from '@/vite/operator-team/TeamView'
 import { teamInvitesQueryOptions, teamMembersQueryOptions } from '@/vite/operator-team/api'
 import { sessionQueryOptions } from '@/vite/session'
 import type { OperatorInviteData, OperatorMemberData } from '@kuruma/shared/types/operator-team'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, redirect } from '@tanstack/react-router'
 import { UserPlus } from 'lucide-react'
 import { useState } from 'react'
@@ -19,9 +20,12 @@ import { useTranslations } from 'use-intl'
 // Operator self-service team management (#904). URL `/<locale>/manage/team` —
 // behind the `_business` guard. The loader prefetches the session + members +
 // pending invites (no FOUC); the component reads the same options via
-// useSuspenseQuery. Tenant scoping is server-side (the client names no
-// operatorId). Inviting is owner-only (isOperatorOwnerSession), mirroring the
-// API's requireOperatorOwnerWrite gate; staff and bypass roles see read-only.
+// useSuspenseQuery. Picker-admin (PLATFORM_ADMIN only, per slice 6 #1230): the
+// ?operator= param is honored — legacy STAFF/ADMIN are NOT pickers (their team
+// read would 403 on a foreign operator), so the param drops for them.
+// OperatorTeamData is a keyed child: key={operatorId} remounts it on every
+// tenant switch, resetting all local dialog state (inviteOpen, selectedInvite,
+// selectedMember) cleanly without manual imperative resets.
 export const Route = createFileRoute('/$locale/_business/manage/team')({
   // Post-MVP feature (#904), hidden in the beta demo. The nav link is already
   // filtered out; this blocks a direct URL too, falling back to the bookings page.
@@ -33,13 +37,22 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }
   },
-  loader: async ({ context }) => {
+  loaderDeps: ({ search }: { search: { operator?: string | undefined } }) => ({
+    operator: search.operator,
+  }),
+  loader: async ({ context, deps }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
-    const operatorId = session?.user.operatorId ?? ''
-    await Promise.all([
-      context.queryClient.ensureQueryData(teamMembersQueryOptions(operatorId)),
-      context.queryClient.ensureQueryData(teamInvitesQueryOptions(operatorId)),
-    ])
+    // Capability-gated: a retained ?operator= is honored only for a picker-admin,
+    // never a legacy STAFF/ADMIN (whose team read would 403). Search params are
+    // input, not permission — derive from session capability first.
+    const picked = canPickOperatorContext(session ?? null) ? deps.operator : undefined
+    const operatorId = session?.user.operatorId ?? picked
+    if (operatorId) {
+      await Promise.all([
+        context.queryClient.ensureQueryData(teamMembersQueryOptions(operatorId)),
+        context.queryClient.ensureQueryData(teamInvitesQueryOptions(operatorId)),
+      ])
+    }
   },
   pendingComponent: PageSkeleton,
   errorComponent: OperatorTeamError,
@@ -49,19 +62,21 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
 export function OperatorTeamRoute() {
   const t = useTranslations('business.team')
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
-  const operatorId = session?.user.operatorId ?? ''
-  const { data: members } = useSuspenseQuery(teamMembersQueryOptions(operatorId))
-  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions(operatorId))
-  const [inviteOpen, setInviteOpen] = useState(false)
-  const [selectedInvite, setSelectedInvite] = useState<OperatorInviteData | null>(null)
-  const [selectedMember, setSelectedMember] = useState<OperatorMemberData | null>(null)
+  const { pickedOperatorId } = useOperatorContext()
+  const canPick = canPickOperatorContext(session ?? null)
+  // Mirror the loader — must stay in lockstep. A legacy admin's retained param drops.
+  const picked = canPick ? pickedOperatorId : undefined
+  const operatorId = session?.user.operatorId ?? picked
+  const canManage = canWriteAsOperatorOwner(session ?? null, pickedOperatorId)
 
-  // A bypass role (PLATFORM_ADMIN / legacy STAFF·ADMIN) carries no operatorId and
-  // has no single team to manage — it onboards operators via the admin portal.
-  const hasOperator = isOperatorSession(session)
-  // Managing (invite / revoke / deactivate) is owner-only; staff see the team
-  // read-only (the API's requireOperatorOwnerWrite gate is the real enforcement).
-  const canManage = isOperatorOwnerSession(session)
+  // Badge label: team reads carry only the user's name, so source the operator name
+  // from the operators list (already cached by BusinessLayout's picker on this route).
+  // operatorNameById from useOperatorScope is empty when a pick is active — do not use it.
+  const { data: operators } = useQuery({
+    ...operatorsQueryOptions(),
+    enabled: canPick && Boolean(pickedOperatorId),
+  })
+  const pickedName = operators?.find((o) => o.id === pickedOperatorId)?.name
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
@@ -71,53 +86,89 @@ export function OperatorTeamRoute() {
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
             <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
           </div>
-          {canManage && (
-            <Button onClick={() => setInviteOpen(true)} className="shrink-0">
-              <UserPlus className="size-4" />
-              {t('invite')}
-            </Button>
-          )}
+          {canPick && Boolean(pickedOperatorId) && <OperatorBadge name={pickedName} />}
         </header>
 
-        {hasOperator ? (
-          <>
-            {!canManage && <p className="mb-6 text-sm text-muted-foreground">{t('staffNotice')}</p>}
-            <TeamView
-              members={members}
-              invites={invites}
-              canManage={canManage}
-              onRevokeInvite={setSelectedInvite}
-              onDeactivateMember={setSelectedMember}
-            />
-          </>
+        {session && operatorId ? (
+          <OperatorTeamData
+            key={operatorId}
+            operatorId={operatorId}
+            canManage={canManage}
+            csrfToken={session.csrfToken}
+          />
         ) : (
-          <p className="text-muted-foreground">{t('noOperatorContext')}</p>
-        )}
-
-        {canManage && session && (
-          <>
-            <InviteStaffDialog
-              open={inviteOpen}
-              onOpenChange={setInviteOpen}
-              csrfToken={session.csrfToken}
-              operatorId={operatorId}
-            />
-            <RevokeInviteDialog
-              invite={selectedInvite}
-              onOpenChange={(open) => !open && setSelectedInvite(null)}
-              csrfToken={session.csrfToken}
-              operatorId={operatorId}
-            />
-            <DeactivateMemberDialog
-              member={selectedMember}
-              onOpenChange={(open) => !open && setSelectedMember(null)}
-              csrfToken={session.csrfToken}
-              operatorId={operatorId}
-            />
-          </>
+          <p className="text-muted-foreground">
+            {canPick ? t('pickOperatorPrompt') : t('noOperatorContext')}
+          </p>
         )}
       </div>
     </main>
+  )
+}
+
+function OperatorTeamData({
+  operatorId,
+  canManage,
+  csrfToken,
+}: {
+  operatorId: string
+  canManage: boolean
+  csrfToken: string
+}) {
+  const t = useTranslations('business.team')
+  const { data: members } = useSuspenseQuery(teamMembersQueryOptions(operatorId))
+  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions(operatorId))
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [selectedInvite, setSelectedInvite] = useState<OperatorInviteData | null>(null)
+  const [selectedMember, setSelectedMember] = useState<OperatorMemberData | null>(null)
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        {!canManage ? (
+          <p className="text-sm text-muted-foreground">{t('staffNotice')}</p>
+        ) : (
+          <span />
+        )}
+        {canManage && (
+          <Button onClick={() => setInviteOpen(true)} className="shrink-0">
+            <UserPlus className="size-4" />
+            {t('invite')}
+          </Button>
+        )}
+      </div>
+
+      <TeamView
+        members={members}
+        invites={invites}
+        canManage={canManage}
+        onRevokeInvite={setSelectedInvite}
+        onDeactivateMember={setSelectedMember}
+      />
+
+      {canManage && (
+        <>
+          <InviteStaffDialog
+            open={inviteOpen}
+            onOpenChange={setInviteOpen}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+          <RevokeInviteDialog
+            invite={selectedInvite}
+            onOpenChange={(open) => !open && setSelectedInvite(null)}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+          <DeactivateMemberDialog
+            member={selectedMember}
+            onOpenChange={(open) => !open && setSelectedMember(null)}
+            csrfToken={csrfToken}
+            operatorId={operatorId}
+          />
+        </>
+      )}
+    </>
   )
 }
 

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -34,10 +34,11 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
     }
   },
   loader: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
+    const operatorId = session?.user.operatorId ?? ''
     await Promise.all([
-      context.queryClient.ensureQueryData(sessionQueryOptions()),
-      context.queryClient.ensureQueryData(teamMembersQueryOptions()),
-      context.queryClient.ensureQueryData(teamInvitesQueryOptions()),
+      context.queryClient.ensureQueryData(teamMembersQueryOptions(operatorId)),
+      context.queryClient.ensureQueryData(teamInvitesQueryOptions(operatorId)),
     ])
   },
   pendingComponent: PageSkeleton,
@@ -48,8 +49,9 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
 export function OperatorTeamRoute() {
   const t = useTranslations('business.team')
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
-  const { data: members } = useSuspenseQuery(teamMembersQueryOptions())
-  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions())
+  const operatorId = session?.user.operatorId ?? ''
+  const { data: members } = useSuspenseQuery(teamMembersQueryOptions(operatorId))
+  const { data: invites } = useSuspenseQuery(teamInvitesQueryOptions(operatorId))
   const [inviteOpen, setInviteOpen] = useState(false)
   const [selectedInvite, setSelectedInvite] = useState<OperatorInviteData | null>(null)
   const [selectedMember, setSelectedMember] = useState<OperatorMemberData | null>(null)
@@ -98,16 +100,19 @@ export function OperatorTeamRoute() {
               open={inviteOpen}
               onOpenChange={setInviteOpen}
               csrfToken={session.csrfToken}
+              operatorId={operatorId}
             />
             <RevokeInviteDialog
               invite={selectedInvite}
               onOpenChange={(open) => !open && setSelectedInvite(null)}
               csrfToken={session.csrfToken}
+              operatorId={operatorId}
             />
             <DeactivateMemberDialog
               member={selectedMember}
               onOpenChange={(open) => !open && setSelectedMember(null)}
               csrfToken={session.csrfToken}
+              operatorId={operatorId}
             />
           </>
         )}

--- a/packages/web/src/vite/nav/BusinessLayout.test.tsx
+++ b/packages/web/src/vite/nav/BusinessLayout.test.tsx
@@ -121,7 +121,8 @@ describe('BusinessLayout', () => {
   })
 
   it('hides the operator picker for a PLATFORM_ADMIN on a route that does not honor ?operator', () => {
-    h.routeId = '/$locale/_business/manage/team'
+    // messages is not in OPERATOR_CONTEXT_ROUTE_IDS; team was added in slice 6.
+    h.routeId = '/$locale/_business/manage/messages'
     renderBusinessLayout({ role: 'PLATFORM_ADMIN' })
     expect(screen.queryByLabelText('Operator')).toBeNull()
   })

--- a/packages/web/src/vite/operator-context/operator-context.test.ts
+++ b/packages/web/src/vite/operator-context/operator-context.test.ts
@@ -96,7 +96,11 @@ describe('useIsOperatorContextRoute', () => {
   })
 
   it('is false on an unscoped business route that does not honor ?operator', () => {
-    h.matches = [{ routeId: '/$locale/_business' }, { routeId: '/$locale/_business/manage/team' }]
+    // messages is not in OPERATOR_CONTEXT_ROUTE_IDS; team was added in slice 6.
+    h.matches = [
+      { routeId: '/$locale/_business' },
+      { routeId: '/$locale/_business/manage/messages' },
+    ]
     const { result } = renderHook(() => useIsOperatorContextRoute())
     expect(result.current).toBe(false)
   })

--- a/packages/web/src/vite/operator-context/operator-context.ts
+++ b/packages/web/src/vite/operator-context/operator-context.ts
@@ -104,6 +104,7 @@ export const OPERATOR_CONTEXT_ROUTE_IDS: ReadonlySet<string> = new Set([
   '/$locale/_business/manage/insurance',
   '/$locale/_business/manage/locations',
   '/$locale/_business/manage/settings', // slice 2 — picker honored on settings
+  '/$locale/_business/manage/team', // slice 6 — picker honored on team management
 ])
 
 // True when the active route is one that honors `?operator` (a descendant match

--- a/packages/web/src/vite/operator-team/DeactivateMemberDialog.tsx
+++ b/packages/web/src/vite/operator-team/DeactivateMemberDialog.tsx
@@ -16,6 +16,7 @@ interface DeactivateMemberDialogProps {
   member: OperatorMemberData | null
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  operatorId: string
 }
 
 // #904 slice 2: owner-only deactivation of a staff member. The API refuses the
@@ -26,11 +27,12 @@ export function DeactivateMemberDialog({
   member,
   onOpenChange,
   csrfToken,
+  operatorId,
 }: DeactivateMemberDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: (id: string) => deactivateMember(id, csrfToken),
+    mutationFn: (id: string) => deactivateMember(id, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_MEMBERS_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
+++ b/packages/web/src/vite/operator-team/InviteStaffDialog.tsx
@@ -17,6 +17,7 @@ interface InviteStaffDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  operatorId: string
 }
 
 // #904: owner-only staff invite. On success the dialog does NOT close — it
@@ -24,14 +25,19 @@ interface InviteStaffDialogProps {
 // no email is sent yet), so the owner copies it to share. The new pending row is
 // pulled in by invalidating the invites query. Closing resets both the mutation
 // and the local form/copy state so a prior reveal never lingers on reopen.
-export function InviteStaffDialog({ open, onOpenChange, csrfToken }: InviteStaffDialogProps) {
+export function InviteStaffDialog({
+  open,
+  onOpenChange,
+  csrfToken,
+  operatorId,
+}: InviteStaffDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const [email, setEmail] = useState('')
   const [copied, setCopied] = useState(false)
 
   const mutation = useMutation({
-    mutationFn: (value: string) => inviteStaff({ email: value }, csrfToken),
+    mutationFn: (value: string) => inviteStaff({ email: value }, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_INVITES_QUERY_KEY })
     },

--- a/packages/web/src/vite/operator-team/RevokeInviteDialog.tsx
+++ b/packages/web/src/vite/operator-team/RevokeInviteDialog.tsx
@@ -16,17 +16,23 @@ interface RevokeInviteDialogProps {
   invite: OperatorInviteData | null
   onOpenChange: (open: boolean) => void
   csrfToken: string
+  operatorId: string
 }
 
 // #904 slice 2: owner-only revoke of a pending staff invite. The API returns 404
 // for an unknown/foreign id (tenant is session-derived), surfaced inline via the
 // thrown ApiError message. Success invalidates the invites query and closes;
 // closing resets the mutation so a prior refusal never lingers on reopen.
-export function RevokeInviteDialog({ invite, onOpenChange, csrfToken }: RevokeInviteDialogProps) {
+export function RevokeInviteDialog({
+  invite,
+  onOpenChange,
+  csrfToken,
+  operatorId,
+}: RevokeInviteDialogProps) {
   const t = useTranslations('business.team')
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: (id: string) => revokeInvite(id, csrfToken),
+    mutationFn: (id: string) => revokeInvite(id, csrfToken, operatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TEAM_INVITES_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-team/api.ts
+++ b/packages/web/src/vite/operator-team/api.ts
@@ -11,9 +11,9 @@ import { queryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
 // #904: operator self-service team page. Cookie-based and operator-scoped
-// server-side — the client names NO operatorId, so a cross-tenant read/write is
-// impossible by construction (the API derives the tenant from the session). The
-// invite POST threads the session CSRF token (global double-submit guard).
+// server-side — PLATFORM_ADMIN callers pass ?operatorId= to scope to a picked
+// tenant; operator roles are scoped server-side from the session and ignore it.
+// The invite POST threads the session CSRF token (global double-submit guard).
 
 // Network-seam validators pinned to the shared DTOs with `satisfies` so a field
 // drift fails to compile here, not silently at render.
@@ -36,25 +36,42 @@ const memberSchema = z.object({
   joinedAt: z.string(),
 }) satisfies z.ZodType<OperatorMemberData>
 
+// 2-element prefix kept as-is so dialogs can invalidate by prefix without
+// knowing the operatorId. The query options append the id as a third element.
 export const TEAM_INVITES_QUERY_KEY = ['operator-team', 'invites'] as const
 export const TEAM_MEMBERS_QUERY_KEY = ['operator-team', 'members'] as const
 
-export async function fetchTeamInvites(): Promise<OperatorInviteData[]> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, { credentials: 'include' })
+// Scope every team call to the picked (or session) operator. Operator sessions
+// send their own id (ignored server-side); a PLATFORM_ADMIN sends the picked one.
+const operatorQuery = (operatorId: string): string =>
+  `?operatorId=${encodeURIComponent(operatorId)}`
+
+export async function fetchTeamInvites(operatorId: string): Promise<OperatorInviteData[]> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites${operatorQuery(operatorId)}`, {
+    credentials: 'include',
+  })
   return unwrap(res, inviteSchema.array())
 }
 
-export async function fetchTeamMembers(): Promise<OperatorMemberData[]> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/members`, { credentials: 'include' })
+export async function fetchTeamMembers(operatorId: string): Promise<OperatorMemberData[]> {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/members${operatorQuery(operatorId)}`, {
+    credentials: 'include',
+  })
   return unwrap(res, memberSchema.array())
 }
 
-export function teamInvitesQueryOptions() {
-  return queryOptions({ queryKey: TEAM_INVITES_QUERY_KEY, queryFn: fetchTeamInvites })
+export function teamInvitesQueryOptions(operatorId: string) {
+  return queryOptions({
+    queryKey: [...TEAM_INVITES_QUERY_KEY, operatorId],
+    queryFn: () => fetchTeamInvites(operatorId),
+  })
 }
 
-export function teamMembersQueryOptions() {
-  return queryOptions({ queryKey: TEAM_MEMBERS_QUERY_KEY, queryFn: fetchTeamMembers })
+export function teamMembersQueryOptions(operatorId: string) {
+  return queryOptions({
+    queryKey: [...TEAM_MEMBERS_QUERY_KEY, operatorId],
+    queryFn: () => fetchTeamMembers(operatorId),
+  })
 }
 
 /** The one-time invite reveal: the URL embeds the token (never persisted in
@@ -73,8 +90,9 @@ const createdInviteSchema = z.object({
 export async function inviteStaff(
   input: InviteStaffInput,
   csrfToken: string,
+  operatorId: string,
 ): Promise<CreatedInviteResult> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites`, {
+  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites${operatorQuery(operatorId)}`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
@@ -89,24 +107,30 @@ export async function inviteStaff(
 const mutatedEntitySchema = z.object({ id: z.string() })
 
 // Owner-only writes. Both are cookie-authed POSTs (CSRF double-submit) to
-// `/operators/me/*` id paths — the API derives the tenant from the session, so
-// the client never names an operatorId. unwrap throws an ApiError carrying the
-// server message (404 for an unknown/foreign id, 409 for the last owner) so the
-// confirm dialog can render it.
-export async function revokeInvite(id: string, csrfToken: string): Promise<void> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/invites/${id}/revoke`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'X-CSRF-Token': csrfToken },
-  })
+// `/operators/me/*` id paths. PLATFORM_ADMIN passes ?operatorId= to scope to
+// the picked tenant; operator roles are scoped from the session server-side.
+// unwrap throws an ApiError carrying the server message (404 for an
+// unknown/foreign id, 409 for the last owner) so the confirm dialog can render it.
+export async function revokeInvite(
+  id: string,
+  csrfToken: string,
+  operatorId: string,
+): Promise<void> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/invites/${id}/revoke${operatorQuery(operatorId)}`,
+    { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
+  )
   await unwrap(res, mutatedEntitySchema)
 }
 
-export async function deactivateMember(id: string, csrfToken: string): Promise<void> {
-  const res = await fetch(`${getApiBaseUrl()}/operators/me/members/${id}/deactivate`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'X-CSRF-Token': csrfToken },
-  })
+export async function deactivateMember(
+  id: string,
+  csrfToken: string,
+  operatorId: string,
+): Promise<void> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/operators/me/members/${id}/deactivate${operatorQuery(operatorId)}`,
+    { method: 'POST', credentials: 'include', headers: { 'X-CSRF-Token': csrfToken } },
+  )
   await unwrap(res, mutatedEntitySchema)
 }

--- a/packages/web/tests/vite/operator-team-api.test.ts
+++ b/packages/web/tests/vite/operator-team-api.test.ts
@@ -4,6 +4,8 @@ import {
   fetchTeamMembers,
   inviteStaff,
   revokeInvite,
+  teamInvitesQueryOptions,
+  teamMembersQueryOptions,
 } from '@/vite/operator-team/api'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -29,7 +31,7 @@ describe('inviteStaff', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await inviteStaff({ email: 'new@x.com' }, 'csrf-1')
+    const result = await inviteStaff({ email: 'new@x.com' }, 'csrf-1', 'op_1')
     expect(result).toEqual({
       inviteUrl: 'https://app/provider/invite/tok',
       expiresAt: '2099-01-01T00:00:00.000Z',
@@ -37,6 +39,7 @@ describe('inviteStaff', () => {
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/invites')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
@@ -48,7 +51,9 @@ describe('inviteStaff', () => {
       'fetch',
       vi.fn(async () => jsonResponse({ success: false, error: 'CSRF token mismatch' }, 403)),
     )
-    await expect(inviteStaff({ email: 'x@x.com' }, 'stale')).rejects.toThrow()
+    await expect(inviteStaff({ email: 'x@x.com' }, 'stale', 'op_1')).rejects.toThrow(
+      'CSRF token mismatch',
+    )
   })
 })
 
@@ -57,10 +62,11 @@ describe('revokeInvite', () => {
     const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: { id: 'i1' } }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await revokeInvite('i1', 'csrf-1')
+    await revokeInvite('i1', 'csrf-1', 'op_1')
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/invites/i1/revoke')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
@@ -71,7 +77,7 @@ describe('revokeInvite', () => {
       'fetch',
       vi.fn(async () => jsonResponse({ success: false, error: 'invite not found' }, 404)),
     )
-    await expect(revokeInvite('nope', 'csrf-1')).rejects.toThrow('invite not found')
+    await expect(revokeInvite('nope', 'csrf-1', 'op_1')).rejects.toThrow('invite not found')
   })
 })
 
@@ -80,10 +86,11 @@ describe('deactivateMember', () => {
     const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: { id: 'm1' } }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await deactivateMember('m1', 'csrf-1')
+    await deactivateMember('m1', 'csrf-1', 'op_1')
 
     const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/operators/me/members/m1/deactivate')
+    expect(url).toContain('operatorId=op_1')
     expect(opts.method).toBe('POST')
     expect((opts.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-1')
     expect(opts.credentials).toBe('include')
@@ -96,7 +103,7 @@ describe('deactivateMember', () => {
         jsonResponse({ success: false, error: 'cannot deactivate the last operator owner' }, 409),
       ),
     )
-    await expect(deactivateMember('m1', 'csrf-1')).rejects.toThrow(
+    await expect(deactivateMember('m1', 'csrf-1', 'op_1')).rejects.toThrow(
       'cannot deactivate the last operator owner',
     )
   })
@@ -104,28 +111,30 @@ describe('deactivateMember', () => {
 
 describe('fetchTeamMembers', () => {
   it('parses the active members joined to name + email', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        jsonResponse({
-          success: true,
-          data: [
-            {
-              id: 'm1',
-              userId: 'u1',
-              name: 'Olive Owner',
-              email: 'owner@x.com',
-              role: 'OPERATOR_OWNER',
-              status: 'ACTIVE',
-              joinedAt: '2026-01-01T00:00:00.000Z',
-            },
-          ],
-        }),
-      ),
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: [
+          {
+            id: 'm1',
+            userId: 'u1',
+            name: 'Olive Owner',
+            email: 'owner@x.com',
+            role: 'OPERATOR_OWNER',
+            status: 'ACTIVE',
+            joinedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
     )
-    const members = await fetchTeamMembers()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const members = await fetchTeamMembers('op_1')
     expect(members).toHaveLength(1)
     expect(members[0]).toMatchObject({ userId: 'u1', name: 'Olive Owner', role: 'OPERATOR_OWNER' })
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('operatorId=op_1')
   })
 
   it('tolerates a null name/email (walk-in-style user) without throwing', async () => {
@@ -148,32 +157,41 @@ describe('fetchTeamMembers', () => {
         }),
       ),
     )
-    const members = await fetchTeamMembers()
+    const members = await fetchTeamMembers('op_1')
     expect(members[0]?.name).toBeNull()
   })
 })
 
 describe('fetchTeamInvites', () => {
   it('parses the pending invites', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        jsonResponse({
-          success: true,
-          data: [
-            {
-              id: 'i1',
-              email: 'pending@x.com',
-              role: 'OPERATOR_STAFF',
-              status: 'PENDING',
-              expiresAt: '2099-01-01T00:00:00.000Z',
-              createdAt: '2026-01-01T00:00:00.000Z',
-            },
-          ],
-        }),
-      ),
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: [
+          {
+            id: 'i1',
+            email: 'pending@x.com',
+            role: 'OPERATOR_STAFF',
+            status: 'PENDING',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
     )
-    const invites = await fetchTeamInvites()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const invites = await fetchTeamInvites('op_1')
     expect(invites[0]).toMatchObject({ email: 'pending@x.com', status: 'PENDING' })
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('operatorId=op_1')
+  })
+})
+
+describe('query keys fold in the operatorId', () => {
+  it('keys team reads on the operator so a tenant switch refetches', () => {
+    expect(teamMembersQueryOptions('op_1').queryKey).toEqual(['operator-team', 'members', 'op_1'])
+    expect(teamInvitesQueryOptions('op_2').queryKey).toEqual(['operator-team', 'invites', 'op_2'])
   })
 })

--- a/packages/web/tests/vite/operator-team/DeactivateMemberDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/DeactivateMemberDialog.test.tsx
@@ -31,7 +31,7 @@ function member(overrides: Partial<OperatorMemberData> = {}): OperatorMemberData
   }
 }
 
-function renderDialog(mem: OperatorMemberData | null) {
+function renderDialog(mem: OperatorMemberData | null, operatorId = 'op_1') {
   const onOpenChange = vi.fn()
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -40,7 +40,12 @@ function renderDialog(mem: OperatorMemberData | null) {
   render(
     <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <DeactivateMemberDialog member={mem} onOpenChange={onOpenChange} csrfToken="csrf-token" />
+        <DeactivateMemberDialog
+          member={mem}
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId={operatorId}
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -63,6 +68,7 @@ describe('DeactivateMemberDialog', () => {
     await waitFor(() => expect(deactivateMember).toHaveBeenCalledTimes(1))
     expect(deactivateMember.mock.calls[0][0]).toBe('mem_1')
     expect(deactivateMember.mock.calls[0][1]).toBe('csrf-token')
+    expect(deactivateMember.mock.calls[0][2]).toBe('op_1')
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: TEAM_MEMBERS_QUERY_KEY })
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })

--- a/packages/web/tests/vite/operator-team/InviteStaffDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/InviteStaffDialog.test.tsx
@@ -1,0 +1,93 @@
+import { ApiError } from '@/lib/api-error'
+import { InviteStaffDialog } from '@/vite/operator-team/InviteStaffDialog'
+import * as api from '@/vite/operator-team/api'
+import { TEAM_INVITES_QUERY_KEY } from '@/vite/operator-team/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+vi.mock('@/vite/operator-team/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/vite/operator-team/api')>()
+  return { ...actual, inviteStaff: vi.fn() }
+})
+
+const inviteStaff = vi.mocked(api.inviteStaff)
+const en = enMessages.business.team
+
+function renderDialog(operatorId = 'op_1') {
+  const onOpenChange = vi.fn()
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const invalidateSpy = vi.spyOn(client, 'invalidateQueries')
+  render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <InviteStaffDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId={operatorId}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+  return { onOpenChange, invalidateSpy }
+}
+
+describe('InviteStaffDialog', () => {
+  afterEach(() => {
+    cleanup()
+    inviteStaff.mockReset()
+  })
+
+  it('sends an invite with the email, csrf token, and operatorId, then invalidates invites', async () => {
+    inviteStaff.mockResolvedValue({
+      inviteUrl: 'https://example.com/invite/token_abc',
+      expiresAt: '2026-07-09T00:00:00.000Z',
+    })
+    const user = userEvent.setup()
+    const { invalidateSpy } = renderDialog()
+
+    await user.type(screen.getByLabelText(en.form.email), 'staff@example.com')
+    await user.click(screen.getByRole('button', { name: en.form.submit }))
+
+    await waitFor(() => expect(inviteStaff).toHaveBeenCalledTimes(1))
+    expect(inviteStaff.mock.calls[0][0]).toEqual({ email: 'staff@example.com' })
+    expect(inviteStaff.mock.calls[0][1]).toBe('csrf-token')
+    expect(inviteStaff.mock.calls[0][2]).toBe('op_1')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: TEAM_INVITES_QUERY_KEY })
+  })
+
+  it('reveals the invite URL on success and does not close', async () => {
+    inviteStaff.mockResolvedValue({
+      inviteUrl: 'https://example.com/invite/token_abc',
+      expiresAt: '2026-07-09T00:00:00.000Z',
+    })
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+
+    await user.type(screen.getByLabelText(en.form.email), 'staff@example.com')
+    await user.click(screen.getByRole('button', { name: en.form.submit }))
+
+    expect(
+      await screen.findByDisplayValue('https://example.com/invite/token_abc'),
+    ).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('surfaces a server error inline and keeps the form open', async () => {
+    inviteStaff.mockRejectedValue(new ApiError('Email already invited', 409))
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+
+    await user.type(screen.getByLabelText(en.form.email), 'staff@example.com')
+    await user.click(screen.getByRole('button', { name: en.form.submit }))
+
+    expect(await screen.findByText('Email already invited')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+})

--- a/packages/web/tests/vite/operator-team/RevokeInviteDialog.test.tsx
+++ b/packages/web/tests/vite/operator-team/RevokeInviteDialog.test.tsx
@@ -30,7 +30,7 @@ function invite(overrides: Partial<OperatorInviteData> = {}): OperatorInviteData
   }
 }
 
-function renderDialog(inv: OperatorInviteData | null) {
+function renderDialog(inv: OperatorInviteData | null, operatorId = 'op_1') {
   const onOpenChange = vi.fn()
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -39,7 +39,12 @@ function renderDialog(inv: OperatorInviteData | null) {
   render(
     <QueryClientProvider client={client}>
       <IntlProvider locale="en" messages={enMessages}>
-        <RevokeInviteDialog invite={inv} onOpenChange={onOpenChange} csrfToken="csrf-token" />
+        <RevokeInviteDialog
+          invite={inv}
+          onOpenChange={onOpenChange}
+          csrfToken="csrf-token"
+          operatorId={operatorId}
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -62,6 +67,7 @@ describe('RevokeInviteDialog', () => {
     await waitFor(() => expect(revokeInvite).toHaveBeenCalledTimes(1))
     expect(revokeInvite.mock.calls[0][0]).toBe('inv_1')
     expect(revokeInvite.mock.calls[0][1]).toBe('csrf-token')
+    expect(revokeInvite.mock.calls[0][2]).toBe('op_1')
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: TEAM_INVITES_QUERY_KEY })
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })

--- a/packages/web/tests/vite/operator-team/TeamRoute.test.tsx
+++ b/packages/web/tests/vite/operator-team/TeamRoute.test.tsx
@@ -1,0 +1,163 @@
+import { OperatorTeamRoute } from '@/routes/$locale/_business/manage/team'
+import { sessionQueryOptions } from '@/vite/session'
+import type { Session } from '@/vite/session'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, Suspense } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import enMessages from '../../../messages/en.json'
+
+// The capability-gated resolution + keyed render-gate child introduced in Slice 6
+// (#1230). Three pins:
+//
+// P1  — PLATFORM_ADMIN with no pick shows the pick-prompt and issues NO
+//       /operators/me/* read (the operatorId-gated OperatorTeamData child never mounts).
+// P2a — A legacy STAFF session with a retained ?operator= is NOT a picker;
+//       shows noOperatorContext with no team read.
+// P3  — Picked mode: scoped read fires with the picked id.
+// P2b — key={operatorId} remounts OperatorTeamData on tenant switch, proven by the
+//       new /operators/me/members?operatorId=op_3 read firing after the switch.
+//
+// We do NOT globally stub useSuspenseQuery — fetch is stubbed per test so the
+// render-gate logic is exercised for real.
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const useOperatorContextMock = vi.fn<() => { pickedOperatorId: string | undefined }>()
+
+// Spread the real module so OperatorBadge / operatorsQueryOptions / other exports
+// the render path may reach survive unchanged.
+vi.mock('@/vite/operator-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/vite/operator-context')>()
+  return { ...actual, useOperatorContext: () => useOperatorContextMock() }
+})
+
+const en = enMessages.business.team
+
+function platformAdminSession(): Session {
+  return { user: { id: 'a', role: 'PLATFORM_ADMIN' }, csrfToken: 'c' }
+}
+
+function staffSession(): Session {
+  // Legacy STAFF: has business access but no operatorId, and is NOT isPlatformAdmin.
+  return { user: { id: 's', role: 'STAFF' }, csrfToken: 'c' }
+}
+
+// Pre-seed session in cache (staleTime=Infinity) so useSuspenseQuery(sessionQueryOptions())
+// returns immediately without firing a fetch — mirrors VehicleDetailRoute.test.tsx pattern.
+function renderRoute(session: Session) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: Number.POSITIVE_INFINITY, retry: false },
+      mutations: { retry: false },
+    },
+  })
+  client.setQueryData(sessionQueryOptions().queryKey, session)
+  return render(<OperatorTeamRoute />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>
+        <IntlProvider locale="en" messages={enMessages}>
+          {/* Suspense boundary required: OperatorTeamData uses useSuspenseQuery */}
+          <Suspense fallback={null}>{children}</Suspense>
+        </IntlProvider>
+      </QueryClientProvider>
+    ),
+  })
+}
+
+describe('OperatorTeamRoute capability-gated resolution (Slice 6 #1230)', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('P1 — PLATFORM_ADMIN with no pick shows the pick-prompt and issues no /operators/me/* read', () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: undefined })
+
+    renderRoute(platformAdminSession())
+
+    // Prompt is visible — the operatorId-gated OperatorTeamData child never mounted.
+    expect(screen.getByText(en.pickOperatorPrompt)).toBeInTheDocument()
+    // No team read fired (the child never mounted, so no useSuspenseQuery calls).
+    const calledTeam = fetchMock.mock.calls.some(([u]) => String(u).includes('/operators/me/'))
+    expect(calledTeam).toBe(false)
+  })
+
+  it('P2a — STAFF with retained pickedOperatorId shows the no-context prompt and fires no team read', () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    // canPickOperatorContext(STAFF) = false → picked = undefined → operatorId = undefined
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+
+    renderRoute(staffSession())
+
+    expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes('/operators/me/'))).toBe(false)
+  })
+
+  it('Picked mode — PLATFORM_ADMIN with a pick fires the scoped team read with ?operatorId=', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+
+    renderRoute(platformAdminSession())
+
+    // OperatorTeamData mounts with key='op_2' and fires members + invites reads.
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) =>
+          String(u).includes('/operators/me/members?operatorId=op_2'),
+        ),
+      ).toBe(true),
+    )
+    // The render gate opened: the pick-prompt is gone (the scoped child mounted),
+    // so a read firing while the prompt still showed would fail here.
+    expect(screen.queryByText(en.pickOperatorPrompt)).not.toBeInTheDocument()
+  })
+
+  it('P2b — key={operatorId} remounts OperatorTeamData on tenant switch, firing new reads for the new tenant', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_2' })
+    const { rerender } = renderRoute(platformAdminSession())
+
+    // Wait for the initial op_2 reads to fire (child mounted with key='op_2').
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) =>
+          String(u).includes('/operators/me/members?operatorId=op_2'),
+        ),
+      ).toBe(true),
+    )
+
+    // Switch to op_3: key changes 'op_2' → 'op_3'. React unmounts the old child
+    // (resetting all useState: inviteOpen, selectedInvite, selectedMember) and
+    // mounts the new one. Proven by the new /operators/me/members?operatorId=op_3 read.
+    fetchMock.mockClear()
+    useOperatorContextMock.mockReturnValue({ pickedOperatorId: 'op_3' })
+    rerender(<OperatorTeamRoute />)
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) =>
+          String(u).includes('/operators/me/members?operatorId=op_3'),
+        ),
+      ).toBe(true),
+    )
+    // op_2 data is in cache (staleTime=Infinity) — its reads must NOT re-fire.
+    expect(
+      fetchMock.mock.calls.some(([u]) =>
+        String(u).includes('/operators/me/members?operatorId=op_2'),
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## ⚠️ Merge note (read before squash-merging)

- This PR should close **#1411 only** (the slice issue).
- The commit `fix(#1230): OperatorNotFoundError extends NotFoundError` uses a `fix(#1230):` subject. On a squash-merge to develop, GitHub scans the squashed commit subjects for closing keywords and **may auto-close epic #1230**. Epic #1230 must stay OPEN (picker-admin manual-booking customer-scoping remains). If it auto-closes on merge, immediately `gh issue reopen 1230`.

---

## What

Epic #1230 **slice 6** (the final, heaviest slice — the only one needing an API change). Lets a `PLATFORM_ADMIN` read and manage (invite / revoke / deactivate) a **picked** operator's team **as that operator**, with the owner-tier write gate, while every tenant-isolation hazard stays closed.

Closes #1411. `Refs #1230` — **do NOT close the epic**.

## Approach — one seam

The team API is `/operators/me/*`, self-scoped with no foreign-id surface. The whole slice is: replace the service's private `requireOwnOperator(ctx)` with a pure `resolveTeamOperatorId(ctx, inputOperatorId?)` in `packages/api/src/tenancy.ts`, and thread an optional `?operatorId=` query param through the five routes + web. **No schema, no migration, no new authorization gate.**

`resolveTeamOperatorId` is an allowlist (deliberately stricter than `resolveOperatorIdForWrite`):
- operator role → own id (any input **ignored** — cannot act cross-tenant)
- `PRIVILEGED_ROLES` (PLATFORM_ADMIN) → the input id (else `422` "specify an operator")
- everyone else (renter / PARTNER / legacy STAFF·ADMIN) → `403`

Writes still gate `requireOperatorOwnerWrite(ctx)` **first**, then resolve — so an `OPERATOR_STAFF` 403s at the gate and a legacy `STAFF`/`ADMIN` 403s at the resolver (pinned by a route test, G6a).

## Slices (10 TDD tasks)

- **API reads + resolver:** resolver + truth-table unit tests; `listMembers`/`listInvites` + read routes thread `?operatorId=`.
- **API writes + c1:** `inviteStaff`/`revokeInvite`/`deactivateMember` thread the id; `requireOwnOperator` deleted; `OperatorNotFoundError extends NotFoundError` (a bogus `?operatorId=` now maps `404`, was `500`); real-pg integration test proving cross-tenant isolation (wrong-tenant deactivate → 404, last-owner → 409, audit carries the picked operatorId).
- **Web:** `api.ts` threads the id + folds it into the query keys (2-element invalidation prefix kept); 3 dialogs take an `operatorId` prop; team route registered in the picker + `business.team.pickOperatorPrompt` (en/ja/zh); `team.tsx` rewritten to a **capability-gated** resolution + a **keyed `OperatorTeamData` render-gate child** so all-mode fires no team read (P1), a legacy admin's retained `?operator=` is dropped (P2a), and a tenant switch resets dialog intent (P2b).

## Verification

- API unit **2739/2739**, web **1979/1979**, full real-pg integration **499/499** (incl new `operator-team-picker.test.ts`).
- `tsc` clean (api + web), web build clean, i18n parity (1492 keys × 3 locales).
- `lint:boundaries` / `lint:modules` / `lint:size` exit 0.
- Merged current `develop` (no conflicts).

## Follow-ups

- **#1420** — sibling `settings.tsx` loader shares the pre-existing un-gated `?operator=` pattern (safe but avoidable 403 round-trip). Out of scope here.

## Design

- Spec: `docs/superpowers/specs/2026-07-02-team-picker-design.md` (5 review rounds)
- Plan: `docs/superpowers/plans/2026-07-02-team-picker.md` (10 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)