### PR TITLE
docs(#1440): record the no-oracle cross-tenant convention in booking-authz

### DIFF
--- a/docs/architecture/booking-authz.md
+++ b/docs/architecture/booking-authz.md
@@ -28,14 +28,14 @@ Defined in `packages/api/src/middleware/auth.ts`:
 
 | Route | Enforced at | Gate | Rationale |
 |-------|-------------|------|-----------|
-| `POST /bookings` | route | any authed user (books for self) | Instant-book. Only `STAFF_ROLES` may set `renterId` / `source=MANUAL` (on-behalf). Operators are excluded from on-behalf: `UserRepository` is not tenant-scoped, so letting an operator resolve an arbitrary `renterId` reopens the #396 cross-tenant user-enumeration vector. A `RENTER` must accept the liability disclaimer (#613). |
+| `POST /bookings` | route + service | any authed user (books for self) | Instant-book. Only `STAFF_ROLES` may set `renterId` / `source=MANUAL` (on-behalf); every non-manual caller is forced to `renterId = self` + `source=DIRECT` by `resolveBookingActor`, so it cannot impersonate another renter nor skip advance-booking-hours via `MANUAL`. Operators are excluded from on-behalf: `UserRepository` is not tenant-scoped, so letting an operator resolve an arbitrary `renterId` reopens the #396 cross-tenant user-enumeration vector. A `RENTER` must accept the liability disclaimer (#613). #1417/#1439: the vehicle/pickup anchor is read with the caller's own `ctx`, so a tenant operator can only reference its OWN fleet (a foreign row returns the same not-found as an unknown id — see the no-oracle principle); non-operators read the cross-operator marketplace unchanged. |
 | `PATCH /:id/status` | route + service | `MANAGEMENT_READ_ROLES`, then operator-bound | Lifecycle advance (`CONFIRMED → ACTIVE → COMPLETED`) is a physical pickup/return event — operational, so platform support is admitted alongside operators. Row-scoping alone would let a renter self-advance via the raw API and skew dashboards / settlement (#643). #1260: a bypass admin (`bookingReadScope = all`) reads every tenant's bookings, so the service binds the write to the operator it picked via `?operatorId=` — unbound → 422 `OPERATOR_REQUIRED`, non-owning → 404 (no oracle). Tenant operators are clamped by read scope and ignore it. |
 | `POST /:id/cancel` | route (PARTNER 403) + service | renter (own) + operator + bypass-admin operator-bound; PARTNER excluded | Tiered cancellation (72h / 48h / 24h / same-day) is a renter-facing feature, so there is **no management route gate**; the service authorizes renter-own and operator-tenant. #1260: because there is no management gate, a bypass admin could otherwise cancel ANY tenant's booking by raw id (a refund-moving cross-tenant write), so it must bind to the operator it picked via `?operatorId=` — same 422/404 contract as `/status`. Renters (renter scope) and operators (tenant scope) are already clamped by `findById`, so they need no `operatorId`. #1367: a PARTNER's `partner` read scope resolves any `source=TRIP_COM` booking across operators, which the operator-binding guard cannot clamp (a channel is not one operator), so the PARTNER is rejected 403 at the route — cancelling is *managing the order*, which a channel does not do (see PARTNER section). |
 | `POST /:id/substitute` | route | `isOperatorRole` | Choosing which car serves a booking is a **fleet-ownership** decision, named to the operator in the marketplace proposal (§321 / §345). There is no admin substitute UI and the audit `actorId` assumes an operator, so platform staff are deliberately excluded. |
 | `GET /:id/substitution-candidates` | route | `isOperatorRole` | Feeds the substitute write only — inherits its gate (see below). |
 | `GET /:id/events` | route | `MANAGEMENT_READ_ROLES` | The lifecycle log exposes `actorId`, internal vehicle ids and substitution reasons. No renter UI consumes a timeline, so renters are rejected (403) rather than served a sanitized projection (§549). |
 
-## Two principles
+## Principles
 
 **A feeder-read inherits its write's gate.** `GET /:id/substitution-candidates`
 exists solely to populate the operator's substitute dialog. It is gated
@@ -52,6 +52,28 @@ that owns the car decides, so platform staff are out). Operators are in both
 sets — the only difference is whether platform staff are admitted, and that
 tracks operational-support vs. ownership, not "how destructive." Do not collapse
 the two onto one set.
+
+**A cross-tenant reference returns the caller's own not-found, never a distinct
+403.** When a caller names inventory or a booking outside its tenant, the response
+is the same not-found it would get for an unknown id — never a `403 Forbidden` that
+confirms the target exists. A distinct 403 is an *existence oracle*: it lets one
+operator probe which vehicle ids, statuses, or bookings belong to a competitor.
+This shows up in three places, and they must stay consistent:
+
+- **Create** (#1417/#1439): `POST /bookings` reads its anchor (SPECIFIC vehicle /
+  CLASS_COMBO pickup) with the caller's own `ctx`, so `operatorReadScope` clamps a
+  tenant operator to its own fleet — a foreign row returns `undefined` and yields
+  the plain `Vehicle not found` / `Pickup location is not available` 400, identical
+  to an unknown id. The read is scoped so the foreign row is *unreachable*, rather
+  than fetched-then-denied.
+- **Lifecycle** (`/status`, `/cancel`, #1260): a bypass admin acting as a
+  non-owning operator gets 404 with the caller's own not-found message, not a 403.
+- **Substitute / assign**: a foreign vehicle returns the same 404 as an unknown
+  vehicle.
+
+Do not "improve" any of these into a 403 — the ambiguity *is* the security
+property. Prefer scoping the read (so the foreign row is never returned) over
+reading unscoped and bolting on a role-keyed denial.
 
 ## PARTNER (Trip.com)
 


### PR DESCRIPTION
Part of #1440. Docs-only — records the no-oracle cross-tenant convention that #1417 / #1439 enforced, so a future author doesn't reintroduce an existence oracle.

## Why
#1439 made booking-create return the *same not-found* for a foreign-operator vehicle/pickup as for an unknown id (no distinct 403). That rule was only encoded in code + commit messages. A `403 Forbidden` on a cross-tenant reference is an **existence oracle** — it confirms the target exists and lets one operator probe a competitor's vehicle ids / statuses. This writes the rule into the canonical `docs/architecture/booking-authz.md` so it isn't "improved" back into a 403.

## What
- New **"a cross-tenant reference returns the caller's own not-found, never a distinct 403"** principle, listing the three places it must stay consistent: create anchor read (#1417/#1439), lifecycle operator-bind (`/status`, `/cancel`, #1260), and substitute/assign. Prefer *scoping the read* (foreign row unreachable) over fetch-then-deny.
- Updated the `POST /bookings` row to record the ctx-scoped anchor read and the `resolveBookingActor` actor-forcing (non-manual callers forced to `renterId = self` + `source = DIRECT`).

## Test plan
- [x] Docs-only, no runtime change.
- [x] Pre-commit hooks pass (biome/file-size/module-boundaries/tsc — no code files touched).

Closes the "403/404 convention doc" item on #1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
