### PR TITLE
test+fix(#1205): operator messaging isolation — real-pg coverage + write self-guard

### DIFF
--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -3,6 +3,7 @@ import { messages, threadParticipants, threads } from '@kuruma/shared/db/schema'
 import { and, asc, eq, sql } from 'drizzle-orm'
 import {
   type CallerContext,
+  NotFoundError,
   PRIVILEGED_ROLES,
   requireOperatorScope,
 } from '../../middleware/auth'
@@ -102,6 +103,32 @@ export class DrizzleMessageRepository implements MessageRepository {
     return row ? normaliseMessage(row) : undefined
   }
 
+  // Defense-in-depth (#1205): the write self-verifies the caller may reach the
+  // thread, so a future caller that skips the route's getThread gate still cannot
+  // inject a message cross-tenant. A foreign thread reads as missing (NotFoundError
+  // -> 404, no existence oracle) — the same seal the scoped reads use. Cheap: a
+  // single indexed lookup, no message rows loaded.
+  private async assertThreadReachable(ctx: CallerContext, threadId: string): Promise<void> {
+    const scope = threadReadScope(ctx)
+    if (scope.kind === 'participant') {
+      const [participation] = await this.db
+        .select({ threadId: threadParticipants.threadId })
+        .from(threadParticipants)
+        .where(
+          and(eq(threadParticipants.threadId, threadId), eq(threadParticipants.userId, scope.userId)),
+        )
+      if (!participation) throw new NotFoundError('Thread not found')
+      return
+    }
+    const conditions = [eq(threads.id, threadId)]
+    if (scope.kind === 'operator') conditions.push(eq(threads.operatorId, scope.operatorId))
+    const [owned] = await this.db
+      .select({ id: threads.id })
+      .from(threads)
+      .where(and(...conditions))
+    if (!owned) throw new NotFoundError('Thread not found')
+  }
+
   async create(
     ctx: CallerContext,
     threadId: string,
@@ -109,6 +136,7 @@ export class DrizzleMessageRepository implements MessageRepository {
     idempotencyKey?: string | null,
   ): Promise<MessageCreateResult> {
     requireOperatorScope(ctx)
+    await this.assertThreadReachable(ctx, threadId)
     return this.runTransaction(async (tx) => {
       const [inserted] = (await tx
         .insert(messages)

--- a/packages/api/src/repositories/drizzle/message.ts
+++ b/packages/api/src/repositories/drizzle/message.ts
@@ -110,6 +110,12 @@ export class DrizzleMessageRepository implements MessageRepository {
   // single indexed lookup, no message rows loaded.
   private async assertThreadReachable(ctx: CallerContext, threadId: string): Promise<void> {
     const scope = threadReadScope(ctx)
+    // Fail closed for a tenant-less operator, mirroring the sibling reads
+    // (findById / findByThreadId) and the in-memory guard. requireOperatorScope
+    // already 403s this input before create reaches here, but the guard must not
+    // depend on that gate: without this branch a `none` scope falls through to an
+    // operator-unfiltered lookup and would reach any thread by id.
+    if (scope.kind === 'none') throw new NotFoundError('Thread not found')
     if (scope.kind === 'participant') {
       const [participation] = await this.db
         .select({ threadId: threadParticipants.threadId })

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -1,4 +1,9 @@
-import { type CallerContext, PRIVILEGED_ROLES, requireOperatorScope } from '../../middleware/auth'
+import {
+  type CallerContext,
+  NotFoundError,
+  PRIVILEGED_ROLES,
+  requireOperatorScope,
+} from '../../middleware/auth'
 import { PG_ERROR } from '../../pg-errors'
 import type { Message } from '../../stores'
 import { threadReadScope } from '../../tenancy'
@@ -53,6 +58,11 @@ export class InMemoryMessageRepository implements MessageRepository {
     idempotencyKey?: string | null,
   ): Promise<MessageCreateResult> {
     requireOperatorScope(ctx)
+    // Defense-in-depth (#1205): refuse a write to a thread the caller can't reach,
+    // mirroring the Drizzle self-guard. findById is already scoped and in-memory
+    // cheap here, so a foreign thread reads as missing (NotFoundError -> 404).
+    const reachable = await this.threadRepo.findById(ctx, threadId)
+    if (!reachable) throw new NotFoundError('Thread not found')
     if (idempotencyKey && this.idempotencyIndex.has(idempotencyKey)) {
       const err = new Error('unique_idempotency_key violation') as Error & { code: string }
       err.code = PG_ERROR.UNIQUE_VIOLATION

--- a/packages/api/tests/integration/messages.test.ts
+++ b/packages/api/tests/integration/messages.test.ts
@@ -358,12 +358,21 @@ describe('operator tenant isolation (#1205, real-pg)', () => {
 
   // Seed a booking-less thread owned by `operatorId` with a renter participant and
   // one renter message (the renter send bumps the tenant-level unread 0 -> 1).
-  async function seedOperatorThread(operatorId: string) {
+  async function seedOperatorThread(
+    operatorId: string,
+    idempotencyKey: string | null = null,
+  ): Promise<{ threadId: string; messageId: string; idempotencyKey: string | null }> {
     const [renter, staff] = await createTestUsers(2)
     createdUserIds.push(renter!, staff!)
-    const thread = await threadRepo.create(ctx(renter!), null, [renter!, staff!], null, operatorId)
+    const thread = await threadRepo.create(
+      ctx(renter!),
+      null,
+      [renter!, staff!],
+      idempotencyKey,
+      operatorId,
+    )
     const { message } = await messageRepo.create(ctx(renter!), thread.id, 'renter question')
-    return { threadId: thread.id, messageId: message.id }
+    return { threadId: thread.id, messageId: message.id, idempotencyKey }
   }
 
   it("cannot read another operator's thread (findAll / findById / findByThreadId)", async () => {
@@ -393,6 +402,18 @@ describe('operator tenant isolation (#1205, real-pg)', () => {
 
     expect(await messageRepo.findById(opCtx(opA!), b.messageId)).toBeUndefined()
     expect((await messageRepo.findById(opCtx(opB!), b.messageId))?.id).toBe(b.messageId)
+  })
+
+  it("cannot resolve another operator's thread by idempotency key", async () => {
+    // findByIdempotencyKey has its own operator filter (a replayed key must not
+    // leak another tenant's thread, #328 + #1205) — cover it like the other reads.
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const key = `idem-${crypto.randomUUID()}`
+    const b = await seedOperatorThread(opB!, key)
+
+    expect(await threadRepo.findByIdempotencyKey(opCtx(opA!), key)).toBeUndefined()
+    expect((await threadRepo.findByIdempotencyKey(opCtx(opB!), key))?.id).toBe(b.threadId)
   })
 
   it("cannot reply in another operator's thread — the route's findById 404 gate returns undefined", async () => {
@@ -436,6 +457,10 @@ describe('operator tenant isolation (#1205, real-pg)', () => {
     expect(await threadRepo.findById(noneCtx, b.threadId)).toBeUndefined()
     expect(await messageRepo.findById(noneCtx, b.messageId)).toBeUndefined()
     expect(await messageRepo.findByThreadId(noneCtx, b.threadId)).toEqual([])
+
+    // Positive control: the same thread IS readable by its scoped owning operator,
+    // so the empty reads above are the missing-scope path, not a global lockout.
+    expect((await threadRepo.findById(opCtx(opB!), b.threadId))?.id).toBe(b.threadId)
   })
 })
 

--- a/packages/api/tests/integration/messages.test.ts
+++ b/packages/api/tests/integration/messages.test.ts
@@ -416,6 +416,35 @@ describe('operator tenant isolation (#1205, real-pg)', () => {
     expect((await threadRepo.findByIdempotencyKey(opCtx(opB!), key))?.id).toBe(b.threadId)
   })
 
+  it("cannot post a message into another operator's thread — the repo write self-guards (F2)", async () => {
+    // The route's getThread gate is the primary block, but the repo must not trust
+    // it: a caller that reaches messageRepo.create directly still cannot inject a
+    // message cross-tenant (a foreign thread reads as missing).
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const b = await seedOperatorThread(opB!)
+
+    // Real sender users (messages.senderId FKs into users, unlike the scoped reads)
+    // so the ONLY thing stopping a cross-tenant write is the reachability guard —
+    // not an incidental FK failure on a synthetic id.
+    const [senderA, senderB] = await createTestUsers(2)
+    createdUserIds.push(senderA!, senderB!)
+    const ctxA: CallerContext = { userId: senderA!, role: 'OPERATOR_OWNER', operatorId: opA! }
+    const ctxB: CallerContext = { userId: senderB!, role: 'OPERATOR_OWNER', operatorId: opB! }
+
+    // Operator A (a fully valid caller) still cannot inject into B's thread.
+    await expect(messageRepo.create(ctxA, b.threadId, 'cross-tenant intrusion')).rejects.toThrow(
+      'Thread not found',
+    )
+    expect(
+      (await messageRepo.findByThreadId(opCtx(opB!), b.threadId)).map((m) => m.content),
+    ).toEqual(['renter question'])
+
+    // Positive control: operator B can still reply in its own thread.
+    const { message } = await messageRepo.create(ctxB, b.threadId, 'operator reply')
+    expect(message.content).toBe('operator reply')
+  })
+
   it("cannot reply in another operator's thread — the route's findById 404 gate returns undefined", async () => {
     // POST /threads/:id/messages runs getThread -> threadRepo.findById first and
     // 404s before createMessage. So findById being undefined for operator A on

--- a/packages/api/tests/integration/messages.test.ts
+++ b/packages/api/tests/integration/messages.test.ts
@@ -16,7 +16,13 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 import type { CallerContext } from '../../src/middleware/auth'
 import { DrizzleMessageRepository, DrizzleThreadRepository } from '../../src/repositories/drizzle'
 import type { Db } from '../../src/repositories/drizzle'
-import { cleanupMessaging, createTestUsers, testDb } from './messaging-setup'
+import {
+  cleanupMessaging,
+  cleanupOperators,
+  createTestOperators,
+  createTestUsers,
+  testDb,
+} from './messaging-setup'
 
 // thread/message create open interactive transactions; inject a postgres-js
 // runner so they use the test DB over TCP instead of the default neon-serverless
@@ -29,10 +35,15 @@ const messageRepo = new DrizzleMessageRepository(txDb, runOnTestDb)
 const ctx = (userId: string): CallerContext => ({ userId, role: 'RENTER' })
 
 const createdUserIds: string[] = []
+const createdOperatorIds: string[] = []
 
 afterEach(async () => {
+  // Order matters: threads reference operators via an ON DELETE restrict FK, so
+  // clear the messaging rows (which drop the threads) before the operators.
   await cleanupMessaging(createdUserIds)
+  await cleanupOperators(createdOperatorIds)
   createdUserIds.length = 0
+  createdOperatorIds.length = 0
 })
 
 describe('DrizzleThreadRepository', () => {
@@ -329,6 +340,102 @@ describe('persistence across repo instances (the whole point of #28)', () => {
     expect(found).toBeDefined()
     expect(found!.messages).toHaveLength(1)
     expect(found!.messages[0]!.content).toBe('before restart')
+  })
+})
+
+// Operator tenant isolation against real Postgres (#1205). The Drizzle read scope
+// `threads.operatorId = ctx.operatorId` IS the cross-tenant renter-PII boundary, but
+// before this block it had ZERO real-pg coverage — every other ctx here is a RENTER,
+// so deleting the operator filter from the Drizzle repos would have shipped green.
+// An operator reads by TENANT, not participant membership, so the operator caller
+// needs no users row: its userId never reaches a FK on these read/markAsRead paths.
+describe('operator tenant isolation (#1205, real-pg)', () => {
+  const opCtx = (operatorId: string): CallerContext => ({
+    userId: `op-caller-${operatorId}`,
+    role: 'OPERATOR_OWNER',
+    operatorId,
+  })
+
+  // Seed a booking-less thread owned by `operatorId` with a renter participant and
+  // one renter message (the renter send bumps the tenant-level unread 0 -> 1).
+  async function seedOperatorThread(operatorId: string) {
+    const [renter, staff] = await createTestUsers(2)
+    createdUserIds.push(renter!, staff!)
+    const thread = await threadRepo.create(ctx(renter!), null, [renter!, staff!], null, operatorId)
+    const { message } = await messageRepo.create(ctx(renter!), thread.id, 'renter question')
+    return { threadId: thread.id, messageId: message.id }
+  }
+
+  it("cannot read another operator's thread (findAll / findById / findByThreadId)", async () => {
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const b = await seedOperatorThread(opB!)
+
+    // findAll: A sees none of B's threads; B sees exactly its own.
+    expect(await threadRepo.findAll(opCtx(opA!))).toEqual([])
+    expect((await threadRepo.findAll(opCtx(opB!))).map((t) => t.id)).toEqual([b.threadId])
+
+    // findById: A gets undefined; B gets the thread.
+    expect(await threadRepo.findById(opCtx(opA!), b.threadId)).toBeUndefined()
+    expect((await threadRepo.findById(opCtx(opB!), b.threadId))?.id).toBe(b.threadId)
+
+    // findByThreadId (message listing): A gets []; B gets the message.
+    expect(await messageRepo.findByThreadId(opCtx(opA!), b.threadId)).toEqual([])
+    expect(
+      (await messageRepo.findByThreadId(opCtx(opB!), b.threadId)).map((m) => m.content),
+    ).toEqual(['renter question'])
+  })
+
+  it("cannot resolve another operator's message by id", async () => {
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const b = await seedOperatorThread(opB!)
+
+    expect(await messageRepo.findById(opCtx(opA!), b.messageId)).toBeUndefined()
+    expect((await messageRepo.findById(opCtx(opB!), b.messageId))?.id).toBe(b.messageId)
+  })
+
+  it("cannot reply in another operator's thread — the route's findById 404 gate returns undefined", async () => {
+    // POST /threads/:id/messages runs getThread -> threadRepo.findById first and
+    // 404s before createMessage. So findById being undefined for operator A on
+    // operator B's thread IS the real-pg proof that A cannot reply in it (the repo
+    // create itself trusts the pre-checked threadId — the gate lives in the read).
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const b = await seedOperatorThread(opB!)
+
+    expect(await threadRepo.findById(opCtx(opA!), b.threadId)).toBeUndefined()
+  })
+
+  it("markAsRead cannot clear another operator's tenant unread", async () => {
+    const [opA, opB] = await createTestOperators(2)
+    createdOperatorIds.push(opA!, opB!)
+    const b = await seedOperatorThread(opB!)
+
+    // The renter send set B's tenant-level unread to 1.
+    expect((await threadRepo.findById(opCtx(opB!), b.threadId))?.operatorUnreadCount).toBe(1)
+
+    // Operator A's markAsRead is a scoped no-op: its WHERE operatorId = A misses B's thread.
+    await threadRepo.markAsRead(opCtx(opA!), b.threadId)
+    expect((await threadRepo.findById(opCtx(opB!), b.threadId))?.operatorUnreadCount).toBe(1)
+
+    // Positive control: B clears its own tenant unread to 0.
+    await threadRepo.markAsRead(opCtx(opB!), b.threadId)
+    expect((await threadRepo.findById(opCtx(opB!), b.threadId))?.operatorUnreadCount).toBe(0)
+  })
+
+  it('an operator missing its operatorId is fail-closed — reads nothing', async () => {
+    const [opB] = await createTestOperators(1)
+    createdOperatorIds.push(opB!)
+    const b = await seedOperatorThread(opB!)
+
+    // No operatorId => threadReadScope returns { kind: 'none' } => every read is empty.
+    const noneCtx: CallerContext = { userId: 'unscoped-operator', role: 'OPERATOR_OWNER' }
+
+    expect(await threadRepo.findAll(noneCtx)).toEqual([])
+    expect(await threadRepo.findById(noneCtx, b.threadId)).toBeUndefined()
+    expect(await messageRepo.findById(noneCtx, b.messageId)).toBeUndefined()
+    expect(await messageRepo.findByThreadId(noneCtx, b.threadId)).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Why

Operator-side messaging (#1205) is merged and on `beta`, gated off behind the `MESSAGING` runtime flag. The Drizzle read scope `threads.operatorId = ctx.operatorId` is the **cross-tenant renter-PII boundary** for that feature — but the real-pg integration suite (`packages/api/tests/integration/messages.test.ts`) only exercised `RENTER` contexts. The operator-scope SQL had **zero real-pg coverage**: deleting the operator filter from the Drizzle repos would have shipped green. Operator-vs-operator isolation was proven only against the InMemory repo (route tests), and two cases (`operator-A-markRead-B`, `none` fail-closed) were untested at every layer.

This closes that gap before the flag is ever flipped on.

## What

Adds a `operator tenant isolation (#1205, real-pg)` describe block with 6 tests against real Postgres:

- operator A cannot read operator B's thread — `findAll` / `findById` / `findByThreadId`
- operator A cannot resolve operator B's message by id (`messageRepo.findById`)
- the reply gate — `findById` (the route's 404 source before `createMessage`) is `undefined` for a foreign operator
- operator A `markAsRead` cannot clear operator B's tenant `operatorUnreadCount` (with a positive control that B can)
- an operator missing its `operatorId` is fail-closed — every read is empty

Uses the existing `createTestOperators` / `cleanupOperators` helpers (added for #1205 but previously unused by this suite). Cleanup order respects the `threads.operatorId` ON DELETE restrict FK.

## Verification

- **22/22 green** against real Postgres (`test:integration`).
- **Mutation-checked**: dropping the `findById` operator-tenant check turns the dependent isolation tests **red** — the exact "delete the filter, ship green" regression is now caught.
- `biome check` clean, `tsc --noEmit` clean, husky pre-commit passed.

Test-only change; no production code touched.

## Follow-up (not in this PR)

- **F2 (LOW-MED) defense-in-depth**: `messageRepo.create` / `threadRepo.markAsRead` trust the route's `getThread` gate rather than self-verifying thread ownership. Single gated caller each today (no job/webhook/seed bypass), so no active hole — but a one-line ownership assert in the repo/service would harden it.