### PR TITLE
feat(#1503): advertise the FleetTimeline roving keys to screen readers

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -298,6 +298,7 @@
         },
         "board": {
           "label": "Fleet planning board, {range}",
+          "keyboardHint": "Use the arrow keys to move between bookings; press Enter or Space to open one.",
           "bookingBar": "{vehicle}. Booking: {renter}, {status}, {range}",
           "blockBar": "{vehicle}. {kind} block: {title}, {range}"
         }

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -298,6 +298,7 @@
         },
         "board": {
           "label": "配車ボード、{range}",
+          "keyboardHint": "矢印キーで予約間を移動し、Enterキーまたはスペースキーで予約を開きます。",
           "bookingBar": "{vehicle}。予約: {renter}、{status}、{range}",
           "blockBar": "{vehicle}。{kind}ブロック: {title}、{range}"
         }

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -298,6 +298,7 @@
         },
         "board": {
           "label": "车队排期板，{range}",
+          "keyboardHint": "使用方向键在预订之间移动，按 Enter 或空格键打开预订。",
           "bookingBar": "{vehicle}。预订：{renter}，{status}，{range}",
           "blockBar": "{vehicle}。{kind}封锁：{title}，{range}"
         }

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.test.tsx
@@ -434,3 +434,26 @@ describe('FleetTimeline roving tabindex (#1470)', () => {
     expect(screen.getByRole('region', { name: /Fleet planning board/ })).toHaveFocus()
   })
 })
+
+// #1503 (follow-up to #1470): the roving arrow-key affordance is invisible to a screen-reader
+// user until they guess it exists. This advertises it two ways: the board region carries an
+// accessible description naming the arrow keys (heard when focus lands on the region — the
+// #1471 restore entry point), and each interactive bar declares aria-keyshortcuts so a
+// focus-mode user who Tabs to a bar hears exactly which keys move focus. The keys named are
+// the ones handleItemKeyDown actually wires (#1470), so the advertisement is truthful.
+describe('FleetTimeline keyboard discoverability (#1503)', () => {
+  it('describes the board region with the arrow-key roving affordance', () => {
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })])
+    expect(
+      screen.getByRole('region', { name: /Fleet planning board/ }),
+    ).toHaveAccessibleDescription(/arrow keys/i)
+  })
+
+  it('advertises the exact roving shortcuts on each interactive bar', () => {
+    renderTimeline([row({ id: 'b1', renterName: 'Alice' })])
+    expect(screen.getByRole('button', { name: /Booking: Alice/ })).toHaveAttribute(
+      'aria-keyshortcuts',
+      'ArrowRight ArrowLeft ArrowDown ArrowUp Home End',
+    )
+  })
+})

--- a/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
+++ b/packages/web/src/vite/operator-bookings/FleetTimeline.tsx
@@ -25,6 +25,7 @@ import { addDays, startOfDay } from 'date-fns'
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -74,6 +75,12 @@ const ARROW_DIRECTIONS: Record<string, RovingDirection> = {
   End: 'end',
 }
 
+// #1503: the space-delimited aria-keyshortcuts advertised on each interactive bar. Derived
+// from ARROW_DIRECTIONS so the advertisement can never drift from the keys handleItemKeyDown
+// actually handles. Enter/Space are omitted — they are the standard button-activation keys AT
+// already implies from role=button, not a bespoke shortcut.
+const ROVING_KEYSHORTCUTS = Object.keys(ARROW_DIRECTIONS).join(' ')
+
 interface FleetTimelineProps {
   readonly rows: readonly CalendarBookingRow[]
   // The operator's fleet — each becomes a row; bookings bind to a row by vehicle id.
@@ -108,6 +115,9 @@ export function FleetTimeline({
   // Shares the switcher with BookingsCalendar; the Timeline option follows the same
   // runtime-toggleable flag (#1322) so both views agree on the offered set.
   const timelineEnabled = useFeatureFlag('FLEET_TIMELINE')
+
+  // #1503: id linking the board region to its sr-only roving hint (aria-describedby below).
+  const keyboardHintId = useId()
 
   // #1471: a date-range nav rebuilds every bar. If keyboard/screen-reader focus sat on a
   // booking bar that the new window drops, React unmounts that node and the browser lets
@@ -319,11 +329,14 @@ export function FleetTimeline({
           // #1470: only the active bar is tabIndex=0 (the board is one tab stop); the rest
           // are tabIndex=-1, reachable by arrow keys. `data-bar-id` lets focusBar find the
           // lib-owned node by id.
+          // #1503: aria-keyshortcuts advertises the arrow/Home/End roving keys to a focus-mode
+          // AT user who Tabs onto the bar, so the affordance is discoverable, not guessed.
           itemProps: it.interactive
             ? {
                 role: 'button',
                 tabIndex: it.id === resolvedActiveId ? 0 : -1,
                 'data-bar-id': it.id,
+                'aria-keyshortcuts': ROVING_KEYSHORTCUTS,
                 ...(it.type === 'block' ? { 'aria-haspopup': 'dialog' as const } : {}),
                 'aria-label': label,
                 onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => handleItemKeyDown(e, it.id),
@@ -375,8 +388,26 @@ export function FleetTimeline({
         views={operatorViews(timelineEnabled)}
       />
       {/* #1349: name the whole board as a region so a screen-reader user gets a
-          landmark to jump to and a label for the mouse-only canvas the lib renders. */}
-      <section ref={regionRef} tabIndex={-1} aria-label={t('board.label', { range: toolbarLabel })}>
+          landmark to jump to and a label for the mouse-only canvas the lib renders.
+          #1503: describe the region with the roving hint (heard when focus lands here — the
+          #1471 restore entry point) so the arrow-key affordance is discoverable.
+
+          A11y waiver (#1503) — NO container role="grid": react-calendar-timeline positions
+          bars ABSOLUTELY over a single canvas, not nested in per-row/per-cell DOM, so a
+          faithful grid (rows of gridcells) has nothing clean to attach to and would fight the
+          lib, risking the #1349 button semantics and #1470 roving focus. No ACCESS is lost —
+          #1349 already exposes every bar as a role="button" a browse-mode AT user reaches
+          element-by-element; the arrow-key roving is a focus-mode optimization we instead
+          advertise via aria-keyshortcuts + this description. */}
+      <section
+        ref={regionRef}
+        tabIndex={-1}
+        aria-label={t('board.label', { range: toolbarLabel })}
+        aria-describedby={keyboardHintId}
+      >
+        <span id={keyboardHintId} className="sr-only">
+          {t('board.keyboardHint')}
+        </span>
         <Timeline
           groups={groups}
           items={items}


### PR DESCRIPTION
## What

Advertise the #1470 arrow-key roving affordance of the FleetTimeline board to screen-reader users. Until now the affordance was invisible to assistive tech — a screen-reader user had to guess that arrow keys move focus between bookings. This is the last a11y item gating the `VITE_FEATURE_FLEET_TIMELINE` flag for GA.

Owner-locked design (Option A — discoverability + documented waiver):

1. **Region description.** The board `<section>` gains `aria-describedby` → a visually-hidden (`sr-only`) hint span keyed by `useId()`, naming the arrow keys. It is announced when focus lands on the region — the #1471 date-nav restore entry point.
2. **Per-bar shortcuts.** Each interactive bar declares `aria-keyshortcuts`, so a focus-mode user who Tabs onto a bar hears exactly which keys move focus. The advertised set is **derived from `ARROW_DIRECTIONS`** (`ROVING_KEYSHORTCUTS`), so it can never drift from the keys `handleItemKeyDown` actually handles.
3. **i18n.** New `board.keyboardHint` key in en / ja / zh (parity-gated by `lint:i18n-parity`).
4. **Documented waiver.** A code comment records the deliberate decision to add **no** `role="grid"`: react-calendar-timeline positions bars absolutely over one canvas (not row/cell-nested DOM), so a faithful grid would fight the lib and risk the #1349 button semantics / #1470 roving focus. No access is lost — #1349 already exposes every bar as a `role="button"` reachable in browse mode; arrow-key roving is a focus-mode optimization, now advertised rather than structurally enforced.

Continues the FleetTimeline a11y thread: #1349 → #1471 → #1470 → #1508.

## Test plan

- [x] TDD, RED-verified: region had empty accessible description, bars had null `aria-keyshortcuts` before the change; both assertions go red without the feature.
- [x] 2 new tests: region carries an accessible description matching `/arrow keys/i`; each interactive bar carries the exact `aria-keyshortcuts` literal.
- [x] Full FleetTimeline suite: 24/24.
- [x] Full web suite: 2208/2208.
- [x] `web typecheck` clean.
- [x] `lint:i18n-parity`: 1571 keys, identical across all 3 locales.
- [x] `biome check` clean; `lint:modules` exit 0 (no new files under the deprecated tree).
- [x] code-reviewer agent: clean, no CRITICAL/HIGH/MEDIUM.

Closes #1503
