### PR TITLE
test(e2e): renter<->operator messaging round-trip

### DIFF
--- a/e2e/real-db/messaging-round-trip.auth.spec.ts
+++ b/e2e/real-db/messaging-round-trip.auth.spec.ts
@@ -1,0 +1,243 @@
+import { expect, test } from '@playwright/test'
+import { RENTER_STORAGE_STATE } from './constants'
+import { testSql } from './pg'
+
+// #1536 messaging round-trip. Proves a message actually travels renter -> operator
+// -> renter on the REAL Vite web -> Hono API -> seeded Postgres stack, across TWO
+// authenticated actors, and that unread counts + read-receipts behave on BOTH
+// sides. Messaging is a pre-GA gate (epic #1476) that had zero e2e coverage.
+//
+// The default `page` is the OPERATOR_OWNER (Best Car Rental); a second context
+// carries RENTER_STORAGE_STATE (Sarah Smith), mirroring marketplace-happy-path.
+//
+// Thread-creation entry point (confirmed while implementing): a thread only exists
+// once a booking commits — the API auto-creates it via `ensureThread` on the
+// booking's post-commit seam, awaited before the response returns. There is NO
+// caller-facing `POST /threads` (removed in #1386 as a spam vector). So the spec
+// first books a car AS the renter (the same wizard marketplace-happy-path drives),
+// then opens that booking's auto-created thread from the renter inbox (#1032).
+
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+// Best Car Rental's KIX storefront — booking here scopes the thread's operatorId to
+// Best Car Rental, the tenant the default OPERATOR_OWNER session read-scopes by.
+const STOREFRONT_NAME = 'Kansai Airport (KIX)'
+const OPERATOR_NAME = 'Best Car Rental'
+const RENTER_NAME = 'Sarah Smith' // the operator thread heading resolves from booking.renter
+
+// Unique per run so the assertions target THIS run's messages even if prior data
+// lingers, and so the two directions never satisfy each other's text match.
+const RUN = `${Date.now()}`
+const RENTER_MSG = `Is the KIX counter staffed at 9am? [${RUN}]`
+const OPERATOR_MSG = `Yes, staffed from 8am - see you there. [${RUN}]`
+
+// A far-future window (+3 months), clear of the seeded near-term bookings AND of
+// marketplace-happy-path's +2-month window, so the two specs never contend for the
+// same KIX vehicle in one suite run. Computed relative to today (a hard-coded date
+// silently rots into the seed range as real time advances).
+const pad = (n: number) => String(n).padStart(2, '0')
+const isoDate = (d: Date) =>
+  `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+const NOW = new Date()
+const WINDOW_START = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 3, 15))
+const WINDOW_END = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 3, 17))
+const FROM = `${isoDate(WINDOW_START)}T10:00`
+const TO = `${isoDate(WINDOW_END)}T10:00`
+
+// bookingId(s) this run creates, torn down in afterAll. Deleting a thread cascades
+// its messages + thread_participants (ON DELETE CASCADE), so the thread delete is
+// enough for the messaging rows.
+const createdBookingIds: string[] = []
+
+test.describe('messaging round-trip - renter <-> operator (real DB)', () => {
+  test.afterAll(cleanup)
+
+  test('renter sends -> operator sees/reads/replies -> renter sees the reply', async ({
+    page,
+    browser,
+    baseURL,
+  }) => {
+    test.setTimeout(150_000) // Vite builds each route on first hit; two actors, real round-trips
+
+    const renterContext = await browser.newContext({ storageState: RENTER_STORAGE_STATE, baseURL })
+    const renter = await renterContext.newPage()
+
+    let threadId = ''
+
+    await test.step('setup: renter books a KIX car (the commit auto-creates the thread)', async () => {
+      // Minimal replay of marketplace-happy-path steps 1-5: search -> storefront ->
+      // vehicle -> 5-step wizard -> instant-book. ensureThread runs synchronously on
+      // the post-commit seam, so the thread exists by the time the confirmation loads.
+      await renter.goto(`/en/search?from=${FROM}&to=${TO}`)
+      const storefront = renter.getByRole('link').filter({ hasText: STOREFRONT_NAME }).first()
+      await expect(storefront).toBeVisible({ timeout: 20_000 })
+      await storefront.click()
+      await expect(renter.getByRole('heading', { name: STOREFRONT_NAME })).toBeVisible()
+      await expect(renter.getByText(OPERATOR_NAME).first()).toBeVisible()
+
+      await renter.getByRole('link', { name: 'Book this car' }).first().click()
+      await expect(renter.getByRole('button', { name: 'Continue', exact: true })).toBeVisible()
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // dates -> addOns
+      await expect(renter.getByText('Add optional extras')).toBeVisible()
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // addOns -> insurance
+      await expect(renter.getByText('No insurance')).toBeVisible()
+      await renter.getByRole('button', { name: 'Continue', exact: true }).click() // insurance -> confirm
+      await expect(renter.getByText('Review your booking')).toBeVisible()
+      await renter.getByRole('button', { name: 'Continue to payment' }).click() // confirm -> payment
+      await expect(renter.getByRole('heading', { name: 'Confirm and reserve' })).toBeVisible()
+      await renter.getByRole('checkbox').check() // liability-disclaimer consent (#613)
+      await renter.getByRole('button', { name: 'Reserve now' }).click() // instant-book submit
+
+      await expect(renter).toHaveURL(/\/bookings\/confirmation\?bookingId=.+/)
+      await expect(renter.getByRole('heading', { name: 'Booking confirmed' })).toBeVisible()
+      const bookingId = new URL(renter.url()).searchParams.get('bookingId') ?? ''
+      expect(bookingId).toMatch(new RegExp(`^${UUID}$`))
+      createdBookingIds.push(bookingId)
+
+      // Resolve the auto-created thread precisely by bookingId. (The confirmation
+      // page's "Message host" deep-link (#1032) shares the nav unread-badge's
+      // threads cache, still within its 30s staleTime right after booking, so it
+      // can lag a beat there — a product quirk, not this spec's concern. Each inbox
+      // visit below is a full page load that refetches, so it never bites there.)
+      threadId = await threadIdForBooking(bookingId)
+      expect(threadId, 'ensureThread should create the booking thread on commit').toMatch(
+        new RegExp(`^${UUID}$`),
+      )
+    })
+
+    const operatorRow = () => page.locator(`a[href$="/manage/messages/${threadId}"]`)
+    const renterRow = () => renter.locator(`a[href$="/messages/${threadId}"]`)
+
+    await test.step('1. renter opens the booking thread from the inbox and sends', async () => {
+      // Entry point: the renter inbox lists the booking's thread (a no-message thread
+      // still shows). A full load refetches GET /threads, so the row is present.
+      await renter.goto('/en/messages')
+      await expect(renter.getByRole('heading', { name: 'Messages' })).toBeVisible()
+      await renterRow().click()
+      await expect(renter).toHaveURL(new RegExp(`/messages/${threadId}`))
+
+      await renter.getByLabel('Compose message').fill(RENTER_MSG)
+      await renter.getByRole('button', { name: 'Send' }).click()
+      // The send invalidates the thread cache; the refetch is the source of truth,
+      // so the sent line reappears as the renter's OWN bubble.
+      await expect(
+        renter.locator('li[data-own="true"]').filter({ hasText: RENTER_MSG }),
+      ).toBeVisible({ timeout: 20_000 })
+    })
+
+    await test.step('2. operator sees the thread unread at /manage/messages', async () => {
+      await page.goto('/en/manage/messages')
+      await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible()
+      // Tenant-level operator unread badge (operatorUnreadCount), bumped by the
+      // renter send. Scoped to THIS thread's row so another thread can't satisfy it.
+      await expect(operatorRow().locator('output[aria-label="1 unread"]')).toBeVisible({
+        timeout: 20_000,
+      })
+      await expect(operatorRow()).toContainText(RENTER_MSG)
+    })
+
+    await test.step('3. operator opens it; unread clears; renter message shows as a counterpart bubble', async () => {
+      await operatorRow().click()
+      await expect(page).toHaveURL(new RegExp(`/manage/messages/${threadId}`))
+      await expect(page.getByRole('heading', { name: RENTER_NAME })).toBeVisible() // from booking.renter
+      await expect(
+        page.locator('li[data-own="false"]').filter({ hasText: RENTER_MSG }),
+      ).toBeVisible()
+      // Opening marks the thread read (ConversationView mount) -> the inbox badge drops.
+      // Re-navigate under toPass so the best-effort read POST has time to land.
+      await expect(async () => {
+        await page.goto('/en/manage/messages')
+        await expect(operatorRow()).toBeVisible()
+        await expect(operatorRow().locator('output')).toHaveCount(0)
+      }).toPass({ timeout: 15_000 })
+    })
+
+    await test.step('4. operator replies', async () => {
+      await page.goto(`/en/manage/messages/${threadId}`)
+      await page.getByLabel('Compose message').fill(OPERATOR_MSG)
+      await page.getByRole('button', { name: 'Send' }).click()
+      await expect(
+        page.locator('li[data-own="true"]').filter({ hasText: OPERATOR_MSG }),
+      ).toBeVisible({ timeout: 20_000 })
+    })
+
+    await test.step('5. renter sees the reply unread, opens it, unread clears', async () => {
+      await renter.goto('/en/messages')
+      await expect(renter.getByRole('heading', { name: 'Messages' })).toBeVisible()
+      // Per-participant renter unread, bumped by the operator reply.
+      await expect(renterRow().locator('output[aria-label="1 unread"]')).toBeVisible({
+        timeout: 20_000,
+      })
+
+      await renterRow().click()
+      await expect(renter).toHaveURL(new RegExp(`/messages/${threadId}`))
+      // Full transcript: the renter's own first message + the operator's reply.
+      await expect(
+        renter.locator('li[data-own="true"]').filter({ hasText: RENTER_MSG }),
+      ).toBeVisible()
+      await expect(
+        renter.locator('li[data-own="false"]').filter({ hasText: OPERATOR_MSG }),
+      ).toBeVisible()
+
+      await expect(async () => {
+        await renter.goto('/en/messages')
+        await expect(renterRow()).toBeVisible()
+        await expect(renterRow().locator('output')).toHaveCount(0)
+      }).toPass({ timeout: 15_000 })
+    })
+
+    await test.step('6. renter translates the operator reply (optional)', async () => {
+      await renter.goto(`/en/messages/${threadId}`)
+      const reply = renter.locator('li[data-own="false"]').filter({ hasText: OPERATOR_MSG })
+      await reply.getByRole('button', { name: 'Translate' }).click()
+      // Local/e2e sets no GOOGLE_TRANSLATE_API_KEY, so the provider is the dev stub
+      // `[<lang>] <text>` (translation-provider-factory) - deterministic and offline.
+      await expect(reply).toContainText(`[en] ${OPERATOR_MSG}`)
+      await expect(reply.getByRole('button', { name: 'Show original' })).toBeVisible()
+    })
+
+    await renterContext.close()
+  })
+})
+
+/**
+ * The auto-created thread's id for a booking (ensureThread, on the booking's
+ * post-commit seam). Polls like marketplace-happy-path's notification poll: the
+ * post-commit effects (thread + notifications) are eventually-consistent from the
+ * client's view, so read until the thread lands rather than assuming it is there
+ * the instant the confirmation page paints.
+ */
+async function threadIdForBooking(bookingId: string): Promise<string> {
+  const sql = testSql()
+  try {
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const rows = await sql<{ id: string }[]>`
+        SELECT id FROM threads WHERE "bookingId" = ${bookingId}
+      `
+      const id = rows[0]?.id
+      if (id) return id
+      await new Promise((resolve) => setTimeout(resolve, 400))
+    }
+    return ''
+  } finally {
+    await sql.end({ timeout: 5 })
+  }
+}
+
+/** Delete the bookings this spec created; the thread delete cascades its messages. */
+async function cleanup(): Promise<void> {
+  if (createdBookingIds.length === 0) return
+  const sql = testSql()
+  try {
+    const ids = createdBookingIds
+    await sql`DELETE FROM notification_log WHERE "bookingId" IN ${sql(ids)}`
+    await sql`DELETE FROM booking_events WHERE "bookingId" IN ${sql(ids)}`
+    // payment_events has no ON DELETE CASCADE — the confirmation step writes one per
+    // booking, so clear it before the booking or the delete below 23503s.
+    await sql`DELETE FROM payment_events WHERE "bookingId" IN ${sql(ids)}`
+    await sql`DELETE FROM threads WHERE "bookingId" IN ${sql(ids)}` // cascades messages + participants
+    await sql`DELETE FROM bookings WHERE id IN ${sql(ids)}`
+  } finally {
+    await sql.end({ timeout: 5 })
+  }
+}

--- a/e2e/real-db/messaging-round-trip.auth.spec.ts
+++ b/e2e/real-db/messaging-round-trip.auth.spec.ts
@@ -106,7 +106,10 @@ test.describe('messaging round-trip - renter <-> operator (real DB)', () => {
     })
 
     const operatorRow = () => page.locator(`a[href$="/manage/messages/${threadId}"]`)
-    const renterRow = () => renter.locator(`a[href$="/messages/${threadId}"]`)
+    // Anchor the renter row to the locale prefix so it can never match an operator
+    // row (whose href also ends with `/messages/<id>`); they never co-render, but
+    // this keeps the selector airtight regardless.
+    const renterRow = () => renter.locator(`a[href$="/en/messages/${threadId}"]`)
 
     await test.step('1. renter opens the booking thread from the inbox and sends', async () => {
       // Entry point: the renter inbox lists the booking's thread (a no-message thread
@@ -202,10 +205,10 @@ test.describe('messaging round-trip - renter <-> operator (real DB)', () => {
 
 /**
  * The auto-created thread's id for a booking (ensureThread, on the booking's
- * post-commit seam). Polls like marketplace-happy-path's notification poll: the
- * post-commit effects (thread + notifications) are eventually-consistent from the
- * client's view, so read until the thread lands rather than assuming it is there
- * the instant the confirmation page paints.
+ * post-commit seam). ensureThread is awaited before the booking response returns,
+ * so the thread is normally readable the instant the confirmation paints; the poll
+ * is defensive belt-and-braces against any lag between the response and a fresh read
+ * connection, mirroring marketplace-happy-path's post-commit notification poll.
  */
 async function threadIdForBooking(bookingId: string): Promise<string> {
   const sql = testSql()
@@ -232,9 +235,8 @@ async function cleanup(): Promise<void> {
     const ids = createdBookingIds
     await sql`DELETE FROM notification_log WHERE "bookingId" IN ${sql(ids)}`
     await sql`DELETE FROM booking_events WHERE "bookingId" IN ${sql(ids)}`
-    // payment_events has no ON DELETE CASCADE — the confirmation step writes one per
-    // booking, so clear it before the booking or the delete below 23503s.
-    await sql`DELETE FROM payment_events WHERE "bookingId" IN ${sql(ids)}`
+    // No payment_events delete: instant-book (Path A) writes none — that table is
+    // populated only by the Stripe webhook path (services/payment/payment.ts).
     await sql`DELETE FROM threads WHERE "bookingId" IN ${sql(ids)}` // cascades messages + participants
     await sql`DELETE FROM bookings WHERE id IN ${sql(ids)}`
   } finally {

--- a/playwright.real-db.config.ts
+++ b/playwright.real-db.config.ts
@@ -35,10 +35,11 @@ if (AUTH_SECRET === undefined || DATABASE_URL === undefined) {
 // These real-DB specs exercise features the beta demo gates OFF — cancellation
 // (#868), operator manual booking (#589), team (#904), settings (#903), reviews
 // (#1083-1086), the fleet timeline (#1100), multi-currency indicative display
-// (#1070), the operator Today panel (#1102) and the calendar booking quick-view
-// (#1282). Enable them here so e2e covers the FULL product; the beta Pages build
-// (deploy.yml) sets none of these, so the demo still hides them. Fail-safe-OFF
-// default lives in vite/config/features.ts. Shared by both Vite servers below.
+// (#1070), the operator Today panel (#1102), the calendar booking quick-view
+// (#1282) and renter<->operator messaging (#1536). Enable them here so e2e covers
+// the FULL product; the beta Pages build (deploy.yml) sets none of these, so the
+// demo still hides them. Fail-safe-OFF default lives in vite/config/features.ts.
+// Shared by both Vite servers below.
 const VITE_FEATURE_ENV = {
   VITE_FEATURE_CANCELLATION: 'true',
   VITE_FEATURE_OPERATOR_MANUAL_BOOKING: 'true',
@@ -50,6 +51,7 @@ const VITE_FEATURE_ENV = {
   VITE_FEATURE_MULTI_CURRENCY: 'true',
   VITE_FEATURE_OPERATOR_TODAY: 'true',
   VITE_FEATURE_CALENDAR_QUICKVIEW: 'true',
+  VITE_FEATURE_MESSAGING: 'true',
 } as const
 
 export default defineConfig({


### PR DESCRIPTION
Closes #1536.

## What

Adds the first end-to-end coverage for renter<->operator messaging (a pre-GA gate, epic #1476, previously untested) and enables the messaging feature flag in the real-DB e2e lane.

- New spec `e2e/real-db/messaging-round-trip.auth.spec.ts` (dual browser context: default `page` = OPERATOR_OWNER, second context = renter Sarah Smith, mirroring `marketplace-happy-path`).
- One line in `playwright.real-db.config.ts`: `VITE_FEATURE_MESSAGING: 'true'` added to the shared `VITE_FEATURE_ENV` (both Vite servers) so the messaging routes don't redirect.

## Round-trip proven (both sides)

renter books a KIX car (thread auto-created) -> renter opens the booking thread from the inbox and sends -> operator sees it unread at `/manage/messages` (tenant-level `operatorUnreadCount` badge) -> operator opens (unread clears) and sees it as a counterpart bubble -> operator replies -> renter sees the reply unread (per-participant `unreadCount`), opens it (full transcript), unread clears -> renter translates the reply.

## Thread-creation entry point (confirmed)

Threads are auto-created by `ensureThread` on the booking's post-commit seam; there is **no** caller-facing `POST /threads` (removed in #1386). The spec resolves the thread by `bookingId` via SQL, polling because the post-commit effects are eventually-consistent from the client's view (same reason `marketplace-happy-path` polls for its notification).

## Verification

- `bun run test:e2e:real-db:local` — **39/39 pass** on a fresh seeded container; the new spec runs in ~4s.
- Confirmed the flag flip regresses none of the existing 38 specs.
- Spec re-run twice back-to-back to confirm stability; Biome + husky (tsc web/api, file-size, module-boundaries) green.
- Creates only far-future (+3mo) rows scoped to a unique window; `afterAll` tears them down (deleting the thread cascades its messages + participants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)