### PR TITLE
feat(#1318): auto machine-translate add-on descriptions on save (Model B)

### DIFF
--- a/docs/plans/2026-07-09-addon-description-mt-design.md
+++ b/docs/plans/2026-07-09-addon-description-mt-design.md
@@ -1,6 +1,6 @@
 # Add-on description machine-translation (auto-fill on save)
 
-Status: DESIGN — awaiting owner review.
+Status: DESIGN — architect-reviewed (SHIP-WITH-FIXES; all findings folded below), awaiting owner review.
 Date: 2026-07-09.
 Issue: #1318 (partial — the add-on-description half only; see Scope).
 Epic: catalog content i18n (#1315). Realizes "Non-goals / deferred item 1" of the superseded
@@ -62,32 +62,54 @@ export interface DescriptionTranslator {
 
 - The real impl wraps a `TranslationProvider`, translating `sourceText` from `sourceLocale` into each other locale.
   The non-source calls run in parallel (`Promise.allSettled`); a rejected one is dropped, not fatal.
-- A **no-op default** (`{ fill: (l, t) => ({ [l]: t }) }`) is exported so every existing `new AddOnService(...)` in
-  tests keeps compiling — the same defaulted-dependency pattern the constructor already uses for `isSharedCatalogEnabled`.
+- **Bounded deadline (LOW-6).** The provider is `TIMEOUT_MS=3000 × MAX_ATTEMPTS=2` ≈ 6s per locale
+  (`google-translation-provider.ts:6-7`); run the locales in parallel and cap the whole `fill` so a slow provider can't
+  make an operator's save feel hung. Keep it synchronous (not `waitUntil`-deferred) — the list refetch reads-after-write.
+- **No silent no-op default (MEDIUM-3).** The `AddOnService` translator param is REQUIRED, not defaulted. A no-op default
+  fails to *degraded output* (source-only, no error) if the composition root forgets to wire the real translator — unlike
+  the `isSharedCatalogEnabled` default whose `true` IS the intended prod value. A test-only exported fake is passed
+  explicitly by the ~7 existing `new AddOnService(...)` sites, and a wired-test pins the real injection (see Testing).
+- **Dev-stub note (NIT-7).** With no key in dev the factory stub returns `[<locale>] <text>`
+  (`translation-provider-factory.ts:21`). Because this slice PERSISTS the fill (unlike message translation's read-time
+  use), a dev/staging DB accumulates literal `[ja] …` descriptions. Harmless, but expected.
 
 ### `AddOnService` changes (`packages/api/src/services/add-on.ts`)
 
-- Constructor gains `descriptionTranslator: DescriptionTranslator = noopDescriptionTranslator` (4th param, defaulted).
-- `create` resolves the persisted bag **once** before dispatching to `createFromTemplate` / `createSelfAuthored`, so both
-  branches store the translated bag instead of the raw `data.descriptionOverride`.
-- `update` resolves the bag when `data.descriptionOverride` is being set, with a **skip-on-unchanged** guard.
+- Constructor gains a **required** `descriptionTranslator: DescriptionTranslator` (4th param, no default — MEDIUM-3).
+- `create` resolves the persisted bag **once** before dispatching to `createFromTemplate` / `createSelfAuthored`.
+- `update` resolves the bag when `data.descriptionOverride` is being set, with a **skip-on-unchanged** guard, gated on
+  `existing.templateId`.
 
-**Bag resolution rule** (`sourceLocale = locale`, the request param):
+**MT applies to SELF-AUTHORED rows only (HIGH-1).** A picked row's description already falls through to the platform
+template's human-curated per-locale text via `resolveDescription` (`add-on-resolve.ts:28`); MT-filling its override would
+SHADOW that curated text with machine output in every locale (`override?.[locale]` wins first) — "fixing" a row the
+Problem section admits has no bug. So MT runs only when the row is self-authored (`nameI18n` set on create;
+`existing.templateId === null` on update). Picked rows store `descriptionOverride` verbatim.
+
+**Never coerce a non-empty bag to null (HIGH-2).** The source slot is `descriptionOverride[locale]` and `?locale=`
+defaults to `en` (`helpers.ts:252`); the API is source-agnostic (Trip.com hits these same routes), so a caller sending
+`{descriptionOverride:{ja:"…"}}` without `?locale=ja` must not lose the `ja` text. MT runs only when a real source slot
+is present; otherwise the caller's bag is stored unchanged.
+
+**Bag resolution rule** (`sourceLocale = locale`, the request param; `sourceText = descriptionOverride[locale]`):
 
 | Incoming `descriptionOverride` | Result |
 |---|---|
-| `undefined` (update only — field not touched) | leave existing bag untouched, no MT |
-| `null`, or source slot empty/absent | store `null` (cleared), no MT |
-| source text unchanged vs the stored row **and** bag already complete (update) | keep the existing bag, no MT |
-| otherwise | `fill(sourceLocale, sourceText)` where `sourceText = descriptionOverride[sourceLocale]` |
+| `undefined` (update — field not touched) | leave existing bag untouched, no MT |
+| explicit `null` | store `null` (cleared), no MT |
+| picked row (`templateId` set / no `nameI18n`) | store the bag **verbatim**, no MT (HIGH-1) |
+| self-authored, `sourceText` present & non-empty, and (create OR changed OR bag incomplete) | `fill(locale, sourceText)` |
+| self-authored, `sourceText` unchanged vs stored row & bag complete (update) | keep existing bag, no MT |
+| self-authored but `sourceText` absent/empty (e.g. caller omitted `?locale=`) | store the bag **verbatim**, no MT (HIGH-2 — no coercion to null) |
 
-"Source slot" = `descriptionOverride[locale]`. Any other keys the client sent are ignored — Model B rebuilds them.
+### Composition (`packages/api/src/index.ts`) — MEDIUM-5
 
-### Composition (`packages/api/src/composition/services.ts`)
-
-Wire the real `DescriptionTranslator` over `createTranslationProvider()` (Google when the key is set; the prod sentinel
-throws on use, so a best-effort `fill` simply drops every locale and stores the source alone — no working translations
-ship silently on a secret drift) and inject it into `AddOnService`.
+`AddOnService` is constructed at `index.ts:498`, and `translationProvider = createTranslationProvider()` already exists at
+`index.ts:214`. Build the real `DescriptionTranslator` over that provider and inject it into `AddOnService`. (The earlier
+draft named `composition/services.ts`, which holds only `resolve*` helpers and constructs neither — optionally add a
+`resolveDescriptionTranslator()` helper there for consistency, but the wiring edit is `index.ts`.) The prod sentinel
+provider throws per-locale, so a best-effort `fill` drops every locale and stores the source alone — no working
+translations ship silently on a secret drift.
 
 ### Web (`packages/web/src/vite/operator-add-ons`)
 
@@ -109,11 +131,18 @@ operator edits description in /ja  ->  PATCH /add-ons/:id?operatorId=..&locale=j
 renter views storefront in /zh       ->  resolveOwnDescription(bag, 'zh')  ->  the MT zh text
 ```
 
+This is the SELF-AUTHORED path (the only one MT touches — HIGH-1). A picked row's override is stored verbatim and its
+other locales resolve through the curated template description, unchanged.
+
 ## Error handling
 
 - Provider throws for a locale -> that locale is omitted from the bag (best-effort). The operator's save still succeeds;
   a `zh` reader falls back through `resolveOwnDescription` exactly as before this slice. No 5xx, no partial-write.
 - The prod sentinel provider (no key) throws for every locale -> the bag holds only the source slot. Correct fail-safe.
+- **Capture the failure (MEDIUM-4).** Request observability only reports `>=500` / `>2s` (`observability/middleware.ts`),
+  so a fully-silent drop is a blind spot — a `GOOGLE_TRANSLATE_API_KEY` drift would degrade every add-on save to
+  source-only with zero signal. On a dropped locale, `console.error` (parity with `message-translation.ts:46`) AND
+  `Sentry.captureException`. Silent-drop the reader fallback, never the operator/ops signal.
 
 ## Testing strategy (TDD, vertical)
 
@@ -124,7 +153,35 @@ renter views storefront in /zh       ->  resolveOwnDescription(bag, 'zh')  ->  t
   - update with unchanged source text and a complete bag makes **zero** provider calls (spy on the fake).
   - update that only changes `priceJpy` does not re-translate.
   - a provider failure still persists the source slot and returns `ok: true`.
+  - **picked-row (HIGH-1)**: a `templateId` create/update with a one-locale override stores it VERBATIM — zero provider
+    calls, template floor intact.
+  - **source-agnostic caller (HIGH-2)**: a self-authored write with a non-empty bag but no `?locale=` stores the bag
+    verbatim (no coercion to null, no data loss).
+- **Wired-test (MEDIUM-3)** — mirror `tests/routes/shared-catalog-killswitch-wired.test.ts`: assert `createApp`'s
+  `AddOnService` gets the REAL `DescriptionTranslator`, so a forgotten injection fails CI.
 - **Web**: a test that `updateAddOn` / `createAddOn` include `&locale=<locale>` in the request URL.
+
+## Architect review (2026-07-09, folded)
+
+Independent architecture pass. Verdict SHIP-WITH-FIXES; no CRITICAL. Code assumptions verified accurate except the two
+noted. All folded into the sections above.
+
+- **HIGH-1 — picked-row MT shadows curated template text.** MT was applied to both create branches; for a picked row that
+  shadows the human-curated per-locale template description with machine output. Fix: gate MT on self-authored only
+  (`nameI18n` / `existing.templateId === null`); picked rows store verbatim.
+- **HIGH-2 — `?locale=` overload silently drops content.** Source slot `descriptionOverride[locale]` with `?locale=`
+  defaulting to `en` meant a source-agnostic caller (Trip.com) sending a `ja`-only bag without `?locale=ja` would have its
+  text coerced to null — a data-loss regression vs today. Fix: MT only when a real source slot is present; otherwise store
+  the caller's bag verbatim.
+- **MEDIUM-3 — no-op default translator.** Silent zero-translation if the composition root forgets to wire the real one.
+  Fix: required constructor param + a wired-test pinning the real injection.
+- **MEDIUM-4 — silent MT failure = observability blind spot.** Request obs only reports 5xx/slow. Fix: `console.error` +
+  `Sentry.captureException` on a dropped locale.
+- **MEDIUM-5 — wrong wiring file named.** `AddOnService` is built in `index.ts:498`, not `composition/services.ts`. Fixed.
+- **LOW-6 — bound the in-request MT deadline** (~6s/locale worst case). Folded into DescriptionTranslator.
+- **NIT-7 — dev stub persists `[ja] …` junk** in dev/staging DBs. Noted.
+- **NIT-8 — divergence from the MessageTranslationService content-keyed cache is justified** (mutable content + Model B
+  overwrite). No change.
 
 ## Accepted limitations (explicit)
 

--- a/docs/plans/2026-07-09-addon-description-mt-design.md
+++ b/docs/plans/2026-07-09-addon-description-mt-design.md
@@ -1,0 +1,139 @@
+# Add-on description machine-translation (auto-fill on save)
+
+Status: DESIGN — awaiting owner review.
+Date: 2026-07-09.
+Issue: #1318 (partial — the add-on-description half only; see Scope).
+Epic: catalog content i18n (#1315). Realizes "Non-goals / deferred item 1" of the superseded
+`docs/plans/2026-06-30-operator-catalog-i18n-design.md` ("On-the-fly machine translation of edited descriptions").
+Branch: `feat/1318-addon-description-mt` off `develop`.
+
+## Problem
+
+An operator authors an add-on `descriptionOverride` in exactly one locale (the UI `$locale` at edit time —
+`EditAddOnDialog.tsx` writes `setLocaleSlot(existing, locale, text)`).
+A reader in another locale never sees a translation:
+
+- Picked rows fall through to the platform template's description for that locale (`resolveDescription`).
+- **Self-authored rows have no template floor** — `resolveOwnDescription` floors to *any* present locale, so a `ja`-only
+  description shows a `zh` reader the Japanese text (readable, but the wrong language).
+
+The infra to fix this is live: `GOOGLE_TRANSLATE_API_KEY` is set on the beta API Worker and drift-guarded in
+`deploy.yml` (#1290/#1297), and the DI-swappable `TranslationProvider` port + `GoogleTranslationProvider` already back
+`MessageTranslationService`. This slice reuses that provider to auto-fill the missing description locales on save.
+
+## Scope
+
+**In:** machine-translate an **add-on** `descriptionOverride` into the remaining `SUPPORTED_LOCALES` when the operator
+saves, so every reader sees the description in their own language.
+
+**Out (stay deferred under #1318):**
+
+- **Insurance descriptions.** `insurance_options.descriptionOverride` exists as a column but is *unwired* — no operator
+  UI authors it, `insurance-resolve.ts` resolves only the name, and no service writes it. Translating a field nothing
+  authors or reads is premature; it waits until insurance description authoring itself exists.
+- **Location names.** `locations.name` is plain `text` with no i18n bundle at all — needs a schema change (a separate,
+  larger slice).
+
+## Locked decisions (from brainstorming — do not relitigate)
+
+1. **Auto, silent on save.** No operator review step, mirroring how chat messages auto-translate. MT is best-effort: the
+   authored locale is always saved; a translation failure degrades gracefully and never fails the operator's save.
+2. **Model B — single source locale, refreshed every save.** The operator has one authoring locale; on every save MT
+   re-derives all *other* locales from it, overwriting. Translations are always current.
+   Accepted limitation: MT owns the non-source locales — operators cannot hand-tune an individual locale, and editing in
+   a different UI locale re-bases the source to that locale.
+3. **Author-time write, not read-time.** The filled bag is persisted into `descriptionOverride`; reads stay pure. This
+   matters because the renter storefront read is public and edge-cached — a DB write inside a cached GET is unsafe.
+4. **The source locale is the existing `?locale=` param, not a new field.** The route already parses `?locale=` on
+   create/update and passes it to the service; the operator authors in that same UI locale, so it doubles as the Model-B
+   source locale. No new wire field, no validator change.
+
+## Architecture
+
+### New collaborator: `DescriptionTranslator` (`packages/api/src/services/description-translation.ts`)
+
+```ts
+export interface DescriptionTranslator {
+  // Build the full override bag: source verbatim + each other SUPPORTED_LOCALE via MT.
+  // Best-effort — a locale whose provider call throws is omitted (reader falls back).
+  fill(sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride>
+}
+```
+
+- The real impl wraps a `TranslationProvider`, translating `sourceText` from `sourceLocale` into each other locale.
+  The non-source calls run in parallel (`Promise.allSettled`); a rejected one is dropped, not fatal.
+- A **no-op default** (`{ fill: (l, t) => ({ [l]: t }) }`) is exported so every existing `new AddOnService(...)` in
+  tests keeps compiling — the same defaulted-dependency pattern the constructor already uses for `isSharedCatalogEnabled`.
+
+### `AddOnService` changes (`packages/api/src/services/add-on.ts`)
+
+- Constructor gains `descriptionTranslator: DescriptionTranslator = noopDescriptionTranslator` (4th param, defaulted).
+- `create` resolves the persisted bag **once** before dispatching to `createFromTemplate` / `createSelfAuthored`, so both
+  branches store the translated bag instead of the raw `data.descriptionOverride`.
+- `update` resolves the bag when `data.descriptionOverride` is being set, with a **skip-on-unchanged** guard.
+
+**Bag resolution rule** (`sourceLocale = locale`, the request param):
+
+| Incoming `descriptionOverride` | Result |
+|---|---|
+| `undefined` (update only — field not touched) | leave existing bag untouched, no MT |
+| `null`, or source slot empty/absent | store `null` (cleared), no MT |
+| source text unchanged vs the stored row **and** bag already complete (update) | keep the existing bag, no MT |
+| otherwise | `fill(sourceLocale, sourceText)` where `sourceText = descriptionOverride[sourceLocale]` |
+
+"Source slot" = `descriptionOverride[locale]`. Any other keys the client sent are ignored — Model B rebuilds them.
+
+### Composition (`packages/api/src/composition/services.ts`)
+
+Wire the real `DescriptionTranslator` over `createTranslationProvider()` (Google when the key is set; the prod sentinel
+throws on use, so a best-effort `fill` simply drops every locale and stores the source alone — no working translations
+ship silently on a secret drift) and inject it into `AddOnService`.
+
+### Web (`packages/web/src/vite/operator-add-ons`)
+
+- `api.ts`: thread the route `$locale` into `createAddOn` / `updateAddOn` and append `&locale=${locale}` to the POST/PATCH
+  URLs (also fixes a latent bug where write responses resolve to `en` regardless of the operator's locale).
+- `AddAddOnDialog.tsx` / `EditAddOnDialog.tsx`: pass `$locale` to those calls. Description input handling is otherwise
+  unchanged — the operator still edits one locale slot; the server now fills the rest.
+
+**No migration. No read-DTO / wire-fence change.** `descriptionOverride` already exists and is already resolved.
+
+## Data flow
+
+```
+operator edits description in /ja  ->  PATCH /add-ons/:id?operatorId=..&locale=ja  body { descriptionOverride: { ja: "…" } }
+  route: locale = ja                 ->  AddOnService.update(ctx, id, data, locale=ja)
+  service: sourceText = data.descriptionOverride.ja
+           translator.fill('ja', sourceText)  ->  { ja: "…", en: MT(ja->en), zh: MT(ja->zh) }
+           repo.update({ descriptionOverride: <full bag> })
+renter views storefront in /zh       ->  resolveOwnDescription(bag, 'zh')  ->  the MT zh text
+```
+
+## Error handling
+
+- Provider throws for a locale -> that locale is omitted from the bag (best-effort). The operator's save still succeeds;
+  a `zh` reader falls back through `resolveOwnDescription` exactly as before this slice. No 5xx, no partial-write.
+- The prod sentinel provider (no key) throws for every locale -> the bag holds only the source slot. Correct fail-safe.
+
+## Testing strategy (TDD, vertical)
+
+- **`DescriptionTranslator` unit** (fake provider): source stored verbatim; each other locale filled; a provider that
+  throws for `zh` yields a bag with `en` + source but no `zh`; empty/whitespace source -> handled by the service, not here.
+- **`AddOnService` unit** (fake provider):
+  - create with a `ja` source fills `en`/`zh` (mutation-resistant: assert the exact translated values from the fake).
+  - update with unchanged source text and a complete bag makes **zero** provider calls (spy on the fake).
+  - update that only changes `priceJpy` does not re-translate.
+  - a provider failure still persists the source slot and returns `ok: true`.
+- **Web**: a test that `updateAddOn` / `createAddOn` include `&locale=<locale>` in the request URL.
+
+## Accepted limitations (explicit)
+
+- MT owns the non-source locales; operators cannot hand-tune a single locale's translation.
+- Editing the description under a different UI locale re-bases the source to that locale (overwriting the prior source's
+  MT — including a previously hand-authored slot, since there is no per-slot provenance).
+- Machine-translation quality is provider-grade; there is no human review before it reaches renters (locked decision 1).
+
+## Out-of-scope follow-ups (do not do here)
+
+- Insurance + location description/name MT (the rest of #1318).
+- Per-slot provenance so a hand-authored locale survives a source re-base.

--- a/docs/superpowers/plans/2026-07-09-addon-description-mt.md
+++ b/docs/superpowers/plans/2026-07-09-addon-description-mt.md
@@ -1,0 +1,830 @@
+# Add-on Description Machine-Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an operator saves an add-on `descriptionOverride`, machine-translate the authored locale into the other `SUPPORTED_LOCALES` so every renter reads the description in their own language.
+
+**Architecture:** A new best-effort `DescriptionTranslator` collaborator wraps the existing DI `TranslationProvider`. `AddOnService` gains it as a REQUIRED constructor param and, for SELF-AUTHORED rows only, fills the missing locales at author-time (persisted, not read-time). Picked rows and source-agnostic callers store their bag verbatim. Failures degrade to source-only and never fail the save.
+
+**Tech Stack:** TypeScript (strict, `noUncheckedIndexedAccess`), Hono, Vitest, `@sentry/cloudflare`, Vite + TanStack Router + use-intl (web).
+
+**Source of truth:** `docs/plans/2026-07-09-addon-description-mt-design.md` (architect-reviewed; HIGH-1, HIGH-2, MEDIUM-3/4/5, LOW-6, NIT-7 all folded).
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/api/src/services/description-translation.ts` — the `DescriptionTranslator` port + `MachineDescriptionTranslator` impl (wraps `TranslationProvider`, best-effort parallel fill, MEDIUM-4 observability).
+- `packages/api/tests/services/description-translation.test.ts` — translator unit tests.
+- `packages/api/tests/helpers/fake-translator.ts` — test-only fakes (`fakeDescriptionTranslator`, `sourceOnlyTranslator`) passed by every `new AddOnService(...)` test site (MEDIUM-3).
+- `packages/api/tests/routes/add-on-description-mt-wired.test.ts` — boots the composed app and proves the real translator MT-fills end-to-end (MEDIUM-3 wiring guard).
+- `packages/web/src/vite/operator-add-ons/api.test.ts` — asserts writes carry `&locale=`.
+
+**Modify:**
+- `packages/api/src/services/add-on.ts` — required `descriptionTranslator` param (3rd, before the defaulted flag); resolve the persisted bag in `create` and `update`; add `resolveDescriptionOverride` + module `isDescriptionComplete`.
+- `packages/api/src/index.ts:498` — build `MachineDescriptionTranslator` over the existing `translationProvider` (index.ts:214) and inject (MEDIUM-5).
+- `packages/api/tests/services/add-on.test.ts`, `packages/api/tests/services/add-on-template.test.ts`, `packages/api/tests/routes/add-ons.test.ts`, `packages/api/tests/integration/add-on-repo.test.ts` — pass a fake translator to every `new AddOnService(...)`.
+- `packages/web/src/vite/operator-add-ons/api.ts` — thread `locale` into `createAddOn`/`updateAddOn`, append `?locale=`/`&locale=`.
+- `packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx`, `EditAddOnDialog.tsx` — pass the already-computed `locale` to the write calls.
+
+**No migration. No validator change. No read-DTO / wire-fence change** — `descriptionOverride` already exists and is already resolved.
+
+---
+
+## Task 1: `DescriptionTranslator` port + `MachineDescriptionTranslator`
+
+Self-contained; no `AddOnService` coupling yet. Best-effort parallel fill: source verbatim, each other locale via the provider; a rejected locale is dropped (reader falls back) but logged (MEDIUM-4). Parallelism bounds wall-clock to the provider's own ~6s-per-locale cap (LOW-6) — no extra timer, which would only drop locales the provider might still return.
+
+**Files:**
+- Create: `packages/api/src/services/description-translation.ts`
+- Test: `packages/api/tests/services/description-translation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/api/tests/services/description-translation.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { MachineDescriptionTranslator } from '../../src/services/description-translation'
+import type { TranslationProvider } from '../../src/services/translation-provider'
+
+// Deterministic fake: `<target><-<text>`, echoing the source code back so a
+// mutation to the wiring (wrong source/target) changes the asserted value.
+const echoProvider: TranslationProvider = {
+  translate: async (text, source, target) => ({
+    translatedText: `${target}<-${text}`,
+    detectedLanguage: source ?? target,
+  }),
+}
+
+describe('MachineDescriptionTranslator.fill', () => {
+  it('stores the source verbatim and fills every other locale via the provider', async () => {
+    const translator = new MachineDescriptionTranslator(echoProvider)
+    const bag = await translator.fill('ja', 'こんにちは')
+    expect(bag).toEqual({ ja: 'こんにちは', en: 'en<-こんにちは', zh: 'zh<-こんにちは' })
+  })
+
+  it('drops (but logs) a locale whose provider call throws; source survives', async () => {
+    const failingZh: TranslationProvider = {
+      translate: async (text, source, target) => {
+        if (target === 'zh') throw new Error('provider down')
+        return { translatedText: `${target}<-${text}`, detectedLanguage: source ?? target }
+      },
+    }
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const translator = new MachineDescriptionTranslator(failingZh)
+    const bag = await translator.fill('ja', 'X')
+    expect(bag).toEqual({ ja: 'X', en: 'en<-X' })
+    expect(errSpy).toHaveBeenCalledOnce()
+    errSpy.mockRestore()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run --filter @kuruma/api test description-translation`
+Expected: FAIL — cannot find module `../../src/services/description-translation`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/api/src/services/description-translation.ts`:
+
+```ts
+import * as Sentry from '@sentry/cloudflare'
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import type { LocalizedTextOverride } from '@kuruma/shared/i18n/localized-text'
+import type { TranslationProvider } from './translation-provider'
+
+/**
+ * Fills an add-on description override so every locale carries text. Model B
+ * (#1318): the operator authors one locale; this re-derives the others by MT on
+ * every save. Best-effort — a locale whose provider call fails is omitted and the
+ * reader falls back via resolveOwnDescription; it is never fatal to the save.
+ */
+export interface DescriptionTranslator {
+  fill(sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride>
+}
+
+export class MachineDescriptionTranslator implements DescriptionTranslator {
+  constructor(private readonly provider: TranslationProvider) {}
+
+  async fill(sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> {
+    // Non-source locales in parallel: total wall-clock ≈ one provider call
+    // (TIMEOUT_MS × MAX_ATTEMPTS ≈ 6s), not the sum (LOW-6). allSettled so one
+    // rejection never sinks the others.
+    const targets = SUPPORTED_LOCALES.filter((locale) => locale !== sourceLocale)
+    const settled = await Promise.allSettled(
+      targets.map((target) => this.provider.translate(sourceText, sourceLocale, target)),
+    )
+
+    return settled.reduce<LocalizedTextOverride>(
+      (bag, result, index) => {
+        const target = targets[index]
+        if (!target) return bag
+        if (result.status === 'fulfilled') {
+          return { ...bag, [target]: result.value.translatedText }
+        }
+        // MEDIUM-4: never a fully-silent drop. Request obs only reports 5xx/slow,
+        // so a GOOGLE_TRANSLATE_API_KEY drift would degrade every save with no
+        // signal. Parity with message-translation.ts, plus Sentry.
+        console.error('Add-on description translation failed', {
+          sourceLocale,
+          target,
+          err: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        })
+        Sentry.captureException(result.reason)
+        return bag
+      },
+      { [sourceLocale]: sourceText },
+    )
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run --filter @kuruma/api test description-translation`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/services/description-translation.ts packages/api/tests/services/description-translation.test.ts
+git commit -m "feat(#1318): DescriptionTranslator port + best-effort MT fill"
+```
+
+---
+
+## Task 2: Thread the required translator through `AddOnService.create`
+
+Introduces the REQUIRED constructor param (3rd, before the defaulted `isSharedCatalogEnabled` so the optional param stays last), rewires every `new AddOnService(...)` site, and implements the create-path fill. Biome's `noUnusedPrivateClassMembers` means the param must be used in the same commit — the create-path logic is that first use.
+
+**Files:**
+- Create: `packages/api/tests/helpers/fake-translator.ts`
+- Modify: `packages/api/src/services/add-on.ts`
+- Modify (rewire sites): `packages/api/tests/services/add-on.test.ts`, `packages/api/tests/services/add-on-template.test.ts`, `packages/api/tests/routes/add-ons.test.ts`, `packages/api/tests/integration/add-on-repo.test.ts`, `packages/api/src/index.ts`
+- Test: `packages/api/tests/services/add-on.test.ts` (new create-MT cases)
+
+- [ ] **Step 1: Create the test fakes**
+
+Create `packages/api/tests/helpers/fake-translator.ts`:
+
+```ts
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import type { LocalizedTextOverride } from '@kuruma/shared/i18n/localized-text'
+import type { DescriptionTranslator } from '../../src/services/description-translation'
+
+/**
+ * Deterministic test double: source verbatim, every other locale `<locale>:<text>`.
+ * Mutation-resistant — tests assert the exact filled value. Spy with
+ * `vi.spyOn(translator, 'fill')` to assert zero-call (skip / picked / verbatim) paths.
+ */
+export function fakeDescriptionTranslator(): DescriptionTranslator {
+  return {
+    fill: async (sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> =>
+      SUPPORTED_LOCALES.reduce<LocalizedTextOverride>(
+        (bag, locale) => ({
+          ...bag,
+          [locale]: locale === sourceLocale ? sourceText : `${locale}:${sourceText}`,
+        }),
+        {},
+      ),
+  }
+}
+
+/** Simulates a total provider outage: fill returns only the source slot. */
+export function sourceOnlyTranslator(): DescriptionTranslator {
+  return {
+    fill: async (sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> => ({
+      [sourceLocale]: sourceText,
+    }),
+  }
+}
+```
+
+- [ ] **Step 2: Add the required constructor param + create-path fill**
+
+In `packages/api/src/services/add-on.ts`:
+
+Add imports near the top (after the existing `Locale` import line):
+
+```ts
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+```
+
+(Replace the existing `import type { Locale } from '@kuruma/shared/i18n/locales'` line with the above — `SUPPORTED_LOCALES` is now needed. Keep it a value import.)
+
+Add after the `import ... from './add-on-resolve'` line:
+
+```ts
+import type { DescriptionTranslator } from './description-translation'
+```
+
+Add this module-level helper just below the `const NOT_FOUND_MESSAGE` block:
+
+```ts
+// A description bag is COMPLETE when every supported locale carries text. Used to
+// skip re-translation on an unchanged self-authored save (and to retry when a prior
+// save dropped a locale). noUncheckedIndexedAccess: bag[locale] is string | undefined.
+function isDescriptionComplete(bag: LocalizedTextOverride): boolean {
+  return SUPPORTED_LOCALES.every((locale) => Boolean(bag[locale]))
+}
+```
+
+Change the constructor to insert `descriptionTranslator` as the 3rd param:
+
+```ts
+  constructor(
+    private readonly repo: AddOnRepository,
+    private readonly templateRepo: AddOnTemplateRepository,
+    // #1318: REQUIRED (no default). A no-op default would fail to degraded output
+    // (source-only, no error) on a forgotten wiring; a required param fails at
+    // compile time instead. Wired in index.ts; tests pass a fake explicitly.
+    private readonly descriptionTranslator: DescriptionTranslator,
+    private readonly isSharedCatalogEnabled: () => Promise<boolean> = () => Promise.resolve(true),
+  ) {}
+```
+
+Add this private method (place it just above `async create`):
+
+```ts
+  /**
+   * Model B fill (#1318). MT owns the non-source locales of a SELF-AUTHORED
+   * description, refreshed on every save. Returns the bag to persist.
+   *
+   * - Picked rows (HIGH-1): verbatim — their other locales resolve through the
+   *   curated template description; MT would shadow human text with machine text.
+   * - No source slot (HIGH-2): verbatim — `?locale=` defaults to `en` and the API
+   *   is source-agnostic (Trip.com), so a ja-only bag sent without `?locale=ja`
+   *   must not be coerced to null / re-based.
+   * - Unchanged source + complete stored bag (update): keep the stored bag, no MT.
+   */
+  private async resolveDescriptionOverride(
+    isSelfAuthored: boolean,
+    locale: Locale,
+    incoming: LocalizedTextOverride | null,
+    existingBag: LocalizedTextOverride | null,
+  ): Promise<LocalizedTextOverride | null> {
+    if (!isSelfAuthored) return incoming
+    if (incoming === null) return null
+    const sourceText = incoming[locale]
+    if (!sourceText) return incoming
+    if (existingBag && existingBag[locale] === sourceText && isDescriptionComplete(existingBag)) {
+      return existingBag
+    }
+    return this.descriptionTranslator.fill(locale, sourceText)
+  }
+```
+
+Change `create` to resolve the bag once before dispatching:
+
+```ts
+  async create(_ctx: CallerContext, data: AddOnCreate, locale: Locale): Promise<AddOnResult> {
+    const descriptionOverride = await this.resolveDescriptionOverride(
+      data.nameI18n != null,
+      locale,
+      data.descriptionOverride,
+      null,
+    )
+    const resolved: AddOnCreate = { ...data, descriptionOverride }
+    if (data.nameI18n) return this.createSelfAuthored(resolved, data.nameI18n, locale)
+    if (data.templateId) {
+      if (!(await this.isSharedCatalogEnabled())) {
+        return { ok: false, error: CATALOG_DISABLED_MESSAGE, status: 422 }
+      }
+      return this.createFromTemplate(resolved, data.templateId, locale)
+    }
+    return { ok: false, error: MISSING_IDENTITY_MESSAGE, status: 400 }
+  }
+```
+
+(The `createFromTemplate` / `createSelfAuthored` bodies are unchanged — they already read `data.descriptionOverride`, now the resolved bag.)
+
+- [ ] **Step 3: Rewire every `new AddOnService(...)` site (compile-green)**
+
+Insert `fakeDescriptionTranslator()` as the 3rd arg (before any flag thunk). Add the import `import { fakeDescriptionTranslator } from '../helpers/fake-translator'` (adjust relative depth: `../helpers/...` from `tests/services` and `tests/routes`, `../helpers/...` from `tests/integration`) to each test file.
+
+`packages/api/tests/services/add-on.test.ts` — 5 sites:
+- L55: `service = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator())`
+- L113-116: `const svc = new AddOnService(new InMemoryAddOnRepository(), new InMemoryAddOnTemplateRepository(store), fakeDescriptionTranslator())`
+- L155-157: `const off = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator(), () => Promise.resolve(false))`
+- L168-170: same shape as L155.
+- L362: `service = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator())`
+
+`packages/api/tests/services/add-on-template.test.ts` L113: `addOnService = new AddOnService(addOnRepo, templateRepo, fakeDescriptionTranslator())`
+
+`packages/api/tests/routes/add-ons.test.ts`:
+- L29: `new AddOnService(repo, new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator())`
+- L62: `new AddOnService(new InMemoryAddOnRepository(), new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator())`
+
+`packages/api/tests/integration/add-on-repo.test.ts`:
+- L144: `const service = new AddOnService(repo, new DrizzleAddOnTemplateRepository(db), fakeDescriptionTranslator())`
+- L194: same shape.
+
+`packages/api/src/index.ts` — build the real translator over the existing provider and inject. After line 214 (`const translationProvider = createTranslationProvider()`) it already exists; at L498 change to:
+
+```ts
+  const addOnService = new AddOnService(
+    addOnRepo,
+    addOnTemplateRepo,
+    new MachineDescriptionTranslator(translationProvider),
+    isSharedCatalogEnabled,
+  )
+```
+
+Add the import to `index.ts` (near the other service imports):
+
+```ts
+import { MachineDescriptionTranslator } from './services/description-translation'
+```
+
+- [ ] **Step 4: Write the failing create-MT tests**
+
+Append to `packages/api/tests/services/add-on.test.ts` inside the `describe('create', ...)` block (the top-level `import { fakeDescriptionTranslator } from '../helpers/fake-translator'` is already added in Step 3; add `sourceOnlyTranslator` to that import if needed later):
+
+```ts
+    it('fills en/zh from a ja-authored self-authored description (Model B)', async () => {
+      const result = await service.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          nameI18n: { en: 'GPS unit' },
+          descriptionOverride: { ja: 'ポータブルGPS' },
+          priceJpy: 1500,
+        },
+        'ja',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({
+          ja: 'ポータブルGPS',
+          en: 'en:ポータブルGPS',
+          zh: 'zh:ポータブルGPS',
+        })
+      }
+    })
+
+    it('stores a PICKED row description VERBATIM — no MT (HIGH-1)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const result = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, templateId: CHILD_SEAT, descriptionOverride: { en: 'My note' }, priceJpy: 1500 },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ en: 'My note' })
+      expect(fillSpy).not.toHaveBeenCalled()
+    })
+
+    it('stores a self-authored bag VERBATIM when the ?locale slot is absent (HIGH-2)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      // ja-only bag, but ?locale defaults to en -> sourceText = bag.en = undefined.
+      const result = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: { ja: '日本語のみ' }, priceJpy: 1500 },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ ja: '日本語のみ' })
+      expect(fillSpy).not.toHaveBeenCalled()
+    })
+```
+
+- [ ] **Step 5: Run tests to verify create-MT fails, then rewiring passes the rest**
+
+Run: `bun run --filter @kuruma/api test add-on.test`
+Expected: the three new create tests were RED before Step 2's `create` change; after Step 2 they PASS. Run the whole file now — all green. If the first MT test was written before the `create` edit, confirm RED first: temporarily assert `.toEqual({ ja: 'ポータブルGPS' })` fails against the filled bag.
+
+- [ ] **Step 6: Verify typecheck + lint across the package**
+
+Run: `bun run --filter @kuruma/api test add-on && bunx tsc --noEmit -p packages/api`
+Expected: PASS, no type errors (all `new AddOnService` sites carry the translator).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api/src/services/add-on.ts packages/api/src/index.ts \
+  packages/api/tests/helpers/fake-translator.ts packages/api/tests/services/add-on.test.ts \
+  packages/api/tests/services/add-on-template.test.ts packages/api/tests/routes/add-ons.test.ts \
+  packages/api/tests/integration/add-on-repo.test.ts
+git commit -m "feat(#1318): MT-fill self-authored add-on descriptions on create"
+```
+
+---
+
+## Task 3: `AddOnService.update` MT (fill, skip-on-unchanged, verbatim, failure-safe)
+
+**Files:**
+- Modify: `packages/api/src/services/add-on.ts` (`update`)
+- Test: `packages/api/tests/services/add-on.test.ts` (new update cases)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/api/tests/services/add-on.test.ts` inside `describe('update', ...)`. Add `sourceOnlyTranslator` to the fake-translator import.
+
+```ts
+    it('re-fills en/zh when a self-authored description changes (Model B)', async () => {
+      const created = await service.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: null, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'New copy' } },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({
+          en: 'New copy',
+          ja: 'ja:New copy',
+          zh: 'zh:New copy',
+        })
+      }
+    })
+
+    it('does NOT re-translate when the source is unchanged and the bag is complete', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: { en: 'Copy' }, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear() // ignore the create-time fill
+      // The web client re-sends the full merged bag; source slot unchanged.
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Copy', ja: 'ja:Copy', zh: 'zh:Copy' } },
+        'en',
+      )
+      expect(fillSpy).not.toHaveBeenCalled()
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({ en: 'Copy', ja: 'ja:Copy', zh: 'zh:Copy' })
+      }
+    })
+
+    it('does NOT translate on a price-only update (descriptionOverride untouched)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: { en: 'Copy' }, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear()
+      await svc.update(ctxFor(opA), created.option.id, { priceJpy: 3000 }, 'en')
+      expect(fillSpy).not.toHaveBeenCalled()
+    })
+
+    it('persists the source slot and returns ok when every translation fails', async () => {
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), sourceOnlyTranslator())
+      const created = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: null, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Only English survives' } },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ en: 'Only English survives' })
+    })
+
+    it('stores a PICKED row description update VERBATIM — no MT (HIGH-1)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(ctxFor(opA), createInput(opA, CHILD_SEAT), 'en')
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear()
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Picked note' } },
+        'en',
+      )
+      expect(fillSpy).not.toHaveBeenCalled()
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ en: 'Picked note' })
+    })
+```
+
+- [ ] **Step 2: Run to verify the fill/verbatim tests fail**
+
+Run: `bun run --filter @kuruma/api test add-on.test`
+Expected: FAIL — `update` currently stores `descriptionOverride` verbatim, so the "re-fills en/zh" test fails (bag has only `en`). The verbatim/skip tests may already pass; the fill test must be RED.
+
+- [ ] **Step 3: Implement the update-path resolve**
+
+In `packages/api/src/services/add-on.ts`, in `update`, replace the `const fields: AddOnUpdate & { name?: string } = { ...data }` line and add the description resolve BEFORE the name re-seal block:
+
+```ts
+    const fields: AddOnUpdate & { name?: string } = { ...data }
+
+    // #1318: MT-fill on a self-authored description change. `undefined` means the
+    // field is untouched — leave the stored bag alone (and never translate on a
+    // price-only edit). A picked row / cleared bag / absent source slot stores
+    // verbatim (see resolveDescriptionOverride).
+    if (data.descriptionOverride !== undefined) {
+      fields.descriptionOverride = await this.resolveDescriptionOverride(
+        existing.templateId === null,
+        locale,
+        data.descriptionOverride,
+        existing.descriptionOverride,
+      )
+    }
+```
+
+(The subsequent `if (data.nameI18n) { ... }` name re-seal block and the `try { repo.update(ctx, id, fields) ... }` are unchanged.)
+
+- [ ] **Step 4: Run to verify all update tests pass**
+
+Run: `bun run --filter @kuruma/api test add-on.test`
+Expected: PASS (all create + update cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/services/add-on.ts packages/api/tests/services/add-on.test.ts
+git commit -m "feat(#1318): MT-fill self-authored descriptions on update, skip-on-unchanged"
+```
+
+---
+
+## Task 4: Wiring guard — real translator MT-fills through the composed app (MEDIUM-3)
+
+Boots the real `createApp` (no `GOOGLE_TRANSLATE_API_KEY` → dev stub returns `[<locale>] <text>`) and proves the create path actually MT-fills end-to-end. Mirrors `shared-catalog-killswitch-wired.test.ts`.
+
+**Files:**
+- Create: `packages/api/tests/routes/add-on-description-mt-wired.test.ts`
+
+- [ ] **Step 1: Write the guard test**
+
+```ts
+import { seedId } from '@kuruma/shared/db/seed-id'
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+// #1318 MEDIUM-3: the service unit tests inject a fake translator, so they cannot
+// catch a composition-root regression (a no-op translator wired by mistake, or the
+// create path never invoking it). This boots the REAL app — no API key, so the dev
+// stub fills `[<locale>] <text>` — and asserts a self-authored create is MT-filled.
+describe('add-on description MT is wired into the composed app (#1318)', () => {
+  it('fills ja/zh for a self-authored description via the real translator', async () => {
+    setupAuthEnv()
+    const app = await createApp({})
+    const res = await app.request('/add-ons', {
+      method: 'POST',
+      headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nameI18n: { en: 'Fast wifi' },
+        descriptionOverride: { en: 'Pocket wifi router' },
+        priceJpy: 500,
+        operatorId: seedId('op_mt_wiring'),
+      }),
+    })
+    expect(res.status).toBe(201)
+    const { data } = (await res.json()) as { data: { descriptionOverride: Record<string, string> } }
+    expect(data.descriptionOverride).toEqual({
+      en: 'Pocket wifi router',
+      ja: '[ja] Pocket wifi router',
+      zh: '[zh] Pocket wifi router',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `bun run --filter @kuruma/api test add-on-description-mt-wired`
+Expected: PASS. (Guard test — green on write; its value is catching a future un-wiring. If it fails, the dev stub env assumption or the create wiring is wrong; do not weaken the assertion.)
+
+Sabotage check: temporarily swap the real translator in `index.ts` for `{ fill: async (l, t) => ({ [l]: t }) }` and confirm this test goes RED, then restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/api/tests/routes/add-on-description-mt-wired.test.ts
+git commit -m "test(#1318): wiring guard proves the real description translator MT-fills"
+```
+
+---
+
+## Task 5: Web — thread the operator locale into add-on writes
+
+Fixes a latent bug too: today the write response resolves to `en` regardless of the operator's locale, because no locale rides the POST/PATCH.
+
+**Files:**
+- Modify: `packages/web/src/vite/operator-add-ons/api.ts`
+- Modify: `packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx`, `EditAddOnDialog.tsx`
+- Test: `packages/web/src/vite/operator-add-ons/api.test.ts`
+
+- [ ] **Step 1: Write the failing web test**
+
+Create `packages/web/src/vite/operator-add-ons/api.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { createAddOn, updateAddOn } from './api'
+
+const addOn = {
+  id: 'ao_1',
+  operatorId: 'op_1',
+  templateId: null,
+  resolvedName: 'GPS',
+  resolvedDescription: 'desc',
+  descriptionOverride: { en: 'desc' },
+  nameI18n: { en: 'GPS' },
+  priceJpy: 1500,
+  status: 'ACTIVE',
+}
+
+function mockOk() {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ success: true, data: addOn }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  )
+}
+
+describe('operator add-on write api threads the locale', () => {
+  it('createAddOn appends ?locale so the server knows the Model-B source locale', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await createAddOn({ nameI18n: { en: 'GPS' }, priceJpy: 1500, operatorId: 'op_1' }, 'csrf', 'ja')
+    expect(f.mock.calls[0]?.[0]).toContain('locale=ja')
+  })
+
+  it('updateAddOn carries the locale alongside any operatorId', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await updateAddOn('ao_1', { priceJpy: 2000 }, 'csrf', 'op_1', 'zh')
+    const url = f.mock.calls[0]?.[0] as string
+    expect(url).toContain('operatorId=op_1')
+    expect(url).toContain('locale=zh')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun run --filter @kuruma/web test operator-add-ons/api.test`
+Expected: FAIL — `createAddOn`/`updateAddOn` do not accept a `locale` arg / do not append it.
+
+- [ ] **Step 3: Implement the locale threading in `api.ts`**
+
+Replace the `operatorQuery` helper and the two write functions:
+
+```ts
+// #1456 (operatorId) + #1318 (locale): compose the write query. `?operatorId=` binds
+// a picker admin's PATCH/DELETE; `?locale=` tells the server the Model-B source locale
+// (and resolves the write response to the operator's UI locale).
+function writeQuery(pickedOperatorId?: string, locale?: Locale): string {
+  const params = new URLSearchParams()
+  if (pickedOperatorId) params.set('operatorId', pickedOperatorId)
+  if (locale) params.set('locale', locale)
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export async function createAddOn(
+  input: WithOperatorId<CreateAddOnInput>,
+  csrfToken: string,
+  locale?: Locale,
+): Promise<OperatorAddOnData> {
+  return writeJson(`/add-ons${writeQuery(undefined, locale)}`, 'POST', input, csrfToken)
+}
+
+export async function updateAddOn(
+  id: string,
+  input: UpdateAddOnInput,
+  csrfToken: string,
+  pickedOperatorId?: string,
+  locale?: Locale,
+): Promise<OperatorAddOnData> {
+  const path = `/add-ons/${encodeURIComponent(id)}${writeQuery(pickedOperatorId, locale)}`
+  return writeJson(path, 'PATCH', input, csrfToken)
+}
+```
+
+Update `archiveAddOn` to reuse `writeQuery` for its `operatorId` (no locale needed — archive does not touch descriptions):
+
+```ts
+export async function archiveAddOn(
+  id: string,
+  csrfToken: string,
+  pickedOperatorId?: string,
+): Promise<OperatorAddOnData> {
+  const path = `/add-ons/${encodeURIComponent(id)}${writeQuery(pickedOperatorId)}`
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: { 'X-CSRF-Token': csrfToken },
+  })
+  return unwrap(res, addOnSchema)
+}
+```
+
+Delete the now-unused `operatorQuery` function. `Locale` is already imported at the top of `api.ts`.
+
+- [ ] **Step 4: Pass `locale` from the dialogs**
+
+In `packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx`, change the mutationFn (L48):
+
+```ts
+    mutationFn: (data: WithOperatorId<CreateAddOnInput>) => createAddOn(data, csrfToken, locale),
+```
+
+In `packages/web/src/vite/operator-add-ons/EditAddOnDialog.tsx`, change the mutationFn (L38-39):
+
+```ts
+    mutationFn: (data: UpdateAddOnInput) =>
+      updateAddOn(addOn?.id ?? '', data, csrfToken, pickedOperatorId, locale),
+```
+
+(Both dialogs already compute `const locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE`.)
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `bun run --filter @kuruma/web test operator-add-ons`
+Expected: PASS (new api.test + existing description-override/name-bundle tests).
+Run: `bunx tsc --noEmit -p packages/web`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/web/src/vite/operator-add-ons/api.ts \
+  packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx \
+  packages/web/src/vite/operator-add-ons/EditAddOnDialog.tsx \
+  packages/web/src/vite/operator-add-ons/api.test.ts
+git commit -m "feat(#1318): thread operator locale into add-on writes (Model-B source)"
+```
+
+---
+
+## Task 6: Full verification
+
+- [ ] **Step 1: API + shared + web suites**
+
+Run: `bun run --filter @kuruma/api test && bun run --filter @kuruma/web test`
+Expected: all green.
+
+- [ ] **Step 2: Typecheck, lint, boundaries, size**
+
+Run: `bunx tsc --noEmit -p packages/api && bunx tsc --noEmit -p packages/web && bun run lint && bun run --filter @kuruma/api lint:boundaries && bun run lint:size`
+Expected: clean. `description-translation.ts` imports `@sentry/cloudflare` (a boundary-neutral infra import, same as `error-handlers.ts`); the layer lint only guards routes→services→repositories direction.
+
+- [ ] **Step 3: Rebase + push + PR**
+
+```bash
+git fetch origin && git rebase origin/develop
+git push -u origin feat/1318-addon-description-mt
+```
+
+Open the PR: `Refs #1318` (the epic stays open — this is the add-on-description slice only; insurance + location MT remain deferred). Body: link the design doc, list HIGH-1/HIGH-2/MEDIUM-3/4/5 coverage, note the accepted limitations (MT owns non-source locales; editing under a different UI locale re-bases the source).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- MT on save into remaining SUPPORTED_LOCALES → Task 1 (fill) + Task 2 (create) + Task 3 (update).
+- Best-effort, silent-on-save → Task 1 (allSettled, drop-and-log) + Task 3 (failure-safe test).
+- Model B single-source, refreshed → Task 2/3 (fill on each save from `bag[locale]`).
+- Author-time persist → create/update write the filled bag; reads unchanged.
+- Source = `?locale=` → route already threads it; service param `locale` is the source.
+- HIGH-1 picked verbatim → `resolveDescriptionOverride` guard + create/update tests.
+- HIGH-2 no coercion / source-agnostic → `if (!sourceText) return incoming` + create test.
+- MEDIUM-3 required param + wired-test → Task 2 constructor + Task 4.
+- MEDIUM-4 console.error + Sentry → Task 1 impl + drop test.
+- MEDIUM-5 wire in index.ts:498 → Task 2 Step 3.
+- LOW-6 bounded deadline → parallel allSettled (documented as the cap; no extra timer, YAGNI).
+- NIT-7 dev stub `[ja] …` persistence → surfaced by the Task 4 wiring assertion (expected).
+- Web `&locale=` → Task 5.
+
+**Placeholder scan:** none — every code step carries full code.
+
+**Type consistency:** `DescriptionTranslator.fill(sourceLocale, sourceText)` and `resolveDescriptionOverride(isSelfAuthored, locale, incoming, existingBag)` signatures match across Tasks 1-3; `writeQuery(pickedOperatorId?, locale?)` used consistently in Task 5. Constructor arg order (repo, templateRepo, descriptionTranslator, isSharedCatalogEnabled) is identical at every rewired site.
+</content>
+</invoke>

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -93,6 +93,7 @@ import { ConsentGateService } from './services/consent-gate'
 import { ConsentGovernanceService } from './services/consent-governance'
 import { resolveSigningKey } from './services/consent-signing'
 import { CustomerService } from './services/customer'
+import { MachineDescriptionTranslator } from './services/description-translation'
 import { documentVerificationGate } from './services/document-verification-gate'
 import type { EmailSender } from './services/email/email-sender'
 import { makeEnsureThread } from './services/ensure-thread'
@@ -495,7 +496,12 @@ export function createApp(overrides?: AppOverrides, repos: Repos = buildRepos(ov
   // off) and the add-on create path (reject a templateId when off) gate on ONE narrow
   // thunk (ISP) rather than the whole FeatureFlagsService.
   const isSharedCatalogEnabled = () => featureFlagsService.isEnabled('SHARED_CATALOG')
-  const addOnService = new AddOnService(addOnRepo, addOnTemplateRepo, isSharedCatalogEnabled)
+  const addOnService = new AddOnService(
+    addOnRepo,
+    addOnTemplateRepo,
+    new MachineDescriptionTranslator(translationProvider),
+    isSharedCatalogEnabled,
+  )
   const addOnTemplateService = new AddOnTemplateService(
     addOnTemplateRepo,
     addOnRepo,

--- a/packages/api/src/services/add-on.ts
+++ b/packages/api/src/services/add-on.ts
@@ -17,6 +17,7 @@ import {
   fleetWriteDenialResult,
 } from '../tenancy'
 import { resolveAddOnDescription, resolveAddOnName } from './add-on-resolve'
+import type { DescriptionTranslator } from './description-translation'
 
 export type AddOnResult =
   | { ok: true; option: OperatorAddOnData }
@@ -91,6 +92,10 @@ export class AddOnService {
   constructor(
     private readonly repo: AddOnRepository,
     private readonly templateRepo: AddOnTemplateRepository,
+    // #1318: REQUIRED (no default). A no-op default would fail to degraded output
+    // (source-only, no error) on a forgotten wiring; a required param fails at
+    // compile time instead. Wired in index.ts; tests pass a fake explicitly.
+    private readonly descriptionTranslator: DescriptionTranslator,
     private readonly isSharedCatalogEnabled: () => Promise<boolean> = () => Promise.resolve(true),
   ) {}
 
@@ -114,6 +119,28 @@ export class AddOnService {
   }
 
   /**
+   * Model B fill (#1318). MT owns the non-source locales of a SELF-AUTHORED
+   * description, refreshed on every save. Returns the bag to persist.
+   *
+   * - Picked rows (HIGH-1): verbatim — their other locales resolve through the
+   *   curated template description; MT would shadow human text with machine text.
+   * - No source slot (HIGH-2): verbatim — `?locale=` defaults to `en` and the API
+   *   is source-agnostic (Trip.com), so a ja-only bag sent without `?locale=ja`
+   *   must not be coerced to null / re-based.
+   */
+  private async resolveDescriptionOverride(
+    isSelfAuthored: boolean,
+    locale: Locale,
+    incoming: LocalizedTextOverride | null,
+  ): Promise<LocalizedTextOverride | null> {
+    if (!isSelfAuthored) return incoming
+    if (incoming === null) return null
+    const sourceText = incoming[locale]
+    if (!sourceText) return incoming
+    return this.descriptionTranslator.fill(locale, sourceText)
+  }
+
+  /**
    * `data.operatorId` is resolved by the route (resolveOperatorIdForWrite), so the
    * service stays auth-mechanism-agnostic. A create is PICKED (`templateId`) or
    * SELF-AUTHORED (`nameI18n`) — the route validator guarantees exactly one; branch
@@ -121,7 +148,13 @@ export class AddOnService {
    * for callers that bypass the validator (never null-name-insert).
    */
   async create(_ctx: CallerContext, data: AddOnCreate, locale: Locale): Promise<AddOnResult> {
-    if (data.nameI18n) return this.createSelfAuthored(data, data.nameI18n, locale)
+    const descriptionOverride = await this.resolveDescriptionOverride(
+      data.nameI18n != null,
+      locale,
+      data.descriptionOverride,
+    )
+    const resolved: AddOnCreate = { ...data, descriptionOverride }
+    if (data.nameI18n) return this.createSelfAuthored(resolved, data.nameI18n, locale)
     if (data.templateId) {
       // Kill-switch: picking from the shared catalog is server-enforced. When off, the
       // operator must self-author (the escape hatch above stays open). Checked here, so
@@ -131,7 +164,7 @@ export class AddOnService {
       if (!(await this.isSharedCatalogEnabled())) {
         return { ok: false, error: CATALOG_DISABLED_MESSAGE, status: 422 }
       }
-      return this.createFromTemplate(data, data.templateId, locale)
+      return this.createFromTemplate(resolved, data.templateId, locale)
     }
     return { ok: false, error: MISSING_IDENTITY_MESSAGE, status: 400 }
   }

--- a/packages/api/src/services/add-on.ts
+++ b/packages/api/src/services/add-on.ts
@@ -1,4 +1,4 @@
-import type { Locale } from '@kuruma/shared/i18n/locales'
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
 import type { LocalizedText, LocalizedTextOverride } from '@kuruma/shared/i18n/localized-text'
 import type { ErrorCode } from '@kuruma/shared/lib/error-codes'
 import type { OperatorAddOnData } from '@kuruma/shared/types/add-on'
@@ -65,6 +65,14 @@ const NOT_FOUND_MESSAGE = 'Add-on not found'
 
 const isUniqueViolation = (err: unknown): boolean => pgErrorCode(err) === PG_ERROR.UNIQUE_VIOLATION
 
+// A description bag is COMPLETE when every supported locale carries text. Skips
+// re-translation on an unchanged self-authored save; an INCOMPLETE stored bag (a
+// prior save dropped a locale) therefore retries MT. noUncheckedIndexedAccess:
+// bag[locale] is string | undefined.
+function isDescriptionComplete(bag: LocalizedTextOverride): boolean {
+  return SUPPORTED_LOCALES.every((locale) => Boolean(bag[locale]))
+}
+
 /**
  * Project a joined read row to the operator wire DTO, resolving the template
  * name/description to the caller locale (catalog i18n slice 2). The multi-locale
@@ -127,16 +135,21 @@ export class AddOnService {
    * - No source slot (HIGH-2): verbatim — `?locale=` defaults to `en` and the API
    *   is source-agnostic (Trip.com), so a ja-only bag sent without `?locale=ja`
    *   must not be coerced to null / re-based.
+   * - Unchanged source + complete stored bag (update): keep the stored bag, no MT.
    */
   private async resolveDescriptionOverride(
     isSelfAuthored: boolean,
     locale: Locale,
     incoming: LocalizedTextOverride | null,
+    existingBag: LocalizedTextOverride | null,
   ): Promise<LocalizedTextOverride | null> {
     if (!isSelfAuthored) return incoming
     if (incoming === null) return null
     const sourceText = incoming[locale]
     if (!sourceText) return incoming
+    if (existingBag && existingBag[locale] === sourceText && isDescriptionComplete(existingBag)) {
+      return existingBag
+    }
     return this.descriptionTranslator.fill(locale, sourceText)
   }
 
@@ -152,6 +165,7 @@ export class AddOnService {
       data.nameI18n != null,
       locale,
       data.descriptionOverride,
+      null,
     )
     const resolved: AddOnCreate = { ...data, descriptionOverride }
     if (data.nameI18n) return this.createSelfAuthored(resolved, data.nameI18n, locale)
@@ -291,6 +305,20 @@ export class AddOnService {
         }
       }
       fields.name = nextName
+    }
+
+    // #1318: MT-fill on a self-authored description change. Runs AFTER the name
+    // dup-check so a 409 name clash doesn't waste a ~6s provider round-trip.
+    // `undefined` = field untouched (never translate on a price-only edit). A
+    // picked row / cleared bag / absent source slot stores verbatim; MT owns the
+    // non-source locales, so a caller's non-source values are re-derived (Model B).
+    if (data.descriptionOverride !== undefined) {
+      fields.descriptionOverride = await this.resolveDescriptionOverride(
+        existing.templateId === null,
+        locale,
+        data.descriptionOverride,
+        existing.descriptionOverride,
+      )
     }
 
     try {

--- a/packages/api/src/services/description-translation.ts
+++ b/packages/api/src/services/description-translation.ts
@@ -1,0 +1,48 @@
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import type { LocalizedTextOverride } from '@kuruma/shared/i18n/localized-text'
+import * as Sentry from '@sentry/cloudflare'
+import type { TranslationProvider } from './translation-provider'
+
+/**
+ * Fills an add-on description override so every locale carries text. Model B
+ * (#1318): the operator authors one locale; this re-derives the others by MT on
+ * every save. Best-effort — a locale whose provider call fails is omitted and the
+ * reader falls back via resolveOwnDescription; it is never fatal to the save.
+ */
+export interface DescriptionTranslator {
+  fill(sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride>
+}
+
+export class MachineDescriptionTranslator implements DescriptionTranslator {
+  constructor(private readonly provider: TranslationProvider) {}
+
+  async fill(sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> {
+    // Non-source locales in parallel: total wall-clock ≈ one provider call
+    // (TIMEOUT_MS × MAX_ATTEMPTS ≈ 6s), not the sum (LOW-6). allSettled so one
+    // rejection never sinks the others.
+    const targets = SUPPORTED_LOCALES.filter((locale) => locale !== sourceLocale)
+    const settled = await Promise.allSettled(
+      targets.map((target) => this.provider.translate(sourceText, sourceLocale, target)),
+    )
+
+    const bag: LocalizedTextOverride = { [sourceLocale]: sourceText }
+    for (const [index, result] of settled.entries()) {
+      const target = targets[index]
+      if (!target) continue
+      if (result.status === 'fulfilled') {
+        bag[target] = result.value.translatedText
+      } else {
+        // MEDIUM-4: never a fully-silent drop. Request obs only reports 5xx/slow,
+        // so a GOOGLE_TRANSLATE_API_KEY drift would degrade every save with no
+        // signal. Parity with message-translation.ts, plus Sentry.
+        console.error('Add-on description translation failed', {
+          sourceLocale,
+          target,
+          err: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        })
+        Sentry.captureException(result.reason)
+      }
+    }
+    return bag
+  }
+}

--- a/packages/api/src/services/description-translation.ts
+++ b/packages/api/src/services/description-translation.ts
@@ -29,19 +29,27 @@ export class MachineDescriptionTranslator implements DescriptionTranslator {
     for (const [index, result] of settled.entries()) {
       const target = targets[index]
       if (!target) continue
-      if (result.status === 'fulfilled') {
-        bag[target] = result.value.translatedText
-      } else {
-        // MEDIUM-4: never a fully-silent drop. Request obs only reports 5xx/slow,
-        // so a GOOGLE_TRANSLATE_API_KEY drift would degrade every save with no
-        // signal. Parity with message-translation.ts, plus Sentry.
-        console.error('Add-on description translation failed', {
-          sourceLocale,
-          target,
-          err: result.reason instanceof Error ? result.reason.message : String(result.reason),
-        })
-        Sentry.captureException(result.reason)
+
+      const translated = result.status === 'fulfilled' ? result.value.translatedText.trim() : ''
+      if (translated) {
+        bag[target] = translated
+        continue
       }
+
+      // Drop a rejected leg OR an empty/whitespace machine result so the reader
+      // falls through to the source: resolveOwnDescription treats an ABSENT locale
+      // (not '') as the fallback trigger, so persisting '' would render blank for
+      // that reader — puncturing the same non-empty guarantee the inbound Zod
+      // `.min(1)` enforces. MEDIUM-4: never a fully-silent drop — a key/API drift
+      // would otherwise degrade every save with no signal.
+      const reason =
+        result.status === 'rejected' ? result.reason : new Error(`empty translation (${target})`)
+      console.error('Add-on description translation failed', {
+        sourceLocale,
+        target,
+        err: reason instanceof Error ? reason.message : String(reason),
+      })
+      Sentry.captureException(reason)
     }
     return bag
   }

--- a/packages/api/tests/helpers/fake-translator.ts
+++ b/packages/api/tests/helpers/fake-translator.ts
@@ -18,3 +18,12 @@ export function fakeDescriptionTranslator(): DescriptionTranslator {
     },
   }
 }
+
+/** Simulates a total provider outage: fill returns only the source slot. */
+export function sourceOnlyTranslator(): DescriptionTranslator {
+  return {
+    fill: async (sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> => ({
+      [sourceLocale]: sourceText,
+    }),
+  }
+}

--- a/packages/api/tests/helpers/fake-translator.ts
+++ b/packages/api/tests/helpers/fake-translator.ts
@@ -1,0 +1,20 @@
+import { type Locale, SUPPORTED_LOCALES } from '@kuruma/shared/i18n/locales'
+import type { LocalizedTextOverride } from '@kuruma/shared/i18n/localized-text'
+import type { DescriptionTranslator } from '../../src/services/description-translation'
+
+/**
+ * Deterministic test double: source verbatim, every other locale `<locale>:<text>`.
+ * Mutation-resistant — tests assert the exact filled value. Spy with
+ * `vi.spyOn(translator, 'fill')` to assert zero-call (skip / picked / verbatim) paths.
+ */
+export function fakeDescriptionTranslator(): DescriptionTranslator {
+  return {
+    fill: async (sourceLocale: Locale, sourceText: string): Promise<LocalizedTextOverride> => {
+      const bag: LocalizedTextOverride = { [sourceLocale]: sourceText }
+      for (const locale of SUPPORTED_LOCALES) {
+        if (locale !== sourceLocale) bag[locale] = `${locale}:${sourceText}`
+      }
+      return bag
+    },
+  }
+}

--- a/packages/api/tests/integration/add-on-repo.test.ts
+++ b/packages/api/tests/integration/add-on-repo.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../src/repositories/drizzle'
 import { AddOnService } from '../../src/services/add-on'
 import type { AddOn } from '../../src/stores'
+import { fakeDescriptionTranslator } from '../helpers/fake-translator'
 import { db } from './setup'
 
 // Catalog i18n (slice 2) against real Postgres. Proves what the in-memory double
@@ -141,7 +142,11 @@ describe('add-on template FK + active-template uniqueness (Drizzle)', () => {
 })
 
 describe('add-on self-authored path (#1437, Drizzle)', () => {
-  const service = new AddOnService(repo, new DrizzleAddOnTemplateRepository(db))
+  const service = new AddOnService(
+    repo,
+    new DrizzleAddOnTemplateRepository(db),
+    fakeDescriptionTranslator(),
+  )
 
   it('round-trips a self-authored nameI18n bundle through jsonb (no template)', async () => {
     const bundle = { en: 'GPS unit', ja: 'GPS ユニット', zh: 'GPS 装置' }
@@ -191,7 +196,11 @@ describe('add-on self-authored path (#1437, Drizzle)', () => {
 })
 
 describe('add-on ?locale= resolution through the service (Drizzle)', () => {
-  const service = new AddOnService(repo, new DrizzleAddOnTemplateRepository(db))
+  const service = new AddOnService(
+    repo,
+    new DrizzleAddOnTemplateRepository(db),
+    fakeDescriptionTranslator(),
+  )
 
   it('resolves the template name to the requested locale on create', async () => {
     const res = await service.create(

--- a/packages/api/tests/routes/add-on-description-mt-wired.test.ts
+++ b/packages/api/tests/routes/add-on-description-mt-wired.test.ts
@@ -1,0 +1,32 @@
+import { seedId } from '@kuruma/shared/db/seed-id'
+import { describe, expect, it } from 'vitest'
+import { createApp } from '../../src/index'
+import { authHeaders, setupAuthEnv } from '../helpers/auth'
+
+// #1318 MEDIUM-3: the service unit tests inject a fake translator, so they cannot
+// catch a composition-root regression (a no-op translator wired by mistake, or the
+// create path never invoking it). This boots the REAL app — no API key, so the dev
+// stub fills `[<locale>] <text>` — and asserts a self-authored create is MT-filled.
+describe('add-on description MT is wired into the composed app (#1318)', () => {
+  it('fills ja/zh for a self-authored description via the real translator', async () => {
+    setupAuthEnv()
+    const app = await createApp({})
+    const res = await app.request('/add-ons', {
+      method: 'POST',
+      headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nameI18n: { en: 'Fast wifi' },
+        descriptionOverride: { en: 'Pocket wifi router' },
+        priceJpy: 500,
+        operatorId: seedId('op_mt_wiring'),
+      }),
+    })
+    expect(res.status).toBe(201)
+    const { data } = (await res.json()) as { data: { descriptionOverride: Record<string, string> } }
+    expect(data.descriptionOverride).toEqual({
+      en: 'Pocket wifi router',
+      ja: '[ja] Pocket wifi router',
+      zh: '[zh] Pocket wifi router',
+    })
+  })
+})

--- a/packages/api/tests/routes/add-ons.test.ts
+++ b/packages/api/tests/routes/add-ons.test.ts
@@ -10,6 +10,7 @@ import {
 import { createAddOnRoutes } from '../../src/routes/add-ons'
 import { AddOnService } from '../../src/services/add-on'
 import { testAuthMiddleware } from '../helpers/auth'
+import { fakeDescriptionTranslator } from '../helpers/fake-translator'
 import { testResolveWriteOperatorId } from '../helpers/operator'
 
 const OP_A = 'operator-aaaaaaaa'
@@ -26,7 +27,7 @@ function mountFor(repo: InMemoryAddOnRepository, role: UserRole, operatorId?: st
   app.route(
     '/',
     createAddOnRoutes(
-      new AddOnService(repo, new InMemoryAddOnTemplateRepository()),
+      new AddOnService(repo, new InMemoryAddOnTemplateRepository(), fakeDescriptionTranslator()),
       testResolveWriteOperatorId(),
     ),
   )
@@ -59,7 +60,11 @@ describe('Add-on routes — auth', () => {
     app.route(
       '/',
       createAddOnRoutes(
-        new AddOnService(new InMemoryAddOnRepository(), new InMemoryAddOnTemplateRepository()),
+        new AddOnService(
+          new InMemoryAddOnRepository(),
+          new InMemoryAddOnTemplateRepository(),
+          fakeDescriptionTranslator(),
+        ),
         testResolveWriteOperatorId(),
       ),
     )

--- a/packages/api/tests/services/add-on-template.test.ts
+++ b/packages/api/tests/services/add-on-template.test.ts
@@ -8,6 +8,7 @@ import {
 import { AddOnService } from '../../src/services/add-on'
 import { AddOnTemplateService } from '../../src/services/add-on-template'
 import type { AddOnTemplate } from '../../src/stores'
+import { fakeDescriptionTranslator } from '../helpers/fake-translator'
 
 const row = (over: Partial<AddOnTemplate>): AddOnTemplate => {
   const now = new Date()
@@ -110,7 +111,7 @@ describe('AddOnTemplateService.listForPicker — already-offered exclusion (P1-3
     addOnRepo = new InMemoryAddOnRepository()
     const templateRepo = new InMemoryAddOnTemplateRepository()
     templateService = new AddOnTemplateService(templateRepo, addOnRepo)
-    addOnService = new AddOnService(addOnRepo, templateRepo)
+    addOnService = new AddOnService(addOnRepo, templateRepo, fakeDescriptionTranslator())
   })
 
   it('excludes a template the target operator already offers on an ACTIVE row', async () => {

--- a/packages/api/tests/services/add-on.test.ts
+++ b/packages/api/tests/services/add-on.test.ts
@@ -7,6 +7,7 @@ import {
   InMemoryAddOnTemplateRepository,
 } from '../../src/repositories/in-memory'
 import { AddOnService } from '../../src/services/add-on'
+import { fakeDescriptionTranslator } from '../helpers/fake-translator'
 
 const uniqueViolation = () =>
   Object.assign(new Error('duplicate key value violates unique constraint'), {
@@ -52,7 +53,11 @@ describe('AddOnService', () => {
 
   beforeEach(() => {
     repo = new InMemoryAddOnRepository()
-    service = new AddOnService(repo, new InMemoryAddOnTemplateRepository())
+    service = new AddOnService(
+      repo,
+      new InMemoryAddOnTemplateRepository(),
+      fakeDescriptionTranslator(),
+    )
   })
 
   describe('create', () => {
@@ -113,6 +118,7 @@ describe('AddOnService', () => {
       const svc = new AddOnService(
         new InMemoryAddOnRepository(),
         new InMemoryAddOnTemplateRepository(store),
+        fakeDescriptionTranslator(),
       )
       const result = await svc.create(ctxFor(opA), createInput(opA, ETC_CARD), LOCALE)
       expect(result.ok).toBe(false)
@@ -152,8 +158,11 @@ describe('AddOnService', () => {
     })
 
     it('rejects a template-picked create when the shared catalog is disabled (#1437)', async () => {
-      const off = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), () =>
-        Promise.resolve(false),
+      const off = new AddOnService(
+        repo,
+        new InMemoryAddOnTemplateRepository(),
+        fakeDescriptionTranslator(),
+        () => Promise.resolve(false),
       )
       const result = await off.create(ctxFor(opA), createInput(opA, CHILD_SEAT), LOCALE)
       expect(result.ok).toBe(false)
@@ -165,8 +174,11 @@ describe('AddOnService', () => {
 
     it('still allows a self-authored create when the shared catalog is disabled (#1437)', async () => {
       // The escape hatch must survive the kill-switch: operators can always self-author.
-      const off = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), () =>
-        Promise.resolve(false),
+      const off = new AddOnService(
+        repo,
+        new InMemoryAddOnTemplateRepository(),
+        fakeDescriptionTranslator(),
+        () => Promise.resolve(false),
       )
       const result = await off.create(
         ctxFor(opA),
@@ -216,6 +228,70 @@ describe('AddOnService', () => {
         expect(result.status).toBe(409)
         expect(result.error).toBe('You already offer an add-on with this name')
       }
+    })
+
+    it('fills en/zh from a ja-authored self-authored description (Model B)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const result = await svc.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          nameI18n: { en: 'GPS unit' },
+          descriptionOverride: { ja: 'ポータブルGPS' },
+          priceJpy: 1500,
+        },
+        'ja',
+      )
+      expect(fillSpy).toHaveBeenCalledWith('ja', 'ポータブルGPS')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({
+          ja: 'ポータブルGPS',
+          en: 'en:ポータブルGPS',
+          zh: 'zh:ポータブルGPS',
+        })
+      }
+    })
+
+    it('stores a PICKED row description VERBATIM — no MT (HIGH-1)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const result = await svc.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          templateId: CHILD_SEAT,
+          descriptionOverride: { en: 'My note' },
+          priceJpy: 1500,
+        },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ en: 'My note' })
+      expect(fillSpy).not.toHaveBeenCalled()
+    })
+
+    it('stores a self-authored bag VERBATIM when the ?locale slot is absent (HIGH-2)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      // ja-only bag, but ?locale defaults to en -> sourceText = bag.en = undefined.
+      const result = await svc.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          nameI18n: { en: 'GPS' },
+          descriptionOverride: { ja: '日本語のみ' },
+          priceJpy: 1500,
+        },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ ja: '日本語のみ' })
+      expect(fillSpy).not.toHaveBeenCalled()
     })
   })
 
@@ -359,7 +435,11 @@ describe('AddOnService — update/archive bind to the picked operator (#1456)', 
 
   beforeEach(() => {
     repo = new InMemoryAddOnRepository()
-    service = new AddOnService(repo, new InMemoryAddOnTemplateRepository())
+    service = new AddOnService(
+      repo,
+      new InMemoryAddOnTemplateRepository(),
+      fakeDescriptionTranslator(),
+    )
   })
 
   // Self-authored so the seed needs no template setup and survives the kill-switch.

--- a/packages/api/tests/services/add-on.test.ts
+++ b/packages/api/tests/services/add-on.test.ts
@@ -7,7 +7,7 @@ import {
   InMemoryAddOnTemplateRepository,
 } from '../../src/repositories/in-memory'
 import { AddOnService } from '../../src/services/add-on'
-import { fakeDescriptionTranslator } from '../helpers/fake-translator'
+import { fakeDescriptionTranslator, sourceOnlyTranslator } from '../helpers/fake-translator'
 
 const uniqueViolation = () =>
   Object.assign(new Error('duplicate key value violates unique constraint'), {
@@ -390,6 +390,124 @@ describe('AddOnService', () => {
       )
       expect(result.ok).toBe(false)
       if (!result.ok) expect(result.status).toBe(409)
+    })
+
+    it('re-fills en/zh when a self-authored description changes (Model B)', async () => {
+      const created = await service.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: null, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      const result = await service.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'New copy' } },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({
+          en: 'New copy',
+          ja: 'ja:New copy',
+          zh: 'zh:New copy',
+        })
+      }
+    })
+
+    it('does NOT re-translate when the source is unchanged and the bag is complete', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          nameI18n: { en: 'GPS' },
+          descriptionOverride: { en: 'Copy' },
+          priceJpy: 1500,
+        },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear() // ignore the create-time fill
+      // The web client re-sends the full merged bag; source slot unchanged.
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Copy', ja: 'ja:Copy', zh: 'zh:Copy' } },
+        'en',
+      )
+      expect(fillSpy).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.option.descriptionOverride).toEqual({
+          en: 'Copy',
+          ja: 'ja:Copy',
+          zh: 'zh:Copy',
+        })
+      }
+    })
+
+    it('does NOT translate on a price-only update (descriptionOverride untouched)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(
+        ctxFor(opA),
+        {
+          operatorId: opA,
+          nameI18n: { en: 'GPS' },
+          descriptionOverride: { en: 'Copy' },
+          priceJpy: 1500,
+        },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear()
+      await svc.update(ctxFor(opA), created.option.id, { priceJpy: 3000 }, 'en')
+      expect(fillSpy).not.toHaveBeenCalled()
+    })
+
+    it('persists the source slot and returns ok when every translation fails', async () => {
+      const svc = new AddOnService(
+        repo,
+        new InMemoryAddOnTemplateRepository(),
+        sourceOnlyTranslator(),
+      )
+      const created = await svc.create(
+        ctxFor(opA),
+        { operatorId: opA, nameI18n: { en: 'GPS' }, descriptionOverride: null, priceJpy: 1500 },
+        'en',
+      )
+      if (!created.ok) throw new Error('seed failed')
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Only English survives' } },
+        'en',
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok)
+        expect(result.option.descriptionOverride).toEqual({ en: 'Only English survives' })
+    })
+
+    it('stores a PICKED row description update VERBATIM — no MT (HIGH-1)', async () => {
+      const translator = fakeDescriptionTranslator()
+      const fillSpy = vi.spyOn(translator, 'fill')
+      const svc = new AddOnService(repo, new InMemoryAddOnTemplateRepository(), translator)
+      const created = await svc.create(ctxFor(opA), createInput(opA, CHILD_SEAT), 'en')
+      if (!created.ok) throw new Error('seed failed')
+      fillSpy.mockClear()
+      const result = await svc.update(
+        ctxFor(opA),
+        created.option.id,
+        { descriptionOverride: { en: 'Picked note' } },
+        'en',
+      )
+      expect(fillSpy).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.option.descriptionOverride).toEqual({ en: 'Picked note' })
     })
   })
 

--- a/packages/api/tests/services/description-translation.test.ts
+++ b/packages/api/tests/services/description-translation.test.ts
@@ -44,4 +44,21 @@ describe('MachineDescriptionTranslator.fill', () => {
     expect(errSpy).toHaveBeenCalledOnce()
     expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error))
   })
+
+  it('drops an empty/whitespace machine result so the reader falls through, not blank', async () => {
+    // A '' or whitespace slot is NOT nullish, so resolveOwnDescription would render
+    // it blank instead of falling through — treat it exactly like a failed leg.
+    const blankZh: TranslationProvider = {
+      translate: async (text, source, target) => ({
+        translatedText: target === 'zh' ? '   ' : `${target}<-${text}`,
+        detectedLanguage: source ?? target,
+      }),
+    }
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const translator = new MachineDescriptionTranslator(blankZh)
+    const bag = await translator.fill('ja', 'X')
+    expect(bag).toEqual({ ja: 'X', en: 'en<-X' })
+    expect(errSpy).toHaveBeenCalledOnce()
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error))
+  })
 })

--- a/packages/api/tests/services/description-translation.test.ts
+++ b/packages/api/tests/services/description-translation.test.ts
@@ -1,0 +1,47 @@
+import * as Sentry from '@sentry/cloudflare'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MachineDescriptionTranslator } from '../../src/services/description-translation'
+import type { TranslationProvider } from '../../src/services/translation-provider'
+
+// Mock Sentry so the MEDIUM-4 escalation is observable: without this the error
+// path could drop the `Sentry.captureException` line and CI would stay green.
+vi.mock('@sentry/cloudflare', () => ({ captureException: vi.fn() }))
+
+// Deterministic fake: `<target><-<text>`, echoing the source code back so a
+// mutation to the wiring (wrong source/target) changes the asserted value.
+const echoProvider: TranslationProvider = {
+  translate: async (text, source, target) => ({
+    translatedText: `${target}<-${text}`,
+    detectedLanguage: source ?? target,
+  }),
+}
+
+describe('MachineDescriptionTranslator.fill', () => {
+  // Restore in afterEach (not inline) so an assertion failure can never leak the
+  // console.error spy into another test file; clear the Sentry vi.fn call history.
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('stores the source verbatim and fills every other locale via the provider', async () => {
+    const translator = new MachineDescriptionTranslator(echoProvider)
+    const bag = await translator.fill('ja', 'こんにちは')
+    expect(bag).toEqual({ ja: 'こんにちは', en: 'en<-こんにちは', zh: 'zh<-こんにちは' })
+  })
+
+  it('drops (but logs) a locale whose provider call throws; source survives', async () => {
+    const failingZh: TranslationProvider = {
+      translate: async (text, source, target) => {
+        if (target === 'zh') throw new Error('provider down')
+        return { translatedText: `${target}<-${text}`, detectedLanguage: source ?? target }
+      },
+    }
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const translator = new MachineDescriptionTranslator(failingZh)
+    const bag = await translator.fill('ja', 'X')
+    expect(bag).toEqual({ ja: 'X', en: 'en<-X' })
+    expect(errSpy).toHaveBeenCalledOnce()
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error))
+  })
+})

--- a/packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx
+++ b/packages/web/src/vite/operator-add-ons/AddAddOnDialog.tsx
@@ -45,7 +45,7 @@ export function AddAddOnDialog({ open, onOpenChange, pickedOperatorId }: AddAddO
   })
 
   const { mutateAsync, isPending, error, reset } = useMutation({
-    mutationFn: (data: WithOperatorId<CreateAddOnInput>) => createAddOn(data, csrfToken),
+    mutationFn: (data: WithOperatorId<CreateAddOnInput>) => createAddOn(data, csrfToken, locale),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ADDON_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-add-ons/EditAddOnDialog.tsx
+++ b/packages/web/src/vite/operator-add-ons/EditAddOnDialog.tsx
@@ -36,7 +36,7 @@ export function EditAddOnDialog({ addOn, onOpenChange, pickedOperatorId }: EditA
 
   const { mutateAsync, isPending, error } = useMutation({
     mutationFn: (data: UpdateAddOnInput) =>
-      updateAddOn(addOn?.id ?? '', data, csrfToken, pickedOperatorId),
+      updateAddOn(addOn?.id ?? '', data, csrfToken, pickedOperatorId, locale),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ADDON_QUERY_KEY })
       onOpenChange(false)

--- a/packages/web/src/vite/operator-add-ons/api.test.ts
+++ b/packages/web/src/vite/operator-add-ons/api.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import { archiveAddOn, createAddOn, updateAddOn } from './api'
+
+const addOn = {
+  id: 'ao_1',
+  operatorId: 'op_1',
+  templateId: null,
+  resolvedName: 'GPS',
+  resolvedDescription: 'desc',
+  descriptionOverride: { en: 'desc' },
+  nameI18n: { en: 'GPS' },
+  priceJpy: 1500,
+  status: 'ACTIVE',
+}
+
+function mockOk() {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ success: true, data: addOn }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  )
+}
+
+describe('operator add-on write api threads the locale', () => {
+  it('createAddOn appends ?locale so the server knows the Model-B source locale', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await createAddOn({ nameI18n: { en: 'GPS' }, priceJpy: 1500, operatorId: 'op_1' }, 'csrf', 'ja')
+    expect(f.mock.calls[0]?.[0]).toContain('locale=ja')
+  })
+
+  it('updateAddOn carries the locale alongside any operatorId', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await updateAddOn('ao_1', { priceJpy: 2000 }, 'csrf', 'op_1', 'zh')
+    const url = String(f.mock.calls[0]?.[0] ?? '')
+    expect(url).toContain('operatorId=op_1')
+    expect(url).toContain('locale=zh')
+  })
+
+  it('omits locale entirely when none is passed (no locale=undefined)', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await createAddOn({ nameI18n: { en: 'GPS' }, priceJpy: 1500, operatorId: 'op_1' }, 'csrf')
+    expect(String(f.mock.calls[0]?.[0] ?? '')).not.toContain('locale=')
+  })
+
+  it('archiveAddOn still binds the picked operator after the writeQuery refactor (#1456)', async () => {
+    const f = mockOk()
+    vi.stubGlobal('fetch', f)
+    await archiveAddOn('ao_1', 'csrf', 'op_1')
+    const [url, init] = f.mock.calls[0] ?? []
+    expect(String(url ?? '')).toContain('operatorId=op_1')
+    expect(init).toMatchObject({ method: 'DELETE' })
+  })
+})

--- a/packages/web/src/vite/operator-add-ons/api.ts
+++ b/packages/web/src/vite/operator-add-ons/api.ts
@@ -95,20 +95,26 @@ async function writeJson(
   return unwrap(res, addOnSchema)
 }
 
+// #1456 (operatorId) + #1318 (locale): compose the write query. `?operatorId=` binds
+// a picker admin's PATCH/DELETE; `?locale=` tells the server the Model-B source locale
+// (and resolves the write response to the operator's UI locale).
+function writeQuery(pickedOperatorId?: string, locale?: Locale): string {
+  const params = new URLSearchParams()
+  if (pickedOperatorId) params.set('operatorId', pickedOperatorId)
+  if (locale) params.set('locale', locale)
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
 // A platform admin operating as a picked tenant must name the target operator in
 // the body (platformAdminCreateAddOnSchema requires it); an operator session omits
 // it and is auto-scoped server-side.
 export async function createAddOn(
   input: WithOperatorId<CreateAddOnInput>,
   csrfToken: string,
+  locale?: Locale,
 ): Promise<OperatorAddOnData> {
-  return writeJson('/add-ons', 'POST', input, csrfToken)
-}
-
-// #1456: PATCH/DELETE bind to the picked operator via `?operatorId=` (the API 422s a
-// bypass admin who names none, 404s a mismatch). An operator session omits it.
-function operatorQuery(pickedOperatorId?: string): string {
-  return pickedOperatorId ? `?operatorId=${encodeURIComponent(pickedOperatorId)}` : ''
+  return writeJson(`/add-ons${writeQuery(undefined, locale)}`, 'POST', input, csrfToken)
 }
 
 export async function updateAddOn(
@@ -116,19 +122,21 @@ export async function updateAddOn(
   input: UpdateAddOnInput,
   csrfToken: string,
   pickedOperatorId?: string,
+  locale?: Locale,
 ): Promise<OperatorAddOnData> {
-  const path = `/add-ons/${encodeURIComponent(id)}${operatorQuery(pickedOperatorId)}`
+  const path = `/add-ons/${encodeURIComponent(id)}${writeQuery(pickedOperatorId, locale)}`
   return writeJson(path, 'PATCH', input, csrfToken)
 }
 
 // Soft-archive (DELETE flips status to ARCHIVED). No body — the CSRF header still
 // rides along because a cookie-authed DELETE is a mutation the guard protects.
+// Archive doesn't touch descriptions so no locale param needed.
 export async function archiveAddOn(
   id: string,
   csrfToken: string,
   pickedOperatorId?: string,
 ): Promise<OperatorAddOnData> {
-  const path = `/add-ons/${encodeURIComponent(id)}${operatorQuery(pickedOperatorId)}`
+  const path = `/add-ons/${encodeURIComponent(id)}${writeQuery(pickedOperatorId)}`
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     method: 'DELETE',
     credentials: 'include',


### PR DESCRIPTION
## What & why

Realizes the add-on-description half of #1318 (catalog content i18n, epic #1315): when an operator saves an add-on `descriptionOverride`, machine-translate the authored locale into the other `SUPPORTED_LOCALES` (en/ja/zh) so every renter reads the description in their own language.

**Model B** (owner-brainstormed, locked): the source locale is the request's `?locale=` (the operator's UI locale); MT owns + overwrites the other locales on every save; best-effort (a provider failure degrades to source-only and never fails the save); author-time persisted so storefront reads stay pure and edge-cacheable.

Reuses the existing DI `TranslationProvider` + `GoogleTranslationProvider` (already live: `GOOGLE_TRANSLATE_API_KEY` set on beta, drift-guarded in `deploy.yml`). **No migration, no validator change, no wire-fence change** — `descriptionOverride` already exists and is already resolved.

Design doc: `docs/superpowers/plans/2026-07-09-addon-description-mt.md` (+ the architect-reviewed spec `docs/plans/2026-07-09-addon-description-mt-design.md`).

## How

- **`DescriptionTranslator`** port + `MachineDescriptionTranslator` (`services/description-translation.ts`): parallel best-effort fill (`Promise.allSettled`, bounded to the provider's ~6s/locale cap). A rejected **or empty/whitespace** leg is dropped and logged (`console.error` + `Sentry.captureException`) so the reader falls through rather than rendering blank.
- **`AddOnService`** gains a required `descriptionTranslator` (3rd ctor arg). A new `resolveDescriptionOverride` decides fill vs verbatim vs null on both create and update; wired into the composition root (`index.ts`) with the real translator.
- **Web** (`operator-add-ons/api.ts` + dialogs): threads the operator locale into `createAddOn`/`updateAddOn` as `?locale=` (also fixes a latent bug where write responses resolved to `en` regardless of UI locale).

## Invariants enforced (architect findings, all tested)

- **HIGH-1** — MT applies to **self-authored rows only** (`nameI18n` / `templateId === null`). A **picked** row stores its override **verbatim** (its other locales resolve through the curated template description; MT would shadow human text).
- **HIGH-2** — never coerce a non-empty bag to null / re-base. `?locale=` defaults to `en` and the API is source-agnostic (Trip.com), so a `{ja:…}` bag sent without `?locale=ja` is stored **verbatim**.
- **MEDIUM-3** — the translator is a **required** param (a forgotten wiring fails at compile time), plus a wiring-guard test boots the real `createApp` and proves end-to-end MT-fill (sabotage-verified).
- **MEDIUM-4** — a dropped locale (failure **or** empty result) is never fully silent: `console.error` + Sentry.
- **skip-on-unchanged** — an update whose source slot is unchanged and whose stored bag is complete makes zero provider calls; an incomplete stored bag (prior partial failure) retries.

## Accepted limitations (locked)

- MT owns the non-source locales; operators cannot hand-tune a single locale's translation.
- Editing the description under a different UI locale re-bases the source to that locale.
- Machine-translation quality is provider-grade; no human review before it reaches renters.

## Test plan

- API `MachineDescriptionTranslator` unit: verbatim source + parallel fill; rejected leg dropped+logged; empty/whitespace leg dropped+logged (falls through, not blank).
- `AddOnService` unit (create + update): Model-B fill (exact values), HIGH-1 picked-verbatim (spy not called), HIGH-2 absent-source-slot verbatim, skip-on-unchanged (zero calls), price-only no-translate, total-outage still `ok:true`.
- Wiring guard: real composed app MT-fills a self-authored create via the dev stub.
- Web: create/update carry `?locale=`; no `locale=` when absent; archive still binds `?operatorId=` (#1456).
- Full suites green: **API 2958, shared 925, web 2212**; tsc (api+web), biome, module-boundaries, size all clean.

Refs #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
