### PR TITLE
perf(#1422): skip class-combo scan on storefront-detail cursor pages

### DIFF
--- a/packages/api/src/services/storefront-detail.test.ts
+++ b/packages/api/src/services/storefront-detail.test.ts
@@ -1,5 +1,5 @@
 import { seedId } from '@kuruma/shared/db/seed-id'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PUBLIC_CONTEXT, SYSTEM_CONTEXT } from '../middleware/auth'
 import { InMemoryAddOnRepository } from '../repositories/in-memory/add-on'
 import { InMemoryAvailabilityRepository } from '../repositories/in-memory/availability'
@@ -35,6 +35,7 @@ let classRepo: InMemoryVehicleClassRepository
 let insuranceRepo: InMemoryInsuranceOptionRepository
 let addOnRepo: InMemoryAddOnRepository
 let classRatePlanRepo: InMemoryClassRatePlanRepository
+let classOfferingService: ClassOfferingService
 let service: StorefrontDetailService
 
 beforeEach(() => {
@@ -53,7 +54,7 @@ beforeEach(() => {
     new InMemoryVehicleBlockRepository(),
     operatorRepo,
   )
-  const classOfferingService = new ClassOfferingService(classRatePlanRepo, availabilityRepo)
+  classOfferingService = new ClassOfferingService(classRatePlanRepo, availabilityRepo)
   service = new StorefrontDetailService(
     storefrontRepo,
     availabilityRepo,
@@ -515,6 +516,52 @@ describe('StorefrontDetailService.getDetail (#391)', () => {
     if (result.ok) throw new Error('expected a failure result for a malformed cursor')
     expect(result.status).toBe(400)
     expect(result.error).toMatch(/cursor/i)
+  })
+
+  it('skips the class-combo scan on a cursor page — offerings ship on the first page only (#1422)', async () => {
+    const op = await makeOperator('Best Car Rental', 'best')
+    const compact = await makeClass({ operatorId: op.id, name: 'Compact', acrissCode: 'CCAR' })
+    const namba = await makeLocation({ operatorId: op.id, name: 'Namba' })
+    const base = { operatorId: op.id, classId: compact.id, pickupLocationId: namba.id }
+    await makeVehicle({ ...base, name: 'Car A' })
+    await makeVehicle({ ...base, name: 'Car B' })
+    await makeRatePlan({
+      operatorId: op.id,
+      classId: compact.id,
+      pickupLocationId: namba.id,
+      dayRateJpy: 6000,
+    })
+
+    const scan = vi.spyOn(classOfferingService, 'findOfferings')
+
+    // First page runs the producer scan once and carries the offering.
+    const page1 = await okData(
+      await service.getDetail(PUBLIC_CONTEXT, {
+        locationId: namba.id,
+        from: FROM,
+        to: TO,
+        limit: 1,
+      }),
+    )
+    expect(page1.classOfferings).toHaveLength(1)
+    expect(scan).toHaveBeenCalledTimes(1)
+    const cursor = page1.nextCursor
+    if (cursor === null) throw new Error('expected a nextCursor for page 1')
+
+    // The load-more (cursor) page must NOT re-run the scan (1 plan + 2 counts/plan)
+    // and ships no offerings — the client already has them from page 1 (#1422).
+    const page2 = await okData(
+      await service.getDetail(PUBLIC_CONTEXT, {
+        locationId: namba.id,
+        from: FROM,
+        to: TO,
+        limit: 1,
+        cursor,
+      }),
+    )
+    expect(scan).toHaveBeenCalledTimes(1)
+    expect(page2.classOfferings).toEqual([])
+    expect(page2.vehicles.map((v) => v.name)).toEqual(['Car B'])
   })
 })
 

--- a/packages/api/src/services/storefront-detail.ts
+++ b/packages/api/src/services/storefront-detail.ts
@@ -221,15 +221,21 @@ export class StorefrontDetailService {
     // scan to this store's operator + location forecloses a stray cross-operator rate
     // plan surfacing a card under the wrong store. Offerings are unpaginated (only
     // `vehicles` pages).
-    const classOfferings = await this.classOfferingService.findOfferings({
-      planFilters: { operatorId: storefront.operatorId, locationIds: [locationId] },
-      from,
-      to,
-      locationById: singleLocationMap(storefront),
-      classById,
-      turnaroundByLocationId: new Map([[storefront.id, storefront.defaultTurnaroundMinutes]]),
-      requested,
-    })
+    // #1422: they ship on the FIRST page only. A load-more `cursor` request already
+    // has them client-side, so re-running the scan (1 plan + 2 count queries per plan)
+    // would be pure waste — skip it and ship `[]` on cursor pages (the response
+    // contract keeps the field; the web client defaults a missing one to `[]`).
+    const classOfferings = cursor
+      ? []
+      : await this.classOfferingService.findOfferings({
+          planFilters: { operatorId: storefront.operatorId, locationIds: [locationId] },
+          from,
+          to,
+          locationById: singleLocationMap(storefront),
+          classById,
+          turnaroundByLocationId: new Map([[storefront.id, storefront.defaultTurnaroundMinutes]]),
+          requested,
+        })
 
     let start = 0
     if (cursor) {


### PR DESCRIPTION
## What

`StorefrontDetailService.getDetail` awaited the `classOfferings` producer scan (**1 plan query + 2 count queries per plan**) on **every** call — including paginated vehicle "load more" (`cursor`) requests. Class-combo offerings are first-page-only (unpaginated), so a cursor request re-ran the scan and re-shipped data the client already had. Follow-up from #1421 (holistic review, Minor 3).

## How

Gate the scan on `!cursor` in `storefront-detail.ts` — ship `[]` for `classOfferings` on cursor pages. The response contract keeps the field (`StorefrontDetailData.classOfferings` stays required), and the web client schema already defaults a missing/empty one to `[]` (`storefrontDetailResultSchema`, independent web/api deploys).

**Safe by construction:** the web issues no cursor request to this endpoint today — there is no load-more UI (`grep` for `fetchNextPage`/`useInfinite`/`loadMore` → zero hits), and both `classOfferings` consumers (`StorefrontDetailView`, `bookings/new`) read the first-page (cursorless) fetch. The two route loaders never pass a cursor.

## Testing

- New service test (`storefront-detail.test.ts`): spies on `ClassOfferingService.findOfferings` and asserts it runs **once** across a first page + a cursor page (not twice), and that the cursor page ships `classOfferings: []` while vehicles still paginate correctly. Mutation-resistant — pins the perf win, not just the shape.
- storefront-detail service suite 33/33, storefronts route suite 13/13, api `tsc` clean, biome, `lint:boundaries` OK.
- No API contract change (field still present), no schema/migration, web untouched.

Closes #1422