### PR TITLE
fix(#1430): forbid one-way CLASS_COMBO bookings (dropoff must equal pickup)

### DIFF
--- a/packages/shared/src/validators/booking.ts
+++ b/packages/shared/src/validators/booking.ts
@@ -82,6 +82,22 @@ export const createBookingSchema = z
     message: 'Provide either renterId or walkInCustomer, not both',
     path: ['walkInCustomer'],
   })
+  // #1430: a CLASS_COMBO must be returned to its pickup location. The renter
+  // books off an availability card that can only size the occupancy window by
+  // the PICKUP turnaround (no dropoff is chosen at browse time), while booking
+  // creation sizes it by the DROPOFF turnaround (booking-creation.ts
+  // resolveDropoffEffectiveEnd). Allowing a one-way combo lets the card and the
+  // write-side disagree ("advertised but sold out at checkout"). One-way combos
+  // are unsupported product-wide, so the contract forbids them here. SPECIFIC
+  // bookings are unaffected (they carry a concrete vehicle, not a class float).
+  .refine(
+    (data) =>
+      data.fulfillmentMode !== 'CLASS_COMBO' || data.dropoffLocationId === data.pickupLocationId,
+    {
+      message: 'Class-combo bookings must be returned to the pickup location',
+      path: ['dropoffLocationId'],
+    },
+  )
 
 export const updateBookingStatusSchema = z.object({
   status: z.enum(BOOKING_STATUSES, {

--- a/packages/shared/tests/validators/booking.test.ts
+++ b/packages/shared/tests/validators/booking.test.ts
@@ -301,6 +301,9 @@ describe('createBookingSchema — fulfillment discriminator (#464)', () => {
     startAt: '2026-04-10T09:00:00Z',
     endAt: '2026-04-10T17:00:00Z',
   }
+  // #1430: a CLASS_COMBO must be returned to its pickup, so combo fixtures pin
+  // dropoff === pickup. SPECIFIC keeps `common` (one-way is allowed there).
+  const comboCommon = { ...common, dropoffLocationId: PICKUP_UUID }
 
   it('defaults a fulfillmentMode-less body to SPECIFIC (back-compat)', () => {
     const result = createBookingSchema.safeParse({ ...common, requestedVehicleId: VALID_UUID })
@@ -332,7 +335,7 @@ describe('createBookingSchema — fulfillment discriminator (#464)', () => {
 
   it('accepts a CLASS_COMBO booking with a classId', () => {
     const result = createBookingSchema.safeParse({
-      ...common,
+      ...comboCommon,
       fulfillmentMode: 'CLASS_COMBO',
       classId: CLASS_UUID,
     })
@@ -346,13 +349,33 @@ describe('createBookingSchema — fulfillment discriminator (#464)', () => {
   })
 
   it('rejects a CLASS_COMBO booking missing classId', () => {
-    const result = createBookingSchema.safeParse({ ...common, fulfillmentMode: 'CLASS_COMBO' })
+    const result = createBookingSchema.safeParse({ ...comboCommon, fulfillmentMode: 'CLASS_COMBO' })
     expect(result.success).toBe(false)
+  })
+
+  // #1430: the availability card the renter books from can only size the
+  // occupancy window by the PICKUP turnaround (no dropoff is chosen at browse
+  // time), while booking creation sizes it by the DROPOFF turnaround — so a
+  // one-way combo would let the card and the write-side disagree ("advertised
+  // but sold out at checkout"). One-way combos are unsupported product-wide, so
+  // the contract forbids them: a CLASS_COMBO must be returned to its pickup.
+  it('rejects a CLASS_COMBO booking dropped off at a different location', () => {
+    const result = createBookingSchema.safeParse({
+      ...common,
+      pickupLocationId: PICKUP_UUID,
+      dropoffLocationId: DROPOFF_UUID,
+      fulfillmentMode: 'CLASS_COMBO',
+      classId: CLASS_UUID,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['dropoffLocationId'])
+    }
   })
 
   it('drops requestedVehicleId from a CLASS_COMBO booking (not a SPECIFIC field)', () => {
     const result = createBookingSchema.safeParse({
-      ...common,
+      ...comboCommon,
       fulfillmentMode: 'CLASS_COMBO',
       classId: CLASS_UUID,
       requestedVehicleId: VALID_UUID,
@@ -374,7 +397,7 @@ describe('createBookingSchema — fulfillment discriminator (#464)', () => {
 
   it('still enforces endAt > startAt across the discriminator', () => {
     const result = createBookingSchema.safeParse({
-      ...common,
+      ...comboCommon,
       fulfillmentMode: 'CLASS_COMBO',
       classId: CLASS_UUID,
       startAt: '2026-04-10T17:00:00Z',


### PR DESCRIPTION
## Summary

Closes #1430. A defensive follow-up from the code review of PR #1421's read-side turnaround fix (`cbd603f3`).

**The gap.** The class-combo availability card and booking creation size their occupancy window from **different turnaround sources**:
- **Read-side** (`ClassOfferingService.toCombo`) sizes `[from, effectiveEndAt)` by the **pickup** storefront's turnaround — the only one it can see at browse time (no dropoff chosen yet).
- **Write-side** (`booking-creation.ts` `resolveDropoffEffectiveEnd`) sizes it by the **dropoff** location's turnaround, and the combo path fully supports `dropoff != pickup`.

So a one-way combo could be advertised as available and then fail at checkout (or the inverse). Not UI-reachable — the renter wizard and manual-booking dialog both hardcode `dropoff == pickup` — but **the API is source-agnostic by design (Trip.com hits the same routes)**, so a 3rd-party `CLASS_COMBO` body with a different-turnaround dropoff triggers it. The validator previously accepted it on purpose.

**The fix.** Forbid one-way class-combo bookings at the validator boundary: a `.refine()` on `createBookingSchema` requires `dropoffLocationId === pickupLocationId` when `fulfillmentMode === 'CLASS_COMBO'` (path `dropoffLocationId` → 400). SPECIFIC bookings are unaffected (they carry a concrete vehicle, not a class float). The read model can only reason about the pickup turnaround, so this codifies what the system can actually honor.

**Reversible:** if one-way combos are wanted later, the read model must change too (size conservatively by dropoff turnaround); this constraint would be lifted then.

## Test plan

- [x] TDD: RED (combo with `dropoff != pickup` → asserts reject + error path `dropoffLocationId`) → GREEN (refine).
- [x] Combo validator fixtures pinned to `dropoff == pickup` via a new `comboCommon`; SPECIFIC keeps `common` (one-way still allowed there).
- [x] `@kuruma/shared` full suite 907, `@kuruma/api` booking + combo consumers 353 (route combo POSTs use same-location, unaffected), typecheck shared/api/web, biome, file-size, module-boundaries.
- No migration. No web change (web already sends `dropoff == pickup` for combos).

## Out of scope

- SPECIFIC one-way bookings (per-vehicle availability; separate concern if a parallel divergence exists).