### PR TITLE
feat(#1361): wire picker-admin booking status/cancel writes from trip detail

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/$bookingId.tsx
@@ -10,6 +10,7 @@ import {
   operatorRowFromDetail,
   substitutionCandidatesQueryOptions,
 } from '@/vite/operator-bookings/api'
+import { useOperatorContext } from '@/vite/operator-context/operator-context'
 import { RateRenterPanel } from '@/vite/reviews'
 import { sessionQueryOptions } from '@/vite/session'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
@@ -52,6 +53,10 @@ export function TripDetailRoute() {
   const { data: detail } = useSuspenseQuery(operatorBookingDetailQueryOptions(bookingId))
   const { data: events } = useSuspenseQuery(bookingEventsQueryOptions(bookingId))
   const { data: session } = useSuspenseQuery(sessionQueryOptions())
+  // #1361: this route is registered in OPERATOR_CONTEXT_ROUTE_IDS, so a picker admin's
+  // chosen operator rides here — thread it into the Actions panel so its status/cancel
+  // writes bind to that operator (#1260). Undefined for a tenant operator.
+  const { pickedOperatorId } = useOperatorContext()
   // The replacement-candidate endpoint is operator-only and only relevant to a
   // live booking, so gate the fetch on both — bypass-role viewers (no operatorId)
   // would 403, and a settled trip can't be substituted.
@@ -86,6 +91,7 @@ export function TripDetailRoute() {
               session={session}
               candidates={candidates}
               candidatesError={candidatesError}
+              pickedOperatorId={pickedOperatorId}
             />
             {/* #1084: rate the renter once the trip is COMPLETED. Operator sessions only —
                 oversight viewers (PLATFORM_ADMIN, no operatorId) aren't review participants

--- a/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingActionsPanel.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { useFeatureFlag } from '@/vite/config'
-import { isOperatorSession } from '@/vite/guards'
+import { canWriteAsOperator, isOperatorSession } from '@/vite/guards'
 import { CancelBookingDialog } from '@/vite/operator-bookings/CancelBookingDialog'
 import { SubstituteVehicleDialog } from '@/vite/operator-bookings/SubstituteVehicleDialog'
 import {
@@ -25,6 +25,10 @@ interface BookingActionsPanelProps {
   /** True when the candidate fetch errored — forwarded so the Substitute dialog
    *  can tell a load failure apart from a genuinely empty list. */
   readonly candidatesError?: boolean
+  /** #1361: the operator a picker admin (PLATFORM_ADMIN) has chosen via the context
+   *  picker. Threaded into the status/cancel writes so the #1260 guard binds to it;
+   *  undefined for a tenant operator (its scope rides the cookie). */
+  readonly pickedOperatorId?: string | undefined
 }
 
 // The status a one-click "advance" moves a live booking to: CONFIRMED -> ACTIVE
@@ -53,6 +57,7 @@ export function BookingActionsPanel({
   session,
   candidates,
   candidatesError = false,
+  pickedOperatorId,
 }: BookingActionsPanelProps) {
   const t = useTranslations('bookings.operator.detail')
   const cancellationEnabled = useFeatureFlag('CANCELLATION')
@@ -60,11 +65,15 @@ export function BookingActionsPanel({
   const csrfToken = session?.csrfToken ?? ''
 
   const statusMutation = useMutation({
-    mutationFn: (next: OperatorBookingStatus) => updateBookingStatus(detail.id, next, csrfToken),
+    mutationFn: (next: OperatorBookingStatus) =>
+      updateBookingStatus(detail.id, next, csrfToken, pickedOperatorId),
     onSuccess: () => invalidateBookingCaches(queryClient),
   })
 
-  if (!isOperatorSession(session)) return null
+  // #1361: a picker admin who has chosen an operator may act here too (#1260 binds
+  // the write to it). Substitute stays operator-only below — the API has no admin
+  // substitute path — so an admin never sees a button that would 403.
+  if (!canWriteAsOperator(session, pickedOperatorId)) return null
 
   // A live booking (CONFIRMED/ACTIVE) is the only one with anything to act on; a
   // COMPLETED/CANCELLED trip is settled, so the panel just explains the absence.
@@ -84,17 +93,26 @@ export function BookingActionsPanel({
           >
             {advanceTarget === 'ACTIVE' ? t('markActive') : t('markCompleted')}
           </Button>
-          <SubstituteVehicleDialog
-            bookingId={detail.id}
-            candidates={candidates}
-            candidatesError={candidatesError}
-            csrfToken={csrfToken}
-          />
+          {/* Substitute is an operator-only fleet decision (POST /substitute is
+              isOperatorRole-gated — no admin path, booking-authz.md), so hide it from
+              a picker admin rather than offer a button that 403s. */}
+          {isOperatorSession(session) && (
+            <SubstituteVehicleDialog
+              bookingId={detail.id}
+              candidates={candidates}
+              candidatesError={candidatesError}
+              csrfToken={csrfToken}
+            />
+          )}
           {/* Only CONFIRMED bookings can be cancelled — the server 409s any other
               status. An ACTIVE (picked-up) trip is past the cancellation window, so
               we hide the button rather than offer a dead-end action. */}
           {cancellationEnabled && detail.status === 'CONFIRMED' && (
-            <CancelBookingDialog bookingId={detail.id} csrfToken={csrfToken} />
+            <CancelBookingDialog
+              bookingId={detail.id}
+              csrfToken={csrfToken}
+              pickedOperatorId={pickedOperatorId}
+            />
           )}
         </div>
       ) : (

--- a/packages/web/src/vite/operator-bookings/CancelBookingDialog.tsx
+++ b/packages/web/src/vite/operator-bookings/CancelBookingDialog.tsx
@@ -17,6 +17,9 @@ import { useTranslations } from 'use-intl'
 interface CancelBookingDialogProps {
   readonly bookingId: string
   readonly csrfToken: string
+  /** #1361: the operator a picker admin has chosen — threaded into the cancel write
+   *  so the #1260 guard binds to it; undefined for a tenant operator. */
+  readonly pickedOperatorId?: string | undefined
 }
 
 // #616: operator cancels a booking. The server applies the tiered cancellation
@@ -26,13 +29,17 @@ interface CancelBookingDialogProps {
 // invalidateBookingCaches so the detail + timeline reflect the CANCELLED state and
 // the dashboard overview drops the trip (#1099 Theme 4).
 // CSRF-gated; the session token rides the write.
-export function CancelBookingDialog({ bookingId, csrfToken }: CancelBookingDialogProps) {
+export function CancelBookingDialog({
+  bookingId,
+  csrfToken,
+  pickedOperatorId,
+}: CancelBookingDialogProps) {
   const t = useTranslations('bookings.operator.detail.cancelBooking')
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
 
   const mutation = useMutation({
-    mutationFn: () => cancelBooking(bookingId, csrfToken),
+    mutationFn: () => cancelBooking(bookingId, csrfToken, pickedOperatorId),
     onSuccess: () => {
       invalidateBookingCaches(queryClient)
       setOpen(false)

--- a/packages/web/src/vite/operator-bookings/api.ts
+++ b/packages/web/src/vite/operator-bookings/api.ts
@@ -496,18 +496,30 @@ async function writeBooking(
   return unwrap(res, bookingDtoSchema)
 }
 
+// #1260/#1361: a picker admin binds the write to the operator it is acting as via
+// ?operatorId=; a tenant operator omits it (the server drops it, so it can never
+// widen scope). Without it a picker admin's write 422s OPERATOR_REQUIRED.
 export function updateBookingStatus(
   id: string,
   status: OperatorBookingStatus,
   csrfToken: string,
+  pickedOperatorId?: string,
 ): Promise<BookingDto> {
-  return writeBooking(`/bookings/${encodeURIComponent(id)}/status`, 'PATCH', csrfToken, { status })
+  const suffix = pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
+  return writeBooking(`/bookings/${encodeURIComponent(id)}/status${suffix}`, 'PATCH', csrfToken, {
+    status,
+  })
 }
 
 // DELETE-equivalent (the API models cancel as a POST that records a cancellation
 // fee in the meta); the projection in `data` is the now-CANCELLED booking.
-export function cancelBooking(id: string, csrfToken: string): Promise<BookingDto> {
-  return writeBooking(`/bookings/${encodeURIComponent(id)}/cancel`, 'POST', csrfToken)
+export function cancelBooking(
+  id: string,
+  csrfToken: string,
+  pickedOperatorId?: string,
+): Promise<BookingDto> {
+  const suffix = pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
+  return writeBooking(`/bookings/${encodeURIComponent(id)}/cancel${suffix}`, 'POST', csrfToken)
 }
 
 // --- Existing-customer search (#589 1d slice 3) ------------------------------

--- a/packages/web/src/vite/operator-context/operator-context.test.ts
+++ b/packages/web/src/vite/operator-context/operator-context.test.ts
@@ -120,11 +120,35 @@ describe('useIsOperatorContextRoute', () => {
     const { result } = renderHook(() => useIsOperatorContextRoute())
     expect(result.current).toBe(true)
   })
+
+  it('is false on the by-id trip-detail route (#1361 — by-id read, no picker chip)', () => {
+    // Like fleet/$vehicleId (#1264), the booking by-id detail is NOT a picker route:
+    // its read is by-id, so an interactive pick that diverges from the booking on
+    // screen would dead-end the write at the API's ownership 404. The write still
+    // binds via the retained ?operator= param, without showing the chip here.
+    h.matches = [
+      { routeId: '/$locale/_business' },
+      { routeId: '/$locale/_business/manage/bookings/$bookingId' },
+    ]
+    const { result } = renderHook(() => useIsOperatorContextRoute())
+    expect(result.current).toBe(false)
+  })
 })
 
 describe('OPERATOR_CONTEXT_ROUTE_IDS', () => {
   it('treats the fleet list as a picker route but not the by-id detail route (#1264)', () => {
     expect(OPERATOR_CONTEXT_ROUTE_IDS.has('/$locale/_business/manage/fleet/')).toBe(true)
     expect(OPERATOR_CONTEXT_ROUTE_IDS.has('/$locale/_business/manage/fleet/$vehicleId')).toBe(false)
+  })
+
+  // The booking LIST is a picker route, but the by-id trip-detail is NOT (#1361) — same
+  // rationale as fleet/$vehicleId: a by-id read the pick does not re-scope must not host
+  // an interactive picker. The detail's status/cancel writes still bind via the retained
+  // ?operator= param (useOperatorContext), so the picker chip is simply not shown there.
+  it('treats the bookings list as a picker route but not the by-id trip-detail (#1361)', () => {
+    expect(OPERATOR_CONTEXT_ROUTE_IDS.has('/$locale/_business/manage/bookings/')).toBe(true)
+    expect(OPERATOR_CONTEXT_ROUTE_IDS.has('/$locale/_business/manage/bookings/$bookingId')).toBe(
+      false,
+    )
   })
 })

--- a/packages/web/src/vite/operator-context/operator-context.ts
+++ b/packages/web/src/vite/operator-context/operator-context.ts
@@ -98,6 +98,11 @@ export const OPERATOR_CONTEXT_ROUTE_IDS: ReadonlySet<string> = new Set([
   '/$locale/_business/dashboard', // slice 4 — overview + fleet-overview narrow to picked operator
   '/$locale/_business/manage/add-ons',
   '/$locale/_business/manage/bookings/', // slice 5a — bookings reads narrow to picked operator
+  // NB: the by-id trip-detail ($bookingId) is intentionally NOT registered — like
+  // fleet/$vehicleId (#1264). Its read is by-id (not pick-scoped), so showing an
+  // interactive picker there would let the pick diverge from the booking on screen and
+  // dead-end the write at the API's ownership 404 (#1361). The write still binds: the
+  // route reads the ?operator= param (retained by _business) via useOperatorContext.
   '/$locale/_business/manage/classes',
   '/$locale/_business/manage/fees',
   '/$locale/_business/manage/fleet/', // slice 4 residual (#1264) — list reads narrow; detail is by-id, intentionally NOT registered

--- a/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingActionsPanel.test.tsx
@@ -56,11 +56,17 @@ function renderPanel(
   session: Session | null,
   bookingDetail: OperatorBookingDetailDto,
   candidates: SubstitutionCandidate[] = [candidate],
+  pickedOperatorId?: string,
 ) {
   render(
     <QueryClientProvider client={new QueryClient()}>
       <IntlProvider locale="en" messages={enMessages}>
-        <BookingActionsPanel detail={bookingDetail} session={session} candidates={candidates} />
+        <BookingActionsPanel
+          detail={bookingDetail}
+          session={session}
+          candidates={candidates}
+          pickedOperatorId={pickedOperatorId}
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -155,7 +161,8 @@ describe('BookingActionsPanel status transition', () => {
 
     await user.click(screen.getByRole('button', { name: d.markActive }))
 
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-9', 'ACTIVE', 't'))
+    // #1361: a tenant operator carries no picked operator, so the 4th arg is undefined.
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-9', 'ACTIVE', 't', undefined))
   })
 
   it('advances ACTIVE to COMPLETED when mark-returned is clicked', async () => {
@@ -165,7 +172,7 @@ describe('BookingActionsPanel status transition', () => {
 
     await user.click(screen.getByRole('button', { name: d.markCompleted }))
 
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'COMPLETED', 't'))
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'COMPLETED', 't', undefined))
   })
 
   it('surfaces a status error when the transition fails', async () => {
@@ -176,5 +183,41 @@ describe('BookingActionsPanel status transition', () => {
     await user.click(screen.getByRole('button', { name: d.markActive }))
 
     expect(await screen.findByText(d.statusError)).toBeInTheDocument()
+  })
+})
+
+// #1361: a picker admin (PLATFORM_ADMIN) who has chosen an operator via the context
+// picker may act on the booking here too — the #1260 API guard binds the write to that
+// operator. Substitute stays operator-only (no admin substitute path — booking-authz.md).
+describe('BookingActionsPanel picker-admin (#1361)', () => {
+  it('lets a picker admin with a chosen operator advance, threading the picked operator', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'updateBookingStatus').mockResolvedValue({} as never)
+    renderPanel(bypassSession, detail({ id: 'bk-9', status: 'CONFIRMED' }), [candidate], 'op_7')
+
+    await user.click(screen.getByRole('button', { name: d.markActive }))
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-9', 'ACTIVE', 't', 'op_7'))
+  })
+
+  it('offers Cancel but HIDES Substitute for a picker admin (the API 403s admin substitute)', () => {
+    renderPanel(bypassSession, detail({ status: 'CONFIRMED' }), [candidate], 'op_7')
+    expect(screen.getByRole('button', { name: d.cancelBooking.action })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: sub.action })).not.toBeInTheDocument()
+  })
+
+  it('still renders nothing for a picker admin who has NOT chosen an operator', () => {
+    const { container } = render(
+      <QueryClientProvider client={new QueryClient()}>
+        <IntlProvider locale="en" messages={enMessages}>
+          <BookingActionsPanel
+            detail={detail({ status: 'CONFIRMED' })}
+            session={bypassSession}
+            candidates={[candidate]}
+          />
+        </IntlProvider>
+      </QueryClientProvider>,
+    )
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/packages/web/tests/vite/operator-bookings/CancelBookingDialog.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/CancelBookingDialog.test.tsx
@@ -9,11 +9,15 @@ import enMessages from '../../../messages/en.json'
 
 const c = enMessages.bookings.operator.detail.cancelBooking
 
-function renderDialog(queryClient = new QueryClient()) {
+function renderDialog(queryClient = new QueryClient(), pickedOperatorId?: string) {
   return render(
     <QueryClientProvider client={queryClient}>
       <IntlProvider locale="en" messages={enMessages}>
-        <CancelBookingDialog bookingId="bk-1" csrfToken="csrf-tok" />
+        <CancelBookingDialog
+          bookingId="bk-1"
+          csrfToken="csrf-tok"
+          pickedOperatorId={pickedOperatorId}
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -32,7 +36,20 @@ describe('CancelBookingDialog', () => {
     expect(spy).not.toHaveBeenCalled()
 
     await user.click(screen.getByRole('button', { name: c.confirm }))
-    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok'))
+    // #1361: a tenant operator carries no picked operator, so the 4th arg is undefined.
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok', undefined))
+  })
+
+  // #1361: a picker admin's cancel must carry its chosen operator (?operatorId=) or the
+  // #1260 write guard 422s. tsc can't catch a dropped optional arg, so pin the thread.
+  it('threads the picked operator into the cancel write for a picker admin', async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'cancelBooking').mockResolvedValue({} as never)
+    renderDialog(new QueryClient(), 'op_7')
+
+    await user.click(screen.getByRole('button', { name: c.action }))
+    await user.click(screen.getByRole('button', { name: c.confirm }))
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'csrf-tok', 'op_7'))
   })
 
   it('invalidates the booking + overview caches and closes on success', async () => {

--- a/packages/web/tests/vite/operator-bookings/TripDetailRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/TripDetailRoute.test.tsx
@@ -12,6 +12,11 @@ import enMessages from '../../../messages/en.json'
 
 const d = enMessages.bookings.operator.detail
 
+// #1361: the picked operator the route reads via useOperatorContext ->
+// businessRoute.useSearch(). Hoisted so the router mock can close over it; each test
+// sets it. Undefined = a tenant operator (no pick).
+const routeCtx = vi.hoisted(() => ({ operator: undefined as string | undefined }))
+
 // Render the route component outside a RouterProvider: stub createFileRoute
 // (Route.useParams / useLoaderData), Link (-> anchor), and useRouter, then seed
 // every useSuspenseQuery from cache. Mirrors OperatorFleetRoute.test.tsx (#598).
@@ -22,6 +27,10 @@ vi.mock('@tanstack/react-router', async () => ({
     useLoaderData: () => ({ detail: detailDto('CONFIRMED') }),
   }),
   useRouter: () => ({ invalidate: vi.fn() }),
+  getRouteApi: () => ({
+    useSearch: () => ({ operator: routeCtx.operator }),
+    useNavigate: () => vi.fn(),
+  }),
   Link: ({ children, ...rest }: { children: ReactNode }) => <a {...rest}>{children}</a>,
 }))
 
@@ -56,14 +65,17 @@ const operatorSession: Session = {
   csrfToken: 't',
 }
 
+// A picker admin (PLATFORM_ADMIN, no operatorId) — acts only through a chosen operator.
+const bypassSession: Session = { user: { id: 'a', role: 'PLATFORM_ADMIN' }, csrfToken: 't' }
+
 // staleTime=Infinity stops a mount-time background refetch, so the seeded CONFIRMED
 // detail only changes when a mutation's invalidateQueries forces a refetch — which
 // is exactly the behaviour under test.
-function renderRoute() {
+function renderRoute(session: Session = operatorSession) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY, retry: false } },
   })
-  queryClient.setQueryData(['session'], operatorSession)
+  queryClient.setQueryData(['session'], session)
   queryClient.setQueryData(
     api.operatorBookingDetailQueryOptions('bk-1').queryKey,
     detailDto('CONFIRMED'),
@@ -82,6 +94,7 @@ function renderRoute() {
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  routeCtx.operator = undefined
 })
 
 describe('TripDetailRoute refreshes after an operator action (#616)', () => {
@@ -117,5 +130,21 @@ describe('TripDetailRoute refreshes after an operator action (#616)', () => {
       expect(screen.getByRole('button', { name: d.markCompleted })).toBeInTheDocument(),
     )
     expect(screen.queryByRole('button', { name: d.markActive })).not.toBeInTheDocument()
+  })
+})
+
+// #1361: locks the route -> panel handoff. tsc can't catch a dropped optional
+// `pickedOperatorId` prop, so prove the picked operator (from useOperatorContext)
+// actually reaches the status write for a picker admin.
+describe('TripDetailRoute threads the picked operator into the write (#1361)', () => {
+  it('a picker admin advancing carries the chosen operator as ?operatorId=', async () => {
+    routeCtx.operator = 'op_7'
+    const user = userEvent.setup()
+    const spy = vi.spyOn(api, 'updateBookingStatus').mockResolvedValue(detailDto('ACTIVE') as never)
+    renderRoute(bypassSession)
+
+    await user.click(screen.getByRole('button', { name: d.markActive }))
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('bk-1', 'ACTIVE', 't', 'op_7'))
   })
 })

--- a/packages/web/tests/vite/operator-bookings/api.test.ts
+++ b/packages/web/tests/vite/operator-bookings/api.test.ts
@@ -550,6 +550,9 @@ describe('updateBookingStatus', () => {
 
     const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
     expect(new URL(url, 'http://x').pathname).toBe('/api/bookings/bk-1/status')
+    // #1361: a tenant operator (no pick) must NOT append operatorId — an always-append
+    // mutation would send `operatorId=undefined`, which pathname-only checks miss.
+    expect(new URL(url, 'http://x').searchParams.has('operatorId')).toBe(false)
     expect(init.method).toBe('PATCH')
     expect(init.credentials).toBe('include')
     expect(init.headers).toEqual({ 'Content-Type': 'application/json', 'X-CSRF-Token': 'csrf-1' })
@@ -572,6 +575,18 @@ describe('updateBookingStatus', () => {
       'Invalid status transition',
     )
   })
+
+  it('appends ?operatorId= when a picker admin acts as an operator (#1361)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: bookingRaw({ status: 'ACTIVE' }) }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateBookingStatus('bk-1', 'ACTIVE', 'csrf-1', 'op_7')
+
+    const [url] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect(new URL(url, 'http://x').searchParams.get('operatorId')).toBe('op_7')
+  })
 })
 
 describe('cancelBooking', () => {
@@ -589,11 +604,25 @@ describe('cancelBooking', () => {
 
     const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
     expect(new URL(url, 'http://x').pathname).toBe('/api/bookings/bk-1/cancel')
+    // #1361: no pick -> no operatorId (see updateBookingStatus note above).
+    expect(new URL(url, 'http://x').searchParams.has('operatorId')).toBe(false)
     expect(init.method).toBe('POST')
     expect(init.credentials).toBe('include')
     expect(init.headers).toEqual({ 'X-CSRF-Token': 'csrf-2' })
     expect(init.body).toBeUndefined()
     expect(result).toMatchObject({ id: 'bk-1', status: 'CANCELLED' })
+  })
+
+  it('appends ?operatorId= when a picker admin acts as an operator (#1361)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ success: true, data: bookingRaw({ status: 'CANCELLED' }) }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await cancelBooking('bk-1', 'csrf-2', 'op_7')
+
+    const [url] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect(new URL(url, 'http://x').searchParams.get('operatorId')).toBe('op_7')
   })
 })
 


### PR DESCRIPTION
## What

Web follow-up to the #1260 tenancy epic. #1260 slice 2 bound `PATCH /bookings/:id/status` and `POST /bookings/:id/cancel` on the API to a picked operator (`?operatorId=`), but the web was deliberately left unchanged: `BookingActionsPanel` gated its controls on `isOperatorSession`, so a picker admin (PLATFORM_ADMIN, no `operatorId`) never rendered them. Now that the operator-context picker (#1230) covers `manage/*`, this wires the trip-detail page so a picker admin who has chosen an operator can advance/cancel that operator's booking.

## Changes

- `updateBookingStatus` / `cancelBooking` take an optional `pickedOperatorId` and append `?operatorId=` (additive; tenant operators omit it).
- `BookingActionsPanel` gate flips `isOperatorSession` → `canWriteAsOperator(session, pickedOperatorId)` and threads the picked operator into the status mutation + `CancelBookingDialog`.
- **Substitute stays operator-only** (`isOperatorSession`): `POST /substitute` has no admin path (`booking-authz.md`), so a picker admin must not see a button that would 403.
- The trip-detail route reads `useOperatorContext()` (the `?operator=` param retained by the `_business` layout) and passes it to the panel.

## Design note (differs from the issue's literal step 1)

The issue proposed registering `manage/bookings/$bookingId` in `OPERATOR_CONTEXT_ROUTE_IDS`. Code review (2 independent reviewers) found that would render the interactive picker chip on a **by-id** page whose read the pick does not re-scope — letting the pick diverge from the booking on screen and dead-end the write at the API's ownership 404. So the by-id route is **intentionally NOT registered**, mirroring `fleet/$vehicleId` (#1264). The write still binds via the retained `?operator=` param; only the redundant chip on the fixed-owner detail page is omitted.

## Test plan

- [x] `api.test.ts` — both writes append `?operatorId=` when picked; assert **no** `operatorId` when omitted (guards an always-append mutation).
- [x] `BookingActionsPanel.test.tsx` — picker admin advances threading the operator; Substitute hidden for admin / shown for operator; no-pick admin renders nothing; tenant-operator regression.
- [x] `CancelBookingDialog.test.tsx` — threads the picked operator into the cancel write.
- [x] `TripDetailRoute.test.tsx` — route → panel handoff carries the picked operator (guards a dropped optional prop tsc can't catch).
- [x] `operator-context.test.ts` — by-id trip-detail is NOT a picker route (matches fleet precedent).
- [x] Full web suite (1989) + tsc + biome + module/size lints green.

## Follow-ups (out of scope)

- `TodayPanel` dashboard status advance stays operator-only — the two status surfaces now diverge; worth aligning.
- If an "acting as X" chip on trip detail is wanted, expose `operatorId` on the booking detail DTO and bind the write to the booking's owner (like #1264's `vehicle?.operatorId ?? pickedOperatorId`).
- `packages/web/src/vite/operator-bookings/api.ts` is 622 lines (>400 cap) — split by concern in a dedicated refactor.

Closes #1361
Refs #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)