### PR TITLE
fix: moderation-queue keyset precision + participant-read allowlist (architect-review follow-ups)

### DIFF
--- a/packages/api/src/repositories/drizzle/review.ts
+++ b/packages/api/src/repositories/drizzle/review.ts
@@ -148,14 +148,28 @@ export class DrizzleReviewRepository implements ReviewRepository {
     // unactioned (VISIBLE) and never accumulates HIDDEN rows (#1451) — and (b) keyset-
     // paginate on (lastReportedAt DESC, reviewId DESC). reportCount === distinct reporters
     // (the one-per-reporter unique seal), so the join to reviews doesn't fan out the count.
-    const lastReportedAt = max(reviewReports.createdAt)
+    // Sort key, truncated to MILLISECONDS so the DB-side precision equals the cursor's:
+    // review_reports.createdAt is defaultNow() (MICROSECONDS), but the cursor round-trips
+    // through Date.toISOString() (ms). Comparing a µs aggregate against an ms cursor silently
+    // drops a same-ms/different-µs neighbour on the far side of a page boundary — a reported
+    // review the moderator never sees, so it is never hidden and keeps counting in the public
+    // aggregate. Truncating both sides to ms makes the boundary exact — the lossless round-trip
+    // #1449 gets for free from its JS-Date-written publishedAt. (InMemory can't catch the gap:
+    // its reports stamp ms JS Dates, so it is already lossless.)
+    // `.mapWith` reattaches the createdAt column's date decoder that the raw `date_trunc`
+    // wrapper drops, so the SELECT still returns a JS Date for the cursor (not a raw string).
+    const lastReportedAt = sql`date_trunc('milliseconds', ${max(reviewReports.createdAt)})`.mapWith(
+      reviewReports.createdAt,
+    )
     // Keyset in HAVING (the sort key is an aggregate): strictly past the previous page's
-    // (lastReportedAt, reviewId) boundary in the DESC ordering. The boundary instant is
-    // bound as an explicitly-cast timestamptz STRING, never a raw Date: the left side is an
+    // (lastReportedAt, reviewId) boundary in the DESC ordering. The boundary instant is bound
+    // as an explicitly-cast timestamptz STRING (ms), never a raw Date: the left side is an
     // aggregate expression, not a Column, so drizzle has no column mapper to encode a Date
     // param here — postgres-js rejects the raw Date ("must be of type string"), and neon-http
     // would lean on undocumented Date coercion. `${iso}::timestamptz` binds a string both
-    // drivers serialize identically. (`reviewId` is already text, so it needs no cast.)
+    // drivers serialize identically, and now matches the ms-truncated left side. The reviewId
+    // tiebreak compares under COLLATE "C" so its byte order matches the InMemory JS `<` (mirrors
+    // #1449) — load-bearing here because the ms truncation deliberately increases exact ties.
     const cursorTs = cursor
       ? sql`${cursor.lastReportedAt.toISOString()}::timestamptz`
       : undefined
@@ -163,7 +177,10 @@ export class DrizzleReviewRepository implements ReviewRepository {
       cursor && cursorTs
         ? or(
             lt(lastReportedAt, cursorTs),
-            and(eq(lastReportedAt, cursorTs), lt(reviewReports.reviewId, cursor.reviewId)),
+            and(
+              eq(lastReportedAt, cursorTs),
+              sql`${reviewReports.reviewId} COLLATE "C" < ${cursor.reviewId}`,
+            ),
           )
         : undefined
     const grouped = await this.db
@@ -180,7 +197,7 @@ export class DrizzleReviewRepository implements ReviewRepository {
       .where(eq(reviews.moderationStatus, status))
       .groupBy(reviewReports.reviewId)
       .having(keyset)
-      .orderBy(desc(lastReportedAt), desc(reviewReports.reviewId))
+      .orderBy(desc(lastReportedAt), sql`${reviewReports.reviewId} COLLATE "C" DESC`)
       // Peek one past the page so `nextCursor` is precise (null exactly when exhausted),
       // never handing back a cursor that resolves to an empty page.
       .limit(limit + 1)

--- a/packages/api/src/services/review.test.ts
+++ b/packages/api/src/services/review.test.ts
@@ -382,6 +382,22 @@ describe('ReviewService — double-blind reveal on read', () => {
       status: 403,
     })
   })
+
+  it('projects the participant read to an allowlist so moderation internals never cross the wire', async () => {
+    const { service } = makeHarness()
+    await service.submit(renterCtx, submitInput(), NOW)
+
+    const view = await service.getForBooking(renterCtx, BOOKING_ID, NOW)
+    if (!view.ok) throw new Error('expected ok')
+    const row = view.reviews[0]
+    // Exactly the participant-facing fields. The raw entity would also carry moderatedBy (a
+    // platform admin's userId — a #1086 leak to the very author who was moderated),
+    // moderationStatus, moderatedAt, authorUserId, operatorId, subRatings and the internal
+    // reveal deadline. Pinning the exact key set fails if any of those leak back in.
+    expect(row && Object.keys(row).sort()).toEqual(
+      ['authorRole', 'bookingId', 'comment', 'id', 'overall', 'publishedAt', 'subject'].sort(),
+    )
+  })
 })
 
 describe('ReviewService.submit — reveal on write (#1195)', () => {

--- a/packages/api/src/services/review.ts
+++ b/packages/api/src/services/review.ts
@@ -39,7 +39,35 @@ type Ok<T> = { readonly ok: true } & T
 
 export type SubmitResult = Ok<{ review: Review }> | Fail
 export type EditResult = Ok<{ review: Review }> | Fail
-export type GetReviewsResult = Ok<{ reviews: Review[] }> | Fail
+
+/** The participant-facing projection of a review (#1086 follow-up). The double-blind read
+ *  returns the caller's own rows plus revealed counterparty rows — but the raw entity also
+ *  carries internal moderation state (moderatedBy is a platform admin's userId; moderationStatus
+ *  and moderatedAt are operator/audit-only) plus authorUserId, operatorId and the reveal
+ *  deadline. Allowlist exactly the fields the client reads so none of that crosses the wire. */
+export interface ParticipantReview {
+  readonly id: Review['id']
+  readonly bookingId: Review['bookingId']
+  readonly authorRole: Review['authorRole']
+  readonly subject: Review['subject']
+  readonly overall: Review['overall']
+  readonly comment: Review['comment']
+  readonly publishedAt: Review['publishedAt']
+}
+
+function toParticipantReview(r: Review): ParticipantReview {
+  return {
+    id: r.id,
+    bookingId: r.bookingId,
+    authorRole: r.authorRole,
+    subject: r.subject,
+    overall: r.overall,
+    comment: r.comment,
+    publishedAt: r.publishedAt,
+  }
+}
+
+export type GetReviewsResult = Ok<{ reviews: ParticipantReview[] }> | Fail
 export type ReportResult = Ok<{ report: ReviewReport }> | Fail
 export interface SweepSummary {
   readonly scanned: number
@@ -280,7 +308,7 @@ export class ReviewService {
       if (r.moderationStatus !== 'VISIBLE') return false
       return r.publishedAt !== null || (role === 'OPERATOR' && r.authorRole === 'OPERATOR')
     })
-    return { ok: true, reviews: visible }
+    return { ok: true, reviews: visible.map(toParticipantReview) }
   }
 
   /** Flag a review for moderator attention (#1086). Only a publicly-visible review

--- a/packages/api/tests/integration/review-moderation-queue.test.ts
+++ b/packages/api/tests/integration/review-moderation-queue.test.ts
@@ -1,5 +1,5 @@
 import { reviewReports, reviews } from '@kuruma/shared/db/schema'
-import { inArray } from 'drizzle-orm'
+import { inArray, sql } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { DrizzleReviewRepository } from '../../src/repositories/drizzle/review'
 import type { ReportedQueueCursor } from '../../src/repositories/types-review'
@@ -107,7 +107,64 @@ async function seedReportedReview(
   return id
 }
 
+/** Seed one VISIBLE OPERATOR review whose single report lands at an explicit sub-millisecond
+ *  instant. `createdAtLiteral` is bound as a raw `timestamptz` because JS `Date` is ms-only
+ *  and cannot express the microseconds that expose the ms-cursor truncation. */
+async function seedReviewReportedAtLiteral(
+  booking: SeededBooking,
+  id: string,
+  createdAtLiteral: string,
+): Promise<void> {
+  await db.insert(reviews).values({
+    id,
+    bookingId: booking.booking.id,
+    operatorId: booking.operatorId,
+    authorUserId: booking.renterId,
+    authorRole: 'RENTER',
+    subject: 'OPERATOR',
+    overall: 4,
+    moderationStatus: 'VISIBLE',
+    revealDeadlineAt: new Date('2027-01-21T09:00:00Z'),
+  })
+  await db.insert(reviewReports).values({
+    id: crypto.randomUUID(),
+    reviewId: id,
+    reporterUserId: booking.renterId,
+    reason: 'inappropriate',
+    createdAt: sql`${createdAtLiteral}::timestamptz`,
+  })
+}
+
 describe('DrizzleReviewRepository.listReported (#1451, real pg)', () => {
+  it('does not drop a reported review whose newest report shares a millisecond but differs in microseconds', async () => {
+    // review_reports.createdAt is defaultNow() = MICROSECOND precision, but the queue cursor is
+    // serialized to MILLISECONDS (Date.toISOString). Two reviews reported in the same ms but
+    // different µs must BOTH survive pagination — the ms cursor must not exclude the sub-ms
+    // neighbour on the far side of a page boundary (a dropped row is a reported review the
+    // moderator never sees, so it is never hidden and keeps counting in the public aggregate).
+    // The InMemory mirror CANNOT catch this: its reports stamp ms JS Dates, so it is lossless.
+    const SAME_MS = '2099-07-01 00:00:00.123'
+    const idA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const idB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    // A's report is later WITHIN the same ms (µs 900) so it leads the raw-µs DESC order; B
+    // (µs 100) is the neighbour the buggy ms cursor drops once A's page boundary is passed.
+    await seedReviewReportedAtLiteral(b0, idA, `${SAME_MS}900+00`)
+    await seedReviewReportedAtLiteral(b1, idB, `${SAME_MS}100+00`)
+
+    // Walk one row per page following the cursor; both must be visited exactly once.
+    const collected: string[] = []
+    let cursor: ReportedQueueCursor | undefined
+    for (let guard = 0; guard < 12 && collected.length < 2; guard++) {
+      const page = await repo.listReported({ limit: 1, status: 'VISIBLE', cursor })
+      for (const item of page.items) {
+        if (item.review.id === idA || item.review.id === idB) collected.push(item.review.id)
+      }
+      if (!page.nextCursor) break
+      cursor = page.nextCursor
+    }
+    expect([...collected].sort()).toEqual([idA, idB])
+  })
+
   it('orders reports newest-first with distinct-reporter count and reasons', async () => {
     const r0 = await seedReportedReview(b0, {
       reports: [{ reporter: b0.renterId, at: new Date('2099-01-01T00:00:00Z'), reason: 'spam' }],


### PR DESCRIPTION
Two follow-ups surfaced by an architect review of the review subsystem (#1067) after ~8 slices landed in parallel. The review otherwise found the subsystem coherent (privacy allowlist, moderation visibility, tenancy scoping, layering, in-memory/Drizzle parity all verified holding).

## M1 (was MEDIUM) — moderation queue silently skips reported reviews
`packages/api/src/repositories/drizzle/review.ts` — `listReported`

The #1451 queue keysets on `max(review_reports.createdAt)`, but that column is `defaultNow()` (**microsecond** precision) while the cursor round-trips through `Date.toISOString()` (**milliseconds**). A review whose newest report shares a millisecond but has a smaller microsecond, on the far side of a page boundary, matches neither keyset branch → dropped from the queue, never hidden, keeps counting in the public aggregate. Same class of "in-mem green / prod wrong" bug the #1451 real-pg gate caught before (the InMemory mirror stamps ms JS Dates, so it is lossless and can't see it).

**Fix:** `date_trunc('milliseconds', max(createdAt))` so the DB-side sort-key precision equals the cursor's (`.mapWith(createdAt)` reattaches the Date decoder the raw wrapper drops), and the `reviewId` tiebreak now compares under `COLLATE "C"` (mirrors #1449) so its byte order matches the InMemory JS `<` — load-bearing here because the truncation increases exact ties.

**Reproduction (real pg):** two reviews reported in the same ms but different µs (seeded via a raw `timestamptz` literal, since JS `Date` is ms-only) must both survive `limit=1` pagination. RED before, green after; existing tie/pagination cases still pass.

## L2 (was LOW) — participant read leaked moderation internals
`packages/api/src/services/review.ts` — `getForBooking`

`GET /bookings/:id/reviews` returned the raw `Review` entity, so `moderatedBy` (the acting platform admin's userId), `moderationStatus`, `moderatedAt`, `authorUserId`, `operatorId` and the reveal deadline all crossed the wire. The web strips them, but a 3rd-party/API caller — or the author who was admin-moderated — could read which admin hid their review.

**Fix:** project each already-visibility-filtered row to a `ParticipantReview` allowlist (id, bookingId, authorRole, subject, overall, comment, publishedAt) — exactly what the client parses. The projection runs on the double-blind result, so the reveal/visibility logic is untouched. A unit test pins the exact key set (19 → 7).

## Verification
- Real-pg review integration: 28/28 (incl. the new µs-keyset reproduction).
- Full api unit suite: 2891/2891 (incl. the new allowlist test).
- api + web `tsc` clean, api import-boundaries OK, biome clean. No migration (repo-query + service-projection only).

Follow-up to #1451 and #1086; refs #1067. (Both issues already closed — not re-closing.)