### PR TITLE
Promote develop → beta: fix Google login (CSP form-action) + prod-env limiters

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -251,6 +251,23 @@ namespace_id = "2006"
 simple.limit = 5
 simple.period = 60
 
+# Messaging GA limiters (#1476) — mirror beta's MESSAGE_TRANSLATE_LIMITER (1007)
+# and MESSAGE_SEND_LIMITER (1008), added to the top-level after this env block
+# was first written (#1522). Without them, prod messaging translate/send run
+# UNTHROTTLED (the binding-absent path no-ops the limiter, index.ts:214-221) —
+# an abuse/cost gap once messaging is enabled. Prod namespaces 2007/2008.
+[[env.production.ratelimits]]
+name = "MESSAGE_TRANSLATE_LIMITER"
+namespace_id = "2007"
+simple.limit = 20
+simple.period = 60
+
+[[env.production.ratelimits]]
+name = "MESSAGE_SEND_LIMITER"
+namespace_id = "2008"
+simple.limit = 30
+simple.period = 60
+
 # R2 buckets — SEPARATE prod buckets. Owner must create both once (folds into
 # #1009 CF provisioning):
 #   npx wrangler r2 bucket create kuruma-vehicle-photos-production

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -27,8 +27,13 @@
 #               placehold.co is the fallback; both pass through the photo decoder
 #               verbatim to <img>). TEMPORARY: drop once the catalog is re-hosted
 #               to R2 (docs/plans/2026-06-16-vehicle-photo-optimization.md, #1507).
-#               Google OAuth itself is a full-page navigation (form-action 'self'
-#               → 302), not an XHR, so it needs no connect-src entry.
+#               Google OAuth itself is a full-page navigation (a form POST → 302),
+#               not an XHR, so it needs no connect-src entry.
+#   form-action 'self' + accounts.google.com — the Google button POSTs to the
+#               same-origin /auth/google/start (self), but the API answers with a
+#               302 to accounts.google.com. form-action is enforced against the
+#               REDIRECT TARGET too, so 'self' alone silently blocks sign-in in
+#               Chrome (login-does-nothing). Pinned by csp-script-hash.test.ts.
 #   style-src keeps 'unsafe-inline' — inline style attributes can't be hashed.
 # COEP is intentionally omitted — `require-corp` would block Unsplash images.
 # NOTE (#1042): when the Sentry browser SDK is given a prod DSN, add its ingest
@@ -38,4 +43,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: SAMEORIGIN
   Cross-Origin-Opener-Policy: same-origin-allow-popups
-  Content-Security-Policy: default-src 'self'; img-src 'self' data: https://images.unsplash.com https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev https://lh3.googleusercontent.com https://cyberjapandata.gsi.go.jp https://upload.wikimedia.org https://placehold.co; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: https://images.unsplash.com https://pub-a6e9e98522e945a7aa1871f4fe741448.r2.dev https://lh3.googleusercontent.com https://cyberjapandata.gsi.go.jp https://upload.wikimedia.org https://placehold.co; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-2S6frsINm4/FKaaiq6qA65fjvkeL2N9Um5j1Yra+lT0='; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com

--- a/packages/web/tests/deploy/csp-script-hash.test.ts
+++ b/packages/web/tests/deploy/csp-script-hash.test.ts
@@ -34,6 +34,7 @@ const cspLines = headers
   .filter((l) => /^\s+Content-Security-Policy(-Report-Only)?:/.test(l))
 const scriptSrcs = cspLines.map((l) => l.match(/script-src ([^;]*)/)?.[1]?.trim() ?? '')
 const imgSrcs = cspLines.map((l) => l.match(/img-src ([^;]*)/)?.[1]?.trim() ?? '')
+const formActions = cspLines.map((l) => l.match(/form-action ([^;]*)/)?.[1]?.trim() ?? '')
 
 // Every non-'self' image host the app can render — an enforcing CSP silently
 // blocks any it omits, so pin the FULL set: a drift guard that covered only some
@@ -89,5 +90,18 @@ describe('CSP script-src hash (#500)', () => {
     expect(imgSrcs.length).toBeGreaterThan(0)
     for (const imgSrc of imgSrcs)
       for (const host of REQUIRED_IMG_HOSTS) expect(imgSrc).toContain(host)
+  })
+
+  // form-action governs the redirect TARGET of a form submission, not just the
+  // literal action URL. The Google button POSTs to same-origin /auth/google/start
+  // (allowed by 'self'), but the API answers with a 302 to accounts.google.com —
+  // and Chrome enforces form-action against that redirect, so an omitted host
+  // silently kills sign-in with no JS error (the login-does-nothing regression).
+  test('EVERY CSP header allows the Google OAuth redirect target in form-action', () => {
+    expect(formActions.length).toBeGreaterThan(0)
+    for (const formAction of formActions) {
+      expect(formAction).toContain("'self'") // same-origin /auth/google/start POST + all app form posts
+      expect(formAction).toContain('https://accounts.google.com') // the /start → Google 302 target
+    }
   })
 })


### PR DESCRIPTION
Promotes 2 commits to beta to deploy the Google-login hotfix.

- **#1531 fix(csp): allow the Google OAuth 302 target in form-action** — beta Google sign-in did nothing for every user; the enforcing CSP `form-action 'self'` silently blocked the `/auth/google/start` → `accounts.google.com` 302. Adds the host + drift-guard test. **This is the reason for the promote.**
- #1529 fix(prod-env): mirror messaging rate-limiters into `[env.production]` — inert on beta (beta runs the top-level config, not `[env.production]`); rides along because it's already on develop.

Deploys to beta on merge (CI-on-beta → Deploy workflow → CF Pages, `WEB_PAGES_DEPLOY_ENABLED=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)