### PR TITLE
feat(#1448): vehicle review list on the reservation dates step

### DIFF
--- a/packages/web/src/vite/reservation/ReservationWizard.test.tsx
+++ b/packages/web/src/vite/reservation/ReservationWizard.test.tsx
@@ -1,0 +1,172 @@
+import { FeatureFlagsProvider } from '@/vite/config'
+import type { AvailableVehicleData } from '@/vite/storefronts/api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// Repo test pattern (AvailableVehicleCard): the summary bar's first-step "back to
+// listing" affordance is a router <Link>, which needs no RouterProvider once mocked
+// to a plain anchor. Only the dates step renders a Link, so this is all we need.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: ReactNode }) => <a href="#link">{children}</a>,
+}))
+
+import { ReservationWizard } from './ReservationWizard'
+import type { ReservationSubject } from './subject'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllEnvs()
+})
+
+const vehicle: AvailableVehicleData = {
+  id: 'v1',
+  classId: 'c1',
+  name: 'Toyota Aqua',
+  make: 'Toyota',
+  model: 'Aqua',
+  year: 2024,
+  seats: 5,
+  luggageCapacity: 2,
+  luggageSize: 'MEDIUM',
+  transmission: 'AUTO',
+  acrissCode: 'CDMR',
+  classLabel: 'Compact',
+  dailyRateJpy: 8000,
+  hourlyRateJpy: 1200,
+  photos: ['veh-front.jpg'],
+}
+const specificSubject: ReservationSubject = { kind: 'SPECIFIC', vehicle }
+const comboSubject: ReservationSubject = {
+  kind: 'CLASS_COMBO',
+  offering: {
+    kind: 'CLASS_COMBO',
+    location: {
+      locationId: 'loc1',
+      operatorId: 'op1',
+      operatorName: 'Osaka Cars',
+      name: 'Namba Store',
+      address: '1-1 Namba',
+      latitude: null,
+      longitude: null,
+    },
+    dailyRateJpy: 6000,
+    hourlyRateJpy: null,
+    classLabel: 'Economy',
+    acrissCode: 'ECMR',
+    seats: 4,
+    photos: ['class-eco.jpg'],
+    classId: 'class-eco',
+    availableCount: 3,
+  },
+}
+
+// A distinctive comment so its presence unambiguously proves the vehicle review
+// list rendered data fetched from the vehicle endpoint (not the heading alone).
+const REVIEW_COMMENT = 'Impeccable little kei car'
+const reviewPage = {
+  success: true,
+  data: {
+    reviews: [
+      {
+        id: 'rev1',
+        overall: 5,
+        subRatings: {},
+        comment: REVIEW_COMMENT,
+        publishedAt: '2026-06-02T03:00:00.000Z',
+        reviewerFirstName: 'Jack',
+      },
+    ],
+    nextCursor: null,
+  },
+}
+
+function renderWizard(subject: ReservationSubject, reviewsEnabled: boolean) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['feature-flags'], { REVIEWS: reviewsEnabled })
+  return render(
+    <QueryClientProvider client={client}>
+      <IntlProvider locale="en" messages={en}>
+        <FeatureFlagsProvider>
+          <ReservationWizard
+            locale="en"
+            subject={subject}
+            locationId="loc1"
+            addOns={[]}
+            insuranceOptions={[]}
+            from={new Date('2026-08-01T10:00:00+09:00')}
+            to={new Date('2026-08-03T10:00:00+09:00')}
+          />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ReservationWizard vehicle reviews (#1448)', () => {
+  it('renders the picked car reviews on the dates step and reads the VEHICLE endpoint', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(reviewPage))
+    renderWizard(specificSubject, true)
+
+    expect(await screen.findByText(REVIEW_COMMENT)).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/api/reviews/for/vehicles/v1')
+  })
+
+  it('never fetches or renders vehicle reviews for a CLASS_COMBO subject (operator assigns the car later)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(reviewPage))
+    renderWizard(comboSubject, true)
+
+    // The class-combo has no concrete car, so there is nothing to review yet.
+    await waitFor(() => expect(screen.getByText('Economy')).toBeInTheDocument())
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.queryByText(REVIEW_COMMENT)).toBeNull()
+  })
+
+  it('stays silent (no fetch, no list) when the REVIEWS flag is off', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(reviewPage))
+    renderWizard(specificSubject, false)
+
+    await waitFor(() => expect(screen.getByText('Toyota Aqua')).toBeInTheDocument())
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.queryByText(REVIEW_COMMENT)).toBeNull()
+  })
+
+  it('injects no empty reviews block when the picked car has no reviews yet', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { reviews: [], nextCursor: null } }),
+    )
+    renderWizard(specificSubject, true)
+
+    // A concrete no-review anchor proves the empty query RESOLVED into the tree (so a
+    // passing "absent" assertion can't be a render-timing false negative): the car name
+    // from the dates step is always present once mounted.
+    expect(await screen.findByText('Toyota Aqua')).toBeInTheDocument()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/reviews/for/vehicles/v1'))
+    // Let the resolved empty page flush through react-query's state update.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // A zero-review car must not drop a "No reviews yet" placeholder into the booking
+    // flow — that empty state belongs on the storefront browse page, not mid-checkout.
+    expect(screen.queryByText(en.reviews.list.empty)).toBeNull()
+  })
+
+  it('shows the reviews on the dates step only — advancing to extras hides them', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(reviewPage))
+    renderWizard(specificSubject, true)
+
+    expect(await screen.findByText(REVIEW_COMMENT)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: en.reservation.nav.continue }))
+    expect(screen.queryByText(REVIEW_COMMENT)).toBeNull()
+  })
+})

--- a/packages/web/src/vite/reservation/ReservationWizard.tsx
+++ b/packages/web/src/vite/reservation/ReservationWizard.tsx
@@ -1,7 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { formatJstDateTimeLocal } from '@/lib/datetime'
 import type { CreateBookingDraft } from '@/vite/bookings/api'
+import { useFeatureFlag } from '@/vite/config'
+import { ReviewList, vehicleReviewsInfiniteQueryOptions } from '@/vite/reviews'
 import { carryForwardFilters } from '@/vite/storefronts/params'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ArrowLeft } from 'lucide-react'
 import { useState } from 'react'
@@ -57,12 +60,28 @@ export function ReservationWizard({
   region,
 }: ReservationWizardProps) {
   const t = useTranslations('reservation')
+  const reviewsEnabled = useFeatureFlag('REVIEWS')
   const [stepIndex, setStepIndex] = useState(0)
   const [selectedAddOnIds, setSelectedAddOnIds] = useState<string[]>([])
   const [insuranceOptionId, setInsuranceOptionId] = useState<string | null>(null)
   // One key per wizard mount so a double-tap on Reserve replays the same booking
   // (server idempotency) instead of racing the exclusion constraint into a 409.
   const [idempotencyKey] = useState(() => crypto.randomUUID())
+
+  // #1448: a concrete car has published reviews to show; a class-combo has no car
+  // assigned yet, so there is nothing to review. The query stays disabled (never
+  // fetches) unless the subject is SPECIFIC and the REVIEWS flag is on.
+  const vehicleId = subject.kind === 'SPECIFIC' ? subject.vehicle.id : null
+  const {
+    data: reviewPages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    ...vehicleReviewsInfiniteQueryOptions(vehicleId ?? ''),
+    enabled: reviewsEnabled && vehicleId !== null,
+  })
+  const vehicleReviews = reviewPages?.pages.flatMap((page) => page.reviews)
 
   const step: Step = STEPS[stepIndex] ?? 'dates'
   const display = subjectDisplay(subject)
@@ -134,7 +153,24 @@ export function ReservationWizard({
       </header>
 
       {step === 'dates' ? (
-        <DateRangeStep locale={locale} vehicleName={display.label} from={from} to={to} />
+        <>
+          <DateRangeStep locale={locale} vehicleName={display.label} from={from} to={to} />
+          {/* #1448: the picked car's public reviews, on the orient step only — hidden
+              once the renter moves on to extras/insurance/payment. ReviewList also
+              self-gates on the REVIEWS flag, so this is double-sealed. Skipped entirely
+              when the car has no reviews yet: the storefront browse page shows an empty
+              state, but a "No reviews yet" placeholder is just noise mid-checkout. */}
+          {vehicleId !== null && vehicleReviews !== undefined && vehicleReviews.length > 0 ? (
+            <ReviewList
+              reviews={vehicleReviews}
+              hasMore={hasNextPage}
+              onLoadMore={() => {
+                void fetchNextPage()
+              }}
+              isLoadingMore={isFetchingNextPage}
+            />
+          ) : null}
+        </>
       ) : null}
       {step === 'addOns' ? (
         <AddOnsStep addOns={addOns} selectedIds={selectedAddOnIds} onToggle={toggleAddOn} />

--- a/packages/web/src/vite/reviews/api.test.ts
+++ b/packages/web/src/vite/reviews/api.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchAggregates,
   fetchOperatorReviews,
+  fetchVehicleReviews,
   operatorReviewsInfiniteQueryOptions,
   reviewAggregatesQueryOptions,
+  vehicleReviewsInfiniteQueryOptions,
 } from './api'
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -130,6 +132,66 @@ describe('operatorReviewsInfiniteQueryOptions', () => {
   it('stops paging when a page returns nextCursor null', () => {
     const opts = operatorReviewsInfiniteQueryOptions('op1')
     // A null nextCursor tells react-query there is no further page (hasNextPage=false).
+    expect(
+      opts.getNextPageParam({ reviews: [sampleReview], nextCursor: null }, [], null, []),
+    ).toBeNull()
+  })
+})
+
+// #1448: the vehicle reader mirrors the operator reader against a different subject
+// path segment. Same wire shape (public review page), same cursor semantics — the only
+// things that MUST differ are the URL segment and the cache-key subject, so those are
+// what the assertions pin.
+describe('fetchVehicleReviews (#1448)', () => {
+  it('parses the {reviews, nextCursor} page from the data envelope', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { reviews: [sampleReview], nextCursor: 'TOK' } }),
+    )
+    const result = await fetchVehicleReviews('veh1')
+    expect(result).toEqual({ reviews: [sampleReview], nextCursor: 'TOK' })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/reviews/for/vehicles/veh1')
+  })
+
+  it('appends the ?after cursor (url-encoded) when paging', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { reviews: [], nextCursor: null } }),
+    )
+    await fetchVehicleReviews('veh1', 'a+b/c=')
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/reviews/for/vehicles/veh1?after=a%2Bb%2Fc%3D')
+  })
+
+  it('omits ?after entirely for the first page (null cursor)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { reviews: [], nextCursor: null } }),
+    )
+    await fetchVehicleReviews('veh1', null)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/reviews/for/vehicles/veh1')
+  })
+
+  it('throws ParseError when a review field is dropped (seam parse)', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ success: true, data: { reviews: [{ id: 'r1' }], nextCursor: null } }),
+    )
+    await expect(fetchVehicleReviews('veh1')).rejects.toThrow(ParseError)
+  })
+})
+
+describe('vehicleReviewsInfiniteQueryOptions (#1448)', () => {
+  it('keys the cache under the vehicle subject + id so it never collides with the operator list', () => {
+    const opts = vehicleReviewsInfiniteQueryOptions('veh_abc')
+    expect(opts.queryKey).toEqual(['reviews', 'list', 'vehicles', 'veh_abc'])
+  })
+
+  it('starts with no cursor and advances the page param via nextCursor', () => {
+    const opts = vehicleReviewsInfiniteQueryOptions('veh1')
+    expect(opts.initialPageParam).toBeNull()
+    expect(
+      opts.getNextPageParam({ reviews: [sampleReview], nextCursor: 'NEXT' }, [], null, []),
+    ).toBe('NEXT')
+  })
+
+  it('stops paging when a page returns nextCursor null', () => {
+    const opts = vehicleReviewsInfiniteQueryOptions('veh1')
     expect(
       opts.getNextPageParam({ reviews: [sampleReview], nextCursor: null }, [], null, []),
     ).toBeNull()

--- a/packages/web/src/vite/reviews/api.ts
+++ b/packages/web/src/vite/reviews/api.ts
@@ -187,25 +187,45 @@ export type PublicReviewDto = z.infer<typeof publicReviewDtoSchema>
 
 // One page of reviews + the opaque keyset cursor for the next (#1449). `nextCursor` is
 // required (null on the last page) so a dropped field fails at the seam, not as a silent
-// "no more pages" that would truncate the list.
-const operatorReviewPageSchema = z.object({
+// "no more pages" that would truncate the list. Subject-agnostic: the operator (#1449) and
+// vehicle (#1448) lists share this exact wire shape — only the URL segment + cache key differ.
+const reviewPageSchema = z.object({
   reviews: z.array(publicReviewDtoSchema),
   nextCursor: z.string().nullable(),
 })
 
-/** A page of the public operator review list. */
-export type OperatorReviewPage = z.infer<typeof operatorReviewPageSchema>
+/** A page of a public review list (operator or vehicle subject). */
+export type ReviewPage = z.infer<typeof reviewPageSchema>
 
 /** GET /reviews/for/operators/:id[?after=cursor] — public, anonymous (no credentials).
  *  `after` is the opaque token from a previous page's nextCursor; omit for the first page. */
 export async function fetchOperatorReviews(
   operatorId: string,
   after?: string | null,
-): Promise<OperatorReviewPage> {
-  const base = `${getApiBaseUrl()}/reviews/for/operators/${encodeURIComponent(operatorId)}`
+): Promise<ReviewPage> {
+  return fetchSubjectReviews('operators', operatorId, after)
+}
+
+/** GET /reviews/for/vehicles/:id[?after=cursor] — public, anonymous (#1448). Mirrors the
+ *  operator reader against the VEHICLE subject path the API already serves. */
+export async function fetchVehicleReviews(
+  vehicleId: string,
+  after?: string | null,
+): Promise<ReviewPage> {
+  return fetchSubjectReviews('vehicles', vehicleId, after)
+}
+
+/** Shared fetch for the public per-subject review list. The subject is a fixed URL
+ *  segment (`operators` | `vehicles`), never user input, so it needs no encoding. */
+async function fetchSubjectReviews(
+  subject: 'operators' | 'vehicles',
+  id: string,
+  after?: string | null,
+): Promise<ReviewPage> {
+  const base = `${getApiBaseUrl()}/reviews/for/${subject}/${encodeURIComponent(id)}`
   const url = after ? `${base}?after=${encodeURIComponent(after)}` : base
   const res = await fetch(url)
-  return unwrap(res, operatorReviewPageSchema)
+  return unwrap(res, reviewPageSchema)
 }
 
 /** Infinite ("load more") query over the operator review list (#1449). The page param IS
@@ -215,6 +235,17 @@ export function operatorReviewsInfiniteQueryOptions(operatorId: string) {
   return infiniteQueryOptions({
     queryKey: ['reviews', 'list', 'operators', operatorId] as const,
     queryFn: ({ pageParam }) => fetchOperatorReviews(operatorId, pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  })
+}
+
+/** Infinite ("load more") query over a vehicle's review list (#1448). Keyed under the
+ *  `vehicles` subject so it can never collide with the same-shaped operator list. */
+export function vehicleReviewsInfiniteQueryOptions(vehicleId: string) {
+  return infiniteQueryOptions({
+    queryKey: ['reviews', 'list', 'vehicles', vehicleId] as const,
+    queryFn: ({ pageParam }) => fetchVehicleReviews(vehicleId, pageParam),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
   })

--- a/packages/web/src/vite/reviews/index.ts
+++ b/packages/web/src/vite/reviews/index.ts
@@ -10,9 +10,10 @@ export {
   type AggregateMap,
   type AggregateSubjectKind,
   operatorReviewsInfiniteQueryOptions,
-  type OperatorReviewPage,
   type PublicReviewDto,
   renterReviewedSubjects,
+  type ReviewPage,
   reviewAggregatesQueryOptions,
   reviewsForBookingQueryOptions,
+  vehicleReviewsInfiniteQueryOptions,
 } from './api'


### PR DESCRIPTION
## What

Wires the public vehicle-review read path (`GET /reviews/for/vehicles/:id`, shipped with #1067) into the web. It had no consumer, so it was API-only and untested end-to-end. Renders the shared `<ReviewList>` for the picked car on the reservation flow, flag-gated by `VITE_FEATURE_REVIEWS`.

## Why the reservation flow

There is **no standalone vehicle page** in the renter web today (only operator and class aggregates are consumed anywhere). The reservation flow (`/bookings/new?vehicleId=` → `ReservationWizard`, `subject.kind === 'SPECIFIC'`) is the only renter-facing single-vehicle surface, so the reviews live there — on the **dates step only** (the orient step), hidden once the renter moves on to extras/insurance/payment. A `CLASS_COMBO` has no assigned car yet, so it shows nothing.

## Changes

- **`reviews/api`**: `fetchVehicleReviews` + `vehicleReviewsInfiniteQueryOptions`, mirroring the operator reader (incl. load-more). Folds the page schema/type to a subject-agnostic `ReviewPage` via a shared `fetchSubjectReviews` helper so the operator/vehicle lists can't drift. `OperatorReviewPage` was internal-only (no component consumed it).
- **`ReservationWizard`**: renders the list on the dates step for a SPECIFIC subject; the query stays disabled (no fetch) for CLASS_COMBO or flag-off. The section is skipped entirely when the car has zero reviews — a "No reviews yet" placeholder is browse-page copy, not booking-flow copy.
- No migration, no API change, no new i18n keys (reuses the existing `reviews.list.*` block).

## Test plan

- `reviews/api.test.ts` (+7): vehicle reader hits `/reviews/for/vehicles/:id`, url-encodes `?after`, `ParseError` on a dropped field; infinite-query key `['reviews','list','vehicles',id]` + cursor advance/stop.
- `ReservationWizard.test.tsx` (new, 5): SPECIFIC + flag on renders reviews and reads the vehicle endpoint; CLASS_COMBO and flag-off make **zero** fetches and render nothing; zero-review car injects no empty block; reviews are dates-step-only (gone after advancing).
- Verified green: web `tsc`, full web suite (2128 tests), i18n parity (1533 keys × 3 locales), biome, module-boundaries (no new reach-in — imports via the `@/vite/reviews` barrel), file-size. Code-reviewed (no CRITICAL/HIGH/MEDIUM; the one actionable LOW — empty-state mid-checkout — is folded in).

Closes #1448
Refs #1067