### PR TITLE
chore(#1492): type-enforce serverOnly⇒serverDefault + harden add-on templateId guard

### DIFF
--- a/packages/shared/src/feature-flags/registry.ts
+++ b/packages/shared/src/feature-flags/registry.ts
@@ -14,18 +14,38 @@
 // migrates the flag off the build-time isXEnabled() reader (#1322); the admin page
 // badges a not-yet-migrated flag as "build-time only" so its toggle isn't mistaken
 // for a no-op.
-// A registry entry. `env` is the build-time VITE_FEATURE_* var a web flag reads;
-// a `serverOnly` flag has NONE (it is enforced by the API and defaults from code,
-// not the bundle) and instead carries a `serverDefault` fail-safe floor. Typing
-// the registry as Record<Key, FeatureFlagEntry> (below) keeps indexed `.env`
-// access uniform even though serverOnly entries omit it.
+// The strict authoring contract: a registry entry is exactly one of two shapes,
+// enforced by `satisfies Record<string, FeatureFlagSpec>` on REGISTRY (below).
+//   - A web flag pins a build-time `env` (VITE_FEATURE_*) and no serverDefault.
+//   - A `serverOnly` flag (#1437 SHARED_CATALOG) has NO env — it is enforced by
+//     the API and defaults from code — and MUST carry a `serverDefault` boolean
+//     fail-safe floor (the web floors to it; the API reads it as the no-override
+//     default). The discriminated union statically FORCES a serverOnly flag to
+//     declare serverDefault, so the invariant can't be forgotten at authoring
+//     time rather than only caught by a runtime test (#1492).
+type WebFeatureFlagEntry = {
+  env: string
+  label: string
+  runtimeControlled: boolean
+  serverOnly?: false
+}
+type ServerOnlyFeatureFlagEntry = {
+  label: string
+  runtimeControlled: boolean
+  serverOnly: true
+  serverDefault: boolean
+}
+type FeatureFlagSpec = WebFeatureFlagEntry | ServerOnlyFeatureFlagEntry
+
+// The shape consumers index into. Deliberately a WIDE flat record (env/serverDefault
+// optional), NOT the FeatureFlagSpec union: indexed `FEATURE_FLAGS[key].env` and
+// `.serverDefault` must stay uniform across every key (a consumed union would force
+// each call site to narrow first). The strict contract lives on the REGISTRY literal
+// via `satisfies`; this type is only how that already-enforced data is read back.
 export type FeatureFlagEntry = {
   env?: string
   label: string
   runtimeControlled: boolean
-  // Server-enforced flag with no web build-time env (#1437 SHARED_CATALOG). The
-  // web floors it to `serverDefault` rather than a build-time reader; the API
-  // reads `serverDefault` as the default when no admin override exists.
   serverOnly?: boolean
   serverDefault?: boolean
 }
@@ -101,7 +121,7 @@ const REGISTRY = {
     serverOnly: true,
     serverDefault: true,
   },
-} satisfies Record<string, FeatureFlagEntry>
+} satisfies Record<string, FeatureFlagSpec>
 
 // Typed as Record<Key, FeatureFlagEntry> (not the `as const` literal) so indexed
 // `.env` access is uniformly `string | undefined` across all entries - a serverOnly

--- a/packages/shared/tests/validators/add-on.test.ts
+++ b/packages/shared/tests/validators/add-on.test.ts
@@ -206,11 +206,16 @@ describe('updateAddOnSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('does not accept a templateId change on update (identity is fixed)', () => {
-    const result = updateAddOnSchema.safeParse({ templateId: TEMPLATE_ID })
+  it('strips templateId on update — the retired picker field can never re-enter (identity is fixed, #1492)', () => {
+    // A picked add-on's template identity is fixed at create; the update path
+    // deliberately dropped templateId (#1437). Parse it ALONGSIDE a legit field so
+    // the assertion proves the strip is surgical (not a blanket empty return): a
+    // future edit that re-admits templateId to updateAddOnSchema fails right here.
+    const result = updateAddOnSchema.safeParse({ priceJpy: 1500, templateId: TEMPLATE_ID })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect((result.data as Record<string, unknown>).templateId).toBeUndefined()
+      expect(result.data).not.toHaveProperty('templateId')
+      expect(result.data.priceJpy).toBe(1500)
     }
   })
 


### PR DESCRIPTION
Two low-risk hardening nits deferred from #1437 slice 3c (#1488), which stayed a clean deletion. No user-facing behavior change; shared-only, no migration.

## (a) Type-enforce `serverOnly ⇒ serverDefault` on the flag registry

The issue asked to make `FeatureFlagEntry` a discriminated union so a `serverOnly` flag is *statically required* to carry a `serverDefault` boolean. It flagged that #1479 recently touched this file and "the nit may need reframing" — it did.

`registry.test.ts` (typechecked, under `src/**`) reads `.env`, `.serverDefault`, and `.serverOnly` off `FEATURE_FLAGS[key]`, and lines 39-41 read **both** `.serverDefault` and `.env` on the same `SHARED_CATALOG` entry. Making the *consumed* `FeatureFlagEntry` a union would break those accesses (and `feature-flags.ts` + `feature-flags-parity.test.ts`) — you can't read both arms off one narrowed entry without casts. The existing code also deliberately types `FEATURE_FLAGS` as a wide `Record<Key, FeatureFlagEntry>` precisely to keep indexed `.env` access uniform.

So the enforcement lives at the **authoring boundary** instead: a strict internal `FeatureFlagSpec` discriminated union gates the `REGISTRY` `satisfies`, statically forcing every `serverOnly` entry to declare `serverDefault`. The exported `FeatureFlagEntry` stays the wide flat read-shape.

- Same static guarantee the issue wants; the runtime "every serverOnly has a boolean serverDefault" test is kept as belt-and-suspenders.
- **Zero** consumer/test churn — all three packages typecheck unchanged.
- Sabotage-verified: dropping `serverDefault` from `SHARED_CATALOG` now fails tsc with `Property 'serverDefault' is missing ... but required in type 'ServerOnlyFeatureFlagEntry'`.

## (b) Regression guard: `updateAddOnSchema` strips `templateId`

An existing test already stripped a templateId-only input (added during slice 3a/3b, after the nit was reconned). Rather than add a near-duplicate, I hardened that test to be mutation-resistant: parse `templateId` alongside a legit field (`priceJpy`) and assert the strip is surgical (`.not.toHaveProperty('templateId')` + kept field survives). Sabotage-verified: re-admitting `templateId` to `updateAddOnSchema` fails exactly this guard.

## Verification
- `bun run --filter '*' typecheck` — all green (shared, api, web)
- `bun run --filter @kuruma/shared test` — 919 pass
- `bun run --filter @kuruma/api test -- feature-flag` — 14 pass (runtime unchanged)
- biome clean; both sabotage checks confirmed enforcement

Closes #1492