### PR TITLE
feat(#1437): insurance read-resolution + operator-wire rename (slice 3b)

### DIFF
--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -22,6 +22,7 @@ import {
   parseBody,
   parseCrossOperatorRead,
   parseId,
+  parseLocale,
   parseScopedCreate,
   stripUndefined,
 } from './helpers'
@@ -45,10 +46,13 @@ export function createInsuranceOptionRoutes(
       // operator-private config (unlike the public vehicle catalog).
       if (!MANAGEMENT_READ_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
 
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
+
       const ctx = toCallerContext(user)
       const filters: InsuranceOptionFilters = { ...parseArchivableFilters(c) }
 
-      return ok(c, await service.findAll(ctx, parseCrossOperatorRead(c), filters))
+      return ok(c, await service.findAll(ctx, parseCrossOperatorRead(c), filters, locale.locale))
     })
     .get('/insurance-options/:id', async (c) => {
       const user = requireUser(c)
@@ -57,13 +61,19 @@ export function createInsuranceOptionRoutes(
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
 
-      const option = await service.findById(toCallerContext(user), idResult.id)
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
+
+      const option = await service.findById(toCallerContext(user), idResult.id, locale.locale)
       if (!option) return fail(c, 'Insurance option not found', 404)
       return ok(c, option)
     })
     .post('/insurance-options', async (c) => {
       const user = requireUser(c)
       if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
 
       const ctx = toCallerContext(user)
       const parsed = await parseScopedCreate(
@@ -75,13 +85,17 @@ export function createInsuranceOptionRoutes(
       if (!parsed.ok) return parsed.response
       const { data: d, operatorId } = parsed
 
-      const result = await service.create(ctx, {
-        operatorId,
-        nameI18n: d.nameI18n,
-        description: d.description ?? null,
-        dailyPriceJpy: d.dailyPriceJpy,
-        deductibleJpy: d.deductibleJpy ?? null,
-      })
+      const result = await service.create(
+        ctx,
+        {
+          operatorId,
+          nameI18n: d.nameI18n,
+          description: d.description ?? null,
+          dailyPriceJpy: d.dailyPriceJpy,
+          deductibleJpy: d.deductibleJpy ?? null,
+        },
+        locale.locale,
+      )
       if (!result.ok) return failResult(c, result)
       return ok(c, result.option, 201)
     })
@@ -95,10 +109,14 @@ export function createInsuranceOptionRoutes(
       const parsed = await parseBody(c, updateInsuranceOptionSchema)
       if (!parsed.ok) return parsed.response
 
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
+
       const result = await service.update(
         toCallerContext(user),
         idResult.id,
         stripUndefined(parsed.data),
+        locale.locale,
       )
       if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
@@ -110,7 +128,10 @@ export function createInsuranceOptionRoutes(
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
 
-      const result = await service.archive(toCallerContext(user), idResult.id)
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
+
+      const result = await service.archive(toCallerContext(user), idResult.id, locale.locale)
       if (!result.ok) return failResult(c, result)
       return ok(c, result.option)
     })

--- a/packages/api/src/routes/storefronts.ts
+++ b/packages/api/src/routes/storefronts.ts
@@ -96,10 +96,20 @@ export function createStorefrontRoutes(
       const idResult = parseId(c, 'locationId')
       if (!idResult.ok) return idResult.response
 
+      // Catalog i18n (slice 3b): resolve names to the renter's locale. Parse
+      // BEFORE cachePublic — a bad ?locale= is a 400 that must never be cached
+      // (a cached error would pin the miss edge-wide until TTL).
+      const locale = parseLocale(c)
+      if (!locale.ok) return locale.response
+
       // The ACTIVE coverage a renter can add when booking at this storefront
       // (#392). Public + active-only + single-operator — see the service for the
       // [P0] seal rationale. 404 mirrors the vehicles route (unknown/archived).
-      const result = await detailService.getInsuranceOptions(PUBLIC_CONTEXT, idResult.id)
+      const result = await detailService.getInsuranceOptions(
+        PUBLIC_CONTEXT,
+        idResult.id,
+        locale.locale,
+      )
       if (!result.ok) return failResult(c, result)
       cachePublic(c, CACHE_SECONDS)
       return ok(c, result.data)

--- a/packages/api/src/services/insurance-option.ts
+++ b/packages/api/src/services/insurance-option.ts
@@ -1,4 +1,6 @@
+import type { Locale } from '@kuruma/shared/i18n/locales'
 import type { LocalizedText } from '@kuruma/shared/i18n/localized-text'
+import type { InsuranceOptionData } from '@kuruma/shared/types/insurance-option'
 import type { CallerContext } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
@@ -7,10 +9,33 @@ import type {
   InsuranceOptionRepository,
 } from '../repositories/types'
 import { type CrossOperatorRead, applyCrossOperatorReadScope } from '../tenancy'
+import { resolveInsuranceName } from './insurance-resolve'
 
 export type InsuranceOptionResult =
-  | { ok: true; option: InsuranceOption }
+  | { ok: true; option: InsuranceOptionData }
   | { ok: false; error: string; status: number }
+
+/**
+ * Project a read row to the operator wire DTO, resolving `nameI18n` to the caller
+ * locale (catalog i18n slice 3b). The multi-locale bundle stays server-side; the
+ * wire carries one resolved label + the raw `nameI18n` bag so the edit form can
+ * show/edit the authored-locale slots. Dates render as ISO strings (JSON has no
+ * Date) — the operator wire keeps timestamps (unlike the add-on DTO).
+ */
+function toInsuranceOptionData(row: InsuranceOption, locale: Locale): InsuranceOptionData {
+  return {
+    id: row.id,
+    operatorId: row.operatorId,
+    resolvedName: resolveInsuranceName(row, locale),
+    nameI18n: row.nameI18n,
+    description: row.description,
+    dailyPriceJpy: row.dailyPriceJpy,
+    deductibleJpy: row.deductibleJpy,
+    status: row.status,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
 
 /**
  * The create intent (#1437 slice 3). Insurance is purely self-authored, so the
@@ -52,13 +77,20 @@ export class InsuranceOptionService {
   async findAll(
     ctx: CallerContext,
     read: CrossOperatorRead,
-    filters: InsuranceOptionFilters = {},
-  ): Promise<InsuranceOption[]> {
-    return this.repo.findAll(ctx, applyCrossOperatorReadScope(ctx, read, filters))
+    filters: InsuranceOptionFilters,
+    locale: Locale,
+  ): Promise<InsuranceOptionData[]> {
+    const rows = await this.repo.findAll(ctx, applyCrossOperatorReadScope(ctx, read, filters))
+    return rows.map((row) => toInsuranceOptionData(row, locale))
   }
 
-  async findById(ctx: CallerContext, id: string): Promise<InsuranceOption | undefined> {
-    return this.repo.findById(ctx, id)
+  async findById(
+    ctx: CallerContext,
+    id: string,
+    locale: Locale,
+  ): Promise<InsuranceOptionData | undefined> {
+    const row = await this.repo.findById(ctx, id)
+    return row ? toInsuranceOptionData(row, locale) : undefined
   }
 
   /**
@@ -67,7 +99,11 @@ export class InsuranceOptionService {
    * ACTIVE rows only; the pre-check yields a friendly 409, the DB partial unique
    * index is the real seal.
    */
-  async create(_ctx: CallerContext, data: InsuranceOptionCreate): Promise<InsuranceOptionResult> {
+  async create(
+    _ctx: CallerContext,
+    data: InsuranceOptionCreate,
+    locale: Locale,
+  ): Promise<InsuranceOptionResult> {
     // The `name` column mirrors nameI18n.en — the ACTIVE-name unique seal, the
     // asc(name) ordering key, and the booking-snapshot source (#1437 slice 3).
     const name = data.nameI18n.en
@@ -87,7 +123,7 @@ export class InsuranceOptionService {
         deductibleJpy: data.deductibleJpy,
         status: 'ACTIVE',
       })
-      return { ok: true, option }
+      return { ok: true, option: toInsuranceOptionData(option, locale) }
     } catch (err) {
       if (isDuplicateName(err)) return { ok: false, error: DUPLICATE_NAME_MESSAGE, status: 409 }
       throw err
@@ -98,6 +134,7 @@ export class InsuranceOptionService {
     ctx: CallerContext,
     id: string,
     data: InsuranceOptionUpdate,
+    locale: Locale,
   ): Promise<InsuranceOptionResult> {
     // Caller-scoped existence check: an operator may only edit its own option.
     // A cross-tenant id reads as undefined here, so the write below never runs
@@ -123,7 +160,7 @@ export class InsuranceOptionService {
       if (data.nameI18n) patch.name = data.nameI18n.en
       const updated = await this.repo.update(ctx, id, patch)
       if (!updated) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
-      return { ok: true, option: updated }
+      return { ok: true, option: toInsuranceOptionData(updated, locale) }
     } catch (err) {
       // Same lost-race seal as create: a concurrent rename onto this name maps
       // to a friendly 409 rather than surfacing the raw unique-violation.
@@ -132,7 +169,7 @@ export class InsuranceOptionService {
     }
   }
 
-  async archive(ctx: CallerContext, id: string): Promise<InsuranceOptionResult> {
+  async archive(ctx: CallerContext, id: string, locale: Locale): Promise<InsuranceOptionResult> {
     // Same caller-scoped guard as update — load before mutate so a cross-tenant
     // id can never be archived.
     const existing = await this.repo.findById(ctx, id)
@@ -140,6 +177,6 @@ export class InsuranceOptionService {
 
     const archived = await this.repo.archive(ctx, id)
     if (!archived) return { ok: false, error: NOT_FOUND_MESSAGE, status: 404 }
-    return { ok: true, option: archived }
+    return { ok: true, option: toInsuranceOptionData(archived, locale) }
   }
 }

--- a/packages/api/src/services/insurance-resolve.ts
+++ b/packages/api/src/services/insurance-resolve.ts
@@ -1,0 +1,20 @@
+import type { Locale } from '@kuruma/shared/i18n/locales'
+import { resolveLocalized } from '@kuruma/shared/i18n/localized-text'
+import type { InsuranceOption } from '../stores'
+
+/**
+ * Catalog i18n (#1437 slice 3b): the one pure resolver that turns an insurance
+ * read row into a caller-locale label. Insurance is PURELY self-authored (no
+ * template, unlike add-ons), so there are only two shapes:
+ *
+ * - SELF-AUTHORED (`nameI18n` present): the operator's own bundle drives the name,
+ *   floored to English for any locale it omits (`resolveLocalized`).
+ * - LEGACY (`nameI18n` null, pre-slice-3 rows): fall back to the `name` mirror.
+ *
+ * Shared by the operator service projection (`toInsuranceOptionData`) and the
+ * renter storefront read so the fallback rule stays in ONE place.
+ */
+export function resolveInsuranceName(row: InsuranceOption, locale: Locale): string {
+  if (row.nameI18n) return resolveLocalized(row.nameI18n, locale)
+  return row.name
+}

--- a/packages/api/src/services/storefront-detail.test.ts
+++ b/packages/api/src/services/storefront-detail.test.ts
@@ -720,7 +720,7 @@ describe('getInsuranceOptions', () => {
       deductibleJpy: 50000,
     })
 
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id)
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id, 'en')
 
     if (!result.ok) throw new Error('expected ok result')
     expect(result.data).toEqual([
@@ -734,6 +734,24 @@ describe('getInsuranceOptions', () => {
     ])
   })
 
+  it('resolves a self-authored insurance name to the renter locale (#1437 slice 3b)', async () => {
+    const op = await makeOperator('Op A', 'op-a')
+    const loc = await makeLocation({ operatorId: op.id })
+    await makeInsurance({
+      operatorId: op.id,
+      name: 'Full Cover', // en mirror — must NOT win over the ja bundle
+      nameI18n: { en: 'Full Cover', ja: 'フルカバー' },
+      dailyPriceJpy: 1500,
+    })
+
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id, 'ja')
+
+    if (!result.ok) throw new Error('expected ok result')
+    // The RENTER wire keeps the field name `name` (unlike the operator rename);
+    // its value is the ja-resolved label.
+    expect(result.data[0]?.name).toBe('フルカバー')
+  })
+
   it('excludes ARCHIVED options', async () => {
     const op = await makeOperator('Op A', 'op-a')
     const loc = await makeLocation({ operatorId: op.id })
@@ -741,7 +759,7 @@ describe('getInsuranceOptions', () => {
     const archived = await makeInsurance({ operatorId: op.id, name: 'Old CDW', dailyPriceJpy: 800 })
     await insuranceRepo.archive(SYSTEM_CONTEXT, archived.id)
 
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id)
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id, 'en')
 
     if (!result.ok) throw new Error('expected ok result')
     expect(result.data.map((o) => o.name)).toEqual(['Active CDW'])
@@ -754,7 +772,7 @@ describe('getInsuranceOptions', () => {
     await makeInsurance({ operatorId: opA.id, name: 'A-CDW', dailyPriceJpy: 1000 })
     await makeInsurance({ operatorId: opB.id, name: 'B-CDW', dailyPriceJpy: 2000 })
 
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, locA.id)
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, locA.id, 'en')
 
     if (!result.ok) throw new Error('expected ok result')
     expect(result.data.map((o) => o.name)).toEqual(['A-CDW'])
@@ -764,14 +782,14 @@ describe('getInsuranceOptions', () => {
     const op = await makeOperator('Op A', 'op-a')
     const loc = await makeLocation({ operatorId: op.id })
 
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id)
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id, 'en')
 
     if (!result.ok) throw new Error('expected ok result')
     expect(result.data).toEqual([])
   })
 
   it('404s for an unknown location', async () => {
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, crypto.randomUUID())
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, crypto.randomUUID(), 'en')
     expect(result).toEqual({ ok: false, error: 'Storefront not found', status: 404 })
   })
 
@@ -780,7 +798,7 @@ describe('getInsuranceOptions', () => {
     const loc = await makeLocation({ operatorId: op.id })
     await locationRepo.archive(SYSTEM_CONTEXT, loc.id)
 
-    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id)
+    const result = await service.getInsuranceOptions(PUBLIC_CONTEXT, loc.id, 'en')
     expect(result).toEqual({ ok: false, error: 'Storefront not found', status: 404 })
   })
 })

--- a/packages/api/src/services/storefront-detail.ts
+++ b/packages/api/src/services/storefront-detail.ts
@@ -16,6 +16,7 @@ import type {
 } from '../repositories/types'
 import { resolveAddOnDescription, resolveAddOnName } from './add-on-resolve'
 import type { ClassOfferingService } from './class-offering'
+import { resolveInsuranceName } from './insurance-resolve'
 import { clampLimit, decodeCursor, encodeCursor } from './search-paging'
 
 export interface StorefrontSummary {
@@ -139,18 +140,23 @@ export class StorefrontDetailService {
   async getInsuranceOptions(
     ctx: CallerContext,
     locationId: string,
+    locale: Locale,
   ): Promise<StorefrontInsuranceResult> {
     const [storefront] = await this.storefrontRepo.findActiveStorefronts(ctx, {
       pickupLocationId: locationId,
     })
     if (!storefront) return { ok: false, error: 'Storefront not found', status: 404 }
 
+    // Catalog i18n (slice 3b): resolve the self-authored name to the renter's
+    // locale here, at the boundary — the multi-locale bundle never reaches the
+    // wire. The RENTER field stays `name` (unlike the operator DTO's rename);
+    // legacy nameI18n-null rows fall back to their `name` column.
     const options = await this.insuranceOptionRepo.findActiveByOperator(storefront.operatorId)
     return {
       ok: true,
       data: options.map((o) => ({
         id: o.id,
-        name: o.name,
+        name: resolveInsuranceName(o, locale),
         description: o.description,
         dailyPriceJpy: o.dailyPriceJpy,
         deductibleJpy: o.deductibleJpy,

--- a/packages/api/src/wire-contract.test.ts
+++ b/packages/api/src/wire-contract.test.ts
@@ -1,18 +1,18 @@
 import type { FeeScheduleData } from '@kuruma/shared/types/fee-schedule'
-import type { InsuranceOptionData } from '@kuruma/shared/types/insurance-option'
 import { expect, test } from 'vitest'
-import type { FeeSchedule, InsuranceOption } from './stores'
+import type { FeeSchedule } from './stores'
 
-// #847: the operator fee/insurance routes return their store row verbatim
-// (`ok(c, row)`); Hono's `c.json` renders Date columns as ISO strings and leaves
-// every other field untouched. `Jsonified` mirrors that single transform, so it
-// is the exact wire shape the web client receives.
+// #847: the operator fee route returns its store row verbatim (`ok(c, row)`);
+// Hono's `c.json` renders Date columns as ISO strings and leaves every other
+// field untouched. `Jsonified` mirrors that single transform, so it is the exact
+// wire shape the web client receives.
 //
-// Catalog i18n (slice 2): the ADD-ON fence is retired here. Its operator DTO is
-// now a hand-projected service model (resolvedName/resolvedDescription, no raw
-// `name` column), so the read can no longer be a verbatim row and
-// `Jsonified<AddOn>` can no longer equal the DTO — it moves to the web-side
-// `satisfies` pin like the storefront projections (#864).
+// Catalog i18n: the ADD-ON (slice 2) and INSURANCE (slice 3b) fences are retired
+// here. Each operator DTO is now a hand-projected service model (add-on:
+// resolvedName/resolvedDescription; insurance: resolvedName, no raw `name`
+// column), so the read can no longer be a verbatim row and `Jsonified<row>` can
+// no longer equal the DTO — both move to the web-side `satisfies` pin like the
+// storefront projections (#864). Only the fee route stays a verbatim row.
 //
 // `JsonifiedValue` takes V as a naked type parameter so the conditional
 // distributes over unions: a future `Date | null` column maps to `string | null`,
@@ -25,16 +25,15 @@ type Jsonified<T> = { [K in keyof T]: JsonifiedValue<T[K]> }
 // to the SAME contract. If a store row type (and ultimately the Drizzle table it
 // mirrors) gains, renames, or retypes a field, one direction stops compiling —
 // forcing the shared DTO, and therefore the web schema, to move in lockstep.
-// That closes the last fee/add-on/insurance runtime-only seam to compile time:
-// drift now fails `typecheck` instead of surfacing as a render-time ParseError.
+// That closes the fee runtime-only seam to compile time: drift now fails
+// `typecheck` instead of surfacing as a render-time ParseError.
 type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never
 
 const feeContract: Exact<Jsonified<FeeSchedule>, FeeScheduleData> = true
-const insuranceContract: Exact<Jsonified<InsuranceOption>, InsuranceOptionData> = true
 
-test('fee/insurance wire DTOs equal the JSON shape of their API row types', () => {
-  // The assignments above are the real check (resolved by tsc). Asserting them at
+test('fee wire DTO equals the JSON shape of its API row type', () => {
+  // The assignment above is the real check (resolved by tsc). Asserting it at
   // runtime keeps the fence in the suite, so a `never` collapse fails loudly here
   // too rather than only in a separate typecheck step.
-  expect([feeContract, insuranceContract]).toEqual([true, true])
+  expect(feeContract).toBe(true)
 })

--- a/packages/api/tests/integration/insurance-options.test.ts
+++ b/packages/api/tests/integration/insurance-options.test.ts
@@ -175,19 +175,24 @@ describe('cross-operator insurance-option WRITE denial (service seal, #404)', ()
   })
 
   it('operator B cannot update operator A option (404, row untouched)', async () => {
-    const res = await service.update(ctxFor(opBId), optionA.id, { nameI18n: { en: 'hijacked' } })
+    const res = await service.update(
+      ctxFor(opBId),
+      optionA.id,
+      { nameI18n: { en: 'hijacked' } },
+      'en',
+    )
     expect(res).toMatchObject({ ok: false, status: 404, error: 'Insurance option not found' })
     expect(await repo.findById(SYSTEM_CONTEXT, optionA.id)).toMatchObject({ name: 'Premium' })
   })
 
   it('operator B cannot archive operator A option (404, still ACTIVE)', async () => {
-    const res = await service.archive(ctxFor(opBId), optionA.id)
+    const res = await service.archive(ctxFor(opBId), optionA.id, 'en')
     expect(res).toMatchObject({ ok: false, status: 404 })
     expect(await repo.findById(SYSTEM_CONTEXT, optionA.id)).toMatchObject({ status: 'ACTIVE' })
   })
 
   it('operator A can update its own option', async () => {
-    const res = await service.update(ctxFor(opAId), optionA.id, { dailyPriceJpy: 2000 })
+    const res = await service.update(ctxFor(opAId), optionA.id, { dailyPriceJpy: 2000 }, 'en')
     expect(res).toMatchObject({ ok: true, option: { dailyPriceJpy: 2000 } })
   })
 
@@ -195,13 +200,17 @@ describe('cross-operator insurance-option WRITE denial (service seal, #404)', ()
   // column persists null in Postgres while the in-memory repo keeps it (spreads
   // ...data), so this round-trip is the ONLY layer that catches the regression.
   it('[#1437] service create round-trips nameI18n through Postgres and mirrors name = en', async () => {
-    const res = await service.create(ctxFor(opAId), {
-      operatorId: opAId,
-      nameI18n: { en: 'Gold', ja: 'ゴールド', zh: '黄金' },
-      description: null,
-      dailyPriceJpy: 1500,
-      deductibleJpy: null,
-    })
+    const res = await service.create(
+      ctxFor(opAId),
+      {
+        operatorId: opAId,
+        nameI18n: { en: 'Gold', ja: 'ゴールド', zh: '黄金' },
+        description: null,
+        dailyPriceJpy: 1500,
+        deductibleJpy: null,
+      },
+      'en',
+    )
     expect(res.ok).toBe(true)
     if (!res.ok) return
     // Read back with a FRESH SELECT (not the create return) to prove Postgres stored it.

--- a/packages/api/tests/routes/insurance-options.test.ts
+++ b/packages/api/tests/routes/insurance-options.test.ts
@@ -71,11 +71,31 @@ describe('Insurance option routes — operator CRUD', () => {
     expect(res.status).toBe(201)
     const { data } = await res.json()
     expect(data.operatorId).toBe(OP_A)
-    expect(data.name).toBe('Standard Cover')
+    expect(data.resolvedName).toBe('Standard Cover')
     expect(data.nameI18n).toEqual({ en: 'Standard Cover' })
     expect(data.dailyPriceJpy).toBe(1500)
     expect(data.deductibleJpy).toBe(150000)
     expect(data.status).toBe('ACTIVE')
+  })
+
+  it('resolves resolvedName to ?locale= on the list read (#1437 slice 3b)', async () => {
+    const repo = new InMemoryInsuranceOptionRepository()
+    await POST(
+      mountFor(repo, 'OPERATOR_OWNER', OP_A),
+      body({ nameI18n: { en: 'Full Cover', ja: 'フルカバー' } }),
+    )
+    const res = await mountFor(repo, 'OPERATOR_OWNER', OP_A).request('/insurance-options?locale=ja')
+    const { data } = await res.json()
+    expect(data[0].resolvedName).toBe('フルカバー')
+    // The raw bundle rides along so the edit form can prefill locale slots.
+    expect(data[0].nameI18n).toEqual({ en: 'Full Cover', ja: 'フルカバー' })
+  })
+
+  it('rejects an unknown ?locale= with 400 (never coerced)', async () => {
+    const repo = new InMemoryInsuranceOptionRepository()
+    await POST(mountFor(repo, 'OPERATOR_OWNER', OP_A))
+    const res = await mountFor(repo, 'OPERATOR_OWNER', OP_A).request('/insurance-options?locale=xx')
+    expect(res.status).toBe(400)
   })
 
   it('lists only the caller operator options', async () => {

--- a/packages/api/tests/routes/storefronts.test.ts
+++ b/packages/api/tests/routes/storefronts.test.ts
@@ -114,6 +114,7 @@ function makeInsurance(
   return ctx.insuranceOptionRepo.create({
     operatorId,
     name: 'CDW',
+    nameI18n: null,
     description: null,
     dailyPriceJpy: 1500,
     deductibleJpy: null,

--- a/packages/api/tests/services/insurance-option.test.ts
+++ b/packages/api/tests/services/insurance-option.test.ts
@@ -42,30 +42,31 @@ describe('InsuranceOptionService', () => {
 
   describe('create', () => {
     it('creates an option for the caller operator', async () => {
-      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       expect(result.ok).toBe(true)
       if (result.ok) {
-        expect(result.option.name).toBe('Premium')
+        expect(result.option.resolvedName).toBe('Premium')
         expect(result.option.operatorId).toBe(opA)
       }
     })
 
-    it('persists the nameI18n bundle and mirrors name = nameI18n.en', async () => {
+    it('persists the nameI18n bundle and resolves the create locale', async () => {
       const result = await service.create(
         ctxFor(opA),
         createInput(opA, 'Premium', { ja: 'プレミアム', zh: '高级' }),
+        'ja',
       )
       expect(result.ok).toBe(true)
       if (result.ok) {
         expect(result.option.nameI18n).toEqual({ en: 'Premium', ja: 'プレミアム', zh: '高级' })
-        // The `name` column is the en mirror — the unique seal + booking snapshot source.
-        expect(result.option.name).toBe('Premium')
+        // The wire carries the resolved label (ja here); the raw bundle rides along.
+        expect(result.option.resolvedName).toBe('プレミアム')
       }
     })
 
     it('rejects a duplicate ACTIVE name within the same operator with 409', async () => {
-      await service.create(ctxFor(opA), createInput(opA, 'Premium'))
-      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
+      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       expect(result.ok).toBe(false)
       if (!result.ok) {
         expect(result.status).toBe(409)
@@ -74,91 +75,133 @@ describe('InsuranceOptionService', () => {
     })
 
     it('allows the same name under a different operator', async () => {
-      await service.create(ctxFor(opA), createInput(opA, 'Premium'))
-      const result = await service.create(ctxFor(opB), createInput(opB, 'Premium'))
+      await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
+      const result = await service.create(ctxFor(opB), createInput(opB, 'Premium'), 'en')
       expect(result.ok).toBe(true)
     })
 
     it('maps a unique-violation that slips past the pre-check (lost race) to 409', async () => {
       vi.spyOn(repo, 'findActiveByOperatorAndName').mockResolvedValue(undefined)
       vi.spyOn(repo, 'create').mockRejectedValue(uniqueViolation())
-      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const result = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(409)
     })
   })
 
+  describe('read projection (#1437 slice 3b)', () => {
+    it('findById resolves resolvedName to the caller locale, keeping the raw bundle', async () => {
+      const created = await service.create(
+        ctxFor(opA),
+        createInput(opA, 'Premium', { ja: 'プレミアム' }),
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+
+      const found = await service.findById(ctxFor(opA), created.option.id, 'ja')
+      expect(found?.resolvedName).toBe('プレミアム')
+      expect(found?.nameI18n).toEqual({ en: 'Premium', ja: 'プレミアム' })
+    })
+
+    it('findById floors to en for a locale the bundle omits', async () => {
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
+      if (!created.ok) throw new Error('seed failed')
+
+      const found = await service.findById(ctxFor(opA), created.option.id, 'zh')
+      expect(found?.resolvedName).toBe('Premium')
+    })
+  })
+
   describe('update', () => {
     it('updates a field for an owned option', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
-      const result = await service.update(ctxFor(opA), created.option.id, { dailyPriceJpy: 3000 })
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { dailyPriceJpy: 3000 },
+        'en',
+      )
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.option.dailyPriceJpy).toBe(3000)
     })
 
     it('returns 404 (not 403) when the id belongs to another operator', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
-      const result = await service.update(ctxFor(opB), created.option.id, {
-        nameI18n: { en: 'Hijack' },
-      })
+      const result = await service.update(
+        ctxFor(opB),
+        created.option.id,
+        { nameI18n: { en: 'Hijack' } },
+        'en',
+      )
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(404)
     })
 
     it('loads the row (scoped) before writing, never writes on a cross-tenant id', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
       const updateSpy = vi.spyOn(repo, 'update')
-      await service.update(ctxFor(opB), created.option.id, { nameI18n: { en: 'Hijack' } })
+      await service.update(ctxFor(opB), created.option.id, { nameI18n: { en: 'Hijack' } }, 'en')
       expect(updateSpy).not.toHaveBeenCalled()
     })
 
     it('rejects renaming to a name already used by the same operator with 409', async () => {
-      await service.create(ctxFor(opA), createInput(opA, 'Premium'))
-      const standard = await service.create(ctxFor(opA), createInput(opA, 'Standard'))
+      await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
+      const standard = await service.create(ctxFor(opA), createInput(opA, 'Standard'), 'en')
       if (!standard.ok) throw new Error('seed failed')
-      const result = await service.update(ctxFor(opA), standard.option.id, {
-        nameI18n: { en: 'Premium' },
-      })
+      const result = await service.update(
+        ctxFor(opA),
+        standard.option.id,
+        { nameI18n: { en: 'Premium' } },
+        'en',
+      )
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(409)
     })
 
     it('allows a no-name-change edit without a self-collision (excludes current id)', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
       // Patch the same name back plus a price change — must not 409 on itself.
-      const result = await service.update(ctxFor(opA), created.option.id, {
-        nameI18n: { en: 'Premium' },
-        dailyPriceJpy: 1800,
-      })
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { nameI18n: { en: 'Premium' }, dailyPriceJpy: 1800 },
+        'en',
+      )
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.option.dailyPriceJpy).toBe(1800)
     })
 
-    it('keeps the name mirror in lockstep when nameI18n.en changes', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+    it('keeps the resolved name in lockstep when nameI18n.en changes', async () => {
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
-      const result = await service.update(ctxFor(opA), created.option.id, {
-        nameI18n: { en: 'Platinum', ja: 'プラチナ' },
-      })
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { nameI18n: { en: 'Platinum', ja: 'プラチナ' } },
+        'en',
+      )
       expect(result.ok).toBe(true)
       if (result.ok) {
-        expect(result.option.name).toBe('Platinum')
+        expect(result.option.resolvedName).toBe('Platinum')
         expect(result.option.nameI18n).toEqual({ en: 'Platinum', ja: 'プラチナ' })
       }
     })
 
     it('maps a unique-violation on rename that slips past the pre-check to 409', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
       vi.spyOn(repo, 'findActiveByOperatorAndName').mockResolvedValue(undefined)
       vi.spyOn(repo, 'update').mockRejectedValue(uniqueViolation())
-      const result = await service.update(ctxFor(opA), created.option.id, {
-        nameI18n: { en: 'Standard' },
-      })
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { nameI18n: { en: 'Standard' } },
+        'en',
+      )
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(409)
     })
@@ -166,28 +209,28 @@ describe('InsuranceOptionService', () => {
 
   describe('archive', () => {
     it('sets status to ARCHIVED for an owned option', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
-      const result = await service.archive(ctxFor(opA), created.option.id)
+      const result = await service.archive(ctxFor(opA), created.option.id, 'en')
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.option.status).toBe('ARCHIVED')
     })
 
     it('returns 404 and does not write when archiving another operator option', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
       const archiveSpy = vi.spyOn(repo, 'archive')
-      const result = await service.archive(ctxFor(opB), created.option.id)
+      const result = await service.archive(ctxFor(opB), created.option.id, 'en')
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(404)
       expect(archiveSpy).not.toHaveBeenCalled()
     })
 
     it('frees the name so a new ACTIVE option can reuse it', async () => {
-      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      const created = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       if (!created.ok) throw new Error('seed failed')
-      await service.archive(ctxFor(opA), created.option.id)
-      const recreated = await service.create(ctxFor(opA), createInput(opA, 'Premium'))
+      await service.archive(ctxFor(opA), created.option.id, 'en')
+      const recreated = await service.create(ctxFor(opA), createInput(opA, 'Premium'), 'en')
       expect(recreated.ok).toBe(true)
     })
   })

--- a/packages/api/tests/services/insurance-resolve.test.ts
+++ b/packages/api/tests/services/insurance-resolve.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { resolveInsuranceName } from '../../src/services/insurance-resolve'
+import type { InsuranceOption } from '../../src/stores'
+
+function insuranceRow(overrides: Partial<InsuranceOption> = {}): InsuranceOption {
+  return {
+    id: 'ins_1',
+    operatorId: 'op_1',
+    name: 'Basic Cover',
+    nameI18n: null,
+    description: null,
+    dailyPriceJpy: 1000,
+    deductibleJpy: null,
+    status: 'ACTIVE',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+describe('resolveInsuranceName', () => {
+  it('returns the caller-locale value from the self-authored bundle', () => {
+    const row = insuranceRow({
+      nameI18n: { en: 'Basic Cover', ja: 'ベーシック補償', zh: '基本保障' },
+    })
+    expect(resolveInsuranceName(row, 'ja')).toBe('ベーシック補償')
+    expect(resolveInsuranceName(row, 'zh')).toBe('基本保障')
+    expect(resolveInsuranceName(row, 'en')).toBe('Basic Cover')
+  })
+
+  it('floors to English when the requested locale is absent from the bundle', () => {
+    const row = insuranceRow({ nameI18n: { en: 'Basic Cover' } })
+    expect(resolveInsuranceName(row, 'ja')).toBe('Basic Cover')
+  })
+
+  it('falls back to the name mirror for a legacy row (nameI18n null)', () => {
+    const row = insuranceRow({ name: 'Legacy Plan', nameI18n: null })
+    expect(resolveInsuranceName(row, 'ja')).toBe('Legacy Plan')
+  })
+})

--- a/packages/shared/src/types/insurance-option.ts
+++ b/packages/shared/src/types/insurance-option.ts
@@ -6,9 +6,10 @@
  * lives here, drizzle-free; the status union comes from `@kuruma/shared/enums` (#814).
  *
  * Dates are ISO 8601 strings (JSON has no Date). The web schema pins to this via
- * `satisfies z.ZodType<InsuranceOptionData>` and the API row type is fenced against
- * `Jsonified<InsuranceOption>` (api `wire-contract.test.ts`), so a producer-side
- * field rename fails `typecheck` instead of surfacing as a runtime ParseError.
+ * `satisfies z.ZodType<InsuranceOptionData>`. Catalog i18n (slice 3b): the operator
+ * DTO is a hand-projected service model (`resolvedName` + the raw `nameI18n` bundle,
+ * no `name` column), so the old `Jsonified<InsuranceOption>` compile-fence is retired
+ * (api `wire-contract.test.ts`) — the `satisfies` pin is now the single seam.
  */
 
 import type { InsuranceStatus } from '../enums'
@@ -17,11 +18,12 @@ import type { LocalizedText } from '../i18n/localized-text'
 export interface InsuranceOptionData {
   id: string
   operatorId: string
-  name: string
+  /** Self-authored name resolved to the caller locale (English fallback). */
+  resolvedName: string
   /**
-   * SELF-AUTHORED name bundle (#1437 slice 3). Additive in slice 3a: the read
-   * still returns the resolved label in `name`; slice 3b renames `name` ->
-   * `resolvedName`. Null for legacy rows (rendered from the `name` mirror).
+   * The operator's RAW authored name bundle (#1437 slice 3), returned so the edit
+   * form can add ja/zh or fix en later (D5). Null for a legacy row, which resolves
+   * from the `name` mirror server-side.
    */
   nameI18n: LocalizedText | null
   description: string | null

--- a/packages/web/src/routes/$locale/_business/manage/insurance.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/insurance.tsx
@@ -1,11 +1,12 @@
 import { PageSkeleton } from '@/vite/PageSkeleton'
 import { RouteRetryError } from '@/vite/RouteRetryError'
+import { DEFAULT_LOCALE, isLocale } from '@/vite/i18n/locale'
 import { useOperatorScope } from '@/vite/operator-context'
 import { OperatorInsuranceView } from '@/vite/operator-insurance/OperatorInsuranceView'
 import { insuranceOptionsQueryOptions } from '@/vite/operator-insurance/api'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { type ErrorComponentProps, createFileRoute } from '@tanstack/react-router'
-import { useTranslations } from 'use-intl'
+import { useLocale, useTranslations } from 'use-intl'
 
 // Operator insurance-option management (#530). URL `/<locale>/manage/insurance`
 // — behind the `_business` guard, so only business roles reach it. Tenant scoping
@@ -19,8 +20,10 @@ export const Route = createFileRoute('/$locale/_business/manage/insurance')({
   loaderDeps: ({ search }: { search: { operator?: string | undefined } }) => ({
     operator: search.operator,
   }),
-  loader: ({ context, deps }) =>
-    context.queryClient.ensureQueryData(insuranceOptionsQueryOptions(deps.operator)),
+  loader: ({ context, deps, params }) => {
+    const locale = isLocale(params.locale) ? params.locale : DEFAULT_LOCALE
+    return context.queryClient.ensureQueryData(insuranceOptionsQueryOptions(deps.operator, locale))
+  },
   pendingComponent: PageSkeleton,
   errorComponent: OperatorInsuranceError,
   component: OperatorInsuranceRoute,
@@ -29,7 +32,11 @@ export const Route = createFileRoute('/$locale/_business/manage/insurance')({
 function OperatorInsuranceRoute() {
   const t = useTranslations('business.insurance')
   const scope = useOperatorScope()
-  const { data: options } = useSuspenseQuery(insuranceOptionsQueryOptions(scope.pickedOperatorId))
+  const rawLocale = useLocale()
+  const locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE
+  const { data: options } = useSuspenseQuery(
+    insuranceOptionsQueryOptions(scope.pickedOperatorId, locale),
+  )
 
   return (
     <main className="flex-1 px-4 py-10 sm:px-6 lg:px-8">

--- a/packages/web/src/routes/$locale/_renter/bookings/new.tsx
+++ b/packages/web/src/routes/$locale/_renter/bookings/new.tsx
@@ -96,12 +96,12 @@ export const Route = createFileRoute('/$locale/_renter/bookings/new')({
     }
 
     // The $locale layout already 404s an invalid param; narrow it to satisfy the
-    // typed client (fall back to the default defensively). Add-on names resolve to
-    // this locale server-side; a locale change re-runs the loader via the path.
+    // typed client (fall back to the default defensively). Add-on + insurance names
+    // resolve to this locale server-side; a locale change re-runs the loader via the path.
     const locale = isLocale(params.locale) ? params.locale : DEFAULT_LOCALE
     const [addOns, insuranceOptions] = await Promise.all([
       fetchAddOns(deps.locationId, locale),
-      fetchInsuranceOptions(deps.locationId),
+      fetchInsuranceOptions(deps.locationId, locale),
     ])
     return {
       subject,

--- a/packages/web/src/vite/operator-insurance/EditInsuranceDialog.tsx
+++ b/packages/web/src/vite/operator-insurance/EditInsuranceDialog.tsx
@@ -41,7 +41,7 @@ export function EditInsuranceDialog({ option, onOpenChange }: EditInsuranceDialo
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t('editOption')}</DialogTitle>
-          <DialogDescription>{option?.name}</DialogDescription>
+          <DialogDescription>{option?.resolvedName}</DialogDescription>
         </DialogHeader>
         {error && (
           <p className="text-sm text-destructive px-1">
@@ -63,8 +63,8 @@ export function EditInsuranceDialog({ option, onOpenChange }: EditInsuranceDialo
             isSubmitting={isPending}
             defaultValues={{
               // Prefill the locale slots; a legacy row (nameI18n null) seeds `en`
-              // from the `name` mirror so a price-only edit needn't re-type the name.
-              nameEn: option.nameI18n?.en ?? option.name,
+              // from the server-resolved name so a price-only edit needn't re-type it.
+              nameEn: option.nameI18n?.en ?? option.resolvedName,
               nameJa: option.nameI18n?.ja ?? '',
               nameZh: option.nameI18n?.zh ?? '',
               description: option.description ?? '',

--- a/packages/web/src/vite/operator-insurance/InsuranceArchiveDialog.tsx
+++ b/packages/web/src/vite/operator-insurance/InsuranceArchiveDialog.tsx
@@ -46,7 +46,7 @@ export function InsuranceArchiveDialog({ option, onOpenChange }: InsuranceArchiv
     <Dialog open={option !== null} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('archiveTitle', { name: option?.name ?? '' })}</DialogTitle>
+          <DialogTitle>{t('archiveTitle', { name: option?.resolvedName ?? '' })}</DialogTitle>
           <DialogDescription>{t('archiveDescription')}</DialogDescription>
         </DialogHeader>
 

--- a/packages/web/src/vite/operator-insurance/InsuranceRow.tsx
+++ b/packages/web/src/vite/operator-insurance/InsuranceRow.tsx
@@ -29,7 +29,7 @@ export function InsuranceRow({
     <div className="border border-border rounded-lg p-4 flex items-start gap-4 hover:bg-accent/30 transition-colors">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <h3 className="text-lg font-medium truncate">{o.name}</h3>
+          <h3 className="text-lg font-medium truncate">{o.resolvedName}</h3>
           <InsuranceStatusBadge status={o.status} />
           <OperatorBadge name={operatorName} />
         </div>

--- a/packages/web/src/vite/operator-insurance/OperatorInsuranceView.tsx
+++ b/packages/web/src/vite/operator-insurance/OperatorInsuranceView.tsx
@@ -32,7 +32,10 @@ export function OperatorInsuranceView({ options, scope }: OperatorInsuranceViewP
   const [archiving, setArchiving] = useState<InsuranceOptionData | null>(null)
 
   // API already returns name-asc, but defend against drift.
-  const sorted = useMemo(() => [...options].sort((a, b) => a.name.localeCompare(b.name)), [options])
+  const sorted = useMemo(
+    () => [...options].sort((a, b) => a.resolvedName.localeCompare(b.resolvedName)),
+    [options],
+  )
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/vite/operator-insurance/api.ts
+++ b/packages/web/src/vite/operator-insurance/api.ts
@@ -2,6 +2,7 @@ import { unwrap } from '@/lib/api-error'
 import { getApiBaseUrl } from '@/vite/api-base'
 import { type WithOperatorId, buildScopeParam } from '@/vite/operator-context'
 import { INSURANCE_STATUSES } from '@kuruma/shared/enums'
+import { DEFAULT_LOCALE, type Locale } from '@kuruma/shared/i18n/locales'
 import { localizedTextSchema } from '@kuruma/shared/i18n/localized-text'
 import type { InsuranceOptionData } from '@kuruma/shared/types/insurance-option'
 import type {
@@ -23,14 +24,14 @@ export type { CreateInsuranceOptionInput, UpdateInsuranceOptionInput }
 
 // JSON-serialized InsuranceOption — dates arrive as ISO strings. Pinned to the
 // shared wire DTO with `satisfies` (#847) so a producer-side field drift fails to
-// compile here, not silently as a runtime ParseError. The API row type is fenced
-// to the same DTO in api `wire-contract.test.ts`, closing the seam at both ends.
+// compile here, not silently as a runtime ParseError. Catalog i18n (slice 3b): the
+// server resolves the self-authored `nameI18n` bundle to `?locale=` and returns a
+// single `resolvedName`; the raw bundle rides along so the edit form can prefill
+// each locale slot.
 const insuranceOptionSchema = z.object({
   id: z.string(),
   operatorId: z.string(),
-  name: z.string(),
-  // #1437 slice 3: additive self-authored bundle (the read still returns the
-  // resolved label in `name` until slice 3b renames it to `resolvedName`).
+  resolvedName: z.string(),
   nameI18n: localizedTextSchema.nullable(),
   description: z.string().nullable(),
   dailyPriceJpy: z.number(),
@@ -49,23 +50,27 @@ export const INSURANCE_QUERY_KEY = ['operator-insurance'] as const
 // `includeAll=true` — the bypass-role read default that satisfies the API's
 // cross-operator guard (this is what clears the admin 400; the parameterless read
 // previously sent neither flag). An operator session ignores it and auto-scopes.
+// `?locale=` resolves the self-authored name server-side (slice 3b); absent ⇒ EN.
 export async function fetchInsuranceOptions(
   pickedOperatorId?: string,
+  locale?: Locale,
 ): Promise<InsuranceOptionData[]> {
+  const localeParam = locale ? `&locale=${locale}` : ''
   const res = await fetch(
-    `${getApiBaseUrl()}/insurance-options?includeArchived=true&${buildScopeParam(pickedOperatorId)}`,
+    `${getApiBaseUrl()}/insurance-options?includeArchived=true&${buildScopeParam(pickedOperatorId)}${localeParam}`,
     { credentials: 'include' },
   )
   return unwrap(res, insuranceOptionSchema.array())
 }
 
-// The picked operator id is part of the cache key so switching context refetches
-// (and never serves another tenant's cached list). Optional param keeps any
-// no-arg caller working.
-export function insuranceOptionsQueryOptions(pickedOperatorId?: string) {
+// The picked operator id AND the locale are part of the cache key so switching
+// context or language refetches (and never serves another tenant's / locale's
+// cached list). Optional params keep any no-arg caller working.
+export function insuranceOptionsQueryOptions(pickedOperatorId?: string, locale?: Locale) {
+  const resolvedLocale = locale ?? DEFAULT_LOCALE
   return queryOptions({
-    queryKey: [...INSURANCE_QUERY_KEY, pickedOperatorId ?? 'all'] as const,
-    queryFn: () => fetchInsuranceOptions(pickedOperatorId),
+    queryKey: [...INSURANCE_QUERY_KEY, pickedOperatorId ?? 'all', resolvedLocale] as const,
+    queryFn: () => fetchInsuranceOptions(pickedOperatorId, resolvedLocale),
   })
 }
 

--- a/packages/web/src/vite/reservation/api.ts
+++ b/packages/web/src/vite/reservation/api.ts
@@ -39,10 +39,10 @@ export type ReservationInsuranceOption = StorefrontInsuranceData
 // cross-tenant leaks). A 404 (unknown/archived storefront) surfaces as an
 // ApiError so the wizard loader can bounce the renter back to search.
 //
-// Catalog i18n slice 2 (#1315): add-on name/description are templated + resolved
-// server-side to `?locale=`, so the renter read threads its route locale (absent
-// ⇒ server default EN). A bad locale is a 400 the server never caches, so the
-// wizard only ever passes a validated `Locale`. Insurance stays EN until slice 3.
+// Catalog i18n (#1315 add-ons slice 2, #1437 insurance slice 3b): add-on and
+// insurance names are resolved server-side to `?locale=`, so the renter read
+// threads its route locale (absent ⇒ server default EN). A bad locale is a 400 the
+// server never caches, so the wizard only ever passes a validated `Locale`.
 export async function fetchAddOns(
   locationId: string,
   locale?: Locale,
@@ -57,9 +57,11 @@ export async function fetchAddOns(
 
 export async function fetchInsuranceOptions(
   locationId: string,
+  locale?: Locale,
 ): Promise<ReservationInsuranceOption[]> {
+  const localeParam = locale ? `?locale=${locale}` : ''
   const res = await fetch(
-    `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/insurance-options`,
+    `${getApiBaseUrl()}/storefronts/${encodeURIComponent(locationId)}/insurance-options${localeParam}`,
     { credentials: 'include' },
   )
   return unwrap(res, reservationInsuranceOptionSchema.array())

--- a/packages/web/tests/vite/operator-insurance/AddInsuranceDialog.test.tsx
+++ b/packages/web/tests/vite/operator-insurance/AddInsuranceDialog.test.tsx
@@ -19,7 +19,7 @@ const NAME_LABEL = en.business.insurance.form.nameEn
 const createdRow = {
   id: 'ins1',
   operatorId: 'op_9',
-  name: 'Full cover',
+  resolvedName: 'Full cover',
   nameI18n: { en: 'Full cover' },
   description: null,
   dailyPriceJpy: 0,

--- a/packages/web/tests/vite/operator-insurance/EditInsuranceDialog.test.tsx
+++ b/packages/web/tests/vite/operator-insurance/EditInsuranceDialog.test.tsx
@@ -19,7 +19,7 @@ const SAVE = en.business.insurance.form.save
 const baseRow: InsuranceOptionData = {
   id: 'ins_1',
   operatorId: 'op_1',
-  name: 'Full cover',
+  resolvedName: 'Full cover',
   nameI18n: null,
   description: null,
   dailyPriceJpy: 2000,
@@ -46,7 +46,7 @@ describe('EditInsuranceDialog prefill (#1437 Finding 8)', () => {
   it('prefills all three name slots from a self-authored nameI18n bundle', () => {
     const option = {
       ...baseRow,
-      name: 'Full cover',
+      resolvedName: 'Full cover',
       nameI18n: { en: 'Full cover', ja: 'フルカバー', zh: '全保' },
     }
     renderDialog(<EditInsuranceDialog option={option} onOpenChange={vi.fn()} />)
@@ -56,18 +56,18 @@ describe('EditInsuranceDialog prefill (#1437 Finding 8)', () => {
     expect(screen.getByLabelText(NAME_ZH)).toHaveValue('全保')
   })
 
-  it('seeds the English slot from the name mirror for a legacy row (nameI18n null)', () => {
-    const option = { ...baseRow, name: 'Legacy Cover', nameI18n: null }
+  it('seeds the English slot from the resolved name for a legacy row (nameI18n null)', () => {
+    const option = { ...baseRow, resolvedName: 'Legacy Cover', nameI18n: null }
     renderDialog(<EditInsuranceDialog option={option} onOpenChange={vi.fn()} />)
 
-    // A price-only edit must not force re-typing the name — en falls back to the mirror.
+    // A price-only edit must not force re-typing the name — en falls back to resolvedName.
     expect(screen.getByLabelText(NAME_EN)).toHaveValue('Legacy Cover')
     expect(screen.getByLabelText(NAME_JA)).toHaveValue('')
     expect(screen.getByLabelText(NAME_ZH)).toHaveValue('')
   })
 
   it('submits the edited slots as a nameI18n bundle to the PATCH', async () => {
-    const option = { ...baseRow, name: 'Full cover', nameI18n: { en: 'Full cover' } }
+    const option = { ...baseRow, resolvedName: 'Full cover', nameI18n: { en: 'Full cover' } }
     fetchSpy.mockResolvedValue(
       new Response(
         JSON.stringify({

--- a/packages/web/tests/vite/operator-insurance/OperatorInsuranceView.test.tsx
+++ b/packages/web/tests/vite/operator-insurance/OperatorInsuranceView.test.tsx
@@ -59,8 +59,9 @@ function wrapper({ children }: { children: ReactNode }) {
 const option = {
   id: 'ins_1',
   operatorId: 'op_1',
-  name: 'Full cover',
-  // 3a: the row renders from the `name` mirror; a legacy null bundle is valid.
+  // 3b: the row renders from the server-resolved `resolvedName`; a legacy null
+  // bundle is valid (the server resolved it from the `name` mirror).
+  resolvedName: 'Full cover',
   nameI18n: null,
   description: 'Everything covered',
   dailyPriceJpy: 2000,
@@ -88,8 +89,8 @@ describe('OperatorInsuranceView', () => {
   })
 
   it('sorts options by name ascending', () => {
-    const b = { ...option, id: 'b', name: 'Basic' }
-    const z = { ...option, id: 'z', name: 'Zen' }
+    const b = { ...option, id: 'b', resolvedName: 'Basic' }
+    const z = { ...option, id: 'z', resolvedName: 'Zen' }
     render(<OperatorInsuranceView options={[z, b]} scope={writeScope} />, { wrapper })
     const headings = screen.getAllByRole('heading').map((h) => h.textContent)
     expect(headings).toEqual(['Basic', 'Zen'])
@@ -109,7 +110,12 @@ describe('OperatorInsuranceView', () => {
   })
 
   it('disables the archive action for an already-archived option', () => {
-    const archived = { ...option, id: 'arch', name: 'Old plan', status: 'ARCHIVED' as const }
+    const archived = {
+      ...option,
+      id: 'arch',
+      resolvedName: 'Old plan',
+      status: 'ARCHIVED' as const,
+    }
     render(<OperatorInsuranceView options={[archived]} scope={writeScope} />, { wrapper })
     expect(screen.getByRole('button', { name: 'archiveAction' })).toBeDisabled()
   })

--- a/packages/web/tests/vite/operator-insurance/api.test.ts
+++ b/packages/web/tests/vite/operator-insurance/api.test.ts
@@ -25,10 +25,11 @@ afterEach(() => fetchMock.mockReset())
 const option = {
   id: 'ins_1',
   operatorId: 'op_1',
-  name: 'Full cover',
-  // #1437 slice 3: the read carries the self-authored bundle (nameI18n) alongside
-  // the resolved `name` mirror. A faithful row so the schema's localizedTextSchema
-  // actually parses (an omitted bundle would 500 the read as a ParseError).
+  // #1437 slice 3b: the read carries the resolved label (`resolvedName`) plus the
+  // raw self-authored bundle (`nameI18n`). A faithful row so the schema's
+  // localizedTextSchema actually parses (an omitted bundle would 500 the read as a
+  // ParseError).
+  resolvedName: 'Full cover',
   nameI18n: { en: 'Full cover' },
   description: null,
   dailyPriceJpy: 2000,
@@ -65,6 +66,13 @@ describe('fetchInsuranceOptions', () => {
     expect(url).toContain('operatorId=op_9')
     expect(url).not.toContain('includeAll')
     expect(url).toContain('includeArchived=true')
+  })
+
+  it('threads ?locale= so the server resolves resolvedName to the caller language (#1437)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: [] }))
+    await fetchInsuranceOptions('op_9', 'ja')
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('locale=ja')
   })
 
   it('throws an ApiError carrying the status on a failure envelope', async () => {
@@ -156,11 +164,16 @@ describe('archiveInsuranceOption', () => {
 describe('insuranceOptionsQueryOptions', () => {
   it('exposes the stable INSURANCE_QUERY_KEY prefix so writes can invalidate every scope', () => {
     // INSURANCE_QUERY_KEY is the prefix; the per-scope key appends the picked
-    // operator (or 'all') so switching context refetches without serving another
-    // tenant's cached list. A prefix invalidate
-    // (invalidateQueries({ queryKey: INSURANCE_QUERY_KEY })) still clears all scopes.
+    // operator (or 'all') AND the locale (default 'en') so switching context or
+    // language refetches without serving another tenant's / locale's cached list. A
+    // prefix invalidate (invalidateQueries({ queryKey: INSURANCE_QUERY_KEY })) still
+    // clears all scopes.
     expect(INSURANCE_QUERY_KEY).toEqual(['operator-insurance'])
-    expect(insuranceOptionsQueryOptions().queryKey).toEqual(['operator-insurance', 'all'])
-    expect(insuranceOptionsQueryOptions('op_9').queryKey).toEqual(['operator-insurance', 'op_9'])
+    expect(insuranceOptionsQueryOptions().queryKey).toEqual(['operator-insurance', 'all', 'en'])
+    expect(insuranceOptionsQueryOptions('op_9', 'ja').queryKey).toEqual([
+      'operator-insurance',
+      'op_9',
+      'ja',
+    ])
   })
 })

--- a/packages/web/tests/vite/operator-insurance/insurance.route.test.ts
+++ b/packages/web/tests/vite/operator-insurance/insurance.route.test.ts
@@ -6,23 +6,26 @@ import { describe, expect, it, vi } from 'vitest'
 // The loader's only job is to prefetch the insurance list into the query cache
 // so the component's useSuspenseQuery resolves without a FOUC. (The api helpers
 // it composes are covered in api.test.ts.) It reads the operator from loaderDeps so
-// a context switch refetches; with no operator picked the scoped key resolves to 'all'.
+// a context switch refetches, and the `$locale` route param so a language switch
+// refetches; with no operator picked the scoped key resolves to 'all'.
 const loader = Route.options.loader as (args: {
   context: { queryClient: { ensureQueryData: ReturnType<typeof vi.fn> } }
   deps: { operator: string | undefined }
+  params: { locale: string }
 }) => Promise<unknown>
 
 describe('insurance route loader', () => {
-  it('prefetches the operator-insurance list query scoped to the picked operator', async () => {
+  it('prefetches the operator-insurance list query scoped to the picked operator and locale', async () => {
     const ensureQueryData = vi.fn().mockResolvedValue([])
     await loader({
       context: { queryClient: { ensureQueryData } },
       deps: { operator: 'op_9' },
+      params: { locale: 'ja' },
     })
 
     expect(ensureQueryData).toHaveBeenCalledTimes(1)
     const options = ensureQueryData.mock.calls[0][0] as { queryKey: unknown }
-    expect(options.queryKey).toEqual(['operator-insurance', 'op_9'])
+    expect(options.queryKey).toEqual(['operator-insurance', 'op_9', 'ja'])
   })
 })
 

--- a/packages/web/tests/vite/reservation/api.test.ts
+++ b/packages/web/tests/vite/reservation/api.test.ts
@@ -98,6 +98,19 @@ describe('fetchInsuranceOptions', () => {
       credentials: 'include',
     })
   })
+
+  // Catalog i18n (#1437 slice 3b): insurance names are now self-authored + resolved
+  // server-side to `?locale=`, so the renter wizard threads its route locale.
+  it('appends the caller locale so the server resolves insurance names to it', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ success: true, data: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchInsuranceOptions('loc-1', 'ja')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/storefronts/loc-1/insurance-options?locale=ja', {
+      credentials: 'include',
+    })
+  })
 })
 
 // #711: validate the response body at the network seam. A renamed/dropped field


### PR DESCRIPTION
## Slice 3b of #1437 — insurance read-resolution + operator-wire rename

Refs #1437 (epic stays open — slice 3c is the closer). Follows slice 3a (`31a1b9f0`, PR #1474), which added the additive `nameI18n` authoring foundation.

### What this does
Localizes self-authored insurance-option names to the caller's locale and renames the **operator** wire field `InsuranceOptionData.name` → `resolvedName` (keeping the raw `nameI18n`). The **renter** wire keeps `name` (mirrors the shipped add-on slice), so the reservation wizard does not churn.

### Changes
- **shared** — `InsuranceOptionData.name` → `resolvedName`; retire the insurance half of `wire-contract.test.ts` (the operator DTO no longer mirrors the store entity 1:1 once renamed; `feeContract` fence remains).
- **api** — new pure `services/insurance-resolve.ts` (`resolveInsuranceName`); `insurance-option` service gains `toInsuranceOptionData(row, locale)` and threads `locale` through all 5 methods; operator routes `insurance-options.ts` and the renter `storefronts.ts` read parse `?locale=`; renter `storefront-detail.getInsuranceOptions(..., locale)` resolves into `name`.
- **web** — operator `operator-insurance/api.ts` schema `name` → `resolvedName` + `&locale=` + locale in the query key; consumers (`InsuranceRow`, `OperatorInsuranceView` sort, `EditInsuranceDialog` display/prefill, `InsuranceArchiveDialog`) read `resolvedName`; `insurance.tsx` route loader + component thread locale (mirror add-ons); reservation `api.ts fetchInsuranceOptions(..., locale)` + `new.tsx` caller passes locale.

### Verification (merged tree, 0-behind develop)
- tsc × 3 · api `lint:boundaries` · web `lint:modules` (exit 0)
- shared 932 · api unit 2927 · api integration 517 (real-pg) · web 2153
- No migration in this slice (3a landed the only additive column).

### Not in this slice
Slice 3c (the epic closer, references #1437 without a closing keyword): dead template audit/backfill cleanup (D2) + cancel the NOT-NULL-flip intent comments + fold #1459 nits.
