### PR TITLE
feat(#1349): keyboard + ARIA a11y on the FleetTimeline bars

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -293,6 +293,11 @@
             "empty": "No floats awaiting assignment",
             "overflowLabel": "At least {limit} awaiting assignment (showing the first {limit})"
           }
+        },
+        "board": {
+          "label": "Fleet planning board, {range}",
+          "bookingBar": "{vehicle}. Booking: {renter}, {status}, {range}",
+          "blockBar": "{vehicle}. {kind} block: {title}, {range}"
         }
       },
       "detail": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -293,6 +293,11 @@
             "empty": "未割当のフロート予約はありません",
             "overflowLabel": "少なくとも{limit}件が割当待ち（先頭{limit}件を表示）"
           }
+        },
+        "board": {
+          "label": "配車ボード、{range}",
+          "bookingBar": "{vehicle}。予約: {renter}、{status}、{range}",
+          "blockBar": "{vehicle}。{kind}ブロック: {title}、{range}"
         }
       },
       "detail": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -293,6 +293,11 @@
             "empty": "暂无待分配的浮动预订",
             "overflowLabel": "至少 {limit} 项待分配（仅显示前 {limit} 项）"
           }
+        },
+        "board": {
+          "label": "车队排期板，{range}",
+          "bookingBar": "{vehicle}。预订：{renter}，{status}，{range}",
+          "blockBar": "{vehicle}。{kind}封锁：{title}，{range}"
         }
       },
       "detail": {

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { createEvent, fireEvent, render, screen } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
@@ -138,5 +138,69 @@ describe('FleetTimeline', () => {
     fireEvent.mouseUp(bar as Element)
     expect(onSelectBlock).toHaveBeenCalledWith(blk)
     expect(onSelectEvent).not.toHaveBeenCalled()
+  })
+})
+
+// #1349: the board was mouse-only (no keyboard/ARIA on bars), gating the GA flag
+// flip. Each interactive bar is now a focusable, screen-reader-labelled button that
+// opens the same detail on Enter/Space that a click opens; the whole board is a
+// labelled region. The pure timeline-layout tests pin WHICH bars are interactive
+// (one stop per booking); these pin how the shell renders that.
+describe('FleetTimeline keyboard + ARIA (#1349)', () => {
+  it('exposes a booking bar as a button naming the vehicle, renter, and status', () => {
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })])
+    expect(
+      screen.getByRole('button', { name: /Corolla\. Booking: Alice, Confirmed/ }),
+    ).toBeInTheDocument()
+  })
+
+  it('opens the booking on Enter — keyboard parity with click', () => {
+    const onSelectEvent = vi.fn()
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })], { onSelectEvent })
+    fireEvent.keyDown(screen.getByRole('button', { name: /Booking: Alice/ }), { key: 'Enter' })
+    expect(onSelectEvent).toHaveBeenCalledWith('b1')
+  })
+
+  it('activates on Space and prevents the default page scroll', () => {
+    const onSelectEvent = vi.fn()
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })], { onSelectEvent })
+    const bar = screen.getByRole('button', { name: /Booking: Alice/ })
+    const ev = createEvent.keyDown(bar, { key: ' ' })
+    fireEvent(bar, ev)
+    expect(ev.defaultPrevented).toBe(true)
+    expect(onSelectEvent).toHaveBeenCalledWith('b1')
+  })
+
+  it('exposes a scheduled block as a button and opens the block (not a trip) on Enter', () => {
+    const onSelectEvent = vi.fn()
+    const onSelectBlock = vi.fn()
+    const blk = block({ id: 'blk7', title: 'Bodywork', reason: 'Bodywork', kind: 'MAINTENANCE' })
+    renderTimeline([], { blocks: [blk], onSelectEvent, onSelectBlock })
+    fireEvent.keyDown(
+      screen.getByRole('button', { name: /Corolla\. Maintenance block: Bodywork/ }),
+      { key: 'Enter' },
+    )
+    expect(onSelectBlock).toHaveBeenCalledWith(blk)
+    expect(onSelectEvent).not.toHaveBeenCalled()
+  })
+
+  it('makes a booking exactly one keyboard stop, aria-hiding the redundant turnaround tail', () => {
+    // Booked + tail both in-window: the booked band is the sole button; the tail bar
+    // still renders for mouse users but is removed from the a11y tree (no second stop).
+    renderTimeline([
+      row({
+        id: 'b1',
+        renterName: 'Alice',
+        endAt: '2026-07-04T09:00:00.000Z',
+        effectiveEndAt: '2026-07-04T15:00:00.000Z',
+      }),
+    ])
+    expect(screen.getAllByRole('button', { name: /Booking: Alice/ })).toHaveLength(1)
+    expect(document.querySelector('.rct-item[aria-hidden="true"]')).not.toBeNull()
+  })
+
+  it('labels the whole board as a region for screen-reader navigation', () => {
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })])
+    expect(screen.getByRole('region', { name: /Fleet planning board/ })).toBeInTheDocument()
   })
 })

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -16,7 +16,7 @@ import {
   buildTimelineLayout,
 } from '@/vite/operator-bookings/timeline-layout'
 import { addDays, startOfDay } from 'date-fns'
-import { useCallback, useMemo } from 'react'
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useMemo } from 'react'
 import Timeline, {
   type Id,
   type TimelineGroupBase,
@@ -34,9 +34,15 @@ import './fleet-timeline-theme.css'
 //
 // react-calendar-timeline is pinned to 0.30.0-beta.18 ON PURPOSE (#1330): no stable release
 // supports React 19 (0.28.0, the last stable, is React 16/17 era), so this pre-release is the
-// newest version that exists. Do NOT widen the exact pin or "downgrade to stable". Known a11y
-// gap: the bars are mouse-only (no keyboard/ARIA) — #1349 gates flipping VITE_FEATURE_FLEET_TIMELINE
-// on for GA. Full rationale: docs/2026-07-02-fleet-timeline-lib-pin.md.
+// newest version that exists. Do NOT widen the exact pin or "downgrade to stable". Full
+// rationale: docs/2026-07-02-fleet-timeline-lib-pin.md.
+//
+// A11y (#1349): the lib ships no keyboard/ARIA on its bars, so this shell adds them via each
+// item's `itemProps` — every interactive bar is a focusable role=button with a localized
+// aria-label that opens its detail on Enter/Space (parity with click); the redundant
+// turnaround tail is aria-hidden (one stop per booking, decided in buildTimelineLayout). This
+// closes the GA gate for VITE_FEATURE_FLEET_TIMELINE. Remaining a11y follow-up: roving-tabindex
+// so a dense board is one composite widget rather than N tab stops (deferred, see #1349).
 
 interface FleetTimelineProps {
   readonly rows: readonly CalendarBookingRow[]
@@ -65,6 +71,9 @@ export function FleetTimeline({
   onSelectBlock,
 }: FleetTimelineProps) {
   const t = useTranslations('business.bookings.calendar')
+  // Block kind labels live in a separate namespace (bookings.operator.blocks.kinds),
+  // reused here so a bar's aria-label reads the same localized kind the legend shows.
+  const tBlockKinds = useTranslations('bookings.operator.blocks.kinds')
   const culture = locale === 'zh' ? 'zh-CN' : locale
   // Shares the switcher with BookingsCalendar; the Timeline option follows the same
   // runtime-toggleable flag (#1322) so both views agree on the offered set.
@@ -120,38 +129,25 @@ export function FleetTimeline({
     [layout.groups],
   )
 
-  const items = useMemo<TimelineItemBase<number>[]>(
-    () =>
-      layout.items.map((it) => ({
-        id: it.id,
-        group: it.group,
-        title: it.title,
-        // #1250: faux-local so the bar lands at its Tokyo wall clock on the local axis.
-        start_time: instantToJstFauxLocal(new Date(it.start)).getTime(),
-        end_time: instantToJstFauxLocal(new Date(it.end)).getTime(),
-        canMove: false,
-        canResize: false,
-        // #1244: a booking bar wears its status color (+ dashed turnaround tail); a
-        // block bar wears its kind band so it never reads as a booking.
-        className:
-          it.type === 'block'
-            ? BLOCK_KIND_CLASS[it.kind]
-            : `${STATUS_CLASS[it.status]}${it.band === 'turnaround' ? ' fleet-bar--turnaround' : ''}`,
-      })),
-    [layout.items],
+  // Vehicle (row) title by group id — a bar's aria-label leads with the car, the
+  // board's primary axis, since the sidebar row label is not linked to the bar.
+  const groupTitleById = useMemo(
+    () => new Map(layout.groups.map((g) => [g.id, g.title] as const)),
+    [layout.groups],
   )
 
-  const handleNavigate = useCallback(
-    (action: 'PREV' | 'NEXT' | 'TODAY') => {
-      if (action === 'TODAY') {
-        // #1250: the JST calendar day (see BookingsCalendar) — off-JST the browser-local
-        // day can differ from the Tokyo day the operator plans in.
-        onDateChange(todayInJst())
-        return
-      }
-      onDateChange(shiftCalendarDate('timeline', date, action === 'PREV' ? -1 : 1))
-    },
-    [date, onDateChange],
+  // A bar's aria-label reads the Tokyo wall clock (#1250) straight off the true
+  // instant, so a screen reader announces the same times the axis shows on any tz.
+  const barRangeFmt = useMemo(
+    () =>
+      new Intl.DateTimeFormat(culture, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: 'Asia/Tokyo',
+      }),
+    [culture],
   )
 
   // The lib hands back only the clicked bar's id, not the item, so we recover the
@@ -175,6 +171,79 @@ export function FleetTimeline({
     [blockById, onSelectBlock, onSelectEvent],
   )
 
+  // #1349 keyboard parity: Enter or Space opens the same detail a click opens. Space
+  // is preventDefault'd so it never scrolls the page; every other key bubbles (Tab
+  // still moves focus between bars). Emulating both keys on keydown is the accepted
+  // APG simplification for a button-role element.
+  const handleItemKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>, itemId: string) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return
+      e.preventDefault()
+      handleItemSelect(itemId)
+    },
+    [handleItemSelect],
+  )
+
+  const items = useMemo<TimelineItemBase<number>[]>(
+    () =>
+      layout.items.map((it) => {
+        const vehicle = groupTitleById.get(it.group) ?? it.group
+        const range = `${barRangeFmt.format(it.start)} - ${barRangeFmt.format(it.end)}`
+        const label =
+          it.type === 'block'
+            ? t('board.blockBar', { vehicle, kind: tBlockKinds(it.kind), title: it.title, range })
+            : t('board.bookingBar', {
+                vehicle,
+                renter: it.title,
+                status: t(`sidebar.statuses.${it.status}`),
+                range,
+              })
+        return {
+          id: it.id,
+          group: it.group,
+          title: it.title,
+          // #1250: faux-local so the bar lands at its Tokyo wall clock on the local axis.
+          start_time: instantToJstFauxLocal(new Date(it.start)).getTime(),
+          end_time: instantToJstFauxLocal(new Date(it.end)).getTime(),
+          canMove: false,
+          canResize: false,
+          // #1244: a booking bar wears its status color (+ dashed turnaround tail); a
+          // block bar wears its kind band so it never reads as a booking.
+          className:
+            it.type === 'block'
+              ? BLOCK_KIND_CLASS[it.kind]
+              : `${STATUS_CLASS[it.status]}${it.band === 'turnaround' ? ' fleet-bar--turnaround' : ''}`,
+          // #1349: an interactive bar is a focusable, labelled button that opens its
+          // detail on Enter/Space (parity with click). A suppressed turnaround tail is
+          // taken out of the a11y tree (aria-hidden + non-focusable) so a keyboard user
+          // never lands on two bars for one booking; a mouse click on it still works.
+          itemProps: it.interactive
+            ? {
+                role: 'button',
+                tabIndex: 0,
+                'aria-haspopup': 'dialog',
+                'aria-label': label,
+                onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => handleItemKeyDown(e, it.id),
+              }
+            : { 'aria-hidden': true },
+        }
+      }),
+    [layout.items, groupTitleById, barRangeFmt, t, tBlockKinds, handleItemKeyDown],
+  )
+
+  const handleNavigate = useCallback(
+    (action: 'PREV' | 'NEXT' | 'TODAY') => {
+      if (action === 'TODAY') {
+        // #1250: the JST calendar day (see BookingsCalendar) — off-JST the browser-local
+        // day can differ from the Tokyo day the operator plans in.
+        onDateChange(todayInJst())
+        return
+      }
+      onDateChange(shiftCalendarDate('timeline', date, action === 'PREV' ? -1 : 1))
+    },
+    [date, onDateChange],
+  )
+
   // Pin the canvas to the toolbar-driven window: the board is navigated by our
   // toolbar (a 14-day planning span), not free-panned. The lib calls this on any
   // internal pan/zoom; we snap it back so the view stays aligned with the fetch.
@@ -194,21 +263,25 @@ export function FleetTimeline({
         onView={onViewChange}
         views={operatorViews(timelineEnabled)}
       />
-      <Timeline
-        groups={groups}
-        items={items}
-        defaultTimeStart={from}
-        defaultTimeEnd={to}
-        visibleTimeStart={from}
-        visibleTimeEnd={to}
-        onTimeChange={handleTimeChange}
-        onItemSelect={handleItemSelect}
-        onItemClick={handleItemSelect}
-        sidebarWidth={200}
-        lineHeight={44}
-        canMove={false}
-        canResize={false}
-      />
+      {/* #1349: name the whole board as a region so a screen-reader user gets a
+          landmark to jump to and a label for the mouse-only canvas the lib renders. */}
+      <section aria-label={t('board.label', { range: toolbarLabel })}>
+        <Timeline
+          groups={groups}
+          items={items}
+          defaultTimeStart={from}
+          defaultTimeEnd={to}
+          visibleTimeStart={from}
+          visibleTimeEnd={to}
+          onTimeChange={handleTimeChange}
+          onItemSelect={handleItemSelect}
+          onItemClick={handleItemSelect}
+          sidebarWidth={200}
+          lineHeight={44}
+          canMove={false}
+          canResize={false}
+        />
+      </section>
     </div>
   )
 }

--- a/packages/web/src/vite/operator-bookings/fleet-timeline-theme.css
+++ b/packages/web/src/vite/operator-bookings/fleet-timeline-theme.css
@@ -17,6 +17,17 @@
   line-height: 1.3;
 }
 
+/* #1349 keyboard focus: a clear ring on the focused bar so a keyboard user can see
+   which booking/block is active. :focus-visible keeps it keyboard-only (no ring on a
+   mouse click). An outline (not box-shadow) is unaffected by the !important bar
+   backgrounds below and survives forced-colors/high-contrast mode; the raised z-index
+   keeps the ring above adjacent absolutely-positioned bars instead of being clipped. */
+.rct-item:focus-visible {
+  outline: 2px solid oklch(0.45 0.19 264);
+  outline-offset: 2px;
+  z-index: 90;
+}
+
 /* Status-based bar colors — same tokens as the rbc calendar so the two views read
    identically. */
 .rct-item.rbc-event--confirmed {

--- a/packages/web/src/vite/operator-bookings/timeline-layout.test.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-layout.test.ts
@@ -92,6 +92,7 @@ describe('buildTimelineLayout', () => {
         end: Date.UTC(2027, 0, 14),
         band: 'booked',
         status: 'CONFIRMED',
+        interactive: true,
       },
     ])
   })
@@ -146,6 +147,34 @@ describe('buildTimelineLayout', () => {
     const { items: i2 } = build([row({ renterName: null, renterEmail: null })])
     expect(i2[0]?.title).toBe('KUR-1')
   })
+
+  // #1349 a11y: a booking must be exactly ONE keyboard/screen-reader stop. When both
+  // its booked band and turnaround tail render, the booked band is the interactive one
+  // and the tail is suppressed (aria-hidden, non-focusable) so a keyboard user does not
+  // land on two bars that open the same trip.
+  it('marks the booked band interactive and its turnaround tail non-interactive', () => {
+    const { items } = build([row({ effectiveEndAt: iso(2027, 1, 16) })])
+    const booked = items.find((i) => i.type === 'booking' && i.band === 'booked')
+    const tail = items.find((i) => i.type === 'booking' && i.band === 'turnaround')
+    expect(booked?.interactive).toBe(true)
+    expect(tail?.interactive).toBe(false)
+  })
+
+  // But a tail that is its booking's ONLY in-window bar (the booked band was clipped
+  // out before the window) must stay interactive — else the booking is visible on
+  // screen yet unreachable by keyboard, a worse failure than the double-stop.
+  it('keeps a lone surviving turnaround tail interactive (booked band clipped out)', () => {
+    const { items } = build([
+      row({ startAt: iso(2027, 1, 4), endAt: iso(2027, 1, 8), effectiveEndAt: iso(2027, 1, 12) }),
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ band: 'turnaround', interactive: true })
+  })
+
+  it('marks a scheduled block interactive (always its own keyboard stop)', () => {
+    const { items } = build([], FLEET, [block()])
+    expect(items[0]?.interactive).toBe(true)
+  })
 })
 
 describe('buildTimelineLayout blocks', () => {
@@ -161,6 +190,7 @@ describe('buildTimelineLayout blocks', () => {
         start: Date.UTC(2027, 0, 12),
         end: Date.UTC(2027, 0, 14),
         kind: 'MAINTENANCE',
+        interactive: true,
       },
     ])
   })

--- a/packages/web/src/vite/operator-bookings/timeline-layout.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-layout.ts
@@ -42,6 +42,12 @@ interface TimelineItemCommon {
   title: string
   start: number
   end: number
+  /** #1349 a11y: whether this bar is the keyboard/screen-reader stop for its subject.
+   *  A booking is exactly ONE stop — the booked band when it renders, otherwise its
+   *  lone-surviving turnaround tail. A suppressed tail (booked sibling present) is
+   *  `false` so the shell can aria-hide it and drop it from the tab order. Blocks are
+   *  always their own stop. */
+  interactive: boolean
 }
 
 /** A booking bar — status-colored, click-decodes back to its booking. */
@@ -130,6 +136,7 @@ export function buildTimelineLayout({
         end: booked.end,
         band: 'booked',
         status: r.status,
+        interactive: true,
       })
       if (group === UNASSIGNED_GROUP_ID) hasUnassignedRow = true
     }
@@ -150,6 +157,11 @@ export function buildTimelineLayout({
           end: tail.end,
           band: 'turnaround',
           status: r.status,
+          // #1349: the tail is a keyboard/SR stop ONLY when its booked band did not
+          // render (clipped out before the window) — otherwise the booked band is the
+          // single stop and this redundant tail is suppressed. `booked` is truthy iff
+          // that band was pushed above.
+          interactive: !booked,
         })
         if (group === UNASSIGNED_GROUP_ID) hasUnassignedRow = true
       }
@@ -173,6 +185,7 @@ export function buildTimelineLayout({
       start: band.start,
       end: band.end,
       kind: b.kind,
+      interactive: true,
     })
   }
 


### PR DESCRIPTION
Closes #1349

## What & why

The operator fleet planning board (`react-calendar-timeline`) was mouse-only — bars could only be opened by clicking. This blocked the GA flip of `VITE_FEATURE_FLEET_TIMELINE`. This PR makes the bars keyboard- and screen-reader-usable. The flag stays **OFF**; this only unblocks a future flip.

## Key insight

The board is **read-only** (`canMove`/`canResize` = false), so the real gap is *view + select*, not drag. Solved via the library's native per-item `itemProps` hook — no custom item renderer needed.

## Changes

- **`timeline-layout.ts`** (pure): new `interactive` flag — `booked` = true, `block` = true, turnaround `tail` = `!booked` (interactive only when the tail is the booking's lone in-window bar, so a lone-survivor tail stays reachable). One keyboard stop per booking.
- **`FleetTimeline.tsx`**: interactive bar → `role=button`, `tabIndex=0`, `aria-haspopup=dialog`, localized `aria-label` (leads with vehicle name), Enter/Space opens the same detail as click; suppressed tail → `aria-hidden` + non-focusable (avoids the focusable-yet-hidden axe violation). Board wrapped in a labelled `<section>` region.
- **i18n** (`messages/{en,ja,zh}.json`): `board.{label,bookingBar,blockBar}` templates, reusing existing status/kind keys.
- **CSS**: `:focus-visible` ring.

Approach was architect-reviewed before coding (verdict: approve-with-changes, all folded in).

## Verification

- Web typecheck: 0 errors
- Full web suite: **2138/2138 passed**
- Targeted: `timeline-layout` 24, `FleetTimeline` 11, `operator-bookings` 333

## Follow-ups (out of scope)

- Roving-tabindex — a dense board is 100-200 tab stops; architect recommended simple stops now, composite arrow-key nav later.
- Focus-on-date-nav — focus falls to `<body>` on date navigation (the dialog-close path is fine); documented limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)