### PR TITLE
chore: isolated [env.production] API worker + go-live checklist

### DIFF
--- a/docs/plans/2026-07-11-go-live-checklist.md
+++ b/docs/plans/2026-07-11-go-live-checklist.md
@@ -31,6 +31,9 @@ not exist yet — this checklist builds it.
       `AUTH_URL` (secret) + the Google OAuth redirect.
 - [ ] **Delete the stale Neon `production` branch** (br-shy-tooth) — empty, un-migratable,
       superseded by `production-live`. I'm blocked from deleting it; do it in the Neon console.
+- [ ] **Pickup document verification** — `REQUIRE_DOCUMENT_VERIFICATION` is unset (off) in
+      prod, same as beta. Confirm you want ID-at-pickup enforcement off for real rentals, or
+      set it on the prod worker.
 
 ## 3. Owner procurement (lead-time / money / CF console)
 
@@ -40,17 +43,26 @@ not exist yet — this checklist builds it.
 - [ ] **Cloudflare prod resources (#1009):**
   - [ ] `npx wrangler r2 bucket create kuruma-vehicle-photos-production`
   - [ ] `npx wrangler r2 bucket create kuruma-renter-documents-production`
-  - [ ] Enable r2.dev public access on the vehicle-photos bucket → copy its URL into
-        `VEHICLE_PHOTOS_PUBLIC_URL` (wrangler.toml `[env.production.vars]`, currently empty).
+  - [ ] Enable r2.dev public access on the vehicle-photos bucket, then in `wrangler.toml`
+        **uncomment the `VEHICLE_PHOTOS` r2_bucket binding AND set `VEHICLE_PHOTOS_PUBLIC_URL`
+        to its r2.dev URL in the same deploy** (both together — a live binding with an empty
+        URL 500s the API on boot). Until then, photo upload is off; the rest of prod works.
   - [ ] Create the prod Pages project: `wrangler pages project create kuruma-web-production`
         with `nodejs_compat` + `global_fetch_strictly_public` flags (mirror `pages:create-project`).
   - [ ] (Optional) `GEOCODE_CACHE` KV namespace — else it falls back to in-memory.
 - [ ] **Google OAuth** — register `<prod web origin>/auth/google/callback` as a redirect URI.
 - [ ] **Prod Worker secrets** — set on the `kuruma-api-production` worker (each is a
       separate `wrangler secret put ... --env production`, sourced from GitHub Secrets):
-      `DATABASE_URL` = production-live conn string, `AUTH_SECRET`, `AUTH_URL`,
-      `AUTH_GOOGLE_ID/SECRET`, `RESEND_API_KEY`, `STRIPE_SECRET_KEY/WEBHOOK_SECRET` (live),
-      `SENTRY_DSN`, `CONSENT_SIGNING_KEY(_ID)`, `GOOGLE_TRANSLATE_API_KEY`.
+      `DATABASE_URL`, `AUTH_SECRET`, `AUTH_URL`, `AUTH_GOOGLE_ID/SECRET`, `RESEND_API_KEY`,
+      `STRIPE_SECRET_KEY/WEBHOOK_SECRET` (live), `SENTRY_DSN`, `CONSENT_SIGNING_KEY(_ID)`,
+      `GOOGLE_TRANSLATE_API_KEY`. Optional (fail closed if unset): `STATS_API_KEY` (the
+      `/stats` dashboard), `PARTNER_API_KEY` (Trip.com partner API).
+  - [ ] **Do NOT reuse the beta secret `PROD_DATABASE_URL`** — it holds the **beta** DB
+        connection string (feeds beta's `DATABASE_URL` + migrations). Create a NEW,
+        distinctly-named GitHub secret (e.g. `PRODUCTION_LIVE_DATABASE_URL`) = the
+        `production-live` conn string, and source the prod worker's `DATABASE_URL` from it.
+        Same caution for `AUTH_SECRET`/`AUTH_URL` if those GitHub secrets are beta-scoped —
+        prod must not share beta's session-signing key or callback origin.
 
 ## 4. In-repo work remaining (mine — unblocks once §3 exists)
 
@@ -58,6 +70,10 @@ not exist yet — this checklist builds it.
       Wire a prod-targeted deploy (workflow or parameterized `deploy.yml`) once the
       prod worker + Pages project exist. Deferred deliberately: a guarded-but-dead
       prod CI job beside the live beta one is the "two truths in CI" footgun.
+      NOTE: unlike beta's CI deploy, the manual `deploy:production` does NOT run
+      migrations first — until this pipeline exists, migrate `production-live` by hand
+      before shipping any schema change (`production-live` is at schema 103 today, so
+      the first deploy is fine).
 - [ ] **Prod web Pages deploy** — `deploy.yml` is beta-only; add a `kuruma-web-production`
       deploy path once that Pages project exists.
 - [ ] **Prod secret rotation** — a `rotate-secrets.yml` variant that targets `--env production`.

--- a/docs/plans/2026-07-11-go-live-checklist.md
+++ b/docs/plans/2026-07-11-go-live-checklist.md
@@ -1,0 +1,75 @@
+# Go-Live Checklist (staged)
+
+**Date:** 2026-07-11 · **Epic:** #1476 (path to GA)
+
+The last mile to real customers. Engineering is essentially done; what remains is
+**your** decisions + procurement, plus a little in-repo wiring that unblocks once
+the Cloudflare resources exist. Four buckets, in the order they gate each other.
+
+Live envs today: **beta** = the pre-contract env (`kuruma-web-pages.pages.dev` +
+`kuruma-api.kanata-studio.workers.dev`, Neon `beta` branch). **production** does
+not exist yet — this checklist builds it.
+
+---
+
+## 1. Done (in repo / DB)
+
+- [x] Features / engineering — essentially complete.
+- [x] Clean prod database — Neon `production-live` (br-steep-rice-anpni2dm), schema 103, zero data.
+- [x] **Prod API Worker config** — `[env.production]` in `packages/api/wrangler.toml`
+      (`kuruma-api-production`), fully isolated from beta: separate `*-production`
+      R2 buckets, distinct rate-limiter namespaces (2001-2006), `SENTRY_ENVIRONMENT=production`.
+- [x] **Prod deploy command** — `bun run --filter @kuruma/api deploy:production`
+      (inert until the resources + secrets below exist; no CI job on purpose).
+
+## 2. Owner decisions (no money — just choices)
+
+- [ ] **GA feature flags (#1476)** — resolve the open questions + pick which Tier-1
+      flags to flip. Zero-code, done from the admin switchboard.
+- [ ] **Prod web domain** — a real custom domain, or accept the interim
+      `kuruma-web-production.pages.dev`. This sets `WEB_ORIGIN` (wrangler.toml) +
+      `AUTH_URL` (secret) + the Google OAuth redirect.
+- [ ] **Delete the stale Neon `production` branch** (br-shy-tooth) — empty, un-migratable,
+      superseded by `production-live`. I'm blocked from deleting it; do it in the Neon console.
+
+## 3. Owner procurement (lead-time / money / CF console)
+
+- [ ] **Domain** — register + point DNS at Cloudflare.
+- [ ] **Stripe LIVE keys** — needs business verification. Yields `STRIPE_SECRET_KEY`
+      + `STRIPE_WEBHOOK_SECRET` (live mode).
+- [ ] **Cloudflare prod resources (#1009):**
+  - [ ] `npx wrangler r2 bucket create kuruma-vehicle-photos-production`
+  - [ ] `npx wrangler r2 bucket create kuruma-renter-documents-production`
+  - [ ] Enable r2.dev public access on the vehicle-photos bucket → copy its URL into
+        `VEHICLE_PHOTOS_PUBLIC_URL` (wrangler.toml `[env.production.vars]`, currently empty).
+  - [ ] Create the prod Pages project: `wrangler pages project create kuruma-web-production`
+        with `nodejs_compat` + `global_fetch_strictly_public` flags (mirror `pages:create-project`).
+  - [ ] (Optional) `GEOCODE_CACHE` KV namespace — else it falls back to in-memory.
+- [ ] **Google OAuth** — register `<prod web origin>/auth/google/callback` as a redirect URI.
+- [ ] **Prod Worker secrets** — set on the `kuruma-api-production` worker (each is a
+      separate `wrangler secret put ... --env production`, sourced from GitHub Secrets):
+      `DATABASE_URL` = production-live conn string, `AUTH_SECRET`, `AUTH_URL`,
+      `AUTH_GOOGLE_ID/SECRET`, `RESEND_API_KEY`, `STRIPE_SECRET_KEY/WEBHOOK_SECRET` (live),
+      `SENTRY_DSN`, `CONSENT_SIGNING_KEY(_ID)`, `GOOGLE_TRANSLATE_API_KEY`.
+
+## 4. In-repo work remaining (mine — unblocks once §3 exists)
+
+- [ ] **Prod deploy pipeline** — today it's the manual `deploy:production` command.
+      Wire a prod-targeted deploy (workflow or parameterized `deploy.yml`) once the
+      prod worker + Pages project exist. Deferred deliberately: a guarded-but-dead
+      prod CI job beside the live beta one is the "two truths in CI" footgun.
+- [ ] **Prod web Pages deploy** — `deploy.yml` is beta-only; add a `kuruma-web-production`
+      deploy path once that Pages project exists.
+- [ ] **Prod secret rotation** — a `rotate-secrets.yml` variant that targets `--env production`.
+- [ ] **`deploy.yml` presence check** — add Stripe / Sentry / Consent / Translate to the
+      required-secret gate once prod genuinely depends on them.
+
+---
+
+## Ordering
+
+§2 (domain + flag decisions) and the start of §3 (procurement lead-time) run in
+parallel now. Then: create CF resources → set prod secrets → I wire §4 → first
+prod deploy (`deploy:production` + prod Pages deploy) → smoke-test OAuth round-trip
++ a payment in Stripe live mode → flip DNS. Nothing here is blocked on more
+engineering; it's coordination + procurement from here.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "build": "wrangler deploy --dry-run",
     "deploy": "wrangler deploy --outdir dist --var SENTRY_RELEASE:$(git rev-parse HEAD)",
+    "deploy:production": "wrangler deploy --env production --outdir dist --var SENTRY_RELEASE:$(git rev-parse HEAD)",
     "sentry:sourcemaps": "sentry-cli sourcemaps upload --org \"$SENTRY_ORG\" --project \"$SENTRY_PROJECT_API\" --release \"$SENTRY_RELEASE\" dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -236,11 +236,23 @@ simple.period = 60
 # #1009 CF provisioning):
 #   npx wrangler r2 bucket create kuruma-vehicle-photos-production
 #   npx wrangler r2 bucket create kuruma-renter-documents-production
-# then enable r2.dev public access on the vehicle-photos one and paste its
-# public URL into VEHICLE_PHOTOS_PUBLIC_URL below.
-[[env.production.r2_buckets]]
-binding = "VEHICLE_PHOTOS"
-bucket_name = "kuruma-vehicle-photos-production"
+#
+# VEHICLE_PHOTOS is DELIBERATELY COMMENTED OUT (like the KV block below), NOT
+# just left with an empty URL. A DECLARED VEHICLE_PHOTOS binding + empty
+# VEHICLE_PHOTOS_PUBLIC_URL does NOT gracefully disable uploads — it THROWS at
+# the composition root and 500s the entire API (assertPhotosBaseConfigured in
+# composition/repositories.ts refuses to boot in that state, because an empty
+# base also disables the #967 cross-tenant photo-spoof guard). With the binding
+# absent, the composition root falls back to DisabledPhotoStorage: uploads are
+# off, every other route works. To turn photos ON at go-live: create + enable
+# r2.dev public access on the bucket, then UNCOMMENT this binding AND set
+# VEHICLE_PHOTOS_PUBLIC_URL below IN THE SAME DEPLOY (both together, or it 500s).
+# While commented, `wrangler deploy --env production` prints a harmless "binding
+# VEHICLE_PHOTOS at top level but not on env.production" info note — that
+# asymmetry is intentional; do NOT "fix" it by re-adding the binding alone.
+# [[env.production.r2_buckets]]
+# binding = "VEHICLE_PHOTOS"
+# bucket_name = "kuruma-vehicle-photos-production"
 
 [[env.production.r2_buckets]]
 binding = "RENTER_DOCUMENTS"
@@ -265,11 +277,11 @@ WEB_ORIGIN = "https://kuruma-web-production.pages.dev"
 # a Worker secret rotated via rotate-secrets.yml.
 EMAIL_FROM = "noreply@mail.jack-li.dev"
 
-# Public base URL for the PROD vehicle-photos bucket's r2.dev access. Left EMPTY
-# on purpose = fail-closed: photo upload falls back to DisabledPhotoStorage
-# (repositories.ts, r2-photo-storage.ts) until the owner creates the prod bucket,
-# enables r2.dev public access, and pastes its URL here. Deploying with this
-# empty simply disables uploads rather than writing photos to a dead URL.
+# Public base URL for the PROD vehicle-photos bucket's r2.dev access. Kept
+# PRESENT but EMPTY (not deleted) so it mirrors the top-level var and stays
+# harmless while the VEHICLE_PHOTOS binding above is commented out (empty URL is
+# only dangerous WITH a live binding — see that block). At go-live, uncomment
+# that binding and set this to the prod bucket's real r2.dev URL in one deploy.
 VEHICLE_PHOTOS_PUBLIC_URL = ""
 
 # Sentry environment tag for prod (beta uses "beta"). Groups prod errors

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -144,3 +144,137 @@ SENTRY_ENVIRONMENT = "beta"
 
 [version_metadata]
 binding = "CF_VERSION_METADATA"
+
+# ---------------------------------------------------------------------------
+# [env.production] — the real go-live API Worker (#1476 path-to-GA).
+#
+# Everything ABOVE this line is the default env = the `beta` deploy
+# (`kuruma-api.kanata-studio.workers.dev`, Neon `beta` branch). This section
+# defines a SECOND, isolated Worker for real customers, pointed at the clean
+# `production-live` Neon branch (br-steep-rice-anpni2dm).
+#
+# Deploy with:  bun run --filter @kuruma/api deploy:production
+#   ( = wrangler deploy --env production ... — see packages/api/package.json )
+# It is INERT until someone runs that command with the prod secrets + CF
+# resources in place. Nothing in CI targets it yet (deploy.yml is beta-only) —
+# a guarded-but-dead prod job beside the live one is the exact "two truths in
+# CI" footgun we removed in the #378 Pages cutover, so the prod deploy stays a
+# deliberate manual command until the owner's CF resources (#1009) exist.
+#
+# NOTE: now that a named env exists, the beta deploy (`bun run deploy`, no
+# `--env`) logs a harmless "Multiple environments are defined ... no target
+# environment was specified" warning. Expected — a bare deploy targets this
+# top-level config (= beta) exactly as before; the warning is informational.
+#
+# WRANGLER ENV INHERITANCE (why some keys are duplicated and some are not):
+#   - INHERITABLE (taken from the top-level automatically, NOT repeated here):
+#     main, compatibility_date, compatibility_flags, upload_source_maps.
+#   - NON-INHERITABLE (MUST be re-declared per-env or they silently vanish):
+#     vars, r2_buckets, ratelimits, version_metadata, kv_namespaces.
+#   A dropped non-inheritable binding = a Worker that boots then 500s at
+#   runtime (e.g. missing RATE_LIMITER), so every binding is re-declared below.
+#   `triggers` is inheritable, but re-declared anyway so a prod deploy can't
+#   silently skip the daily refund-reconciler / compliance-digest backstops.
+#
+# ISOLATION FROM BETA (owner decision 2026-07-11 — "fully isolated"):
+#   - Separate R2 buckets (`*-production`) so real renter ID documents never
+#     share storage with the beta test env.
+#   - Distinct rate-limiter namespace ids (2001-2006 vs beta's 1001-1006) so
+#     prod and beta don't share rate-limit counters.
+# See docs/plans/2026-07-11-go-live-checklist.md for the owner steps that make
+# this section deployable (create buckets, set secrets, prod Pages project).
+# ---------------------------------------------------------------------------
+[env.production]
+name = "kuruma-api-production"
+
+# Same daily 23:00 UTC (08:00 JST) cron as beta. Re-declared (not inherited)
+# so prod is guaranteed to run worker.ts `scheduled`: the #916 fleet-compliance
+# digest + the #851 refund-on-cancellation reconciler backstop.
+[env.production.triggers]
+crons = ["0 23 * * *"]
+
+# Rate limiters — same limits/periods as beta, DISTINCT namespace ids (2001-2006)
+# so prod counters are isolated from beta. See the beta blocks above for the
+# rationale behind each limit; only the namespace_id changes here.
+[[env.production.ratelimits]]
+name = "RATE_LIMITER"
+namespace_id = "2001"
+simple.limit = 100
+simple.period = 60
+
+[[env.production.ratelimits]]
+name = "PHOTO_UPLOAD_LIMITER"
+namespace_id = "2002"
+simple.limit = 10
+simple.period = 60
+
+[[env.production.ratelimits]]
+name = "PHOTO_UPLOAD_USER_LIMITER"
+namespace_id = "2003"
+simple.limit = 50
+simple.period = 60
+
+[[env.production.ratelimits]]
+name = "PUBLIC_CATALOG_LIMITER"
+namespace_id = "2004"
+simple.limit = 30
+simple.period = 60
+
+[[env.production.ratelimits]]
+name = "GEOCODE_LIMITER"
+namespace_id = "2005"
+simple.limit = 1
+simple.period = 10
+
+[[env.production.ratelimits]]
+name = "OPERATOR_APPLICATION_LIMITER"
+namespace_id = "2006"
+simple.limit = 5
+simple.period = 60
+
+# R2 buckets — SEPARATE prod buckets. Owner must create both once (folds into
+# #1009 CF provisioning):
+#   npx wrangler r2 bucket create kuruma-vehicle-photos-production
+#   npx wrangler r2 bucket create kuruma-renter-documents-production
+# then enable r2.dev public access on the vehicle-photos one and paste its
+# public URL into VEHICLE_PHOTOS_PUBLIC_URL below.
+[[env.production.r2_buckets]]
+binding = "VEHICLE_PHOTOS"
+bucket_name = "kuruma-vehicle-photos-production"
+
+[[env.production.r2_buckets]]
+binding = "RENTER_DOCUMENTS"
+bucket_name = "kuruma-renter-documents-production"
+
+# Geocode cache KV — same as beta, still blocked on KV provisioning (#601/#304).
+# Falls back to the in-process InMemoryGeocodeCache until provisioned. To
+# activate: create a SEPARATE prod namespace and uncomment:
+#   npx wrangler kv namespace create GEOCODE_CACHE --env production
+# [[env.production.kv_namespaces]]
+# binding = "GEOCODE_CACHE"
+# id = "<run: npx wrangler kv namespace create GEOCODE_CACHE --env production>"
+
+[env.production.vars]
+# The live web origin for prod. Feeds CORS + post-login redirect + Stripe
+# return base + provider-invite links (resolveGoogleOAuthConfig / webBaseUrl).
+# Placeholder = the planned prod Pages project's default domain. TODO(go-live):
+# replace with the real custom domain once procured, then redeploy.
+WEB_ORIGIN = "https://kuruma-web-production.pages.dev"
+
+# Same Resend-verified sending domain as beta (not a secret). RESEND_API_KEY is
+# a Worker secret rotated via rotate-secrets.yml.
+EMAIL_FROM = "noreply@mail.jack-li.dev"
+
+# Public base URL for the PROD vehicle-photos bucket's r2.dev access. Left EMPTY
+# on purpose = fail-closed: photo upload falls back to DisabledPhotoStorage
+# (repositories.ts, r2-photo-storage.ts) until the owner creates the prod bucket,
+# enables r2.dev public access, and pastes its URL here. Deploying with this
+# empty simply disables uploads rather than writing photos to a dead URL.
+VEHICLE_PHOTOS_PUBLIC_URL = ""
+
+# Sentry environment tag for prod (beta uses "beta"). Groups prod errors
+# separately. SENTRY_DSN itself is a secret (rotate-secrets.yml).
+SENTRY_ENVIRONMENT = "production"
+
+[env.production.version_metadata]
+binding = "CF_VERSION_METADATA"


### PR DESCRIPTION
Builds the **in-repo half** of the production app stack (path-to-GA #1476). The prod stack does not exist yet; this adds the config + docs that the owner's Cloudflare procurement (#1009) unblocks.

## What
- **`packages/api/wrangler.toml` → `[env.production]`** (`kuruma-api-production`), pointed at the clean `production-live` Neon branch. **Fully isolated from beta** (owner decision):
  - Separate `kuruma-vehicle-photos-production` / `kuruma-renter-documents-production` R2 buckets — real renter ID documents never share storage with the beta test env.
  - Distinct rate-limiter namespaces (2001-2006 vs beta's 1001-1006).
  - `SENTRY_ENVIRONMENT=production`; `VEHICLE_PHOTOS_PUBLIC_URL` left **empty = fail-closed** (uploads disabled until the prod bucket's r2.dev URL is set).
  - Non-inheritable bindings re-declared per wrangler's env model; crons re-declared so prod can't silently skip the refund/compliance backstops.
- **`deploy:production` script** — single source of truth for the `--env production` + `--outdir`/`SENTRY_RELEASE` flags (mirrors `deploy`, keeps #959 sourcemaps intact).
- **`docs/plans/2026-07-11-go-live-checklist.md`** — staged checklist: done / owner decisions / owner procurement / in-repo work remaining.

## Safety / why zero deploy risk
- Validated with `wrangler deploy --env production --dry-run`: all bindings resolve.
- **Inert**: no CI job targets the prod env (deploy.yml is beta-only). A guarded-but-dead prod deploy job beside the live beta one is the "two truths in CI" footgun removed in the #378 Pages cutover, so prod deploy stays a deliberate manual command (`bun run --filter @kuruma/api deploy:production`) until CF resources exist.
- Beta's top-level config is untouched; the default `bun run deploy` still deploys beta (it now logs a harmless "multiple environments" warning, documented inline).

## Not in this PR (owner-gated, see checklist)
Prod CF resources (#1009: R2 buckets, `kuruma-web-production` Pages project, KV), domain, live Stripe/OAuth/prod secrets, and the prod deploy/rotate pipeline wiring (deferred until the resources exist).

Refs #1476, #1009. **Owner-gated: please do not merge without review** — though it's safe to merge to develop anytime (inert until the prod env is provisioned).