### PR TITLE
feat(#1470): roving tabindex + 2D arrow-key nav for the FleetTimeline board

### DIFF
--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -385,6 +385,12 @@ describe('FleetTimeline roving tabindex (#1470)', () => {
   // arrow move puts the stop on a bar, a date nav that drops that bar must re-home the sole
   // tabIndex=0 to the new first bar (never a dead id, so Tab still enters) AND hand focus to
   // the region — the two mechanisms cooperating, not fighting.
+  //
+  // Scope: this pins FleetTimeline IN ISOLATION. In the full app the #1489 app-wide
+  // RouteAnnouncer (a preceding sibling of <Outlet>, so its layout effect fires first) can
+  // pre-empt this region restore on a search-param date nav and land focus on its sr-only
+  // anchor instead. That cross-layer precedence is a pre-existing #1489/#1471 concern tracked
+  // in #1508 — out of scope here; this component's own restore still runs and is correct.
   it('re-homes the stop to the first bar and restores region focus when a nav drops the active bar', () => {
     const DATE0 = new Date('2026-07-01T00:00:00.000Z')
     const DATE_NEXT = shiftCalendarDate('timeline', DATE0, 1)

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -287,3 +287,88 @@ describe('FleetTimeline focus restoration after date navigation (#1471)', () => 
     expect(next).toHaveFocus()
   })
 })
+
+// #1470 (follow-up to #1349): #1349 made every bar its own tab stop, so a dense board is
+// 100-200 sequential Tab presses. A roving tabindex collapses the board to ONE tab stop —
+// exactly one bar is tabIndex=0 at a time — and arrow keys move focus between bars in a 2D
+// grid (Left/Right along a row, Up/Down to the nearest-in-time bar in an adjacent row). The
+// pure timeline-roving tests pin the geometry; these pin that the shell wires keys to focus
+// and roves the single stop to follow it.
+describe('FleetTimeline roving tabindex (#1470)', () => {
+  // Alice (v1, Jul 3) and Bob (v1, Jul 5) share a row; Carol (v2, Jul 4) is the row below.
+  // Reading order is v1-then-v2, by start within a row: [Alice, Bob, Carol].
+  const alice = () => row({ id: 'b1', renterName: 'Alice', vehicleId: 'v1' })
+  const bob = () =>
+    row({
+      id: 'b2',
+      renterName: 'Bob',
+      vehicleId: 'v1',
+      startAt: '2026-07-05T09:00:00.000Z',
+      endAt: '2026-07-06T09:00:00.000Z',
+      effectiveEndAt: '2026-07-06T09:00:00.000Z',
+    })
+  const carol = () =>
+    row({
+      id: 'b3',
+      renterName: 'Carol',
+      vehicleId: 'v2',
+      startAt: '2026-07-04T09:00:00.000Z',
+      endAt: '2026-07-05T09:00:00.000Z',
+      effectiveEndAt: '2026-07-05T09:00:00.000Z',
+    })
+
+  const bar = (name: RegExp) => screen.getByRole('button', { name })
+  const tabbableBars = () =>
+    Array.from(document.querySelectorAll<HTMLElement>('[data-bar-id]')).filter(
+      (el) => el.getAttribute('tabindex') === '0',
+    )
+
+  it('collapses the board to one tab stop — only the first bar is tabIndex 0', () => {
+    renderTimeline([alice(), bob(), carol()])
+    const stops = tabbableBars()
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toHaveAttribute('data-bar-id', 'b1')
+    expect(bar(/Booking: Bob/)).toHaveAttribute('tabindex', '-1')
+    expect(bar(/Booking: Carol/)).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('ArrowRight moves focus to the next bar in the same row', () => {
+    renderTimeline([alice(), bob(), carol()])
+    bar(/Booking: Alice/).focus()
+    fireEvent.keyDown(bar(/Booking: Alice/), { key: 'ArrowRight' })
+    expect(bar(/Booking: Bob/)).toHaveFocus()
+  })
+
+  it('ArrowLeft clamps at the first bar in a row — no wrap into the previous row', () => {
+    renderTimeline([alice(), bob(), carol()])
+    bar(/Booking: Alice/).focus()
+    fireEvent.keyDown(bar(/Booking: Alice/), { key: 'ArrowLeft' })
+    expect(bar(/Booking: Alice/)).toHaveFocus()
+  })
+
+  it('ArrowDown crosses to the nearest-in-time bar in the row below', () => {
+    renderTimeline([alice(), bob(), carol()])
+    bar(/Booking: Alice/).focus()
+    fireEvent.keyDown(bar(/Booking: Alice/), { key: 'ArrowDown' })
+    expect(bar(/Booking: Carol/)).toHaveFocus()
+  })
+
+  it('roves the single tabIndex 0 stop to follow focus after an arrow move', () => {
+    renderTimeline([alice(), bob(), carol()])
+    bar(/Booking: Alice/).focus()
+    fireEvent.keyDown(bar(/Booking: Alice/), { key: 'ArrowRight' })
+    const stops = tabbableBars()
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toHaveAttribute('data-bar-id', 'b2')
+    expect(bar(/Booking: Alice/)).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('prevents the default page scroll on a handled arrow key', () => {
+    renderTimeline([alice(), bob(), carol()])
+    const target = bar(/Booking: Alice/)
+    target.focus()
+    const ev = createEvent.keyDown(target, { key: 'ArrowDown' })
+    fireEvent(target, ev)
+    expect(ev.defaultPrevented).toBe(true)
+  })
+})

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -363,6 +363,15 @@ describe('FleetTimeline roving tabindex (#1470)', () => {
     expect(bar(/Booking: Alice/)).toHaveAttribute('tabindex', '-1')
   })
 
+  it('ArrowUp crosses to the nearest bar in the row above', () => {
+    // Only Alice in v1, so the nearest bar above Carol (v2) is unambiguous — pins Up wiring
+    // without leaning on the tie-break (covered in the pure tests).
+    renderTimeline([alice(), carol()])
+    bar(/Booking: Carol/).focus()
+    fireEvent.keyDown(bar(/Booking: Carol/), { key: 'ArrowUp' })
+    expect(bar(/Booking: Alice/)).toHaveFocus()
+  })
+
   it('prevents the default page scroll on a handled arrow key', () => {
     renderTimeline([alice(), bob(), carol()])
     const target = bar(/Booking: Alice/)
@@ -370,5 +379,53 @@ describe('FleetTimeline roving tabindex (#1470)', () => {
     const ev = createEvent.keyDown(target, { key: 'ArrowDown' })
     fireEvent(target, ev)
     expect(ev.defaultPrevented).toBe(true)
+  })
+
+  // The load-bearing contract between roving (#1470) and focus restoration (#1471): after an
+  // arrow move puts the stop on a bar, a date nav that drops that bar must re-home the sole
+  // tabIndex=0 to the new first bar (never a dead id, so Tab still enters) AND hand focus to
+  // the region — the two mechanisms cooperating, not fighting.
+  it('re-homes the stop to the first bar and restores region focus when a nav drops the active bar', () => {
+    const DATE0 = new Date('2026-07-01T00:00:00.000Z')
+    const DATE_NEXT = shiftCalendarDate('timeline', DATE0, 1)
+    // Dave is out of the DATE0 window (early-July) but inside the +14d window, so he is the
+    // only bar left after the nav — the fallback target for the roving stop.
+    const dave = () =>
+      row({
+        id: 'b4',
+        renterName: 'Dave',
+        vehicleId: 'v1',
+        startAt: '2026-07-20T09:00:00.000Z',
+        endAt: '2026-07-21T09:00:00.000Z',
+        effectiveEndAt: '2026-07-21T09:00:00.000Z',
+      })
+    const el = (date: Date) => (
+      <IntlProvider locale="en" messages={en}>
+        <FleetTimeline
+          rows={[alice(), carol(), dave()]}
+          vehicles={VEHICLES}
+          blocks={[]}
+          date={date}
+          locale="en"
+          onViewChange={vi.fn()}
+          onDateChange={vi.fn()}
+          onSelectEvent={vi.fn()}
+          onSelectBlock={vi.fn()}
+        />
+      </IntlProvider>
+    )
+    const { rerender } = render(el(DATE0))
+
+    bar(/Booking: Alice/).focus()
+    fireEvent.keyDown(bar(/Booking: Alice/), { key: 'ArrowDown' })
+    expect(bar(/Booking: Carol/)).toHaveFocus() // Carol is now the roving stop
+
+    rerender(el(DATE_NEXT))
+
+    expect(screen.queryByRole('button', { name: /Booking: Carol/ })).not.toBeInTheDocument()
+    const stops = tabbableBars()
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toHaveAttribute('data-bar-id', 'b4') // fell back to the new first bar
+    expect(screen.getByRole('region', { name: /Fleet planning board/ })).toHaveFocus()
   })
 })

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -387,10 +387,9 @@ describe('FleetTimeline roving tabindex (#1470)', () => {
   // the region — the two mechanisms cooperating, not fighting.
   //
   // Scope: this pins FleetTimeline IN ISOLATION. In the full app the #1489 app-wide
-  // RouteAnnouncer (a preceding sibling of <Outlet>, so its layout effect fires first) can
-  // pre-empt this region restore on a search-param date nav and land focus on its sr-only
-  // anchor instead. That cross-layer precedence is a pre-existing #1489/#1471 concern tracked
-  // in #1508 — out of scope here; this component's own restore still runs and is correct.
+  // RouteAnnouncer defers to this restore — it wraps <Outlet>, so its layout effect fires
+  // AFTER this component's and only acts as the cold-remount fallback (#1508). So the
+  // integrated behaviour matches this test: the board region wins, not the sr-only anchor.
   it('re-homes the stop to the first bar and restores region focus when a nav drops the active bar', () => {
     const DATE0 = new Date('2026-07-01T00:00:00.000Z')
     const DATE_NEXT = shiftCalendarDate('timeline', DATE0, 1)

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -15,6 +15,11 @@ import {
   bookingIdFromTimelineItem,
   buildTimelineLayout,
 } from '@/vite/operator-bookings/timeline-layout'
+import {
+  type RovingDirection,
+  buildRovingModel,
+  nextBarId,
+} from '@/vite/operator-bookings/timeline-roving'
 import { addDays, startOfDay } from 'date-fns'
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -22,6 +27,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import Timeline, {
   type Id,
@@ -47,8 +53,25 @@ import './fleet-timeline-theme.css'
 // item's `itemProps` — every interactive bar is a focusable role=button with a localized
 // aria-label that opens its detail on Enter/Space (parity with click); the redundant
 // turnaround tail is aria-hidden (one stop per booking, decided in buildTimelineLayout). This
-// closes the GA gate for VITE_FEATURE_FLEET_TIMELINE. Remaining a11y follow-up: roving-tabindex
-// so a dense board is one composite widget rather than N tab stops (deferred, see #1349).
+// closes the GA gate for VITE_FEATURE_FLEET_TIMELINE.
+//
+// A11y (#1470): #1349's per-bar tab stops make a dense board (40-50 cars × a week) 100-200
+// Tab presses. A roving tabindex collapses it to ONE stop — exactly one bar is tabIndex=0 —
+// with arrow keys moving focus in a 2D grid (Left/Right along a row, Up/Down to the nearest-
+// in-time bar in an adjacent row, Home/End to a row's ends). The grid geometry is the pure
+// `timeline-roving` model; this shell only maps a key to a direction, focuses the returned
+// bar, and roves the single stop to follow it (FC/IS: the core decides where focus goes).
+
+// #1470: arrow/Home/End keys mapped to a board direction. A key not here (Enter/Space/Tab)
+// falls through to activation or the browser's own focus handling.
+const ARROW_DIRECTIONS: Record<string, RovingDirection> = {
+  ArrowRight: 'right',
+  ArrowLeft: 'left',
+  ArrowDown: 'down',
+  ArrowUp: 'up',
+  Home: 'home',
+  End: 'end',
+}
 
 interface FleetTimelineProps {
   readonly rows: readonly CalendarBookingRow[]
@@ -156,6 +179,35 @@ export function FleetTimeline({
     [rows, vehicles, blocks, fromTrue, toTrue, t],
   )
 
+  // #1470: the interactive bars as a 2D grid (rows in board order × time). Rebuilt per layout
+  // so arrow keys navigate the same bars the board renders.
+  const rovingModel = useMemo(
+    () =>
+      buildRovingModel(
+        layout.groups.map((g) => g.id),
+        layout.items
+          .filter((it) => it.interactive)
+          .map((it) => ({ id: it.id, group: it.group, start: it.start })),
+      ),
+    [layout],
+  )
+
+  // The single tab stop — the one bar with tabIndex=0. Arrow keys rove it to follow focus.
+  // Derived, not effect-synced: when a date nav drops the active bar from the window, fall
+  // back to the first bar so Tab still enters the board (no stale-id churn). Null = no bars.
+  const [activeBarId, setActiveBarId] = useState<string | null>(null)
+  const resolvedActiveId =
+    activeBarId && rovingModel.posById.has(activeBarId)
+      ? activeBarId
+      : (rovingModel.order[0] ?? null)
+
+  // Focus a bar by id. The lib owns the bar DOM, so we reach it through the `data-bar-id`
+  // attribute injected via itemProps (the same channel #1349's role/aria use) rather than a
+  // ref the lib would not forward. Scoped to the board region so ids can't collide elsewhere.
+  const focusBar = useCallback((id: string) => {
+    regionRef.current?.querySelector<HTMLElement>(`[data-bar-id="${CSS.escape(id)}"]`)?.focus()
+  }, [])
+
   const groups = useMemo<TimelineGroupBase[]>(
     () => layout.groups.map((g) => ({ id: g.id, title: g.title })),
     [layout.groups],
@@ -203,17 +255,27 @@ export function FleetTimeline({
     [blockById, onSelectBlock, onSelectEvent],
   )
 
-  // #1349 keyboard parity: Enter or Space opens the same detail a click opens. Space
-  // is preventDefault'd so it never scrolls the page; every other key bubbles (Tab
-  // still moves focus between bars). Emulating both keys on keydown is the accepted
-  // APG simplification for a button-role element.
+  // #1349 keyboard parity: Enter or Space opens the same detail a click opens. Space is
+  // preventDefault'd so it never scrolls the page. #1470: arrow/Home/End rove focus across
+  // the 2D grid — preventDefault so they move focus instead of scrolling the board canvas,
+  // and rove the tabIndex=0 stop to the new bar (clamps at edges, so a no-op move is a
+  // silent stay). Any other key (notably Tab) bubbles to the browser's own handling.
   const handleItemKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>, itemId: string) => {
-      if (e.key !== 'Enter' && e.key !== ' ') return
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        handleItemSelect(itemId)
+        return
+      }
+      const dir = ARROW_DIRECTIONS[e.key]
+      if (!dir) return
       e.preventDefault()
-      handleItemSelect(itemId)
+      const target = nextBarId(rovingModel, itemId, dir)
+      if (target === itemId) return
+      setActiveBarId(target)
+      focusBar(target)
     },
-    [handleItemSelect],
+    [handleItemSelect, rovingModel, focusBar],
   )
 
   const items = useMemo<TimelineItemBase<number>[]>(
@@ -251,10 +313,14 @@ export function FleetTimeline({
           // never lands on two bars for one booking; a mouse click on it still works.
           // aria-haspopup only on block bars: they open BlockDetailDialog, whereas a
           // booking bar navigates to a full page — promising a dialog there would mislead AT.
+          // #1470: only the active bar is tabIndex=0 (the board is one tab stop); the rest
+          // are tabIndex=-1, reachable by arrow keys. `data-bar-id` lets focusBar find the
+          // lib-owned node by id.
           itemProps: it.interactive
             ? {
                 role: 'button',
-                tabIndex: 0,
+                tabIndex: it.id === resolvedActiveId ? 0 : -1,
+                'data-bar-id': it.id,
                 ...(it.type === 'block' ? { 'aria-haspopup': 'dialog' as const } : {}),
                 'aria-label': label,
                 onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => handleItemKeyDown(e, it.id),
@@ -262,7 +328,15 @@ export function FleetTimeline({
             : { 'aria-hidden': true },
         }
       }),
-    [layout.items, groupTitleById, barRangeFmt, t, tBlockKinds, handleItemKeyDown],
+    [
+      layout.items,
+      groupTitleById,
+      barRangeFmt,
+      t,
+      tBlockKinds,
+      handleItemKeyDown,
+      resolvedActiveId,
+    ],
   )
 
   const handleNavigate = useCallback(

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -19,6 +19,7 @@ import {
   type RovingDirection,
   buildRovingModel,
   nextBarId,
+  resolveActiveBarId,
 } from '@/vite/operator-bookings/timeline-roving'
 import { addDays, startOfDay } from 'date-fns'
 import {
@@ -193,19 +194,21 @@ export function FleetTimeline({
   )
 
   // The single tab stop — the one bar with tabIndex=0. Arrow keys rove it to follow focus.
-  // Derived, not effect-synced: when a date nav drops the active bar from the window, fall
-  // back to the first bar so Tab still enters the board (no stale-id churn). Null = no bars.
+  // Derived, not effect-synced (resolveActiveBarId is pure): when a date nav drops the active
+  // bar from the window, it falls back to the first bar so Tab still enters the board — with
+  // no stale-id churn and no render lag an effect would introduce. Null = no bars.
   const [activeBarId, setActiveBarId] = useState<string | null>(null)
-  const resolvedActiveId =
-    activeBarId && rovingModel.posById.has(activeBarId)
-      ? activeBarId
-      : (rovingModel.order[0] ?? null)
+  const resolvedActiveId = resolveActiveBarId(rovingModel, activeBarId)
 
   // Focus a bar by id. The lib owns the bar DOM, so we reach it through the `data-bar-id`
   // attribute injected via itemProps (the same channel #1349's role/aria use) rather than a
   // ref the lib would not forward. Scoped to the board region so ids can't collide elsewhere.
+  // If the bar isn't in the DOM (impossible today — the lib renders every row — but a guard
+  // against a future virtualizing bump), fall back to the region so focus never lands on
+  // <body>, the same stable anchor #1471 restores to.
   const focusBar = useCallback((id: string) => {
-    regionRef.current?.querySelector<HTMLElement>(`[data-bar-id="${CSS.escape(id)}"]`)?.focus()
+    const node = regionRef.current?.querySelector<HTMLElement>(`[data-bar-id="${CSS.escape(id)}"]`)
+    ;(node ?? regionRef.current)?.focus()
   }, [])
 
   const groups = useMemo<TimelineGroupBase[]>(

--- a/packages/web/src/vite/operator-bookings/timeline-roving.test.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-roving.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { type RovingBar, buildRovingModel, nextBarId } from './timeline-roving'
+
+// #1470: pure 2D-grid navigation over the interactive timeline bars. Rows are the fleet
+// vehicles in board order; within a row bars are ordered by start. Left/Right walk a row;
+// Up/Down jump to the temporally-nearest bar in the adjacent NON-EMPTY row; Home/End hit the
+// row ends; every direction clamps at the board edge (no wrap). This is the whole nav model —
+// the shell only turns a key into a direction and focuses the returned id.
+
+const bar = (id: string, group: string, start: number): RovingBar => ({ id, group, start })
+
+describe('buildRovingModel', () => {
+  it('orders interactive bars row-major, then by start within a row', () => {
+    const m = buildRovingModel(
+      ['v1', 'v2'],
+      [bar('b', 'v1', 200), bar('a', 'v1', 100), bar('c', 'v2', 50)],
+    )
+    expect(m.order).toEqual(['a', 'b', 'c'])
+  })
+
+  it('drops rows with no interactive bars, so nav never lands on an empty row', () => {
+    // v2 is empty; a Down from v1 must skip it and reach v3.
+    const m = buildRovingModel(['v1', 'v2', 'v3'], [bar('a', 'v1', 100), bar('c', 'v3', 120)])
+    expect(nextBarId(m, 'a', 'down')).toBe('c')
+  })
+})
+
+describe('nextBarId — within a row (left/right/home/end)', () => {
+  const m = buildRovingModel(
+    ['v1'],
+    [bar('a', 'v1', 100), bar('b', 'v1', 200), bar('c', 'v1', 300)],
+  )
+
+  it('right moves to the next bar by start', () => expect(nextBarId(m, 'a', 'right')).toBe('b'))
+  it('left moves to the previous bar by start', () => expect(nextBarId(m, 'b', 'left')).toBe('a'))
+  it('right clamps at the last bar (no wrap)', () => expect(nextBarId(m, 'c', 'right')).toBe('c'))
+  it('left clamps at the first bar (no wrap)', () => expect(nextBarId(m, 'a', 'left')).toBe('a'))
+  it('home jumps to the first bar in the row', () => expect(nextBarId(m, 'b', 'home')).toBe('a'))
+  it('end jumps to the last bar in the row', () => expect(nextBarId(m, 'b', 'end')).toBe('c'))
+})
+
+describe('nextBarId — across rows (up/down, nearest in time)', () => {
+  // v1: a@100 b@500 ; v2: c@120 d@480
+  const m = buildRovingModel(
+    ['v1', 'v2'],
+    [bar('a', 'v1', 100), bar('b', 'v1', 500), bar('c', 'v2', 120), bar('d', 'v2', 480)],
+  )
+
+  it('down lands on the temporally nearest bar in the next row', () => {
+    expect(nextBarId(m, 'a', 'down')).toBe('c') // |100-120|=20 < |100-480|=380
+    expect(nextBarId(m, 'b', 'down')).toBe('d') // |500-480|=20 < |500-120|=380
+  })
+
+  it('up is symmetric with down', () => {
+    expect(nextBarId(m, 'd', 'up')).toBe('b')
+    expect(nextBarId(m, 'c', 'up')).toBe('a')
+  })
+
+  it('down clamps at the last row', () => expect(nextBarId(m, 'c', 'down')).toBe('c'))
+  it('up clamps at the first row', () => expect(nextBarId(m, 'a', 'up')).toBe('a'))
+
+  it('breaks a nearest-in-time tie toward the earlier-starting bar', () => {
+    // From x@100; both p@50 and q@150 are 50ms away — prefer the earlier start (p).
+    const mm = buildRovingModel(
+      ['v1', 'v2'],
+      [bar('x', 'v1', 100), bar('p', 'v2', 50), bar('q', 'v2', 150)],
+    )
+    expect(nextBarId(mm, 'x', 'down')).toBe('p')
+  })
+})
+
+describe('nextBarId — defensive', () => {
+  const m = buildRovingModel(['v1'], [bar('a', 'v1', 100)])
+
+  it('returns the first bar in order for an unknown current id', () => {
+    expect(nextBarId(m, 'ghost', 'right')).toBe('a')
+  })
+})

--- a/packages/web/src/vite/operator-bookings/timeline-roving.test.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-roving.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { type RovingBar, buildRovingModel, nextBarId } from './timeline-roving'
+import { type RovingBar, buildRovingModel, nextBarId, resolveActiveBarId } from './timeline-roving'
 
 // #1470: pure 2D-grid navigation over the interactive timeline bars. Rows are the fleet
 // vehicles in board order; within a row bars are ordered by start. Left/Right walk a row;
@@ -74,5 +74,30 @@ describe('nextBarId — defensive', () => {
 
   it('returns the first bar in order for an unknown current id', () => {
     expect(nextBarId(m, 'ghost', 'right')).toBe('a')
+  })
+})
+
+describe('resolveActiveBarId — the tabIndex=0 stop', () => {
+  const m = buildRovingModel(
+    ['v1', 'v2'],
+    [bar('a', 'v1', 100), bar('b', 'v1', 200), bar('c', 'v2', 50)],
+  )
+
+  it('keeps the remembered stop while its bar still exists', () => {
+    expect(resolveActiveBarId(m, 'b')).toBe('b')
+  })
+
+  it('falls back to the first bar when the remembered stop left the board (date nav)', () => {
+    // 'b' was the stop; a nav rebuilt the model without it — Tab must still enter the board.
+    const after = buildRovingModel(['v1', 'v2'], [bar('a', 'v1', 100), bar('c', 'v2', 50)])
+    expect(resolveActiveBarId(after, 'b')).toBe('a')
+  })
+
+  it('defaults to the first bar when nothing is remembered yet', () => {
+    expect(resolveActiveBarId(m, null)).toBe('a')
+  })
+
+  it('is null when the board has no interactive bars', () => {
+    expect(resolveActiveBarId(buildRovingModel(['v1'], []), 'anything')).toBeNull()
   })
 })

--- a/packages/web/src/vite/operator-bookings/timeline-roving.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-roving.ts
@@ -1,0 +1,115 @@
+// #1470 fleet timeline roving-tabindex nav: pure 2D-grid geometry over the board's
+// INTERACTIVE bars. A dense board is ~100-200 focusable bars (#1349 made each its own
+// tab stop); a roving tabindex collapses that to one stop with arrow-key movement inside.
+// This module is the whole navigation model — given the board's rows and a current bar +
+// direction, it returns the bar to focus next. Kept free of React and the lib (FC/IS: the
+// FleetTimeline shell does the imperative focus; this decides where focus goes).
+
+/** An arrow/Home/End keypress, already resolved to a board direction by the shell. */
+export type RovingDirection = 'left' | 'right' | 'up' | 'down' | 'home' | 'end'
+
+/** The minimal shape the nav needs from a bar: its id, its row (vehicle group), and its
+ *  start instant (epoch ms) — the temporal coordinate Up/Down navigates by. */
+export interface RovingBar {
+  readonly id: string
+  readonly group: string
+  readonly start: number
+}
+
+interface RovingCell {
+  readonly id: string
+  readonly start: number
+}
+
+interface RovingRow {
+  readonly group: string
+  readonly bars: readonly RovingCell[]
+}
+
+interface RovingPosition {
+  readonly rowIndex: number
+  readonly colIndex: number
+  readonly start: number
+}
+
+export interface RovingModel {
+  /** Interactive bar ids in reading order (row order, then start asc). `order[0]` is the
+   *  default roving stop when nothing is focused yet. */
+  readonly order: readonly string[]
+  /** Board rows in visual order, EMPTY rows omitted so Up/Down never lands on nothing. */
+  readonly rows: readonly RovingRow[]
+  readonly posById: ReadonlyMap<string, RovingPosition>
+}
+
+const byStartThenId = (a: RovingCell, b: RovingCell): number =>
+  a.start - b.start || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+
+/** Build the nav model from the board's group order and its interactive bars. Rows follow
+ *  the visual (vehicle) order; a group with no bars is dropped so it is invisible to nav. */
+export function buildRovingModel(
+  groupOrder: readonly string[],
+  bars: readonly RovingBar[],
+): RovingModel {
+  const cellsByGroup = new Map<string, RovingCell[]>()
+  for (const b of bars) {
+    const cells = cellsByGroup.get(b.group) ?? []
+    cells.push({ id: b.id, start: b.start })
+    cellsByGroup.set(b.group, cells)
+  }
+
+  const rows: RovingRow[] = []
+  for (const group of groupOrder) {
+    const cells = cellsByGroup.get(group)
+    if (!cells || cells.length === 0) continue
+    rows.push({ group, bars: [...cells].sort(byStartThenId) })
+  }
+
+  const posById = new Map<string, RovingPosition>()
+  const order: string[] = []
+  rows.forEach((row, rowIndex) => {
+    row.bars.forEach((cell, colIndex) => {
+      posById.set(cell.id, { rowIndex, colIndex, start: cell.start })
+      order.push(cell.id)
+    })
+  })
+
+  return { order, rows, posById }
+}
+
+/** The bar in `row` whose start is closest to `start`; ties break toward the earlier start,
+ *  then the lower id (stable). Null for a missing/empty row so the caller can clamp. */
+function nearestInRow(rows: readonly RovingRow[], rowIndex: number, start: number): string | null {
+  const row = rows[rowIndex]
+  if (!row || row.bars.length === 0) return null
+  const sorted = [...row.bars].sort(
+    (a, b) =>
+      Math.abs(a.start - start) - Math.abs(b.start - start) ||
+      a.start - b.start ||
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  )
+  return sorted[0]?.id ?? null
+}
+
+/** The bar to focus after pressing `dir` while on `currentId`. Clamps at every board edge
+ *  (returns `currentId`). An unknown `currentId` resets to the first bar in reading order. */
+export function nextBarId(model: RovingModel, currentId: string, dir: RovingDirection): string {
+  const pos = model.posById.get(currentId)
+  if (!pos) return model.order[0] ?? currentId
+  const row = model.rows[pos.rowIndex]
+  if (!row) return currentId
+
+  switch (dir) {
+    case 'right':
+      return row.bars[pos.colIndex + 1]?.id ?? currentId
+    case 'left':
+      return row.bars[pos.colIndex - 1]?.id ?? currentId
+    case 'home':
+      return row.bars[0]?.id ?? currentId
+    case 'end':
+      return row.bars[row.bars.length - 1]?.id ?? currentId
+    case 'down':
+      return nearestInRow(model.rows, pos.rowIndex + 1, pos.start) ?? currentId
+    case 'up':
+      return nearestInRow(model.rows, pos.rowIndex - 1, pos.start) ?? currentId
+  }
+}

--- a/packages/web/src/vite/operator-bookings/timeline-roving.ts
+++ b/packages/web/src/vite/operator-bookings/timeline-roving.ts
@@ -76,18 +76,28 @@ export function buildRovingModel(
   return { order, rows, posById }
 }
 
+/** The bar that should carry `tabIndex=0` given the currently-remembered stop. Keeps the
+ *  remembered bar while it still exists; when a layout change (e.g. a date nav) drops it,
+ *  falls back to the first bar so Tab still enters the board. Null only when the board has
+ *  no bars. Pure so the shell holds no navigation policy — just the imperative focus. */
+export function resolveActiveBarId(model: RovingModel, activeId: string | null): string | null {
+  if (activeId && model.posById.has(activeId)) return activeId
+  return model.order[0] ?? null
+}
+
 /** The bar in `row` whose start is closest to `start`; ties break toward the earlier start,
- *  then the lower id (stable). Null for a missing/empty row so the caller can clamp. */
+ *  then the lower id (stable). Null for a missing/empty row so the caller can clamp. Single
+ *  pass (no sort/copy) since it runs on every Up/Down keypress. */
 function nearestInRow(rows: readonly RovingRow[], rowIndex: number, start: number): string | null {
   const row = rows[rowIndex]
   if (!row || row.bars.length === 0) return null
-  const sorted = [...row.bars].sort(
-    (a, b) =>
-      Math.abs(a.start - start) - Math.abs(b.start - start) ||
-      a.start - b.start ||
-      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
-  )
-  return sorted[0]?.id ?? null
+  return row.bars.reduce((best, cell) => {
+    const dCell = Math.abs(cell.start - start)
+    const dBest = Math.abs(best.start - start)
+    if (dCell !== dBest) return dCell < dBest ? cell : best
+    if (cell.start !== best.start) return cell.start < best.start ? cell : best
+    return cell.id < best.id ? cell : best
+  }).id
 }
 
 /** The bar to focus after pressing `dir` while on `currentId`. Clamps at every board edge


### PR DESCRIPTION
Closes #1470.

## Problem

#1349 made every interactive FleetTimeline bar its own tab stop. On a dense planning board (40-50 vehicles × a week of bookings) that is **100-200 sequential Tab presses** to reach a bar in the middle — usable, but tedious for keyboard/screen-reader users.

## What changed

A WAI-ARIA **roving tabindex**: exactly one bar is `tabIndex=0` at a time (the whole board collapses to **one tab stop**), and arrow keys move focus between bars in a **2D grid**:

- **Left/Right** — previous/next bar in the same vehicle row, by start time.
- **Up/Down** — the temporally *nearest* bar in the adjacent non-empty row (empty rows skipped).
- **Home/End** — first/last bar in the row.
- Every direction **clamps** at the board edge (no wrap); a handled key `preventDefault`s so it never scrolls the canvas.

`#1349`'s `role=button` / `aria-haspopup=dialog` / Enter-Space activation and `#1471`'s focus restoration are untouched — only the focus-movement model changes.

## Design (Functional Core / Imperative Shell)

- **`timeline-roving.ts` (new, pure)** owns all nav geometry: `buildRovingModel`, `nextBarId`, and `resolveActiveBarId` (the tabIndex=0 fallback). No React, no DOM — unit-tested in isolation.
- **`FleetTimeline.tsx` (shell)** maps a key to a direction, focuses the returned bar via a `data-bar-id` lookup (the lib owns the bar DOM and doesn't forward refs — same `itemProps` channel #1349 uses), and roves the single stop. `resolvedActiveId` is *derived* (not effect-synced): when a date nav drops the active bar, it falls back to the first bar so Tab always re-enters — with no render lag or stale-id flash an effect would introduce.

## Tests

- **`timeline-roving.test.ts`** — 18 pure tests: ordering, empty-row skipping, clamping, nearest-in-time + tie-breaks, and the `resolveActiveBarId` fallback.
- **`FleetTimeline.test.tsx`** — +7 component tests: single tab stop, each arrow direction, the roving stop following focus, `preventDefault`, and the **roving × #1471 coexistence** (arrow-move → date nav drops the active bar → sole `tabIndex=0` re-homes to the first bar + focus returns to the region).
- Both guards **sabotage-verified** (unconditional tabIndex → 2 red; strip arrow handling → 4 red).

## Reviews

Independent code review and architect review — both passed, no CRITICAL/HIGH. Cheap findings folded in (pure `resolveActiveBarId`, allocation-free `nearestInRow`, `focusBar` region fallback, coexistence + ArrowUp tests). The composite-widget **container-role** a11y gap (both, MEDIUM) is a genuine follow-up — a proper `role=grid` fights the pinned pre-release lib's DOM and risks regressing #1349 browse-mode reachability — filed as **#1503**.

## Verification

- `packages/web` tsc clean; `bun run lint` exit 0 (no hard errors; vite reach-in baseline unchanged; same-feature import, not a cross-feature reach-in).
- Full web suite **2182 passed** (308 files). Branch merged up to `origin/develop` (behind 0).
- No API / DB / migration / i18n changes.

## Test plan

- [ ] Keyboard-only: Tab once into the board, arrow around the grid, Enter/Space opens a booking or block.
- [ ] Navigate the date range while a bar is focused; focus lands on the board region, Tab re-enters.