### PR TITLE
feat(#1479): migrate the last two build-time flags to the runtime hook (Tier 2)

### DIFF
--- a/packages/shared/src/feature-flags/registry.test.ts
+++ b/packages/shared/src/feature-flags/registry.test.ts
@@ -69,6 +69,9 @@ describe('feature flag registry', () => {
         'OPERATOR_SETTINGS',
         'RENTER_DOCUMENTS',
         'MESSAGING',
+        // #1479 (Tier 2, path-to-GA #1476): the last two build-time-only flags,
+        // migrated to useFeatureFlag() so the admin switchboard flips them live.
+        'OPERATOR_TODAY',
         // Server-only, but the web reads it via useFeatureFlag() to hide the
         // operator picker + admin template library live, so it is runtimeControlled.
         'SHARED_CATALOG',

--- a/packages/shared/src/feature-flags/registry.test.ts
+++ b/packages/shared/src/feature-flags/registry.test.ts
@@ -55,7 +55,8 @@ describe('feature flag registry', () => {
     // so a dashboard toggle actually takes effect. Flip this to true in the same
     // slice that migrates the flag (#1322) — the admin page badges the difference.
     const controlled = FEATURE_FLAG_KEYS.filter((k) => FEATURE_FLAGS[k].runtimeControlled)
-    // Every flag is migrated as of #1322 (PR3 finished the batch). A newly added,
+    // Every flag is now migrated: #1322 (PR3) did the batch, #1479 finished the last
+    // two (OPERATOR_TODAY, CALENDAR_QUICKVIEW) for path-to-GA #1476. A newly added,
     // not-yet-migrated flag would be absent here and must be added on migration.
     expect(new Set(controlled)).toEqual(
       new Set([
@@ -72,6 +73,7 @@ describe('feature flag registry', () => {
         // #1479 (Tier 2, path-to-GA #1476): the last two build-time-only flags,
         // migrated to useFeatureFlag() so the admin switchboard flips them live.
         'OPERATOR_TODAY',
+        'CALENDAR_QUICKVIEW',
         // Server-only, but the web reads it via useFeatureFlag() to hide the
         // operator picker + admin template library live, so it is runtimeControlled.
         'SHARED_CATALOG',

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -83,7 +83,7 @@ const REGISTRY = {
   OPERATOR_TODAY: {
     env: 'VITE_FEATURE_OPERATOR_TODAY',
     label: 'Operator today panel',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   CALENDAR_QUICKVIEW: {
     env: 'VITE_FEATURE_CALENDAR_QUICKVIEW',

--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -88,7 +88,7 @@ const REGISTRY = {
   CALENDAR_QUICKVIEW: {
     env: 'VITE_FEATURE_CALENDAR_QUICKVIEW',
     label: 'Calendar quick-view',
-    runtimeControlled: false,
+    runtimeControlled: true,
   },
   // #1437: platform kill-switch for the shared add-on template catalog. Default ON
   // in CODE (serverDefault) - the feature_flags table is override-only, so no seed

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -2,7 +2,6 @@ import { Button } from '@/components/ui/button'
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import {
   featureFlagsQueryOptions,
-  isCalendarQuickViewEnabled,
   isVisibleToViewer,
   resolveFeatureFlag,
   useFeatureFlag,
@@ -146,8 +145,9 @@ export function OperatorBookingsRoute() {
 
   // The booking quick-view chip (#1282) is gated OFF for the beta MVP (#1329). When
   // off, a booking band is a plain link-less span, so booking navigation moves back
-  // to the rbc event-click (handleSelectEvent) — the pre-#1282 baseline.
-  const quickViewEnabled = isCalendarQuickViewEnabled()
+  // to the rbc event-click (handleSelectEvent) — the pre-#1282 baseline. Read via the
+  // runtime hook (#1479) so the /admin switchboard toggles it live.
+  const quickViewEnabled = useFeatureFlag('CALENDAR_QUICKVIEW')
 
   // Block dialogs (#1101): a schedule (create) form with an optional slot prefill,
   // and a click-to-view detail keyed on the selected block.

--- a/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
+++ b/packages/web/src/vite/operator-bookings/BookingsCalendar.tsx
@@ -1,6 +1,6 @@
 import { instantToJstFauxLocal, jstWallClockToInstant, todayInJst } from '@/lib/datetime'
 import { localizer } from '@/lib/rbc-localizer'
-import { isCalendarQuickViewEnabled, useFeatureFlag } from '@/vite/config'
+import { useFeatureFlag } from '@/vite/config'
 import { CalendarEventChip } from '@/vite/operator-bookings/CalendarEventChip'
 import { CalendarToolbar } from '@/vite/operator-bookings/CalendarToolbar'
 import {
@@ -62,10 +62,10 @@ export function BookingsCalendar({
   // The Timeline option in the switcher follows the runtime-toggleable flag (#1322):
   // a dashboard override flips it live, falling back to the build-time default.
   const timelineEnabled = useFeatureFlag('FLEET_TIMELINE')
-  // The booking quick-view chip (#1282) is gated OFF for the beta MVP (#1329);
-  // when off, a booking renders as a plain band like a block. Build-time flag for
-  // now (runtime migration tracked by #1322).
-  const quickViewEnabled = isCalendarQuickViewEnabled()
+  // The booking quick-view chip (#1282) is gated OFF for the beta MVP (#1329); when
+  // off, a booking renders as a plain band like a block. Read via the runtime hook
+  // (#1479) so the admin switchboard flips it live, falling back to the build-time default.
+  const quickViewEnabled = useFeatureFlag('CALENDAR_QUICKVIEW')
 
   const toolbarLabel = useMemo(() => {
     const fmt = (opts: Intl.DateTimeFormatOptions) =>

--- a/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
+++ b/packages/web/src/vite/operator-dashboard/OperatorDashboardView.tsx
@@ -1,4 +1,4 @@
-import { isOperatorTodayEnabled } from '@/vite/config'
+import { useFeatureFlag } from '@/vite/config'
 import { TodayPanel } from '@/vite/operator-dashboard/TodayPanel'
 import { ComplianceBanner } from '@/vite/operator-fleet/ComplianceBanner'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
@@ -35,6 +35,9 @@ export function OperatorDashboardView({
   pickedOperatorId,
 }: OperatorDashboardViewProps) {
   const t = useTranslations('business')
+  // #1479 (Tier 2, path-to-GA #1476): read via the runtime hook so the admin switchboard
+  // can flip the Today panel live; falls back to the build-time default outside the provider.
+  const operatorTodayEnabled = useFeatureFlag('OPERATOR_TODAY')
 
   const tiles = [
     { label: t('stats.totalBookings'), icon: CalendarDays, value: overview.totalBookings },
@@ -52,7 +55,7 @@ export function OperatorDashboardView({
 
         {/* #1102 Today panel, gated OFF for the beta MVP (#1329). The panel also
             self-gates to an operator session; this flag hides it entirely otherwise. */}
-        {isOperatorTodayEnabled() && (
+        {operatorTodayEnabled && (
           <TodayPanel
             today={overview.today}
             vehicles={vehicles}

--- a/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/BookingsCalendar.test.tsx
@@ -1,4 +1,5 @@
 import { todayInJst } from '@/lib/datetime'
+import { FeatureFlagsProvider } from '@/vite/config'
 import { BookingsCalendar } from '@/vite/operator-bookings/BookingsCalendar'
 import type {
   BlockCalendarEvent,
@@ -6,6 +7,8 @@ import type {
   CalendarItem,
   CalendarResource,
 } from '@/vite/operator-bookings/calendar-events'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import type { ComponentType } from 'react'
 import type { EventProps, SlotInfo } from 'react-big-calendar'
@@ -194,6 +197,43 @@ describe('BookingsCalendar event rendering (quick-view chip vs block band)', () 
     )
   }
 
+  // Runtime-override proof (#1479): CALENDAR_QUICKVIEW is now read via useFeatureFlag,
+  // so a server override must beat the build-time env. Render the calendar inside the
+  // real FeatureFlagsProvider with the ['feature-flags'] cache seeded (fresh for
+  // staleTime -> no network), so components.event captures the OVERRIDDEN flag; then
+  // render that event component in isolation. The same seam the #1322 flags use.
+  function renderEventWithOverride(item: CalendarItem, overrides: FeatureFlagOverrides) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(['feature-flags'], overrides)
+    render(
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en" messages={enMessages}>
+          <FeatureFlagsProvider>
+            <BookingsCalendar
+              events={[] as readonly CalendarItem[]}
+              resources={[] as readonly CalendarResource[]}
+              view="week"
+              date={new Date('2026-07-01T00:00:00.000Z')}
+              locale="en"
+              onViewChange={vi.fn()}
+              onDateChange={vi.fn()}
+              onSelectEvent={vi.fn()}
+            />
+          </FeatureFlagsProvider>
+        </IntlProvider>
+      </QueryClientProvider>,
+    )
+    const EventComp = (
+      calendarProps.components as { event: ComponentType<EventProps<CalendarItem>> }
+    ).event
+    return render(
+      <IntlProvider locale="en" messages={enMessages}>
+        {/* biome-ignore lint/suspicious/noExplicitAny: rbc injects the rest of EventProps at runtime */}
+        <EventComp {...({ event: item, title: item.title } as any)} />
+      </IntlProvider>,
+    )
+  }
+
   it('wires a custom event component onto rbc', () => {
     renderCalendar(vi.fn())
     expect(typeof (calendarProps.components as { event?: unknown }).event).toBe('function')
@@ -214,6 +254,19 @@ describe('BookingsCalendar event rendering (quick-view chip vs block band)', () 
   it('renders a booking as a plain band (no chip) when the quick-view flag is OFF (#1329)', () => {
     vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', undefined)
     const { container } = renderEvent(bookingItem)
+    expect(within(container).queryByRole('button')).toBeNull()
+    expect(within(container).getByText('Jane Doe')).toBeInTheDocument()
+  })
+
+  it('renders the quick-view chip when the CALENDAR_QUICKVIEW runtime override is ON despite the build-time env being OFF (#1479)', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', undefined)
+    const { container } = renderEventWithOverride(bookingItem, { CALENDAR_QUICKVIEW: true })
+    expect(within(container).getByRole('button', { name: /Jane Doe/ })).toBeInTheDocument()
+  })
+
+  it('renders a booking as a plain band when the CALENDAR_QUICKVIEW runtime override is OFF despite the build-time env being ON (#1479)', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', 'true')
+    const { container } = renderEventWithOverride(bookingItem, { CALENDAR_QUICKVIEW: false })
     expect(within(container).queryByRole('button')).toBeNull()
     expect(within(container).getByText('Jane Doe')).toBeInTheDocument()
   })

--- a/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
+++ b/packages/web/tests/vite/operator-bookings/OperatorBookingsRoute.test.tsx
@@ -477,4 +477,43 @@ describe('OperatorBookingsRoute runtime feature-flag overrides (#1322)', () => {
     )
     expect(screen.queryByText(B.legend.title)).not.toBeInTheDocument()
   })
+
+  // #1479: the quick-view flag (booking-click navigation ownership) is now runtime-read
+  // too, so an override wins over the build-time env end-to-end through the route.
+  it('a quick-view override OFF restores booking-click navigation even when the build default is ON', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', 'true')
+    renderRoute(
+      operatorSession,
+      blocksFleet,
+      [],
+      { bookings: [calendarBooking] },
+      { CALENDAR_QUICKVIEW: false },
+    )
+    const booking = (calendarProps.events as { type: string; id: string }[]).find(
+      (e) => e.type === 'booking',
+    )
+    act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(booking))
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/$locale/manage/bookings/$bookingId',
+        params: expect.objectContaining({ bookingId: 'bk-1' }),
+      }),
+    )
+  })
+
+  it('a quick-view override ON suppresses booking-click navigation even when the build default is OFF', () => {
+    vi.stubEnv('VITE_FEATURE_CALENDAR_QUICKVIEW', undefined)
+    renderRoute(
+      operatorSession,
+      blocksFleet,
+      [],
+      { bookings: [calendarBooking] },
+      { CALENDAR_QUICKVIEW: true },
+    )
+    const booking = (calendarProps.events as { type: string; id: string }[]).find(
+      (e) => e.type === 'booking',
+    )
+    act(() => (calendarProps.onSelectEvent as (i: unknown) => void)(booking))
+    expect(navigate).not.toHaveBeenCalled()
+  })
 })

--- a/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
+++ b/packages/web/tests/vite/operator-dashboard/OperatorDashboardView.test.tsx
@@ -1,6 +1,8 @@
+import { FeatureFlagsProvider } from '@/vite/config'
 import { OperatorDashboardView } from '@/vite/operator-dashboard/OperatorDashboardView'
 import type { OperatorFleetVehicle } from '@/vite/operator-fleet/api'
 import type { Session } from '@/vite/session'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import type { OperatorOverview } from '@kuruma/shared/types/overview'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
@@ -104,6 +106,34 @@ function renderDashboard(
   )
 }
 
+// Runtime-override proof (#1479): OPERATOR_TODAY is now read via useFeatureFlag, so a
+// server override must beat the build-time env. Seed the ['feature-flags'] cache (fresh
+// for staleTime, so the provider's query never touches the network) and wrap in the real
+// FeatureFlagsProvider — the same seam the reservation wizard / #1322 flags are tested by.
+function renderDashboardWithOverride(
+  overrides: FeatureFlagOverrides,
+  session: Session | null,
+  pickedOperatorId: string | undefined = undefined,
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(['feature-flags'], overrides)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <FeatureFlagsProvider>
+          <OperatorDashboardView
+            overview={overview}
+            vehicles={[vehicle()]}
+            session={session}
+            locale="en"
+            pickedOperatorId={pickedOperatorId}
+          />
+        </FeatureFlagsProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  )
+}
+
 describe('OperatorDashboardView', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -151,6 +181,18 @@ describe('OperatorDashboardView', () => {
   it('hides the Today panel from a picker admin who has not picked an operator (#1433)', () => {
     vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', 'true')
     renderDashboard([vehicle()], ADMIN_SESSION)
+    expect(screen.queryByRole('region', { name: TODAY_PANEL_TITLE })).not.toBeInTheDocument()
+  })
+
+  it('shows the Today panel when the OPERATOR_TODAY runtime override is ON despite the build-time env being OFF (#1479)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', undefined)
+    renderDashboardWithOverride({ OPERATOR_TODAY: true }, OPERATOR_SESSION)
+    expect(screen.getByRole('region', { name: TODAY_PANEL_TITLE })).toBeInTheDocument()
+  })
+
+  it('hides the Today panel when the OPERATOR_TODAY runtime override is OFF despite the build-time env being ON (#1479)', () => {
+    vi.stubEnv('VITE_FEATURE_OPERATOR_TODAY', 'true')
+    renderDashboardWithOverride({ OPERATOR_TODAY: false }, OPERATOR_SESSION)
     expect(screen.queryByRole('region', { name: TODAY_PANEL_TITLE })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What

Migrates the **last two** build-time-only feature flags to the runtime `useFeatureFlag()` hook, so the platform-admin switchboard can flip them **live** for GA. After this, **every** registry flag is `runtimeControlled` — no build-time-only flag remains.

This is **Tier 2** of the path-to-GA audit (#1476). Two vertical slices on one branch:

| Slice | Flag | Consumer swapped |
|-------|------|------------------|
| A (`9b67e609`) | `OPERATOR_TODAY` | `OperatorDashboardView` Today panel (#1102) |
| B (`2153f0b4`) | `CALENDAR_QUICKVIEW` | `BookingsCalendar` chip + `OperatorBookingsRoute` booking-click nav (#1282/#1329) |

## How

Mirrors the established #1322 / `FLEET_TIMELINE` pattern exactly — the runtime infra (`resolveFeatureFlag`, `useFeatureFlag`, the admin switchboard) already exists; only the consumer call sites change:

- `registry.ts`: each flag's `runtimeControlled` flips `false -> true`.
- Consumers swap `isXEnabled()` -> `useFeatureFlag('X')`. Effective value is unchanged off the override path: `useFeatureFlag` resolves to `override ?? isBuildTimeEnabled(key)`, and with an empty context that is byte-for-byte the old build-time reader.
- The build-time readers stay in `features.ts` (`BUILD_TIME_READERS`) as the default source and remain parity-tested — nothing about the beta default changes; only a server override can now win.

## Tests

RED-first for both slices. Added runtime-override proofs in **both directions** (override ON beats env OFF; override OFF beats env ON), using the `setQueryData(['feature-flags'], {...})` + real `FeatureFlagsProvider` seam:
- Slice A: `OperatorDashboardView.test.tsx` — Today panel shown/hidden by override.
- Slice B: `BookingsCalendar.test.tsx` — chip vs plain band by override; `OperatorBookingsRoute.test.tsx` — booking-click navigation restored/suppressed by override.
- `registry.test.ts` controlled-set now pins all 13 flags as `runtimeControlled`.

## Verification

- shared `932/932`, web `2151/2151`
- shared + web `tsc --noEmit` clean
- biome clean, `lint:size` + `lint:modules` exit 0
- no new i18n keys (parity holds)
- code-reviewer pass: clean, "ship it"

Closes #1479
Refs #1476 (checks the two Tier-2 boxes; the epic stays open for the remaining tiers)