### PR TITLE
fix(messaging): GA hardening tail from the tenant-isolation review

### DIFF
--- a/packages/api/src/app-overrides.ts
+++ b/packages/api/src/app-overrides.ts
@@ -109,6 +109,12 @@ export type AppOverrides = {
   photoUploadUserLimiter?: RateLimitBinding
   publicCatalogLimiter?: RateLimitBinding
   operatorApplicationLimiter?: RateLimitBinding
+  // Per-user caps on the authenticated messaging surface (messaging GA, #1476):
+  // send throttles POST /threads/:id/messages; translate throttles the external
+  // translation provider on POST /messages/:id/translate. Absent ⇒ the
+  // globalThis-resolved CF binding, or unthrottled local dev.
+  messageSendLimiter?: RateLimitBinding
+  messageTranslateLimiter?: RateLimitBinding
   // Over-limit ⇒ the geocoder skips the lookup (#574). Inject a deny-binding in
   // tests; absent ⇒ the globalThis-resolved GEOCODE_LIMITER (or unthrottled dev).
   geocodeLimiter?: RateLimitBinding

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -210,6 +210,14 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     ((globalThis as Record<string, unknown>).OPERATOR_APPLICATION_LIMITER as
       | RateLimitBinding
       | undefined)
+  const messageSendLimiter =
+    overrides?.messageSendLimiter ??
+    ((globalThis as Record<string, unknown>).MESSAGE_SEND_LIMITER as RateLimitBinding | undefined)
+  const messageTranslateLimiter =
+    overrides?.messageTranslateLimiter ??
+    ((globalThis as Record<string, unknown>).MESSAGE_TRANSLATE_LIMITER as
+      | RateLimitBinding
+      | undefined)
 
   const translationProvider = createTranslationProvider()
 
@@ -605,12 +613,15 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
     .route('/', createFeatureFlagsRoutes(featureFlagsService))
     .route('/', createAdminOverviewRoutes(adminOverviewService))
     .route('/', createPaymentAnomalyRoutes(paymentAnomalyService))
-    .route('/', createMessageRoutes(messageService))
+    .route('/', createMessageRoutes(messageService, messageSendLimiter))
     .route('/', createConsentRoutes(consentService))
     .route('/', createAdminConsentRoutes(consentGovernanceService))
     .route(
       '/',
-      createTranslateRoutes(new MessageTranslationService(messageRepo, translationProvider)),
+      createTranslateRoutes(
+        new MessageTranslationService(messageRepo, translationProvider),
+        messageTranslateLimiter,
+      ),
     )
     .route('/', createCustomerRoutes(customerService))
     .route('/', createUserRoutes(userDirectoryService))

--- a/packages/api/src/repositories/drizzle/shared.ts
+++ b/packages/api/src/repositories/drizzle/shared.ts
@@ -325,7 +325,6 @@ export const messageColumns = {
   content: messages.content,
   sourceLanguage: messages.sourceLanguage,
   translations: messages.translations,
-  idempotencyKey: messages.idempotencyKey,
   createdAt: messages.createdAt,
 }
 
@@ -800,7 +799,6 @@ export type RawMessageRow = {
   content: string
   sourceLanguage: string | null
   translations: Record<string, string>
-  idempotencyKey: string | null
   createdAt: Date
 }
 
@@ -814,7 +812,6 @@ export function normaliseMessage(row: RawMessageRow): Message {
     content: row.content,
     sourceLanguage: row.sourceLanguage,
     translations: row.translations,
-    idempotencyKey: row.idempotencyKey ?? null,
     createdAt: row.createdAt,
   }
 }

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -1,6 +1,6 @@
 import type { RunTx } from '@kuruma/shared/db'
 import { messages, threadParticipants, threads } from '@kuruma/shared/db/schema'
-import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm'
 import { type CallerContext, requireOperatorScope } from '../../middleware/auth'
 import type { Message, Thread, ThreadParticipant } from '../../stores'
 import { threadReadScope } from '../../tenancy'
@@ -58,16 +58,86 @@ export class DrizzleThreadRepository implements ThreadRepository {
         .where(inArray(threads.id, threadIds))).map(toThread)
     }
 
+    return this.hydrate(threadRows)
+  }
+
+  // #1476: page the caller's in-scope threads with limit/offset + the total count
+  // pushed into SQL, so the service never materialises every in-scope thread (a
+  // PLATFORM_ADMIN `all` scope would otherwise scan platform-wide per GET /threads).
+  // Ordered newest createdAt first with id as the tiebreaker for a stable page
+  // boundary; the in-memory repo mirrors the same order.
+  async findPage(
+    ctx: CallerContext,
+    { limit, offset }: { limit: number; offset: number },
+  ): Promise<{
+    threads: Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>
+    total: number
+  }> {
+    const scope = threadReadScope(ctx)
+    if (scope.kind === 'none') return { threads: [], total: 0 }
+
+    const order = [desc(threads.createdAt), desc(threads.id)] as const
+    let total: number
+    let threadRows: Thread[]
+
+    if (scope.kind === 'all') {
+      total = (await this.db.select({ value: count() }).from(threads))[0]?.value ?? 0
+      threadRows = (await this.db
+        .select(threadColumns)
+        .from(threads)
+        .orderBy(...order)
+        .limit(limit)
+        .offset(offset)).map(toThread)
+    } else if (scope.kind === 'operator') {
+      const where = eq(threads.operatorId, scope.operatorId)
+      total = (await this.db.select({ value: count() }).from(threads).where(where))[0]?.value ?? 0
+      threadRows = (await this.db
+        .select(threadColumns)
+        .from(threads)
+        .where(where)
+        .orderBy(...order)
+        .limit(limit)
+        .offset(offset)).map(toThread)
+    } else {
+      // participant: join through thread_participants (one row per thread, given the
+      // (threadId,userId) unique) so limit/offset + the count stay in SQL.
+      const where = eq(threadParticipants.userId, scope.userId)
+      total =
+        (await this.db
+          .select({ value: count() })
+          .from(threads)
+          .innerJoin(threadParticipants, eq(threadParticipants.threadId, threads.id))
+          .where(where))[0]?.value ?? 0
+      threadRows = (
+        (await this.db
+          .select(threadColumns)
+          .from(threads)
+          .innerJoin(threadParticipants, eq(threadParticipants.threadId, threads.id))
+          .where(where)
+          .orderBy(...order)
+          .limit(limit)
+          .offset(offset)) as Array<Parameters<typeof toThread>[0]>
+      ).map(toThread)
+    }
+
+    return { threads: await this.hydrate(threadRows), total }
+  }
+
+  // Attach each thread's participants and most-recent message in two batched
+  // round-trips. Shared by findAll and findPage so both shape rows identically.
+  private async hydrate(
+    threadRows: Thread[],
+  ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>> {
     const threadIds = threadRows.map((t) => t.id)
     if (threadIds.length === 0) return []
 
-    // Step 3: fetch all participants for those threads in one round-trip.
+    // Fetch all participants for those threads in one round-trip.
     const participantRows = (await this.db
       .select(participantColumns)
       .from(threadParticipants)
       .where(inArray(threadParticipants.threadId, threadIds))).map(toThreadParticipant)
 
-    // Step 4: fetch only the latest message per thread.
+    // Fetch only the latest message per thread.
     const lastMessageRows = await this.db.execute<RawMessageRow>(sql`
       SELECT DISTINCT ON ("threadId")
         "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "createdAt"

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -64,8 +64,10 @@ export class DrizzleThreadRepository implements ThreadRepository {
   // #1476: page the caller's in-scope threads with limit/offset + the total count
   // pushed into SQL, so the service never materialises every in-scope thread (a
   // PLATFORM_ADMIN `all` scope would otherwise scan platform-wide per GET /threads).
-  // Ordered newest createdAt first with id as the tiebreaker for a stable page
-  // boundary; the in-memory repo mirrors the same order.
+  // Ordered newest createdAt first with id as the tiebreaker (id order follows the
+  // DB text collation) for a stable page boundary within this repo — the in-memory
+  // repo uses the same ordering key. A single repo drives every page in production,
+  // so the offset sweep never gaps or overlaps.
   async findPage(
     ctx: CallerContext,
     { limit, offset }: { limit: number; offset: number },

--- a/packages/api/src/repositories/drizzle/thread.ts
+++ b/packages/api/src/repositories/drizzle/thread.ts
@@ -70,7 +70,7 @@ export class DrizzleThreadRepository implements ThreadRepository {
     // Step 4: fetch only the latest message per thread.
     const lastMessageRows = await this.db.execute<RawMessageRow>(sql`
       SELECT DISTINCT ON ("threadId")
-        "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "idempotencyKey", "createdAt"
+        "id", "threadId", "senderId", "content", "sourceLanguage", "translations", "createdAt"
       FROM "messages"
       WHERE "threadId" IN (${sql.join(
         threadIds.map((id) => sql`${id}`),

--- a/packages/api/src/repositories/in-memory/message.ts
+++ b/packages/api/src/repositories/in-memory/message.ts
@@ -76,7 +76,6 @@ export class InMemoryMessageRepository implements MessageRepository {
       content,
       sourceLanguage: null,
       translations: {},
-      idempotencyKey: idempotencyKey ?? null,
       createdAt: new Date(),
     }
     // A renter send (participant scope) bumps the operator's tenant-level unread;

--- a/packages/api/src/repositories/in-memory/thread.test.ts
+++ b/packages/api/src/repositories/in-memory/thread.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { CallerContext } from '../../middleware/auth'
+import { InMemoryThreadRepository } from './thread'
+
+// Messaging GA hardening (Refs #1476): findPage pushes limit/offset + the total
+// count down instead of the service loading every in-scope thread and slicing in
+// memory (a PLATFORM_ADMIN 'all' scope would otherwise fan out platform-wide on
+// every GET /threads). These pin the paginated contract + deterministic ordering
+// that the Drizzle side must mirror (asserted against real-pg in integration).
+
+const RENTER = 'renter-findpage'
+const ctx: CallerContext = { userId: RENTER, role: 'RENTER' }
+
+/** Seed n threads the caller participates in, oldest first, with distinct
+ *  createdAt so newest-first ordering is unambiguous. Returns ids in creation
+ *  order (ids[0] oldest ... ids[n-1] newest). */
+async function seedThreads(repo: InMemoryThreadRepository, n: number): Promise<string[]> {
+  const ids: string[] = []
+  for (let i = 0; i < n; i++) {
+    const thread = await repo.create(ctx, null, [RENTER, `peer-${i}`], null, null)
+    ids.push(thread.id)
+    await new Promise((r) => setTimeout(r, 2))
+  }
+  return ids
+}
+
+describe('InMemoryThreadRepository.findPage', () => {
+  it('returns the requested slice and the total in-scope count', async () => {
+    const repo = new InMemoryThreadRepository()
+    const ids = await seedThreads(repo, 5)
+
+    const page = await repo.findPage(ctx, { limit: 2, offset: 1 })
+
+    expect(page.total).toBe(5)
+    expect(page.threads).toHaveLength(2)
+    for (const t of page.threads) expect(ids).toContain(t.id)
+  })
+
+  it('orders newest-created first and paginates with no overlap or gaps', async () => {
+    const repo = new InMemoryThreadRepository()
+    const ids = await seedThreads(repo, 5)
+
+    const p1 = await repo.findPage(ctx, { limit: 2, offset: 0 })
+    const p2 = await repo.findPage(ctx, { limit: 2, offset: 2 })
+    const p3 = await repo.findPage(ctx, { limit: 2, offset: 4 })
+
+    const ordered = [...p1.threads, ...p2.threads, ...p3.threads].map((t) => t.id)
+    expect(ordered).toEqual([...ids].reverse())
+    expect(p3.threads).toHaveLength(1)
+  })
+
+  it('scopes total to the caller and hydrates participants + last message', async () => {
+    const repo = new InMemoryThreadRepository()
+    // A thread the caller is NOT part of must not count toward total.
+    await repo.create({ userId: 'someone-else', role: 'RENTER' }, null, ['someone-else', 'x'])
+    const [mine] = await seedThreads(repo, 1)
+
+    const page = await repo.findPage(ctx, { limit: 10, offset: 0 })
+
+    expect(page.total).toBe(1)
+    expect(page.threads).toHaveLength(1)
+    expect(page.threads[0]!.id).toBe(mine)
+    expect(page.threads[0]!.participants.map((p) => p.userId).sort()).toEqual(['peer-0', RENTER])
+    expect(page.threads[0]!.lastMessage).toBeNull()
+  })
+})

--- a/packages/api/src/repositories/in-memory/thread.ts
+++ b/packages/api/src/repositories/in-memory/thread.ts
@@ -12,34 +12,56 @@ export class InMemoryThreadRepository implements ThreadRepository {
   async findAll(
     ctx: CallerContext,
   ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>> {
+    return this.scopedThreads(ctx).map((thread) => this.hydrate(thread))
+  }
+
+  // #1476: page limit/offset over the in-scope set instead of the service loading
+  // everything and slicing. Mirrors the Drizzle SQL LIMIT/OFFSET + COUNT — same
+  // deterministic order (newest createdAt first, id as the tiebreaker) so a
+  // stable page boundary can't split a createdAt tie differently across repos.
+  async findPage(
+    ctx: CallerContext,
+    { limit, offset }: { limit: number; offset: number },
+  ): Promise<{
+    threads: Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>
+    total: number
+  }> {
+    const scoped = this.scopedThreads(ctx)
+    const ordered = [...scoped].sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime() || b.id.localeCompare(a.id),
+    )
+    const page = ordered.slice(offset, offset + limit).map((thread) => this.hydrate(thread))
+    return { threads: page, total: scoped.length }
+  }
+
+  // The threads visible to the caller under its read scope (#1205): admin sees
+  // all, an operator only its own tenant, a renter only threads it participates
+  // in, a tokenless operator nothing. Shared by findAll and findPage.
+  private scopedThreads(ctx: CallerContext): Thread[] {
     const scope = threadReadScope(ctx)
     if (scope.kind === 'none') return []
-    let filteredThreads: Thread[]
-
-    if (scope.kind === 'all') {
-      filteredThreads = [...this.threads.values()]
-    } else if (scope.kind === 'operator') {
-      filteredThreads = [...this.threads.values()].filter((t) => t.operatorId === scope.operatorId)
-    } else {
-      const threadIds = new Set(
-        [...this.participants.values()]
-          .filter((p) => p.userId === scope.userId)
-          .map((p) => p.threadId),
-      )
-      filteredThreads = [...this.threads.values()].filter((t) => threadIds.has(t.id))
+    if (scope.kind === 'all') return [...this.threads.values()]
+    if (scope.kind === 'operator') {
+      return [...this.threads.values()].filter((t) => t.operatorId === scope.operatorId)
     }
+    const threadIds = new Set(
+      [...this.participants.values()]
+        .filter((p) => p.userId === scope.userId)
+        .map((p) => p.threadId),
+    )
+    return [...this.threads.values()].filter((t) => threadIds.has(t.id))
+  }
 
-    return filteredThreads.map((thread) => {
-      const threadParticipants = [...this.participants.values()].filter(
-        (p) => p.threadId === thread.id,
-      )
-      const threadMessages = [...this.messages.values()]
+  private hydrate(
+    thread: Thread,
+  ): Thread & { participants: ThreadParticipant[]; lastMessage: Message | null } {
+    const participants = [...this.participants.values()].filter((p) => p.threadId === thread.id)
+    const lastMessage =
+      [...this.messages.values()]
         .filter((m) => m.threadId === thread.id)
         .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-      const lastMessage = threadMessages.at(-1) ?? null
-
-      return { ...thread, participants: threadParticipants, lastMessage }
-    })
+        .at(-1) ?? null
+    return { ...thread, participants, lastMessage }
   }
 
   async findById(

--- a/packages/api/src/repositories/in-memory/thread.ts
+++ b/packages/api/src/repositories/in-memory/thread.ts
@@ -16,9 +16,12 @@ export class InMemoryThreadRepository implements ThreadRepository {
   }
 
   // #1476: page limit/offset over the in-scope set instead of the service loading
-  // everything and slicing. Mirrors the Drizzle SQL LIMIT/OFFSET + COUNT — same
-  // deterministic order (newest createdAt first, id as the tiebreaker) so a
-  // stable page boundary can't split a createdAt tie differently across repos.
+  // everything and slicing. Mirrors the Drizzle SQL LIMIT/OFFSET + COUNT and the
+  // same ordering key (newest createdAt first, id as the tiebreaker) so each repo
+  // paginates stably. The tiebreaker only decides exact createdAt ties; it uses a
+  // code-unit id comparison (not locale-aware localeCompare) so the boundary is
+  // collation-independent within this repo. Cross-repo byte-identical order isn't
+  // relied on: production runs one repo, and the parity tests seed distinct times.
   async findPage(
     ctx: CallerContext,
     { limit, offset }: { limit: number; offset: number },
@@ -28,7 +31,8 @@ export class InMemoryThreadRepository implements ThreadRepository {
   }> {
     const scoped = this.scopedThreads(ctx)
     const ordered = [...scoped].sort(
-      (a, b) => b.createdAt.getTime() - a.createdAt.getTime() || b.id.localeCompare(a.id),
+      (a, b) =>
+        b.createdAt.getTime() - a.createdAt.getTime() || (a.id < b.id ? 1 : a.id > b.id ? -1 : 0),
     )
     const page = ordered.slice(offset, offset + limit).map((thread) => this.hydrate(thread))
     return { threads: page, total: scoped.length }

--- a/packages/api/src/repositories/types-messaging.ts
+++ b/packages/api/src/repositories/types-messaging.ts
@@ -9,6 +9,19 @@ export interface ThreadRepository {
   findAll(
     ctx: CallerContext,
   ): Promise<Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>>
+  /**
+   * Paginated read of the caller's in-scope threads (#1476). Pushes limit/offset
+   * and the total count into the query so a `GET /threads` never materialises
+   * every in-scope thread (a PLATFORM_ADMIN `all` scope spans the platform).
+   * Ordered newest createdAt first, id as the tiebreaker, for a stable boundary.
+   */
+  findPage(
+    ctx: CallerContext,
+    opts: { limit: number; offset: number },
+  ): Promise<{
+    threads: Array<Thread & { participants: ThreadParticipant[]; lastMessage: Message | null }>
+    total: number
+  }>
   findById(
     ctx: CallerContext,
     id: string,

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,12 +1,23 @@
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
 import { sendMessageSchema } from '@kuruma/shared/validators/message'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageService } from '../services/message'
 import { fail, ok, parseBody, parseId, parsePagination } from './helpers'
 
-export function createMessageRoutes(service: MessageService) {
+export function createMessageRoutes(service: MessageService, sendLimiter?: RateLimitBinding) {
+  const app = new Hono()
+
+  // Cap message sends per authenticated user so one account can't flood a thread.
+  // Per-user (not per-IP) so NAT'd callers get independent budgets; the global
+  // RATE_LIMITER still covers the per-IP case. Absent binding = unthrottled dev.
+  const userKey = (c: Context) => requireUser(c).id
+  if (sendLimiter) {
+    app.use('/threads/:id/messages', rateLimit(sendLimiter, userKey))
+  }
+
   return (
-    new Hono()
+    app
       .get('/threads', async (c) => {
         const ctx = toCallerContext(requireUser(c))
 

--- a/packages/api/src/routes/translate.ts
+++ b/packages/api/src/routes/translate.ts
@@ -1,11 +1,26 @@
+import { type RateLimitBinding, rateLimit } from '@elithrar/workers-hono-rate-limit'
 import { translateMessageSchema } from '@kuruma/shared/validators/translation'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { requireUser, toCallerContext } from '../middleware/auth'
 import type { MessageTranslationService } from '../services/message-translation'
 import { failResult, ok, parseBody, parseId } from './helpers'
 
-export function createTranslateRoutes(service: MessageTranslationService) {
-  return new Hono().post('/messages/:id/translate', async (c) => {
+export function createTranslateRoutes(
+  service: MessageTranslationService,
+  limiter?: RateLimitBinding,
+) {
+  const app = new Hono()
+
+  // Each uncached (message, language) hits an EXTERNAL translation provider, so
+  // cap it per authenticated user. Per-user (not per-IP) so NAT'd callers get
+  // independent budgets; the global RATE_LIMITER still covers the per-IP case.
+  // Absent in local dev (no binding) — unthrottled, mirroring the photo routes.
+  const userKey = (c: Context) => requireUser(c).id
+  if (limiter) {
+    app.use('/messages/:id/translate', rateLimit(limiter, userKey))
+  }
+
+  return app.post('/messages/:id/translate', async (c) => {
     const ctx = toCallerContext(requireUser(c))
 
     const idResult = parseId(c)

--- a/packages/api/src/services/message.ts
+++ b/packages/api/src/services/message.ts
@@ -46,8 +46,9 @@ export class MessageService {
     limit: number,
     offset: number,
   ): Promise<{ threads: ThreadListItem[]; total: number }> {
-    const all = await this.threadRepo.findAll(ctx)
-    return { threads: all.slice(offset, offset + limit), total: all.length }
+    // #1476: limit/offset + the total count are pushed into the repository query
+    // instead of loading every in-scope thread and slicing here.
+    return this.threadRepo.findPage(ctx, { limit, offset })
   }
 
   async getThread(ctx: CallerContext, id: string): Promise<ThreadDetail | undefined> {

--- a/packages/api/src/services/message.ts
+++ b/packages/api/src/services/message.ts
@@ -135,8 +135,10 @@ async function idempotentCreate<T>(
       if (existing) return { record: existing, status: 200 }
       // The key is globally unique but the scoped re-fetch found nothing: a
       // DIFFERENT sender already claimed it (find is sender-scoped, #328). Surface
-      // a clean 409 rather than letting the raw UNIQUE_VIOLATION escape as a 500 —
-      // and without a cross-sender existence oracle. Messaging GA (Refs #1476).
+      // a clean 409 rather than letting the raw UNIQUE_VIOLATION escape as a 500.
+      // The 409 still signals "some sender claimed this key", but the key is no
+      // longer readable off the read model (idempotencyKey drop) and is a UUID, so
+      // there's nothing to probe with. Messaging GA (Refs #1476).
       throw new ConflictError('idempotency key already used')
     }
     throw err

--- a/packages/api/src/services/message.ts
+++ b/packages/api/src/services/message.ts
@@ -1,4 +1,4 @@
-import type { CallerContext } from '../middleware/auth'
+import { type CallerContext, ConflictError } from '../middleware/auth'
 import { PG_ERROR, pgErrorCode } from '../pg-errors'
 import type {
   MessageCreateResult,
@@ -132,6 +132,11 @@ async function idempotentCreate<T>(
     if (pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION && key) {
       const existing = await find(key)
       if (existing) return { record: existing, status: 200 }
+      // The key is globally unique but the scoped re-fetch found nothing: a
+      // DIFFERENT sender already claimed it (find is sender-scoped, #328). Surface
+      // a clean 409 rather than letting the raw UNIQUE_VIOLATION escape as a 500 —
+      // and without a cross-sender existence oracle. Messaging GA (Refs #1476).
+      throw new ConflictError('idempotency key already used')
     }
     throw err
   }

--- a/packages/api/src/services/user-directory.ts
+++ b/packages/api/src/services/user-directory.ts
@@ -38,9 +38,10 @@ export class UserDirectoryService {
     if (PRIVILEGED_ROLES.has(ctx.role)) return 'all'
     // #396: OPERATOR_* are self-only here. The thread lookup below uses a
     // synthetic RENTER context to resolve a caller's co-participants for renter
-    // messaging; operators have no messaging surface yet (slice 7) and must not
-    // resolve another tenant's users via a shared thread. Fail closed until
-    // operator messaging is deliberately modeled.
+    // messaging. Operator messaging ships now (#1205), but operators read their
+    // inbox by tenant scope (threads.operatorId), not by participation — so they
+    // must never resolve another tenant's users via a shared thread. The directory
+    // stays self-only and fail-closed for them by design.
     if (isOperatorRole(ctx.role)) return new Set<string>([ctx.userId])
     const threads = await this.threadRepo.findAll({ userId: ctx.userId, role: 'RENTER' })
     const allowed = new Set<string>([ctx.userId])

--- a/packages/api/src/stores.ts
+++ b/packages/api/src/stores.ts
@@ -269,7 +269,6 @@ export interface Message {
   content: string
   sourceLanguage: string | null
   translations: Record<string, string>
-  idempotencyKey: string | null
   createdAt: Date
 }
 

--- a/packages/api/tests/integration/messages.test.ts
+++ b/packages/api/tests/integration/messages.test.ts
@@ -131,6 +131,66 @@ describe('DrizzleThreadRepository', () => {
     })
   })
 
+  // #1476: limit/offset + the total count are pushed into SQL so GET /threads
+  // never materialises every in-scope thread. Same contract the in-memory repo
+  // mirrors (src/repositories/in-memory/thread.test.ts).
+  describe('findPage', () => {
+    it('applies limit/offset in the query and returns the in-scope total, newest first', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const ids: string[] = []
+      for (let i = 0; i < 5; i++) {
+        const thread = await threadRepo.create(ctx(alice!), null, [alice!, bob!])
+        ids.push(thread.id)
+        await new Promise((r) => setTimeout(r, 5)) // distinct createdAt for stable order
+      }
+
+      const page = await threadRepo.findPage(ctx(alice!), { limit: 2, offset: 1 })
+      expect(page.total).toBe(5)
+      expect(page.threads).toHaveLength(2)
+
+      // A full sweep is the reverse of insertion order (newest createdAt first)
+      // with no gaps or duplicates across page boundaries.
+      const p1 = await threadRepo.findPage(ctx(alice!), { limit: 2, offset: 0 })
+      const p2 = await threadRepo.findPage(ctx(alice!), { limit: 2, offset: 2 })
+      const p3 = await threadRepo.findPage(ctx(alice!), { limit: 2, offset: 4 })
+      const swept = [...p1.threads, ...p2.threads, ...p3.threads].map((t) => t.id)
+      expect(swept).toEqual([...ids].reverse())
+      expect(p3.threads).toHaveLength(1)
+    })
+
+    it('scopes total and page to the caller (no cross-participant leak)', async () => {
+      const [alice, bob, carol] = await createTestUsers(3)
+      createdUserIds.push(alice!, bob!, carol!)
+
+      const aliceThread = await threadRepo.create(ctx(alice!), null, [alice!, bob!])
+      // A thread alice is NOT part of must not count toward her total or page.
+      await threadRepo.create(ctx(bob!), null, [bob!, carol!])
+
+      const page = await threadRepo.findPage(ctx(alice!), { limit: 10, offset: 0 })
+      expect(page.total).toBe(1)
+      expect(page.threads.map((t) => t.id)).toEqual([aliceThread.id])
+    })
+
+    it('hydrates participants and the most recent message per page row', async () => {
+      const [alice, bob] = await createTestUsers(2)
+      createdUserIds.push(alice!, bob!)
+
+      const thread = await threadRepo.create(ctx(alice!), null, [alice!, bob!])
+      await messageRepo.create(ctx(alice!), thread.id, 'first')
+      await new Promise((r) => setTimeout(r, 5))
+      await messageRepo.create(ctx(bob!), thread.id, 'second')
+
+      const page = await threadRepo.findPage(ctx(alice!), { limit: 10, offset: 0 })
+      expect(page.threads).toHaveLength(1)
+      const t = page.threads[0]!
+      expect(t.participants).toHaveLength(2)
+      expect(t.lastMessage).not.toBeNull()
+      expect(t.lastMessage!.content).toBe('second')
+    })
+  })
+
   describe('findById', () => {
     it('returns thread with participants and ordered messages', async () => {
       const [alice, bob] = await createTestUsers(2)

--- a/packages/api/tests/routes/message-ratelimit.test.ts
+++ b/packages/api/tests/routes/message-ratelimit.test.ts
@@ -1,0 +1,130 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import {
+  InMemoryMessageRepository,
+  InMemoryThreadRepository,
+} from '../../src/repositories/in-memory'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+// Messaging GA hardening (Refs #1476): prove the per-user messaging limiters are
+// resolved AND routed by the composition root — not just by the route factories.
+// These go through the real createApp(), so a wiring swap (send limiter applied to
+// translate, or vice versa) or a dropped argument is caught here, where the
+// route-factory unit tests structurally cannot see it.
+
+const RENTER = { sub: 'renter-1', role: 'RENTER' as const }
+
+/** In-process stand-in for the CF native rate-limit binding. */
+function createFakeLimiter(limit: number): RateLimitBinding {
+  const counts = new Map<string, number>()
+  return {
+    async limit({ key }) {
+      const next = (counts.get(key) ?? 0) + 1
+      counts.set(key, next)
+      return { success: next <= limit }
+    },
+  }
+}
+
+function createTestApp(opts?: {
+  messageSendLimiter?: RateLimitBinding
+  messageTranslateLimiter?: RateLimitBinding
+}) {
+  setupAuthEnv()
+  const threadRepo = new InMemoryThreadRepository()
+  const messageRepo = new InMemoryMessageRepository(threadRepo)
+  const app = createApp({
+    threadRepo,
+    messageRepo,
+    messageSendLimiter: opts?.messageSendLimiter,
+    messageTranslateLimiter: opts?.messageTranslateLimiter,
+  })
+  return { app, threadRepo, messageRepo }
+}
+
+async function seedThreadAndMessage(ctx: ReturnType<typeof createTestApp>): Promise<{
+  threadId: string
+  messageId: string
+}> {
+  const thread = await ctx.threadRepo.create({ userId: 'renter-1', role: 'RENTER' }, null, [
+    'renter-1',
+    'u2',
+  ])
+  const { message } = await ctx.messageRepo.create(
+    { userId: 'renter-1', role: 'RENTER' },
+    thread.id,
+    'こんにちは',
+  )
+  return { threadId: thread.id, messageId: message.id }
+}
+
+const jsonHeaders = async () => ({
+  ...(await authHeaders(RENTER)),
+  'Content-Type': 'application/json',
+})
+
+const send = (
+  app: Awaited<ReturnType<typeof createTestApp>>['app'],
+  threadId: string,
+  headers: HeadersInit,
+) =>
+  app.request(`/threads/${threadId}/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ content: 'flood' }),
+  })
+
+const translate = (
+  app: Awaited<ReturnType<typeof createTestApp>>['app'],
+  messageId: string,
+  headers: HeadersInit,
+  targetLanguage: string,
+) =>
+  app.request(`/messages/${messageId}/translate`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ targetLanguage }),
+  })
+
+describe('messaging per-user rate limits (composition root wiring)', () => {
+  let ctx: ReturnType<typeof createTestApp>
+  let headers: HeadersInit
+  let ids: { threadId: string; messageId: string }
+
+  describe('send limiter wired to POST /threads/:id/messages only', () => {
+    beforeEach(async () => {
+      ctx = createTestApp({ messageSendLimiter: createFakeLimiter(1) })
+      headers = await jsonHeaders()
+      ids = await seedThreadAndMessage(ctx)
+    })
+
+    it('429s the second send once the per-user send limit is exceeded', async () => {
+      expect((await send(ctx.app, ids.threadId, headers)).status).toBe(201)
+      expect((await send(ctx.app, ids.threadId, headers)).status).toBe(429)
+    })
+
+    it('does not apply the send limiter to translate (no swap)', async () => {
+      expect((await translate(ctx.app, ids.messageId, headers, 'en')).status).toBe(200)
+      expect((await translate(ctx.app, ids.messageId, headers, 'zh')).status).toBe(200)
+    })
+  })
+
+  describe('translate limiter wired to POST /messages/:id/translate only', () => {
+    beforeEach(async () => {
+      ctx = createTestApp({ messageTranslateLimiter: createFakeLimiter(1) })
+      headers = await jsonHeaders()
+      ids = await seedThreadAndMessage(ctx)
+    })
+
+    it('429s the second translate once the per-user translate limit is exceeded', async () => {
+      expect((await translate(ctx.app, ids.messageId, headers, 'en')).status).toBe(200)
+      expect((await translate(ctx.app, ids.messageId, headers, 'zh')).status).toBe(429)
+    })
+
+    it('does not apply the translate limiter to sends (no swap)', async () => {
+      expect((await send(ctx.app, ids.threadId, headers)).status).toBe(201)
+      expect((await send(ctx.app, ids.threadId, headers)).status).toBe(201)
+    })
+  })
+})

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -267,7 +267,8 @@ describe('Message Routes', () => {
         const secondBody = await second.json()
 
         expect(secondBody.data.id).toBe(firstBody.data.id)
-        expect(secondBody.data.idempotencyKey).toBe(MSG_KEY_A)
+        // idempotencyKey is a write-only concern and never echoed on the read model.
+        expect(secondBody.data).not.toHaveProperty('idempotencyKey')
       })
 
       it('creates distinct messages when different keys are sent', async () => {
@@ -302,7 +303,7 @@ describe('Message Routes', () => {
         })
         expect(res.status).toBe(201)
         const body = await res.json()
-        expect(body.data.idempotencyKey).toBeNull()
+        expect(body.data).not.toHaveProperty('idempotencyKey')
       })
 
       it('concurrent duplicate requests yield exactly one 201 and one 200', async () => {
@@ -413,6 +414,28 @@ describe('Message Routes', () => {
       expect(body.data.messages[0].senderId).toBe(U1)
       expect(body.data.messages[1].content).toBe('Hi there!')
       expect(body.data.messages[1].senderId).toBe(U2)
+    })
+
+    // idempotencyKey is a write-side dedup concern; it must never be echoed on the
+    // read model (it was leaked to every thread participant on GET, and gave a
+    // 500-vs-201 existence oracle for another sender's key). See messaging GA review.
+    it('does not expose idempotencyKey on returned messages', async () => {
+      const threadId = await seedThread([U1, U2])
+      await appAs(U1).request(`/threads/${threadId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: 'Hi',
+          idempotencyKey: '00000000-0000-4000-8000-cccc00000001',
+        }),
+      })
+
+      const res = await app.request(`/threads/${threadId}`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.messages).toHaveLength(1)
+      expect(body.data.messages[0]).not.toHaveProperty('idempotencyKey')
     })
 
     it('returns 404 for a valid-but-nonexistent thread id', async () => {

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { setupGlobalHandlers } from '../../src/error-handlers'
 import {
   InMemoryMessageRepository,
   InMemoryThreadRepository,
@@ -25,6 +26,9 @@ function appAs(userId: string, role: TestRole = 'RENTER', operatorId?: string): 
   // The operator new-message alert (#1205) is exercised in message.test.ts; the
   // route tests only assert HTTP behavior, so a no-op alert port keeps them focused.
   a.route('/', createMessageRoutes(new MessageService(threadRepo, messageRepo, async () => {})))
+  // Wire the production error handler so domain errors map to their real status
+  // (e.g. ConflictError -> 409) instead of a bare-Hono 500. Mirrors createApp.
+  setupGlobalHandlers(a)
   return a
 }
 
@@ -331,10 +335,12 @@ describe('Message Routes', () => {
         expect(b1.data.id).toBe(b2.data.id)
       })
 
-      // Issue #328: findByIdempotencyKey must scope to sender. Two
-      // participants in the same thread replaying the same key must
-      // not see each other's messages.
-      it('cross-tenant: U2 replaying U1 message key does not leak U1 message', async () => {
+      // Issue #328: findByIdempotencyKey must scope to sender. Two participants in
+      // the same thread replaying the same key must not see each other's messages.
+      // The key is globally unique (messages_idempotency_key), so U2's replay of
+      // U1's key can't resolve on the sender-scoped re-fetch — messaging GA (#1476)
+      // surfaces that as a clean 409, never U1's message and never a raw 500.
+      it('cross-sender: U2 replaying U1 message key gets 409, never U1 message', async () => {
         // U1's thread with U2.
         const threadId = await seedThread([U1, U2])
 
@@ -347,18 +353,17 @@ describe('Message Routes', () => {
         expect(u1Msg.status).toBe(201)
         const u1MsgId = (await u1Msg.json()).data.id
 
-        // U2 sends in the same thread with the same key. U2 must NOT get U1's message back.
+        // U2 sends in the same thread with the same key. U2 must NOT get U1's message.
         const u2Msg = await appAs(U2).request(`/threads/${threadId}/messages`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ content: 'From U2', idempotencyKey: sharedKey }),
         })
-        if (u2Msg.status === 200 || u2Msg.status === 201) {
-          const body = await u2Msg.json()
-          expect(body.data.id).not.toBe(u1MsgId)
-          expect(body.data.senderId).toBe(U2)
-        }
-        expect([200, 201, 500]).toContain(u2Msg.status)
+        expect(u2Msg.status).toBe(409)
+        const body = await u2Msg.json()
+        expect(body.success).toBe(false)
+        expect(body).not.toHaveProperty('data')
+        expect(JSON.stringify(body)).not.toContain(u1MsgId)
       })
 
       it('same sender replaying own key returns their existing message', async () => {

--- a/packages/api/tests/routes/messages.test.ts
+++ b/packages/api/tests/routes/messages.test.ts
@@ -1,3 +1,4 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { setupGlobalHandlers } from '../../src/error-handlers'
@@ -18,14 +19,36 @@ type TestRole = 'RENTER' | 'PLATFORM_ADMIN' | 'OPERATOR_OWNER' | 'OPERATOR_STAFF
 let threadRepo: InMemoryThreadRepository
 let messageRepo: InMemoryMessageRepository
 
+/** In-process stand-in for the CF native rate-limit binding: counts per key and
+ *  denies past `limit`, mirroring the vehicle-photo rate-limit test double. */
+function createFakeLimiter(limit: number): RateLimitBinding {
+  const counts = new Map<string, number>()
+  return {
+    async limit({ key }) {
+      const next = (counts.get(key) ?? 0) + 1
+      counts.set(key, next)
+      return { success: next <= limit }
+    },
+  }
+}
+
 /** Create a Hono app authenticated as the given user. Pass `operatorId` to
- *  simulate a tenant-scoped OPERATOR_* caller. */
-function appAs(userId: string, role: TestRole = 'RENTER', operatorId?: string): Hono {
+ *  simulate a tenant-scoped OPERATOR_* caller, and `limiter` to exercise the
+ *  per-user send rate limit. */
+function appAs(
+  userId: string,
+  role: TestRole = 'RENTER',
+  operatorId?: string,
+  limiter?: RateLimitBinding,
+): Hono {
   const a = new Hono()
   a.use('*', testAuthMiddleware(userId, role, operatorId))
   // The operator new-message alert (#1205) is exercised in message.test.ts; the
   // route tests only assert HTTP behavior, so a no-op alert port keeps them focused.
-  a.route('/', createMessageRoutes(new MessageService(threadRepo, messageRepo, async () => {})))
+  a.route(
+    '/',
+    createMessageRoutes(new MessageService(threadRepo, messageRepo, async () => {}), limiter),
+  )
   // Wire the production error handler so domain errors map to their real status
   // (e.g. ConflictError -> 409) instead of a bare-Hono 500. Mirrors createApp.
   setupGlobalHandlers(a)
@@ -385,6 +408,40 @@ describe('Message Routes', () => {
         })
         expect(replay.status).toBe(200)
         expect((await replay.json()).data.id).toBe(firstId)
+      })
+    })
+
+    // Messaging GA hardening (Refs #1476): cap thread-message sends per user so a
+    // single account can't flood a thread. Per-user (authed endpoint) beats the
+    // global per-IP limiter behind NAT; absent binding = unthrottled local dev.
+    describe('per-user send rate limit', () => {
+      it('returns 429 once the per-user send limit is exceeded', async () => {
+        const limitedApp = appAs(U1, 'RENTER', undefined, createFakeLimiter(1))
+        const threadId = await seedThread([U1, U2])
+        const send = () =>
+          limitedApp.request(`/threads/${threadId}/messages`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: 'flood' }),
+          })
+
+        const first = await send()
+        const second = await send()
+
+        expect(first.status).toBe(201)
+        expect(second.status).toBe(429)
+      })
+
+      it('does not rate-limit when no binding is injected (local dev)', async () => {
+        const threadId = await seedThread([U1, U2])
+        for (let i = 0; i < 3; i++) {
+          const res = await app.request(`/threads/${threadId}/messages`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: `msg-${i}` }),
+          })
+          expect(res.status).toBe(201)
+        }
       })
     })
   })

--- a/packages/api/tests/routes/translate.test.ts
+++ b/packages/api/tests/routes/translate.test.ts
@@ -1,3 +1,4 @@
+import type { RateLimitBinding } from '@elithrar/workers-hono-rate-limit'
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
@@ -8,7 +9,20 @@ import { createTranslateRoutes } from '../../src/routes/translate'
 import { MessageTranslationService } from '../../src/services/message-translation'
 import { testAuthMiddleware } from '../helpers/auth'
 
-function appWith(messageRepo: InMemoryMessageRepository) {
+/** In-process stand-in for the CF native rate-limit binding: counts per key and
+ *  denies past `limit`, mirroring the vehicle-photo rate-limit test double. */
+function createFakeLimiter(limit: number): RateLimitBinding {
+  const counts = new Map<string, number>()
+  return {
+    async limit({ key }) {
+      const next = (counts.get(key) ?? 0) + 1
+      counts.set(key, next)
+      return { success: next <= limit }
+    },
+  }
+}
+
+function appWith(messageRepo: InMemoryMessageRepository, limiter?: RateLimitBinding) {
   const a = new Hono()
   const service = new MessageTranslationService(messageRepo, {
     translate: async (text, _src, target) => ({
@@ -17,7 +31,7 @@ function appWith(messageRepo: InMemoryMessageRepository) {
     }),
   })
   a.use('*', testAuthMiddleware('u1', 'RENTER'))
-  a.route('/', createTranslateRoutes(service))
+  a.route('/', createTranslateRoutes(service, limiter))
   return a
 }
 
@@ -97,5 +111,38 @@ describe('POST /messages/:id/translate', () => {
       body: JSON.stringify({ targetLanguage: 'xx' }),
     })
     expect(res.status).toBe(400)
+  })
+
+  // Messaging GA hardening (Refs #1476): each uncached (message, language) hits an
+  // external translation provider, so cap it per authenticated user (per-user beats
+  // the global per-IP limiter behind NAT). The limiter runs before the handler.
+  it('returns 429 once the per-user translate limit is exceeded', async () => {
+    const app = appWith(messageRepo, createFakeLimiter(1))
+
+    const first = await app.request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'en' }),
+    })
+    const second = await app.request(`/messages/${messageId}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetLanguage: 'zh' }),
+    })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(429)
+  })
+
+  it('does not rate-limit when no binding is injected (local dev)', async () => {
+    const app = appWith(messageRepo)
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request(`/messages/${messageId}/translate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetLanguage: 'en' }),
+      })
+      expect(res.status).toBe(200)
+    }
   })
 })

--- a/packages/api/tests/services/message.test.ts
+++ b/packages/api/tests/services/message.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { type AuthUser, toCallerContext } from '../../src/middleware/auth'
+import { type AuthUser, ConflictError, toCallerContext } from '../../src/middleware/auth'
 import {
   InMemoryMessageRepository,
   InMemoryThreadRepository,
@@ -54,6 +54,23 @@ describe('MessageService.createMessage', () => {
     expect(first.status).toBe(201)
     expect(second.status).toBe(200)
     expect(second.message.id).toBe(first.message.id)
+  })
+
+  // Messaging GA hardening (Refs #1476): idempotencyKey is globally unique, but
+  // findByIdempotencyKey is sender-scoped (#328). So a DIFFERENT sender replaying
+  // another sender's key can't resolve it on re-fetch — that used to escape as the
+  // raw UNIQUE_VIOLATION (a 500). Surface it as a ConflictError (-> 409) instead:
+  // a clean "key already claimed" client error, and no cross-sender existence leak.
+  it('throws ConflictError when a different sender replays another sender key', async () => {
+    const ctxU1 = ctxFor(U1, 'RENTER')
+    const thread = await threadRepo.create(ctxU1, null, [U1, U2], null, null)
+    const sharedKey = 'shared-key-collision'
+
+    await service.createMessage(ctxU1, thread.id, 'from u1', sharedKey)
+
+    await expect(
+      service.createMessage(ctxFor(U2, 'RENTER'), thread.id, 'from u2', sharedKey),
+    ).rejects.toBeInstanceOf(ConflictError)
   })
 })
 

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -88,6 +88,25 @@ namespace_id = "1006"
 simple.limit = 5
 simple.period = 60
 
+# Per-user cap on message translation (messaging GA, #1476). Each uncached
+# (message, language) hits an EXTERNAL translation provider, so key per authed
+# user (not per IP) to give NAT'd callers independent budgets. 20/60s comfortably
+# covers reading a thread in another language while blocking provider-cost abuse.
+[[ratelimits]]
+name = "MESSAGE_TRANSLATE_LIMITER"
+namespace_id = "1007"
+simple.limit = 20
+simple.period = 60
+
+# Per-user cap on thread message sends (messaging GA, #1476). Stops a single
+# account flooding a thread. 30/60s is generous for real back-and-forth chat and
+# still bounds abuse; the global RATE_LIMITER covers the per-IP dimension.
+[[ratelimits]]
+name = "MESSAGE_SEND_LIMITER"
+namespace_id = "1008"
+simple.limit = 30
+simple.period = 60
+
 # R2 buckets — R2 enabled on the account + buckets created 2026-06-14.
 # VEHICLE_PHOTOS: public car photos, served via VEHICLE_PHOTOS_PUBLIC_URL (below).
 # The composition root uses R2PhotoStorage only when BOTH the binding and that var


### PR DESCRIPTION
Implements the 6 non-blocking hardening findings from the messaging tenant-isolation security review, filing off the rough edges before the `MESSAGING` feature flag flips on for GA. The isolation model itself was already reviewed SOUND (no CRITICAL/HIGH). **This PR does not flip the flag.**

Refs #1476 (GA epic — stays open).

## The 6 fixes

1. **Drop `idempotencyKey` from the message read model** (`1438cd51`). It was echoed to every thread participant on `GET /threads/:id` and gave a 500-vs-201 existence oracle for another sender's key. Removed from the `Message` type, `messageColumns`, `RawMessageRow`, `normaliseMessage`, the DISTINCT-ON SELECT, and the in-memory shaping. The write path (`sendMessageSchema`, `create()` param, the DB column + unique index, the in-memory dedup index) is intentionally unchanged.

2 & 4. **Per-user rate limits on translate + send** (`0c87b3d6`). The global `RATE_LIMITER` is per-IP, which NAT collapses. Added `MESSAGE_TRANSLATE_LIMITER` (20/60s) on `POST /messages/:id/translate` (each uncached (message, language) hits an external provider) and `MESSAGE_SEND_LIMITER` (30/60s) on `POST /threads/:id/messages` (thread flooding). Optional `AppOverrides` seams; resolved in `index.ts`; new `wrangler.toml` bindings (namespace_id 1007/1008). Mirrors `routes/vehicle-photos.ts`. A composition-root test drives `createApp` end-to-end and guards against a send/translate limiter swap.

3. **Cross-sender idempotency-key collision → 409** (`0a214f4d`). The key is globally unique but `findByIdempotencyKey` is sender-scoped (#328), so a different sender replaying another sender's key escaped as a raw `UNIQUE_VIOLATION` 500. Now a clean `ConflictError` → 409.

5. **Push thread-list limit/offset into the query** (`510c9251`). `listThreads` loaded every in-scope thread via `findAll()` then sliced in memory — a `PLATFORM_ADMIN` `all` scope meant every thread on the platform per `GET /threads`. New `ThreadRepository.findPage(ctx, {limit, offset})` pushes `LIMIT/OFFSET` + `COUNT(*)` into SQL (Drizzle) with an in-memory mirror, ordered newest `createdAt` first. `findAll()` is untouched (user-directory needs the full set); its hydration is extracted into a shared helper.

6. **Refresh a stale user-directory comment** (`cb5a790f`). Operator messaging ships now (#1205); the operator self-only directory scoping is a deliberate isolation choice, not a not-built-yet placeholder. Comment-only.

`36fc49ab` folds in two LOW precision fixes from the code-review pass (collation-independent in-memory tiebreaker; honest 409 comment).

## Verification

- tsc clean ×3 (shared, api, web).
- `lint:boundaries` OK; `lint:modules` soft-warn only (pre-existing web-tree baseline, untouched here).
- api unit **2970/2970**; full integration **520/520** real-pg; web **2208/2208**.
- Every fix is TDD (RED → GREEN); the two guard tests (limiter swap, findPage offset pushdown) are sabotage-verified.
- Fresh `code-reviewer` pass: **SHIP** — no CRITICAL/HIGH/MEDIUM; both LOW findings addressed in `36fc49ab`.

## Not in scope

- Does not flip the `MESSAGING` flag.
- No schema migration (none of the 6 fixes touch the schema).