### PR TITLE
fix(#1433): thread picked-operator into TodayPanel status advance

### DIFF
--- a/packages/web/src/routes/$locale/_business/dashboard.tsx
+++ b/packages/web/src/routes/$locale/_business/dashboard.tsx
@@ -53,6 +53,7 @@ function OperatorDashboardRoute() {
       vehicles={vehicles}
       session={session ?? null}
       locale={locale}
+      pickedOperatorId={pickedOperatorId}
     />
   )
 }

--- a/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
+++ b/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
@@ -15,9 +15,12 @@ interface OperatorDashboardViewProps {
   // Manage Fleet link, so reading it here is a cache hit, not a second round-trip.
   readonly vehicles: readonly OperatorFleetVehicle[]
   // #1102: the Today panel's inline advance is a CSRF-gated write, so it needs the
-  // session token; the panel also gates itself to an operator session.
+  // session token; the panel also gates itself via `canWriteAsOperator`.
   readonly session: Session | null
   readonly locale: string
+  // #1433: forwarded to the Today panel so a picker admin's inline status advance
+  // binds to the operator it is acting as (mirrors the trip-detail write surface).
+  readonly pickedOperatorId?: string | undefined
 }
 
 // Presentational operator overview (#524). The route owns the loader /
@@ -29,6 +32,7 @@ export function OperatorDashboardView({
   vehicles,
   session,
   locale,
+  pickedOperatorId,
 }: OperatorDashboardViewProps) {
   const t = useTranslations('business')
 
@@ -54,6 +58,7 @@ export function OperatorDashboardView({
             vehicles={vehicles}
             session={session}
             locale={locale}
+            pickedOperatorId={pickedOperatorId}
           />
         )}
 

--- a/packages/web/src/vite/operator-dashboard/TodayPanel.test.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.test.tsx
@@ -69,13 +69,20 @@ function renderPanel(
   today: TodayBuckets,
   session: Session | null = OPERATOR_SESSION,
   locale = 'en',
+  pickedOperatorId: string | undefined = undefined,
 ) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
   const view = render(
     <QueryClientProvider client={qc}>
       <IntlProvider locale="en" messages={en}>
-        <TodayPanel today={today} vehicles={VEHICLES} session={session} locale={locale} />
+        <TodayPanel
+          today={today}
+          vehicles={VEHICLES}
+          session={session}
+          locale={locale}
+          pickedOperatorId={pickedOperatorId}
+        />
       </IntlProvider>
     </QueryClientProvider>,
   )
@@ -143,7 +150,11 @@ describe('TodayPanel', () => {
       buckets({ pickups: [row({ id: 'bk1', status: 'CONFIRMED' })] }),
     )
     fireEvent.click(screen.getByRole('button', { name: M.markPickedUp }))
-    await waitFor(() => expect(updateStatusMock).toHaveBeenCalledWith('bk1', 'ACTIVE', 'test-csrf'))
+    // A tenant operator passes NO operator binding (undefined) — the server infers
+    // scope from the session cookie; only a picker admin sends an explicit operatorId.
+    await waitFor(() =>
+      expect(updateStatusMock).toHaveBeenCalledWith('bk1', 'ACTIVE', 'test-csrf', undefined),
+    )
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: OPERATOR_OVERVIEW_QUERY_KEY })
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: OPERATOR_BOOKINGS_KEY })
@@ -155,7 +166,7 @@ describe('TodayPanel', () => {
     renderPanel(buckets({ returns: [row({ id: 'r1', status: 'ACTIVE' })] }))
     fireEvent.click(screen.getByRole('button', { name: M.markReturned }))
     await waitFor(() =>
-      expect(updateStatusMock).toHaveBeenCalledWith('r1', 'COMPLETED', 'test-csrf'),
+      expect(updateStatusMock).toHaveBeenCalledWith('r1', 'COMPLETED', 'test-csrf', undefined),
     )
   })
 
@@ -164,12 +175,26 @@ describe('TodayPanel', () => {
     renderPanel(buckets({ overdue: [row({ id: 'o1', status: 'ACTIVE' })] }))
     fireEvent.click(screen.getByRole('button', { name: M.markReturned }))
     await waitFor(() =>
-      expect(updateStatusMock).toHaveBeenCalledWith('o1', 'COMPLETED', 'test-csrf'),
+      expect(updateStatusMock).toHaveBeenCalledWith('o1', 'COMPLETED', 'test-csrf', undefined),
     )
   })
 
-  it('renders nothing for a non-operator (bypass admin) session', () => {
+  it('renders nothing for a picker admin who has not yet picked an operator', () => {
     const { container } = renderPanel(buckets({ pickups: [row({ id: 'p1' })] }), ADMIN_SESSION)
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lets a picker admin advance a booking, binding the write to the picked operator (#1433)', async () => {
+    updateStatusMock.mockResolvedValue({})
+    renderPanel(
+      buckets({ pickups: [row({ id: 'bk1', status: 'CONFIRMED' })] }),
+      ADMIN_SESSION,
+      'en',
+      'op_7',
+    )
+    fireEvent.click(screen.getByRole('button', { name: M.markPickedUp }))
+    await waitFor(() =>
+      expect(updateStatusMock).toHaveBeenCalledWith('bk1', 'ACTIVE', 'test-csrf', 'op_7'),
+    )
   })
 })

--- a/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
+++ b/packages/web/src/vite/operator-dashboard/TodayPanel.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { formatJstTime } from '@/lib/datetime'
-import { isOperatorSession } from '@/vite/guards'
+import { canWriteAsOperator } from '@/vite/guards'
 import {
   type OperatorBookingStatus,
   invalidateBookingCaches,
@@ -23,6 +23,9 @@ interface TodayPanelProps {
   readonly vehicles: readonly Pick<OperatorFleetVehicle, 'id' | 'name'>[]
   readonly session: Session | null
   readonly locale: string
+  // #1433: a picker admin (#1260) acting as a chosen operator binds each status
+  // write to that operator via ?operatorId=; a tenant operator leaves it undefined.
+  readonly pickedOperatorId?: string | undefined
 }
 
 type BucketKey = 'pickups' | 'returns' | 'overdue'
@@ -44,18 +47,25 @@ interface SectionSpec {
 // overdue vehicles, each a clickable row (deep-links to the trip detail) with a
 // one-click advance (mark picked-up / returned). Presentational: buckets + fleet
 // arrive as props from the dashboard route; only the status mutation is owned here
-// (mirrors BookingActionsPanel). Operator-only: a bypass admin reads the overview
-// cross-tenant (a meaningless platform-wide "today") and cannot act on a single
-// tenant, so the whole panel is gated on an operator session like the other
-// operator-portal write affordances (#581/#583/#598).
-export function TodayPanel({ today, vehicles, session, locale }: TodayPanelProps) {
+// (mirrors BookingActionsPanel). Gated on `canWriteAsOperator`: a real operator, OR
+// a picker admin (#1260/#1433) who has chosen an operator to act as — the same write
+// gate BookingActionsPanel uses, so the trip-detail and dashboard status surfaces no
+// longer diverge. A bypass admin with no pick reads a meaningless platform-wide
+// "today" and cannot act on a single tenant, so the panel stays hidden for it.
+export function TodayPanel({
+  today,
+  vehicles,
+  session,
+  locale,
+  pickedOperatorId,
+}: TodayPanelProps) {
   const t = useTranslations('business.today')
   const queryClient = useQueryClient()
   const csrfToken = session?.csrfToken ?? ''
 
   const statusMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: OperatorBookingStatus }) =>
-      updateBookingStatus(id, status, csrfToken),
+      updateBookingStatus(id, status, csrfToken, pickedOperatorId),
     // The advance changes a booking's lifecycle status, so refresh both the
     // dashboard overview (today buckets + counts) and the operator-bookings prefix
     // — whose documented cascade (#616) covers the calendar, list and detail
@@ -65,7 +75,7 @@ export function TodayPanel({ today, vehicles, session, locale }: TodayPanelProps
 
   const vehicleNamesById = useMemo(() => new Map(vehicles.map((v) => [v.id, v.name])), [vehicles])
 
-  if (!isOperatorSession(session)) return null
+  if (!canWriteAsOperator(session, pickedOperatorId)) return null
 
   const isRowPending = (id: string) =>
     statusMutation.isPending && statusMutation.variables?.id === id

--- a/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
@@ -68,6 +68,12 @@ const OPERATOR_SESSION: Session = {
   user: { id: 'u_op', role: 'OPERATOR_OWNER', operatorId: 'op_1', operatorSlug: 'osaka' },
   csrfToken: 'test-csrf',
 }
+// A picker admin (#1260) — no operatorId of its own; it can only act on the operator
+// it has picked. Used to prove the view forwards `pickedOperatorId` to the Today panel.
+const ADMIN_SESSION: Session = {
+  user: { id: 'u_admin', role: 'PLATFORM_ADMIN' },
+  csrfToken: 'test-csrf',
+}
 
 const TODAY_PANEL_TITLE = enMessages.business.today.title
 
@@ -77,7 +83,11 @@ const TODAY_PANEL_TITLE = enMessages.business.today.title
 // panel-visibility tests pass an operator session AND stub the flag. The
 // QueryClientProvider is still required — TodayPanel calls useQueryClient/useMutation
 // before its early return (rules of hooks).
-function renderDashboard(vehicles: OperatorFleetVehicle[], session: Session | null = null) {
+function renderDashboard(
+  vehicles: OperatorFleetVehicle[],
+  session: Session | null = null,
+  pickedOperatorId: string | undefined = undefined,
+) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
@@ -87,6 +97,7 @@ function renderDashboard(vehicles: OperatorFleetVehicle[], session: Session | nu
           vehicles={vehicles}
           session={session}
           locale="en"
+          pickedOperatorId={pickedOperatorId}
         />
       </IntlProvider>
     </QueryClientProvider>,
@@ -124,6 +135,22 @@ describe('OperatorDashboardView', () => {
   it('omits the Today panel for an operator session when the flag is OFF (#1329)', () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', undefined)
     renderDashboard([vehicle()], OPERATOR_SESSION)
+    expect(screen.queryByRole('region', { name: TODAY_PANEL_TITLE })).not.toBeInTheDocument()
+  })
+
+  // Seam guard (#1433): the view must forward pickedOperatorId to the Today panel. A
+  // picker admin has no operatorId, so the panel's canWriteAsOperator gate only passes
+  // when the picked id reaches it — if the forward is dropped the panel gets undefined
+  // and renders nothing. Asserting the region mounts therefore proves the pass-through.
+  it('forwards the picked operator to the Today panel so a picker admin sees it (#1433)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', 'true')
+    renderDashboard([vehicle()], ADMIN_SESSION, 'op_7')
+    expect(screen.getByRole('region', { name: TODAY_PANEL_TITLE })).toBeInTheDocument()
+  })
+
+  it('hides the Today panel from a picker admin who has not picked an operator (#1433)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', 'true')
+    renderDashboard([vehicle()], ADMIN_SESSION)
     expect(screen.queryByRole('region', { name: TODAY_PANEL_TITLE })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Surfaced by the #1361 review (PR #1432). #1361 flipped the trip-detail `BookingActionsPanel` to `canWriteAsOperator`, so a picker admin (#1260) can advance/cancel a booking from trip detail. But the sibling one-click status surface — the dashboard `TodayPanel` — was left gated on `isOperatorSession` and called `updateBookingStatus` with no operator binding, so the two surfaces diverged: a picker admin could advance from trip detail but **not** from the dispatch board.

This mirrors #1361 on the dashboard, web-only:

- **`TodayPanel.tsx`** — gate flipped `isOperatorSession(session)` → `canWriteAsOperator(session, pickedOperatorId)`; `pickedOperatorId` threaded into the `updateBookingStatus(id, status, csrfToken, pickedOperatorId)` call (the same seam #1361 added — a tenant operator leaves it `undefined`, a picker admin binds via `?operatorId=`).
- **`OperatorDashboardView.tsx` / `dashboard.tsx`** — forward `pickedOperatorId` (already in scope from `useOperatorContext`) down to the panel, mirroring `BookingActionsPanel`'s prop-driven wiring.

The API guard (#1260) already accepts `?operatorId=`. The panel stays behind the `isOperatorTodayEnabled()` beta flag (#1329); this just removes the asymmetry for when it is on.

## Test plan

- [x] TDD: added a picker-admin test — a `PLATFORM_ADMIN` with a picked operator renders the panel and binds the advance to `('bk1','ACTIVE','test-csrf','op_7')`; the no-pick admin still renders nothing.
- [x] Tightened the 3 existing tenant-operator advance assertions to include the explicit `undefined` 4th arg (proves a tenant operator sends no operator binding).
- [x] `TodayPanel` + `OperatorDashboardView` suites green; full web suite `1990 passed`.
- [x] tsc (web + api), biome, `lint:modules`, `lint:size` all clean.

Closes #1433
Refs #1361 #1260