### PR TITLE
fix(#1420): capability-gate ?operator= in settings loader + component

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -38,9 +38,12 @@ export const Route = createFileRoute('/$locale/_business/manage/settings')({
   }),
   loader: async ({ context, deps }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions())
-    // Effective id: own operator session id wins; a bypass admin falls back to the
-    // picked param. Matches OperatorSettingsRoute exactly (one resolution, two readers).
-    const operatorId = session?.user.operatorId ?? deps.operator
+    // Capability-gated: a retained ?operator= is honored only for a picker-admin,
+    // never a legacy STAFF/ADMIN (whose profile read would 403). Search params are
+    // input, not permission — derive from session capability first. Matches
+    // OperatorSettingsRoute exactly (one resolution, two readers must stay in lockstep).
+    const picked = canPickOperatorContext(session ?? null) ? deps.operator : undefined
+    const operatorId = session?.user.operatorId ?? picked
     if (operatorId) {
       await context.queryClient.ensureQueryData(operatorProfileQueryOptions(operatorId))
     }
@@ -54,10 +57,12 @@ export function OperatorSettingsRoute() {
   const t = useTranslations('business.settings')
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
   const { pickedOperatorId } = useOperatorContext()
-  // Effective operator id: a real operator session's own id always wins; a bypass
-  // admin falls back to the picked id. Mirrors the loader (must stay in lockstep).
-  const operatorId = session?.user.operatorId ?? pickedOperatorId
   const canPick = canPickOperatorContext(session ?? null)
+  // Effective operator id: a real operator session's own id always wins; a picker-admin
+  // falls back to the picked id. Mirror the loader (must stay in lockstep) — a legacy
+  // STAFF/ADMIN's retained param drops, so it never drives a foreign profile read.
+  const picked = canPick ? pickedOperatorId : undefined
+  const operatorId = session?.user.operatorId ?? picked
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">

--- a/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-settings/OperatorSettingsRoute.test.tsx
@@ -119,4 +119,14 @@ describe('OperatorSettingsRoute (#903)', () => {
     expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
     expect(screen.queryByLabelText(en.form.name)).not.toBeInTheDocument()
   })
+
+  it('drops a retained ?operator pick for a legacy STAFF session — no-context notice, no foreign profile read (#1420)', () => {
+    // The bug: without the capability gate, operatorId ?? pickedOperatorId resolves
+    // the retained foreign id and drives a profile read the API denies (403). A legacy
+    // STAFF is not a picker, so the param must drop and the terminal notice shows.
+    h.picked = 'op_foreign' // no profile seeded for it — a read would suspend/fetch
+    renderRoute(legacyStaffSession)
+    expect(screen.getByText(en.noOperatorContext)).toBeInTheDocument()
+    expect(screen.queryByLabelText(en.form.name)).not.toBeInTheDocument()
+  })
 })

--- a/packages/web/tests/vite/operator-settings/settings.route.test.ts
+++ b/packages/web/tests/vite/operator-settings/settings.route.test.ts
@@ -91,4 +91,16 @@ describe('/manage/settings loader effective-id prefetch', () => {
     const profileCall = ensureQueryData.mock.calls[1][0] as { queryKey: unknown }
     expect(profileCall.queryKey).toEqual(['operator-profile', 'op_self'])
   })
+
+  it('drops a retained ?operator param for a legacy STAFF/ADMIN (no own operatorId, not a picker) — no foreign prefetch (#1420)', async () => {
+    // Without the capability gate, operatorId ?? deps.operator resolves the retained
+    // foreign id and prefetches a profile the API denies (an avoidable 403 round-trip).
+    // A legacy STAFF carries no operatorId and is not a picker (canPickOperatorContext).
+    const ensureQueryData = vi
+      .fn()
+      .mockResolvedValueOnce({ user: { id: 'u', role: 'STAFF' }, csrfToken: 't' }) // session only
+    await loader({ context: { queryClient: { ensureQueryData } }, deps: { operator: 'op_9' } })
+    // Only the session was fetched; the gate drops the param, so no profile prefetch.
+    expect(ensureQueryData).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## What

Surfaced by the slice-6 team-picker review. `manage/settings.tsx` resolved `operatorId = session?.user.operatorId ?? deps.operator` (loader) / `?? pickedOperatorId` (component) **without** a `canPickOperatorContext` gate. A legacy `STAFF`/`ADMIN` (no `operatorId`, not a picker) arriving with a retained `?operator=` param — kept globally by the `_business` layout's `retainSearchParams(['operator'])` — drove an `operatorProfileQueryOptions(param)` prefetch that 403s and lands on the error component.

The behavior was already **safe** (the server denies it); this just removes the avoidable 403 round-trip.

## Fix

Gate the param behind `canPickOperatorContext` in **both** the loader and the component, mirroring what slice 6's `team.tsx` did (search params are input, not permission — derive from session capability first):

```ts
const picked = canPickOperatorContext(session ?? null) ? deps.operator : undefined
const operatorId = session?.user.operatorId ?? picked
```

Own `operatorId` still wins; a `PLATFORM_ADMIN`'s pick is still honored. Loader and component stay in lockstep.

## Tests (TDD, RED→GREEN)

- `settings.route.test.ts`: legacy STAFF + retained `?operator=` → loader prefetches **only** the session, no foreign profile.
- `OperatorSettingsRoute.test.tsx`: legacy STAFF + retained pick → terminal no-context notice, no foreign profile read.

Full web suite green (1980), tsc ×2 clean, biome/module/size lints clean.

Closes #1420
Refs #1230 (does not close the epic)