### PR TITLE
refactor(#1484): extend requireFleetWriteRole to the 6 sibling fleet-write resources (Phase 2)

### DIFF
--- a/packages/api/src/routes/add-ons.ts
+++ b/packages/api/src/routes/add-ons.ts
@@ -5,7 +5,6 @@ import {
 } from '@kuruma/shared/validators/add-on'
 import { Hono } from 'hono'
 import {
-  FLEET_WRITE_ROLES,
   MANAGEMENT_READ_ROLES,
   requireAuth,
   requireUser,
@@ -24,6 +23,7 @@ import {
   parseId,
   parseLocale,
   parseScopedCreate,
+  requireFleetWriteRole,
   stripUndefined,
 } from './helpers'
 
@@ -70,7 +70,8 @@ export function createAddOnRoutes(
     })
     .post('/add-ons', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const locale = parseLocale(c)
       if (!locale.ok) return locale.response
@@ -103,7 +104,8 @@ export function createAddOnRoutes(
     })
     .patch('/add-ons/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
@@ -127,7 +129,8 @@ export function createAddOnRoutes(
     })
     .delete('/add-ons/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response

--- a/packages/api/src/routes/fee-schedules.ts
+++ b/packages/api/src/routes/fee-schedules.ts
@@ -5,7 +5,6 @@ import {
 } from '@kuruma/shared/validators/fee-schedule'
 import { Hono } from 'hono'
 import {
-  FLEET_WRITE_ROLES,
   MANAGEMENT_READ_ROLES,
   requireAuth,
   requireUser,
@@ -23,6 +22,7 @@ import {
   parseCrossOperatorRead,
   parseId,
   parseScopedCreate,
+  requireFleetWriteRole,
   stripUndefined,
 } from './helpers'
 
@@ -71,7 +71,8 @@ export function createFeeScheduleRoutes(
     })
     .post('/fee-schedules', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const ctx = toCallerContext(user)
       const parsed = await parseScopedCreate(
@@ -96,7 +97,8 @@ export function createFeeScheduleRoutes(
     })
     .patch('/fee-schedules/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
@@ -115,7 +117,8 @@ export function createFeeScheduleRoutes(
     })
     .delete('/fee-schedules/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response

--- a/packages/api/src/routes/insurance-options.ts
+++ b/packages/api/src/routes/insurance-options.ts
@@ -5,7 +5,6 @@ import {
 } from '@kuruma/shared/validators/insurance-option'
 import { Hono } from 'hono'
 import {
-  FLEET_WRITE_ROLES,
   MANAGEMENT_READ_ROLES,
   requireAuth,
   requireUser,
@@ -24,6 +23,7 @@ import {
   parseId,
   parseLocale,
   parseScopedCreate,
+  requireFleetWriteRole,
   stripUndefined,
 } from './helpers'
 
@@ -70,7 +70,8 @@ export function createInsuranceOptionRoutes(
     })
     .post('/insurance-options', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const locale = parseLocale(c)
       if (!locale.ok) return locale.response
@@ -101,7 +102,8 @@ export function createInsuranceOptionRoutes(
     })
     .patch('/insurance-options/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
@@ -123,7 +125,8 @@ export function createInsuranceOptionRoutes(
     })
     .delete('/insurance-options/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response

--- a/packages/api/src/routes/locations.ts
+++ b/packages/api/src/routes/locations.ts
@@ -4,7 +4,7 @@ import {
   updateLocationSchema,
 } from '@kuruma/shared/validators/location'
 import { Hono } from 'hono'
-import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import { requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import { LOCATIONS_REGION_FK, PG_ERROR, pgConstraintName, pgErrorCode } from '../pg-errors'
 import type { LocationFilters } from '../services/filters'
 import type { LocationService } from '../services/location'
@@ -16,6 +16,7 @@ import {
   parseBody,
   parseId,
   parseScopedCreate,
+  requireFleetWriteRole,
   stripUndefined,
 } from './helpers'
 
@@ -33,7 +34,8 @@ export function createLocationRoutes(
   return app
     .get('/locations', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const ctx = toCallerContext(user)
       const filters: LocationFilters = {}
@@ -54,7 +56,8 @@ export function createLocationRoutes(
     })
     .get('/locations/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
@@ -65,7 +68,8 @@ export function createLocationRoutes(
     })
     .post('/locations', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const ctx = toCallerContext(user)
       const parsed = await parseScopedCreate(
@@ -108,7 +112,8 @@ export function createLocationRoutes(
     })
     .patch('/locations/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response
@@ -139,7 +144,8 @@ export function createLocationRoutes(
     })
     .delete('/locations/:id', async (c) => {
       const user = requireUser(c)
-      if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+      const denied = requireFleetWriteRole(c, user)
+      if (denied) return denied
 
       const idResult = parseId(c)
       if (!idResult.ok) return idResult.response

--- a/packages/api/src/routes/operators.ts
+++ b/packages/api/src/routes/operators.ts
@@ -1,8 +1,8 @@
 import { updateOperatorSchema } from '@kuruma/shared/validators/operator'
 import { Hono } from 'hono'
-import { FLEET_WRITE_ROLES, requireAuth, requireUser, toCallerContext } from '../middleware/auth'
+import { requireAuth, requireUser, toCallerContext } from '../middleware/auth'
 import { type OperatorService, toOperatorProfile } from '../services/operator'
-import { fail, ok, parseBody, parseId } from './helpers'
+import { fail, ok, parseBody, parseId, requireFleetWriteRole } from './helpers'
 
 /**
  * Read-only operator resolution for the business portal (#387). The web layout
@@ -24,7 +24,8 @@ export function createOperatorRoutes(service: OperatorService) {
       // OPERATOR_* caller sees only its own row (scoped in the service).
       .get('/operators', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const operators = await service.list(toCallerContext(user))
         return ok(
@@ -36,7 +37,8 @@ export function createOperatorRoutes(service: OperatorService) {
       // `:id` so `/operators/by-slug/foo` can never be captured as an id.
       .get('/operators/by-slug/:slug', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const operator = await service.getBySlug(toCallerContext(user), c.req.param('slug'))
         if (!operator) return fail(c, 'Operator not found', 404)
@@ -44,7 +46,8 @@ export function createOperatorRoutes(service: OperatorService) {
       })
       .get('/operators/:id', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const idResult = parseId(c)
         if (!idResult.ok) return idResult.response
@@ -59,7 +62,8 @@ export function createOperatorRoutes(service: OperatorService) {
       // foreign id never surfaces as a 403. The service projects the response.
       .patch('/operators/:id', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const idResult = parseId(c)
         if (!idResult.ok) return idResult.response

--- a/packages/api/src/routes/vehicle-classes.ts
+++ b/packages/api/src/routes/vehicle-classes.ts
@@ -5,7 +5,6 @@ import {
 } from '@kuruma/shared/validators/vehicle-class'
 import { Hono } from 'hono'
 import {
-  FLEET_WRITE_ROLES,
   PUBLIC_CONTEXT,
   requireAuth,
   requireManagementRead,
@@ -27,6 +26,7 @@ import {
   parseCrossOperatorRead,
   parseDateRange,
   parseId,
+  requireFleetWriteRole,
   stripUndefined,
 } from './helpers'
 import { rateLimitByIp } from './rate-limit'
@@ -124,7 +124,8 @@ export function createVehicleClassRoutes(
       })
       .post('/vehicle-classes', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const parsed = await parseBody(c, createVehicleClassSchema)
         if (!parsed.ok) return parsed.response
@@ -165,7 +166,8 @@ export function createVehicleClassRoutes(
       })
       .patch('/vehicle-classes/:id', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const idResult = parseId(c)
         if (!idResult.ok) return idResult.response
@@ -183,7 +185,8 @@ export function createVehicleClassRoutes(
       })
       .delete('/vehicle-classes/:id', async (c) => {
         const user = requireUser(c)
-        if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)
+        const denied = requireFleetWriteRole(c, user)
+        if (denied) return denied
 
         const idResult = parseId(c)
         if (!idResult.ok) return idResult.response


### PR DESCRIPTION
## What

Phase 2 (the closer) of #1484. Phase 1 (#1490) extracted the shared `requireFleetWriteRole(c, user)` route guard and wired it into the 9 fleet-write handlers on `/vehicles/*`. This PR applies the identical swap to the remaining six fleet-write resources on their own prefixes:

| Resource | Gate sites swapped |
|----------|-------------------|
| operators | 4 |
| locations | 5 |
| insurance-options | 3 |
| vehicle-classes | 3 |
| add-ons | 3 |
| fee-schedules | 3 |
| **total** | **21** |

Each `if (!FLEET_WRITE_ROLES.has(user.role)) return fail(c, 'Forbidden', 403)` becomes:

```ts
const denied = requireFleetWriteRole(c, user)
if (denied) return denied
```

Every registry fleet-write gate now routes through one enforcement point, so a per-handler retighten can no longer silently drift the tier (the #1406 regression class).

## Scope discipline

- **Non-fleet-write gates left untouched**: the `MANAGEMENT_READ_ROLES` read gates (insurance-options / add-ons / fee-schedules) and vehicle-classes' `requireManagementRead`.
- `FLEET_WRITE_ROLES` import dropped from each file (now unused); `MANAGEMENT_READ_ROLES` kept where a read gate still needs it.
- **operators PATCH** — the architect-flagged single-sealed thin spot — swaps cleanly: its owner-only re-assert lives in the *service* (`preAuthHandoffUrl`, after the 404 check), not the route, so only the plain fleet-write baseline gate changes here.

Behavior-preserving: the return-variant helper is byte-equivalent to the inline gate in every mount context (matching Phase 1's throw-vs-return decision — a throwing gate would 500 in the bare-`new Hono()` isolation tests that don't wire `setupGlobalHandlers`).

## Verification

- `tsc` (api + web), `lint:boundaries`, `biome check`: green.
- api unit suite **2933/2933** green — no test changes (behavior-preserving refactor; the existing per-resource 403 route tests are the regression harness).
- **Sabotage check**: neutering the helper (`if (false && ...)`) turned **23 tests red across all six Phase 2 resources' route tests** (operators ×4, locations, insurance-options, vehicle-classes, add-ons, fee-schedules) plus the #1477 `/vehicles/*` drift guard — then reverted to green. This proves the shared helper is the live enforcement path for all 21 new sites, not just dead code.

## Lineage

#1406 → #1477 → #1482 → #1484 (Phase 1 #1490 → this Phase 2).

Closes #1484.