### PR TITLE
fix(#1498): in-memory replaceOperatorDraftRows atomicity parity + witness test

### DIFF
--- a/packages/api/src/repositories/in-memory/consent.test.ts
+++ b/packages/api/src/repositories/in-memory/consent.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { ConsentDocument } from '../../stores'
-import type { NewConsentAcceptance } from '../types'
+import type { NewConsentAcceptance, NewConsentDocument } from '../types'
 import { CONSENT_ACCEPTANCE_LIST_LIMIT } from '../types-consent'
 import { InMemoryConsentRepository } from './consent'
 
@@ -38,6 +38,44 @@ const baseAcceptance: NewConsentAcceptance = {
   signingKeyId: 'v1',
   signatureCanonicalVersion: 'v1',
   documentSnapshot: null,
+}
+
+const OP = 'op_kuruma'
+const TERMS = 'OPERATOR_RENTAL_TERMS' as const
+
+function opDoc(
+  over: Partial<ConsentDocument> & Pick<ConsentDocument, 'id' | 'version' | 'locale' | 'status'>,
+): ConsentDocument {
+  return {
+    type: TERMS,
+    operatorId: OP,
+    title: 'Terms',
+    body: 'body',
+    acceptanceLabel: 'I agree',
+    contentHash: 'b'.repeat(64),
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    publishedAt: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...over,
+  }
+}
+
+function newOpRow(over: Partial<NewConsentDocument> = {}): NewConsentDocument {
+  return {
+    operatorId: OP,
+    type: TERMS,
+    version: 'v1',
+    locale: 'en',
+    title: 'Terms',
+    body: 'body',
+    acceptanceLabel: 'I agree',
+    contentHash: 'c'.repeat(64),
+    status: 'DRAFT',
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    publishedAt: null,
+    ...over,
+  }
 }
 
 describe('InMemoryConsentRepository', () => {
@@ -131,6 +169,50 @@ describe('InMemoryConsentRepository', () => {
       repo.createAcceptance({ ...operatorAcceptance, documentId: 'doc_other' }),
     ).resolves.toBeDefined()
     expect((await repo.findOperatorDocumentAcceptance('op_1', DOC.id))?.id).toBe(created.id)
+  })
+
+  it('replaceOperatorDraftRows is atomic: a unique clash on insert leaves the prior draft intact (rollback parity with the drizzle runTx, #1498)', async () => {
+    // A PUBLISHED en row of v1 blocks the new en insert; a DRAFT ja row of the SAME
+    // version is the prior draft a rollback must preserve. The drizzle path runs
+    // delete+insert in ONE runTx, so the 23505 on insert rolls the delete back and the
+    // ja draft survives. The in-memory twin must match, or Slice B's test double lies.
+    const seeded = new InMemoryConsentRepository([
+      opDoc({ id: 'pub_v1_en', version: 'v1', locale: 'en', status: 'PUBLISHED' }),
+      opDoc({ id: 'draft_v1_ja', version: 'v1', locale: 'ja', status: 'DRAFT' }),
+    ])
+
+    await expect(
+      seeded.replaceOperatorDraftRows(OP, TERMS, 'v1', [newOpRow({ locale: 'en' })]),
+    ).rejects.toMatchObject({
+      code: '23505',
+      constraint_name: 'consent_documents_operator_tvl_unique',
+    })
+
+    // The prior ja draft must NOT have been destroyed by the aborted rewrite.
+    const surviving = await seeded.findOperatorDocuments(OP, TERMS)
+    expect(surviving.map((d) => d.id).sort()).toEqual(['draft_v1_ja', 'pub_v1_en'])
+  })
+
+  it('replaceOperatorDraftRows rejects an intra-batch duplicate locale before mutating, so the prior draft survives (#1498)', async () => {
+    // Two en rows in one batch violate the same (operatorId,type,version,locale) seal
+    // the real partial unique index enforces; validate-before-mutate must reject the
+    // batch without first deleting the existing ja draft.
+    const seeded = new InMemoryConsentRepository([
+      opDoc({ id: 'draft_v1_ja', version: 'v1', locale: 'ja', status: 'DRAFT' }),
+    ])
+
+    await expect(
+      seeded.replaceOperatorDraftRows(OP, TERMS, 'v1', [
+        newOpRow({ locale: 'en' }),
+        newOpRow({ locale: 'en' }),
+      ]),
+    ).rejects.toMatchObject({
+      code: '23505',
+      constraint_name: 'consent_documents_operator_tvl_unique',
+    })
+
+    const surviving = await seeded.findOperatorDocuments(OP, TERMS)
+    expect(surviving.map((d) => d.id)).toEqual(['draft_v1_ja'])
   })
 
   it('findAcceptanceById returns the acceptance, findAcceptancesByUser scopes by user, findAcceptancesByBooking returns empty for unknown booking', async () => {

--- a/packages/api/src/repositories/in-memory/consent.ts
+++ b/packages/api/src/repositories/in-memory/consent.ts
@@ -187,25 +187,36 @@ export class InMemoryConsentRepository implements ConsentRepository {
     // DRAFT of this version, then insert — throwing the SAME 23505 / constraint
     // name the real DB would if a surviving row already occupies (operatorId,
     // type, version, locale). Keeps the InMemory <-> Drizzle parity the suite asserts.
-    for (const [id, d] of this.docs) {
-      if (
-        d.operatorId === operatorId &&
-        d.type === type &&
-        d.version === version &&
-        d.status === 'DRAFT'
-      ) {
-        this.docs.delete(id)
-      }
-    }
+    //
+    // Validate BEFORE mutating so a clash aborts with the existing draft intact —
+    // the drizzle path runs delete+insert in one runTx, so a 23505 on insert rolls
+    // the delete back. `survivors` = everything that is NOT a prior DRAFT of this exact
+    // version (those rows are the ones being replaced); a new row clashes iff it matches
+    // a survivor, or a same-locale sibling already in this batch (the partial unique
+    // index rejects an intra-batch (operatorId,type,version,locale) dup too).
+    const isPriorDraft = (d: ConsentDocument) =>
+      d.operatorId === operatorId &&
+      d.type === type &&
+      d.version === version &&
+      d.status === 'DRAFT'
+    const survivors = [...this.docs.values()].filter((d) => !isPriorDraft(d))
+    const seen = new Set<string>()
     for (const r of rows) {
-      const clash = [...this.docs.values()].some(
-        (d) =>
-          d.operatorId === r.operatorId &&
-          d.type === r.type &&
-          d.version === r.version &&
-          d.locale === r.locale,
-      )
+      const key = `${r.operatorId}|${r.type}|${r.version}|${r.locale}`
+      const clash =
+        seen.has(key) ||
+        survivors.some(
+          (d) =>
+            d.operatorId === r.operatorId &&
+            d.type === r.type &&
+            d.version === r.version &&
+            d.locale === r.locale,
+        )
       if (clash) throw uniqueViolation('consent_documents_operator_tvl_unique')
+      seen.add(key)
+    }
+    for (const [id, d] of this.docs) {
+      if (isPriorDraft(d)) this.docs.delete(id)
     }
     const created: ConsentDocument[] = rows.map((r) => ({
       ...r,

--- a/packages/api/tests/integration/consent-operator-repo.test.ts
+++ b/packages/api/tests/integration/consent-operator-repo.test.ts
@@ -108,4 +108,33 @@ describe('DrizzleConsentRepository operator authoring', () => {
     // Byte-for-byte parity with the constant OperatorTermsService branches on.
     expect(pgConstraintName(caught)).toBe(CONSENT_DOC_OPERATOR_TVL_CONSTRAINT)
   })
+
+  it('runTx rolls the delete back on the unique clash — the prior DRAFT of the version survives (#1498 atomicity, witnessed)', async () => {
+    // Seed a mixed-status version directly: PUBLISHED en (blocks the new en insert) plus
+    // a DRAFT ja of the SAME version (the prior draft a rollback must preserve). The
+    // rewrite deletes DRAFTs of v1 then inserts en; the 23505 on the published en must
+    // roll the whole tx back, leaving BOTH seeded rows intact. This is the atomicity
+    // guarantee the InMemory twin mirrors (see in-memory/consent.test.ts).
+    await db.insert(consentDocuments).values([
+      {
+        ...row({ version: 'v1', locale: 'en', title: 'pub' }),
+        id: crypto.randomUUID(),
+        status: 'PUBLISHED',
+        publishedAt: new Date('2026-05-01T00:00:00Z'),
+      },
+      { ...row({ version: 'v1', locale: 'ja', title: 'draft-ja' }), id: crypto.randomUUID() },
+    ])
+
+    await expect(
+      repo.replaceOperatorDraftRows(OP, TYPE, 'v1', [
+        row({ version: 'v1', locale: 'en', title: 'new' }),
+      ]),
+    ).rejects.toSatisfy((e) => pgConstraintName(e) === CONSENT_DOC_OPERATOR_TVL_CONSTRAINT)
+
+    const all = await repo.findOperatorDocuments(OP, TYPE)
+    expect(all.map((d) => `${d.locale}:${d.status}:${d.title}`).sort()).toEqual([
+      'en:PUBLISHED:pub',
+      'ja:DRAFT:draft-ja',
+    ])
+  })
 })


### PR DESCRIPTION
Follow-up hardening to #1498 (PR #1511), surfaced by a code review while scoping consent Slice B. Refs #1498, #877.

## Problem
`DrizzleConsentRepository.replaceOperatorDraftRows` runs delete+insert in one `runTx`, so a 23505 on the insert rolls the delete back and the operator's prior draft survives. The **in-memory twin diverged**: it deleted the prior DRAFT rows (mutating the store) and *then* threw on a clash — no rollback. It also missed an **intra-batch** duplicate-locale clash that the real partial unique index (`consent_documents_operator_tvl_unique`) rejects.

Unreachable through today's `OperatorTermsService` (a fresh version is always chosen, so there's no prior draft to lose), but it sits on exactly the seam **consent Slice B** (renter accepts operator terms atomically at booking-create) will build on — a Slice B test that constructs such a state would silently disagree with real-pg (false green/red).

## Fix
- **in-memory:** validate-before-mutate. Compute `survivors` (every row except the prior DRAFT of this version, which is being replaced) and reject any new row that clashes with a survivor *or* a same-locale sibling already in the batch, **before** deleting/inserting. Throws the same `23505` / `consent_documents_operator_tvl_unique` for service-layer 409 parity.
- No behavior change to the drizzle path (already atomic) or `OperatorTermsService`.

## Tests
- **unit** (`in-memory/consent.test.ts`): two RED-first tests — a unique clash leaves the prior draft intact; an intra-batch duplicate locale is rejected before mutating.
- **integration** (`consent-operator-repo.test.ts`): a real-pg test that *witnesses* the `runTx` rollback (seed PUBLISHED en + DRAFT ja of one version, clash the rewrite, assert both survive) — pairs with the in-memory test for true cross-impl parity, and strengthens the prior "throws 23505" test which never actually observed a rollback.

## Verification
- api unit **2947/2947** (2 new), consent-operator-repo integration **5/5 real-pg** (1 new)
- api + shared `tsc`, `lint:boundaries`, biome — all clean (husky pre-commit green)