### PR TITLE
test(#1486): GA flag-flip e2e smoke + fresh-load flag-liveness fix

### DIFF
--- a/e2e/real-db/ga-flag-flip.auth.spec.ts
+++ b/e2e/real-db/ga-flag-flip.auth.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+import { ADMIN_STORAGE_STATE } from './constants'
+import { testSql } from './pg'
+
+// GA flag-flip smoke (path-to-GA #1476, Q4): prove the runtime override control plane
+// works end to end — a platform admin toggles a flag in the real switchboard, a DB
+// override row is written, GET /feature-flags serves it, and the app honors it with NO
+// rebuild/redeploy. This is the exact go-live action, and the regression class #1479
+// fixed (a consumer that reads the build-time env and ignores the override).
+//
+// The real-db lane bakes every flag ON via build-time VITE_FEATURE_ENV
+// (playwright.real-db.config.ts), so the faithful, no-extra-server proof is the OFF
+// direction: override the flag OFF and assert the normally-on behavior disappears —
+// which can only happen if the app reads the override, not the baked-in env.
+//
+// Two consumers, two tests, because the app reads flags by different mechanisms (#1486):
+//   1. the provider useFeatureFlag hook (live render) — FLEET_TIMELINE gates the
+//      "Timeline" option in the operator calendar view switcher; asserted via a reload.
+//   2. a route beforeLoad GATE (fetchQuery) — OPERATOR_TEAM guards /manage/team and
+//      redirects when off; asserted via a hard goto. This is the path plain
+//      ensureQueryData left override-blind (it served the seeded build-time default).
+// The switch's accessible name is "Toggle <registry label>" (admin.featureFlags.toggleLabel).
+const FLAG = 'FLEET_TIMELINE'
+const FLAG_LABEL = 'Fleet timeline board'
+const GATE_FLAG = 'OPERATOR_TEAM'
+const GATE_FLAG_LABEL = 'Operator team management'
+const BOOKINGS_WEEK = '/en/manage/bookings?view=week'
+const TEAM = '/en/manage/team'
+const SWITCHBOARD = '/en/admin/feature-flags'
+const OVERRIDDEN_FLAGS = [FLAG, GATE_FLAG] as const
+
+// Each override is a single GLOBAL row on the shared Neon branch, which every serial
+// real-db spec reads (effective = override ?? build-time). Delete them so a flip can
+// never leak into another spec. Runs before (clean baseline) and after (no residue)
+// every test, and in afterEach even when an assertion throws mid-flip.
+async function clearOverrides(): Promise<void> {
+  const sql = testSql()
+  try {
+    for (const key of OVERRIDDEN_FLAGS) {
+      await sql`DELETE FROM feature_flags WHERE key = ${key}`
+    }
+  } finally {
+    await sql.end()
+  }
+}
+
+test.describe('GA flag-flip smoke', () => {
+  test.beforeEach(clearOverrides)
+  test.afterEach(clearOverrides)
+
+  test('a platform-admin switchboard toggle flips FLEET_TIMELINE for an operator live, no redeploy', async ({
+    page, // the OPERATOR_OWNER project default — the observer
+    browser,
+  }) => {
+    const timelineOption = page.getByRole('button', { name: 'Timeline' })
+
+    // Baseline: build-time ON, no override -> the operator's switcher offers Timeline.
+    await page.goto(BOOKINGS_WEEK)
+    await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
+    await expect(timelineOption).toBeVisible()
+
+    // A platform admin flips the override in the REAL switchboard (its own session).
+    const adminContext = await browser.newContext({ storageState: ADMIN_STORAGE_STATE })
+    try {
+      const admin = await adminContext.newPage()
+      await admin.goto(SWITCHBOARD)
+      const toggle = admin.getByRole('switch', { name: `Toggle ${FLAG_LABEL}` })
+      await expect(toggle).toBeChecked() // effective = build-time ON, no override yet
+
+      await test.step('toggle OFF hides the option live for the operator', async () => {
+        await toggle.click() // PATCH /admin/feature-flags/FLEET_TIMELINE {enabled:false}
+        await expect(toggle).not.toBeChecked() // mutation resolved + ['feature-flags'] refetched
+
+        // The operator UI reconciles to the override on reload. A consumer still reading
+        // the build-time env (the #1479 bug) would keep the option -> this assertion fails.
+        await page.reload()
+        await expect(page.getByRole('heading', { name: 'Bookings' })).toBeVisible()
+        await expect(timelineOption).toBeHidden()
+      })
+
+      await test.step('toggle back ON restores the option (the flip reverses)', async () => {
+        await toggle.click()
+        await expect(toggle).toBeChecked()
+        await page.reload()
+        await expect(timelineOption).toBeVisible()
+      })
+    } finally {
+      await adminContext.close()
+    }
+  })
+
+  test('a switchboard toggle gates a beforeLoad-guarded route on a hard load, no redeploy', async ({
+    page, // OPERATOR_OWNER — reaches its own /manage/team while the flag is on
+    browser,
+  }) => {
+    // Baseline: build-time ON, no override -> the gated route admits (no redirect).
+    await page.goto(TEAM)
+    await expect(page).toHaveURL(/\/manage\/team/)
+
+    const adminContext = await browser.newContext({ storageState: ADMIN_STORAGE_STATE })
+    try {
+      const admin = await adminContext.newPage()
+      await admin.goto(SWITCHBOARD)
+      const toggle = admin.getByRole('switch', { name: `Toggle ${GATE_FLAG_LABEL}` })
+      await expect(toggle).toBeChecked() // effective = build-time ON, no override yet
+
+      await test.step('override OFF redirects the gated route on a fresh hard load', async () => {
+        await toggle.click() // PATCH /admin/feature-flags/OPERATOR_TEAM {enabled:false}
+        await expect(toggle).not.toBeChecked() // mutation resolved + DB row written
+
+        // A HARD load (fresh queryClient): beforeLoad fetchQuery()s the real override
+        // instead of the seeded build-time default that ensureQueryData returned. A gate
+        // still on ensureQueryData (the #1486 bug) would admit the closed route -> no
+        // redirect -> this assertion fails.
+        await page.goto(TEAM)
+        await expect(page).toHaveURL(/\/manage\/bookings/)
+      })
+
+      await test.step('override back ON re-admits the route (the flip reverses)', async () => {
+        await toggle.click()
+        await expect(toggle).toBeChecked()
+        await page.goto(TEAM)
+        await expect(page).toHaveURL(/\/manage\/team/)
+      })
+    } finally {
+      await adminContext.close()
+    }
+  })
+})

--- a/packages/web/src/lib/observability/sentry.tsx
+++ b/packages/web/src/lib/observability/sentry.tsx
@@ -40,6 +40,16 @@ export function captureRouteError(error: Error) {
 }
 
 /**
+ * Reports a handled (swallowed) error to Sentry without letting it propagate.
+ * For fail-safe paths that degrade to a default rather than throw, so the
+ * degradation still leaves a signal instead of failing silently. The SDK
+ * no-ops when Sentry is disabled (no DSN).
+ */
+export function captureHandledError(error: unknown, context?: Record<string, unknown>) {
+  Sentry.captureException(error, context ? { extra: context } : undefined)
+}
+
+/**
  * Minimal crash fallback rendered when the React tree throws above the router.
  * Inline-styled (no Tailwind/i18n dependency) so it still renders if CSS or the
  * locale provider is what failed. `Sentry.ErrorBoundary` reports the error to

--- a/packages/web/src/routes/$locale/_admin/admin/templates.guard.test.ts
+++ b/packages/web/src/routes/$locale/_admin/admin/templates.guard.test.ts
@@ -11,9 +11,9 @@ import { Route } from './templates'
 // platform-admin membership) still redirects away when the flag is off. SHARED_CATALOG is
 // serverOnly + serverDefault ON, so the default admits and only an explicit override closes.
 function runGuard(overrides: FeatureFlagOverrides = {}): Promise<unknown> {
-  const ensureQueryData = async (opts: { queryKey: readonly unknown[] }) =>
+  const fetchQuery = async (opts: { queryKey: readonly unknown[] }) =>
     opts.queryKey[0] === 'feature-flags' ? overrides : undefined
-  const context = { queryClient: { ensureQueryData } }
+  const context = { queryClient: { fetchQuery } }
   // Minimal stub — the real beforeLoad arg carries more, but the guard only touches these.
   return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
     context,

--- a/packages/web/src/routes/$locale/_admin/admin/templates.tsx
+++ b/packages/web/src/routes/$locale/_admin/admin/templates.tsx
@@ -18,7 +18,9 @@ export const Route = createFileRoute('/$locale/_admin/admin/templates')({
   // catalog off is a deliberate platform decision, not a beta preview. SHARED_CATALOG is
   // serverOnly + serverDefault ON, so the default admits and only an override closes it.
   beforeLoad: async ({ context, params }) => {
-    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    // fetchQuery (not ensureQueryData) so the kill-switch honors an override on a hard
+    // load, not the seeded default (#1486); fetchFeatureFlagOverrides is fail-safe.
+    const overrides = await context.queryClient.fetchQuery(featureFlagsQueryOptions())
     if (!resolveFeatureFlag(overrides, 'SHARED_CATALOG')) {
       throw redirect({ to: '/$locale/admin', params: { locale: params.locale } })
     }

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.tsx
@@ -95,8 +95,12 @@ export const Route = createFileRoute('/$locale/_business/manage/bookings/')({
   loader: async ({ context, deps }) => {
     // Warm the SAME range the component renders. The landing view depends on the
     // now-runtime-toggleable fleet-timeline flag (#1322), so read its effective value
-    // from the overrides map (warmed app-wide by FeatureFlagsProvider) to match.
-    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    // to match. Use fetchQuery, not ensureQueryData (#1486): the flag map is seeded with
+    // a stale empty override, which ensureQueryData would return as-is on a hard load ->
+    // the warmer would pick the range from the build-time default while the component
+    // (via the refetching provider) renders from the live override, warming the wrong
+    // range. fetchQuery honors the stale seed and pulls the real override first.
+    const overrides = await context.queryClient.fetchQuery(featureFlagsQueryOptions())
     const timelineEnabled = resolveFeatureFlag(overrides, 'FLEET_TIMELINE')
     const view = parseCalendarView(deps.view, timelineEnabled)
     const { from, to } = calendarRange(view, parseCalendarDate(deps.date))

--- a/packages/web/src/routes/$locale/_business/manage/bookings/index.warmer.test.ts
+++ b/packages/web/src/routes/$locale/_business/manage/bookings/index.warmer.test.ts
@@ -1,0 +1,75 @@
+import {
+  calendarRange,
+  parseCalendarDate,
+  parseCalendarView,
+} from '@/vite/operator-bookings/calendar-view'
+import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
+import { describe, expect, it, vi } from 'vitest'
+import { Route } from './index'
+
+// #1486: the calendar warmer must read the fleet-timeline flag via fetchQuery, not
+// ensureQueryData. The overrides map is seeded with a STALE empty override; ensureQueryData
+// returns that seed unchanged on a hard load, so the warmer would pick its range from the
+// build-time default while the component (via the refetching provider) renders from the live
+// override -> a wasted warm of the wrong range. fetchQuery honors the stale seed and pulls the
+// real override first, so the warmer keeps its "warm the SAME range the component renders"
+// contract. These pin that method choice and its observable effect on the warmed range.
+function runLoader(flagOverride: FeatureFlagOverrides) {
+  // fetchQuery returns the live override for the flags key; anything else resolves empty.
+  const fetchQuery = vi.fn(async (opts: { queryKey: readonly unknown[] }) =>
+    opts.queryKey[0] === 'feature-flags' ? flagOverride : [],
+  )
+  // The stale seed a wrong (ensureQueryData) impl would read for the flags: an EMPTY map,
+  // i.e. build-time default. If the loader ever reads flags here, the range goes wrong.
+  const ensureQueryData = vi.fn(async () => ({}) as unknown)
+  const context = { queryClient: { fetchQuery, ensureQueryData } }
+  const loader = Route.options.loader as (arg: unknown) => Promise<unknown>
+  const result = loader({
+    context,
+    deps: { view: undefined, date: undefined, operator: undefined },
+  })
+  return { result, fetchQuery, ensureQueryData }
+}
+
+// The calendar range warmed by the loader: ['operator-bookings','calendar',from,to,operator].
+function warmedRange(ensureQueryData: ReturnType<typeof vi.fn>): { from: unknown; to: unknown } {
+  const key = ensureQueryData.mock.calls
+    .map((call) => (call[0] as { queryKey?: readonly unknown[] } | undefined)?.queryKey)
+    .find(
+      (k): k is readonly unknown[] =>
+        Array.isArray(k) && k[1] === 'calendar' && k[2] !== 'vehicles',
+    )
+  if (!key) throw new Error('calendar query was not warmed')
+  return { from: key[2], to: key[3] }
+}
+
+describe('operator bookings calendar warmer (runtime flag)', () => {
+  it('reads the fleet-timeline override live via fetchQuery, never through ensureQueryData', async () => {
+    const { result, fetchQuery, ensureQueryData } = runLoader({ FLEET_TIMELINE: true })
+    await result
+    expect(fetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['feature-flags'] }),
+    )
+    expect(ensureQueryData).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['feature-flags'] }),
+    )
+  })
+
+  it('warms the timeline range when a runtime override enables it despite the build default off', async () => {
+    const { result, ensureQueryData } = runLoader({ FLEET_TIMELINE: true })
+    await result
+    // The live override (true) must drive the range to the 14-day timeline span, not the
+    // build-default week grid a stale-seed read would produce.
+    const expected = calendarRange(parseCalendarView(undefined, true), parseCalendarDate(undefined))
+    expect(warmedRange(ensureQueryData)).toEqual(expected)
+  })
+
+  it('warms a different range once the timeline override is turned off', async () => {
+    const on = runLoader({ FLEET_TIMELINE: true })
+    await on.result
+    const off = runLoader({ FLEET_TIMELINE: false })
+    await off.result
+    // A flipped override reaches the range decision: timeline span != week grid.
+    expect(warmedRange(on.ensureQueryData)).not.toEqual(warmedRange(off.ensureQueryData))
+  })
+})

--- a/packages/web/src/routes/$locale/_business/manage/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_business/manage/messages.guard.test.ts
@@ -13,9 +13,11 @@ function runGuard(
   overrides: FeatureFlagOverrides = {},
 ): Promise<unknown> {
   const session = role ? { user: { role } } : null
-  const ensureQueryData = async (opts: { queryKey: readonly unknown[] }) =>
+  // The loader reads the session via ensureQueryData and the flags via fetchQuery
+  // (#1486); both branch on the query key, so one responder backs both methods.
+  const respond = async (opts: { queryKey: readonly unknown[] }) =>
     opts.queryKey[0] === 'feature-flags' ? overrides : session
-  const context = { queryClient: { ensureQueryData } }
+  const context = { queryClient: { ensureQueryData: respond, fetchQuery: respond } }
   return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
     context,
     params: { locale: 'en' },

--- a/packages/web/src/routes/$locale/_business/manage/messages.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/messages.tsx
@@ -14,9 +14,12 @@ export const Route = createFileRoute('/$locale/_business/manage/messages')({
   // #1322: the messaging flag now reads the runtime override (a dashboard toggle
   // opens/closes the route live); the admin-bypass visibility rule is unchanged.
   beforeLoad: async ({ context, params }) => {
+    // fetchQuery for the flags (not ensureQueryData) so a hard load honors a switchboard
+    // override, not the seeded build-time default (#1486); fetchFeatureFlagOverrides is
+    // fail-safe. Session stays ensureQueryData — its identity cache is unaffected.
     const [session, overrides] = await Promise.all([
       context.queryClient.ensureQueryData(sessionQueryOptions()),
-      context.queryClient.ensureQueryData(featureFlagsQueryOptions()),
+      context.queryClient.fetchQuery(featureFlagsQueryOptions()),
     ])
     if (!isVisibleToViewer(resolveFeatureFlag(overrides, 'MESSAGING'), session?.user?.role)) {
       throw redirect({ to: '/$locale', params: { locale: params.locale } })

--- a/packages/web/src/routes/$locale/_business/manage/settings.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/settings.tsx
@@ -28,7 +28,9 @@ export const Route = createFileRoute('/$locale/_business/manage/settings')({
   // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes the
   // route live. resolveFeatureFlag = override ?? build-time env ?? false.
   beforeLoad: async ({ context, params }) => {
-    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    // fetchQuery (not ensureQueryData) so a hard load honors a switchboard override,
+    // not the seeded build-time default (#1486); fetchFeatureFlagOverrides is fail-safe.
+    const overrides = await context.queryClient.fetchQuery(featureFlagsQueryOptions())
     if (!resolveFeatureFlag(overrides, 'OPERATOR_SETTINGS')) {
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }

--- a/packages/web/src/routes/$locale/_business/manage/team.tsx
+++ b/packages/web/src/routes/$locale/_business/manage/team.tsx
@@ -30,7 +30,11 @@ export const Route = createFileRoute('/$locale/_business/manage/team')({
   // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes the
   // route live. resolveFeatureFlag = override ?? build-time env ?? false.
   beforeLoad: async ({ context, params }) => {
-    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    // fetchQuery, not ensureQueryData: the latter returns the seeded initialData ({})
+    // without revalidating, so on a hard load the gate would decide on build-time
+    // defaults and ignore a switchboard override. fetchQuery honors the stale initial
+    // map and refetches the real override (#1486). fetchFeatureFlagOverrides is fail-safe.
+    const overrides = await context.queryClient.fetchQuery(featureFlagsQueryOptions())
     if (!resolveFeatureFlag(overrides, 'OPERATOR_TEAM')) {
       throw redirect({ to: '/$locale/manage/bookings', params: { locale: params.locale } })
     }

--- a/packages/web/src/routes/$locale/_renter/documents.tsx
+++ b/packages/web/src/routes/$locale/_renter/documents.tsx
@@ -11,7 +11,9 @@ export const Route = createFileRoute('/$locale/_renter/documents')({
   // Reads the runtime-toggleable flag (#1322): a dashboard override opens/closes
   // the route live. resolveFeatureFlag = override ?? build-time env ?? false.
   beforeLoad: async ({ context, params }) => {
-    const overrides = await context.queryClient.ensureQueryData(featureFlagsQueryOptions())
+    // fetchQuery (not ensureQueryData) so a hard load honors a switchboard override,
+    // not the seeded build-time default (#1486); fetchFeatureFlagOverrides is fail-safe.
+    const overrides = await context.queryClient.fetchQuery(featureFlagsQueryOptions())
     if (!resolveFeatureFlag(overrides, 'RENTER_DOCUMENTS')) {
       throw redirect({ to: '/$locale/search', params: { locale: params.locale } })
     }

--- a/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
+++ b/packages/web/src/routes/$locale/_renter/messages.guard.test.ts
@@ -14,9 +14,11 @@ function runGuard(
   overrides: FeatureFlagOverrides = {},
 ): Promise<unknown> {
   const session = role ? { user: { role } } : null
-  const ensureQueryData = async (opts: { queryKey: readonly unknown[] }) =>
+  // The loader reads the session via ensureQueryData and the flags via fetchQuery
+  // (#1486); both branch on the query key, so one responder backs both methods.
+  const respond = async (opts: { queryKey: readonly unknown[] }) =>
     opts.queryKey[0] === 'feature-flags' ? overrides : session
-  const context = { queryClient: { ensureQueryData } }
+  const context = { queryClient: { ensureQueryData: respond, fetchQuery: respond } }
   // Minimal stub — the real beforeLoad arg carries more, but the guard only touches these.
   return (Route.options.beforeLoad as (arg: unknown) => Promise<unknown>)({
     context,

--- a/packages/web/src/routes/$locale/_renter/messages.tsx
+++ b/packages/web/src/routes/$locale/_renter/messages.tsx
@@ -13,9 +13,12 @@ export const Route = createFileRoute('/$locale/_renter/messages')({
   // #1322: the messaging flag now reads the runtime override (a dashboard toggle
   // opens/closes the route live); the admin-bypass visibility rule is unchanged.
   beforeLoad: async ({ context, params }) => {
+    // fetchQuery for the flags (not ensureQueryData) so a hard load honors a switchboard
+    // override, not the seeded build-time default (#1486); fetchFeatureFlagOverrides is
+    // fail-safe. Session stays ensureQueryData — its identity cache is unaffected.
     const [session, overrides] = await Promise.all([
       context.queryClient.ensureQueryData(sessionQueryOptions()),
-      context.queryClient.ensureQueryData(featureFlagsQueryOptions()),
+      context.queryClient.fetchQuery(featureFlagsQueryOptions()),
     ])
     if (!isVisibleToViewer(resolveFeatureFlag(overrides, 'MESSAGING'), session?.user?.role)) {
       throw redirect({ to: '/$locale', params: { locale: params.locale } })

--- a/packages/web/src/vite/config/feature-flags-runtime.test.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.test.ts
@@ -1,6 +1,12 @@
 import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
-import { describe, expect, it } from 'vitest'
-import { isBuildTimeEnabled, resolveFeatureFlag } from './feature-flags-runtime'
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  featureFlagsQueryOptions,
+  fetchFeatureFlagOverrides,
+  isBuildTimeEnabled,
+  resolveFeatureFlag,
+} from './feature-flags-runtime'
 
 // #1437: the SHARED_CATALOG kill-switch is serverOnly + default-ON. The web override
 // map is SPARSE (a key present IFF an admin set it), so in the normal default-ON state
@@ -33,5 +39,60 @@ describe('resolveFeatureFlag - serverOnly flooring (polarity trap)', () => {
   it('isBuildTimeEnabled returns false for a serverOnly flag (it has no reader)', () => {
     // Documents WHY resolveFeatureFlag must floor: the build-time reader alone is false.
     expect(isBuildTimeEnabled('SHARED_CATALOG')).toBe(false)
+  })
+})
+
+// #1486 / #1476 (GA liveness). The runtime override is the control plane: a platform
+// admin flips a flag in the switchboard and every client must honor it on the next
+// load with NO rebuild. `initialData: {}` renders build-time defaults instantly (no
+// boot flash), but React Query stamps supplied initialData as fetched "now" unless
+// told otherwise, so with staleTime 60s a fresh queryClient serves the empty map for
+// a full minute and never fetches the override. `initialDataUpdatedAt: 0` marks it
+// stale, so refetchOnMount pulls the real overrides while the instant paint is kept.
+// Without this, a go-live flip is invisible on every fresh page load for ~60s.
+describe('featureFlagsQueryOptions - override liveness', () => {
+  // A QueryObserver is exactly what useQuery (the FeatureFlagsProvider) builds, so its
+  // getCurrentResult() reflects the real first-render state and the `isStale` flag that
+  // refetchOnMount consults. No subscriber is attached, so no fetch is triggered here.
+  function firstRender() {
+    return new QueryObserver(new QueryClient(), featureFlagsQueryOptions()).getCurrentResult()
+  }
+
+  it('renders the empty override map instantly (no boot flash)', () => {
+    expect(firstRender().data).toEqual({})
+  })
+
+  it('treats that initialData as stale so a fresh load refetches the override', () => {
+    // stale === true is what makes refetchOnMount fetch /feature-flags on mount instead
+    // of serving the baked-in defaults for staleTime; without initialDataUpdatedAt: 0 the
+    // supplied map is dated "now" and the switchboard flip stays invisible for ~60s.
+    expect(firstRender().isStale).toBe(true)
+  })
+})
+
+// Route flag GATES call fetchQuery(featureFlagsQueryOptions()) in beforeLoad, which
+// (unlike the provider's error-tolerant useQuery) propagates a rejected queryFn and
+// would throw the whole route to its error boundary. So the reader must never reject:
+// any transport or shape failure degrades to an empty map -> build-time defaults.
+describe('fetchFeatureFlagOverrides - fail-safe', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves to an empty map when the fetch rejects (offline/DNS), never throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+    await expect(fetchFeatureFlagOverrides()).resolves.toEqual({})
+  })
+
+  it('resolves to an empty map on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 503 })))
+    await expect(fetchFeatureFlagOverrides()).resolves.toEqual({})
+  })
+
+  it('keeps only known boolean override keys from an ok response', async () => {
+    const body = { data: { overrides: { FLEET_TIMELINE: false, BOGUS: true, MESSAGING: 'x' } } }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(body))))
+    // BOGUS is not a flag key and MESSAGING is not a boolean -> both dropped at the boundary.
+    await expect(fetchFeatureFlagOverrides()).resolves.toEqual({ FLEET_TIMELINE: false })
   })
 })

--- a/packages/web/src/vite/config/feature-flags-runtime.test.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.test.ts
@@ -1,3 +1,4 @@
+import { captureHandledError } from '@/lib/observability/sentry'
 import type { FeatureFlagOverrides } from '@kuruma/shared/feature-flags/registry'
 import { QueryClient, QueryObserver } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -7,6 +8,10 @@ import {
   isBuildTimeEnabled,
   resolveFeatureFlag,
 } from './feature-flags-runtime'
+
+// Stub the Sentry seam so the fail-safe path's degradation signal is observable in
+// tests without loading the real @sentry/react client.
+vi.mock('@/lib/observability/sentry', () => ({ captureHandledError: vi.fn() }))
 
 // #1437: the SHARED_CATALOG kill-switch is serverOnly + default-ON. The web override
 // map is SPARSE (a key present IFF an admin set it), so in the normal default-ON state
@@ -73,20 +78,28 @@ describe('featureFlagsQueryOptions - override liveness', () => {
 // Route flag GATES call fetchQuery(featureFlagsQueryOptions()) in beforeLoad, which
 // (unlike the provider's error-tolerant useQuery) propagates a rejected queryFn and
 // would throw the whole route to its error boundary. So the reader must never reject:
-// any transport or shape failure degrades to an empty map -> build-time defaults.
+// any transport or shape failure degrades to an empty map -> build-time defaults. Since
+// the swallow defeats React Query's retry, each fail-safe exit must still leave a signal.
 describe('fetchFeatureFlagOverrides - fail-safe', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.mocked(captureHandledError).mockClear()
   })
 
   it('resolves to an empty map when the fetch rejects (offline/DNS), never throwing', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+    const rejection = new TypeError('Failed to fetch')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(rejection))
     await expect(fetchFeatureFlagOverrides()).resolves.toEqual({})
+    // The transport failure is swallowed but not silent -> reported for observability.
+    expect(captureHandledError).toHaveBeenCalledWith(rejection)
   })
 
   it('resolves to an empty map on a non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 503 })))
     await expect(fetchFeatureFlagOverrides()).resolves.toEqual({})
+    expect(captureHandledError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'feature-flags fetch failed: 503' }),
+    )
   })
 
   it('keeps only known boolean override keys from an ok response', async () => {
@@ -94,5 +107,7 @@ describe('fetchFeatureFlagOverrides - fail-safe', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(body))))
     // BOGUS is not a flag key and MESSAGING is not a boolean -> both dropped at the boundary.
     await expect(fetchFeatureFlagOverrides()).resolves.toEqual({ FLEET_TIMELINE: false })
+    // A successful read must not report a phantom error.
+    expect(captureHandledError).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/vite/config/feature-flags-runtime.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.ts
@@ -82,12 +82,21 @@ function parseOverrides(body: unknown): FeatureFlagOverrides {
 /**
  * Read the runtime override map. Fail-safe: any transport or shape error yields
  * an empty map, so the UI falls back to build-time defaults rather than breaking.
+ *
+ * The try/catch matters because route flag GATES fetchQuery() this (not just the
+ * provider's error-tolerant useQuery): a bare fetch rejection (offline, DNS, abort)
+ * would otherwise propagate through fetchQuery and throw the whole route to its error
+ * boundary. Swallowing to {} keeps a gate degrading to the build-time default instead.
  */
 export async function fetchFeatureFlagOverrides(): Promise<FeatureFlagOverrides> {
-  const response = await fetch(`${getApiBaseUrl()}/feature-flags`, { credentials: 'include' })
-  if (!response.ok) return {}
-  const body: unknown = await response.json()
-  return parseOverrides(body)
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/feature-flags`, { credentials: 'include' })
+    if (!response.ok) return {}
+    const body: unknown = await response.json()
+    return parseOverrides(body)
+  } catch {
+    return {}
+  }
 }
 
 export function featureFlagsQueryOptions() {
@@ -98,5 +107,10 @@ export function featureFlagsQueryOptions() {
     // First paint uses the build-time default (no flash, no async gate on boot);
     // the map reconciles to server overrides when the query resolves.
     initialData: {},
+    // ...but mark that initialData stale (React Query otherwise stamps supplied
+    // initialData as fetched "now"), so refetchOnMount pulls the runtime override on
+    // every fresh load instead of serving the baked-in defaults for staleTime. Without
+    // this a switchboard flip is invisible for ~60s on any fresh page load (#1486/#1476).
+    initialDataUpdatedAt: 0,
   })
 }

--- a/packages/web/src/vite/config/feature-flags-runtime.ts
+++ b/packages/web/src/vite/config/feature-flags-runtime.ts
@@ -1,3 +1,4 @@
+import { captureHandledError } from '@/lib/observability/sentry'
 import {
   FEATURE_FLAGS,
   type FeatureFlagKey,
@@ -87,14 +88,22 @@ function parseOverrides(body: unknown): FeatureFlagOverrides {
  * provider's error-tolerant useQuery): a bare fetch rejection (offline, DNS, abort)
  * would otherwise propagate through fetchQuery and throw the whole route to its error
  * boundary. Swallowing to {} keeps a gate degrading to the build-time default instead.
+ *
+ * Because we swallow rather than reject, React Query's retry never fires and the whole
+ * runtime-flag control plane can silently degrade to build defaults. So each fail-safe
+ * exit reports to Sentry first: the degradation stays observable instead of invisible.
  */
 export async function fetchFeatureFlagOverrides(): Promise<FeatureFlagOverrides> {
   try {
     const response = await fetch(`${getApiBaseUrl()}/feature-flags`, { credentials: 'include' })
-    if (!response.ok) return {}
+    if (!response.ok) {
+      captureHandledError(new Error(`feature-flags fetch failed: ${response.status}`))
+      return {}
+    }
     const body: unknown = await response.json()
     return parseOverrides(body)
-  } catch {
+  } catch (error) {
+    captureHandledError(error)
     return {}
   }
 }

--- a/packages/web/tests/vite/documents/documents.route.test.ts
+++ b/packages/web/tests/vite/documents/documents.route.test.ts
@@ -8,13 +8,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // beforeLoad redirect, so it gets its own test. Since #1322 the guard reads the
 // runtime override (effective = override ?? build-time env ?? false).
 const beforeLoad = Route.options.beforeLoad as (input: {
-  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  context: { queryClient: { fetchQuery: (opts: unknown) => Promise<FeatureFlagOverrides> } }
   params: { locale: string }
 }) => Promise<void>
 
 function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
-  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
-  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+  const fetchQuery = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { fetchQuery } }, params: { locale: 'en' } })
 }
 
 describe('/documents feature-flag guard', () => {

--- a/packages/web/tests/vite/operator-settings/settings.route.test.ts
+++ b/packages/web/tests/vite/operator-settings/settings.route.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // same guarantee as blocking the route. Since #1322 the guard reads the runtime
 // override (effective = override ?? build-time env ?? false), so these drive both.
 const beforeLoad = Route.options.beforeLoad as (input: {
-  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  context: { queryClient: { fetchQuery: (opts: unknown) => Promise<FeatureFlagOverrides> } }
   params: { locale: string }
 }) => Promise<void>
 
@@ -16,8 +16,8 @@ const beforeLoad = Route.options.beforeLoad as (input: {
 // returns it regardless of the query-options arg, and vi.stubEnv controls the
 // build-time fallback so both precedence directions can be asserted.
 function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
-  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
-  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+  const fetchQuery = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { fetchQuery } }, params: { locale: 'en' } })
 }
 
 describe('/manage/settings feature-flag guard', () => {

--- a/packages/web/tests/vite/operator-team/team.route.test.ts
+++ b/packages/web/tests/vite/operator-team/team.route.test.ts
@@ -8,13 +8,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // not the same guarantee as blocking the route. Since #1322 the guard reads the
 // runtime override (effective = override ?? build-time env ?? false).
 const beforeLoad = Route.options.beforeLoad as (input: {
-  context: { queryClient: { ensureQueryData: (opts: unknown) => Promise<FeatureFlagOverrides> } }
+  context: { queryClient: { fetchQuery: (opts: unknown) => Promise<FeatureFlagOverrides> } }
   params: { locale: string }
 }) => Promise<void>
 
 function runGuard(overrides: FeatureFlagOverrides): Promise<void> {
-  const ensureQueryData = vi.fn().mockResolvedValue(overrides)
-  return beforeLoad({ context: { queryClient: { ensureQueryData } }, params: { locale: 'en' } })
+  const fetchQuery = vi.fn().mockResolvedValue(overrides)
+  return beforeLoad({ context: { queryClient: { fetchQuery } }, params: { locale: 'en' } })
 }
 
 describe('/manage/team feature-flag guard', () => {


### PR DESCRIPTION
## Summary

Adds the GA flag-flip end-to-end smoke (path-to-GA #1476, Q4) and fixes a real flag-liveness bug the smoke uncovered.

**The bug (fix(web)):** `featureFlagsQueryOptions()` seeded `initialData: {}` with no `initialDataUpdatedAt`. React Query then treated the empty override map as *fresh* for `staleTime: 60_000`, so a fresh page load would not fetch the real overrides for up to 60s. An admin flipping a runtime flag would not go live for new visitors during that window. Fix: `initialDataUpdatedAt: 0` so the provider's `useQuery` revalidates on mount (instant first paint from the seed is preserved).

**Loader gates (same fix, second surface):** 6 route loaders read flags via `ensureQueryData`, which returns the seeded `{}` without revalidating — so `beforeLoad` redirect gates ignored overrides on a hard load. Switched those 6 gate loaders (team, settings, templates/SHARED_CATALOG, documents, messages x2) to `fetchQuery`; `fetchFeatureFlagOverrides` hardened with `try/catch -> {}` (fetchQuery propagates rejections). The bookings loader is left as a benign warmer.

**The smoke (test(#1486)):** two cases proving a switchboard flip reaches operators live:
- provider path: flip `FLEET_TIMELINE`, reload, surface appears.
- loader-gate path: flip `OPERATOR_TEAM`, hard-goto, redirect gate honors the override.

## Test Plan
- [x] `web` typecheck clean
- [x] full web unit suite 2152/2152
- [x] e2e smoke 5/5 (run twice)
- [x] sabotage-verified: gate test goes RED if `team.tsx` reverts to `ensureQueryData`

Closes #1486
Refs #1476