### PR TITLE
feat(#1440): gate PARTNER out of POST /bookings + document booking-authz conventions

### DIFF
--- a/docs/architecture/booking-authz.md
+++ b/docs/architecture/booking-authz.md
@@ -28,7 +28,7 @@ Defined in `packages/api/src/middleware/auth.ts`:
 
 | Route | Enforced at | Gate | Rationale |
 |-------|-------------|------|-----------|
-| `POST /bookings` | route | any authed user (books for self) | Instant-book. Only `STAFF_ROLES` may set `renterId` / `source=MANUAL` (on-behalf). Operators are excluded from on-behalf: `UserRepository` is not tenant-scoped, so letting an operator resolve an arbitrary `renterId` reopens the #396 cross-tenant user-enumeration vector. A `RENTER` must accept the liability disclaimer (#613). |
+| `POST /bookings` | route (PARTNER 403) | any authed user **except PARTNER** (books for self) | Instant-book. Only `STAFF_ROLES` may set `renterId` / `source=MANUAL` (on-behalf). Operators are excluded from on-behalf: `UserRepository` is not tenant-scoped, so letting an operator resolve an arbitrary `renterId` reopens the #396 cross-tenant user-enumeration vector. A `RENTER` must accept the liability disclaimer (#613). #1440: a `PARTNER` is rejected 403 at the route — a channel books through its integration, not this manual-create endpoint; the previous pass-through was only *accidentally* safe (its synthetic `partner:api-key` renterId FK-fails), so the exclusion is now explicit (see PARTNER section). |
 | `PATCH /:id/status` | route + service | `MANAGEMENT_READ_ROLES`, then operator-bound | Lifecycle advance (`CONFIRMED → ACTIVE → COMPLETED`) is a physical pickup/return event — operational, so platform support is admitted alongside operators. Row-scoping alone would let a renter self-advance via the raw API and skew dashboards / settlement (#643). #1260: a bypass admin (`bookingReadScope = all`) reads every tenant's bookings, so the service binds the write to the operator it picked via `?operatorId=` — unbound → 422 `OPERATOR_REQUIRED`, non-owning → 404 (no oracle). Tenant operators are clamped by read scope and ignore it. |
 | `POST /:id/cancel` | route (PARTNER 403) + service | renter (own) + operator + bypass-admin operator-bound; PARTNER excluded | Tiered cancellation (72h / 48h / 24h / same-day) is a renter-facing feature, so there is **no management route gate**; the service authorizes renter-own and operator-tenant. #1260: because there is no management gate, a bypass admin could otherwise cancel ANY tenant's booking by raw id (a refund-moving cross-tenant write), so it must bind to the operator it picked via `?operatorId=` — same 422/404 contract as `/status`. Renters (renter scope) and operators (tenant scope) are already clamped by `findById`, so they need no `operatorId`. #1367: a PARTNER's `partner` read scope resolves any `source=TRIP_COM` booking across operators, which the operator-binding guard cannot clamp (a channel is not one operator), so the PARTNER is rejected 403 at the route — cancelling is *managing the order*, which a channel does not do (see PARTNER section). |
 | `POST /:id/substitute` | route | `isOperatorRole` | Choosing which car serves a booking is a **fleet-ownership** decision, named to the operator in the marketplace proposal (§321 / §345). There is no admin substitute UI and the audit `actorId` assumes an operator, so platform staff are deliberately excluded. |
@@ -55,10 +55,66 @@ the two onto one set.
 
 ## PARTNER (Trip.com)
 
-`PARTNER` can `POST /bookings` (it is a booking source) but is excluded from
-`/status`, `/cancel`, `/substitute`, `/substitution-candidates`, and `/events`: a
-3rd-party caller books, it does not manage the order or read internal lifecycle
-data. `/status` and the substitute routes enforce this via their role gates;
-`/cancel` has no management gate (it serves renter self-cancel), so it rejects a
-PARTNER with an explicit 403 (#1367) — otherwise a PARTNER's cross-operator
-`partner` read scope would let it cancel any `TRIP_COM`-sourced booking.
+`PARTNER` is a 3rd-party booking channel: it does not manage orders or read
+internal lifecycle data, so it is excluded from `POST /bookings`, `/status`,
+`/cancel`, `/substitute`, `/substitution-candidates`, and `/events`. `/status`,
+`/substitute`, `/substitution-candidates`, and `/events` enforce this through
+their `MANAGEMENT_READ_ROLES` / `isOperatorRole` gates. Two routes have **no
+management gate** (they serve renter self-service), so each rejects a PARTNER with
+an explicit 403:
+
+- `POST /bookings` (#1440) — renters self-book, so the route admits any authed
+  user. A PARTNER's create was only *accidentally* safe: `resolveBookingActor`
+  forces its synthetic `partner:api-key` id as `renterId` (no user row → renter FK
+  fails) and the inventory bind passes partners through (`bookingReadScope =
+  partner`, never `all`). The route 403 makes the exclusion designed rather than an
+  FK accident. A partner-initiated create is a future channel integration, not this
+  endpoint.
+- `POST /:id/cancel` (#1367) — otherwise a PARTNER's cross-operator `partner` read
+  scope would let it cancel any `TRIP_COM`-sourced booking (a channel is not one
+  operator, so the operator-binding guard cannot clamp it).
+
+## Cross-tenant references resolve to the caller's own not-found (#1440)
+
+When a write names inventory (a vehicle, a pickup location, a booking) the caller
+cannot see, the refusal must be **indistinguishable from a genuinely unknown id** —
+never a distinct 403 that confirms "this exists, but not for you" (an existence
+oracle). How the booking-create path (`packages/api/src/services/booking-creation.ts`,
+`submitInTx`) enforces it:
+
+- **The anchor read is caller-scoped (#1417 / #1439).** The requested vehicle is
+  read with the caller's own `ctx` (`vehicleRepo.findById(ctx, …)`), so
+  `operatorReadScope` clamps a tenant operator to its own fleet: a foreign car
+  returns `undefined` → a plain `400 'Vehicle not found'`, identical to a truly
+  unknown id. The marketplace tiers (renter, PARTNER, bypass admin) resolve `all` and
+  read any public vehicle, unchanged.
+- **The bypass `all` tier binds to a named operator — still no oracle.** A platform
+  admin reads every tenant's inventory, so it must name the operator it acts as via
+  `?operatorId=` (#1260). Only that `all` reader is bound:
+  `assertBookingWriteWithinOperator` short-circuits to `null` for every non-`all`
+  caller, and `fleetWriteDenialResult` maps a non-owning pick to **404**
+  `not-in-scope` (the caller's own not-found) and an absent pick to **422**
+  `OPERATOR_REQUIRED`. Renters and operators are already clamped by the read scope;
+  a PARTNER never reaches here (route 403, above).
+
+There is **no 403 existence oracle** in the inventory path: a cross-tenant vehicle
+reference is always a not-found (`400`/`404`), never a distinguishable "forbidden".
+#1439 removed the earlier explicit-403 branch by moving the clamp into the
+`ctx`-scoped anchor read. (The only 403 in create is a different axis — a manual
+booker naming a `renterId` outside its own customer scope, `booking-creation.ts`
+`assertRenterWithinScope` — not an inventory reference.) Do not reintroduce a
+403 for an unreachable-inventory reference: it hands an attacker an id-enumeration
+oracle. Cross-ref `operatorReadScope`, `assertBookingWriteWithinOperator`, and
+`fleetWriteDenialResult` in `tenancy.ts`.
+
+## Why `/substitute` and `/assign` carry no service-level operator bind (#1440)
+
+`/status` and `/cancel` bind the write to the picked operator at the *service*
+(the #1260 `assertBookingWriteWithinOperator` guard) because they admit the
+bypass-admin `all` reader, which `findById` hands every tenant's booking. `POST
+/:id/substitute` and `POST /:id/assign` do **not** need that bind: both are gated
+`isOperatorRole` at the route, so the only callers are tenant-scoped operators that
+`findById` already clamps to their own fleet (foreign id → 404, no oracle). There
+is no `all`-scope caller to bind, so the single route seal is sufficient. If a
+future change admits platform staff (an `all` reader) to either route, add the
+service-level operator-bind then — the route gate alone would no longer clamp them.

--- a/packages/api/src/routes/bookings.ts
+++ b/packages/api/src/routes/bookings.ts
@@ -152,6 +152,19 @@ export function createBookingRoutes(service: BookingService, consentGate: Consen
     .post('/bookings', async (c) => {
       const ctx = toCallerContext(requireUser(c))
 
+      // #1440 (MED-2): a PARTNER (Trip.com) is a booking CHANNEL, not a manual booker.
+      // Unlike /status and /substitution-candidates, this route has no
+      // MANAGEMENT_READ_ROLES gate (renters self-serve), so a PARTNER would otherwise
+      // reach the service — where its create is only *accidentally* safe (the synthetic
+      // 'partner:api-key' renterId FK-fails; the inventory bind passes partners through,
+      // bookingReadScope='partner' never 'all'). Reject at the route so the exclusion is
+      // DESIGNED, not reliant on an FK accident. A partner-initiated create is a future
+      // channel integration (its own issue), not this endpoint.
+      // authz model: docs/architecture/booking-authz.md
+      if (ctx.role === 'PARTNER') {
+        return fail(c, 'Partners cannot create bookings', 403)
+      }
+
       const parsed = await parseBody(c, createBookingSchema)
       if (!parsed.ok) return parsed.response
 

--- a/packages/api/tests/routes/bookings.test.ts
+++ b/packages/api/tests/routes/bookings.test.ts
@@ -799,6 +799,31 @@ describe('Booking Routes', () => {
       expect(body.data.bookingCode.length).toBeGreaterThan(0)
     })
 
+    // #1440 (MED-2): POST /bookings has no MANAGEMENT_READ_ROLES gate (renters
+    // self-serve), so a PARTNER (Trip.com) reaches the service. Its create is only
+    // *accidentally* safe in prod — resolveBookingActor forces the synthetic
+    // 'partner:api-key' userId as renterId (no user row -> renter FK fails), and the
+    // inventory bind passes partners through unclamped (bookingReadScope = 'partner',
+    // never 'all'). This harness seeds USER2 as a real user, so WITHOUT an explicit
+    // gate the create would succeed (201) — proving the safety is not designed. Gate
+    // it: a partner books through its channel integration, not manual-create.
+    it('forbids a PARTNER from creating a booking (403) (#1440)', async () => {
+      const partnerApp = new Hono()
+      partnerApp.use('*', testAuthMiddleware(USER2, 'PARTNER'))
+      partnerApp.route('/', createBookingRoutes(service, inertConsentGate))
+
+      const res = await partnerApp.request('/bookings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBookingInput()),
+      })
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBe('Partners cannot create bookings')
+    })
+
     // #464 slice 2d.4: parallel CLASS_COMBO submits on the same (operator,
     // class, location) triple must serialize through the advisory lock so the
     // class can be sold at most once per available car. Five concurrent POSTs


### PR DESCRIPTION
## What

Booking-authz hardening follow-ups deferred from #1417 / #1439. The issue notes none are live holes — these make the safety *designed* rather than incidental, and document the conventions.

**MED-2 — explicit PARTNER gate on `POST /bookings`.**
`POST /bookings` has no route-level role gate (renters self-serve), unlike `/status` and `/substitution-candidates` (`MANAGEMENT_READ_ROLES`). So a `PARTNER` (Trip.com, api-key-only, identity `{id:'partner:api-key', role:'PARTNER'}`) reached the service. Its create was only *accidentally* safe: `resolveBookingActor` forces the synthetic `partner:api-key` as `renterId` (no user row → renter FK fails) and the operator bind `assertBookingWriteWithinOperator` passes partners through (`bookingReadScope='partner'`, never `'all'`). This adds an explicit `403` route gate, mirroring the existing PARTNER `/cancel` 403 (#1367). A partner-initiated create is a future channel integration, not this endpoint.

**MED-1 + LOW — `docs/architecture/booking-authz.md`.**
- The cross-tenant "caller's own not-found, never a 403 oracle" convention, written accurate to the **post-#1439** ctx-scoped anchor read (the earlier explicit-403 inventory branch was removed by #1439 — there is no 403 inventory exception).
- Why `/substitute` and `/assign` need no service-level operator bind (both `isOperatorRole`-gated → no `all` reader reaches them).
- Updated the `POST /bookings` table row + PARTNER section to reflect the new gate.

**NIT (stable `ErrorCode`)** deferred — not needed today (the refusal is deliberately indistinguishable from not-found).

## Testing

- New pinning test `forbids a PARTNER from creating a booking (403) (#1440)` — TDD RED (returned 201 without the gate, since the in-memory harness seeds the partner's test id as a real user, proving the prod safety is only an FK accident) → GREEN.
- Full API suite: **2755 passed**. `tsc` (api) clean, `lint:boundaries` OK, biome clean. Pre-commit hooks (biome, file-size, module-boundaries, tsc×2) green.

## Review note

A code-reviewer pass caught that my first docs draft described the **pre-#1439** design (referenced `bookingInventoryDenialResult` / `foreign-operator`, removed on the current base — a context-decay slip from reading `tenancy.ts` on an older develop). Rewritten and cross-checked every doc symbol against the current source.

Closes #1440