### PR TITLE
fix(#1349): scope aria-haspopup=dialog to block bars only

### DIFF
--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -184,6 +184,21 @@ describe('FleetTimeline keyboard + ARIA (#1349)', () => {
     expect(onSelectEvent).not.toHaveBeenCalled()
   })
 
+  it('promises a dialog only on block bars — a booking bar navigates, so it must not', () => {
+    // aria-haspopup="dialog" is a contract that activation opens an overlay. A block bar
+    // opens BlockDetailDialog (true); a booking bar navigates to a full page (false), so
+    // announcing a dialog would misinform screen-reader users — the defect this GA-gate fixes.
+    const blk = block({ id: 'blk7', title: 'Bodywork', reason: 'Bodywork', kind: 'MAINTENANCE' })
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })], { blocks: [blk] })
+    expect(screen.getByRole('button', { name: /Maintenance block: Bodywork/ })).toHaveAttribute(
+      'aria-haspopup',
+      'dialog',
+    )
+    expect(screen.getByRole('button', { name: /Booking: Alice/ })).not.toHaveAttribute(
+      'aria-haspopup',
+    )
+  })
+
   it('makes a booking exactly one keyboard stop, aria-hiding the redundant turnaround tail', () => {
     // Booked + tail both in-window: the booked band is the sole button; the tail bar
     // still renders for mouse users but is removed from the a11y tree (no second stop).

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -217,11 +217,13 @@ export function FleetTimeline({
           // detail on Enter/Space (parity with click). A suppressed turnaround tail is
           // taken out of the a11y tree (aria-hidden + non-focusable) so a keyboard user
           // never lands on two bars for one booking; a mouse click on it still works.
+          // aria-haspopup only on block bars: they open BlockDetailDialog, whereas a
+          // booking bar navigates to a full page — promising a dialog there would mislead AT.
           itemProps: it.interactive
             ? {
                 role: 'button',
                 tabIndex: 0,
-                'aria-haspopup': 'dialog',
+                ...(it.type === 'block' ? { 'aria-haspopup': 'dialog' as const } : {}),
                 'aria-label': label,
                 onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => handleItemKeyDown(e, it.id),
               }


### PR DESCRIPTION
Follow-up to #1349 (PR #1469) — a code-review finding on the shipped a11y work, fixed before the `VITE_FEATURE_FLEET_TIMELINE` GA flip that #1349 gates.

## The defect

Every interactive FleetTimeline bar carried `aria-haspopup="dialog"`. But the two bar types do different things on activation:

- **Block bars** → `onSelectBlock` → open `BlockDetailDialog`. `aria-haspopup="dialog"` is **correct**.
- **Booking bars** → `onSelectEvent` → `navigate({ to: '/$locale/manage/bookings/$bookingId' })`, a full page. `aria-haspopup="dialog"` is a **false promise** — a screen reader announces "button, has pop-up dialog", then activation navigates the user away. That misinforms AT users, which is exactly the class of defect this a11y work exists to eliminate.

## The fix

Gate the token to `it.type === 'block'`; booking bars keep `role="button"` + Enter/Space activation (a button that navigates is fine), just without the dialog claim. One line in `FleetTimeline.tsx`.

Kept `role="button"` uniformly rather than switching booking bars to `role="link"`: a hrefless `role="link"` would advertise open-in-new-tab / copy-URL affordances the div can't honor and deviates from native link Space-key behavior — trading one false affordance for another.

## Test (TDD)

New test in `FleetTimeline.test.tsx` — RED before the fix — pins that a **block** bar exposes `aria-haspopup="dialog"` and a **booking** bar does **not**.

## Verification

- Web typecheck: 0 errors
- `FleetTimeline` 14/14 · `operator-bookings` 334/334
- Pre-commit: biome + file-size + module-boundaries + both tscs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)