### PR TITLE
fix(#1498): atomic operator-terms saveDraft + 409 on the unique race (resolves #1499)

### DIFF
--- a/packages/api/src/composition/repositories.ts
+++ b/packages/api/src/composition/repositories.ts
@@ -481,7 +481,7 @@ export function buildDrizzleRepos(opts?: { db?: Db; runTx?: RunTx }): Repos {
     operatorMembershipRepo,
     auditLogRepo,
     bookingEventRepo: new DrizzleBookingEventRepository(db),
-    consentRepo: new DrizzleConsentRepository(db),
+    consentRepo: new DrizzleConsentRepository(db, tx),
     reviewRepo: new DrizzleReviewRepository(db),
     featureFlagRepo: new DrizzleFeatureFlagRepository(db),
     operatorApplicationRepo: new DrizzleOperatorApplicationRepository(db),

--- a/packages/api/src/pg-errors.ts
+++ b/packages/api/src/pg-errors.ts
@@ -131,6 +131,16 @@ export const OPERATOR_APPLICATION_EMAIL_CONSTRAINT = 'operator_applications_live
  */
 export const OPERATORS_SLUG_CONSTRAINT = 'operators_slug_unique'
 
+/**
+ * Partial unique index on consent_documents(operatorId, type, version, locale)
+ * WHERE operatorId IS NOT NULL (§4.3, `consent_documents_operator_tvl_unique`).
+ * On the operator terms-authoring path (#1498), two concurrent first-saves both
+ * compute the same next version and race the insert; the loser trips this 23505.
+ * OperatorTermsService maps it to a 409 (a benign "someone else just saved this
+ * version"), never a raw 500.
+ */
+export const CONSENT_DOC_OPERATOR_TVL_CONSTRAINT = 'consent_documents_operator_tvl_unique'
+
 /** Extract the Postgres error code from an unknown thrown value, or null.
  *
  * Drizzle + postgres-js wraps the raw PostgresError inside `err.cause`,

--- a/packages/api/src/repositories/drizzle/consent.ts
+++ b/packages/api/src/repositories/drizzle/consent.ts
@@ -1,3 +1,4 @@
+import type { RunTx } from '@kuruma/shared/db'
 import type { ConsentDocStatus, ConsentType } from '@kuruma/shared/enums'
 import { consentAcceptances, consentDocuments } from '@kuruma/shared/db/schema'
 import { type SQL, and, desc, eq, gte, inArray, isNull, lte } from 'drizzle-orm'
@@ -62,7 +63,10 @@ function toAcceptance(r: AcceptanceRow): ConsentAcceptance {
 }
 
 export class DrizzleConsentRepository implements ConsentRepository {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly runTransaction: RunTx,
+  ) {}
 
   async findDocumentById(id: string): Promise<ConsentDocument | undefined> {
     const [row] = await this.db
@@ -286,28 +290,33 @@ export class DrizzleConsentRepository implements ConsentRepository {
     return rows.map(toDocument)
   }
 
-  async createOperatorDocuments(rows: NewConsentDocument[]): Promise<ConsentDocument[]> {
-    if (rows.length === 0) return []
-    const inserted = await this.db
-      .insert(consentDocuments)
-      .values(rows.map((r) => ({ ...r, id: crypto.randomUUID() })))
-      .returning()
-    return inserted.map(toDocument)
-  }
-
-  async deleteOperatorDraftRows(
+  async replaceOperatorDraftRows(
     operatorId: string,
     type: ConsentType,
     version: string,
-  ): Promise<void> {
-    await this.db.delete(consentDocuments).where(
-      and(
-        eq(consentDocuments.operatorId, operatorId),
-        eq(consentDocuments.type, type),
-        eq(consentDocuments.version, version),
-        eq(consentDocuments.status, 'DRAFT'),
-      ),
-    )
+    rows: NewConsentDocument[],
+  ): Promise<ConsentDocument[]> {
+    // Atomic draft rewrite (#1498): delete the prior draft of this version and
+    // insert the new locale rows in ONE tx, so a failure between the two can't
+    // leave the operator with no draft. A concurrent first-save that already
+    // claimed the version trips consent_documents_operator_tvl_unique (23505),
+    // which OperatorTermsService maps to a 409.
+    return this.runTransaction(async (tx) => {
+      await tx.delete(consentDocuments).where(
+        and(
+          eq(consentDocuments.operatorId, operatorId),
+          eq(consentDocuments.type, type),
+          eq(consentDocuments.version, version),
+          eq(consentDocuments.status, 'DRAFT'),
+        ),
+      )
+      if (rows.length === 0) return []
+      const inserted = await tx
+        .insert(consentDocuments)
+        .values(rows.map((r) => ({ ...r, id: crypto.randomUUID() })))
+        .returning()
+      return inserted.map(toDocument)
+    })
   }
 
   async setOperatorVersionStatus(p: {

--- a/packages/api/src/repositories/in-memory/consent.ts
+++ b/packages/api/src/repositories/in-memory/consent.ts
@@ -177,22 +177,16 @@ export class InMemoryConsentRepository implements ConsentRepository {
     return [...this.docs.values()].filter((d) => d.operatorId === operatorId && d.type === type)
   }
 
-  async createOperatorDocuments(rows: NewConsentDocument[]): Promise<ConsentDocument[]> {
-    const created: ConsentDocument[] = rows.map((r) => ({
-      ...r,
-      id: crypto.randomUUID(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }))
-    for (const d of created) this.docs.set(d.id, d)
-    return created
-  }
-
-  async deleteOperatorDraftRows(
+  async replaceOperatorDraftRows(
     operatorId: string,
     type: ConsentType,
     version: string,
-  ): Promise<void> {
+    rows: NewConsentDocument[],
+  ): Promise<ConsentDocument[]> {
+    // Mirror the drizzle atomic rewrite + its unique seal (#1498): drop the prior
+    // DRAFT of this version, then insert — throwing the SAME 23505 / constraint
+    // name the real DB would if a surviving row already occupies (operatorId,
+    // type, version, locale). Keeps the InMemory <-> Drizzle parity the suite asserts.
     for (const [id, d] of this.docs) {
       if (
         d.operatorId === operatorId &&
@@ -203,6 +197,24 @@ export class InMemoryConsentRepository implements ConsentRepository {
         this.docs.delete(id)
       }
     }
+    for (const r of rows) {
+      const clash = [...this.docs.values()].some(
+        (d) =>
+          d.operatorId === r.operatorId &&
+          d.type === r.type &&
+          d.version === r.version &&
+          d.locale === r.locale,
+      )
+      if (clash) throw uniqueViolation('consent_documents_operator_tvl_unique')
+    }
+    const created: ConsentDocument[] = rows.map((r) => ({
+      ...r,
+      id: crypto.randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }))
+    for (const d of created) this.docs.set(d.id, d)
+    return created
   }
 
   async setOperatorVersionStatus(p: {

--- a/packages/api/src/repositories/types-consent.ts
+++ b/packages/api/src/repositories/types-consent.ts
@@ -113,8 +113,19 @@ export interface ConsentRepository {
   ): Promise<ConsentDocument | undefined>
   /** Every row this operator authored for a type (any status) — the service groups by version. */
   findOperatorDocuments(operatorId: string, type: ConsentType): Promise<ConsentDocument[]>
-  createOperatorDocuments(rows: NewConsentDocument[]): Promise<ConsentDocument[]>
-  deleteOperatorDraftRows(operatorId: string, type: ConsentType, version: string): Promise<void>
+  /**
+   * Atomically rewrite an operator's DRAFT of one version: delete the prior draft
+   * rows of (operatorId, type, version) and insert `rows` in a single transaction
+   * (#1498), so a mid-op failure can't destroy the existing draft with nothing to
+   * replace it. Throws the 23505 `consent_documents_operator_tvl_unique` when a
+   * concurrent save already claimed the version — the service maps that to 409.
+   */
+  replaceOperatorDraftRows(
+    operatorId: string,
+    type: ConsentType,
+    version: string,
+    rows: NewConsentDocument[],
+  ): Promise<ConsentDocument[]>
   setOperatorVersionStatus(params: {
     operatorId: string
     type: ConsentType

--- a/packages/api/src/routes/operator-terms.ts
+++ b/packages/api/src/routes/operator-terms.ts
@@ -23,6 +23,15 @@ export function createOperatorTermsRoutes(
   // Operator-private authoring surface: auth gates every path; the FLEET_WRITE
   // role gate (below) rejects RENTER/PARTNER. An admin without a picked operator
   // sees an empty list; a write without one is 422 (global OperatorRequiredError).
+  //
+  // Dark-flag scope (#1499): OPERATOR_TERMS is a VITE_ (client build-time) flag,
+  // so "dark until Slice B" is enforced on the web only (route redirect + hidden
+  // nav) — these routes stay mounted. That is a conscious decision, not a gap: the
+  // surface is auth + FLEET_WRITE gated (operators/admins only) and the rows are
+  // INERT until Slice B wires renter-side resolution, so an early direct-API write
+  // creates nothing a renter can see. Server-side gating a VITE_FEATURE_* flag is
+  // not a pattern the codebase has; revisit only if OPERATOR_TERMS graduates to a
+  // runtime-registry flag (then gate here via the server flag resolver).
   app.use('/operator-terms', requireAuth())
   app.use('/operator-terms/*', requireAuth())
 

--- a/packages/api/src/services/consent.test.ts
+++ b/packages/api/src/services/consent.test.ts
@@ -215,8 +215,7 @@ describe('ConsentService.recordAcceptance — concurrent-race catch path', () =>
         realRepo.findLatestPublishedVersionForOperator(...args),
       findPublishedOperatorDocument: (...args) => realRepo.findPublishedOperatorDocument(...args),
       findOperatorDocuments: (...args) => realRepo.findOperatorDocuments(...args),
-      createOperatorDocuments: (...args) => realRepo.createOperatorDocuments(...args),
-      deleteOperatorDraftRows: (...args) => realRepo.deleteOperatorDraftRows(...args),
+      replaceOperatorDraftRows: (...args) => realRepo.replaceOperatorDraftRows(...args),
       setOperatorVersionStatus: (...args) => realRepo.setOperatorVersionStatus(...args),
     }
 

--- a/packages/api/src/services/operator-terms.test.ts
+++ b/packages/api/src/services/operator-terms.test.ts
@@ -63,4 +63,27 @@ describe('OperatorTermsService', () => {
     const r = await svc.archive(OP, 'v1', NOW)
     expect(r.ok && r.version.status).toBe('ARCHIVED')
   })
+
+  it('maps a concurrent-save unique violation to a 409, not a raw 500', async () => {
+    // Two tabs first-save at once: both compute v1, the loser trips
+    // consent_documents_operator_tvl_unique. The service must translate it.
+    repo.replaceOperatorDraftRows = async () => {
+      throw Object.assign(new Error('duplicate key value violates unique constraint'), {
+        code: '23505',
+        constraint_name: 'consent_documents_operator_tvl_unique',
+      })
+    }
+    const r = await svc.saveDraft(OP, draft, NOW)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.status).toBe(409)
+    expect(r.error).toMatch(/already exists/)
+  })
+
+  it('re-throws a non-unique repo failure instead of swallowing it as a 409', async () => {
+    repo.replaceOperatorDraftRows = async () => {
+      throw new Error('connection terminated unexpectedly')
+    }
+    await expect(svc.saveDraft(OP, draft, NOW)).rejects.toThrow('connection terminated')
+  })
 })

--- a/packages/api/src/services/operator-terms.ts
+++ b/packages/api/src/services/operator-terms.ts
@@ -1,6 +1,7 @@
 import type { ConsentDocStatus } from '@kuruma/shared/enums'
 import { computeContentHash } from '@kuruma/shared/lib/consent-canonical'
 import type { SaveOperatorTermsDraftInput } from '@kuruma/shared/validators/consent-documents'
+import { CONSENT_DOC_OPERATOR_TVL_CONSTRAINT, pgConstraintName } from '../pg-errors'
 import type { ConsentRepository, NewConsentDocument } from '../repositories/types-consent'
 import type { ConsentDocument } from '../stores'
 
@@ -68,8 +69,6 @@ export class OperatorTermsService {
     const version = draftVersion ?? this.nextVersion(existing)
     const effectiveFrom = input.effectiveFrom ? new Date(input.effectiveFrom) : now
 
-    if (draftVersion) await this.repo.deleteOperatorDraftRows(operatorId, TYPE, version)
-
     const rows: NewConsentDocument[] = LOCALES.flatMap((locale) => {
       const t = input[locale]
       if (!t) return []
@@ -89,8 +88,18 @@ export class OperatorTermsService {
         },
       ]
     })
-    const created = await this.repo.createOperatorDocuments(rows)
-    return { ok: true, version: toVersion(created) }
+
+    try {
+      // Atomic delete-old-draft + insert (#1498) — the repo runs both in one tx.
+      const created = await this.repo.replaceOperatorDraftRows(operatorId, TYPE, version, rows)
+      return { ok: true, version: toVersion(created) }
+    } catch (err) {
+      // Two concurrent first-saves compute the same nextVersion; the loser trips
+      // consent_documents_operator_tvl_unique. Surface a clean 409, not a raw 500.
+      if (pgConstraintName(err) === CONSENT_DOC_OPERATOR_TVL_CONSTRAINT)
+        return { ok: false, error: 'A draft for this version already exists', status: 409 }
+      throw err
+    }
   }
 
   async publish(operatorId: string, version: string, now: Date): Promise<OperatorTermsResult> {

--- a/packages/api/tests/integration/consent-operator-repo.test.ts
+++ b/packages/api/tests/integration/consent-operator-repo.test.ts
@@ -1,9 +1,11 @@
+import type { RunTx } from '@kuruma/shared/db'
 import { BEST_CAR_RENTAL_OPERATOR_ID } from '@kuruma/shared/db/constants'
 import { consentDocuments } from '@kuruma/shared/db/schema'
 import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { CONSENT_DOC_OPERATOR_TVL_CONSTRAINT, pgConstraintName } from '../../src/pg-errors'
 import { DrizzleConsentRepository } from '../../src/repositories/drizzle/consent'
 import type { Db } from '../../src/repositories/drizzle/shared'
 import type { NewConsentDocument } from '../../src/repositories/types-consent'
@@ -12,13 +14,15 @@ const url = process.env.DATABASE_URL
 if (!url) throw new Error('DATABASE_URL must be set to run this test')
 const client = postgres(url, { max: 1 })
 const db = drizzle(client, { schema: { consentDocuments } }) as unknown as Db
-const repo = new DrizzleConsentRepository(db)
+const runOnTestDb: RunTx = (fn) => db.transaction(fn)
+const repo = new DrizzleConsentRepository(db, runOnTestDb)
 const OP = BEST_CAR_RENTAL_OPERATOR_ID
+const TYPE = 'OPERATOR_RENTAL_TERMS' as const
 
 function row(over: Partial<NewConsentDocument>): NewConsentDocument {
   return {
     operatorId: OP,
-    type: 'OPERATOR_RENTAL_TERMS',
+    type: TYPE,
     version: 'v1',
     locale: 'en',
     title: 'T',
@@ -41,19 +45,19 @@ afterAll(async () => {
 })
 
 describe('DrizzleConsentRepository operator authoring', () => {
-  it('creates rows and lists them by operator+type', async () => {
-    await repo.createOperatorDocuments([row({}), row({ locale: 'ja' })])
-    const all = await repo.findOperatorDocuments(OP, 'OPERATOR_RENTAL_TERMS')
+  it('replaceOperatorDraftRows inserts the version rows and lists them by operator+type', async () => {
+    await repo.replaceOperatorDraftRows(OP, TYPE, 'v1', [row({}), row({ locale: 'ja' })])
+    const all = await repo.findOperatorDocuments(OP, TYPE)
     expect(all.map((d) => d.locale).sort()).toEqual(['en', 'ja'])
     expect(all.every((d) => d.operatorId === OP)).toBe(true)
   })
 
   it('flips a version DRAFT→PUBLISHED and resolves the latest published version', async () => {
-    await repo.createOperatorDocuments([row({ version: 'v1' })])
+    await repo.replaceOperatorDraftRows(OP, TYPE, 'v1', [row({ version: 'v1' })])
     const now = new Date('2026-06-01T00:00:00Z')
     const published = await repo.setOperatorVersionStatus({
       operatorId: OP,
-      type: 'OPERATOR_RENTAL_TERMS',
+      type: TYPE,
       version: 'v1',
       from: 'DRAFT',
       to: 'PUBLISHED',
@@ -62,16 +66,46 @@ describe('DrizzleConsentRepository operator authoring', () => {
     })
     expect(published).toHaveLength(1)
     expect(published[0]?.status).toBe('PUBLISHED')
-    expect(await repo.findLatestPublishedVersionForOperator(OP, 'OPERATOR_RENTAL_TERMS', now)).toBe(
-      'v1',
-    )
-    const doc = await repo.findPublishedOperatorDocument(OP, 'OPERATOR_RENTAL_TERMS', 'v1', 'en')
+    expect(await repo.findLatestPublishedVersionForOperator(OP, TYPE, now)).toBe('v1')
+    const doc = await repo.findPublishedOperatorDocument(OP, TYPE, 'v1', 'en')
     expect(doc?.title).toBe('T')
   })
 
-  it('deletes only DRAFT rows of a version', async () => {
-    await repo.createOperatorDocuments([row({ version: 'v2', status: 'DRAFT' })])
-    await repo.deleteOperatorDraftRows(OP, 'OPERATOR_RENTAL_TERMS', 'v2')
-    expect(await repo.findOperatorDocuments(OP, 'OPERATOR_RENTAL_TERMS')).toHaveLength(0)
+  it('atomically drops the prior DRAFT of the version and inserts the new rows (#1498)', async () => {
+    await repo.replaceOperatorDraftRows(OP, TYPE, 'v2', [
+      row({ version: 'v2', title: 'old', locale: 'en' }),
+      row({ version: 'v2', locale: 'ja' }),
+    ])
+    const rewritten = await repo.replaceOperatorDraftRows(OP, TYPE, 'v2', [
+      row({ version: 'v2', title: 'new', locale: 'en' }),
+    ])
+    expect(rewritten.map((d) => d.locale)).toEqual(['en'])
+    const all = await repo.findOperatorDocuments(OP, TYPE)
+    expect(all).toHaveLength(1) // the stale ja draft is gone
+    expect(all[0]?.title).toBe('new')
+  })
+
+  it('throws the operator_tvl unique (23505) when a surviving row already claims the (version, locale) — the seam the service maps to 409 (#1498)', async () => {
+    // Publish v1/en, then a draft rewrite of v1: the delete touches only DRAFTs so
+    // the PUBLISHED row survives, and the insert collides on (operator, type, v1, en).
+    await repo.replaceOperatorDraftRows(OP, TYPE, 'v1', [row({ version: 'v1' })])
+    const now = new Date('2026-06-01T00:00:00Z')
+    await repo.setOperatorVersionStatus({
+      operatorId: OP,
+      type: TYPE,
+      version: 'v1',
+      from: 'DRAFT',
+      to: 'PUBLISHED',
+      publishedAt: now,
+      now,
+    })
+    let caught: unknown
+    try {
+      await repo.replaceOperatorDraftRows(OP, TYPE, 'v1', [row({ version: 'v1' })])
+    } catch (e) {
+      caught = e
+    }
+    // Byte-for-byte parity with the constant OperatorTermsService branches on.
+    expect(pgConstraintName(caught)).toBe(CONSENT_DOC_OPERATOR_TVL_CONSTRAINT)
   })
 })

--- a/packages/api/tests/integration/consent-repo.test.ts
+++ b/packages/api/tests/integration/consent-repo.test.ts
@@ -18,7 +18,7 @@ const client = postgres(url, { max: 1 })
 // Cast to Db (NeonHttp type) — postgres-js is structurally compatible for the
 // query methods DrizzleConsentRepository uses (select/insert/delete).
 const db = drizzle(client, { schema }) as unknown as Db
-const repo = new DrizzleConsentRepository(db)
+const repo = new DrizzleConsentRepository(db, (fn) => db.transaction(fn))
 
 const createdDocIds: string[] = []
 const createdAcceptanceIds: string[] = []

--- a/scripts/consent-evidence.ts
+++ b/scripts/consent-evidence.ts
@@ -2,11 +2,11 @@ import { DrizzleConsentRepository } from '../packages/api/src/repositories/drizz
 import { ConsentEvidenceService } from '../packages/api/src/services/consent-evidence'
 import { resolveSigningKey } from '../packages/api/src/services/consent-signing'
 // Usage: bun run consent:evidence -- <acceptanceId> | --user <id> | --booking <id>
-import { getDb } from '../packages/shared/src/db'
+import { getDb, runTx } from '../packages/shared/src/db'
 
 async function main() {
   const [a, b] = process.argv.slice(2)
-  const repo = new DrizzleConsentRepository(getDb())
+  const repo = new DrizzleConsentRepository(getDb(), runTx)
   const svc = new ConsentEvidenceService(repo, (keyId) => {
     const k = resolveSigningKey()
     return k && k.keyId === keyId ? k : undefined


### PR DESCRIPTION
Two loose ends from the Slice A code review (#877 operator rental-terms authoring).

## #1498 — `saveDraft` atomicity + 409

`OperatorTermsService.saveDraft` did `deleteOperatorDraftRows` then `createOperatorDocuments` as **two un-transacted awaits**:
- A failure between them destroyed the operator's existing draft with nothing to replace it.
- Two concurrent first-saves (double-click / two tabs) both computed the same `nextVersion`; the loser hit `consent_documents_operator_tvl_unique` (23505) and surfaced a **raw 500**.

**Fix:**
- Replaced the two repo primitives with one atomic **`replaceOperatorDraftRows`** — the drizzle impl runs delete+insert in a **`runTx`** (mirrors the thread repo; `RunTx` now injected into `DrizzleConsentRepository`); the in-memory twin mirrors it and throws the **same 23505 / constraint name** for parity.
- `OperatorTermsService` catches that constraint → clean **409**, and **re-throws** anything else (never swallows an unexpected error).
- `pg-errors`: `CONSENT_DOC_OPERATOR_TVL_CONSTRAINT` names the seam.

## #1499 — dark-flag scope decision (accept web-only)

Resolved as **option (a): the `OPERATOR_TERMS` dark gate stays web-only.** It's a VITE_ (client) flag; the authoring routes are **auth + FLEET_WRITE gated** (operators/admins only) and the rows are **inert until Slice B** wires renter-side resolution, so a direct-API write while dark creates nothing a renter can see. Server-side gating a `VITE_FEATURE_*` flag isn't a pattern the codebase has. **Documented the decision at the route mount** (revisit only if the flag graduates to the runtime registry).

## Verification
- api `tsc`, `lint:boundaries`, full unit **2945/2945** (2 new service tests, sabotage-checked by neutering the guard → red)
- `consent-operator-repo` integration **4/4 real-pg**: atomic rewrite drops the stale draft, and a genuine collision throws `consent_documents_operator_tvl_unique` (byte-parity with the constant the 409 branches on)

Closes #1498
Resolves #1499