### PR TITLE
chore(web): drop dead dayjs dependency (#1385)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
-        "dayjs": "^1.11.10",
         "interactjs": "1.10.27",
         "lucide-react": "^1.7.0",
         "pigeon-maps": "^0.22.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,7 +25,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
-    "dayjs": "^1.11.10",
     "interactjs": "1.10.27",
     "lucide-react": "^1.7.0",
     "pigeon-maps": "^0.22.1",


### PR DESCRIPTION
## What
Removes the unused direct `dayjs` dependency from `packages/web`.

## Why
`packages/web/package.json` declared `dayjs` but a repo-wide search finds **zero** source imports — `date-fns` + native `Intl` are the canonical date tooling. Dead dep = extra install/audit surface and reader confusion about which date lib is canonical.

## Safety
- `dayjs` remains resolvable **transitively** via `react-calendar-timeline` (3 lockfile refs after removal), so nothing that relies on it breaks.
- Only 2 deletions: the `package.json` line and its direct `bun.lock` entry.
- knip (`lint:deps`) is a **local-only** script, not a CI gate; it flags `dayjs` today and won't after this.

## Verification
- `tsc --noEmit` (web): clean
- `bun run build` (web): success
- Full web suite: **1971 passed** (286 files)

Part of #1369 (maintainability tracker, W4).

Closes #1385