### PR TITLE
feat(#1244): render scheduled-block bands on the fleet timeline

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -180,10 +180,9 @@ export function OperatorBookingsRoute() {
   const anchorDate = useMemo(() => parseCalendarDate(date), [date])
   const { from, to } = calendarRange(view, anchorDate)
 
-  // Block bands render only on the calendar (day/week/month) views — the fleet
-  // timeline shows bookings only (block bands on the timeline is a follow-up). So the
-  // Schedule affordance is offered only where a created block becomes visible:
-  // inviting a create on the timeline (the default view) would refetch into nothing.
+  // Block bands render on every view now (#1244 added them to the timeline). The
+  // Schedule (create) affordance, however, is driven by an rbc slot-drag the timeline
+  // lib doesn't offer, so it stays on the calendar (day/week/month) views only.
   const canScheduleBlock = canManageBlocks && view !== 'timeline'
   const { data: bookings } = useSuspenseQuery(
     operatorCalendarQueryOptions(from, to, pickedOperatorId),
@@ -195,11 +194,11 @@ export function OperatorBookingsRoute() {
   // Blocks are an additive layer (not in the suspense loader): a non-suspense query
   // that degrades to empty on error/disabled, so a blocks-read failure never blanks
   // the whole calendar (the coupling that broke the portal when it read fleet-overview).
-  // Skipped on the timeline view — FleetTimeline renders no block bands (#1244), so
-  // fetching them on the default landing view would be a wasted request.
+  // Fetched on every view a viewer can see blocks — the timeline renders block bands
+  // too now (#1244), so it needs the same data as the day/week calendar.
   const { data: blocks } = useQuery({
     ...operatorCalendarBlocksQueryOptions(from, to, pickedOperatorId),
-    enabled: canViewBlocks && view !== 'timeline',
+    enabled: canViewBlocks,
   })
 
   const events = useMemo(() => toCalendarEvents(bookings, vehicles), [bookings, vehicles])
@@ -351,11 +350,13 @@ export function OperatorBookingsRoute() {
                 <FleetTimeline
                   rows={timelineRows}
                   vehicles={timelineVehicles}
+                  blocks={blockEvents}
                   date={anchorDate}
                   locale={locale}
                   onViewChange={handleViewChange}
                   onDateChange={handleDateChange}
                   onSelectEvent={navigateToBooking}
+                  onSelectBlock={setSelectedBlock}
                 />
               </Suspense>
             ) : (

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -237,6 +237,14 @@ export function OperatorBookingsRoute() {
     () => vehicles.filter((v) => filters.isVehicleChecked(v.id)),
     [vehicles, filters],
   )
+  // The timeline owns its own view-filtering for all three inputs symmetrically:
+  // rows, vehicles, and blocks each drop hidden vehicles here. Blocks have no status,
+  // so only the vehicle filter applies. (buildTimelineLayout still drops orphaned
+  // blocks, but that's data integrity — the hide-filter lives here, not there.)
+  const timelineBlocks = useMemo(
+    () => blockEvents.filter((b) => filters.isVehicleChecked(b.resourceId)),
+    [blockEvents, filters],
+  )
 
   const handleViewChange = useCallback(
     (next: CalendarView) => {
@@ -341,6 +349,9 @@ export function OperatorBookingsRoute() {
             pickedOperatorId={pickedOperatorId}
           />
           <div className="min-w-0 flex-1">
+            {/* Block bands render on every view now (#1244), so the kind-color legend
+                is hoisted above both — the timeline's hatched bands need it too. */}
+            {canViewBlocks && <BlockLegend />}
             {view === 'timeline' ? (
               <Suspense
                 fallback={
@@ -350,7 +361,7 @@ export function OperatorBookingsRoute() {
                 <FleetTimeline
                   rows={timelineRows}
                   vehicles={timelineVehicles}
-                  blocks={blockEvents}
+                  blocks={timelineBlocks}
                   date={anchorDate}
                   locale={locale}
                   onViewChange={handleViewChange}
@@ -360,20 +371,17 @@ export function OperatorBookingsRoute() {
                 />
               </Suspense>
             ) : (
-              <>
-                {canViewBlocks && <BlockLegend />}
-                <BookingsCalendar
-                  events={visibleEvents}
-                  resources={visibleResources}
-                  view={view}
-                  date={anchorDate}
-                  locale={locale}
-                  onViewChange={handleViewChange}
-                  onDateChange={handleDateChange}
-                  onSelectEvent={handleSelectEvent}
-                  onSelectSlot={canManualBook || canManageBlocks ? handleSelectSlot : undefined}
-                />
-              </>
+              <BookingsCalendar
+                events={visibleEvents}
+                resources={visibleResources}
+                view={view}
+                date={anchorDate}
+                locale={locale}
+                onViewChange={handleViewChange}
+                onDateChange={handleDateChange}
+                onSelectEvent={handleSelectEvent}
+                onSelectSlot={canManualBook || canManageBlocks ? handleSelectSlot : undefined}
+              />
             )}
           </div>
         </div>

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.jst.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.jst.test.tsx
@@ -43,12 +43,14 @@ function renderTimeline(rows: CalendarBookingRow[]) {
       <FleetTimeline
         rows={rows}
         vehicles={VEHICLES}
+        blocks={[]}
         // Local noon of the calendar day Jul 1 (TZ-independent anchor day).
         date={new Date(2026, 6, 1, 12)}
         locale="en"
         onViewChange={vi.fn()}
         onDateChange={vi.fn()}
         onSelectEvent={vi.fn()}
+        onSelectBlock={vi.fn()}
       />
     </IntlProvider>,
   )

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
 import { FleetTimeline } from './FleetTimeline'
 import type { CalendarBookingRow } from './api'
+import type { BlockCalendarEvent } from './calendar-events'
 
 const VEHICLES = [
   { id: 'v1', name: 'Corolla' },
@@ -26,17 +27,41 @@ function row(over: Partial<CalendarBookingRow> & { id: string }): CalendarBookin
   }
 }
 
-function renderTimeline(rows: CalendarBookingRow[], onSelectEvent: (id: string) => void = vi.fn()) {
+function block(over: Partial<BlockCalendarEvent> = {}): BlockCalendarEvent {
+  return {
+    type: 'block',
+    id: 'blk1',
+    title: 'Maintenance',
+    start: new Date('2026-07-03T09:00:00.000Z'),
+    end: new Date('2026-07-04T09:00:00.000Z'),
+    resourceId: 'v1',
+    kind: 'MAINTENANCE',
+    reason: 'Maintenance',
+    notes: null,
+    ...over,
+  }
+}
+
+interface RenderOpts {
+  onSelectEvent?: (id: string) => void
+  onSelectBlock?: (block: BlockCalendarEvent) => void
+  blocks?: BlockCalendarEvent[]
+}
+
+function renderTimeline(rows: CalendarBookingRow[], opts: RenderOpts = {}) {
+  const { onSelectEvent = vi.fn(), onSelectBlock = vi.fn(), blocks = [] } = opts
   return render(
     <IntlProvider locale="en" messages={en}>
       <FleetTimeline
         rows={rows}
         vehicles={VEHICLES}
+        blocks={blocks}
         date={new Date('2026-07-01T00:00:00.000Z')}
         locale="en"
         onViewChange={vi.fn()}
         onDateChange={vi.fn()}
         onSelectEvent={onSelectEvent}
+        onSelectBlock={onSelectBlock}
       />
     </IntlProvider>,
   )
@@ -58,11 +83,13 @@ describe('FleetTimeline', () => {
         <FleetTimeline
           rows={[row({ id: 'b2', vehicleId: null, renterName: 'Bob' })]}
           vehicles={VEHICLES}
+          blocks={[]}
           date={new Date('2026-07-01T00:00:00.000Z')}
           locale="en"
           onViewChange={vi.fn()}
           onDateChange={vi.fn()}
           onSelectEvent={vi.fn()}
+          onSelectBlock={vi.fn()}
         />
       </IntlProvider>,
     )
@@ -82,7 +109,7 @@ describe('FleetTimeline', () => {
           effectiveEndAt: '2026-07-04T15:00:00.000Z',
         }),
       ],
-      onSelectEvent,
+      { onSelectEvent },
     )
     const bars = screen.getAllByText('Alice')
     expect(bars.length).toBeGreaterThan(0)
@@ -91,5 +118,25 @@ describe('FleetTimeline', () => {
     fireEvent.mouseDown(bar as Element)
     fireEvent.mouseUp(bar as Element)
     expect(onSelectEvent).toHaveBeenCalledWith('b1')
+  })
+
+  it('paints a scheduled block with its kind band class, not a booking status', () => {
+    renderTimeline([], { blocks: [block({ kind: 'MAINTENANCE' })] })
+    const bar = screen.getByText('Maintenance').closest('.rct-item')
+    expect(bar).not.toBeNull()
+    expect(bar).toHaveClass('rbc-event--block-maintenance')
+    expect(bar).not.toHaveClass('rbc-event--confirmed')
+  })
+
+  it('opens the block detail (not a booking) when a block band is clicked', () => {
+    const onSelectEvent = vi.fn()
+    const onSelectBlock = vi.fn()
+    const blk = block({ id: 'blk7', title: 'Bodywork', reason: 'Bodywork' })
+    renderTimeline([], { blocks: [blk], onSelectEvent, onSelectBlock })
+    const bar = screen.getByText('Bodywork').closest('.rct-item')
+    fireEvent.mouseDown(bar as Element)
+    fireEvent.mouseUp(bar as Element)
+    expect(onSelectBlock).toHaveBeenCalledWith(blk)
+    expect(onSelectEvent).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -154,8 +154,10 @@ export function FleetTimeline({
     [date, onDateChange],
   )
 
-  // A block bar's id is its block id (bookings share the booking-id / turnaround
-  // space); look it up here so a clicked band routes to the block dialog, not a trip.
+  // The lib hands back only the clicked bar's id, not the item, so we recover the
+  // bar's type by membership: block-bar ids are block-table UUIDs, disjoint from
+  // booking ids and their `::turnaround` suffix, so "id is a known block" is an exact
+  // discriminant. The map also carries the full block (reason/notes) for the dialog.
   const blockById = useMemo(() => new Map(blocks.map((b) => [b.id, b])), [blocks])
 
   // Both events fire on a bar click (select first, click on a re-click); wire both

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -1,8 +1,9 @@
 import { instantToJstFauxLocal, todayInJst } from '@/lib/datetime'
-import { STATUS_CLASS } from '@/lib/event-colors'
+import { BLOCK_KIND_CLASS, STATUS_CLASS } from '@/lib/event-colors'
 import { useFeatureFlag } from '@/vite/config'
 import { CalendarToolbar } from '@/vite/operator-bookings/CalendarToolbar'
 import type { CalendarBookingRow } from '@/vite/operator-bookings/api'
+import type { BlockCalendarEvent } from '@/vite/operator-bookings/calendar-events'
 import {
   type CalendarView,
   TIMELINE_SPAN_DAYS,
@@ -41,21 +42,27 @@ interface FleetTimelineProps {
   readonly rows: readonly CalendarBookingRow[]
   // The operator's fleet — each becomes a row; bookings bind to a row by vehicle id.
   readonly vehicles: readonly { id: string; name: string }[]
+  // Scheduled maintenance/hold bands (#1244) — kind-colored, bound to a fleet row.
+  readonly blocks: readonly BlockCalendarEvent[]
   readonly date: Date
   readonly locale: string
   readonly onViewChange: (view: CalendarView) => void
   readonly onDateChange: (date: Date) => void
   readonly onSelectEvent: (bookingId: string) => void
+  // A block band opens its detail dialog (day/week parity) rather than a trip.
+  readonly onSelectBlock: (block: BlockCalendarEvent) => void
 }
 
 export function FleetTimeline({
   rows,
   vehicles,
+  blocks,
   date,
   locale,
   onViewChange,
   onDateChange,
   onSelectEvent,
+  onSelectBlock,
 }: FleetTimelineProps) {
   const t = useTranslations('business.bookings.calendar')
   const culture = locale === 'zh' ? 'zh-CN' : locale
@@ -100,11 +107,12 @@ export function FleetTimeline({
       buildTimelineLayout({
         rows,
         vehicles,
+        blocks,
         from: fromTrue,
         to: toTrue,
         unassignedLabel: t('unassigned'),
       }),
-    [rows, vehicles, fromTrue, toTrue, t],
+    [rows, vehicles, blocks, fromTrue, toTrue, t],
   )
 
   const groups = useMemo<TimelineGroupBase[]>(
@@ -123,9 +131,12 @@ export function FleetTimeline({
         end_time: instantToJstFauxLocal(new Date(it.end)).getTime(),
         canMove: false,
         canResize: false,
-        className: `${STATUS_CLASS[it.status]}${
-          it.band === 'turnaround' ? ' fleet-bar--turnaround' : ''
-        }`,
+        // #1244: a booking bar wears its status color (+ dashed turnaround tail); a
+        // block bar wears its kind band so it never reads as a booking.
+        className:
+          it.type === 'block'
+            ? BLOCK_KIND_CLASS[it.kind]
+            : `${STATUS_CLASS[it.status]}${it.band === 'turnaround' ? ' fleet-bar--turnaround' : ''}`,
       })),
     [layout.items],
   )
@@ -143,11 +154,23 @@ export function FleetTimeline({
     [date, onDateChange],
   )
 
+  // A block bar's id is its block id (bookings share the booking-id / turnaround
+  // space); look it up here so a clicked band routes to the block dialog, not a trip.
+  const blockById = useMemo(() => new Map(blocks.map((b) => [b.id, b])), [blocks])
+
   // Both events fire on a bar click (select first, click on a re-click); wire both
-  // so a single click always opens the trip, regardless of selection state.
+  // so a single click always opens the trip (or block), regardless of selection state.
   const handleItemSelect = useCallback(
-    (itemId: Id) => onSelectEvent(bookingIdFromTimelineItem(String(itemId))),
-    [onSelectEvent],
+    (itemId: Id) => {
+      const id = String(itemId)
+      const block = blockById.get(id)
+      if (block) {
+        onSelectBlock(block)
+        return
+      }
+      onSelectEvent(bookingIdFromTimelineItem(id))
+    },
+    [blockById, onSelectBlock, onSelectEvent],
   )
 
   // Pin the canvas to the toolbar-driven window: the board is navigated by our

--- a/packages/web/src/vite/operator-bookings/fleet-timeline-theme.css
+++ b/packages/web/src/vite/operator-bookings/fleet-timeline-theme.css
@@ -49,3 +49,49 @@
   opacity: 0.55;
   border-style: dashed !important;
 }
+
+/* #1244 scheduled-block bands — mirror calendar-theme.css so the timeline reads
+   identically to the day/week views: a diagonal hatch + dashed border marks "not a
+   booking", the per-kind hue distinguishes maintenance / out-of-service / manual. The
+   lib's inline background is overridden with !important, as the booking rules above. */
+.rct-item.rbc-event--block-maintenance,
+.rct-item.rbc-event--block-out-of-service,
+.rct-item.rbc-event--block-manual {
+  border-style: dashed !important;
+  color: oklch(0.32 0.01 286) !important;
+  background-color: oklch(0.95 0.004 286) !important;
+}
+
+.rct-item.rbc-event--block-maintenance {
+  border-color: oklch(0.62 0.13 75) !important;
+  background-image: repeating-linear-gradient(
+    45deg,
+    oklch(0.92 0.06 80) 0,
+    oklch(0.92 0.06 80) 6px,
+    transparent 6px,
+    transparent 12px
+  ) !important;
+}
+
+.rct-item.rbc-event--block-out-of-service {
+  border-color: oklch(0.58 0.16 28) !important;
+  color: oklch(0.32 0.09 28) !important;
+  background-image: repeating-linear-gradient(
+    45deg,
+    oklch(0.9 0.06 28) 0,
+    oklch(0.9 0.06 28) 6px,
+    transparent 6px,
+    transparent 12px
+  ) !important;
+}
+
+.rct-item.rbc-event--block-manual {
+  border-color: oklch(0.55 0.02 286) !important;
+  background-image: repeating-linear-gradient(
+    45deg,
+    oklch(0.88 0.005 286) 0,
+    oklch(0.88 0.005 286) 6px,
+    transparent 6px,
+    transparent 12px
+  ) !important;
+}

--- a/packages/web/src/vite/operator-bookings/timeline-layout.test.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-layout.test.ts
@@ -1,4 +1,5 @@
 import type { CalendarBookingRow } from '@/vite/operator-bookings/api'
+import type { BlockCalendarEvent } from '@/vite/operator-bookings/calendar-events'
 import { describe, expect, it } from 'vitest'
 import {
   UNASSIGNED_GROUP_ID,
@@ -32,8 +33,30 @@ const FLEET = [
   { id: 'v2', name: 'Note' },
 ]
 
-function build(rows: CalendarBookingRow[], vehicles = FLEET) {
-  return buildTimelineLayout({ rows, vehicles, from: FROM, to: TO, unassignedLabel: 'Unassigned' })
+function block(over: Partial<BlockCalendarEvent> = {}): BlockCalendarEvent {
+  return {
+    type: 'block',
+    id: 'blk1',
+    title: 'Oil change',
+    start: new Date(Date.UTC(2027, 0, 12)),
+    end: new Date(Date.UTC(2027, 0, 14)),
+    resourceId: 'v1',
+    kind: 'MAINTENANCE',
+    reason: 'Oil change',
+    notes: null,
+    ...over,
+  }
+}
+
+function build(rows: CalendarBookingRow[], vehicles = FLEET, blocks: BlockCalendarEvent[] = []) {
+  return buildTimelineLayout({
+    rows,
+    vehicles,
+    blocks,
+    from: FROM,
+    to: TO,
+    unassignedLabel: 'Unassigned',
+  })
 }
 
 describe('buildTimelineLayout', () => {
@@ -60,6 +83,7 @@ describe('buildTimelineLayout', () => {
     const { items } = build([row()])
     expect(items).toEqual([
       {
+        type: 'booking',
         id: 'bk1',
         bookingId: 'bk1',
         group: 'v1',
@@ -75,7 +99,7 @@ describe('buildTimelineLayout', () => {
   it('splits a turnaround tail into a second lighter band', () => {
     const { items } = build([row({ effectiveEndAt: iso(2027, 1, 16) })])
     expect(items).toHaveLength(2)
-    const tail = items.find((i) => i.band === 'turnaround')
+    const tail = items.find((i) => i.type === 'booking' && i.band === 'turnaround')
     expect(tail).toMatchObject({
       id: 'bk1::turnaround',
       bookingId: 'bk1',
@@ -93,13 +117,13 @@ describe('buildTimelineLayout', () => {
 
   it('clamps a turnaround running past the window to the window end', () => {
     const { items } = build([row({ endAt: iso(2027, 1, 22), effectiveEndAt: iso(2027, 1, 30) })])
-    const tail = items.find((i) => i.band === 'turnaround')
+    const tail = items.find((i) => i.type === 'booking' && i.band === 'turnaround')
     expect(tail?.end).toBe(TO)
   })
 
   it('drops a turnaround band that falls entirely after the window', () => {
     const { items } = build([row({ endAt: iso(2027, 1, 24), effectiveEndAt: iso(2027, 1, 26) })])
-    expect(items.every((i) => i.band === 'booked')).toBe(true)
+    expect(items.every((i) => i.type === 'booking' && i.band === 'booked')).toBe(true)
   })
 
   it('drops a booked band entirely before the window but keeps an in-window tail', () => {
@@ -124,6 +148,63 @@ describe('buildTimelineLayout', () => {
   })
 })
 
+describe('buildTimelineLayout blocks', () => {
+  it('renders a block as a kind-tagged band on its vehicle row', () => {
+    const { items } = build([], FLEET, [block()])
+    expect(items).toEqual([
+      {
+        type: 'block',
+        id: 'blk1',
+        blockId: 'blk1',
+        group: 'v1',
+        title: 'Oil change',
+        start: Date.UTC(2027, 0, 12),
+        end: Date.UTC(2027, 0, 14),
+        kind: 'MAINTENANCE',
+      },
+    ])
+  })
+
+  it('carries the block discriminant with a kind and no booking status', () => {
+    const { items } = build([], FLEET, [block({ kind: 'OUT_OF_SERVICE' })])
+    const it0 = items[0]
+    expect(it0).toMatchObject({ type: 'block', kind: 'OUT_OF_SERVICE' })
+    expect(it0 && 'status' in it0).toBe(false)
+    expect(it0 && 'bookingId' in it0).toBe(false)
+  })
+
+  it('clamps a block spanning past both window edges to the window', () => {
+    const { items } = build([], FLEET, [
+      block({ start: new Date(Date.UTC(2027, 0, 5)), end: new Date(Date.UTC(2027, 0, 30)) }),
+    ])
+    expect(items[0]).toMatchObject({ type: 'block', start: FROM, end: TO })
+  })
+
+  it('drops a block that falls entirely outside the window', () => {
+    const { items } = build([], FLEET, [
+      block({ start: new Date(Date.UTC(2027, 0, 1)), end: new Date(Date.UTC(2027, 0, 3)) }),
+    ])
+    expect(items).toHaveLength(0)
+  })
+
+  it('skips a block on a non-fleet vehicle and never opens an Unassigned row for it', () => {
+    const { groups, items } = build([], FLEET, [block({ resourceId: 'ghost' })])
+    expect(items).toHaveLength(0)
+    expect(groups.some((g) => g.id === UNASSIGNED_GROUP_ID)).toBe(false)
+  })
+
+  it('lays booking and block bands together, bookings first', () => {
+    const { items } = build([row()], FLEET, [
+      block({
+        id: 'blk9',
+        start: new Date(Date.UTC(2027, 0, 16)),
+        end: new Date(Date.UTC(2027, 0, 18)),
+      }),
+    ])
+    expect(items.map((i) => i.type)).toEqual(['booking', 'block'])
+  })
+})
+
 describe('bookingIdFromTimelineItem', () => {
   it('returns the id unchanged for a booked-band bar', () => {
     expect(bookingIdFromTimelineItem('booking-123')).toBe('booking-123')
@@ -144,7 +225,7 @@ describe('bookingIdFromTimelineItem', () => {
     const { items } = build([
       row({ id: 'bk9', endAt: iso(2027, 1, 14), effectiveEndAt: iso(2027, 1, 15) }),
     ])
-    const tail = items.find((i) => i.band === 'turnaround')
+    const tail = items.find((i) => i.type === 'booking' && i.band === 'turnaround')
     expect(tail).toBeDefined()
     expect(tail?.id).not.toBe('bk9') // it carries the suffix
     expect(bookingIdFromTimelineItem(tail!.id)).toBe('bk9')

--- a/packages/web/src/vite/operator-bookings/timeline-layout.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-layout.ts
@@ -1,4 +1,6 @@
 import type { CalendarBookingRow, OperatorBookingStatus } from '@/vite/operator-bookings/api'
+import type { BlockCalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import type { VehicleBlockKind } from '@kuruma/shared/enums'
 
 // #1100 fleet timeline: pure transforms turning the operator's calendar rows into
 // the groups (vehicle rows) + items (bars) react-calendar-timeline consumes. Kept
@@ -33,17 +35,34 @@ export interface TimelineGroup {
   title: string
 }
 
-/** One bar. Times are epoch ms already clamped to the visible window. */
-export interface TimelineItem {
+/** Fields every bar shares. Times are epoch ms already clamped to the window. */
+interface TimelineItemCommon {
   id: string
-  bookingId: string
   group: string
   title: string
   start: number
   end: number
+}
+
+/** A booking bar — status-colored, click-decodes back to its booking. */
+export type TimelineBookingItem = TimelineItemCommon & {
+  type: 'booking'
+  bookingId: string
   band: TimelineBand
   status: OperatorBookingStatus
 }
+
+/** A scheduled-block bar — kind-colored, opens the block detail dialog. Carries a
+ *  `kind` (never a `status`), mirroring the calendar's `BlockCalendarEvent` (#1244). */
+export type TimelineBlockItem = TimelineItemCommon & {
+  type: 'block'
+  blockId: string
+  kind: VehicleBlockKind
+}
+
+/** One bar: a booking or a scheduled block. Consumers switch on `type` at the
+ *  boundary (styling, click) so a block never reads as a booking (#1101 P1.2). */
+export type TimelineItem = TimelineBookingItem | TimelineBlockItem
 
 export interface TimelineLayout {
   groups: TimelineGroup[]
@@ -53,6 +72,10 @@ export interface TimelineLayout {
 export interface BuildTimelineArgs {
   readonly rows: readonly CalendarBookingRow[]
   readonly vehicles: readonly { id: string; name: string }[]
+  /** Scheduled maintenance/hold bands, keyed to a fleet vehicle by `resourceId`.
+   *  A block on a vehicle absent from `vehicles` is dropped (never Unassigned —
+   *  blocks are always car-specific, unlike class-only booking floats). */
+  readonly blocks: readonly BlockCalendarEvent[]
   /** Visible window, epoch ms. Bars are clamped to `[from, to]`. */
   readonly from: number
   readonly to: number
@@ -76,6 +99,7 @@ function clampBand(
 export function buildTimelineLayout({
   rows,
   vehicles,
+  blocks,
   from,
   to,
   unassignedLabel,
@@ -97,6 +121,7 @@ export function buildTimelineLayout({
     const booked = clampBand(startMs, endMs, from, to)
     if (booked) {
       items.push({
+        type: 'booking',
         id: r.id,
         bookingId: r.id,
         group,
@@ -116,6 +141,7 @@ export function buildTimelineLayout({
       const tail = clampBand(endMs, effEndMs, from, to)
       if (tail) {
         items.push({
+          type: 'booking',
           id: `${r.id}${TURNAROUND_SUFFIX}`,
           bookingId: r.id,
           group,
@@ -128,6 +154,26 @@ export function buildTimelineLayout({
         if (group === UNASSIGNED_GROUP_ID) hasUnassignedRow = true
       }
     }
+  }
+
+  // Scheduled blocks are bound to a specific car. A block on a vehicle not in the
+  // fleet list is dropped (not routed to Unassigned like a class-only booking float)
+  // — a block has no meaning without its column. Its own window is clamped so a band
+  // straddling the edge still shows its in-window slice.
+  for (const b of blocks) {
+    if (!fleetIds.has(b.resourceId)) continue
+    const band = clampBand(b.start.getTime(), b.end.getTime(), from, to)
+    if (!band) continue
+    items.push({
+      type: 'block',
+      id: b.id,
+      blockId: b.id,
+      group: b.resourceId,
+      title: b.title,
+      start: band.start,
+      end: band.end,
+      kind: b.kind,
+    })
   }
 
   const groups: TimelineGroup[] = vehicles.map((v) => ({ id: v.id, title: v.name }))

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -420,11 +420,19 @@ describe('OperatorBookingsRoute blocks layer (#1101)', () => {
     expect(screen.getByRole('button', { name: B.scheduleAction })).toBeInTheDocument()
   })
 
-  it('hides the Schedule affordance on the default timeline view (a created block renders no band there)', () => {
+  it('hides the Schedule affordance on the timeline view (its create is an rbc slot-drag the timeline lib lacks)', () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_BLOCKS', 'true')
     searchState.value = { view: 'timeline', date: ANCHOR }
     renderRoute(operatorSession, blocksFleet)
     expect(screen.queryByRole('button', { name: B.scheduleAction })).not.toBeInTheDocument()
+  })
+
+  it('shows the block legend on the timeline view too, since its bands now render there (#1244)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_BLOCKS', 'true')
+    searchState.value = { view: 'timeline', date: ANCHOR }
+    renderRoute(operatorSession, blocksFleet, [], { blocks: [maintenanceBlock] })
+    expect(screen.getByTestId('fleet-timeline')).toBeInTheDocument()
+    expect(screen.getByText(B.legend.title)).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## What

The operator **fleet timeline** (react-calendar-timeline Gantt, one row per vehicle) rendered bookings only. The day/week rbc calendar views already render maintenance/hold **block bands**. This adds those bands to the timeline, **clickable to the existing `BlockDetailDialog`** (day/week parity).

Behind `VITE_FEATURE_FLEET_TIMELINE` (off by default) — this is the last band-rendering polish gating the timeline for GA. Web-only: no API, schema, or i18n changes.

## How

- **`timeline-layout.ts`** — `TimelineItem` is now a discriminated union (`type: 'booking'` `{bookingId,band,status}` | `type: 'block'` `{blockId,kind}`), mirroring the calendar's `CalendarItem`. `buildTimelineLayout` takes `blocks` and lays out one clamped band per block on its fleet row; blocks on a non-fleet vehicle are dropped (never routed to Unassigned — a block is car-specific).
- **`FleetTimeline.tsx`** — `blocks` + `onSelectBlock` props; className branches booking-status vs block-kind; block-bar clicks route to `onSelectBlock`, the booking path is unchanged.
- **`bookings/index.tsx`** — fetch blocks on the timeline view too; pass a `isVehicleChecked`-filtered `timelineBlocks` + `onSelectBlock={setSelectedBlock}` (reuses the existing `selectedBlock` state + dialog); hoist `<BlockLegend>` above both views so the kind colors are explained on the timeline too.
- **`fleet-timeline-theme.css`** — `.rct-item.rbc-event--block-*` bands mirroring `calendar-theme.css`.

## Testing

- TDD: pure `timeline-layout.test.ts` (block placed / clamped / dropped-outside / skipped-on-non-fleet / discriminant), `FleetTimeline.test.tsx` (kind-band class, block-click → `onSelectBlock` not `onSelectEvent`), route test (legend renders on timeline).
- Full web suite **1998/1998**, `tsc` clean (web + api), biome, lint:size/modules.
- Code review + deep architecture review run; both MEDIUM findings folded in (explicit block view-filter to remove coincidental coupling; legend parity).

Closes #1244