### PR TITLE
chore(web): remove dead build-time flag readers orphaned by #1481

### DIFF
--- a/packages/web/src/vite/config/features.ts
+++ b/packages/web/src/vite/config/features.ts
@@ -81,25 +81,3 @@ export function isFleetTimelineEnabled(): boolean {
 export function isMultiCurrencyEnabled(): boolean {
   return isEnvTrue(import.meta.env.VITE_FEATURE_MULTI_CURRENCY)
 }
-
-/**
- * Operator "Today" dispatch panel (#1102): the dashboard's pickups / returns /
- * overdue board with one-click status advances. Shipped un-gated in #1099; gated
- * OFF here for the beta MVP so the demo dashboard mirrors the contracted scope.
- * Operator-only surface, so it is uniformly on/off. Build-time only for now
- * (runtime migration tracked by #1322).
- */
-export function isOperatorTodayEnabled(): boolean {
-  return isEnvTrue(import.meta.env.VITE_FEATURE_OPERATOR_TODAY)
-}
-
-/**
- * Calendar booking quick-view chip (#1282): the hover-peek / click-pin popover on
- * each operator booking band. Shipped un-gated in #1099; gated OFF here for the
- * beta MVP — the calendar falls back to a plain, non-interactive booking band.
- * Operator-only surface, so it is uniformly on/off. Build-time only for now
- * (runtime migration tracked by #1322).
- */
-export function isCalendarQuickViewEnabled(): boolean {
-  return isEnvTrue(import.meta.env.VITE_FEATURE_CALENDAR_QUICKVIEW)
-}

--- a/packages/web/tests/vite/config/features.test.ts
+++ b/packages/web/tests/vite/config/features.test.ts
@@ -1,5 +1,4 @@
 import {
-  isCalendarQuickViewEnabled,
   isCancellationEnabled,
   isFleetTimelineEnabled,
   isMessagingEnabled,
@@ -8,7 +7,6 @@ import {
   isOperatorManualBookingEnabled,
   isOperatorSettingsEnabled,
   isOperatorTeamEnabled,
-  isOperatorTodayEnabled,
   isRenterDocumentsEnabled,
   isReviewsEnabled,
 } from '@/vite/config/features'
@@ -28,8 +26,6 @@ const FLAGS = [
   { name: 'VITE_FEATURE_REVIEWS', read: isReviewsEnabled },
   { name: 'VITE_FEATURE_FLEET_TIMELINE', read: isFleetTimelineEnabled },
   { name: 'VITE_FEATURE_MULTI_CURRENCY', read: isMultiCurrencyEnabled },
-  { name: 'VITE_FEATURE_OPERATOR_TODAY', read: isOperatorTodayEnabled },
-  { name: 'VITE_FEATURE_CALENDAR_QUICKVIEW', read: isCalendarQuickViewEnabled },
 ] as const
 
 describe('post-MVP feature flags', () => {


### PR DESCRIPTION
## What

Deletes two dead functions and their test rows:

- `isOperatorTodayEnabled()` and `isCalendarQuickViewEnabled()` in `packages/web/src/vite/config/features.ts`
- their two rows + imports in `packages/web/tests/vite/config/features.test.ts`

## Why

#1481 migrated `OPERATOR_TODAY` and `CALENDAR_QUICKVIEW` from these build-time readers to the runtime `useFeatureFlag` path, removing their last production callers. The functions were left as dead exports (only the parameterized `features.test.ts` table still referenced them).

## What stays (still live)

- `VITE_FEATURE_OPERATOR_TODAY` / `VITE_FEATURE_CALENDAR_QUICKVIEW` env-type declarations in `vite-env.d.ts`
- the runtime resolver reads in `feature-flags-runtime.ts` (`OPERATOR_TODAY` / `CALENDAR_QUICKVIEW` defaults)
- the other tests that stub those env vars directly (dashboard / bookings-calendar suites)

Net: 26 deletions, no behavior change.

## Verification

- `bun run --filter @kuruma/web typecheck` — clean
- `bun run --filter @kuruma/web test` — 2147 passed / 305 files
- `bun run lint:modules` — pass (pre-existing baseline warning only)
- pre-commit hook (biome + file-size + module-boundaries + web/api tsc) — pass

Refs #1476 (path-to-GA feature-flag go-live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)