### PR TITLE
refactor(shared): fold payment_anomaly_* enums into enums.ts SSoT (#1383)

### DIFF
--- a/packages/shared/src/db/payment.ts
+++ b/packages/shared/src/db/payment.ts
@@ -9,7 +9,12 @@ import {
   timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
-import { PAYMENT_EVENT_STATUSES, PAYMENT_REFUND_STATUSES } from '../enums'
+import {
+  PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
+  PAYMENT_EVENT_STATUSES,
+  PAYMENT_REFUND_STATUSES,
+} from '../enums'
 import { operators } from './auth'
 import { bookings } from './booking'
 
@@ -111,18 +116,14 @@ export const paymentRefunds = pgTable(
 // Persisted (not just logged, #461 P1b) so the admin surface can list duplicates to
 // refund rather than scrape logs. Kept OUT of payment_events so revenue math (which sums
 // SUCCEEDED rows) is never polluted by a flagged-for-review charge.
-export const paymentAnomalyKindEnum = pgEnum('payment_anomaly_kind', [
-  'DOUBLE_PAYMENT',
-  'AMOUNT_MISMATCH',
-])
+export const paymentAnomalyKindEnum = pgEnum('payment_anomaly_kind', PAYMENT_ANOMALY_KINDS)
 // How a platform admin closed a flagged charge (#1075 slice 3). Carries NO money —
 // v1 only clears the review queue; the duplicate's actual refund happens in the
 // Stripe dashboard (REFUNDED_EXTERNALLY) until in-app refund ships as its own slice.
-export const paymentAnomalyResolutionEnum = pgEnum('payment_anomaly_resolution', [
-  'BENIGN',
-  'INVESTIGATED',
-  'REFUNDED_EXTERNALLY',
-])
+export const paymentAnomalyResolutionEnum = pgEnum(
+  'payment_anomaly_resolution',
+  PAYMENT_ANOMALY_RESOLUTIONS,
+)
 export const paymentAnomalies = pgTable(
   'payment_anomalies',
   {

--- a/packages/shared/src/enums.test.ts
+++ b/packages/shared/src/enums.test.ts
@@ -7,6 +7,8 @@ import {
   OPERATOR_APPLICATION_BUSINESS_TYPES,
   OPERATOR_APPLICATION_FLEET_SIZES,
   OPERATOR_APPLICATION_STATUSES,
+  PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
   REVIEW_DIMENSIONS,
 } from './enums'
 
@@ -45,6 +47,15 @@ describe('operator application enums', () => {
   })
   it('pins business types', () => {
     expect(OPERATOR_APPLICATION_BUSINESS_TYPES).toEqual(['INDIVIDUAL', 'COMPANY'])
+  })
+})
+
+describe('payment anomaly enums', () => {
+  it('pins the anomaly kinds (order matches the payment_anomaly_kind pgEnum)', () => {
+    expect(PAYMENT_ANOMALY_KINDS).toEqual(['DOUBLE_PAYMENT', 'AMOUNT_MISMATCH'])
+  })
+  it('pins the resolution codes (order matches the payment_anomaly_resolution pgEnum)', () => {
+    expect(PAYMENT_ANOMALY_RESOLUTIONS).toEqual(['BENIGN', 'INVESTIGATED', 'REFUNDED_EXTERNALLY'])
   })
 })
 

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -97,6 +97,25 @@ export type PaymentEventStatus = (typeof PAYMENT_EVENT_STATUSES)[number]
 export const PAYMENT_REFUND_STATUSES = ['PENDING', 'SUCCEEDED', 'FAILED'] as const
 export type PaymentRefundStatus = (typeof PAYMENT_REFUND_STATUSES)[number]
 
+// Payment anomalies needing operator/admin review (#508 P2). A verified webhook can
+// report a charge that does NOT become a clean payment_events row: a second distinct
+// Session paying an already-paid booking (DOUBLE_PAYMENT — refund the duplicate) or a
+// session whose amount/currency != the booking snapshot (AMOUNT_MISMATCH — investigate).
+// Kept out of payment_events so revenue math (sum of SUCCEEDED rows) is never polluted.
+export const PAYMENT_ANOMALY_KINDS = ['DOUBLE_PAYMENT', 'AMOUNT_MISMATCH'] as const
+export type PaymentAnomalyKind = (typeof PAYMENT_ANOMALY_KINDS)[number]
+
+// How a platform admin closed a flagged charge (#1075 slice 3). Carries NO money —
+// v1 only clears the review queue: BENIGN (not actually a problem), INVESTIGATED
+// (looked into, no action), REFUNDED_EXTERNALLY (refunded in the Stripe dashboard,
+// since in-app refund is deferred to a future slice).
+export const PAYMENT_ANOMALY_RESOLUTIONS = [
+  'BENIGN',
+  'INVESTIGATED',
+  'REFUNDED_EXTERNALLY',
+] as const
+export type PaymentAnomalyResolution = (typeof PAYMENT_ANOMALY_RESOLUTIONS)[number]
+
 export const ADD_ON_STATUSES = ['ACTIVE', 'ARCHIVED'] as const
 export type AddOnStatus = (typeof ADD_ON_STATUSES)[number]
 

--- a/packages/shared/src/types/payment-anomaly.ts
+++ b/packages/shared/src/types/payment-anomaly.ts
@@ -14,25 +14,24 @@
  * Stripe sent a malformed event.
  */
 
-/** The `payment_anomaly_kind` DB enum, mirrored for the web boundary. Order must
- *  match the schema enum — pinned by `tests/types/payment-anomaly.test.ts`. */
-export const PAYMENT_ANOMALY_KINDS = ['DOUBLE_PAYMENT', 'AMOUNT_MISMATCH'] as const
+// The `payment_anomaly_kind` / `payment_anomaly_resolution` enums live in the
+// `enums.ts` SSoT (fed to `pgEnum` in `db/payment.ts`, pinned by `enums.test.ts`).
+// Re-exported here so the web boundary import path
+// (`@kuruma/shared/types/payment-anomaly`) stays stable — web cannot import the
+// Drizzle schema, so it reads these unions as pure data from this subpath.
+import {
+  PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
+  type PaymentAnomalyKind,
+  type PaymentAnomalyResolution,
+} from '../enums'
 
-export type PaymentAnomalyKind = (typeof PAYMENT_ANOMALY_KINDS)[number]
-
-/** The `payment_anomaly_resolution` DB enum, mirrored for the web boundary (#1075
- *  slice 3). An admin clears the review queue by tagging WHY a flagged charge is
- *  closed — it carries no money: `BENIGN` (not actually a problem), `INVESTIGATED`
- *  (looked into, no action), `REFUNDED_EXTERNALLY` (refunded in the Stripe
- *  dashboard, since in-app refund is deferred to a future slice). Order must match
- *  the schema enum — pinned by `tests/types/payment-anomaly.test.ts`. */
-export const PAYMENT_ANOMALY_RESOLUTIONS = [
-  'BENIGN',
-  'INVESTIGATED',
-  'REFUNDED_EXTERNALLY',
-] as const
-
-export type PaymentAnomalyResolution = (typeof PAYMENT_ANOMALY_RESOLUTIONS)[number]
+export {
+  PAYMENT_ANOMALY_KINDS,
+  PAYMENT_ANOMALY_RESOLUTIONS,
+  type PaymentAnomalyKind,
+  type PaymentAnomalyResolution,
+}
 
 /** One unresolved anomaly. Identifiers are carried so an admin can reconcile or
  *  refund: `stripeEventId` is the reconciliation handle, `stripePaymentIntentId`

--- a/packages/shared/tests/types/payment-anomaly.test.ts
+++ b/packages/shared/tests/types/payment-anomaly.test.ts
@@ -1,23 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { paymentAnomalyKindEnum, paymentAnomalyResolutionEnum } from '../../src/db/schema'
-import {
-  PAYMENT_ANOMALY_KINDS,
-  PAYMENT_ANOMALY_RESOLUTIONS,
-  type PaymentAnomalyView,
-} from '../../src/types/payment-anomaly'
+import type { PaymentAnomalyView } from '../../src/types/payment-anomaly'
 
 describe('PaymentAnomalyView contract', () => {
-  // Drift fence: the web-facing kind union must stay identical to the DB enum
-  // (payment_anomaly_kind). Web cannot import the schema, so this is the only
-  // place the two are pinned together — mirrors the roleEnum guard in schema.test.ts.
-  it('PAYMENT_ANOMALY_KINDS mirrors the payment_anomaly_kind DB enum (order matters)', () => {
-    expect([...PAYMENT_ANOMALY_KINDS]).toEqual([...paymentAnomalyKindEnum.enumValues])
-  })
-
-  it('PAYMENT_ANOMALY_RESOLUTIONS mirrors the payment_anomaly_resolution DB enum (order matters)', () => {
-    expect([...PAYMENT_ANOMALY_RESOLUTIONS]).toEqual([...paymentAnomalyResolutionEnum.enumValues])
-  })
-
+  // The payment_anomaly_kind / _resolution value sets are pinned to literals in
+  // enums.test.ts (the SSoT they now derive from), and enums.ts -> migration drift
+  // is caught by db:verify / the db-drift CI job. This file guards only the
+  // web-facing PaymentAnomalyView JSON shape (ISO-string dates, nullable amounts).
   it('a DOUBLE_PAYMENT view carries the refund/reconcile identifiers', () => {
     const view: PaymentAnomalyView = {
       id: 'pa_1',


### PR DESCRIPTION
## What
Folds the `payment_anomaly_kind` and `payment_anomaly_resolution` value sets into the `enums.ts` single source of truth — the last domain enum that was still hand-copied.

## Why
The arrays were declared **twice**: inline literals fed to `pgEnum` in `db/payment.ts`, and again as `PAYMENT_ANOMALY_KINDS` / `PAYMENT_ANOMALY_RESOLUTIONS` in `types/payment-anomaly.ts`, linked only by a mirror test. Every other pgEnum already derives from `enums.ts`. Two literal copies = the drift class this SSoT exists to kill.

## How
- Move both arrays (+ derived types) into `enums.ts`, grouped with the other `payment_*` enums, docs carried over.
- Feed them to `pgEnum(...)` in `db/payment.ts` (identical values/order → **no SQL change**).
- Re-export from `types/payment-anomaly.ts` so the web boundary import path (`@kuruma/shared/types/payment-anomaly`) stays **stable** — web reads them as pure data since it cannot import the Drizzle schema.
- Pin both arrays with literals in `enums.test.ts` (the old mirror test is now tautological, so this literal pin is the real fence for the SSoT values).

## Out of scope
`packages/api/src/stores.ts` still declares a local `PaymentAnomalyKind` union (`'DOUBLE_PAYMENT' | 'AMOUNT_MISMATCH'`) — an api-internal copy, left untouched to keep this PR scoped to `shared` per the issue.

## Verification
- `bun run db:generate`: **"No schema changes, nothing to migrate"** (zero diff, no migration)
- `bun run db:verify`: 3 static drift checks pass; `drizzle/` untouched
- tsc: shared / api / web all clean (re-export contract holds)
- shared suite: **906 passed** (incl. new enum pins + the mirror test)

Part of #1369 (maintainability tracker, S3).

Closes #1383