### PR TITLE
feat(#1437): SHARED_CATALOG kill-switch (slice 2 of 3)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -486,8 +486,17 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   const vehicleService = new VehicleService(vehicleRepo, resolveWriteOperatorId, photosPublicUrl)
   const locationService = new LocationService(locationRepo, bookingRepo, cachedGeocoder, regionRepo)
   const insuranceOptionService = new InsuranceOptionService(insuranceOptionRepo)
-  const addOnService = new AddOnService(addOnRepo, addOnTemplateRepo)
-  const addOnTemplateService = new AddOnTemplateService(addOnTemplateRepo, addOnRepo)
+  const featureFlagsService = new FeatureFlagsService(featureFlagRepo)
+  // #1437: SHARED_CATALOG is server-enforced. Both the operator picker read (empty when
+  // off) and the add-on create path (reject a templateId when off) gate on ONE narrow
+  // thunk (ISP) rather than the whole FeatureFlagsService.
+  const isSharedCatalogEnabled = () => featureFlagsService.isEnabled('SHARED_CATALOG')
+  const addOnService = new AddOnService(addOnRepo, addOnTemplateRepo, isSharedCatalogEnabled)
+  const addOnTemplateService = new AddOnTemplateService(
+    addOnTemplateRepo,
+    addOnRepo,
+    isSharedCatalogEnabled,
+  )
   const templateLibraryService = new TemplateLibraryService(
     addOnTemplateRepo,
     insuranceTemplateRepo,
@@ -524,7 +533,6 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   )
   const reviewAggregateService = new ReviewAggregateService(reviewRepo)
   const reviewListService = new ReviewListService(reviewRepo)
-  const featureFlagsService = new FeatureFlagsService(featureFlagRepo)
 
   // Chain .route() calls so TypeScript infers the full route type tree.
   // hc<AppType> needs this to produce typed client methods.

--- a/packages/api/src/services/add-on-template.ts
+++ b/packages/api/src/services/add-on-template.ts
@@ -18,15 +18,24 @@ import type { AddOnRepository, AddOnTemplateRepository } from '../repositories/t
  * enumeration.
  */
 export class AddOnTemplateService {
+  // #1437: the SHARED_CATALOG kill-switch. Defaults to ON, mirroring the registry
+  // serverDefault (and the whole feature's fail-OPEN stance) so existing callers and
+  // tests need no change; the composition root injects the real flag-backed thunk.
   constructor(
     private readonly repo: AddOnTemplateRepository,
     private readonly addOnRepo: AddOnRepository,
+    private readonly isSharedCatalogEnabled: () => Promise<boolean> = () => Promise.resolve(true),
   ) {}
 
   async listForPicker(
     locale: Locale,
     excludeOfferedByOperatorId?: string,
   ): Promise<AddOnTemplatePickerData[]> {
+    // Kill-switch: when the shared catalog is off, the operator picker shows nothing
+    // (they must self-author). Existing picked items still resolve elsewhere - only
+    // the picker read is gated here.
+    if (!(await this.isSharedCatalogEnabled())) return []
+
     const templates = await this.repo.findActive()
     const offered = excludeOfferedByOperatorId
       ? await this.offeredTemplateIds(excludeOfferedByOperatorId)

--- a/packages/api/src/services/add-on.ts
+++ b/packages/api/src/services/add-on.ts
@@ -118,9 +118,11 @@ export class AddOnService {
     if (data.templateId) {
       // Kill-switch: picking from the shared catalog is server-enforced. When off, the
       // operator must self-author (the escape hatch above stays open). Checked here, so
-      // a client that bypasses the hidden picker still cannot pick a template.
+      // a client that bypasses the hidden picker still cannot pick a template. 422 (not
+      // 403): the request is well-formed and the caller is authorized — the catalog is
+      // just disabled — so this is a state, not an authz denial (surfacing != authz).
       if (!(await this.isSharedCatalogEnabled())) {
-        return { ok: false, error: CATALOG_DISABLED_MESSAGE, status: 403 }
+        return { ok: false, error: CATALOG_DISABLED_MESSAGE, status: 422 }
       }
       return this.createFromTemplate(data, data.templateId, locale)
     }

--- a/packages/api/src/services/add-on.ts
+++ b/packages/api/src/services/add-on.ts
@@ -49,6 +49,7 @@ export type AddOnUpdate = {
 const DUPLICATE_TEMPLATE_MESSAGE = 'You already offer this add-on'
 const DUPLICATE_NAME_MESSAGE = 'You already offer an add-on with this name'
 const UNKNOWN_TEMPLATE_MESSAGE = 'Unknown or unavailable add-on template'
+const CATALOG_DISABLED_MESSAGE = 'The shared catalog is disabled; create a custom add-on instead'
 const PICKED_RENAME_MESSAGE =
   'A template-based add-on cannot be renamed; its name comes from the catalog'
 const MISSING_IDENTITY_MESSAGE = 'An add-on needs either a template or a custom name'
@@ -77,9 +78,13 @@ function toOperatorAddOn(row: AddOnWithTemplate, locale: Locale): OperatorAddOnD
 }
 
 export class AddOnService {
+  // #1437: the SHARED_CATALOG kill-switch. Defaults to ON, mirroring the registry
+  // serverDefault (and the feature's fail-OPEN stance) so existing callers/tests need
+  // no change; the composition root injects the real flag-backed thunk.
   constructor(
     private readonly repo: AddOnRepository,
     private readonly templateRepo: AddOnTemplateRepository,
+    private readonly isSharedCatalogEnabled: () => Promise<boolean> = () => Promise.resolve(true),
   ) {}
 
   async findAll(
@@ -110,7 +115,15 @@ export class AddOnService {
    */
   async create(_ctx: CallerContext, data: AddOnCreate, locale: Locale): Promise<AddOnResult> {
     if (data.nameI18n) return this.createSelfAuthored(data, data.nameI18n, locale)
-    if (data.templateId) return this.createFromTemplate(data, data.templateId, locale)
+    if (data.templateId) {
+      // Kill-switch: picking from the shared catalog is server-enforced. When off, the
+      // operator must self-author (the escape hatch above stays open). Checked here, so
+      // a client that bypasses the hidden picker still cannot pick a template.
+      if (!(await this.isSharedCatalogEnabled())) {
+        return { ok: false, error: CATALOG_DISABLED_MESSAGE, status: 403 }
+      }
+      return this.createFromTemplate(data, data.templateId, locale)
+    }
     return { ok: false, error: MISSING_IDENTITY_MESSAGE, status: 400 }
   }
 

--- a/packages/api/src/services/feature-flags.ts
+++ b/packages/api/src/services/feature-flags.ts
@@ -1,4 +1,8 @@
-import type { FeatureFlagKey, FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import {
+  FEATURE_FLAGS,
+  type FeatureFlagKey,
+  type FeatureFlagOverrides,
+} from '@kuruma/shared/feature-flags/registry'
 import type { CallerContext } from '../auth/context'
 import type { FeatureFlagRepository } from '../repositories/types'
 
@@ -12,6 +16,18 @@ export class FeatureFlagsService {
 
   async getOverrides(): Promise<FeatureFlagOverrides> {
     return this.repo.getOverrides()
+  }
+
+  /**
+   * The definitive server-side value of a flag: an admin override wins, else the
+   * registry `serverDefault` (the override map is sparse, so a default-ON flag has
+   * NO row in the normal state). Single-sources the default from the registry with
+   * the web flooring (feature-flags-runtime.ts), so server enforcement and the web
+   * surface cannot drift. Used to server-enforce SHARED_CATALOG (#1437).
+   */
+  async isEnabled(key: FeatureFlagKey): Promise<boolean> {
+    const overrides = await this.repo.getOverrides()
+    return overrides[key] ?? FEATURE_FLAGS[key].serverDefault ?? false
   }
 
   async setOverride(ctx: CallerContext, key: FeatureFlagKey, enabled: boolean): Promise<void> {

--- a/packages/api/src/services/feature-flags.ts
+++ b/packages/api/src/services/feature-flags.ts
@@ -24,6 +24,10 @@ export class FeatureFlagsService {
    * NO row in the normal state). Single-sources the default from the registry with
    * the web flooring (feature-flags-runtime.ts), so server enforcement and the web
    * surface cannot drift. Used to server-enforce SHARED_CATALOG (#1437).
+   *
+   * Meaningful ONLY for `serverOnly` flags: a plain web flag has no `serverDefault`
+   * (its real default is a `VITE_*` env the API can't read), so this floors it to
+   * `false` — which is not that flag's build-time default. Do not call it for one.
    */
   async isEnabled(key: FeatureFlagKey): Promise<boolean> {
     const overrides = await this.repo.getOverrides()

--- a/packages/api/tests/routes/shared-catalog-killswitch-wired.test.ts
+++ b/packages/api/tests/routes/shared-catalog-killswitch-wired.test.ts
@@ -1,0 +1,60 @@
+import { seedId } from '@kuruma/shared/db/seed-id'
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import { InMemoryFeatureFlagRepository } from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+// Wiring guard for the SHARED_CATALOG kill-switch (#1437). The service unit tests
+// inject a hand-written thunk, so they cannot catch a composition-root regression:
+// the gate is an OPTIONAL constructor arg defaulting to catalog-ON, so DROPPING the
+// `isSharedCatalogEnabled` argument from `new AddOnService(...)` / `new
+// AddOnTemplateService(...)` in index.ts compiles clean and passes every unit test
+// while silently disabling server enforcement. This boots the real composed app,
+// flips the flag off via the real FeatureFlagRepository, and proves BOTH the picker
+// read and the create path actually observe the switch end-to-end.
+const CHILD_SEAT = seedId('tmpl_child_seat')
+
+function appWithCatalog(enabled: boolean) {
+  setupAuthEnv()
+  const featureFlagRepo = new InMemoryFeatureFlagRepository()
+  // Default is ON in code (registry serverDefault); only write a row to turn it OFF.
+  const seed = enabled
+    ? Promise.resolve()
+    : featureFlagRepo.setOverride('SHARED_CATALOG', false, 'admin-1')
+  return seed.then(() => createApp({ featureFlagRepo }))
+}
+
+describe('SHARED_CATALOG kill-switch is wired into the composed app (#1437)', () => {
+  it('serves the seeded picker when the catalog is ON (control)', async () => {
+    const app = await appWithCatalog(true)
+    const res = await app.request('/add-on-templates', { headers: await authHeaders() })
+    expect(res.status).toBe(200)
+    const { data } = (await res.json()) as { data: { key: string }[] }
+    expect(data.map((t) => t.key)).toContain('child_seat')
+  })
+
+  it('empties the picker when the catalog is OFF (AddOnTemplateService is wired)', async () => {
+    const app = await appWithCatalog(false)
+    const res = await app.request('/add-on-templates', { headers: await authHeaders() })
+    expect(res.status).toBe(200)
+    const { data } = (await res.json()) as { data: unknown[] }
+    expect(data).toEqual([])
+  })
+
+  it('rejects a template-picked create when the catalog is OFF (AddOnService is wired)', async () => {
+    const app = await appWithCatalog(false)
+    // Platform admin so the admin create schema (operatorId required) validates; the
+    // OFF gate returns 422 before any operator/template lookup, so a synthetic
+    // operatorId is fine — this asserts the switch, not ownership.
+    const res = await app.request('/add-ons', {
+      method: 'POST',
+      headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        templateId: CHILD_SEAT,
+        priceJpy: 1500,
+        operatorId: seedId('op_killswitch_wiring'),
+      }),
+    })
+    expect(res.status).toBe(422)
+  })
+})

--- a/packages/api/tests/services/add-on-template.test.ts
+++ b/packages/api/tests/services/add-on-template.test.ts
@@ -72,6 +72,21 @@ describe('AddOnTemplateService.listForPicker', () => {
 
     expect(picker.map((t) => t.resolvedName)).toEqual(['Additional driver', 'Snow tires'])
   })
+
+  it('returns an empty picker when the shared catalog is disabled (#1437)', async () => {
+    // Seed a real ACTIVE template so an empty result proves the kill-switch gate,
+    // not merely an empty catalog.
+    const store = new Map<string, AddOnTemplate>([
+      ['a', row({ id: 'a', key: 'child_seat', name: { en: 'Child seat' } })],
+    ])
+    const service = new AddOnTemplateService(
+      new InMemoryAddOnTemplateRepository(store),
+      emptyAddOnRepo(),
+      () => Promise.resolve(false),
+    )
+
+    expect(await service.listForPicker('en')).toEqual([])
+  })
 })
 
 describe('AddOnTemplateService.listForPicker — already-offered exclusion (P1-3)', () => {

--- a/packages/api/tests/services/add-on.test.ts
+++ b/packages/api/tests/services/add-on.test.ts
@@ -151,6 +151,31 @@ describe('AddOnService', () => {
       expect(result.ok).toBe(true)
     })
 
+    it('rejects a template-picked create when the shared catalog is disabled (#1437)', async () => {
+      const off = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), () =>
+        Promise.resolve(false),
+      )
+      const result = await off.create(ctxFor(opA), createInput(opA, CHILD_SEAT), LOCALE)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.status).toBe(403)
+        expect(result.error).toBe('The shared catalog is disabled; create a custom add-on instead')
+      }
+    })
+
+    it('still allows a self-authored create when the shared catalog is disabled (#1437)', async () => {
+      // The escape hatch must survive the kill-switch: operators can always self-author.
+      const off = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), () =>
+        Promise.resolve(false),
+      )
+      const result = await off.create(
+        ctxFor(opA),
+        selfAuthoredInput(opA, { en: 'GPS unit' }),
+        LOCALE,
+      )
+      expect(result.ok).toBe(true)
+    })
+
     it('rejects a second self-authored add-on with the same en name (distinct 409)', async () => {
       await service.create(ctxFor(opA), selfAuthoredInput(opA, { en: 'GPS unit' }), LOCALE)
       const result = await service.create(

--- a/packages/api/tests/services/add-on.test.ts
+++ b/packages/api/tests/services/add-on.test.ts
@@ -158,7 +158,7 @@ describe('AddOnService', () => {
       const result = await off.create(ctxFor(opA), createInput(opA, CHILD_SEAT), LOCALE)
       expect(result.ok).toBe(false)
       if (!result.ok) {
-        expect(result.status).toBe(403)
+        expect(result.status).toBe(422)
         expect(result.error).toBe('The shared catalog is disabled; create a custom add-on instead')
       }
     })

--- a/packages/api/tests/services/feature-flags.test.ts
+++ b/packages/api/tests/services/feature-flags.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryFeatureFlagRepository } from '../../src/repositories/in-memory/feature-flags'
+import { FeatureFlagsService } from '../../src/services/feature-flags'
+
+// #1437: the server enforces SHARED_CATALOG, so it needs a definitive isEnabled()
+// that floors to the registry serverDefault when no admin override exists (the
+// override map is sparse). This single-sources the default with the web flooring,
+// so server enforcement and the web surface can never disagree on "catalog ON".
+describe('FeatureFlagsService.isEnabled', () => {
+  it('returns the registry serverDefault (ON) for SHARED_CATALOG with no override', async () => {
+    const service = new FeatureFlagsService(new InMemoryFeatureFlagRepository())
+    expect(await service.isEnabled('SHARED_CATALOG')).toBe(true)
+  })
+
+  it('honours an admin override that turns SHARED_CATALOG off', async () => {
+    const repo = new InMemoryFeatureFlagRepository()
+    await repo.setOverride('SHARED_CATALOG', false)
+    const service = new FeatureFlagsService(repo)
+    expect(await service.isEnabled('SHARED_CATALOG')).toBe(false)
+  })
+
+  it('honours an admin override that turns SHARED_CATALOG back on', async () => {
+    const repo = new InMemoryFeatureFlagRepository()
+    await repo.setOverride('SHARED_CATALOG', true)
+    const service = new FeatureFlagsService(repo)
+    expect(await service.isEnabled('SHARED_CATALOG')).toBe(true)
+  })
+})

--- a/packages/shared/src/feature-flags/registry.test.ts
+++ b/packages/shared/src/feature-flags/registry.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it } from 'vitest'
 import { FEATURE_FLAGS, FEATURE_FLAG_KEYS, isFeatureFlagKey } from './registry'
 
 describe('feature flag registry', () => {
-  it('gives every flag a VITE_FEATURE_ env name and a non-empty label', () => {
+  it('gives every web flag a VITE_FEATURE_ env name and every flag a non-empty label', () => {
     for (const key of FEATURE_FLAG_KEYS) {
       const entry = FEATURE_FLAGS[key]
-      expect(entry.env).toMatch(/^VITE_FEATURE_[A-Z_]+$/)
       expect(entry.label.length).toBeGreaterThan(0)
+      // A serverOnly flag has no web build-time env; its default lives in code
+      // (serverDefault). Every other flag pins a VITE_FEATURE_ env.
+      if (entry.serverOnly) {
+        expect(entry.env).toBeUndefined()
+      } else {
+        expect(entry.env).toMatch(/^VITE_FEATURE_[A-Z_]+$/)
+      }
     }
   })
 
@@ -20,9 +26,28 @@ describe('feature flag registry', () => {
     )
   })
 
-  it('maps each flag to a distinct env var', () => {
-    const envs = FEATURE_FLAG_KEYS.map((k) => FEATURE_FLAGS[k].env)
+  it('maps each web flag to a distinct env var', () => {
+    // serverOnly flags carry no env, so exclude them before the distinctness check.
+    const envs = FEATURE_FLAG_KEYS.filter((k) => !FEATURE_FLAGS[k].serverOnly).map(
+      (k) => FEATURE_FLAGS[k].env,
+    )
     expect(new Set(envs).size).toBe(envs.length)
+  })
+
+  it('registers SHARED_CATALOG as a server-only flag (default ON in code, no env)', () => {
+    const entry = FEATURE_FLAGS.SHARED_CATALOG
+    expect(entry.serverOnly).toBe(true)
+    expect(entry.serverDefault).toBe(true)
+    expect(entry.env).toBeUndefined()
+    expect(entry.runtimeControlled).toBe(true)
+  })
+
+  it('gives every server-only flag an explicit boolean serverDefault (fail-safe floor)', () => {
+    for (const key of FEATURE_FLAG_KEYS) {
+      if (FEATURE_FLAGS[key].serverOnly) {
+        expect(typeof FEATURE_FLAGS[key].serverDefault).toBe('boolean')
+      }
+    }
   })
 
   it('marks exactly the runtime-migrated flags as runtimeControlled', () => {
@@ -44,6 +69,9 @@ describe('feature flag registry', () => {
         'OPERATOR_SETTINGS',
         'RENTER_DOCUMENTS',
         'MESSAGING',
+        // Server-only, but the web reads it via useFeatureFlag() to hide the
+        // operator picker + admin template library live, so it is runtimeControlled.
+        'SHARED_CATALOG',
       ]),
     )
   })

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -14,7 +14,23 @@
 // migrates the flag off the build-time isXEnabled() reader (#1322); the admin page
 // badges a not-yet-migrated flag as "build-time only" so its toggle isn't mistaken
 // for a no-op.
-export const FEATURE_FLAGS = {
+// A registry entry. `env` is the build-time VITE_FEATURE_* var a web flag reads;
+// a `serverOnly` flag has NONE (it is enforced by the API and defaults from code,
+// not the bundle) and instead carries a `serverDefault` fail-safe floor. Typing
+// the registry as Record<Key, FeatureFlagEntry> (below) keeps indexed `.env`
+// access uniform even though serverOnly entries omit it.
+export type FeatureFlagEntry = {
+  env?: string
+  label: string
+  runtimeControlled: boolean
+  // Server-enforced flag with no web build-time env (#1437 SHARED_CATALOG). The
+  // web floors it to `serverDefault` rather than a build-time reader; the API
+  // reads `serverDefault` as the default when no admin override exists.
+  serverOnly?: boolean
+  serverDefault?: boolean
+}
+
+const REGISTRY = {
   CANCELLATION: {
     env: 'VITE_FEATURE_CANCELLATION',
     label: 'Self-service cancellation',
@@ -74,9 +90,26 @@ export const FEATURE_FLAGS = {
     label: 'Calendar quick-view',
     runtimeControlled: false,
   },
-} as const
+  // #1437: platform kill-switch for the shared add-on template catalog. Default ON
+  // in CODE (serverDefault) - the feature_flags table is override-only, so no seed
+  // row exists. serverOnly because the API enforces it (picker endpoint + create
+  // path), which no existing web-only flag does. runtimeControlled: the web reads it
+  // to hide the operator picker + admin template library live.
+  SHARED_CATALOG: {
+    label: 'Shared add-on template catalog',
+    runtimeControlled: true,
+    serverOnly: true,
+    serverDefault: true,
+  },
+} satisfies Record<string, FeatureFlagEntry>
 
-export type FeatureFlagKey = keyof typeof FEATURE_FLAGS
+// Typed as Record<Key, FeatureFlagEntry> (not the `as const` literal) so indexed
+// `.env` access is uniformly `string | undefined` across all entries - a serverOnly
+// entry omits `env`, which would otherwise make `FEATURE_FLAGS[key].env` a union
+// error. Keys stay literal via `keyof typeof REGISTRY`.
+export const FEATURE_FLAGS: Record<keyof typeof REGISTRY, FeatureFlagEntry> = REGISTRY
+
+export type FeatureFlagKey = keyof typeof REGISTRY
 export const FEATURE_FLAG_KEYS = Object.keys(FEATURE_FLAGS) as FeatureFlagKey[]
 
 /** A sparse override map: only keys the platform admin has explicitly set. */

--- a/packages/web/src/vite/config/feature-flags-parity.test.ts
+++ b/packages/web/src/vite/config/feature-flags-parity.test.ts
@@ -10,7 +10,12 @@ describe('feature-flag registry <-> vite-env.d.ts parity', () => {
     .map((m) => m[0])
     .filter((s): s is string => Boolean(s))
   const declaredSet = new Set(declared)
-  const registryEnvs = FEATURE_FLAG_KEYS.map((k) => FEATURE_FLAGS[k].env)
+  // serverOnly flags (e.g. SHARED_CATALOG) carry no VITE_FEATURE_ env, so they are not
+  // part of the vite-env.d.ts parity contract - the undefined filter drops them (and
+  // narrows to string[] for the Set<string> membership checks below).
+  const registryEnvs = FEATURE_FLAG_KEYS.map((k) => FEATURE_FLAGS[k].env).filter(
+    (env): env is string => env !== undefined,
+  )
 
   it('every VITE_FEATURE_ env declared in vite-env.d.ts has a registry entry', () => {
     for (const env of declaredSet) {

--- a/packages/web/src/vite/config/feature-flags-runtime.test.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.test.ts
@@ -1,0 +1,37 @@
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { describe, expect, it } from 'vitest'
+import { isBuildTimeEnabled, resolveFeatureFlag } from './feature-flags-runtime'
+
+// #1437: the SHARED_CATALOG kill-switch is serverOnly + default-ON. The web override
+// map is SPARSE (a key present IFF an admin set it), so in the normal default-ON state
+// there is NO override row for it. A naive resolver would then fall to the build-time
+// reader, which for an envless flag yields false -> the catalog would hide ITSELF in
+// its own default state (the "polarity trap"). resolveFeatureFlag must instead floor a
+// serverOnly key to its registry serverDefault. These lock that in.
+describe('resolveFeatureFlag - serverOnly flooring (polarity trap)', () => {
+  const NO_OVERRIDES: FeatureFlagOverrides = {}
+
+  it('floors SHARED_CATALOG to its serverDefault (ON) when the map is empty', () => {
+    // The critical case: default state, no override row, no env. Must be ON, not off.
+    expect(resolveFeatureFlag(NO_OVERRIDES, 'SHARED_CATALOG')).toBe(true)
+  })
+
+  it('lets an explicit admin override turn SHARED_CATALOG off', () => {
+    expect(resolveFeatureFlag({ SHARED_CATALOG: false }, 'SHARED_CATALOG')).toBe(false)
+  })
+
+  it('lets an explicit admin override keep SHARED_CATALOG on', () => {
+    expect(resolveFeatureFlag({ SHARED_CATALOG: true }, 'SHARED_CATALOG')).toBe(true)
+  })
+
+  it('does NOT floor a normal web flag - it falls to its (false) build-time reader', () => {
+    // CANCELLATION has no override and no env set in the test env, so it resolves off.
+    // This proves flooring is scoped to serverOnly keys, not applied blanket.
+    expect(resolveFeatureFlag(NO_OVERRIDES, 'CANCELLATION')).toBe(false)
+  })
+
+  it('isBuildTimeEnabled returns false for a serverOnly flag (it has no reader)', () => {
+    // Documents WHY resolveFeatureFlag must floor: the build-time reader alone is false.
+    expect(isBuildTimeEnabled('SHARED_CATALOG')).toBe(false)
+  })
+})

--- a/packages/web/src/vite/config/feature-flags-runtime.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.ts
@@ -1,4 +1,5 @@
 import {
+  FEATURE_FLAGS,
   type FeatureFlagKey,
   type FeatureFlagOverrides,
   isFeatureFlagKey,
@@ -17,7 +18,9 @@ import { isEnvTrue } from './env-flag'
 // module deliberately does NOT import `./features` — a consumer that partially mocks
 // that module in tests can't break the barrel that also re-exports this one. The env
 // names are pinned to the registry by the parity test (feature-flags-parity.test.ts).
-const BUILD_TIME_READERS: Record<FeatureFlagKey, () => boolean> = {
+// Partial: a serverOnly flag (e.g. SHARED_CATALOG) has NO build-time reader - its
+// default lives in the registry (serverDefault) and resolveFeatureFlag floors to it.
+const BUILD_TIME_READERS: Partial<Record<FeatureFlagKey, () => boolean>> = {
   CANCELLATION: () => isEnvTrue(import.meta.env.VITE_FEATURE_CANCELLATION),
   OPERATOR_MANUAL_BOOKING: () => isEnvTrue(import.meta.env.VITE_FEATURE_OPERATOR_MANUAL_BOOKING),
   OPERATOR_TEAM: () => isEnvTrue(import.meta.env.VITE_FEATURE_OPERATOR_TEAM),
@@ -33,7 +36,9 @@ const BUILD_TIME_READERS: Record<FeatureFlagKey, () => boolean> = {
 }
 
 export function isBuildTimeEnabled(key: FeatureFlagKey): boolean {
-  return BUILD_TIME_READERS[key]()
+  // A serverOnly flag has no reader here; it is never a build-time default, so false.
+  const reader = BUILD_TIME_READERS[key]
+  return reader ? reader() : false
 }
 
 /**
@@ -44,7 +49,14 @@ export function isBuildTimeEnabled(key: FeatureFlagKey): boolean {
  * drift from what the hook renders (#1322).
  */
 export function resolveFeatureFlag(overrides: FeatureFlagOverrides, key: FeatureFlagKey): boolean {
-  return overrides[key] ?? isBuildTimeEnabled(key)
+  const entry = FEATURE_FLAGS[key]
+  // serverOnly keys (e.g. SHARED_CATALOG) floor to the registry serverDefault, NOT the
+  // build-time reader: the sparse map carries no row in the default state, and an envless
+  // reader is false, so falling to it would hide a default-ON flag from itself. Flooring
+  // to serverDefault makes every fail-safe path (empty initialData, non-ok fetch, parse
+  // error) resolve to the flag's real default. Non-serverOnly keys keep build-time fallback.
+  const fallback = entry.serverOnly ? (entry.serverDefault ?? false) : isBuildTimeEnabled(key)
+  return overrides[key] ?? fallback
 }
 
 interface OverridesEnvelope {

--- a/packages/web/src/vite/nav/AdminSidebar.tsx
+++ b/packages/web/src/vite/nav/AdminSidebar.tsx
@@ -37,9 +37,12 @@ export const SIDEBAR_ITEMS = [
 
 // Sidebar items hidden unless a runtime feature flag is on (keyed by `to`); an
 // item absent here is always shown. Review moderation only matters once reviews
-// are enabled (#1086) — dark-launched, so the link stays hidden by default.
+// are enabled (#1086) — dark-launched, so the link stays hidden by default. The
+// template library follows the SHARED_CATALOG kill-switch (#1437): default-ON, so
+// it shows unless a platform admin switches the shared catalog off.
 const FLAG_GATED_ITEMS: Partial<Record<(typeof SIDEBAR_ITEMS)[number]['to'], FeatureFlagKey>> = {
   '/$locale/admin/reviews': 'REVIEWS',
+  '/$locale/admin/templates': 'SHARED_CATALOG',
 }
 
 // Single static className; active state is the `aria-current="page"` attribute
@@ -55,7 +58,10 @@ export function AdminSidebar() {
   const t = useTranslations('admin')
   const locale = useLocale()
   // One lookup per gated flag; the map fail-closes (an unknown flag → hidden).
-  const flags: Partial<Record<FeatureFlagKey, boolean>> = { REVIEWS: useFeatureFlag('REVIEWS') }
+  const flags: Partial<Record<FeatureFlagKey, boolean>> = {
+    REVIEWS: useFeatureFlag('REVIEWS'),
+    SHARED_CATALOG: useFeatureFlag('SHARED_CATALOG'),
+  }
   const visibleItems = SIDEBAR_ITEMS.filter((item) => {
     const flag = FLAG_GATED_ITEMS[item.to]
     return flag === undefined || flags[flag] === true

--- a/packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx
+++ b/packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { useFeatureFlag } from '@/vite/config'
 import { DEFAULT_LOCALE, isLocale } from '@/vite/i18n/locale'
 import { AddOnForm } from '@/vite/operator-add-ons/AddOnForm'
 import { ADDON_QUERY_KEY, type CreateAddOnInput, createAddOn } from '@/vite/operator-add-ons/api'
@@ -32,12 +33,15 @@ export function AddAddOnDialog({ open, onOpenChange, pickedOperatorId }: AddAddO
   const csrfToken = useSession().data?.csrfToken ?? ''
   const rawLocale = useLocale()
   const locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE
+  // #1437: when the shared catalog is off, the picker is hidden and the operator must
+  // self-author — so skip the picker fetch and force the form's custom path.
+  const sharedCatalogEnabled = useFeatureFlag('SHARED_CATALOG')
 
-  // Only fetch the picker while the dialog is open; the server resolves each name
-  // to `locale` and drops templates this operator already offers.
+  // Only fetch the picker while the dialog is open AND the catalog is on; the server
+  // resolves each name to `locale` and drops templates this operator already offers.
   const { data: templates } = useQuery({
     ...addOnTemplatesQueryOptions(locale, pickedOperatorId),
-    enabled: open,
+    enabled: open && sharedCatalogEnabled,
   })
 
   const { mutateAsync, isPending, error, reset } = useMutation({
@@ -68,6 +72,7 @@ export function AddAddOnDialog({ open, onOpenChange, pickedOperatorId }: AddAddO
         <AddOnForm
           mode="create"
           templates={templates ?? []}
+          sharedCatalogEnabled={sharedCatalogEnabled}
           onSubmit={async (data) => {
             const descriptionOverride = setLocaleSlot(null, locale, data.description)
             // Exactly one identity: a custom item sends its own name bundle; a picked

--- a/packages/web/src/vite/operator-add-ons/AddOnForm.tsx
+++ b/packages/web/src/vite/operator-add-ons/AddOnForm.tsx
@@ -74,6 +74,13 @@ interface AddOnFormProps {
   templateName?: string
   /** EDIT: which identity the edited row uses. A custom row edits its name (D5). */
   editIdentity?: AddOnIdentityMode
+  /**
+   * #1437: whether the shared template catalog is on. When OFF, CREATE hides the
+   * picker + the template/custom toggle and forces the self-author path. Defaults
+   * to true (the registry serverDefault). EDIT is unaffected — a picked row keeps
+   * showing its read-only template name regardless.
+   */
+  sharedCatalogEnabled?: boolean
   defaultValues?: Partial<AddOnFormValues>
 }
 
@@ -85,6 +92,7 @@ export function AddOnForm({
   templates,
   templateName,
   editIdentity,
+  sharedCatalogEnabled = true,
   defaultValues,
 }: AddOnFormProps) {
   const t = useTranslations('business.addOns')
@@ -100,7 +108,14 @@ export function AddOnForm({
   } = useForm<AddOnFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      identityMode: mode === 'edit' ? (editIdentity ?? 'template') : 'template',
+      // CREATE defaults to the picker when the catalog is on, else the self-author path
+      // (the only option when off). EDIT keeps the row's fixed identity.
+      identityMode:
+        mode === 'edit'
+          ? (editIdentity ?? 'template')
+          : sharedCatalogEnabled
+            ? 'template'
+            : 'custom',
       templateId: '',
       nameEn: '',
       nameJa: '',
@@ -112,8 +127,10 @@ export function AddOnForm({
   })
 
   // In CREATE mode the operator toggles the path; in EDIT it is fixed by the row.
+  // The toggle + picker only exist when the shared catalog is on (#1437).
   const identityMode = watch('identityMode')
-  const showPicker = mode === 'create' && identityMode === 'template'
+  const showToggle = mode === 'create' && sharedCatalogEnabled
+  const showPicker = mode === 'create' && identityMode === 'template' && sharedCatalogEnabled
   const showCustomName = identityMode === 'custom'
   const showReadOnlyTemplate = mode === 'edit' && identityMode === 'template'
 
@@ -124,7 +141,7 @@ export function AddOnForm({
       })}
       className="space-y-4"
     >
-      {mode === 'create' && (
+      {showToggle && (
         <fieldset className="space-y-1">
           <legend className="text-sm font-medium">{t('form.identityLegend')}</legend>
           <div className="flex gap-4">

--- a/packages/web/tests/vite/nav/AdminSidebar.test.tsx
+++ b/packages/web/tests/vite/nav/AdminSidebar.test.tsx
@@ -1,9 +1,14 @@
+import { FeatureFlagsProvider } from '@/vite/config'
 import { AdminSidebar } from '@/vite/nav/AdminSidebar'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+
+const TEMPLATES_LINK = '[data-to="/$locale/admin/templates"]'
 
 // Mirror the Navbar test: stub the typed router Link to a plain anchor so the
 // unit test asserts our wiring (to + labels), not TanStack's active-class
@@ -33,6 +38,22 @@ function renderSidebar() {
   )
 }
 
+// Seed the runtime override map so FeatureFlagsProvider reads it from cache (no
+// fetch), mirroring the BusinessSidebar test — lets us drive a flag-gated link.
+function renderSidebarWithFlags(overrides: FeatureFlagOverrides) {
+  const client = new QueryClient()
+  client.setQueryData(['feature-flags'], overrides)
+  return render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        <FeatureFlagsProvider>
+          <AdminSidebar />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
 describe('AdminSidebar', () => {
   it('renders the overview + revenue links with admin.nav labels', () => {
     renderSidebar()
@@ -46,6 +67,17 @@ describe('AdminSidebar', () => {
   it('renders a Back to site link to the marketplace home so the admin can leave the portal', () => {
     renderSidebar()
     expect(screen.getByText('Back to site').closest('a')).toHaveAttribute('data-to', '/$locale')
+  })
+
+  it('shows the template library link when the shared catalog is on (default)', () => {
+    // No provider -> SHARED_CATALOG floors to its registry serverDefault (ON), #1437.
+    const { container } = renderSidebar()
+    expect(container.querySelector(TEMPLATES_LINK)).not.toBeNull()
+  })
+
+  it('hides the template library link when the shared catalog is switched off (#1437)', () => {
+    const { container } = renderSidebarWithFlags({ SHARED_CATALOG: false })
+    expect(container.querySelector(TEMPLATES_LINK)).toBeNull()
   })
 
   it('marks its root with data-admin-sidebar so the global nav is suppressed', () => {

--- a/packages/web/tests/vite/operator-add-ons/AddOnForm.test.tsx
+++ b/packages/web/tests/vite/operator-add-ons/AddOnForm.test.tsx
@@ -30,6 +30,22 @@ describe('AddOnForm', () => {
       expect(screen.getByRole('option', { name: 'ETC card' })).toBeInTheDocument()
     })
 
+    it('hides the picker and forces the custom path when the shared catalog is off (#1437)', () => {
+      render(
+        <AddOnForm
+          mode="create"
+          templates={templates}
+          sharedCatalogEnabled={false}
+          onSubmit={vi.fn()}
+        />,
+      )
+      // No picker, no template-vs-custom toggle: self-author is the only path.
+      expect(screen.queryByLabelText('form.template')).not.toBeInTheDocument()
+      expect(screen.queryByText('form.identityTemplate')).not.toBeInTheDocument()
+      // The custom English-name field is shown instead.
+      expect(screen.getByLabelText('form.nameEn')).toBeInTheDocument()
+    })
+
     it('submits the picked templateId with priceJpy as a number (valueAsNumber coercion)', async () => {
       const onSubmit = vi.fn().mockResolvedValue(undefined)
       const user = userEvent.setup()


### PR DESCRIPTION
Slice 2 of 3 for #1437 (operator-authored catalog items + shared-catalog kill-switch). Follows slice 1 (operator self-authored add-ons, #1445). Design: \`docs/plans/2026-07-03-operator-custom-items-and-catalog-killswitch.md\`.

## What

Adds a platform kill-switch, \`SHARED_CATALOG\`, that turns off the shared add-on template catalog. When off, operators must self-author add-ons (the escape hatch from slice 1); the picker and platform template library disappear.

## How

- **Registry (`@kuruma/shared`).** New `SHARED_CATALOG` flag typed as a `serverOnly` entry (`serverDefault: true`) — it has no `VITE_FEATURE_*` build-time env; the API owns it and the web floors to `serverDefault`. Registry retyped `Record<Key, FeatureFlagEntry>` so indexed `.env` access stays uniform.
- **API enforcement.** `FeatureFlagsService.isEnabled(key)` is the single server-side seam (admin override wins, else registry `serverDefault`). `AddOnTemplateService.listForPicker` returns `[]` when off; `AddOnService.create` returns **422** (well-formed, authorized, catalog just disabled) if a `templateId` is picked while off. Both services take a `() => Promise<boolean>` thunk defaulting to `true` (fail-OPEN) so existing callers/tests are untouched; the composition root injects the real flag-backed thunk.
- **Web surface.** `resolveFeatureFlag` floors `serverOnly` keys to `serverDefault` on every fail-safe path. `AdminSidebar` hides the template-library link; `AddOnForm` hides the picker + identity toggle and forces the self-author path in CREATE when off (EDIT unaffected).

## Verification

- `tsc --noEmit` ×3 (shared/api/web) clean
- API import boundaries + web module boundaries clean
- Tests: shared 9/9, api 37/37 (incl. an end-to-end wired-route test proving the composed app empties the picker at 200 and rejects a template pick at 422), web 26/26 — **72 passing**

## Scope

`Refs #1437` (non-closing — epic stays open for slice 3: insurance purely self-authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)