### PR TITLE
refactor: drain #1383 payment-anomaly SSoT follow-ups

### DIFF
--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -46,7 +46,10 @@ import type { ComplianceAlertBand, ComplianceDocumentType } from '@kuruma/shared
 import type { DocumentSnapshot } from '@kuruma/shared/lib/consent-canonical'
 import type { LuggageSize } from '@kuruma/shared/lib/luggage'
 import type { LocationOperatingHours } from '@kuruma/shared/types/location'
-import type { PaymentAnomalyResolution } from '@kuruma/shared/types/payment-anomaly'
+import type {
+  PaymentAnomalyKind,
+  PaymentAnomalyResolution,
+} from '@kuruma/shared/types/payment-anomaly'
 
 /**
  * The notification kind/status sets have a single source of truth: the
@@ -207,7 +210,9 @@ export interface PaymentRefund {
   updatedAt: Date
 }
 
-export type PaymentAnomalyKind = 'DOUBLE_PAYMENT' | 'AMOUNT_MISMATCH'
+// Kind lives in the @kuruma/shared enums.ts SSoT (#1383/#1427); re-exported so
+// api consumers (services/payment/payment.ts) keep importing it from ../../stores.
+export type { PaymentAnomalyKind }
 
 // A verified Stripe charge that needs human review rather than becoming revenue
 // (#508 P2): a duplicate charge on an already-paid booking (DOUBLE_PAYMENT) or an

--- a/packages/shared/tests/types/payment-anomaly.test.ts
+++ b/packages/shared/tests/types/payment-anomaly.test.ts
@@ -1,23 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { paymentAnomalyKindEnum, paymentAnomalyResolutionEnum } from '../../src/db/schema'
-import {
-  PAYMENT_ANOMALY_KINDS,
-  PAYMENT_ANOMALY_RESOLUTIONS,
-  type PaymentAnomalyView,
-} from '../../src/types/payment-anomaly'
+import type { PaymentAnomalyView } from '../../src/types/payment-anomaly'
 
+// The kind/resolution unions are pinned to the DB enums (order included) by the
+// #688 SSoT loop in enums.test.ts and the db-drift CI job; this file only guards
+// the PaymentAnomalyView wire shape the API returns and the web consumes.
 describe('PaymentAnomalyView contract', () => {
-  // Drift fence: the web-facing kind union must stay identical to the DB enum
-  // (payment_anomaly_kind). Web cannot import the schema, so this is the only
-  // place the two are pinned together — mirrors the roleEnum guard in schema.test.ts.
-  it('PAYMENT_ANOMALY_KINDS mirrors the payment_anomaly_kind DB enum (order matters)', () => {
-    expect([...PAYMENT_ANOMALY_KINDS]).toEqual([...paymentAnomalyKindEnum.enumValues])
-  })
-
-  it('PAYMENT_ANOMALY_RESOLUTIONS mirrors the payment_anomaly_resolution DB enum (order matters)', () => {
-    expect([...PAYMENT_ANOMALY_RESOLUTIONS]).toEqual([...paymentAnomalyResolutionEnum.enumValues])
-  })
-
   it('a DOUBLE_PAYMENT view carries the refund/reconcile identifiers', () => {
     const view: PaymentAnomalyView = {
       id: 'pa_1',


### PR DESCRIPTION
Two XS code-review loose ends from #1383 (which folded the `payment_anomaly_*` enums into the `@kuruma/shared` `enums.ts` SSoT). Both are behavior-preserving.

## #1429 — drop tautological mirror tests (shared, test-only)
`packages/shared/tests/types/payment-anomaly.test.ts` still asserted `PAYMENT_ANOMALY_KINDS`/`PAYMENT_ANOMALY_RESOLUTIONS` equal `paymentAnomalyKindEnum`/`paymentAnomalyResolutionEnum.enumValues`. After the fold, both sides derive from the same `enums.ts` array (the pgEnum is built from it), so the assertions compared an array to itself and could never go red.

- Deleted the two `mirrors the ... DB enum` cases + the now-dead `../../src/db/schema` and array imports.
- Corrected the stale header comment (it claimed this was "the only place the two are pinned together").
- The real order fence remains: the #688 SSoT loop in `enums.test.ts` (pins `enumValues` to the source array, order included) + the `db-drift` CI job.
- Kept the `PaymentAnomalyView` wire-shape cases.

> Learn: Tautological Test — an assertion whose two sides trace to one source can never fail, giving false confidence. After a dedupe, ask "could this test still go red?"

## #1427 — fold the last inline kind copy (api, type-only)
`packages/api/src/stores.ts` still hand-declared `PaymentAnomalyKind = 'DOUBLE_PAYMENT' | 'AMOUNT_MISMATCH'` — the last of three copies. The same file already imports the sibling `PaymentAnomalyResolution` from shared, so it was half-migrated. Now imports `PaymentAnomalyKind` from `@kuruma/shared/types/payment-anomaly` and re-exports it, so `services/payment/payment.ts` keeps importing it from `../../stores`.

## Verification
- `tsc` green: `@kuruma/shared` and `@kuruma/api`.
- `@kuruma/shared` tests: 904 pass (was 906 — the two tautological cases removed).
- `@kuruma/api` tests: 2737 pass (type-only change, consumers still resolve).
- biome clean; pre-commit (file-size, module-boundaries, web+api tsc) green.

Closes #1429
Closes #1427