### PR TITLE
test(#1423): e2e class-deal search card -> store page on a map-enabled lane

### DIFF
--- a/e2e/real-db/renter-combo-search.map.spec.ts
+++ b/e2e/real-db/renter-combo-search.map.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test'
+import { RENTER_STORAGE_STATE } from './constants'
+
+// #1423 (#464 follow-up). Covers acceptance #1's first clause — "a class deal *in
+// search* links to the store page" — which the sibling renter-combo-booking spec
+// cannot reach: that spec runs on the store-grid search view (VITE_SEARCH_MAP_ENABLED
+// OFF) and enters the combo through the store's "Class deals" section instead.
+//
+// This spec runs on the map-enabled twin server (playwright.real-db.config.ts, the
+// `authenticated-real-db-map` project / MAP_BASE_URL), where /search renders the
+// map+list view and its CLASS_COMBO `ComboRow` card. It proves ONLY the discovery
+// hop: search -> the Kei-class ComboRow -> its "View cars" CTA lands on the pickup
+// store page. The booking journey past that point is already covered by the sibling,
+// so this stays a focused, write-free navigation test (no bookings, no cleanup).
+//
+// Seed + selectors mirror the sibling: Best Car Rental / Namba is the only seeded
+// location with ACTIVE class rate plans (seed-data/class-rate-plans.ts), so the Kei
+// combo is the one deterministic CLASS_COMBO row for this window.
+const STORE_NAME = 'Namba'
+const CLASS_LABEL = 'Kei car'
+
+// Real ids are UUIDs (db/seed-id.ts); asserting the store URL's shape also proves
+// the ComboRow CTA carried a real locationId, not a slug or an empty segment.
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+// The same far-future window as the sibling: anchored to the 15th of the month TWO
+// months out and computed RELATIVE TO TODAY, so the combo class always reads
+// AVAILABLE and a hard-coded date can't silently rot into the demo-relative seed
+// range as real time advances (#1401).
+const pad = (n: number) => String(n).padStart(2, '0')
+const isoDate = (d: Date) =>
+  `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+const NOW = new Date()
+const WINDOW_START = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 2, 15))
+const WINDOW_END = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 2, 17))
+const FROM = `${isoDate(WINDOW_START)}T10:00`
+const TO = `${isoDate(WINDOW_END)}T10:00`
+
+test.describe('renter class-combo search discovery (real DB, map view)', () => {
+  test('a class deal in search links to the pickup store page', async ({ browser, baseURL }) => {
+    test.setTimeout(120_000) // Vite builds each route on first hit; real-DB round-trips
+
+    const context = await browser.newContext({ storageState: RENTER_STORAGE_STATE, baseURL })
+    const page = await context.newPage()
+
+    await test.step('1. search renders the map+list view with the Kei-class ComboRow', async () => {
+      await page.goto(`/en/search?from=${FROM}&to=${TO}`)
+      await expect(page).toHaveURL(/\/search\?from=.+&to=.+/)
+
+      // The map-enabled results view lists rows in <ul aria-label="Available cars">.
+      // Scope every assertion to it: the map popup carousel renders the SAME ComboRow
+      // on pin hover/select, so an unscoped locator would be strict-mode ambiguous.
+      const list = page.getByRole('list', { name: 'Available cars' })
+      await expect(list).toBeVisible({ timeout: 20_000 })
+
+      // A CLASS_COMBO row titles its class in an <h3> (a SPECIFIC row puts the class
+      // in a badge span and the car NAME in the <h3>), so the level-3 "Kei car"
+      // heading uniquely targets the combo card. Exactly one such row exists — the
+      // Namba Kei combo — so a count of 1 fails if the map view or the flat-search
+      // combo read-side ever stops surfacing it.
+      const comboCard = list
+        .locator('article')
+        .filter({ has: page.getByRole('heading', { name: CLASS_LABEL, level: 3 }) })
+      await expect(comboCard).toHaveCount(1)
+      await expect(comboCard.getByText('Class deal')).toBeVisible()
+      await expect(comboCard.getByText('Exact car assigned at pickup')).toBeVisible()
+
+      // The CTA is the ComboRow's sole navigation affordance (#885 1b).
+      await comboCard.getByRole('link', { name: 'View cars' }).click()
+    })
+
+    await test.step('2. the CTA lands on the pickup store page carrying the window', async () => {
+      // The store URL keeps the search window (dates survive the drill-down, #885 1b)
+      // and a real UUID locationId — proof the search card linked to a concrete store.
+      await expect(page).toHaveURL(new RegExp(`/storefronts/${UUID}\\?from=.+&to=.+`))
+      await expect(
+        page.getByRole('heading', { name: STORE_NAME, level: 1, exact: true }),
+      ).toBeVisible()
+      // The store the combo pointed at exposes its own "Class deals" section — proof
+      // the search card linked to the RIGHT storefront with its class context intact.
+      await expect(page.getByRole('heading', { name: 'Class deals', level: 2 })).toBeVisible()
+    })
+
+    await context.close()
+  })
+})

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -6,8 +6,16 @@ import { STORAGE_STATE } from './e2e/real-db/constants'
 // branch, with a minted Auth.js session cookie. Own ports so it never collides
 // with the mock track's servers (web 3001 / mock-api 8787).
 const WEB_PORT = 3002
+// #1423: a SECOND Vite server, identical to the one above but with
+// VITE_SEARCH_MAP_ENABLED baked ON, so /search renders the map+list view and its
+// CLASS_COMBO `ComboRow` card. It exists so the one spec that needs the in-search
+// class-deal card can run WITHOUT flipping the flag for the whole lane — which would
+// swap every other spec's store-grid view out from under it and, worse, stop testing
+// the actual default beta view (the store grid).
+const MAP_WEB_PORT = 3003
 const API_PORT = 8788
 const BASE_URL = `http://localhost:${WEB_PORT}`
+const MAP_BASE_URL = `http://localhost:${MAP_WEB_PORT}`
 const API_URL = `http://localhost:${API_PORT}`
 
 // knip (lint:deps) imports this module to resolve its entry points (webServer
@@ -23,6 +31,26 @@ if (AUTH_SECRET === undefined || DATABASE_URL === undefined) {
       'Run: AUTH_SECRET=<secret> DATABASE_URL=<neon-branch-url> bun run test:e2e:real-db',
   )
 }
+
+// These real-DB specs exercise features the beta demo gates OFF — cancellation
+// (#868), operator manual booking (#589), team (#904), settings (#903), reviews
+// (#1083-1086), the fleet timeline (#1100), multi-currency indicative display
+// (#1070), the operator Today panel (#1102) and the calendar booking quick-view
+// (#1282). Enable them here so e2e covers the FULL product; the beta Pages build
+// (deploy.yml) sets none of these, so the demo still hides them. Fail-safe-OFF
+// default lives in vite/config/features.ts. Shared by both Vite servers below.
+const VITE_FEATURE_ENV = {
+  VITE_FEATURE_CANCELLATION: 'true',
+  VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
+  VITE_FEATURE_OPERATOR_TEAM: 'true',
+  VITE_FEATURE_OPERATOR_SETTINGS: 'true',
+  VITE_FEATURE_RENTER_DOCUMENTS: 'true',
+  VITE_FEATURE_REVIEWS: 'true',
+  VITE_FEATURE_FLEET_TIMELINE: 'true',
+  VITE_FEATURE_MULTI_CURRENCY: 'true',
+  VITE_FEATURE_OPERATOR_TODAY: 'true',
+  VITE_FEATURE_CALENDAR_QUICKVIEW: 'true',
+} as const
 
 export default defineConfig({
   testDir: './e2e/real-db',
@@ -45,6 +73,17 @@ export default defineConfig({
       testMatch: /.*\.auth\.spec\.ts/,
       dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+    },
+    {
+      // #1423: the CLASS_COMBO in-search discovery spec. Runs against the map-enabled
+      // Vite server (MAP_BASE_URL) so /search renders the map+list view + ComboRow.
+      // Its own `*.map.spec.ts` suffix keeps it out of the store-grid project above
+      // (whose `/.*\.auth\.spec\.ts/` never matches it) and vice-versa, so each view
+      // is exercised only by the specs written for it.
+      name: 'authenticated-real-db-map',
+      testMatch: /.*\.map\.spec\.ts/,
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE, baseURL: MAP_BASE_URL },
     },
   ],
 
@@ -73,24 +112,23 @@ export default defineConfig({
       timeout: 120_000,
       env: {
         VITE_DEV_API_PROXY: API_URL,
-        // These real-DB specs exercise features the beta demo gates OFF —
-        // cancellation (#868), operator manual booking (#589), team (#904),
-        // settings (#903), reviews (#1083-1086), the fleet timeline (#1100),
-        // multi-currency indicative display (#1070), the operator Today panel
-        // (#1102) and the calendar booking quick-view (#1282). Enable them here so
-        // e2e covers the FULL product; the beta Pages build (deploy.yml) sets none
-        // of these, so the demo still hides them. Fail-safe-OFF default lives in
-        // vite/config/features.ts.
-        VITE_FEATURE_CANCELLATION: 'true',
-        VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
-        VITE_FEATURE_OPERATOR_TEAM: 'true',
-        VITE_FEATURE_OPERATOR_SETTINGS: 'true',
-        VITE_FEATURE_RENTER_DOCUMENTS: 'true',
-        VITE_FEATURE_REVIEWS: 'true',
-        VITE_FEATURE_FLEET_TIMELINE: 'true',
-        VITE_FEATURE_MULTI_CURRENCY: 'true',
-        VITE_FEATURE_OPERATOR_TODAY: 'true',
-        VITE_FEATURE_CALENDAR_QUICKVIEW: 'true',
+        ...VITE_FEATURE_ENV,
+      },
+    },
+    {
+      // #1423: map-enabled twin of the Vite server above. Same real API + proxy +
+      // feature flags; the ONLY delta is VITE_SEARCH_MAP_ENABLED, which flips
+      // /search to the map+list view so the CLASS_COMBO ComboRow renders for the
+      // `authenticated-real-db-map` project's `*.map.spec.ts`.
+      command: 'bunx vite --port 3003',
+      cwd: 'packages/web',
+      url: MAP_BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        VITE_DEV_API_PROXY: API_URL,
+        ...VITE_FEATURE_ENV,
+        VITE_SEARCH_MAP_ENABLED: 'true',
       },
     },
   ],


### PR DESCRIPTION
Closes #1423 (follow-up from #464 / #1421 e2e review).

## Problem
The renter class-combo journey is only e2e-covered via the store's **Class deals** section, because the in-search `ComboRow` card is gated behind the build-time `VITE_SEARCH_MAP_ENABLED` flag, which the real-DB lane leaves **OFF**. That left acceptance #1's first clause -- *"a class deal in search links to the store page"* -- unverified by a browser.

## Why not just flip the flag for the lane
`VITE_SEARCH_MAP_ENABLED` doesn't just reveal the card -- it swaps the entire `/search` view from the **store grid** to the **map+list** view. Turning it on for the whole lane would break 5 store-grid specs and, worse, stop testing the actual default beta view.

## Approach -- isolated map-enabled twin
- A **second Vite dev server** on `:3003` with `VITE_SEARCH_MAP_ENABLED=true`, sharing the same real API, DB seed and auth as the `:3002` store-grid server. The 10 shared feature flags are lifted into a `VITE_FEATURE_ENV` const spread into both servers.
- A new **`authenticated-real-db-map`** project bound to `:3003`, matching a distinct `*.map.spec.ts` suffix so it never overlaps the store-grid `*.auth.spec.ts` project (and vice-versa).
- **`renter-combo-search.map.spec.ts`**: search -> the Kei-class `ComboRow` -> its "View cars" CTA lands on the pickup store page. Write-free (no bookings/cleanup); the booking journey past that hop is already covered by the sibling `renter-combo-booking.auth.spec.ts`.

## Test plan
Verified against a disposable seeded Postgres:
- [x] New map spec passes: `[authenticated-real-db-map] renter-combo-search.map.spec.ts` (12.7s) -- ComboRow renders (count == 1), "Class deal" badge + hint, "View cars" -> `/storefronts/<uuid>?from=..&to=..` with the store's "Class deals" section.
- [x] No regression: store-grid `renter-combo-booking.auth.spec.ts` still passes on `:3002` (flag off), proving the env refactor preserved every flag and the default view is unchanged.
- [x] `--list` confirms project/spec partition (map spec claimed only by the map project).
- [x] Pre-commit gate green: biome, file-size, module-boundaries, tsc (web + api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)