### PR TITLE
a11y(#1489): route-level focus-on-navigate announcer

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -104,7 +104,8 @@
     "newBookings": "{count, plural, one {# new booking} other {# new bookings}}",
     "unreadMessages": "{count, plural, one {# unread message} other {# unread messages}}",
     "settings": "Settings",
-    "team": "Team"
+    "team": "Team",
+    "routeAnnouncerLabel": "Page content"
   },
   "acriss": {
     "MCAR": "Mini",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -104,7 +104,8 @@
     "newBookings": "新規予約 {count}件",
     "unreadMessages": "未読メッセージ {count}件",
     "settings": "設定",
-    "team": "チーム"
+    "team": "チーム",
+    "routeAnnouncerLabel": "ページコンテンツ"
   },
   "acriss": {
     "MCAR": "ミニ",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -104,7 +104,8 @@
     "newBookings": "{count} 个新订单",
     "unreadMessages": "{count} 条未读消息",
     "settings": "设置",
-    "team": "团队"
+    "team": "团队",
+    "routeAnnouncerLabel": "页面内容"
   },
   "acriss": {
     "MCAR": "微型车",

--- a/packages/web/src/routes/$locale.tsx
+++ b/packages/web/src/routes/$locale.tsx
@@ -35,11 +35,12 @@ function LocaleLayout() {
         <CurrencyProvider>
           <ViewModeProvider>
             <LayoutPreferenceProvider>
+              <Navbar />
               {/* #1489: app-wide focus-on-navigate anchor; mounted here (a stable parent
                   that survives child route + pendingComponent swaps) so a navigation never
-                  strands screen-reader focus on <body>. */}
+                  strands screen-reader focus on <body>. Placed just before <Outlet> so
+                  restored focus lands at the content boundary, past the (unchanged) nav. */}
               <RouteAnnouncer />
-              <Navbar />
               <Outlet />
             </LayoutPreferenceProvider>
           </ViewModeProvider>

--- a/packages/web/src/routes/$locale.tsx
+++ b/packages/web/src/routes/$locale.tsx
@@ -5,6 +5,7 @@ import { CurrencyProvider } from '@/vite/currency'
 import { isLocale } from '@/vite/i18n/locale'
 import { messagesQueryOptions } from '@/vite/i18n/messages'
 import { Navbar } from '@/vite/nav/Navbar'
+import { RouteAnnouncer } from '@/vite/nav/RouteAnnouncer'
 import { Outlet, createFileRoute, notFound } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { IntlProvider } from 'use-intl'
@@ -34,6 +35,10 @@ function LocaleLayout() {
         <CurrencyProvider>
           <ViewModeProvider>
             <LayoutPreferenceProvider>
+              {/* #1489: app-wide focus-on-navigate anchor; mounted here (a stable parent
+                  that survives child route + pendingComponent swaps) so a navigation never
+                  strands screen-reader focus on <body>. */}
+              <RouteAnnouncer />
               <Navbar />
               <Outlet />
             </LayoutPreferenceProvider>

--- a/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
 describe('RouteAnnouncer (#1489)', () => {
   it('renders a visually-hidden, focusable, localized anchor', () => {
     renderAnnouncer()
-    const anchor = screen.getByLabelText('Page content')
+    const anchor = screen.getByRole('region', { name: 'Page content' })
     expect(anchor).toHaveClass('sr-only')
     expect(anchor).toHaveAttribute('tabindex', '-1')
   })
@@ -38,7 +38,7 @@ describe('RouteAnnouncer (#1489)', () => {
   it('does not grab focus on the initial resolution', () => {
     href.value = '/en/dashboard'
     renderAnnouncer()
-    expect(screen.getByLabelText('Page content')).not.toHaveFocus()
+    expect(screen.getByRole('region', { name: 'Page content' })).not.toHaveFocus()
     expect(document.body).toHaveFocus()
   })
 
@@ -53,6 +53,6 @@ describe('RouteAnnouncer (#1489)', () => {
       </IntlProvider>,
     )
 
-    expect(screen.getByLabelText('Page content')).toHaveFocus()
+    expect(screen.getByRole('region', { name: 'Page content' })).toHaveFocus()
   })
 })

--- a/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+
+// The repo tests route components by mocking the router hooks (no RouterProvider). Here the
+// mock lets a test drive `resolvedLocation.href` to model a completed navigation, exercising
+// the real component wiring (the selector + the localized label), not just the hook.
+const href = vi.hoisted(() => ({ value: '/en' }))
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
+    select({ resolvedLocation: { href: href.value } }),
+}))
+
+import { RouteAnnouncer } from './RouteAnnouncer'
+
+function renderAnnouncer() {
+  return render(
+    <IntlProvider locale="en" messages={en}>
+      <RouteAnnouncer />
+    </IntlProvider>,
+  )
+}
+
+afterEach(() => {
+  href.value = '/en'
+})
+
+describe('RouteAnnouncer (#1489)', () => {
+  it('renders a visually-hidden, focusable, localized anchor', () => {
+    renderAnnouncer()
+    const anchor = screen.getByLabelText('Page content')
+    expect(anchor).toHaveClass('sr-only')
+    expect(anchor).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('does not grab focus on the initial resolution', () => {
+    href.value = '/en/dashboard'
+    renderAnnouncer()
+    expect(screen.getByLabelText('Page content')).not.toHaveFocus()
+    expect(document.body).toHaveFocus()
+  })
+
+  it('focuses the anchor when a completed navigation leaves focus on <body>', () => {
+    href.value = '/en/a'
+    const { rerender } = renderAnnouncer() // initial resolve -> seeded, no steal
+
+    href.value = '/en/b' // navigation completes to a new location
+    rerender(
+      <IntlProvider locale="en" messages={en}>
+        <RouteAnnouncer />
+      </IntlProvider>,
+    )
+
+    expect(screen.getByLabelText('Page content')).toHaveFocus()
+  })
+})

--- a/packages/web/src/vite/nav/RouteAnnouncer.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.tsx
@@ -17,10 +17,18 @@ import { useTranslations } from 'use-intl'
  */
 export function RouteAnnouncer() {
   const t = useTranslations('nav')
-  const anchorRef = useRef<HTMLDivElement>(null)
+  // A named `<section>` (role="region") — not a bare `<div>` (role="generic", on which
+  // `aria-label` is prohibited and dropped): a generic anchor is silent on VoiceOver, exactly
+  // the AT #1471's stranded-focus bug lived on. Mirrors the FleetTimeline board region.
+  const anchorRef = useRef<HTMLElement>(null)
   const navKey = useRouterState({ select: (s) => s.resolvedLocation?.href ?? '' })
   useRouteFocusRestoration(navKey, anchorRef)
   return (
-    <div ref={anchorRef} tabIndex={-1} className="sr-only" aria-label={t('routeAnnouncerLabel')} />
+    <section
+      ref={anchorRef}
+      tabIndex={-1}
+      className="sr-only"
+      aria-label={t('routeAnnouncerLabel')}
+    />
   )
 }

--- a/packages/web/src/vite/nav/RouteAnnouncer.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.tsx
@@ -1,0 +1,26 @@
+import { useRouteFocusRestoration } from '@/vite/nav/useRouteFocusRestoration'
+import { useRouterState } from '@tanstack/react-router'
+import { useRef } from 'react'
+import { useTranslations } from 'use-intl'
+
+/**
+ * #1489: an app-wide focus-on-navigate anchor. Mounted once in the locale layout — a stable
+ * parent that survives every child route change and the role layouts' `pendingComponent`
+ * swaps — it returns focus to a visually-hidden anchor whenever a navigation strands focus
+ * on `<body>`. The restoration policy (only when focus fell to `<body>`, never on the
+ * initial load) lives in `useRouteFocusRestoration`.
+ *
+ * The nav key is `resolvedLocation.href`, which changes exactly when a navigation COMPLETES
+ * (the new content is committed and the old subtree — with the element that had focus — is
+ * unmounted). Keying on the pending `location` instead would fire before that unmount, while
+ * focus is still on a live element, and miss the drop entirely.
+ */
+export function RouteAnnouncer() {
+  const t = useTranslations('nav')
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const navKey = useRouterState({ select: (s) => s.resolvedLocation?.href ?? '' })
+  useRouteFocusRestoration(navKey, anchorRef)
+  return (
+    <div ref={anchorRef} tabIndex={-1} className="sr-only" aria-label={t('routeAnnouncerLabel')} />
+  )
+}

--- a/packages/web/src/vite/nav/useRouteFocusRestoration.test.tsx
+++ b/packages/web/src/vite/nav/useRouteFocusRestoration.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { useRef } from 'react'
+import { describe, expect, it } from 'vitest'
+import { useRouteFocusRestoration } from './useRouteFocusRestoration'
+
+// The hook is the testable core of RouteAnnouncer (#1489). `navKey` stands in for the
+// resolved-location key the component derives from useRouterState — changing it models a
+// COMPLETED navigation. Toggling `showContent` models a route change / pendingComponent
+// swap that unmounts the element that had focus (dropping focus to <body>), exactly the
+// browser-agnostic mechanism the real bug relies on.
+function Harness({ navKey, showContent }: { navKey: string; showContent: boolean }) {
+  const anchorRef = useRef<HTMLDivElement>(null)
+  useRouteFocusRestoration(navKey, anchorRef)
+  return (
+    <>
+      <div ref={anchorRef} tabIndex={-1} data-testid="anchor" />
+      {showContent && (
+        <button type="button" data-testid="content">
+          content
+        </button>
+      )}
+    </>
+  )
+}
+
+describe('useRouteFocusRestoration (#1489)', () => {
+  it('moves focus to the anchor when a navigation strands focus on <body>', () => {
+    const { rerender } = render(<Harness navKey="/a" showContent />)
+    screen.getByTestId('content').focus()
+    expect(screen.getByTestId('content')).toHaveFocus()
+
+    // Navigation resolves to a new location AND unmounts the focused content.
+    rerender(<Harness navKey="/b" showContent={false} />)
+
+    expect(screen.getByTestId('anchor')).toHaveFocus()
+  })
+
+  it('leaves focus alone when it is still on a live element after the nav', () => {
+    // Focus sat on stable chrome (e.g. a Navbar link) that survives the nav, so it is NOT
+    // on <body>; the restoration must not steal it.
+    const { rerender } = render(<Harness navKey="/a" showContent />)
+    screen.getByTestId('content').focus()
+    rerender(<Harness navKey="/b" showContent />)
+    expect(screen.getByTestId('content')).toHaveFocus()
+  })
+
+  it('does not steal focus on the initial resolution (WCAG 3.2.1)', () => {
+    render(<Harness navKey="/a" showContent={false} />)
+    expect(screen.getByTestId('anchor')).not.toHaveFocus()
+    expect(document.body).toHaveFocus()
+  })
+
+  it('skips the first real key even when it arrives after mount (fresh load)', () => {
+    // On a cold load resolvedLocation is briefly '' then becomes the landing href; that
+    // first real key is the initial load, not a navigation -> no focus steal.
+    const { rerender } = render(<Harness navKey="" showContent={false} />)
+    rerender(<Harness navKey="/landing" showContent={false} />)
+    expect(screen.getByTestId('anchor')).not.toHaveFocus()
+    expect(document.body).toHaveFocus()
+  })
+})

--- a/packages/web/src/vite/nav/useRouteFocusRestoration.ts
+++ b/packages/web/src/vite/nav/useRouteFocusRestoration.ts
@@ -18,6 +18,12 @@ import { type RefObject, useLayoutEffect, useRef } from 'react'
  * `useLayoutEffect` (not `useEffect`): restore synchronously post-commit/pre-paint so focus
  * never sits on `<body>` for a painted frame (which can bump an AT virtual cursor to the top
  * of the page). Client-only Vite SPA — no SSR caveat.
+ *
+ * The "focus fell to the document root" guard is also what lets this coexist with per-component
+ * restorers (e.g. FleetTimeline focusing its own board region): React runs child effects before
+ * parent effects, so a more-specific child restores first, and this parent then sees a live
+ * element and stands down. This app-wide anchor is the fallback for the cold-remount path where
+ * the child that owned focus is itself unmounted and can't run its effect.
  */
 export function useRouteFocusRestoration<T extends HTMLElement>(
   navKey: string,
@@ -32,6 +38,12 @@ export function useRouteFocusRestoration<T extends HTMLElement>(
     }
     if (prevKeyRef.current === navKey) return // not a navigation
     prevKeyRef.current = navKey
-    if (document.activeElement === document.body) anchorRef.current?.focus()
+    // Focus was stranded: removing the focused node resets `activeElement` to the document
+    // root — `<body>` on most engines, `<html>` or `null` on others. Restore only then;
+    // `preventScroll` keeps the hidden anchor from tugging the viewport.
+    const active = document.activeElement
+    if (!active || active === document.body || active === document.documentElement) {
+      anchorRef.current?.focus({ preventScroll: true })
+    }
   }, [navKey, anchorRef])
 }

--- a/packages/web/src/vite/nav/useRouteFocusRestoration.ts
+++ b/packages/web/src/vite/nav/useRouteFocusRestoration.ts
@@ -1,0 +1,37 @@
+import { type RefObject, useLayoutEffect, useRef } from 'react'
+
+/**
+ * #1489: return keyboard/screen-reader focus to a stable anchor after a client-side
+ * navigation that stranded it on `<body>`.
+ *
+ * When a route change (or a `pendingComponent` swap on a slow/cold nav) unmounts the
+ * element that had focus, the browser drops focus to `<body>`, so a screen-reader user
+ * loses their place and reads from the top of the page. On each COMPLETED navigation
+ * (`navKey` = the resolved-location key), if focus has fallen to `<body>`, move it to
+ * `anchorRef`. Focus that is still on a live element — stable nav chrome (a Navbar link)
+ * drove the nav — is left untouched, so ordinary link-to-link navigation is unaffected.
+ *
+ * The first non-empty key is the initial page load, not a navigation, so it never steals
+ * focus (WCAG 3.2.1: no focus change on load). `prevKeyRef` starts null and is seeded by
+ * that first key without focusing.
+ *
+ * `useLayoutEffect` (not `useEffect`): restore synchronously post-commit/pre-paint so focus
+ * never sits on `<body>` for a painted frame (which can bump an AT virtual cursor to the top
+ * of the page). Client-only Vite SPA — no SSR caveat.
+ */
+export function useRouteFocusRestoration<T extends HTMLElement>(
+  navKey: string,
+  anchorRef: RefObject<T | null>,
+): void {
+  const prevKeyRef = useRef<string | null>(null)
+  useLayoutEffect(() => {
+    if (!navKey) return // not resolved yet
+    if (prevKeyRef.current === null) {
+      prevKeyRef.current = navKey // first resolution = initial load; never steal focus
+      return
+    }
+    if (prevKeyRef.current === navKey) return // not a navigation
+    prevKeyRef.current = navKey
+    if (document.activeElement === document.body) anchorRef.current?.focus()
+  }, [navKey, anchorRef])
+}

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -108,7 +108,9 @@ const DEPRECATED_WEB_TREE_BASELINE = 170
 // fails CI; draining one shrinks the count and triggers a soft notice to lock
 // in the new baseline. Refresh with --update-baseline (same flag as the tree
 // ratchet above).
-const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 162
+// 163 (#1489): routes/$locale.tsx composes the RouteAnnouncer feature component, the same
+// sanctioned routes-compose-a-vite-feature pattern as its sibling Navbar/AdminSidebar imports.
+const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 163
 
 export type DeprecatedTreeStatus = {
   count: number


### PR DESCRIPTION
Closes #1489.

## What

App-wide, route-level focus-on-navigate announcer. When a client-side navigation — or a slow/cold nav's `pendingComponent: PageSkeleton` swap — unmounts the element that held keyboard/screen-reader focus, the browser drops focus to `<body>`, stranding the user. A component can't restore focus across its own unmount, so the restoration lives in a stable parent (`$locale.tsx` `LocaleLayout`, which survives every child-route and role-layout swap and sits inside `IntlProvider`).

This is the deferred architect MEDIUM from #1471 / PR #1485 (FleetTimeline focus-after-date-nav), generalized app-wide (`PageSkeleton` backs ~34 routes).

## How

- `vite/nav/useRouteFocusRestoration.ts` — testable core hook (FC/IS). `useLayoutEffect` keyed on a nav key: skips the initial load (WCAG 3.2.1 — never steal focus on first paint); on each completed nav, restores focus to a stable anchor **only when focus fell to the document root** (`<body>`/`<html>`/`null`), leaving live focus (a nav-chrome link drove the nav) untouched.
- `vite/nav/RouteAnnouncer.tsx` — thin shell reading `useRouterState({ select: s => s.resolvedLocation?.href })`. Keys on `resolvedLocation.href` (nav **complete** — old subtree unmounted, focus on body), not `location.href` (nav **start** — too early). Renders a visually-hidden, focusable, localized `<section>` (`role="region"`).
- Mounted once in `$locale.tsx`, just before `<Outlet>`.
- i18n `nav.routeAnnouncerLabel` (en/ja/zh).

## Review outcome (code-reviewer + architect)

Both agents reviewed the feature commit. One ship-blocker + two fold-ins, all addressed in `442b11cd`:

- **H1 (blocker):** the anchor was a bare `<div aria-label>` = `role="generic"`, on which `aria-label` is prohibited (dropped by Chromium/Firefox) and which is **silent on VoiceOver focus** — the exact AT #1471's bug lived on. Now a named `<section>` (`role="region"`), mirroring the FleetTimeline board region it generalizes: announces name+role on focus, axe-clean.
- **L1:** anchor moved below `<Navbar>`, just before `<Outlet>`, so restored focus lands at the content boundary.
- **L2:** test now asserts `getByRole('region', { name })` (not `getByLabelText`) — a real regression guard that goes red on a bare div (sabotage-verified).
- Hardened the restore guard (treat `null`/`documentElement` like `body`; `focus({ preventScroll: true })`).

Deferred as backlog (both agents agreed non-blocking): a per-route-title `aria-live` region (needs route-title plumbing into the layout) and gating the cold-load redirect-chain edge on a "has navigated once" flag.

## Test plan

- `useRouteFocusRestoration.test.tsx` (4): restore-on-body / don't-steal-live / skip-initial ×2 — sabotage-verified.
- `RouteAnnouncer.test.tsx` (3): named region + sr-only + tabindex / no-steal-on-initial / focus-on-completed-nav.
- Gates green: web+api `tsc`, biome, module-boundaries, file-size, full web suite **2156/2156**.

The focus-drop mechanism (removed node → focus reverts to document root) is browser-agnostic, so the repro is a jsdom component test; no `RouterProvider` integration harness exists here (the repo mocks router hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
