### PR TITLE
refactor(#1417): clamp booking-create inventory via ctx-scoped anchor read (Option B)

### DIFF
--- a/packages/api/src/services/booking-creation.ts
+++ b/packages/api/src/services/booking-creation.ts
@@ -8,9 +8,9 @@ import { BOOKING_CODE_CONSTRAINT, PG_ERROR, pgConstraintName, pgErrorCode } from
 import type { BookingRepository, RunInTransaction, TransactionRepos } from '../repositories/types'
 import type { Location, Vehicle } from '../stores'
 import {
-  assertBookingInventoryWithinOperator,
-  bookingInventoryDenialResult,
+  assertBookingWriteWithinOperator,
   bookingReadScope,
+  fleetWriteDenialResult,
 } from '../tenancy'
 import { resolveBookingActor } from './booking-actor'
 import { rejectIfOperatorDeactivated } from './booking-creation-operator-guard'
@@ -229,12 +229,11 @@ export class BookingCreationService {
     return { ok: true, dropoff, effectiveEndAt }
   }
 
-  // The atomic decision-and-record (FC/IS: the decision; ensureThread is the
-  // imperative shell). Resolution reads run as SYSTEM_CONTEXT — these are
-  // internal pricing/snapshot reads, and insurance/fee reads reject RENTER
-  // callers by design; the booking's tenant is derived from the vehicle, not
-  // the caller. The booking + event WRITES use the caller's ctx (renter-own /
-  // operator scope is enforced at the repo).
+  // The atomic decision-and-record (FC/IS: the decision; ensureThread is the imperative
+  // shell). The ANCHOR read (vehicle/pickup) is ctx-scoped (#1417) — it derives the tenant
+  // AND clamps operators; downstream pricing/snapshot/insurance/fee reads stay SYSTEM_CONTEXT,
+  // cross-checked against that operatorId (insurance/fee also reject RENTER callers). WRITES
+  // use the caller's ctx (scope enforced at the repo).
   private async submitInTx(
     ctx: CallerContext,
     input: CreateBookingInput,
@@ -251,18 +250,19 @@ export class BookingCreationService {
     if (input.fulfillmentMode === 'CLASS_COMBO') {
       return this.submitComboInTx(ctx, input, renterId, now, repos, actingOperatorId)
     }
-    const vehicle = await repos.vehicleRepo.findById(SYSTEM_CONTEXT, input.requestedVehicleId)
+    // #1417: read the ANCHOR vehicle with the caller's own ctx, so operatorReadScope clamps
+    // a tenant operator to its own fleet — a foreign car returns undefined -> the plain
+    // 'Vehicle not found' below (no oracle). Marketplace tiers still resolve `all`, unchanged.
+    const vehicle = await repos.vehicleRepo.findById(ctx, input.requestedVehicleId)
     if (!vehicle) {
       return { ok: false, status: 400, error: 'Vehicle not found' }
     }
     const operatorId = vehicle.operatorId
-    // #1260/#1417: bind BEFORE the vehicle-state gates below. The read is SYSTEM_CONTEXT
-    // (unscoped), so a foreign car is reachable by raw id; binding first refuses a cross-
-    // tenant caller uniformly and stops it probing B's status/class/shaken-expiry via the
-    // 400s that follow. Bypass `all` names its operator (404 no-oracle); a tenant operator
-    // is own-fleet only (foreign -> 403); renters pass through (marketplace).
-    const inventoryDenial = assertBookingInventoryWithinOperator(ctx, operatorId, actingOperatorId)
-    if (inventoryDenial) return bookingInventoryDenialResult(inventoryDenial, 'Vehicle not found')
+    // #1260: only the bypass `all` tier reads cross-operator inventory above, so bind just its
+    // pick-an-operator claim, BEFORE the vehicle-state gates (a mismatched admin pick must not
+    // probe them). Operators/renters/partners already pass — clamped or marketplace.
+    const denial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
+    if (denial) return fleetWriteDenialResult(denial, 'Vehicle not found')
     if (vehicle.status !== 'AVAILABLE') {
       return { ok: false, status: 400, error: 'Vehicle is not available' }
     }
@@ -477,17 +477,17 @@ export class BookingCreationService {
     // The pickup location anchors the booking's operator + the (op, class, loc)
     // triple every other read keys off (a forged classId from another tenant
     // gets rejected at the class-belongs-to-operator gate below).
-    const pickup = await repos.locationRepo.findById(SYSTEM_CONTEXT, input.pickupLocationId)
+    // #1417: read the ANCHOR pickup with the caller's own ctx (mirrors SPECIFIC's vehicle
+    // read) — a tenant operator's foreign pickup returns undefined -> the plain 'not
+    // available' below (no oracle). Marketplace tiers still resolve `all`, unchanged.
+    const pickup = await repos.locationRepo.findById(ctx, input.pickupLocationId)
     if (!pickup) {
       return { ok: false, status: 400, error: 'Pickup location is not available' }
     }
     const operatorId = pickup.operatorId
-    // #1260/#1417: bind the combo's pickup/inventory operator (mirrors the SPECIFIC
-    // path) — bypass `all` names its operator (404 no-oracle), a tenant operator is
-    // own-fleet only (foreign pickup -> 403), renters pass through (marketplace).
-    const inventoryDenial = assertBookingInventoryWithinOperator(ctx, operatorId, actingOperatorId)
-    if (inventoryDenial)
-      return bookingInventoryDenialResult(inventoryDenial, 'Pickup location is not available')
+    // #1260: bind only the bypass `all` tier's pick-an-operator claim (mirrors SPECIFIC).
+    const denial = assertBookingWriteWithinOperator(ctx, operatorId, actingOperatorId)
+    if (denial) return fleetWriteDenialResult(denial, 'Pickup location is not available')
     const operatorBlock = await rejectIfOperatorDeactivated(repos, operatorId)
     if (operatorBlock) return operatorBlock
     const classId = input.classId

--- a/packages/api/src/tenancy.ts
+++ b/packages/api/src/tenancy.ts
@@ -208,16 +208,6 @@ export function threadReadScope(ctx: CallerContext): ThreadReadScope {
 export type FleetWriteDenial = { kind: 'operator-required' } | { kind: 'not-in-scope' }
 
 /**
- * The booking-CREATE superset of {@link FleetWriteDenial} (#1417). Adds:
- * - `foreign-operator` — a tenant operator referenced another operator's PUBLIC
- *                        storefront inventory; an explicit 403 (the vehicle is public,
- *                        so there is no existence oracle to hide behind a 404).
- * Kept OFF `FleetWriteDenial` so the lifecycle/maintenance writes that share
- * {@link fleetWriteDenialResult} never have to model a 403 they can never produce.
- */
-export type BookingInventoryDenial = FleetWriteDenial | { kind: 'foreign-operator' }
-
-/**
  * The core operator-binding denial (#1260): when a caller reached the target
  * through an UNSCOPED `all` read, it must name the operator it is acting as, and
  * that operator must own the target. Row/tenant-scoped callers pass through — the
@@ -268,6 +258,12 @@ export function assertFleetWriteWithinOperator(
  * `!isOperatorRole` (the fleet key): `/cancel` has no route gate and admits
  * renters (self-cancel) and legacy STAFF/ADMIN — both renter-scoped for bookings —
  * who must never be forced to name an operator, and the fleet key would 422 them.
+ *
+ * Also guards booking CREATE (#1417): that path now reads the vehicle/pickup anchor
+ * with the caller's own ctx, so a tenant operator can no longer reach a foreign car
+ * at all (`findById` returns undefined -> a plain 'not found'). Only the bypass `all`
+ * tier still reads cross-operator inventory, so this same pick-an-operator bind is all
+ * create needs — no create-specific denial kind.
  */
 export function assertBookingWriteWithinOperator(
   ctx: CallerContext,
@@ -282,36 +278,10 @@ export function assertBookingWriteWithinOperator(
 }
 
 /**
- * Bind a booking CREATE's inventory (vehicle / pickup) to the caller's tenant (#1417).
- *
- * The create path resolves the vehicle/pickup with SYSTEM_CONTEXT (unscoped) for EVERY
- * tier, so the read-scope clamp {@link operatorBindingDenial} relies on is absent here:
- * a tenant operator can reach a foreign operator's PUBLIC storefront vehicle by raw id
- * and persist a stranger booking under it (availability griefing + cross-tenant PII).
- * So bind explicitly by role:
- *  - OPERATOR_* : manual booking is own-fleet only. A foreign (or absent) operatorId is
- *    `foreign-operator` -> 403. The vehicle is already public on the target's storefront,
- *    so there is no existence oracle to hide; an explicit refusal beats a 404. Fail-closed
- *    when the operator has no operatorId (it owns no inventory).
- *  - everyone else : delegate to {@link assertBookingWriteWithinOperator}. The bypass
- *    `all` tier keeps its pick-an-operator bind; renters/partners pass through, because a
- *    renter booking ANY operator's storefront vehicle is the marketplace, not a leak.
- */
-export function assertBookingInventoryWithinOperator(
-  ctx: CallerContext,
-  targetOperatorId: string,
-  actingOperatorId: string | undefined,
-): BookingInventoryDenial | null {
-  if (isOperatorRole(ctx.role)) {
-    return ctx.operatorId === targetOperatorId ? null : { kind: 'foreign-operator' }
-  }
-  return assertBookingWriteWithinOperator(ctx, targetOperatorId, actingOperatorId)
-}
-
-/**
  * Map a {@link FleetWriteDenial} to the shape a fleet-write service returns
- * (#1260). Wired to booking status writes today; the block/vehicle slices adopt
- * the same mapper so the refusal contract stays identical everywhere:
+ * (#1260). Wired to booking status writes and booking CREATE (#1417); the
+ * block/vehicle slices adopt the same mapper so the refusal contract stays
+ * identical everywhere:
  * - operator-required -> 422 carrying the same OPERATOR_REQUIRED code the global
  *   OperatorRequiredError emits, so the web can discriminate "pick an operator".
  * - not-in-scope      -> 404 with the CALLER's own not-found message: from the
@@ -331,25 +301,6 @@ export function fleetWriteDenialResult(
         code: 'OPERATOR_REQUIRED',
       }
     : { ok: false, status: 404, error: notFoundError }
-}
-
-/**
- * Map a {@link BookingInventoryDenial} to a booking-create service result (#1417).
- * Superset of {@link fleetWriteDenialResult}: `foreign-operator` becomes a uniform 403
- * (same message for the vehicle and the pickup-location paths), everything else defers to
- * the shared mapper. Kept separate so only the create path carries the 403 in its type.
- */
-export function bookingInventoryDenialResult(
-  denial: BookingInventoryDenial,
-  notFoundError: string,
-): { ok: false; status: 422 | 404 | 403; error: string; code?: ErrorCode } {
-  return denial.kind === 'foreign-operator'
-    ? {
-        ok: false,
-        status: 403,
-        error: 'This booking references inventory owned by another operator',
-      }
-    : fleetWriteDenialResult(denial, notFoundError)
 }
 
 /**

--- a/packages/api/tests/services/booking-write-scope.test.ts
+++ b/packages/api/tests/services/booking-write-scope.test.ts
@@ -33,10 +33,8 @@ import type { RunInTransaction, TransactionRepos } from '../../src/repositories/
 import { BookingService } from '../../src/services/booking'
 import type { Booking, Operator } from '../../src/stores'
 import {
-  assertBookingInventoryWithinOperator,
   assertBookingWriteWithinOperator,
   assertFleetWriteWithinOperator,
-  bookingInventoryDenialResult,
   fleetWriteDenialResult,
 } from '../../src/tenancy'
 
@@ -111,58 +109,6 @@ describe('assertBookingWriteWithinOperator — bypass keying (#1260)', () => {
   })
 })
 
-// #1417: the booking CREATE path reads inventory (vehicle/pickup) with SYSTEM_CONTEXT
-// (unscoped) for EVERY tier, so the read-scope clamp the binding model relies on is
-// absent -- an operator can reach a foreign operator's PUBLIC storefront vehicle by raw
-// id. This bind makes an OPERATOR_* own-fleet only. Renters/partners still pass through
-// (booking any storefront vehicle is the marketplace); the bypass `all` tier keeps its
-// pick-an-operator bind unchanged.
-describe('assertBookingInventoryWithinOperator — operator-tier create bind (#1417)', () => {
-  const FOREIGN_OP = 'op-foreign-b'
-
-  it('denies a tenant operator that books FOREIGN inventory (403 forbidden)', () => {
-    expect(assertBookingInventoryWithinOperator(operatorCtxA, FOREIGN_OP, undefined)).toEqual({
-      kind: 'foreign-operator',
-    })
-  })
-
-  it('allows a tenant operator that books its OWN inventory', () => {
-    expect(assertBookingInventoryWithinOperator(operatorCtxA, OP_A, undefined)).toBeNull()
-  })
-
-  it('binds an operator to its OWN operatorId, ignoring a stray acting id naming the target', () => {
-    expect(assertBookingInventoryWithinOperator(operatorCtxA, FOREIGN_OP, FOREIGN_OP)).toEqual({
-      kind: 'foreign-operator',
-    })
-  })
-
-  it('fails closed for an OPERATOR_* with no operatorId (owns no inventory)', () => {
-    const noOpCtx: CallerContext = {
-      userId: 'op-user-x',
-      role: 'OPERATOR_OWNER',
-      bypassScope: false,
-    }
-    expect(assertBookingInventoryWithinOperator(noOpCtx, OP_A, undefined)).toEqual({
-      kind: 'foreign-operator',
-    })
-  })
-
-  it('is a no-op for a renter (booking any storefront vehicle is the marketplace)', () => {
-    const renterCtx: CallerContext = { userId: RENTER_ID, role: 'RENTER', bypassScope: false }
-    expect(assertBookingInventoryWithinOperator(renterCtx, FOREIGN_OP, undefined)).toBeNull()
-  })
-
-  it('still binds the bypass admin (no pick -> required, wrong pick -> not-in-scope, own -> ok)', () => {
-    expect(assertBookingInventoryWithinOperator(adminCtx, OP_A, undefined)).toEqual({
-      kind: 'operator-required',
-    })
-    expect(assertBookingInventoryWithinOperator(adminCtx, OP_A, 'op-else')).toEqual({
-      kind: 'not-in-scope',
-    })
-    expect(assertBookingInventoryWithinOperator(adminCtx, OP_A, OP_A)).toBeNull()
-  })
-})
-
 describe('fleetWriteDenialResult — denial -> service result (#1260)', () => {
   it('maps operator-required to 422 carrying OPERATOR_REQUIRED', () => {
     expect(fleetWriteDenialResult({ kind: 'operator-required' }, 'Booking not found')).toEqual({
@@ -178,29 +124,6 @@ describe('fleetWriteDenialResult — denial -> service result (#1260)', () => {
       ok: false,
       status: 404,
       error: 'Booking not found',
-    })
-  })
-})
-
-describe('bookingInventoryDenialResult — create denial -> service result (#1417)', () => {
-  it('maps foreign-operator to 403 forbidden (operator referenced another tenant)', () => {
-    expect(bookingInventoryDenialResult({ kind: 'foreign-operator' }, 'Vehicle not found')).toEqual(
-      {
-        ok: false,
-        status: 403,
-        error: 'This booking references inventory owned by another operator',
-      },
-    )
-  })
-
-  it('delegates non-foreign denials to the shared mapper (422 required, 404 not-found)', () => {
-    expect(
-      bookingInventoryDenialResult({ kind: 'operator-required' }, 'Vehicle not found'),
-    ).toMatchObject({ status: 422, code: 'OPERATOR_REQUIRED' })
-    expect(bookingInventoryDenialResult({ kind: 'not-in-scope' }, 'Vehicle not found')).toEqual({
-      ok: false,
-      status: 404,
-      error: 'Vehicle not found',
     })
   })
 })
@@ -272,32 +195,23 @@ describe('BookingService.cancel — operator write scope (#1260)', () => {
 })
 
 // #1417 end-to-end repro: a tenant operator (A) manual-books a car owned by operator B.
-// It is reachable because submitInTx reads the vehicle with SYSTEM_CONTEXT (unscoped),
-// so B's PUBLIC storefront car is found by raw id. Before the fix the operator-tier bind
-// no-ops and the booking persists under B (availability griefing + cross-tenant PII);
-// the fix refuses it 403 and writes nothing under B. Walk-in so no renter seeding is
-// needed — the bind fires before the walk-in renter is minted.
+// submitInTx/submitComboInTx now read the ANCHOR vehicle/pickup with the CALLER's own ctx,
+// so operatorReadScope clamps A to its own fleet -- B's PUBLIC storefront car resolves to
+// undefined for A and never enters the create path. Walk-in so no renter seeding is needed.
 const OP_B = 'op-write-scope-b'
 
-// #1417 end-to-end (both create paths). Note the layering: the booking repo's own tenant
-// guard (#329) already refuses a cross-tenant INSERT (bookingRepo.create throws
-// ForbiddenError -> 403 'Forbidden'), so a booking never actually persists under B. The
-// #1417 bind sits IN FRONT of that backstop and returns a clean, SPECIFIC 403 early --
-// before any vehicle-state gate can leak B's status/class/shaken-expiry (the hoist in
-// submitInTx) and before wasted work (rental rules, capacity lock). Removing the operator
-// branch of the guard makes create hit the repo backstop instead (ForbiddenError thrown),
-// so these tests genuinely fail on mutation.
-describe('BookingCreationService.create — operator inventory bind (#1417)', () => {
+// #1417 end-to-end (both create paths), Option B (structural). The foreign row is now
+// UNREACHABLE at the repo read, so create returns the very same not-found ('Vehicle not
+// found' / 'Pickup location is not available') a truly-unknown id yields -- no distinguishable
+// 403 to confirm existence, and no vehicle-state gate ever runs to leak B's status/class/
+// shaken-expiry. Mutation check: reverting the anchor read to SYSTEM_CONTEXT makes B's car
+// reachable to A again, so create no longer returns the not-found -- these tests fail.
+describe('BookingCreationService.create — operator inventory clamp (#1417)', () => {
   const now = new Date('2027-07-15T00:00:00Z')
   const startAt = new Date('2027-08-01T09:00:00Z')
   const endAt = new Date('2027-08-03T09:00:00Z')
-  const foreign403 = {
-    ok: false,
-    status: 403,
-    error: 'This booking references inventory owned by another operator',
-  }
 
-  it('refuses a SPECIFIC booking of a FOREIGN operator vehicle with a clean early 403', async () => {
+  it('refuses a SPECIFIC booking of a FOREIGN operator vehicle as an unfound vehicle (no oracle)', async () => {
     const { service, bookingRepo, bVehicleId, bLocationId } = await createHarness()
 
     const res = await service.create(
@@ -316,13 +230,14 @@ describe('BookingCreationService.create — operator inventory bind (#1417)', ()
       now,
     )
 
-    // Specific, typed 403 from the bind -- NOT the repo backstop's generic thrown Forbidden.
-    expect(res).toMatchObject(foreign403)
+    // The ctx-scoped read makes B's car unreachable to A -> the same not-found a
+    // truly-unknown id yields, NOT a distinguishable 403 existence oracle.
+    expect(res).toMatchObject({ ok: false, status: 400, error: 'Vehicle not found' })
     const all = await bookingRepo.findAll(SYSTEM_CONTEXT)
     expect(all.filter((b) => b.operatorId === OP_B)).toEqual([])
   })
 
-  it('refuses a CLASS_COMBO booking at a FOREIGN operator pickup with the same 403', async () => {
+  it('refuses a CLASS_COMBO booking at a FOREIGN operator pickup as an unfound pickup', async () => {
     const { service, bookingRepo, bLocationId } = await createHarness()
 
     // submitComboInTx binds on pickup.operatorId (= B), so the foreign pickup is refused
@@ -343,7 +258,11 @@ describe('BookingCreationService.create — operator inventory bind (#1417)', ()
       now,
     )
 
-    expect(res).toMatchObject(foreign403)
+    expect(res).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'Pickup location is not available',
+    })
     const all = await bookingRepo.findAll(SYSTEM_CONTEXT)
     expect(all.filter((b) => b.operatorId === OP_B)).toEqual([])
   })


### PR DESCRIPTION
Follow-up to #1417 (PR #1434). Architect "Option B" — the structural consolidation that #1434 deferred.

## Why
#1434 closed the operator cross-tenant booking-create gap with a **compensating guard**: it read the anchor inventory (SPECIFIC vehicle / CLASS_COMBO pickup) with `SYSTEM_CONTEXT` (unscoped) for every tier, then a role-keyed `assertBookingInventoryWithinOperator` returned a `foreign-operator` 403 when a tenant operator referenced another operator's row.

That left three same-signature scope helpers (`assertFleetWriteWithinOperator`, `assertBookingWriteWithinOperator`, `assertBookingInventoryWithinOperator`) that differed only by an **invisible precondition** — was the target read *scoped* (`findById` clamps) or *unscoped* (`SYSTEM_CONTEXT`). A future unscoped create path that called the wrong one would compile, pass review, and silently reopen the hole. The invariant rested on a doc comment, not the type system.

## What
Read the two **anchor** reads with the caller's own `ctx`. `operatorReadScope` then clamps a tenant operator to its own fleet at the repo — a foreign row returns `undefined` and yields the existing **400 "Vehicle not found" / "Pickup location is not available"**, indistinguishable from an unknown id. The foreign row is now **unreachable**, so:

- `assertBookingInventoryWithinOperator`, `bookingInventoryDenialResult`, and the `BookingInventoryDenial` type are **deleted**.
- The create path reuses the existing `assertBookingWriteWithinOperator` + `fleetWriteDenialResult` (the same helpers the lifecycle status/cancel writes use) to bind **only** the bypass `all` tier's pick-an-operator claim.
- **3 scope helpers → 2**; the invisible precondition is gone (net **-125 lines**).

Marketplace tiers (renter/partner/admin) all resolve `all`, so their reads are **unchanged** — verified against the full suite.

## Behavior change (owner-approved)
Foreign inventory now surfaces as a **400 not-found** instead of the prior **403**. This reverses the owner-confirmed 403 from #1417, chosen because the structural clamp is stronger than a documented convention and the 400 *hides* the existence oracle rather than confirming it (a foreign car is now indistinguishable from a nonexistent one). It also aligns create with the existing `assignVehicle`/`substitute` paths, which already return "the same 404 for a foreign vehicle as for an unknown vehicle (no existence leak)".

## Test plan
- [x] TDD: flipped the two e2e repros to the structural 400 contract first (RED against the old 403), then implemented (GREEN).
- [x] Full api suite: **2753 pass / 243 files, 0 fail** — every renter/marketplace/admin booking flow intact.
- [x] `tsc --noEmit` clean (api + web); biome clean; file-size, module-boundary hooks pass.
- [x] Mutation check: reverting the anchor read to `SYSTEM_CONTEXT` makes B's car reachable to A again, so create no longer returns the not-found — the repros fail.
- [x] Independent code-review pass (correctness, no-regression on bypass-admin, dead-code, test mutation-resistance): no CRITICAL/HIGH/MEDIUM findings. Confirmed the other `SYSTEM_CONTEXT` reads (insurance/fee) must stay unscoped (they reject RENTER callers), so only the two anchors were scoped.

## Still deferred (not in this PR)
- MED: 403-vs-404 convention doc — this PR removes the create-path 403, leaving the codebase's not-found convention consistent; documenting it in `docs/architecture` remains open.
- Confirm PARTNER route-gating on manual-create (partners pass through the bind in both designs).
- LOW: substitute/assign single-seal; NIT: stable `ErrorCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
