### PR TITLE
fix(#1406): let operators manage their own vehicle photos

### DIFF
--- a/packages/api/src/routes/vehicle-photos.ts
+++ b/packages/api/src/routes/vehicle-photos.ts
@@ -1,6 +1,6 @@
 import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
 import { type Context, Hono } from 'hono'
-import { STAFF_ROLES, requireUser, toCallerContext } from '../middleware/auth'
+import { FLEET_WRITE_ROLES, requireUser, toCallerContext } from '../middleware/auth'
 import {
   MAX_FILE_SIZE,
   MAX_PHOTOS_PER_VEHICLE,
@@ -41,7 +41,7 @@ export function createVehiclePhotoRoutes(
   return app
     .post('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const idResult = parseId(c)
@@ -62,7 +62,7 @@ export function createVehiclePhotoRoutes(
     })
     .delete('/vehicles/:id/photos', async (c) => {
       const user = requireUser(c)
-      if (!STAFF_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
       const ctx = toCallerContext(user)
 
       const idResult = parseId(c)

--- a/packages/api/src/services/vehicle-photo.ts
+++ b/packages/api/src/services/vehicle-photo.ts
@@ -47,11 +47,13 @@ export class VehiclePhotoService {
       validated.push(result.ok)
     }
 
-    // #1260: the STAFF_ROLES gate is platform-only, so a PLATFORM_ADMIN reads
-    // every operator's vehicles and findById hands it any of them by raw id.
-    // Bind this photo write to the operator it picked. Placed after byte
-    // validation but before any R2 put, so a denied cross-tenant request never
-    // persists an object (mirrors MaintenanceService.toggleStatus).
+    // #1260/#1406: the FLEET_WRITE_ROLES gate admits all-scope platform admins AND
+    // tenant operators. An all-scope caller reads every operator's vehicles and
+    // findById hands it any of them by raw id, so bind this write to the operator it
+    // picked; an operator caller is already clamped to its own tenant by the scoped
+    // findById and the guard no-ops for it. Placed after byte validation but before
+    // any R2 put, so a denied cross-tenant request never persists an object (mirrors
+    // MaintenanceService.toggleStatus).
     const existing = await this.repo.findById(ctx, vehicleId)
     if (!existing) return { ok: false, status: 404, error: 'Vehicle not found' }
     const denial = assertFleetWriteWithinOperator(ctx, existing.operatorId, actingOperatorId)
@@ -113,11 +115,13 @@ export class VehiclePhotoService {
     url: string,
     actingOperatorId?: string,
   ): Promise<DeleteResult> {
-    // #1260: same acting-operator binding as uploadPhotos. Without it a platform
-    // admin could delete ANY operator's photo by raw id + url — the scoped
-    // removePhotoByUrl below clamps operator callers, but an `all`-scope caller
-    // needs the target operator named first. Denial uses the caller's own
-    // "Photo not found" so there is no cross-tenant existence oracle.
+    // #1260/#1406: same acting-operator binding as uploadPhotos. The
+    // FLEET_WRITE_ROLES gate admits operators (clamped to their own tenant by the
+    // scoped findById + removePhotoByUrl) AND all-scope platform admins. Without
+    // this bind an all-scope caller could delete ANY operator's photo by raw id +
+    // url, so it must name the target operator first; the guard no-ops for operator
+    // callers. Denial uses the caller's own "Photo not found" so there is no
+    // cross-tenant existence oracle.
     const existing = await this.repo.findById(ctx, vehicleId)
     if (!existing) return { ok: false, status: 404, error: 'Photo not found' }
     const denial = assertFleetWriteWithinOperator(ctx, existing.operatorId, actingOperatorId)

--- a/packages/api/tests/helpers/auth.ts
+++ b/packages/api/tests/helpers/auth.ts
@@ -47,9 +47,11 @@ export function setupAuthEnv(): void {
   process.env.AUTH_SECRET = TEST_AUTH_SECRET
 }
 
-export async function authHeaders(payload?: { sub: string; role?: string }): Promise<
-  Record<string, string>
-> {
+export async function authHeaders(payload?: {
+  sub: string
+  role?: string
+  operatorId?: string
+}): Promise<Record<string, string>> {
   const token = await signTestJwt(payload)
   return { Authorization: `Bearer ${token}` }
 }

--- a/packages/api/tests/routes/vehicle-photos.test.ts
+++ b/packages/api/tests/routes/vehicle-photos.test.ts
@@ -473,3 +473,114 @@ describe('#1260 photo writes are bound to the acting operator (HTTP)', () => {
     expect(body.code).toBeUndefined()
   })
 })
+
+// #1406: operators are fleet self-service everywhere else, so the photo write gate
+// widened from STAFF_ROLES (platform-admin only) to FLEET_WRITE_ROLES. A tenant
+// operator now manages ITS OWN vehicles' photos with no ?operatorId= (the acting-
+// operator guard no-ops for operator callers; the operator-scoped findById is the
+// tenant fence — a cross-tenant id resolves to 404, never the vehicle).
+describe('#1406 operators manage their own vehicle photos', () => {
+  let app: ReturnType<typeof createTestApp>['app']
+  let vehicleRepo: InMemoryVehicleRepository
+  let vehicleId: string
+
+  beforeEach(async () => {
+    const ctx = createTestApp()
+    app = ctx.app
+    vehicleRepo = ctx.vehicleRepo
+    const v = await vehicleRepo.create(
+      SYSTEM_CONTEXT,
+      vehicleInput({ photos: ['https://test.com/a.jpg'] }),
+    )
+    vehicleId = v.id
+  })
+
+  it('OPERATOR_OWNER uploads to its own vehicle (no ?operatorId= needed)', async () => {
+    const headers = await authHeaders({
+      sub: 'op-owner-1',
+      role: 'OPERATOR_OWNER',
+      operatorId: TEST_OPERATOR_ID,
+    })
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: makeFormData('car.jpg', 'image/jpeg', 1024),
+    })
+
+    expect(res.status).toBe(201)
+    const updated = await vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(updated?.photos).toHaveLength(2)
+  })
+
+  it('OPERATOR_OWNER deletes its own vehicle photo', async () => {
+    const headers = await authHeaders({
+      sub: 'op-owner-1',
+      role: 'OPERATOR_OWNER',
+      operatorId: TEST_OPERATOR_ID,
+    })
+
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
+
+    expect(res.status).toBe(200)
+    const updated = await vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(updated?.photos).toEqual([])
+  })
+
+  it('an operator from another tenant gets 404, never the vehicle', async () => {
+    const headers = await authHeaders({
+      sub: 'op-other-1',
+      role: 'OPERATOR_OWNER',
+      operatorId: 'op_other',
+    })
+
+    const res = await app.request(`/vehicles/${vehicleId}/photos`, {
+      method: 'POST',
+      headers,
+      body: makeFormData('car.jpg', 'image/jpeg', 1024),
+    })
+
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toBe('Vehicle not found')
+    const updated = await vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(updated?.photos).toEqual(['https://test.com/a.jpg'])
+  })
+
+  it('OPERATOR_STAFF (not just OWNER) also manages its own vehicle photos', async () => {
+    const headers = await authHeaders({
+      sub: 'op-staff-1',
+      role: 'OPERATOR_STAFF',
+      operatorId: TEST_OPERATOR_ID,
+    })
+
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
+
+    expect(res.status).toBe(200)
+    const updated = await vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(updated?.photos).toEqual([])
+  })
+
+  it('an operator from another tenant cannot DELETE a photo (404, unchanged)', async () => {
+    const headers = await authHeaders({
+      sub: 'op-other-1',
+      role: 'OPERATOR_OWNER',
+      operatorId: 'op_other',
+    })
+
+    const res = await app.request(
+      `/vehicles/${vehicleId}/photos?url=${encodeURIComponent('https://test.com/a.jpg')}`,
+      { method: 'DELETE', headers },
+    )
+
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toBe('Photo not found')
+    const updated = await vehicleRepo.findById(SYSTEM_CONTEXT, vehicleId)
+    expect(updated?.photos).toEqual(['https://test.com/a.jpg'])
+  })
+})

--- a/packages/api/tests/services/vehicle-photo-write-scope.test.ts
+++ b/packages/api/tests/services/vehicle-photo-write-scope.test.ts
@@ -1,10 +1,13 @@
-// #1260 slice 4: bind photo writes (POST/DELETE /vehicles/:id/photos ->
-// VehiclePhotoService.uploadPhotos / deletePhoto) to the picked operator. The
-// route gate is STAFF_ROLES = PLATFORM_ROLES = {PLATFORM_ADMIN}, so only a
-// platform admin is route-reachable (legacy STAFF/ADMIN and operators are 403'd
-// upstream) — hence no legacy-STAFF case here, unlike the BUSINESS_ROLES-gated
-// maintenance/trio writes. The guard still keys on `!isOperatorRole` at the
-// service level so a future non-platform reuse fails closed.
+// #1260 slice 4 + #1406: bind photo writes (POST/DELETE /vehicles/:id/photos ->
+// VehiclePhotoService.uploadPhotos / deletePhoto) to the picked operator. These
+// are SERVICE-level guard tests, exercising both caller classes the route gate
+// admits: all-scope callers (`admin`, !isOperatorRole -> must name the owning
+// operator or 422/404) and tenant operators (`opA` -> auto-clamped by read scope;
+// a stray acting id is ignored). #1406 widened the route gate from STAFF_ROLES to
+// FLEET_WRITE_ROLES, so operators and legacy STAFF/ADMIN are now route-reachable;
+// legacy STAFF/ADMIN need no separate case here because they are all-scope
+// (!isOperatorRole), behaving identically to the `admin` cases. The guard keys on
+// `!isOperatorRole`, so any admitted non-operator fails closed without an operator.
 
 import { beforeEach, describe, expect, it } from 'vitest'
 import { type CallerContext, SYSTEM_CONTEXT } from '../../src/middleware/auth'

--- a/packages/web/src/vite/operator-fleet/PhotoUpload.tsx
+++ b/packages/web/src/vite/operator-fleet/PhotoUpload.tsx
@@ -22,8 +22,10 @@ interface PhotoUploadProps {
   readonly vehicleId: string | null
   /** Current photo URLs, passed down from the fleet read model. Defaults to []. */
   readonly photos?: readonly string[]
-  // #1260: a picker-admin binds photo writes to the operator it picked; undefined
-  // for an operator session (the API scopes those by the session cookie).
+  // #1260/#1406: a picker-admin binds photo writes to the operator it picked; an
+  // operator session names no tenant and manages its own vehicles' photos, scoped
+  // server-side by the session cookie (photo writes admit operators as of #1406,
+  // matching every other fleet write).
   readonly pickedOperatorId?: string | undefined
 }
 


### PR DESCRIPTION
## What

`POST/DELETE /vehicles/:id/photos` gated on `STAFF_ROLES` (= `PLATFORM_ROLES` = PLATFORM_ADMIN only), so **operator sessions 403'd before ever reaching the service** — a dead branch, since every other fleet write is operator self-service. Per the owner product call (operators *should* manage their own vehicles' photos), this widens the gate to `FLEET_WRITE_ROLES` (= `BUSINESS_ROLES` = {STAFF, ADMIN, PLATFORM_ADMIN, OPERATOR_OWNER, OPERATOR_STAFF}), matching the rest of fleet management.

## Why it's safe (tenant isolation preserved)

The #1260 acting-operator binding guard already lives in `uploadPhotos`/`deletePhoto`:
- **Operator callers** are clamped to their own tenant by the operator-scoped `findById` — a cross-tenant id resolves to **404, never the vehicle** (no existence oracle). The `assertFleetWriteWithinOperator` guard no-ops for them.
- **All-scope callers** (platform admin / legacy STAFF/ADMIN) still must name an owning `?operatorId=` or get 422/404 — unchanged from #1260.
- **RENTER / PARTNER** stay excluded (403 at the gate).

So the role gate is just *admission*; the row-scoped repo read remains the isolation fence.

## Changes
- `routes/vehicle-photos.ts`: `STAFF_ROLES` → `FLEET_WRITE_ROLES` on both POST and DELETE.
- Reconcile the now-live operator-session comments (`services/vehicle-photo.ts`, `operator-fleet/PhotoUpload.tsx`) — the "dead operator branch" the issue flagged is now the intended path.
- `tests/helpers/auth.ts`: `authHeaders` gains an optional `operatorId` claim (backward-compatible; `signTestJwt` already supported it) to mint operator sessions.

## Test plan
- [x] RED→GREEN: operator own-vehicle **upload** (OWNER) and **delete** (OWNER + STAFF) → success; assert `photos` mutated.
- [x] Cross-tenant operator **upload** and **delete** → 404, `photos` unchanged.
- [x] Existing RENTER 403 / no-auth 401 / admin #1260 binding tests unaffected.
- [x] Gates: api/web/shared tsc, api `lint:boundaries`, full api unit suite (2895), biome — all green.

Reviewed by the code-reviewer agent (verdict: sound; 3 LOW findings all folded in).

Closes #1406