### PR TITLE
fix(#1514): page a human when cancellation refunds are stranded at Stripe

### DIFF
--- a/packages/api/src/observability/money-alerts.test.ts
+++ b/packages/api/src/observability/money-alerts.test.ts
@@ -1,0 +1,31 @@
+import * as Sentry from '@sentry/cloudflare'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { reportStrandedFunds } from './money-alerts'
+
+vi.mock('@sentry/cloudflare', () => ({ captureMessage: vi.fn() }))
+
+describe('reportStrandedFunds', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(Sentry.captureMessage).mockClear()
+  })
+
+  it('raises an error-level Sentry event carrying the message and context', () => {
+    // The SDK only auto-captures thrown/unhandled errors; a handled money-stuck
+    // condition must be captured explicitly or it never pages anyone.
+    reportStrandedFunds('2 refunds stranded', { bookingId: 'bk_1', failed: 2 })
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('2 refunds stranded', {
+      level: 'error',
+      extra: { bookingId: 'bk_1', failed: 2 },
+    })
+  })
+
+  it('also logs to console.error so the worker/webhook log keeps full context', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    reportStrandedFunds('double charge', { eventId: 'evt_1' })
+
+    expect(errorSpy).toHaveBeenCalledWith('double charge', { eventId: 'evt_1' })
+  })
+})

--- a/packages/api/src/observability/money-alerts.ts
+++ b/packages/api/src/observability/money-alerts.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/cloudflare'
+
+/**
+ * Raise a Sentry error-level event for money that is stuck at Stripe and needs a
+ * human (a stranded cancellation refund, a captured-but-unrefundable mismatch, a
+ * double charge). Handled money-stuck conditions do NOT throw, and the Sentry SDK
+ * only auto-captures thrown/unhandled errors, so without this explicit capture the
+ * signal is a `console.*` line that pages nobody. Logs to `console.error` too so the
+ * worker/webhook log keeps the full identifier context as a breadcrumb.
+ *
+ * No-ops safely when Sentry is disabled (no DSN) or uninitialised (unit tests / a
+ * `createApp` outside the Worker wrapper): `captureMessage` is a no-op there.
+ */
+export function reportStrandedFunds(message: string, context: Record<string, unknown>): void {
+  console.error(message, context)
+  Sentry.captureMessage(message, { level: 'error', extra: context })
+}

--- a/packages/api/src/routes/payments.ts
+++ b/packages/api/src/routes/payments.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
+import { reportStrandedFunds } from '../observability/money-alerts'
 import type { PaymentService } from '../services/payment/payment'
+import { paymentWebhookStrandedAlert } from '../services/payment/webhook-alert'
 import { fail, failResult, ok, parseId } from './helpers'
 
 const STRIPE_SIGNATURE_HEADER = 'stripe-signature'
@@ -49,20 +51,17 @@ export function createPaymentRoutes(service: PaymentService) {
       // amounts). NOTE: persistence happens before the 200 ack, so a transient failure
       // rejects here → 500 → Stripe retry, which re-converges (idempotent) — favouring
       // durable capture over a silent log-only ack.
-      if (result.outcome === 'amount_mismatch') {
-        // #1378: the mismatched charge is AUTO-REFUNDED. Alert LOUD only when the refund
-        // did not go through ('failed'/'unrefundable') — captured funds may still be
-        // stranded and need a human. A completed/pending refund is a warning-level record.
-        const stranded = result.refund === 'failed' || result.refund === 'unrefundable'
-        const emit = stranded ? console.error : console.warn
-        emit('[payment:webhook] amount mismatch', {
+      // Money stuck at Stripe — a stranded #1378 mismatch auto-refund ('failed'/
+      // 'unrefundable'), or a double charge that (unlike a mismatch) is NOT auto-refunded —
+      // must PAGE a human. The SDK only auto-captures thrown errors, so a handled money-stuck
+      // condition needs an explicit Sentry event (reportStrandedFunds), not a log nobody tails.
+      const strandedAlert = paymentWebhookStrandedAlert(result)
+      if (strandedAlert) {
+        reportStrandedFunds(`[payment:webhook] ${strandedAlert}`, { context: result.context })
+      } else if (result.outcome === 'amount_mismatch') {
+        // A completed/pending auto-refund self-healed — a warning-level record, not an alert.
+        console.warn('[payment:webhook] amount mismatch auto-refunded', {
           refund: result.refund,
-          stranded,
-          ...result.context,
-        })
-      } else if (result.outcome === 'double_payment') {
-        console.error('[payment:webhook] anomaly', {
-          outcome: result.outcome,
           ...result.context,
         })
       } else if (result.outcome === 'invalid_signature') {

--- a/packages/api/src/services/payment/cancellation-refund-reconciler.test.ts
+++ b/packages/api/src/services/payment/cancellation-refund-reconciler.test.ts
@@ -6,7 +6,10 @@ import { InMemoryPaymentEventRepository } from '../../repositories/in-memory/pay
 import { InMemoryPaymentRefundRepository } from '../../repositories/in-memory/payment-refund'
 import { InMemoryRefundReconcilerRepository } from '../../repositories/in-memory/refund-reconciler'
 import type { Booking, PaymentRefund } from '../../stores'
-import { CancellationRefundReconciler } from './cancellation-refund-reconciler'
+import {
+  CancellationRefundReconciler,
+  refundReconcilerStrandedAlert,
+} from './cancellation-refund-reconciler'
 import { PaymentService } from './payment'
 import {
   type PaymentGateway,
@@ -224,5 +227,35 @@ describe('CancellationRefundReconciler.run (#851 S4)', () => {
 
     expect(summary).toEqual({ attempted: 0, succeeded: 0, failed: 0, pending: 0 })
     expect(gateway.refundCalls).toHaveLength(0)
+  })
+})
+
+describe('refundReconcilerStrandedAlert', () => {
+  it('raises an alert naming the FAILED count when refunds are stranded', () => {
+    const alert = refundReconcilerStrandedAlert({
+      attempted: 5,
+      succeeded: 3,
+      failed: 2,
+      pending: 0,
+    })
+
+    // A FAILED receipt keeps the booking REFUND_DUE but is excluded from every later
+    // sweep (drizzle/refund-reconciler.ts), so this run is the ONLY signal that money
+    // is stuck — it must page a human, not sit in the info-level summary.
+    expect(alert).toBe(
+      '2 cancellation refund(s) FAILED at Stripe and are stranded at REFUND_DUE — manual reconciliation needed',
+    )
+  })
+
+  it('is silent (null) when no refund failed', () => {
+    expect(
+      refundReconcilerStrandedAlert({ attempted: 4, succeeded: 4, failed: 0, pending: 0 }),
+    ).toBeNull()
+  })
+
+  it('is silent for a clean empty sweep', () => {
+    expect(
+      refundReconcilerStrandedAlert({ attempted: 0, succeeded: 0, failed: 0, pending: 0 }),
+    ).toBeNull()
   })
 })

--- a/packages/api/src/services/payment/cancellation-refund-reconciler.ts
+++ b/packages/api/src/services/payment/cancellation-refund-reconciler.ts
@@ -10,6 +10,21 @@ export interface CancellationRefundReconcilerSummary {
   pending: number
 }
 
+/**
+ * Pure alert policy (Functional Core): a non-zero `failed` count means Stripe REJECTED
+ * one or more refunds, leaving those bookings stuck at REFUND_DUE and EXCLUDED from every
+ * later sweep (`drizzle/refund-reconciler.ts` filters out FAILED receipts) — so this run's
+ * summary is the ONLY signal the money is stranded. Returns the human-facing alert message,
+ * or null when the sweep drove no failures. Kept pure so the worker's Sentry wiring stays a
+ * one-liner (Imperative Shell) and the policy is unit-testable without the cron.
+ */
+export function refundReconcilerStrandedAlert(
+  summary: CancellationRefundReconcilerSummary,
+): string | null {
+  if (summary.failed <= 0) return null
+  return `${summary.failed} cancellation refund(s) FAILED at Stripe and are stranded at REFUND_DUE — manual reconciliation needed`
+}
+
 /** The one entry point the reconciler drives — the idempotent core shared with the
  *  eager fire (PaymentService satisfies this). Narrow by design (ISP): the backstop
  *  needs only to (re-)drive a refund, not the coordinator's `isBookingPaid` read. */

--- a/packages/api/src/services/payment/webhook-alert.test.ts
+++ b/packages/api/src/services/payment/webhook-alert.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { WebhookResult } from './payment'
+import { paymentWebhookStrandedAlert } from './webhook-alert'
+
+const base = (over: Partial<WebhookResult>): WebhookResult => ({
+  status: 200,
+  outcome: 'ignored',
+  ...over,
+})
+
+describe('paymentWebhookStrandedAlert', () => {
+  it('alerts when an amount-mismatch auto-refund FAILED (funds stranded)', () => {
+    expect(
+      paymentWebhookStrandedAlert(base({ outcome: 'amount_mismatch', refund: 'failed' })),
+    ).toBe(
+      'amount-mismatch auto-refund did not complete (failed) — captured funds may be stranded and need manual reconciliation',
+    )
+  })
+
+  it('alerts when the mismatched charge is unrefundable', () => {
+    expect(
+      paymentWebhookStrandedAlert(base({ outcome: 'amount_mismatch', refund: 'unrefundable' })),
+    ).toBe(
+      'amount-mismatch auto-refund did not complete (unrefundable) — captured funds may be stranded and need manual reconciliation',
+    )
+  })
+
+  it('is silent when the mismatch auto-refund completed or is pending', () => {
+    expect(
+      paymentWebhookStrandedAlert(base({ outcome: 'amount_mismatch', refund: 'refunded' })),
+    ).toBeNull()
+    expect(
+      paymentWebhookStrandedAlert(base({ outcome: 'amount_mismatch', refund: 'pending' })),
+    ).toBeNull()
+  })
+
+  it('alerts on a double payment (recorded but never auto-refunded)', () => {
+    expect(paymentWebhookStrandedAlert(base({ outcome: 'double_payment' }))).toBe(
+      'double charge recorded but NOT auto-refunded — the duplicate charge needs a manual refund',
+    )
+  })
+
+  it('is silent for benign outcomes', () => {
+    expect(paymentWebhookStrandedAlert(base({ outcome: 'ignored' }))).toBeNull()
+    expect(paymentWebhookStrandedAlert(base({ outcome: 'recorded' }))).toBeNull()
+    expect(
+      paymentWebhookStrandedAlert(base({ outcome: 'invalid_signature', status: 400 })),
+    ).toBeNull()
+  })
+})

--- a/packages/api/src/services/payment/webhook-alert.ts
+++ b/packages/api/src/services/payment/webhook-alert.ts
@@ -1,0 +1,27 @@
+import type { WebhookResult } from './payment'
+
+/**
+ * Pure alert policy (Functional Core) for the Stripe webhook: which outcomes mean money is
+ * stuck at Stripe and a human must act. Returns the alert message, or null for outcomes that
+ * are benign or already self-healed.
+ *
+ * - `amount_mismatch` with a `failed`/`unrefundable` auto-refund (#1378): the over-charge was
+ *   captured but the corrective refund did NOT go through — funds may be stranded.
+ * - `double_payment`: a second full charge is recorded but, unlike a mismatch, is NOT
+ *   auto-refunded — the duplicate must be refunded by hand.
+ *
+ * A `refunded`/`pending` mismatch, and `ignored`/`recorded`/`invalid_signature`, page nobody.
+ * Kept pure so the route's Sentry wiring (Imperative Shell) stays a one-liner and testable.
+ */
+export function paymentWebhookStrandedAlert(result: WebhookResult): string | null {
+  if (
+    result.outcome === 'amount_mismatch' &&
+    (result.refund === 'failed' || result.refund === 'unrefundable')
+  ) {
+    return `amount-mismatch auto-refund did not complete (${result.refund}) — captured funds may be stranded and need manual reconciliation`
+  }
+  if (result.outcome === 'double_payment') {
+    return 'double charge recorded but NOT auto-refunded — the duplicate charge needs a manual refund'
+  }
+  return null
+}

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -18,7 +18,9 @@ import {
   buildNotificationRetryService,
   createApp,
 } from './index'
+import { reportStrandedFunds } from './observability/money-alerts'
 import { type SentryRuntimeEnv, resolveSentryOptions } from './observability/sentry-options'
+import { refundReconcilerStrandedAlert } from './services/payment/cancellation-refund-reconciler'
 
 let cachedApp: AppType | null = null
 
@@ -27,6 +29,22 @@ function getApp(): AppType {
     cachedApp = createApp()
   }
   return cachedApp
+}
+
+/**
+ * Wrap a cron job with an optional pure `alert` policy over its summary. Pre-computing the
+ * alert here keeps the loop below type-safe without casts (each job captures its own summary
+ * type S) while the escalation itself stays one place. A non-null alert means the job found a
+ * money-stuck / needs-a-human condition that must page beyond the info-level summary log.
+ */
+function cronJob<S>(name: string, run: () => Promise<S>, alert?: (summary: S) => string | null) {
+  return {
+    name,
+    execute: async (): Promise<{ summary: S; alert: string | null }> => {
+      const summary = await run()
+      return { summary, alert: alert?.(summary) ?? null }
+    },
+  }
 }
 
 const handler = {
@@ -51,14 +69,22 @@ const handler = {
     // captures them.
     const errors: unknown[] = []
     for (const job of [
-      { name: 'compliance-digest', run: () => buildComplianceDigestService().run() },
-      { name: 'refund-reconciler', run: () => buildCancellationRefundReconciler().run() },
-      { name: 'notification-retry', run: () => buildNotificationRetryService().run() },
-      { name: 'review-reveal-sweep', run: () => buildReviewRevealSweep().run() },
+      cronJob('compliance-digest', () => buildComplianceDigestService().run()),
+      cronJob(
+        'refund-reconciler',
+        () => buildCancellationRefundReconciler().run(),
+        refundReconcilerStrandedAlert,
+      ),
+      cronJob('notification-retry', () => buildNotificationRetryService().run()),
+      cronJob('review-reveal-sweep', () => buildReviewRevealSweep().run()),
     ]) {
       try {
-        const summary = await job.run()
+        const { summary, alert } = await job.execute()
         console.info(`[cron:${job.name}]`, JSON.stringify(summary))
+        // A completed-but-money-stuck sweep does NOT throw (poison rows are isolated), so
+        // it never reaches the catch below. Escalate the alert explicitly or it stays a
+        // console.info line that pages nobody.
+        if (alert) reportStrandedFunds(`[cron:${job.name}] ${alert}`, { summary })
       } catch (err) {
         console.error(`[cron:${job.name}] failed`, err)
         errors.push(err)

--- a/packages/api/tests/routes/payments.test.ts
+++ b/packages/api/tests/routes/payments.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
 import { type UserRole, requireAuth } from '../../src/middleware/auth'
+import { reportStrandedFunds } from '../../src/observability/money-alerts'
 import { InMemoryBookingRepository } from '../../src/repositories/in-memory/booking'
 import { InMemoryPaymentAnomalyRepository } from '../../src/repositories/in-memory/payment-anomaly'
 import { InMemoryPaymentEventRepository } from '../../src/repositories/in-memory/payment-event'
@@ -20,6 +21,11 @@ import {
 import type { Booking } from '../../src/stores'
 import { testAuthMiddleware } from '../helpers/auth'
 import { makeBooking as makeBookingFixture } from '../helpers/booking'
+
+// The route escalates money-stuck webhook outcomes through reportStrandedFunds; mock it to
+// assert the wiring (the shell's own console.error + Sentry behaviour is unit-tested in
+// observability/money-alerts.test.ts).
+vi.mock('../../src/observability/money-alerts', () => ({ reportStrandedFunds: vi.fn() }))
 
 // Bookings carry DB-generated UUIDs; the route now validates `:bookingId` as a
 // uuid at the boundary (#691), so the fixture id must be a real uuid too.
@@ -211,8 +217,8 @@ describe('POST /webhooks/stripe (public)', () => {
     const { app, gateway } = publicApp()
     gateway.event = mismatch()
     gateway.nextRefund = succeededRefund
+    vi.mocked(reportStrandedFunds).mockClear()
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const res = await app.request('/webhooks/stripe', {
       method: 'POST',
       headers: { 'stripe-signature': 't=1,v1=good' },
@@ -220,24 +226,23 @@ describe('POST /webhooks/stripe (public)', () => {
     })
     expect(res.status).toBe(200)
     expect(gateway.refundCalls).toHaveLength(1)
-    // A clean auto-refund is NOT an alert.
-    expect(error).not.toHaveBeenCalled()
+    // A clean auto-refund self-healed — a warning-level record, NOT a stranded-funds alert.
+    expect(reportStrandedFunds).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith(
-      '[payment:webhook] amount mismatch',
-      expect.objectContaining({ refund: 'refunded', stranded: false, bookingId: BOOKING_ID }),
+      '[payment:webhook] amount mismatch auto-refunded',
+      expect.objectContaining({ refund: 'refunded', bookingId: BOOKING_ID }),
     )
     warn.mockRestore()
-    error.mockRestore()
   })
 
-  it('ALERTS via console.error when the mismatch refund is rejected — funds may be stranded (#1378)', async () => {
+  it('ALERTS via reportStrandedFunds when the mismatch refund is rejected — funds may be stranded (#1378)', async () => {
     const { app, gateway } = publicApp()
     gateway.event = mismatch()
     gateway.nextRefund = () => {
       throw new RefundRejectedError('charge already refunded', 'charge_already_refunded')
     }
+    vi.mocked(reportStrandedFunds).mockClear()
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const res = await app.request('/webhooks/stripe', {
       method: 'POST',
       headers: { 'stripe-signature': 't=1,v1=good' },
@@ -245,20 +250,19 @@ describe('POST /webhooks/stripe (public)', () => {
     })
     // Still a 200 ack (the anomaly + failed disposition are recorded, not re-driven here).
     expect(res.status).toBe(200)
-    expect(error).toHaveBeenCalledWith(
-      '[payment:webhook] amount mismatch',
-      expect.objectContaining({ refund: 'failed', stranded: true, bookingId: BOOKING_ID }),
+    expect(reportStrandedFunds).toHaveBeenCalledWith(
+      '[payment:webhook] amount-mismatch auto-refund did not complete (failed) — captured funds may be stranded and need manual reconciliation',
+      expect.objectContaining({ context: expect.objectContaining({ bookingId: BOOKING_ID }) }),
     )
-    // A stranded alert must be an ALERT, not a soft warning.
+    // A stranded alert routes through reportStrandedFunds, not the soft warning path.
     expect(warn).not.toHaveBeenCalled()
     warn.mockRestore()
-    error.mockRestore()
   })
 
   it('ALERTS when a mismatch is unrefundable (no PaymentIntent to reverse) (#1378)', async () => {
     const { app, gateway } = publicApp()
     gateway.event = { ...mismatch(), paymentIntentId: null }
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(reportStrandedFunds).mockClear()
     const res = await app.request('/webhooks/stripe', {
       method: 'POST',
       headers: { 'stripe-signature': 't=1,v1=good' },
@@ -267,11 +271,10 @@ describe('POST /webhooks/stripe (public)', () => {
     expect(res.status).toBe(200)
     // No PI → we never call Stripe, but the funds are unaccounted → alert.
     expect(gateway.refundCalls).toEqual([])
-    expect(error).toHaveBeenCalledWith(
-      '[payment:webhook] amount mismatch',
-      expect.objectContaining({ refund: 'unrefundable', stranded: true }),
+    expect(reportStrandedFunds).toHaveBeenCalledWith(
+      '[payment:webhook] amount-mismatch auto-refund did not complete (unrefundable) — captured funds may be stranded and need manual reconciliation',
+      expect.objectContaining({ context: expect.objectContaining({ bookingId: BOOKING_ID }) }),
     )
-    error.mockRestore()
   })
 })
 


### PR DESCRIPTION
## What & why

From a maintainability review of the payment/cancellation-refund money path. **Top finding (H1):** a Stripe-**rejected** refund was silently lost to human visibility.

- The daily reconciler counts a durably-FAILED refund as `failed++` but never throws (poison-row isolation), so `worker.ts` logs `failed:N` at **`console.info`** and only escalates to Sentry when a job *throws*. Sentry has no console-capture integration → the signal reaches nobody.
- `drizzle/refund-reconciler.ts:32` permanently **excludes** FAILED receipts from later sweeps; no admin surface reads `payment_refunds`.
- The webhook's #1378 stranded mismatch auto-refund (`failed`/`unrefundable`) and `double_payment` were likewise `console.error`-only.

Net: booking stuck at `REFUND_DUE`, a renter's owed money invisible after one 3am log line.

## Change (alerting only, no migration)

A Functional-Core / Imperative-Shell split:
- `observability/money-alerts.ts` — `reportStrandedFunds(message, context)`: `console.error` **and** `Sentry.captureMessage(error)`.
- `cancellation-refund-reconciler.ts` — pure `refundReconcilerStrandedAlert(summary)` (alert when `failed > 0`).
- `services/payment/webhook-alert.ts` — pure `paymentWebhookStrandedAlert(result)` (alert on stranded mismatch or `double_payment`).
- `worker.ts` cron loop + `routes/payments.ts` webhook wire the predicates → shell.

## Verification

- New unit tests for the shell + both predicates; route tests updated to assert the escalation. **Sabotage-verified**: neutering the shell's capture or either predicate turns the new tests red.
- Full api unit suite **2957/2957**; api+web `tsc`, biome, `lint:boundaries` (route→observability allowed), `lint:size` all green. Behind-0 on develop.

## Residual / follow-ups (filed separately)

- Worker cron wiring itself isn't unit-tested (composition root; consistent with the repo — the *decision* predicate is tested). 
- Durable stranded-funds surface (persist mismatch disposition + admin queue), the two intended-amount formulas' coupling (double-refund/stuck risk), `double_payment` auto-refund, and Low-severity cleanups → separate issues.

Closes #1514