### PR TITLE
fix(csp): Google login silently does nothing (form-action blocks the OAuth redirect)

### DIFF
--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -27,8 +27,13 @@
 #               placehold.co is the fallback; both pass through the photo decoder
 #               verbatim to <img>). TEMPORARY: drop once the catalog is re-hosted
 #               to R2 (docs/plans/2026-06-16-vehicle-photo-optimization.md, #1507).
-#               Google OAuth itself is a full-page navigation (form-action 'self'
-#               → 302), not an XHR, so it needs no connect-src entry.
+#               Google OAuth itself is a full-page navigation (a form POST → 302),
+#               not an XHR, so it needs no connect-src entry.
+#   form-action 'self' + accounts.google.com — the Google button POSTs to the
+#               same-origin /auth/google/start (self), but the API answers with a
+#               302 to accounts.google.com. form-action is enforced against the
+#               REDIRECT TARGET too, so 'self' alone silently blocks sign-in in
+#               Chrome (login-does-nothing). Pinned by csp-script-hash.test.ts.
 #   style-src keeps 'unsafe-inline' — inline style attributes can't be hashed.
 # COEP is intentionally omitted — `require-corp` would block Unsplash images.
 # NOTE (#1042): when the Sentry browser SDK is given a prod DSN, add its ingest
@@ -38,4 +43,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: SAMEORIGIN
   Cross-Origin-Opener-Policy: same-origin-allow-popups
-  Content-Security-Policy: default-src 'self'; img-src 'self' data: https://images.unsplash.com https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev https://lh3.googleusercontent.com https://cyberjapandata.gsi.go.jp https://upload.wikimedia.org https://placehold.co; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: https://images.unsplash.com https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev https://lh3.googleusercontent.com https://cyberjapandata.gsi.go.jp https://upload.wikimedia.org https://placehold.co; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com

--- a/packages/web/tests/deploy/csp-script-hash.test.ts
+++ b/packages/web/tests/deploy/csp-script-hash.test.ts
@@ -34,6 +34,7 @@ const cspLines = headers
   .filter((l) => /^\s+Content-Security-Policy(-Report-Only)?:/.test(l))
 const scriptSrcs = cspLines.map((l) => l.match(/script-src ([^;]*)/)?.[1]?.trim() ?? '')
 const imgSrcs = cspLines.map((l) => l.match(/img-src ([^;]*)/)?.[1]?.trim() ?? '')
+const formActions = cspLines.map((l) => l.match(/form-action ([^;]*)/)?.[1]?.trim() ?? '')
 
 // Every non-'self' image host the app can render — an enforcing CSP silently
 // blocks any it omits, so pin the FULL set: a drift guard that covered only some
@@ -89,5 +90,18 @@ describe('CSP script-src hash (#500)', () => {
     expect(imgSrcs.length).toBeGreaterThan(0)
     for (const imgSrc of imgSrcs)
       for (const host of REQUIRED_IMG_HOSTS) expect(imgSrc).toContain(host)
+  })
+
+  // form-action governs the redirect TARGET of a form submission, not just the
+  // literal action URL. The Google button POSTs to same-origin /auth/google/start
+  // (allowed by 'self'), but the API answers with a 302 to accounts.google.com —
+  // and Chrome enforces form-action against that redirect, so an omitted host
+  // silently kills sign-in with no JS error (the login-does-nothing regression).
+  test('EVERY CSP header allows the Google OAuth redirect target in form-action', () => {
+    expect(formActions.length).toBeGreaterThan(0)
+    for (const formAction of formActions) {
+      expect(formAction).toContain("'self'") // same-origin /auth/google/start POST + all app form posts
+      expect(formAction).toContain('https://accounts.google.com') // the /start → Google 302 target
+    }
   })
 })


### PR DESCRIPTION
## What was broken

On beta, clicking **Continue with Google** did nothing for every user (no navigation, no error, no page change). Not specific to the platform-admin account.

## Root cause

When the web CSP was flipped from Report-Only to enforcing (#500 / PR #1505), it shipped `form-action 'self'`. The Google button is a native `<form method="POST" action="/auth/google/start">`:

1. The POST to `/auth/google/start` is same-origin (`'self'`, allowed).
2. The API answers with a **302 to `https://accounts.google.com/o/oauth2/v2/auth`**.
3. `form-action` is enforced against the **redirect target**, not just the literal action URL, so Chrome **silently cancels** the navigation. Submit fires, `defaultPrevented` stays `false`, a `securitypolicyviolation` (directive `form-action`) is raised, nothing throws.

Diagnosed live via Chrome: `POST /auth/google/start` returns `opaqueredirect` (backend healthy), and the captured violation names `form-action`. (Firefox historically doesn't check redirects against `form-action`, so it may work there.)

## Fix

- `packages/web/public/_headers`: `form-action 'self' https://accounts.google.com`.
- Corrected the stale comment that implied `'self'` sufficed for OAuth.
- Added a RED->GREEN drift guard in `csp-script-hash.test.ts` so a future policy edit can't silently kill sign-in again.

Covers all three OAuth forms (renter login, operator/provider login, provider invite) — they all POST to the same endpoint. No other native off-origin `<form>` exists.

## Verification

- New test fails before the fix, all 8 CSP tests pass after.
- Pre-commit: biome, file-size, module-boundaries, tsc (web + api) green.

## Deploy note

`_headers` is static Cloudflare Pages config (rebuilt into `dist` by `vite build`). This reaches live beta only when `develop` is promoted to the `beta` branch.

Refs #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)