### PR TITLE
fix(#1508): RouteAnnouncer wraps <Outlet> so per-component focus restorers win

### DIFF
--- a/packages/web/src/routes/$locale.tsx
+++ b/packages/web/src/routes/$locale.tsx
@@ -36,12 +36,14 @@ function LocaleLayout() {
           <ViewModeProvider>
             <LayoutPreferenceProvider>
               <Navbar />
-              {/* #1489: app-wide focus-on-navigate anchor; mounted here (a stable parent
+              {/* #1489/#1508: app-wide focus-on-navigate anchor; mounted here (a stable parent
                   that survives child route + pendingComponent swaps) so a navigation never
-                  strands screen-reader focus on <body>. Placed just before <Outlet> so
-                  restored focus lands at the content boundary, past the (unchanged) nav. */}
-              <RouteAnnouncer />
-              <Outlet />
+                  strands screen-reader focus on <body>. It WRAPS <Outlet> (not a preceding
+                  sibling) so its restore effect fires AFTER any per-component restorer nested
+                  inside — the announcer is the fallback, the more-specific restorer wins. */}
+              <RouteAnnouncer>
+                <Outlet />
+              </RouteAnnouncer>
             </LayoutPreferenceProvider>
           </ViewModeProvider>
         </CurrencyProvider>

--- a/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
@@ -80,7 +80,14 @@ function ChildRestorer({ navKey }: { navKey: string }) {
 }
 
 describe('RouteAnnouncer focus precedence (#1508)', () => {
-  function Tree({ navKey, showTransient }: { navKey: string; showTransient: boolean }) {
+  // `childKey` remounts ChildRestorer when it changes (fresh fiber -> its seed guard fires),
+  // modelling the cold-remount path. Left undefined, the child keeps its fiber across a nav —
+  // the in-place re-render path where its restorer actually runs.
+  function Tree({
+    navKey,
+    showTransient,
+    childKey,
+  }: { navKey: string; showTransient: boolean; childKey?: string }) {
     return (
       <IntlProvider locale="en" messages={en}>
         <RouteAnnouncer>
@@ -89,7 +96,7 @@ describe('RouteAnnouncer focus precedence (#1508)', () => {
               x
             </button>
           ) : null}
-          <ChildRestorer navKey={navKey} />
+          <ChildRestorer key={childKey} navKey={navKey} />
         </RouteAnnouncer>
       </IntlProvider>
     )
@@ -111,18 +118,18 @@ describe('RouteAnnouncer focus precedence (#1508)', () => {
     expect(screen.getByRole('region', { name: 'Page content' })).not.toHaveFocus()
   })
 
-  it('still catches a cold remount where no descendant restorer runs', () => {
-    // The child mounts fresh (its seed guard suppresses restore), so nobody reclaims focus —
-    // the announcer must remain the fallback and focus its anchor.
+  it('still catches a cold remount where the fresh subtree cannot restore its own focus', () => {
     href.value = '/en/a'
-    const { rerender } = render(<Tree navKey="a" showTransient />)
+    const { rerender } = render(<Tree navKey="a" showTransient childKey="a" />)
 
     screen.getByTestId('transient').focus()
     href.value = '/en/b'
-    // navKey stays 'a' -> the child's restorer is seeded/no-op, modelling a freshly mounted
-    // subtree that cannot restore its own focus.
-    rerender(<Tree navKey="a" showTransient={false} />)
+    // Changing childKey remounts ChildRestorer: a genuinely fresh fiber whose seed guard
+    // suppresses restore on its first resolution — the cold pendingComponent swap where the
+    // subtree that owned focus is gone. Nobody reclaims focus, so the announcer must.
+    rerender(<Tree navKey="b" showTransient={false} childKey="b" />)
 
     expect(screen.getByRole('region', { name: 'Page content' })).toHaveFocus()
+    expect(screen.getByRole('region', { name: 'component region' })).not.toHaveFocus()
   })
 })

--- a/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
+import { useLayoutEffect, useRef } from 'react'
 import { IntlProvider } from 'use-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
@@ -52,6 +53,75 @@ describe('RouteAnnouncer (#1489)', () => {
         <RouteAnnouncer />
       </IntlProvider>,
     )
+
+    expect(screen.getByRole('region', { name: 'Page content' })).toHaveFocus()
+  })
+})
+
+// #1508: RouteAnnouncer is the app-wide fallback — a per-component restorer nested UNDER it
+// (e.g. FleetTimeline's #1471 region restore) must win on a shared navigation, with the
+// announcer standing down. This only holds when the announcer WRAPS the content: its own
+// layout effect then fires after its descendants' (React post-order), so a deeper restorer
+// reclaims focus first. (As a preceding sibling of <Outlet>, the announcer's effect fired
+// FIRST and pre-empted the region restore onto the invisible anchor — the bug this fixes.)
+function ChildRestorer({ navKey }: { navKey: string }) {
+  const ref = useRef<HTMLElement>(null)
+  const prev = useRef<string | null>(null)
+  useLayoutEffect(() => {
+    if (prev.current === null) {
+      prev.current = navKey // first resolution = seed, never steal
+      return
+    }
+    if (prev.current === navKey) return
+    prev.current = navKey
+    if (document.activeElement === document.body) ref.current?.focus()
+  }, [navKey])
+  return <section ref={ref} tabIndex={-1} aria-label="component region" />
+}
+
+describe('RouteAnnouncer focus precedence (#1508)', () => {
+  function Tree({ navKey, showTransient }: { navKey: string; showTransient: boolean }) {
+    return (
+      <IntlProvider locale="en" messages={en}>
+        <RouteAnnouncer>
+          {showTransient ? (
+            <button type="button" data-testid="transient">
+              x
+            </button>
+          ) : null}
+          <ChildRestorer navKey={navKey} />
+        </RouteAnnouncer>
+      </IntlProvider>
+    )
+  }
+
+  it('defers to a nested per-component restorer — the app-wide anchor stands down', () => {
+    href.value = '/en/a'
+    const { rerender } = render(<Tree navKey="a" showTransient />)
+
+    // Focus a transient control, then one navigation unmounts it AND bumps both nav keys in
+    // the same commit (models the search-param date nav that strands focus on <body>).
+    screen.getByTestId('transient').focus()
+    href.value = '/en/b'
+    rerender(<Tree navKey="b" showTransient={false} />)
+
+    // The descendant (deeper fiber) restores first to its own region; the announcer then sees
+    // a live element and does NOT pull focus to the invisible sr-only anchor.
+    expect(screen.getByRole('region', { name: 'component region' })).toHaveFocus()
+    expect(screen.getByRole('region', { name: 'Page content' })).not.toHaveFocus()
+  })
+
+  it('still catches a cold remount where no descendant restorer runs', () => {
+    // The child mounts fresh (its seed guard suppresses restore), so nobody reclaims focus —
+    // the announcer must remain the fallback and focus its anchor.
+    href.value = '/en/a'
+    const { rerender } = render(<Tree navKey="a" showTransient />)
+
+    screen.getByTestId('transient').focus()
+    href.value = '/en/b'
+    // navKey stays 'a' -> the child's restorer is seeded/no-op, modelling a freshly mounted
+    // subtree that cannot restore its own focus.
+    rerender(<Tree navKey="a" showTransient={false} />)
 
     expect(screen.getByRole('region', { name: 'Page content' })).toHaveFocus()
   })

--- a/packages/web/src/vite/nav/RouteAnnouncer.tsx
+++ b/packages/web/src/vite/nav/RouteAnnouncer.tsx
@@ -1,6 +1,6 @@
 import { useRouteFocusRestoration } from '@/vite/nav/useRouteFocusRestoration'
 import { useRouterState } from '@tanstack/react-router'
-import { useRef } from 'react'
+import { type PropsWithChildren, useRef } from 'react'
 import { useTranslations } from 'use-intl'
 
 /**
@@ -14,8 +14,16 @@ import { useTranslations } from 'use-intl'
  * (the new content is committed and the old subtree — with the element that had focus — is
  * unmounted). Keying on the pending `location` instead would fire before that unmount, while
  * focus is still on a live element, and miss the drop entirely.
+ *
+ * #1508: this WRAPS the routed content (`<RouteAnnouncer><Outlet/></RouteAnnouncer>`) instead
+ * of sitting before it as a sibling, which makes it a true app-wide FALLBACK. React fires
+ * layout effects in post-order, so any per-component restorer nested below (e.g. FleetTimeline's
+ * #1471 board-region restore) runs FIRST and reclaims focus; this anchor's effect then sees a
+ * live element and stands down. As a preceding sibling its effect fired first and pre-empted
+ * those restores onto the invisible anchor. The anchor is still rendered before `children`, so
+ * restored focus (and Tab order) lands at the content boundary, past the unchanged nav.
  */
-export function RouteAnnouncer() {
+export function RouteAnnouncer({ children }: PropsWithChildren) {
   const t = useTranslations('nav')
   // A named `<section>` (role="region") — not a bare `<div>` (role="generic", on which
   // `aria-label` is prohibited and dropped): a generic anchor is silent on VoiceOver, exactly
@@ -24,11 +32,14 @@ export function RouteAnnouncer() {
   const navKey = useRouterState({ select: (s) => s.resolvedLocation?.href ?? '' })
   useRouteFocusRestoration(navKey, anchorRef)
   return (
-    <section
-      ref={anchorRef}
-      tabIndex={-1}
-      className="sr-only"
-      aria-label={t('routeAnnouncerLabel')}
-    />
+    <>
+      <section
+        ref={anchorRef}
+        tabIndex={-1}
+        className="sr-only"
+        aria-label={t('routeAnnouncerLabel')}
+      />
+      {children}
+    </>
   )
 }

--- a/packages/web/src/vite/nav/useRouteFocusRestoration.ts
+++ b/packages/web/src/vite/nav/useRouteFocusRestoration.ts
@@ -19,11 +19,14 @@ import { type RefObject, useLayoutEffect, useRef } from 'react'
  * never sits on `<body>` for a painted frame (which can bump an AT virtual cursor to the top
  * of the page). Client-only Vite SPA — no SSR caveat.
  *
- * The "focus fell to the document root" guard is also what lets this coexist with per-component
- * restorers (e.g. FleetTimeline focusing its own board region): React runs child effects before
- * parent effects, so a more-specific child restores first, and this parent then sees a live
- * element and stands down. This app-wide anchor is the fallback for the cold-remount path where
- * the child that owned focus is itself unmounted and can't run its effect.
+ * The "focus fell to the document root" guard is what lets this coexist with per-component
+ * restorers (e.g. FleetTimeline focusing its own board region). For that to hold the announcer
+ * must WRAP the routed content (see RouteAnnouncer / $locale.tsx, #1508), NOT sit before it as a
+ * sibling: React fires layout effects in post-order, so a restorer nested below this anchor runs
+ * FIRST and reclaims focus, and this effect then sees a live element and stands down. (A
+ * preceding sibling's effect fires first and pre-empts the restore onto this invisible anchor.)
+ * This app-wide anchor is the fallback for the cold-remount path where the child that owned
+ * focus is itself unmounted and can't run its effect.
  */
 export function useRouteFocusRestoration<T extends HTMLElement>(
   navKey: string,


### PR DESCRIPTION
Closes #1508.

## Problem

#1489 shipped an app-wide route focus announcer (`RouteAnnouncer`) mounted once in the locale layout. It sat as a **preceding sibling** of `<Outlet>`:

```tsx
<RouteAnnouncer />
<Outlet />
```

React fires `useLayoutEffect` in **post-order**, so an earlier sibling's effect runs before a later sibling's subtree. On a search-param date nav that strands focus (e.g. FleetTimeline's date navigation), the announcer's effect fired **before** any per-component restorer nested in `<Outlet>` — grabbing focus onto its invisible `sr-only` anchor, after which the more specific restorer (FleetTimeline's #1471 board-region restore) saw a live element and stood down.

Net effect: a silent a11y degradation — the orienting "Fleet planning board" region restore was pre-empted by a generic "Page content" anchor — and the exact inverse of the coexistence #1489's own comment claimed ("child restores first, parent stands down": but the announcer was a *sibling*, not a parent).

Surfaced by an architect integration review while merging develop into the #1470 branch.

## Fix

Make `RouteAnnouncer` **wrap** the routed content:

```tsx
<RouteAnnouncer>
  <Outlet />
</RouteAnnouncer>
```

As a **parent**, its layout effect now fires **after** all descendant effects (post-order). So a per-component restorer nested below reclaims focus first, and the announcer sees a live element and stands down — a true app-wide **fallback**. It still catches the cold-remount path (a freshly-mounted subtree can't restore its own focus).

The `sr-only` anchor still renders before `children`, so Tab order and the content-boundary landing are unchanged. Corrected the misleading ordering comment (architect Finding 4).

## Why wrapping, not the alternatives

The architect floated (A) teach FleetTimeline to reclaim from the announcer anchor — re-encodes the implicit coupling; (C) delete #1471 and accept anchor-wins — loses the orienting region announcement. Wrapping is the deterministic, general fix (any in-`Outlet` restorer wins) with no per-component coupling and no context plumbing.

## Tests

- **`RouteAnnouncer.test.tsx`** +2: a nested restorer wins (announcer defers), and the announcer still catches a true cold remount (fresh fiber via a changed `key`). Sabotage-verified (revert the wrap → both RED).
- Passing `children` is referentially stable, so `RouteAnnouncer` re-rendering on every nav does not re-render the routed subtree (`Outlet` updates via its own subscription) — verified in review.

## Verification

- web tsc clean; `bun run lint` exit 0; full web suite **2168 passed** (308 files); behind 0.
- Independent code review: sound, no CRITICAL/HIGH/MEDIUM. One LOW accepted (no direct `$locale`-render test — needs a heavy router+provider mock; the wrapping invariant is documented in three comments instead).

## Test plan

- [ ] Keyboard/AT: focus a FleetTimeline bar, navigate the date so it drops; focus lands on the **board region**, not the sr-only anchor.
- [ ] A genuine route change to a new page still lands focus on the announcer anchor (fallback intact).