### PR TITLE
fix(#1277): block re-mint when email holds a pending invite at another operator

### DIFF
--- a/packages/api/src/services/operator-application.test.ts
+++ b/packages/api/src/services/operator-application.test.ts
@@ -445,6 +445,44 @@ describe('OperatorApplicationService.approve', () => {
       expect(err).toBeInstanceOf(ConflictError)
       expect(err instanceof Error ? err.message : '').toMatch(/already has an operator/)
     })
+
+    it('C1 — refuses re-mint when the email holds a pending invite at another operator', async () => {
+      const { service, repos } = setupApprove()
+      const { id } = await repos.applications.create(base)
+      const approved = await service.approve(id, 'admin-1')
+
+      // The original owner link is lost, so this operator has no live invite left...
+      const own = [...repos.inviteStore.values()].find(
+        (i) => i.operatorId === approved.operatorId && i.status === 'PENDING',
+      )
+      await repos.invites.revoke(own!.id, approved.operatorId)
+      // ...but the same email now holds a live pending invite at a DIFFERENT operator.
+      const other = await repos.operators.create({
+        name: 'Other Co',
+        slug: 'other-co',
+        preAuthHandoffUrl: null,
+      })
+      await repos.invites.create({
+        email: base.contactEmail,
+        operatorId: other.id,
+        role: 'OPERATOR_OWNER',
+        tokenHash: 'deadbeef'.repeat(8),
+        status: 'PENDING',
+        expiresAt: new Date(Date.now() + 86_400_000),
+        invitedByUserId: 'some-admin',
+        acceptedByUserId: null,
+      })
+
+      // findPendingByEmail is cross-operator but revoke is operator-scoped: without the
+      // C1 check the scoped revoke no-ops and a second live invite is minted (#1277).
+      const err = await service.remintInvite(id, 'admin-2').catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(ConflictError)
+      expect(err instanceof Error ? err.message : '').toMatch(/invited/)
+      // The other operator's invite is untouched and NO duplicate was minted.
+      const pending = [...repos.inviteStore.values()].filter((i) => i.status === 'PENDING')
+      expect(pending).toHaveLength(1)
+      expect(pending[0]?.operatorId).toBe(other.id)
+    })
   })
 })
 

--- a/packages/api/src/services/operator-application.ts
+++ b/packages/api/src/services/operator-application.ts
@@ -247,10 +247,18 @@ export class OperatorApplicationService {
         if (existingUser && (await repos.memberships.findActiveByUserId(existingUser.id))) {
           throw new ConflictError('this email already has an operator')
         }
-        // Revoke the stale PENDING invite (this operator's) so the partial-unique
-        // (operatorId,email) index admits the replacement; then mint the new one.
+        // Revoke the stale PENDING invite so the partial-unique (operatorId,email)
+        // index admits the replacement; then mint the new one. findPendingByEmail is
+        // cross-operator (the C1 guard), but revoke is operator-scoped — so a pending
+        // invite owned by ANOTHER operator must block here (mirroring approve()'s C1),
+        // not silently no-op the revoke and leave two live invites for the email (#1277).
         const pending = await repos.invites.findPendingByEmail(email)
-        if (pending) await repos.invites.revoke(pending.id, operatorId)
+        if (pending) {
+          if (pending.operatorId !== operatorId) {
+            throw new ConflictError('this email is already invited to an operator')
+          }
+          await repos.invites.revoke(pending.id, operatorId)
+        }
         const invite = buildProviderInviteRecord(minted, {
           email,
           operatorId,


### PR DESCRIPTION
Fixes a P2 surfaced in the pre-promotion review of #1466.

## Problem
`remintInvite` (operator-application.ts) used a **cross-operator** `findPendingByEmail(email)` but an **operator-scoped** `revoke(pending.id, operatorId)`, and the pending-invite unique index is partial on `(operatorId, email)`. So when the found pending invite belongs to a *different* operator, the revoke silently no-ops and the create for the approved operator still succeeds — leaving **two live pending invites for one email**, violating the C1 invariant that `approve()` enforces via `assertEmailUnclaimed`.

Reachable (narrow) path: operator A approved (pending A/X) → A's link lost/expired → operator B mints an ordinary pending invite for X (normal invite path has no cross-operator guard; the DB index permits it) → `remintInvite(A)` finds B's invite, no-ops the revoke, and mints a duplicate.

## Fix
When the found pending invite belongs to another operator, throw `ConflictError` (mirroring `approve()`'s C1, same message). Only revoke same-operator stale invites.

## Test plan
- [x] New failing test reproduced the duplicate mint (RED): `C1 — refuses re-mint when the email holds a pending invite at another operator`
- [x] Full `operator-application.test.ts` — 21/21 pass (GREEN, no regressions)
- [x] `tsc --noEmit` (api) clean
- [x] `lint:boundaries` OK

Should merge into develop before #1466 (develop → beta) is merged, so the promotion carries the fix.