### PR TITLE
feat(#1442): picker-admin fee-schedule writes + operator-binding parity on PATCH/DELETE

### DIFF
--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -108,6 +108,7 @@ export function createFeeScheduleRoutes(
         toCallerContext(user),
         idResult.id,
         stripUndefined(parsed.data),
+        c.req.query('operatorId'),
       )
       if (!result.ok) return failResult(c, result)
       return ok(c, result.feeSchedule)
@@ -119,7 +120,11 @@ export function createFeeScheduleRoutes(
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
 
-      const result = await service.archive(toCallerContext(user), idResult.id)
+      const result = await service.archive(
+        toCallerContext(user),
+        idResult.id,
+        c.req.query('operatorId'),
+      )
       if (!result.ok) return failResult(c, result)
       return ok(c, result.feeSchedule)
     })

--- a/packages/api/src/services/fee-schedule.ts
+++ b/packages/api/src/services/fee-schedule.ts
@@ -8,7 +8,12 @@ import {
 import type { CallerContext } from '../middleware/auth'
 import { FEE_SCHEDULES_CLASS_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { FeeSchedule, FeeScheduleFilters, FeeScheduleRepository } from '../repositories/types'
-import { type CrossOperatorRead, applyCrossOperatorReadScope } from '../tenancy'
+import {
+  type CrossOperatorRead,
+  applyCrossOperatorReadScope,
+  assertFleetWriteWithinOperator,
+  fleetWriteDenialResult,
+} from '../tenancy'
 
 export type FeeScheduleResult =
   | { ok: true; feeSchedule: FeeSchedule }
@@ -105,9 +110,16 @@ export class FeeScheduleService {
     ctx: CallerContext,
     id: string,
     data: FeeScheduleUpdate,
+    actingOperatorId?: string,
   ): Promise<FeeScheduleResult> {
     const existing = await this.repo.findById(ctx, id)
     if (!existing) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
+
+    // #1442: a bypass admin reads every operator's fees by raw id, so bind this
+    // write to the operator it picked — no pick -> 422, wrong pick -> 404. An
+    // operator session is already tenant-clamped, so it passes through.
+    const denial = assertFleetWriteWithinOperator(ctx, existing.operatorId, actingOperatorId)
+    if (denial) return fleetWriteDenialResult(denial, NOT_FOUND_MESSAGE)
 
     const mergedFeeType = data.feeType ?? existing.feeType
     const mergedUnit = data.unit ?? existing.unit
@@ -140,9 +152,17 @@ export class FeeScheduleService {
     }
   }
 
-  async archive(ctx: CallerContext, id: string): Promise<FeeScheduleResult> {
+  async archive(
+    ctx: CallerContext,
+    id: string,
+    actingOperatorId?: string,
+  ): Promise<FeeScheduleResult> {
     const existing = await this.repo.findById(ctx, id)
     if (!existing) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
+
+    // #1442: bind the archive to the picked operator (see update()).
+    const denial = assertFleetWriteWithinOperator(ctx, existing.operatorId, actingOperatorId)
+    if (denial) return fleetWriteDenialResult(denial, NOT_FOUND_MESSAGE)
 
     const archived = await this.repo.archive(ctx, id)
     if (!archived) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }

--- a/packages/api/tests/routes/fee-schedules.test.ts
+++ b/packages/api/tests/routes/fee-schedules.test.ts
@@ -207,6 +207,52 @@ describe('Fee-schedule routes — platform-admin scoping (bypass-precedence)', (
     expect(res.status).toBe(201)
     expect((await res.json()).data.operatorId).toBe(OP_A)
   })
+
+  // #1442: PATCH/DELETE bind to the picked operator (?operatorId=), same as create.
+  const patchAmount = (app: Hono, id: string, query = '') =>
+    app.request(`/fee-schedules/${id}${query}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amountJpy: 9000 }),
+    })
+
+  it('422 when a PLATFORM_ADMIN PATCHes a fee without ?operatorId', async () => {
+    const { repo, a } = await seedTwoOperators()
+    const res = await patchAmount(mountFor(repo, 'PLATFORM_ADMIN'), a.id)
+    expect(res.status).toBe(422)
+    expect((await res.json()).code).toBe('OPERATOR_REQUIRED')
+  })
+
+  it('404 when the PATCH ?operatorId does not own the fee', async () => {
+    const { repo, a } = await seedTwoOperators()
+    const res = await patchAmount(mountFor(repo, 'PLATFORM_ADMIN'), a.id, `?operatorId=${OP_B}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('updates when the PATCH ?operatorId owns the fee', async () => {
+    const { repo, a } = await seedTwoOperators()
+    const res = await patchAmount(mountFor(repo, 'PLATFORM_ADMIN'), a.id, `?operatorId=${OP_A}`)
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.amountJpy).toBe(9000)
+  })
+
+  it('422 when a PLATFORM_ADMIN DELETEs a fee without ?operatorId', async () => {
+    const { repo, a } = await seedTwoOperators()
+    const res = await mountFor(repo, 'PLATFORM_ADMIN').request(`/fee-schedules/${a.id}`, {
+      method: 'DELETE',
+    })
+    expect(res.status).toBe(422)
+  })
+
+  it('archives when the DELETE ?operatorId owns the fee', async () => {
+    const { repo, a } = await seedTwoOperators()
+    const res = await mountFor(repo, 'PLATFORM_ADMIN').request(
+      `/fee-schedules/${a.id}?operatorId=${OP_A}`,
+      { method: 'DELETE' },
+    )
+    expect(res.status).toBe(200)
+    expect((await res.json()).data.status).toBe('ARCHIVED')
+  })
 })
 
 describe('Fee-schedule routes — invalid vehicleClassId (composite FK -> 400)', () => {

--- a/packages/api/tests/services/fee-schedule.test.ts
+++ b/packages/api/tests/services/fee-schedule.test.ts
@@ -274,3 +274,70 @@ describe('FeeScheduleService — findAll enforces cross-operator read scope (aud
     expect(mine.map((f) => f.operatorId)).toEqual([opA])
   })
 })
+
+// #1442: PATCH/DELETE bind to the operator a picker admin acts as — parity with
+// bookings/fleet (#1260). A bypass admin reads every operator's fees by raw id, so
+// an unbound write could touch any tenant's fee; require it to name the operator it
+// picked and forbid a mismatch. An operator session is already tenant-clamped by the
+// read scope, so it passes through with no acting id.
+describe('FeeScheduleService — update/archive bind to the picked operator (#1442)', () => {
+  const adminCtx: CallerContext = { userId: 'admin', role: 'PLATFORM_ADMIN', bypassScope: true }
+  let repo: InMemoryFeeScheduleRepository
+  let service: FeeScheduleService
+
+  beforeEach(() => {
+    repo = new InMemoryFeeScheduleRepository()
+    service = new FeeScheduleService(repo)
+  })
+
+  async function seedFeeForOpA(): Promise<string> {
+    const created = await service.create(ctxFor(opA), createInput(opA))
+    if (!created.ok) throw new Error('seed failed')
+    return created.feeSchedule.id
+  }
+
+  it('rejects an admin update with no picked operator (422 OPERATOR_REQUIRED)', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.update(adminCtx, id, { amountJpy: 5000 }, undefined)
+    expect(result).toMatchObject({ ok: false, status: 422, code: 'OPERATOR_REQUIRED' })
+  })
+
+  it('404s an admin update whose picked operator does not own the fee', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.update(adminCtx, id, { amountJpy: 5000 }, opB)
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('applies an admin update bound to the fee-owning operator', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.update(adminCtx, id, { amountJpy: 5000 }, opA)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.feeSchedule.amountJpy).toBe(5000)
+  })
+
+  it('lets an operator session update its own fee with no acting id', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.update(ctxFor(opA), id, { amountJpy: 5000 })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.feeSchedule.amountJpy).toBe(5000)
+  })
+
+  it('rejects an admin archive with no picked operator (422 OPERATOR_REQUIRED)', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.archive(adminCtx, id, undefined)
+    expect(result).toMatchObject({ ok: false, status: 422, code: 'OPERATOR_REQUIRED' })
+  })
+
+  it('404s an admin archive whose picked operator does not own the fee', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.archive(adminCtx, id, opB)
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('archives a fee bound to the fee-owning operator', async () => {
+    const id = await seedFeeForOpA()
+    const result = await service.archive(adminCtx, id, opA)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.feeSchedule.status).toBe('ARCHIVED')
+  })
+})

--- a/packages/web/src/routes/$locale/_business/manage/fees.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fees.tsx
@@ -1,11 +1,9 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { RouteRetryError } from '@/vite/RouteRetryError'
-import { isOperatorSession } from '@/vite/guards'
 import { operatorClassesQueryOptions } from '@/vite/operator-classes/api'
 import { useOperatorScope } from '@/vite/operator-context'
 import { OperatorFeesView } from '@/vite/operator-fees/OperatorFeesView'
 import { feeSchedulesQueryOptions } from '@/vite/operator-fees/api'
-import { useSession } from '@/vite/session'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute } from '@tanstack/react-router'
 import { useTranslations } from 'use-intl'
@@ -36,17 +34,14 @@ export const Route = createFileRoute('/$locale/_business/manage/fees')({
 export function OperatorFeesRoute() {
   const t = useTranslations('business.fees')
   const scope = useOperatorScope()
-  const { data: session } = useSession()
   const { data: fees } = useSuspenseQuery(feeSchedulesQueryOptions(scope.pickedOperatorId))
   const { data: classes } = useSuspenseQuery(
     operatorClassesQueryOptions({}, scope.pickedOperatorId),
   )
 
-  // Picker-admins stay read-only on fees in this slice. The class lookup is now
-  // scoped for display, but the fee create body still does not stamp the picked
-  // operatorId. A real operator session writes under its own tenant as before.
-  const feesScope = { ...scope, canWrite: isOperatorSession(session ?? null) }
-
+  // #1442: writes are picker-aware now. `scope.canWrite` is `canWriteAsOperator`
+  // (a real operator, OR a picker admin who has chosen an operator), and the
+  // create/update/archive calls bind to `scope.pickedOperatorId` end-to-end.
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-4xl">
@@ -54,7 +49,7 @@ export function OperatorFeesRoute() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{t('title')}</h1>
           <p className="mt-2 text-lg text-muted-foreground">{t('subtitle')}</p>
         </header>
-        <OperatorFeesView fees={fees} classes={classes} scope={feesScope} />
+        <OperatorFeesView fees={fees} classes={classes} scope={scope} />
       </div>
     </main>
   )

--- a/packages/web/src/routes/$locale/_business/manage/fees.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/fees.tsx
@@ -29,8 +29,9 @@ export const Route = createFileRoute('/$locale/_business/manage/fees')({
   component: OperatorFeesRoute,
 })
 
-// Exported so a route-level test can pin the P1b read-only override (the
-// `feesScope` junction below); the file route mounts it as the component.
+// Exported so a route-level test can pin that the picker scope is forwarded
+// unchanged (#1442 — no read-only override); the file route mounts it as the
+// component.
 export function OperatorFeesRoute() {
   const t = useTranslations('business.fees')
   const scope = useOperatorScope()

--- a/packages/web/src/vite/operator-fees/AddFeeDialog.tsx
+++ b/packages/web/src/vite/operator-fees/AddFeeDialog.tsx
@@ -19,15 +19,22 @@ interface AddFeeDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   classes: readonly FeeClassOption[]
+  /** #1442: a picker admin stamps the chosen operatorId into the create body; an
+   *  operator session omits it (the server auto-scopes the tenant). */
+  pickedOperatorId?: string | undefined
 }
 
-export function AddFeeDialog({ open, onOpenChange, classes }: AddFeeDialogProps) {
+export function AddFeeDialog({ open, onOpenChange, classes, pickedOperatorId }: AddFeeDialogProps) {
   const t = useTranslations('business.fees')
   const queryClient = useQueryClient()
   const csrfToken = useSession().data?.csrfToken ?? ''
 
   const { mutateAsync, isPending, error, reset } = useMutation({
-    mutationFn: (data: CreateFeeScheduleInput) => createFeeSchedule(data, csrfToken),
+    mutationFn: (data: CreateFeeScheduleInput) =>
+      createFeeSchedule(
+        pickedOperatorId ? { ...data, operatorId: pickedOperatorId } : data,
+        csrfToken,
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: FEE_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-fees/ArchiveFeeDialog.tsx
+++ b/packages/web/src/vite/operator-fees/ArchiveFeeDialog.tsx
@@ -15,15 +15,18 @@ import { useTranslations } from 'use-intl'
 interface ArchiveFeeDialogProps {
   fee: FeeScheduleData | null
   onOpenChange: (open: boolean) => void
+  /** #1442: binds the DELETE to the picked operator via `?operatorId=`; omitted for
+   *  an operator session (tenant-clamped server-side). */
+  pickedOperatorId?: string | undefined
 }
 
-export function ArchiveFeeDialog({ fee, onOpenChange }: ArchiveFeeDialogProps) {
+export function ArchiveFeeDialog({ fee, onOpenChange, pickedOperatorId }: ArchiveFeeDialogProps) {
   const t = useTranslations('business.fees')
   const queryClient = useQueryClient()
   const csrfToken = useSession().data?.csrfToken ?? ''
 
   const { mutate, isPending, error } = useMutation({
-    mutationFn: (id: string) => archiveFeeSchedule(id, csrfToken),
+    mutationFn: (id: string) => archiveFeeSchedule(id, csrfToken, pickedOperatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: FEE_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-fees/EditFeeDialog.tsx
+++ b/packages/web/src/vite/operator-fees/EditFeeDialog.tsx
@@ -20,15 +20,24 @@ interface EditFeeDialogProps {
   fee: FeeScheduleData | null
   onOpenChange: (open: boolean) => void
   classes: readonly FeeClassOption[]
+  /** #1442: binds the PATCH to the picked operator via `?operatorId=`; omitted for
+   *  an operator session (tenant-clamped server-side). */
+  pickedOperatorId?: string | undefined
 }
 
-export function EditFeeDialog({ fee, onOpenChange, classes }: EditFeeDialogProps) {
+export function EditFeeDialog({
+  fee,
+  onOpenChange,
+  classes,
+  pickedOperatorId,
+}: EditFeeDialogProps) {
   const t = useTranslations('business.fees')
   const queryClient = useQueryClient()
   const csrfToken = useSession().data?.csrfToken ?? ''
 
   const { mutateAsync, isPending, error } = useMutation({
-    mutationFn: (data: CreateFeeScheduleInput) => updateFeeSchedule(fee?.id ?? '', data, csrfToken),
+    mutationFn: (data: CreateFeeScheduleInput) =>
+      updateFeeSchedule(fee?.id ?? '', data, csrfToken, pickedOperatorId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: FEE_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-fees/OperatorFeesView.tsx
+++ b/packages/web/src/vite/operator-fees/OperatorFeesView.tsx
@@ -26,11 +26,12 @@ interface OperatorFeesViewProps {
 // In all-mode (a cross-operator reader with no picked operator) the page is
 // read-only: `canWrite` is false so no write affordances render, and
 // `showOperator` turns on the per-row operator label so the mixed-tenant list is
-// legible. P1b: the fee create path is NOT threaded `pickedOperatorId` — only a
-// real operator session writes (the route forces `canWrite` to operator-only
-// until slice 3 scopes the class dropdown), and the server stamps the tenant.
+// legible. #1442: writes are picker-aware — a picker admin who has chosen an
+// operator (`canWrite` true, `pickedOperatorId` set) threads that id into the
+// create body and the update/archive `?operatorId=` so the write binds to the
+// chosen tenant; an operator session omits it and is tenant-clamped server-side.
 export function OperatorFeesView({ fees, classes, scope }: OperatorFeesViewProps) {
-  const { canWrite, showOperator, operatorNameById } = scope
+  const { pickedOperatorId, canWrite, showOperator, operatorNameById } = scope
   const t = useTranslations('business.fees')
   const [showAdd, setShowAdd] = useState(false)
   const [editing, setEditing] = useState<FeeScheduleData | null>(null)
@@ -80,9 +81,23 @@ export function OperatorFeesView({ fees, classes, scope }: OperatorFeesViewProps
 
       {canWrite ? (
         <>
-          <AddFeeDialog open={showAdd} onOpenChange={setShowAdd} classes={classes} />
-          <EditFeeDialog fee={editing} onOpenChange={() => setEditing(null)} classes={classes} />
-          <ArchiveFeeDialog fee={archiving} onOpenChange={() => setArchiving(null)} />
+          <AddFeeDialog
+            open={showAdd}
+            onOpenChange={setShowAdd}
+            classes={classes}
+            pickedOperatorId={pickedOperatorId}
+          />
+          <EditFeeDialog
+            fee={editing}
+            onOpenChange={() => setEditing(null)}
+            classes={classes}
+            pickedOperatorId={pickedOperatorId}
+          />
+          <ArchiveFeeDialog
+            fee={archiving}
+            onOpenChange={() => setArchiving(null)}
+            pickedOperatorId={pickedOperatorId}
+          />
         </>
       ) : null}
     </div>

--- a/packages/web/src/vite/operator-fees/api.ts
+++ b/packages/web/src/vite/operator-fees/api.ts
@@ -1,6 +1,6 @@
 import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
-import { buildScopeParam } from '@/vite/operator-context'
+import { type WithOperatorId, buildScopeParam } from '@/vite/operator-context'
 import { FEE_SCHEDULE_STATUSES, FEE_TYPES, FEE_UNITS } from '@kuruma/shared/enums'
 import type { FeeScheduleData } from '@kuruma/shared/types/fee-schedule'
 import type {
@@ -79,25 +79,41 @@ async function writeJson(
   return unwrap(res, feeScheduleSchema)
 }
 
+// #1442: a picker admin stamps the picked operatorId into the create BODY (the API
+// requires it for a bypass caller); an operator session omits it (server ignores it).
 export async function createFeeSchedule(
-  input: CreateFeeScheduleInput,
+  input: WithOperatorId<CreateFeeScheduleInput>,
   csrfToken: string,
 ): Promise<FeeScheduleData> {
   return writeJson('/fee-schedules', 'POST', input, csrfToken)
+}
+
+// #1442: PATCH/DELETE bind to the picked operator via `?operatorId=` (the API 422s a
+// bypass caller with no pick, 404s a wrong pick). An operator session omits it and is
+// tenant-clamped server-side. Mirrors #1361's updateBookingStatus.
+function operatorQuery(pickedOperatorId?: string): string {
+  return pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
 }
 
 export async function updateFeeSchedule(
   id: string,
   input: UpdateFeeScheduleInput,
   csrfToken: string,
+  pickedOperatorId?: string,
 ): Promise<FeeScheduleData> {
-  return writeJson(`/fee-schedules/${encodeURIComponent(id)}`, 'PATCH', input, csrfToken)
+  const path = `/fee-schedules/${encodeURIComponent(id)}${operatorQuery(pickedOperatorId)}`
+  return writeJson(path, 'PATCH', input, csrfToken)
 }
 
 // Soft-archive (DELETE flips status to ARCHIVED). The CSRF header still rides
 // along because a cookie-authed DELETE is a mutation the guard protects.
-export async function archiveFeeSchedule(id: string, csrfToken: string): Promise<FeeScheduleData> {
-  const res = await fetch(`${getApiBaseUrl()}/fee-schedules/${encodeURIComponent(id)}`, {
+export async function archiveFeeSchedule(
+  id: string,
+  csrfToken: string,
+  pickedOperatorId?: string,
+): Promise<FeeScheduleData> {
+  const path = `/fee-schedules/${encodeURIComponent(id)}${operatorQuery(pickedOperatorId)}`
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method: 'DELETE',
     credentials: 'include',
     headers: { 'X-CSRF-Token': csrfToken },

--- a/packages/web/tests/vite/operator-fees/OperatorFeesRoute.test.tsx
+++ b/packages/web/tests/vite/operator-fees/OperatorFeesRoute.test.tsx
@@ -5,14 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '../../../messages/en.json'
 
-// P1b junction under test: fees.tsx forces a picker-admin to read-only via
-// `feesScope = { ...scope, canWrite: isOperatorSession(session) }`. We drive a
-// GENERIC scope that already grants `canWrite: true` (as the picker would for a
-// chosen tenant) and prove the route's session-derived override still strips the
-// Add affordance for a PLATFORM_ADMIN, while a real operator session keeps it.
+// #1442 junction under test: fees.tsx no longer forces a picker-admin to
+// read-only. It forwards `scope.canWrite` (= `canWriteAsOperator`) straight
+// through to the view, so a picker admin who has chosen a tenant writes. We drive
+// the scope's `canWrite` directly and prove the route respects it without any
+// session-role override — reintroducing the old override would fail these.
 const useOperatorScopeMock = vi.fn<() => OperatorScope>()
 const useSessionMock = vi.fn<() => { data: Session | null }>()
 
@@ -72,29 +72,37 @@ function renderRoute() {
   return render(<OperatorFeesRoute />, { wrapper })
 }
 
-describe('OperatorFeesRoute P1b read-only override', () => {
-  beforeEach(() => {
-    useOperatorScopeMock.mockReturnValue(writableScope)
-  })
-
+describe('OperatorFeesRoute forwards the picker scope (no read-only override)', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
   })
 
-  it('hides the Add affordance for a PLATFORM_ADMIN even when the scope grants canWrite (override forces read-only)', () => {
+  it('shows the Add affordance for a PLATFORM_ADMIN when the picked-operator scope grants canWrite', () => {
+    // #1442: the route no longer strips writes from a platform admin. A picker
+    // admin who has chosen a tenant carries canWrite=true and gets the affordance.
+    useOperatorScopeMock.mockReturnValue({ ...writableScope, pickedOperatorId: 'op_9' })
     useSessionMock.mockReturnValue({ data: platformAdminSession() })
 
     renderRoute()
 
     expect(screen.getByText(en.title)).toBeInTheDocument()
-    // The generic scope said canWrite=true; the session-derived override flips it
-    // to false because a platform admin is not an operator session. If the route
-    // passed `scope` straight through, this Add button would render and fail here.
+    expect(screen.getByRole('button', { name: en.addFee })).toBeInTheDocument()
+  })
+
+  it('hides the Add affordance when the scope denies canWrite (all-mode cross-operator reader)', () => {
+    // A platform admin with NO picked operator is a read-only cross-tenant reader:
+    // canWrite=false, so the write affordances stay hidden.
+    useOperatorScopeMock.mockReturnValue({ ...writableScope, canWrite: false })
+    useSessionMock.mockReturnValue({ data: platformAdminSession() })
+
+    renderRoute()
+
     expect(screen.queryByRole('button', { name: en.addFee })).not.toBeInTheDocument()
   })
 
   it('shows the Add affordance for a real operator session (operatorId present)', () => {
+    useOperatorScopeMock.mockReturnValue(writableScope)
     useSessionMock.mockReturnValue({ data: operatorOwnerSession() })
 
     renderRoute()

--- a/packages/web/tests/vite/operator-fees/OperatorFeesView.test.tsx
+++ b/packages/web/tests/vite/operator-fees/OperatorFeesView.test.tsx
@@ -1,7 +1,7 @@
 import type { OperatorScope } from '@/vite/operator-context'
 import { OperatorFeesView } from '@/vite/operator-fees/OperatorFeesView'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, within } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -166,5 +166,86 @@ describe('OperatorFeesView', () => {
     )
     expect(screen.getByRole('button', { name: 'editFee' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'archiveAction' })).toBeInTheDocument()
+  })
+})
+
+// #1442 seam guard: the view threads `scope.pickedOperatorId` into all three write
+// dialogs so a picker admin's create/update/archive binds to the chosen tenant.
+// Drop the prop on any of view -> dialog -> api and the corresponding call loses
+// its operator binding (a silent 422 / wrong-tenant write in prod) -- these drive
+// the real fetch to catch that, mirroring AddAddOnDialog's stub-fetch pattern.
+describe('OperatorFeesView picker threading (#1442)', () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  afterEach(() => fetchSpy.mockReset())
+
+  function stubWrite() {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: operatorWideFee }), { status: 200 }),
+    )
+  }
+
+  function writeCall(method: string) {
+    return fetchSpy.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === method,
+    )
+  }
+
+  const pickedScope = scope({ canWrite: true, pickedOperatorId: 'op_9' })
+
+  it('stamps the picked operatorId into the create POST body', async () => {
+    stubWrite()
+    const user = userEvent.setup()
+    render(<OperatorFeesView fees={[]} classes={classes} scope={pickedScope} />, { wrapper })
+
+    await user.click(screen.getByRole('button', { name: 'addFee' }))
+    await user.click(await screen.findByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(writeCall('POST')).toBeDefined())
+    const body = JSON.parse(String((writeCall('POST')?.[1] as RequestInit).body))
+    expect(body).toMatchObject({ operatorId: 'op_9' })
+  })
+
+  it('binds the edit PATCH to the picked operator via ?operatorId=', async () => {
+    stubWrite()
+    const user = userEvent.setup()
+    render(<OperatorFeesView fees={[operatorWideFee]} classes={classes} scope={pickedScope} />, {
+      wrapper,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'editFee' }))
+    await user.click(await screen.findByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(writeCall('PATCH')).toBeDefined())
+    expect(String(writeCall('PATCH')?.[0])).toContain('operatorId=op_9')
+  })
+
+  it('binds the archive DELETE to the picked operator via ?operatorId=', async () => {
+    stubWrite()
+    const user = userEvent.setup()
+    render(<OperatorFeesView fees={[operatorWideFee]} classes={classes} scope={pickedScope} />, {
+      wrapper,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'archiveAction' }))
+    await user.click(await screen.findByRole('button', { name: 'archiveConfirm' }))
+
+    await waitFor(() => expect(writeCall('DELETE')).toBeDefined())
+    expect(String(writeCall('DELETE')?.[0])).toContain('operatorId=op_9')
+  })
+
+  it('omits operatorId entirely when no operator is picked (operator session auto-scopes)', async () => {
+    stubWrite()
+    const user = userEvent.setup()
+    render(<OperatorFeesView fees={[]} classes={classes} scope={scope({ canWrite: true })} />, {
+      wrapper,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'addFee' }))
+    await user.click(await screen.findByRole('button', { name: 'form.save' }))
+
+    await waitFor(() => expect(writeCall('POST')).toBeDefined())
+    const body = JSON.parse(String((writeCall('POST')?.[1] as RequestInit).body))
+    expect(body).not.toHaveProperty('operatorId')
+    expect(String(writeCall('POST')?.[0])).not.toContain('operatorId')
   })
 })

--- a/packages/web/tests/vite/operator-fees/api.test.ts
+++ b/packages/web/tests/vite/operator-fees/api.test.ts
@@ -99,6 +99,24 @@ describe('createFeeSchedule', () => {
     expect(JSON.parse(init.body as string)).toEqual(input)
   })
 
+  it('stamps the picked operatorId into the body when a picker admin supplies it (#1442)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: fee }, 201))
+
+    await createFeeSchedule(
+      {
+        feeType: 'CLEANING_FLAT',
+        unit: 'FLAT',
+        amountJpy: 3000,
+        vehicleClassId: null,
+        operatorId: 'op_9',
+      },
+      'csrf',
+    )
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toMatchObject({ operatorId: 'op_9' })
+  })
+
   it('surfaces the INVALID_VEHICLE_CLASS failure (foreign class) as an ApiError', async () => {
     fetchMock.mockResolvedValue(
       jsonResponse(
@@ -128,6 +146,15 @@ describe('updateFeeSchedule', () => {
     expect(init.headers).toEqual({ 'Content-Type': 'application/json', 'X-CSRF-Token': 'csrf-8' })
     expect(JSON.parse(init.body as string)).toEqual({ amountJpy: 4000 })
   })
+
+  it('binds the PATCH to the picked operator via ?operatorId= when supplied (#1442)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: fee }))
+
+    await updateFeeSchedule('fee_1', { amountJpy: 4000 }, 'csrf', 'op_9')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/fee-schedules/fee_1?operatorId=op_9')
+  })
 })
 
 describe('archiveFeeSchedule', () => {
@@ -144,6 +171,17 @@ describe('archiveFeeSchedule', () => {
     expect(init.method).toBe('DELETE')
     expect(init.headers).toEqual({ 'X-CSRF-Token': 'csrf-9' })
     expect(init.body).toBeUndefined()
+  })
+
+  it('binds the DELETE to the picked operator via ?operatorId= when supplied (#1442)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { ...fee, status: 'ARCHIVED' } }),
+    )
+
+    await archiveFeeSchedule('fee_1', 'csrf', 'op_9')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/fee-schedules/fee_1?operatorId=op_9')
   })
 })
 

--- a/packages/web/tests/vite/operator-fees/fees.route.test.ts
+++ b/packages/web/tests/vite/operator-fees/fees.route.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it, vi } from 'vitest'
 // resolves without a FOUC and the class dropdown is fed scoped classes. It reads
 // the operator from loaderDeps so a context switch refetches; the fee key is
 // scoped to the picked operator (or 'all'). The class dropdown uses the same
-// picked operator now that /vehicle-classes/manage accepts operatorId; fees
-// writes remain operator-session-only until create bodies stamp picked operatorId.
+// picked operator now that /vehicle-classes/manage accepts operatorId; #1442
+// threads that same picked operator into the create/update/archive writes too.
 const loaderDeps = Route.options.loaderDeps as (args: {
   search: { operator?: string | undefined }
 }) => { operator: string | undefined }


### PR DESCRIPTION
## What

Lets a **picker admin** (a `PLATFORM_ADMIN` who has chosen an operator via the `?operator=` URL param) create, edit, and archive fee schedules on `/manage/fees` — and closes a pre-existing gap by **binding fee `PATCH`/`DELETE` to the picked operator**, giving fees the same tenancy parity that bookings (#1361) and fleet (#1264) already have (#1260).

Full slice (web + API) — owner chose full parity over web-only.

## Why

Before this, `/manage/fees` forced a platform admin to read-only, and the fee update/archive endpoints ignored the picked operator. A bypass-role caller could reach any tenant's fee row by id, so the **write** path needed its own acting-operator assertion (the read clamp doesn't cover it — the #1260 operator-binding pattern).

## How

**API (`f579a44f`)**
- `services/fee-schedule.ts` `update`/`archive` take an optional `actingOperatorId`; after `findById` they bind via the shared `assertFleetWriteWithinOperator` + `fleetWriteDenialResult` (reused from tenancy.ts — fees share `operatorReadScope`, non-operator → all, like fleet).
- `routes/fee-schedules.ts` `PATCH`/`DELETE` pass `?operatorId=` through (mirrors `vehicles.ts`).
- Contract: no pick → **422 `OPERATOR_REQUIRED`**; wrong pick → **404**; correct pick → proceeds; operator session passes through and stays tenant-clamped. The binding runs **before** any coherence/uniqueness check, so a wrong-tenant caller gets a bare 404 (no existence oracle). `POST` was already picker-bound.

**Web (`cc4b52ba`, `b62be959`)**
- `api.ts`: `createFeeSchedule` stamps `operatorId` into the body; `updateFeeSchedule`/`archiveFeeSchedule` append `?operatorId=` when a tenant is picked.
- `OperatorFeesView` threads `scope.pickedOperatorId` into the Add/Edit/Archive dialogs; the route forwards `scope.canWrite` straight through (no more read-only override).

## Tests

- **API**: 26 service + 25 route tests (422 no-pick / 404 wrong-pick / passthrough / operator-clamp).
- **Web**: view-level **seam guard** drives the real `fetch` through view → dialog → api to prove all three writes bind to the picked operator (a dropped prop = silent 422 in prod), plus the negative "omits operatorId when no pick" case; api-layer pins the exact create-body / PATCH / DELETE wire shape; the stale P1b read-only route test is flipped to the new forward-the-scope junction.
- Gates: web tsc + API tsc, boundaries, full web suite (2045), API fee-schedule suite (79), biome, lint:modules/size — all green. Code review: no CRITICAL/HIGH/MEDIUM.

Closes #1442
Refs #1260, #1230