### PR TITLE
refactor(#1246): extract booking-dialog hooks from the /manage/bookings route

### DIFF
--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -22,7 +22,6 @@ import {
   operatorCalendarVehiclesQueryOptions,
 } from '@/vite/operator-bookings/api'
 import {
-  type BlockCalendarEvent,
   type CalendarItem,
   blocksToCalendarEvents,
   fleetToResources,
@@ -37,13 +36,15 @@ import {
   parseCalendarView,
 } from '@/vite/operator-bookings/calendar-view'
 import { markBookingsSeen } from '@/vite/operator-bookings/new-bookings'
+import { useBlockDialogs } from '@/vite/operator-bookings/useBlockDialogs'
 import { useCalendarFilters } from '@/vite/operator-bookings/useCalendarFilters'
+import { useManualBookingDialog } from '@/vite/operator-bookings/useManualBookingDialog'
 import { useOperatorContext } from '@/vite/operator-context'
 import { operatorLocationsQueryOptions } from '@/vite/operator-locations/api'
 import { useSession } from '@/vite/session'
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute, useRouter } from '@tanstack/react-router'
-import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo } from 'react'
 import { useTranslations } from 'use-intl'
 
 // Code-split the fleet planning board: react-calendar-timeline + interactjs + their
@@ -123,10 +124,7 @@ export function OperatorBookingsRoute() {
   // the same pick into the write gates below (canWriteAsOperator), so a picked admin can
   // write as that operator while an unpicked admin stays read-only.
   const { pickedOperatorId } = useOperatorContext()
-  const [bookingDialogOpen, setBookingDialogOpen] = useState(false)
-  // The clicked slot's range (null when opened from the header button), threaded to
-  // the dialog so a slot-click prefills its pickup/return times.
-  const [slotRange, setSlotRange] = useState<{ start: Date; end: Date } | null>(null)
+  const manualBooking = useManualBookingDialog()
 
   // Operator-only write affordance: a manual booking needs a single target tenant,
   // which only a tenant-scoped operator session supplies (bypass roles read
@@ -151,13 +149,9 @@ export function OperatorBookingsRoute() {
   // to the rbc event-click (handleSelectEvent) — the pre-#1282 baseline.
   const quickViewEnabled = isCalendarQuickViewEnabled()
 
-  // Block dialogs: a schedule (create) form and a click-to-view detail. The schedule
-  // slot prefill carries the clicked vehicle + range; the detail dialog is keyed on
-  // the selected block.
-  const [scheduleBlockOpen, setScheduleBlockOpen] = useState(false)
-  const [blockSlotRange, setBlockSlotRange] = useState<{ start: Date; end: Date } | null>(null)
-  const [blockSlotVehicleId, setBlockSlotVehicleId] = useState<string | undefined>(undefined)
-  const [selectedBlock, setSelectedBlock] = useState<BlockCalendarEvent | null>(null)
+  // Block dialogs (#1101): a schedule (create) form with an optional slot prefill,
+  // and a click-to-view detail keyed on the selected block.
+  const blockDialogs = useBlockDialogs()
 
   // The dialog's pickup/return store list — fetched for operators (the only role
   // that can manual-book), so it's ready the moment they open the dialog and a
@@ -277,7 +271,7 @@ export function OperatorBookingsRoute() {
       // #1101: dispatch by the discriminant. A block opens its detail dialog (view +
       // delete).
       if (item.type === 'block') {
-        setSelectedBlock(item)
+        blockDialogs.selectBlock(item)
         return
       }
       // Booking: with the quick-view chip ON (#1282), its inner <Link> owns
@@ -286,23 +280,8 @@ export function OperatorBookingsRoute() {
       // the pre-#1282 baseline — the click navigates to the booking detail.
       if (!quickViewEnabled) navigateToBooking(item.id)
     },
-    [quickViewEnabled, navigateToBooking],
+    [quickViewEnabled, navigateToBooking, blockDialogs.selectBlock],
   )
-
-  // Both the header button and a calendar slot-click open the dialog; a slot also
-  // prefills the pickup/return range (the button opens an empty range).
-  const handleOpenManualBooking = useCallback((range?: { start: Date; end: Date }) => {
-    setSlotRange(range ?? null)
-    setBookingDialogOpen(true)
-  }, [])
-
-  // The header button opens the schedule dialog with no prefill (vehicle defaults to
-  // the first car, empty range).
-  const handleOpenScheduleBlock = useCallback(() => {
-    setBlockSlotRange(null)
-    setBlockSlotVehicleId(undefined)
-    setScheduleBlockOpen(true)
-  }, [])
 
   // Slot-select precedence (one gesture, two possible dialogs): manual-booking keeps
   // the empty-slot drag when enabled (zero regression); otherwise a block-manager's
@@ -311,14 +290,12 @@ export function OperatorBookingsRoute() {
   const handleSelectSlot = useCallback(
     (range: { start: Date; end: Date; resourceId?: string }) => {
       if (canManualBook) {
-        handleOpenManualBooking({ start: range.start, end: range.end })
+        manualBooking.openDialog({ start: range.start, end: range.end })
       } else if (canManageBlocks) {
-        setBlockSlotRange({ start: range.start, end: range.end })
-        setBlockSlotVehicleId(range.resourceId)
-        setScheduleBlockOpen(true)
+        blockDialogs.openScheduleForSlot({ start: range.start, end: range.end }, range.resourceId)
       }
     },
-    [canManualBook, canManageBlocks, handleOpenManualBooking],
+    [canManualBook, canManageBlocks, manualBooking.openDialog, blockDialogs.openScheduleForSlot],
   )
 
   return (
@@ -331,12 +308,12 @@ export function OperatorBookingsRoute() {
           </div>
           <div className="flex gap-2">
             {canScheduleBlock && (
-              <Button type="button" variant="outline" onClick={handleOpenScheduleBlock}>
+              <Button type="button" variant="outline" onClick={blockDialogs.openSchedule}>
                 {t('blocks.scheduleAction')}
               </Button>
             )}
             {canManualBook && (
-              <Button type="button" onClick={() => handleOpenManualBooking()}>
+              <Button type="button" onClick={() => manualBooking.openDialog()}>
                 {t('newBooking.action')}
               </Button>
             )}
@@ -367,7 +344,7 @@ export function OperatorBookingsRoute() {
                   onViewChange={handleViewChange}
                   onDateChange={handleDateChange}
                   onSelectEvent={navigateToBooking}
-                  onSelectBlock={setSelectedBlock}
+                  onSelectBlock={blockDialogs.selectBlock}
                 />
               </Suspense>
             ) : (
@@ -388,33 +365,35 @@ export function OperatorBookingsRoute() {
       </div>
       {canManualBook && (
         <ManualBookingDialog
-          open={bookingDialogOpen}
-          onOpenChange={setBookingDialogOpen}
+          open={manualBooking.open}
+          onOpenChange={manualBooking.setOpen}
           vehicles={vehicles}
           locations={manualBookingLocations}
           csrfToken={session?.csrfToken ?? ''}
-          initialRange={slotRange ?? undefined}
+          initialRange={manualBooking.slotRange ?? undefined}
           pickedOperatorId={pickedOperatorId}
         />
       )}
       {canManageBlocks && (
         <ScheduleBlockDialog
-          open={scheduleBlockOpen}
-          onOpenChange={setScheduleBlockOpen}
+          open={blockDialogs.scheduleOpen}
+          onOpenChange={blockDialogs.setScheduleOpen}
           vehicles={vehicles}
           csrfToken={session?.csrfToken ?? ''}
-          initialVehicleId={blockSlotVehicleId}
-          initialRange={blockSlotRange ?? undefined}
+          initialVehicleId={blockDialogs.slotVehicleId}
+          initialRange={blockDialogs.slotRange ?? undefined}
           pickedOperatorId={pickedOperatorId}
         />
       )}
       {canViewBlocks && (
         <BlockDetailDialog
-          key={selectedBlock?.id ?? 'closed'}
-          block={selectedBlock}
-          onClose={() => setSelectedBlock(null)}
+          key={blockDialogs.selectedBlock?.id ?? 'closed'}
+          block={blockDialogs.selectedBlock}
+          onClose={blockDialogs.closeDetail}
           vehicleName={
-            selectedBlock ? (vehicleNamesById.get(selectedBlock.resourceId) ?? null) : null
+            blockDialogs.selectedBlock
+              ? (vehicleNamesById.get(blockDialogs.selectedBlock.resourceId) ?? null)
+              : null
           }
           canManage={canManageBlocks}
           csrfToken={session?.csrfToken ?? ''}

--- a/packages/web/src/vite/operator-bookings/useBlockDialogs.ts
+++ b/packages/web/src/vite/operator-bookings/useBlockDialogs.ts
@@ -1,0 +1,68 @@
+import type { BlockCalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { useCallback, useMemo, useState } from 'react'
+
+// #1246: scheduled-block dialog state (#1101), extracted from the /manage/bookings
+// route. Owns two independent dialogs: a schedule (create) form — with an optional
+// slot prefill (clicked vehicle + range) — and a click-to-view detail keyed on the
+// selected block.
+export interface BlockDialogsApi {
+  scheduleOpen: boolean
+  setScheduleOpen: (open: boolean) => void
+  slotRange: { start: Date; end: Date } | null
+  slotVehicleId: string | undefined
+  openSchedule: () => void
+  openScheduleForSlot: (range: { start: Date; end: Date }, vehicleId?: string) => void
+  selectedBlock: BlockCalendarEvent | null
+  selectBlock: (block: BlockCalendarEvent) => void
+  closeDetail: () => void
+}
+
+export function useBlockDialogs(): BlockDialogsApi {
+  const [scheduleOpen, setScheduleOpen] = useState(false)
+  const [slotRange, setSlotRange] = useState<{ start: Date; end: Date } | null>(null)
+  const [slotVehicleId, setSlotVehicleId] = useState<string | undefined>(undefined)
+  const [selectedBlock, setSelectedBlock] = useState<BlockCalendarEvent | null>(null)
+
+  // The header button opens the schedule dialog with no prefill (vehicle defaults to
+  // the first car, empty range).
+  const openSchedule = useCallback(() => {
+    setSlotRange(null)
+    setSlotVehicleId(undefined)
+    setScheduleOpen(true)
+  }, [])
+
+  // A calendar slot-select prefills the schedule dialog with the clicked vehicle + range.
+  const openScheduleForSlot = useCallback(
+    (range: { start: Date; end: Date }, vehicleId?: string) => {
+      setSlotRange(range)
+      setSlotVehicleId(vehicleId)
+      setScheduleOpen(true)
+    },
+    [],
+  )
+
+  const closeDetail = useCallback(() => setSelectedBlock(null), [])
+
+  return useMemo<BlockDialogsApi>(
+    () => ({
+      scheduleOpen,
+      setScheduleOpen,
+      slotRange,
+      slotVehicleId,
+      openSchedule,
+      openScheduleForSlot,
+      selectedBlock,
+      selectBlock: setSelectedBlock,
+      closeDetail,
+    }),
+    [
+      scheduleOpen,
+      slotRange,
+      slotVehicleId,
+      openSchedule,
+      openScheduleForSlot,
+      selectedBlock,
+      closeDetail,
+    ],
+  )
+}

--- a/packages/web/src/vite/operator-bookings/useManualBookingDialog.ts
+++ b/packages/web/src/vite/operator-bookings/useManualBookingDialog.ts
@@ -1,0 +1,30 @@
+import { useCallback, useMemo, useState } from 'react'
+
+// #1246: manual (walk-in) booking dialog state, extracted from the /manage/bookings
+// route (#1101 review). Owns the dialog's open flag and the optional slot prefill —
+// a header-button open carries no range; a calendar slot-click prefills pickup/return.
+export interface ManualBookingDialogApi {
+  open: boolean
+  setOpen: (open: boolean) => void
+  slotRange: { start: Date; end: Date } | null
+  openDialog: (range?: { start: Date; end: Date }) => void
+}
+
+export function useManualBookingDialog(): ManualBookingDialogApi {
+  const [open, setOpen] = useState(false)
+  // The clicked slot's range (null when opened from the header button), threaded to
+  // the dialog so a slot-click prefills its pickup/return times.
+  const [slotRange, setSlotRange] = useState<{ start: Date; end: Date } | null>(null)
+
+  // Both the header button and a calendar slot-click open the dialog; a slot also
+  // prefills the range (the button opens an empty range).
+  const openDialog = useCallback((range?: { start: Date; end: Date }) => {
+    setSlotRange(range ?? null)
+    setOpen(true)
+  }, [])
+
+  return useMemo<ManualBookingDialogApi>(
+    () => ({ open, setOpen, slotRange, openDialog }),
+    [open, slotRange, openDialog],
+  )
+}

--- a/packages/web/tests/vite/operator-bookings/useBlockDialogs.test.ts
+++ b/packages/web/tests/vite/operator-bookings/useBlockDialogs.test.ts
@@ -1,0 +1,83 @@
+import type { BlockCalendarEvent } from '@/vite/operator-bookings/calendar-events'
+import { useBlockDialogs } from '@/vite/operator-bookings/useBlockDialogs'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const RANGE = { start: new Date('2026-08-01T09:00:00Z'), end: new Date('2026-08-01T17:00:00Z') }
+const BLOCK: BlockCalendarEvent = {
+  type: 'block',
+  id: 'blk-1',
+  title: 'Oil change',
+  start: new Date('2026-07-01T00:00:00.000Z'),
+  end: new Date('2026-07-02T00:00:00.000Z'),
+  resourceId: 'veh-2',
+  kind: 'MAINTENANCE',
+  reason: 'Oil change',
+  notes: null,
+}
+
+describe('useBlockDialogs', () => {
+  it('defaults to both dialogs closed with no prefill', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    expect(result.current.scheduleOpen).toBe(false)
+    expect(result.current.slotRange).toBeNull()
+    expect(result.current.slotVehicleId).toBeUndefined()
+    expect(result.current.selectedBlock).toBeNull()
+  })
+
+  it('openSchedule() opens the schedule dialog with no prefill (header button)', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openSchedule())
+    expect(result.current.scheduleOpen).toBe(true)
+    expect(result.current.slotRange).toBeNull()
+    expect(result.current.slotVehicleId).toBeUndefined()
+  })
+
+  it('openScheduleForSlot(range, vehicleId) opens with the clicked range + vehicle', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openScheduleForSlot(RANGE, 'veh-9'))
+    expect(result.current.scheduleOpen).toBe(true)
+    expect(result.current.slotRange).toEqual(RANGE)
+    expect(result.current.slotVehicleId).toBe('veh-9')
+  })
+
+  it('openScheduleForSlot(range) with no vehicle leaves the vehicle unset', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openScheduleForSlot(RANGE))
+    expect(result.current.scheduleOpen).toBe(true)
+    expect(result.current.slotRange).toEqual(RANGE)
+    expect(result.current.slotVehicleId).toBeUndefined()
+  })
+
+  it('openSchedule() after a slot prefill resets the range + vehicle', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openScheduleForSlot(RANGE, 'veh-9'))
+    act(() => result.current.openSchedule())
+    expect(result.current.slotRange).toBeNull()
+    expect(result.current.slotVehicleId).toBeUndefined()
+  })
+
+  it('setScheduleOpen(false) closes the schedule dialog', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openSchedule())
+    act(() => result.current.setScheduleOpen(false))
+    expect(result.current.scheduleOpen).toBe(false)
+  })
+
+  it('selectBlock() sets the detail target; closeDetail() clears it', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.selectBlock(BLOCK))
+    expect(result.current.selectedBlock).toEqual(BLOCK)
+    act(() => result.current.closeDetail())
+    expect(result.current.selectedBlock).toBeNull()
+  })
+
+  it('the detail dialog is independent of the schedule dialog', () => {
+    const { result } = renderHook(() => useBlockDialogs())
+    act(() => result.current.openScheduleForSlot(RANGE, 'veh-9'))
+    act(() => result.current.selectBlock(BLOCK))
+    expect(result.current.selectedBlock).toEqual(BLOCK)
+    expect(result.current.scheduleOpen).toBe(true)
+    expect(result.current.slotVehicleId).toBe('veh-9')
+  })
+})

--- a/packages/web/tests/vite/operator-bookings/useManualBookingDialog.test.ts
+++ b/packages/web/tests/vite/operator-bookings/useManualBookingDialog.test.ts
@@ -1,0 +1,42 @@
+import { useManualBookingDialog } from '@/vite/operator-bookings/useManualBookingDialog'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const RANGE = { start: new Date('2026-08-01T09:00:00Z'), end: new Date('2026-08-01T17:00:00Z') }
+
+describe('useManualBookingDialog', () => {
+  it('defaults to closed with no prefilled slot range', () => {
+    const { result } = renderHook(() => useManualBookingDialog())
+    expect(result.current.open).toBe(false)
+    expect(result.current.slotRange).toBeNull()
+  })
+
+  it('openDialog() with no arg opens the dialog with an empty range (header button)', () => {
+    const { result } = renderHook(() => useManualBookingDialog())
+    act(() => result.current.openDialog())
+    expect(result.current.open).toBe(true)
+    expect(result.current.slotRange).toBeNull()
+  })
+
+  it('openDialog(range) opens the dialog and prefills that slot range (calendar slot-click)', () => {
+    const { result } = renderHook(() => useManualBookingDialog())
+    act(() => result.current.openDialog(RANGE))
+    expect(result.current.open).toBe(true)
+    expect(result.current.slotRange).toEqual(RANGE)
+  })
+
+  it('a later openDialog() clears a previously prefilled range back to null', () => {
+    const { result } = renderHook(() => useManualBookingDialog())
+    act(() => result.current.openDialog(RANGE))
+    act(() => result.current.openDialog())
+    expect(result.current.open).toBe(true)
+    expect(result.current.slotRange).toBeNull()
+  })
+
+  it('setOpen(false) closes the dialog (onOpenChange path)', () => {
+    const { result } = renderHook(() => useManualBookingDialog())
+    act(() => result.current.openDialog(RANGE))
+    act(() => result.current.setOpen(false))
+    expect(result.current.open).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Behaviour-preserving, web-only extraction of the `/manage/bookings` route's inline dialog state into two co-located hooks (mirroring the existing `useCalendarFilters.ts` pattern):

- `src/vite/operator-bookings/useManualBookingDialog.ts` — `{ open, setOpen, slotRange, openDialog }`.
- `src/vite/operator-bookings/useBlockDialogs.ts` — schedule dialog (`scheduleOpen`, `slotRange`, `slotVehicleId`, `openSchedule`, `openScheduleForSlot`) + block detail (`selectedBlock`, `selectBlock`, `closeDetail`).

The route `index.tsx` is rewired to consume the hooks; `handleSelectSlot` / `handleSelectEvent` now delegate to hook methods. Removes 6 `useState` + 2 open-handlers from the route (447 → 426 lines). No behaviour change.

Under epic #1099/#1101, sibling to the #1245 calendar split.

## Test Plan

- [x] `tsc` (web) clean
- [x] Full web suite: 2050/2050 pass (13 new hook tests across `useBlockDialogs.test.ts` + `useManualBookingDialog.test.ts`)
- [x] biome clean on touched files
- [x] `lint:size` / `lint:modules` exit 0 (pre-existing baseline warnings only)

Closes #1246