### PR TITLE
feat(web): type-to-search location combobox with locale-aware ordering (#1543)

### DIFF
--- a/e2e/real-db/locations.auth.spec.ts
+++ b/e2e/real-db/locations.auth.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { testSql } from './pg'
+import { pickRegionCascade } from './region-cascade'
 
 // Names this spec creates; cleaned up in afterAll so a reused local branch
 // doesn't accrete rows (a per-run CI branch is disposable, so this is belt-and-
@@ -64,9 +65,11 @@ test.describe('operator locations (authenticated, real DB)', () => {
     // A synthetic address can't be geocoded, so the server can't auto-derive a
     // region and rejects the create ("needs a region"). Pick one explicitly via the
     // prefecture -> city -> area cascade; only the AREA level yields a regionId.
-    await addDialog.locator('#region-prefecture').selectOption({ label: 'Osaka' })
-    await addDialog.locator('#region-city').selectOption({ label: 'Osaka City' })
-    await addDialog.locator('#region-area').selectOption({ label: 'Namba' })
+    await pickRegionCascade(page, addDialog, {
+      prefecture: 'Osaka',
+      city: 'Osaka City',
+      area: 'Namba',
+    })
     await addDialog.getByRole('button', { name: 'Save location' }).click()
     await expect(page.getByRole('heading', { name, exact: true })).toBeVisible()
 

--- a/e2e/real-db/operator-books-e2e.auth.spec.ts
+++ b/e2e/real-db/operator-books-e2e.auth.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { RENTER_STORAGE_STATE } from './constants'
 import { testSql } from './pg'
+import { pickRegionCascade } from './region-cascade'
 
 // #1257 — operator-authored bookable inventory, end to end on the REAL Vite web ->
 // Hono API -> seeded Postgres stack, across TWO authenticated actors:
@@ -64,9 +65,11 @@ test.describe('operator-authored inventory — operator lists a car, renter book
       await dialog.locator('#location-name').fill(LOCATION_NAME)
       await dialog.locator('#location-address').fill(LOCATION_ADDRESS)
       // Only the leaf (area) selection yields a regionId; prefecture + city narrow it.
-      await dialog.locator('#region-prefecture').selectOption({ label: 'Osaka' })
-      await dialog.locator('#region-city').selectOption({ label: 'Osaka City' })
-      await dialog.locator('#region-area').selectOption({ label: 'Namba' })
+      await pickRegionCascade(page, dialog, {
+        prefecture: 'Osaka',
+        city: 'Osaka City',
+        area: 'Namba',
+      })
       await dialog.getByRole('button', { name: 'Save location' }).click()
       await expect(page.getByRole('heading', { name: LOCATION_NAME, exact: true })).toBeVisible()
     })

--- a/e2e/real-db/region-cascade.ts
+++ b/e2e/real-db/region-cascade.ts
@@ -1,23 +1,31 @@
 import type { Locator, Page } from '@playwright/test'
 
 /**
- * Drive the operator location region cascade (#1543). Each level is a base-ui combobox
- * (type-to-search), not a native <select>, and its options portal to the page root — so
- * the control is located by its accessible label inside the dialog, but options are queried
- * on `page`. Selecting the AREA level is what yields a regionId.
+ * Drive one region combobox level (#1543). Each level is a base-ui combobox (type-to-search),
+ * not a native <select>: open it by its accessible label, then click the chosen option. Options
+ * portal to the page root, so the trigger is located inside `within` (a dialog for the operator
+ * cascade, the page itself for the public RegionPicker) but the option is always queried on `page`.
+ */
+export async function pickRegionLevel(
+  page: Page,
+  label: string,
+  name: string,
+  within: Locator | Page = page,
+): Promise<void> {
+  await within.getByLabel(label).click()
+  await page.getByRole('option', { name, exact: true }).click()
+}
+
+/**
+ * Drive the operator location region cascade (#1543): prefecture -> city -> area, each a combobox
+ * inside the location dialog. Selecting the AREA level is what yields a regionId.
  */
 export async function pickRegionCascade(
   page: Page,
   dialog: Locator,
   levels: { prefecture: string; city: string; area: string },
 ): Promise<void> {
-  const steps: ReadonlyArray<readonly [string, string]> = [
-    ['Prefecture', levels.prefecture],
-    ['City', levels.city],
-    ['Area', levels.area],
-  ]
-  for (const [label, name] of steps) {
-    await dialog.getByLabel(label).click()
-    await page.getByRole('option', { name, exact: true }).click()
-  }
+  await pickRegionLevel(page, 'Prefecture', levels.prefecture, dialog)
+  await pickRegionLevel(page, 'City', levels.city, dialog)
+  await pickRegionLevel(page, 'Area', levels.area, dialog)
 }

--- a/e2e/real-db/region-cascade.ts
+++ b/e2e/real-db/region-cascade.ts
@@ -1,0 +1,23 @@
+import type { Locator, Page } from '@playwright/test'
+
+/**
+ * Drive the operator location region cascade (#1543). Each level is a base-ui combobox
+ * (type-to-search), not a native <select>, and its options portal to the page root — so
+ * the control is located by its accessible label inside the dialog, but options are queried
+ * on `page`. Selecting the AREA level is what yields a regionId.
+ */
+export async function pickRegionCascade(
+  page: Page,
+  dialog: Locator,
+  levels: { prefecture: string; city: string; area: string },
+): Promise<void> {
+  const steps: ReadonlyArray<readonly [string, string]> = [
+    ['Prefecture', levels.prefecture],
+    ['City', levels.city],
+    ['Area', levels.area],
+  ]
+  for (const [label, name] of steps) {
+    await dialog.getByLabel(label).click()
+    await page.getByRole('option', { name, exact: true }).click()
+  }
+}

--- a/e2e/real-db/region-search.auth.spec.ts
+++ b/e2e/real-db/region-search.auth.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { RENTER_STORAGE_STATE } from './constants'
 import { testSql } from './pg'
+import { pickRegionLevel } from './region-cascade'
 
 // #840 / #651 §9 — renter region search on the REAL Vite web -> Hono API ->
 // seeded Postgres stack. Proves the two things the component unit tests (which
@@ -14,8 +15,6 @@ import { testSql } from './pg'
 // each seeded AREA holds exactly one store and the multi-store nodes
 // (city/prefecture) are coordless by design, so the UI can show breadth OR a
 // ranking anchor, never both — there is nothing extra for an e2e to prove there.
-
-const RENTER_EMAIL = 'sarah@example.test'
 
 // Booking-code alphabet (api/lib/booking-code.ts BOOKING_CODE_PATTERN), inlined —
 // @kuruma/api TS can't be required from this CJS-transformed Playwright file.
@@ -35,8 +34,13 @@ const KIX_STORE = 'Kansai Airport (KIX)'
 const NAMBA_STORE = 'Namba' // Osaka City -> a different child city than KIX's Izumisano
 const KYOTO_STORE = 'Kyoto Station' // a different PREFECTURE — must be filtered out
 
+// Booking codes this spec creates via the wizard, so afterAll deletes exactly those and never
+// the date-relative demo bookings that share Sarah's account (#1543): the demo bookings' start
+// dates drift with wall-clock time, so any fixed "future" date window eventually catches them.
+const createdBookingCodes: string[] = []
+
 test.describe('renter region search — subtree filter + nav threading + book (real DB)', () => {
-  test.afterAll(cleanupFutureSarahBookings)
+  test.afterAll(cleanupCreatedBookings)
 
   test('pick an area: filtered + labelled, region survives detail/back, then books', async ({
     browser,
@@ -106,6 +110,7 @@ test.describe('renter region search — subtree filter + nav threading + book (r
       await expect(renter.getByRole('heading', { name: 'Booking confirmed' })).toBeVisible()
       bookingCode = (await renter.locator('span.font-mono').first().innerText()).trim()
       expect(bookingCode).toMatch(BOOKING_CODE_RE)
+      createdBookingCodes.push(bookingCode)
     })
 
     await renterContext.close()
@@ -122,8 +127,9 @@ test.describe('renter region search — subtree filter + nav threading + book (r
 
     await renter.goto(`/en/search?from=${FROM}&to=${TO}`)
     // Anchor at the prefecture level (coordless): a subtree filter only, no ranking.
-    // The cascade emits that node's slug at any level (§6).
-    await renter.getByLabel('Prefecture').selectOption({ label: 'Osaka' })
+    // The cascade emits that node's slug at any level (§6). Prefecture is a base-ui
+    // combobox (#1543), not a native <select>: open it, then click the Osaka option.
+    await pickRegionLevel(renter, 'Prefecture', 'Osaka')
     await renter.getByRole('button', { name: 'Search' }).click()
     await expect(renter).toHaveURL(/[?&]region=osaka\b/)
 
@@ -140,17 +146,19 @@ test.describe('renter region search — subtree filter + nav threading + book (r
   })
 })
 
-/** Delete the future-window Sarah bookings this spec created, children first (FK order). */
-async function cleanupFutureSarahBookings(): Promise<void> {
+/** Delete exactly the bookings this spec created (by their captured codes), children first in
+ * FK order — including payment_events, which the demo/wizard revenue path can attach. Scoping by
+ * code, not by a date window, leaves the shared demo bookings on Sarah's account untouched. */
+async function cleanupCreatedBookings(): Promise<void> {
+  if (createdBookingCodes.length === 0) return
   const sql = testSql()
   try {
-    const ids = await sql<{ id: string }[]>`
-      SELECT b.id FROM bookings b
-      JOIN users u ON u.id = b."renterId"
-      WHERE u.email = ${RENTER_EMAIL} AND b."startAt" >= '2026-07-01'
+    const rows = await sql<{ id: string }[]>`
+      SELECT id FROM bookings WHERE "bookingCode" IN ${sql(createdBookingCodes)}
     `
-    if (ids.length === 0) return
-    const bookingIds = ids.map((r) => r.id)
+    if (rows.length === 0) return
+    const bookingIds = rows.map((r) => r.id)
+    await sql`DELETE FROM payment_events WHERE "bookingId" IN ${sql(bookingIds)}`
     await sql`DELETE FROM notification_log WHERE "bookingId" IN ${sql(bookingIds)}`
     await sql`DELETE FROM booking_events WHERE "bookingId" IN ${sql(bookingIds)}`
     await sql`DELETE FROM threads WHERE "bookingId" IN ${sql(bookingIds)}`

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1981,5 +1981,10 @@
     "approximately": "approximately",
     "disclaimer": "Indicative only — you're charged in JPY",
     "asOf": "Rates as of {date}"
+  },
+  "locationCombobox": {
+    "clear": "Clear",
+    "open": "Open options",
+    "noMatches": "No matches"
   }
 }

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1981,5 +1981,10 @@
     "approximately": "約",
     "disclaimer": "目安です — ご請求は日本円（JPY）です",
     "asOf": "レート基準日 {date}"
+  },
+  "locationCombobox": {
+    "clear": "クリア",
+    "open": "選択肢を開く",
+    "noMatches": "該当する地域がありません"
   }
 }

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1981,5 +1981,10 @@
     "approximately": "约",
     "disclaimer": "仅供参考 — 实际以日元（JPY）结算",
     "asOf": "汇率基准日 {date}"
+  },
+  "locationCombobox": {
+    "clear": "清除",
+    "open": "打开选项",
+    "noMatches": "无匹配地区"
   }
 }

--- a/packages/web/src/vite/operator-locations/RegionCascade.test.tsx
+++ b/packages/web/src/vite/operator-locations/RegionCascade.test.tsx
@@ -1,0 +1,109 @@
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+import { RegionCascade } from './RegionCascade'
+
+function makeRegion(
+  overrides: Pick<RegionNode, 'id' | 'nameEn'> & Partial<RegionNode>,
+): RegionNode {
+  return {
+    parentId: null,
+    slug: null,
+    nameJa: '地域',
+    nameZh: '地区',
+    type: 'AREA',
+    latitude: null,
+    longitude: null,
+    assignable: true,
+    status: 'ACTIVE',
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+const REGIONS: RegionNode[] = [
+  makeRegion({ id: 'osaka', nameEn: 'Osaka', type: 'PREFECTURE' }),
+  makeRegion({ id: 'osaka_city', nameEn: 'Osaka City', type: 'CITY', parentId: 'osaka' }),
+  makeRegion({ id: 'namba', nameEn: 'Namba', type: 'AREA', parentId: 'osaka_city' }),
+  // An assignable AREA that has since been deactivated (still referenced by an old save).
+  makeRegion({
+    id: 'umeda_old',
+    nameEn: 'Umeda (old)',
+    type: 'AREA',
+    parentId: 'osaka_city',
+    status: 'INACTIVE',
+  }),
+]
+
+function renderCascade(props: { value?: string | null } = {}) {
+  const onChange = vi.fn()
+  const utils = render(
+    <IntlProvider locale="en" messages={en}>
+      <RegionCascade regions={REGIONS} value={props.value ?? null} onChange={onChange} />
+    </IntlProvider>,
+  )
+  return { onChange, ...utils }
+}
+
+function openLevel(label: string) {
+  const group = screen.getByLabelText(label).closest('div')
+  if (group === null) throw new Error(`no group for ${label}`)
+  fireEvent.click(within(group).getByRole('button', { name: 'Open options' }))
+}
+
+const input = (label: string) => screen.getByLabelText<HTMLInputElement>(label)
+
+describe('RegionCascade', () => {
+  it('prefills the prefecture/city/area chain from an area value', () => {
+    renderCascade({ value: 'namba' })
+    expect(input('Prefecture').value).toBe('Osaka')
+    expect(input('City').value).toBe('Osaka City')
+    expect(input('Area').value).toBe('Namba')
+  })
+
+  it('emits the assignable city id as a terminal selection', () => {
+    const { onChange } = renderCascade({ value: null })
+    openLevel('Prefecture')
+    fireEvent.click(screen.getByRole('option', { name: 'Osaka' }))
+    openLevel('City')
+    fireEvent.click(screen.getByRole('option', { name: 'Osaka City' }))
+    expect(onChange).toHaveBeenCalledWith('osaka_city')
+  })
+
+  it('falls back to the assignable city when the area is cleared', () => {
+    const { onChange } = renderCascade({ value: 'namba' })
+    openLevel('Area')
+    fireEvent.click(screen.getByRole('option', { name: 'Select...' }))
+    expect(onChange).toHaveBeenCalledWith('osaka_city')
+  })
+
+  it('keeps a since-deactivated area visible so an edit does not blank it (M3)', () => {
+    renderCascade({ value: 'umeda_old' })
+    // The INACTIVE area is filtered out of the normal option set, but the current value
+    // must still render as the area selection rather than a misleading placeholder.
+    expect(input('Area').value).toBe('Umeda (old)')
+  })
+
+  it('resyncs the dropdowns when value changes externally (H1)', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <IntlProvider locale="en" messages={en}>
+        <RegionCascade regions={REGIONS} value="namba" onChange={onChange} />
+      </IntlProvider>,
+    )
+    expect(input('Prefecture').value).toBe('Osaka')
+    expect(input('City').disabled).toBe(false)
+
+    // An external reset (form reset / editing a different location) must reset the chain,
+    // not leave the prefecture/city showing the old selection.
+    rerender(
+      <IntlProvider locale="en" messages={en}>
+        <RegionCascade regions={REGIONS} value={null} onChange={onChange} />
+      </IntlProvider>,
+    )
+    expect(input('Prefecture').value).not.toBe('Osaka')
+    expect(input('City').disabled).toBe(true)
+  })
+})

--- a/packages/web/src/vite/operator-locations/RegionCascade.tsx
+++ b/packages/web/src/vite/operator-locations/RegionCascade.tsx
@@ -1,8 +1,8 @@
 import { Label } from '@/components/ui/label'
-import { NativeSelect } from '@/components/ui/native-select'
+import { LocationCombobox } from '@/vite/regions/LocationCombobox'
 import type { RegionNode } from '@kuruma/shared/types/region'
-import { useState } from 'react'
-import { useLocale, useTranslations } from 'use-intl'
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslations } from 'use-intl'
 
 interface RegionCascadeProps {
   /** Flat taxonomy from GET /regions (every prefecture/city/area node). */
@@ -14,13 +14,6 @@ interface RegionCascadeProps {
   value: string | null
   onChange: (regionId: string | null) => void
   disabled?: boolean
-}
-
-// The API is locale-agnostic (trilingual names); the client picks one by route locale.
-function nameOf(region: RegionNode, locale: string): string {
-  if (locale === 'ja') return region.nameJa
-  if (locale === 'zh') return region.nameZh
-  return region.nameEn
 }
 
 // Resolve a selected region id into its prefecture/city navigation slots so an edit
@@ -52,22 +45,43 @@ function cityTerminalId(regions: readonly RegionNode[], cityId: string | null): 
 }
 
 /**
- * Operator region override (#651 Slice 2b, #1276): dependent dropdowns
+ * Operator region override (#651 Slice 2b, #1276): dependent comboboxes
  * prefecture -> city -> (optional) area. A CITY is now assignable, so selecting one is
- * a valid terminal choice; the AREA select appears only when the chosen city has
+ * a valid terminal choice; the AREA level appears only when the chosen city has
  * assignable ACTIVE area children and refines the selection one level deeper. Leaving
  * everything blank lets the server loop guard auto-derive the nearest area from the
  * location's address.
  */
 export function RegionCascade({ regions, value, onChange, disabled }: RegionCascadeProps) {
   const t = useTranslations('business.locations.form.region')
-  const locale = useLocale()
+  const ids = useId()
 
   // Local navigation state: which prefecture/city is "open". Seeded from the current
-  // value so edit prefills the chain; the dialog's key remount re-seeds it.
+  // value so an edit prefills the chain.
   const seeded = chainFor(regions, value)
   const [prefectureId, setPrefectureId] = useState<string | null>(seeded.prefectureId)
   const [cityId, setCityId] = useState<string | null>(seeded.cityId)
+
+  // Our handlers set this so a self-inflicted onChange doesn't bounce back through the
+  // resync effect and clobber the navigation the operator just made.
+  const selfChange = useRef(false)
+  // Read the latest taxonomy without making the resync fire on `regions` identity churn.
+  const regionsRef = useRef(regions)
+  regionsRef.current = regions
+
+  // Resync local navigation when `value` changes from OUTSIDE this component (a form
+  // reset, editing a different location, a server-driven setValue). The mount-only seed
+  // alone silently desyncs the dropdowns from `value` the moment this control is reused
+  // without a remount (review H1); the skip flag preserves in-progress navigation.
+  useEffect(() => {
+    if (selfChange.current) {
+      selfChange.current = false
+      return
+    }
+    const next = chainFor(regionsRef.current, value)
+    setPrefectureId(next.prefectureId)
+    setCityId(next.cityId)
+  }, [value])
 
   const prefectures = regions.filter((r) => r.type === 'PREFECTURE')
   const cities = regions.filter((r) => r.type === 'CITY' && r.parentId === prefectureId)
@@ -75,25 +89,26 @@ export function RegionCascade({ regions, value, onChange, disabled }: RegionCasc
     (r) => r.type === 'AREA' && r.parentId === cityId && r.assignable && r.status === 'ACTIVE',
   )
 
-  // A CITY terminal lives in the city select, so the area select stays on its
-  // placeholder; an AREA (or a since-removed / INACTIVE id) belongs to the area select.
+  // A CITY terminal lives in the city level, so the area level stays on its placeholder;
+  // an AREA (or a since-removed / INACTIVE id) belongs to the area level.
   const selectedNode = value !== null ? regions.find((r) => r.id === value) : undefined
   const isCityValue = selectedNode?.type === 'CITY'
   const areaValue = isCityValue ? '' : (value ?? '')
   // A previously-assigned AREA that is no longer selectable (INACTIVE or removed) still
-  // arrives as `value`; keep it visible as a fallback so an edit shows the current
-  // assignment instead of a misleading blank a blind re-save could misread.
+  // arrives as `value`; keep it as an option so an edit shows the current assignment
+  // instead of a misleading blank a blind re-save could misread (review M3).
   const showCurrentFallback = value !== null && !isCityValue && !areas.some((a) => a.id === value)
-  // The area level is an optional refinement: render it only when the city offers
-  // assignable areas, or when a fallback area must stay visible.
   const showArea = areas.length > 0 || showCurrentFallback
+  const areaOptions = showCurrentFallback && selectedNode ? [selectedNode, ...areas] : areas
 
   const handlePrefecture = (next: string) => {
+    selfChange.current = true
     setPrefectureId(next || null)
     setCityId(null)
     onChange(null)
   }
   const handleCity = (next: string) => {
+    selfChange.current = true
     const nextCityId = next || null
     setCityId(nextCityId)
     onChange(cityTerminalId(regions, nextCityId))
@@ -101,64 +116,45 @@ export function RegionCascade({ regions, value, onChange, disabled }: RegionCasc
   // Picking an area sets it as the terminal; clearing it falls back to the city when
   // that city is itself assignable, else null.
   const handleArea = (next: string) => {
+    selfChange.current = true
     onChange(next || cityTerminalId(regions, cityId))
   }
 
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
       <div>
-        <Label htmlFor="region-prefecture">{t('prefecture')}</Label>
-        <NativeSelect
-          id="region-prefecture"
+        <Label htmlFor={`${ids}-prefecture`}>{t('prefecture')}</Label>
+        <LocationCombobox
+          id={`${ids}-prefecture`}
+          regions={prefectures}
           value={prefectureId ?? ''}
+          placeholder={t('placeholder')}
           disabled={disabled}
-          onChange={(e) => handlePrefecture(e.target.value)}
-        >
-          <option value="">{t('placeholder')}</option>
-          {prefectures.map((r) => (
-            <option key={r.id} value={r.id}>
-              {nameOf(r, locale)}
-            </option>
-          ))}
-        </NativeSelect>
+          onChange={handlePrefecture}
+        />
       </div>
       <div>
-        <Label htmlFor="region-city">{t('city')}</Label>
-        <NativeSelect
-          id="region-city"
+        <Label htmlFor={`${ids}-city`}>{t('city')}</Label>
+        <LocationCombobox
+          id={`${ids}-city`}
+          regions={cities}
           value={cityId ?? ''}
+          placeholder={t('placeholder')}
           disabled={disabled || prefectureId === null}
-          onChange={(e) => handleCity(e.target.value)}
-        >
-          <option value="">{t('placeholder')}</option>
-          {cities.map((r) => (
-            <option key={r.id} value={r.id}>
-              {nameOf(r, locale)}
-            </option>
-          ))}
-        </NativeSelect>
+          onChange={handleCity}
+        />
       </div>
       {showArea && (
         <div>
-          <Label htmlFor="region-area">{t('area')}</Label>
-          <NativeSelect
-            id="region-area"
+          <Label htmlFor={`${ids}-area`}>{t('area')}</Label>
+          <LocationCombobox
+            id={`${ids}-area`}
+            regions={areaOptions}
             value={areaValue}
+            placeholder={t('placeholder')}
             disabled={disabled || cityId === null}
-            onChange={(e) => handleArea(e.target.value)}
-          >
-            <option value="">{t('placeholder')}</option>
-            {showCurrentFallback && (
-              <option value={value ?? ''}>
-                {selectedNode ? nameOf(selectedNode, locale) : (value ?? '')}
-              </option>
-            )}
-            {areas.map((r) => (
-              <option key={r.id} value={r.id}>
-                {nameOf(r, locale)}
-              </option>
-            ))}
-          </NativeSelect>
+            onChange={handleArea}
+          />
         </div>
       )}
     </div>

--- a/packages/web/src/vite/operator-locations/RegionCascade.tsx
+++ b/packages/web/src/vite/operator-locations/RegionCascade.tsx
@@ -1,5 +1,5 @@
 import { Label } from '@/components/ui/label'
-import { LocationCombobox } from '@/vite/regions/LocationCombobox'
+import { LocationCombobox } from '@/vite/regions'
 import type { RegionNode } from '@kuruma/shared/types/region'
 import { useEffect, useId, useRef, useState } from 'react'
 import { useTranslations } from 'use-intl'

--- a/packages/web/src/vite/regions/LocationCombobox.test.tsx
+++ b/packages/web/src/vite/regions/LocationCombobox.test.tsx
@@ -1,0 +1,96 @@
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { IntlProvider } from 'use-intl'
+import { describe, expect, it, vi } from 'vitest'
+import en from '../../../messages/en.json'
+import ja from '../../../messages/ja.json'
+import { LocationCombobox } from './LocationCombobox'
+
+function makeRegion(
+  overrides: Pick<RegionNode, 'id' | 'nameEn'> & Partial<RegionNode>,
+): RegionNode {
+  return {
+    parentId: null,
+    slug: null,
+    nameJa: '地域',
+    nameZh: '地区',
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: true,
+    status: 'ACTIVE',
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+// English names deliberately out of A-Z input order so the en re-sort is observable.
+const REGIONS: RegionNode[] = [
+  makeRegion({ id: 'osaka', nameEn: 'Osaka', nameJa: '大阪', sortOrder: 0 }),
+  makeRegion({ id: 'aichi', nameEn: 'Aichi', nameJa: '愛知', sortOrder: 1 }),
+  makeRegion({ id: 'kyoto', nameEn: 'Kyoto', nameJa: '京都', sortOrder: 2 }),
+]
+
+function renderCombobox(props: {
+  value?: string
+  locale?: 'en' | 'ja'
+  regions?: RegionNode[]
+}) {
+  const onChange = vi.fn()
+  const messages = props.locale === 'ja' ? ja : en
+  const utils = render(
+    <IntlProvider locale={props.locale ?? 'en'} messages={messages}>
+      <LocationCombobox
+        id="loc"
+        regions={props.regions ?? REGIONS}
+        value={props.value ?? ''}
+        onChange={onChange}
+        placeholder="Anywhere"
+      />
+    </IntlProvider>,
+  )
+  return { onChange, ...utils }
+}
+
+function open(name = 'Open options') {
+  fireEvent.click(screen.getByRole('button', { name }))
+}
+
+describe('LocationCombobox', () => {
+  it('shows the placeholder as the default option and lists every region when opened', () => {
+    renderCombobox({})
+    open()
+    const labels = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(labels).toEqual(['Anywhere', 'Aichi', 'Kyoto', 'Osaka']) // en: A-Z, default pinned first
+  })
+
+  it('emits the region id when an option is selected', () => {
+    const { onChange } = renderCombobox({})
+    open()
+    fireEvent.click(screen.getByRole('option', { name: 'Kyoto' }))
+    expect(onChange).toHaveBeenCalledWith('kyoto')
+  })
+
+  it('emits an empty string when the default option is selected', () => {
+    const { onChange } = renderCombobox({ value: 'kyoto' })
+    open()
+    fireEvent.click(screen.getByRole('option', { name: 'Anywhere' }))
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('filters options as the user types', () => {
+    renderCombobox({})
+    open()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'kyo' } })
+    const labels = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(labels).toEqual(['Kyoto'])
+  })
+
+  it('finds a Japanese-labelled region by its romanized English name', () => {
+    renderCombobox({ locale: 'ja' })
+    open('選択肢を開く')
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'osaka' } })
+    const labels = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(labels).toEqual(['大阪'])
+  })
+})

--- a/packages/web/src/vite/regions/LocationCombobox.tsx
+++ b/packages/web/src/vite/regions/LocationCombobox.tsx
@@ -27,10 +27,10 @@ export interface LocationComboboxProps {
   /** The pinned default option label, e.g. "Anywhere" / "All cities". */
   placeholder: string
   /** Input id so a sibling <Label htmlFor> associates with the control. */
-  id?: string
-  disabled?: boolean
-  'aria-invalid'?: boolean
-  'aria-describedby'?: string
+  id?: string | undefined
+  disabled?: boolean | undefined
+  'aria-invalid'?: boolean | undefined
+  'aria-describedby'?: string | undefined
 }
 
 export function LocationCombobox({

--- a/packages/web/src/vite/regions/LocationCombobox.tsx
+++ b/packages/web/src/vite/regions/LocationCombobox.tsx
@@ -1,0 +1,126 @@
+import { cn } from '@/lib/utils'
+import { Combobox } from '@base-ui/react/combobox'
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { CheckIcon, ChevronDownIcon, XIcon } from 'lucide-react'
+import { useLocale, useTranslations } from 'use-intl'
+import { orderRegionsForLocale, regionMatchesQuery, regionName } from './region-locale'
+
+// One reusable type-to-search + dropdown control for a single cascade level (#1543),
+// used by both the public RegionPicker and the operator RegionCascade. Built on the
+// base-ui Combobox (matches ui/select.tsx styling + a11y). The external contract is a
+// drop-in for the old <NativeSelect>: `value`/`onChange` speak the region **id**, with
+// '' meaning the pinned default option (Anywhere / All cities / All areas).
+
+interface ComboboxItem {
+  id: string
+  label: string
+  // null marks the pinned default ("Anywhere") sentinel; a real node otherwise.
+  region: RegionNode | null
+}
+
+export interface LocationComboboxProps {
+  regions: readonly RegionNode[]
+  /** Selected region id, or '' for the default option. */
+  value: string
+  /** Emits the chosen region id, or '' when the default option is chosen or the input cleared. */
+  onChange: (id: string) => void
+  /** The pinned default option label, e.g. "Anywhere" / "All cities". */
+  placeholder: string
+  /** Input id so a sibling <Label htmlFor> associates with the control. */
+  id?: string
+  disabled?: boolean
+  'aria-invalid'?: boolean
+  'aria-describedby'?: string
+}
+
+export function LocationCombobox({
+  regions,
+  value,
+  onChange,
+  placeholder,
+  id,
+  disabled,
+  'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedby,
+}: LocationComboboxProps) {
+  const locale = useLocale()
+  const t = useTranslations('locationCombobox')
+
+  const sentinel: ComboboxItem = { id: '', label: placeholder, region: null }
+  const items: ComboboxItem[] = [
+    sentinel,
+    ...orderRegionsForLocale(regions, locale).map((region) => ({
+      id: region.id,
+      label: regionName(region, locale),
+      region,
+    })),
+  ]
+  const selected = items.find((item) => item.id === value) ?? sentinel
+
+  // The sentinel shows only on an empty query (it is the "reset" option, not a search hit);
+  // real nodes match by localized name or romanized English name, accent-insensitively.
+  const filter = (item: ComboboxItem, query: string): boolean =>
+    item.region === null ? query.trim() === '' : regionMatchesQuery(item.region, query, locale)
+
+  return (
+    <Combobox.Root
+      items={items}
+      value={selected}
+      disabled={disabled}
+      filter={filter}
+      itemToStringLabel={(item: ComboboxItem) => item.label}
+      isItemEqualToValue={(a: ComboboxItem, b: ComboboxItem) => a.id === b.id}
+      onValueChange={(item: ComboboxItem | null) => onChange(item?.id ?? '')}
+    >
+      <div className="relative">
+        <Combobox.Input
+          id={id}
+          placeholder={placeholder}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedby}
+          className={cn(
+            'flex h-9 w-full rounded-md border border-input bg-transparent py-1 pr-14 pl-3 text-sm shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20',
+          )}
+        />
+        <div className="absolute inset-y-0 right-2 flex items-center gap-0.5">
+          <Combobox.Clear
+            aria-label={t('clear')}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground data-[disabled]:hidden"
+          >
+            <XIcon className="size-4" />
+          </Combobox.Clear>
+          <Combobox.Trigger
+            aria-label={t('open')}
+            className="flex size-5 items-center justify-center text-muted-foreground"
+          >
+            <ChevronDownIcon className="size-4" />
+          </Combobox.Trigger>
+        </div>
+      </div>
+
+      <Combobox.Portal>
+        <Combobox.Positioner sideOffset={4} className="isolate z-50">
+          <Combobox.Popup className="max-h-72 w-(--anchor-width) origin-(--transform-origin) overflow-y-auto rounded-lg bg-popover p-1 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <Combobox.Empty className="px-2 py-1.5 text-muted-foreground">
+              {t('noMatches')}
+            </Combobox.Empty>
+            <Combobox.List>
+              {(item: ComboboxItem) => (
+                <Combobox.Item
+                  key={item.id || '__anywhere__'}
+                  value={item}
+                  className="relative flex cursor-default items-center rounded-md py-1.5 pr-8 pl-2 outline-none select-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                >
+                  <Combobox.ItemIndicator className="absolute right-2 flex items-center">
+                    <CheckIcon className="size-4" />
+                  </Combobox.ItemIndicator>
+                  {item.label}
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  )
+}

--- a/packages/web/src/vite/regions/LocationCombobox.tsx
+++ b/packages/web/src/vite/regions/LocationCombobox.tsx
@@ -79,7 +79,9 @@ export function LocationCombobox({
           aria-invalid={ariaInvalid}
           aria-describedby={ariaDescribedby}
           className={cn(
-            'flex h-9 w-full rounded-md border border-input bg-transparent py-1 pr-14 pl-3 text-sm shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20',
+            // text-base on mobile: iOS Safari zooms the page when a focused input's font is
+            // below 16px; this input is on the public landing/storefront search path.
+            'flex h-9 w-full rounded-md border border-input bg-transparent py-1 pr-14 pl-3 text-base shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 sm:text-sm',
           )}
         />
         <div className="absolute inset-y-0 right-2 flex items-center gap-0.5">

--- a/packages/web/src/vite/regions/RegionPicker.test.tsx
+++ b/packages/web/src/vite/regions/RegionPicker.test.tsx
@@ -119,45 +119,78 @@ function renderPicker(props: { value?: string | null } = {}) {
   return { onChange, ...utils }
 }
 
+// Each level is a combobox; open it via its own trigger (scoped to that level's group so
+// the three identical "Open options" triggers don't collide), then pick an option by name.
+function openLevel(label: string) {
+  const input = screen.getByLabelText(label)
+  const group = input.closest('div')
+  if (group === null) throw new Error(`no group for ${label}`)
+  fireEvent.click(within(group).getByRole('button', { name: 'Open options' }))
+}
+
+function pickOption(name: string) {
+  fireEvent.click(screen.getByRole('option', { name }))
+}
+
 describe('RegionPicker', () => {
   it('builds the prefecture dropdown from the region list', () => {
     renderPicker()
-    const select = screen.getByLabelText('Prefecture')
-    const optionLabels = within(select)
-      .getAllByRole('option')
-      .map((option) => option.textContent)
+    openLevel('Prefecture')
+    const optionLabels = screen.getAllByRole('option').map((option) => option.textContent)
     expect(optionLabels).toContain('Osaka')
     expect(optionLabels).toContain('Kyoto')
   })
 
+  it('lists English options A-Z with the Anywhere default pinned first', () => {
+    renderPicker()
+    openLevel('Prefecture')
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual([
+      'Anywhere',
+      'Kyoto',
+      'Osaka',
+    ])
+  })
+
   it('emits the prefecture slug when a prefecture is chosen', () => {
     const { onChange } = renderPicker()
-    fireEvent.change(screen.getByLabelText('Prefecture'), { target: { value: 'reg_osaka' } })
+    openLevel('Prefecture')
+    pickOption('Osaka')
     expect(onChange).toHaveBeenCalledWith('osaka')
   })
 
   it('emits the city slug when a city is chosen', () => {
     const { onChange } = renderPicker({ value: 'osaka' })
-    fireEvent.change(screen.getByLabelText('City'), { target: { value: 'reg_osaka_city' } })
+    openLevel('City')
+    pickOption('Osaka City')
     expect(onChange).toHaveBeenCalledWith('osaka-city')
   })
 
   it('emits the area slug when an area is chosen', () => {
     const { onChange } = renderPicker({ value: 'osaka-city' })
-    fireEvent.change(screen.getByLabelText('Area'), { target: { value: 'reg_namba' } })
+    openLevel('Area')
+    pickOption('Namba')
     expect(onChange).toHaveBeenCalledWith('namba')
   })
 
-  it('prefills all three selects from an area-slug value', () => {
+  it('prefills all three levels from an area-slug value', () => {
     renderPicker({ value: 'namba' })
-    expect(screen.getByLabelText<HTMLSelectElement>('Prefecture').value).toBe('reg_osaka')
-    expect(screen.getByLabelText<HTMLSelectElement>('City').value).toBe('reg_osaka_city')
-    expect(screen.getByLabelText<HTMLSelectElement>('Area').value).toBe('reg_namba')
+    expect(screen.getByLabelText<HTMLInputElement>('Prefecture').value).toBe('Osaka')
+    expect(screen.getByLabelText<HTMLInputElement>('City').value).toBe('Osaka City')
+    expect(screen.getByLabelText<HTMLInputElement>('Area').value).toBe('Namba')
+  })
+
+  it('emits the parent slug when a deeper level is cleared to its default', () => {
+    // Clearing the city to "All cities" should filter to the whole prefecture, not null.
+    const { onChange } = renderPicker({ value: 'osaka-city' })
+    openLevel('City')
+    pickOption('All cities')
+    expect(onChange).toHaveBeenCalledWith('osaka')
   })
 
   it('emits null when the prefecture is cleared to Anywhere', () => {
     const { onChange } = renderPicker({ value: 'osaka' })
-    fireEvent.change(screen.getByLabelText('Prefecture'), { target: { value: '' } })
+    openLevel('Prefecture')
+    pickOption('Anywhere')
     expect(onChange).toHaveBeenCalledWith(null)
   })
 
@@ -174,6 +207,13 @@ describe('RegionPicker', () => {
     const { onChange } = renderPicker()
     fireEvent.click(screen.getByRole('button', { name: 'Near me' }))
     expect(onChange).toHaveBeenCalledWith('namba')
+  })
+
+  it('passes a timeout so a hung geolocation prompt cannot stall', () => {
+    renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: 'Near me' }))
+    const options = getCurrentPosition.mock.calls[0]?.[2]
+    expect(options).toMatchObject({ timeout: 10_000 })
   })
 
   it('falls back to the full list when Near me is denied', () => {

--- a/packages/web/src/vite/regions/RegionPicker.tsx
+++ b/packages/web/src/vite/regions/RegionPicker.tsx
@@ -1,9 +1,10 @@
 import { Label } from '@/components/ui/label'
-import { NativeSelect } from '@/components/ui/native-select'
 import { nearestAssignableRegion } from '@kuruma/shared/lib/region-distance'
 import type { RegionNode } from '@kuruma/shared/types/region'
-import { useId, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import { useLocale, useTranslations } from 'use-intl'
+import { LocationCombobox } from './LocationCombobox'
+import { regionName } from './region-locale'
 import { regionChain } from './region-lookup'
 
 // Tourist quick-picks (#651 §6). Slugs are stable contracts; a slug absent from the
@@ -11,19 +12,17 @@ import { regionChain } from './region-lookup'
 // renter may anchor at any level, since the backend filters by region subtree.
 const QUICK_PICK_SLUGS = ['namba', 'umeda', 'kix', 'kyoto'] as const
 
+// Cap the geolocation prompt so a hung permission dialog (some in-app browsers never
+// resolve or reject) can't leave the "Near me" button stuck on "Locating…" forever.
+const GEO_TIMEOUT_MS = 10_000
+const GEO_MAX_AGE_MS = 5 * 60_000
+
 export interface RegionPickerProps {
   regions: readonly RegionNode[]
   /** The selected region as its stable slug (the URL contract — #651 Decision 6), or null. */
   value: string | null
   onChange: (slug: string | null) => void
   disabled?: boolean
-}
-
-// The API is locale-agnostic (trilingual names); the client picks one by route locale.
-function nameOf(region: RegionNode, locale: string): string {
-  if (locale === 'ja') return region.nameJa
-  if (locale === 'zh') return region.nameZh
-  return region.nameEn
 }
 
 /**
@@ -46,13 +45,26 @@ export function RegionPicker({ regions, value, onChange, disabled }: RegionPicke
   const selectedId = value !== null ? (bySlug.get(value)?.id ?? null) : null
   const chain = regionChain(regions, selectedId)
 
-  const prefectures = regions.filter((r) => r.type === 'PREFECTURE' && r.status === 'ACTIVE')
+  // A slug-less node is non-addressable (the picker emits slugs — #651 Decision 6), so
+  // selecting one would map to null = "Anywhere" and silently clear. Exclude it here so
+  // an unaddressable node is never offered as an option (review H2).
+  const prefectures = regions.filter(
+    (r) => r.type === 'PREFECTURE' && r.status === 'ACTIVE' && r.slug !== null,
+  )
   const cities = regions.filter(
-    (r) => r.type === 'CITY' && r.parentId === chain.prefecture?.id && r.status === 'ACTIVE',
+    (r) =>
+      r.type === 'CITY' &&
+      r.parentId === chain.prefecture?.id &&
+      r.status === 'ACTIVE' &&
+      r.slug !== null,
   )
   const areas = regions.filter(
     (r) =>
-      r.type === 'AREA' && r.parentId === chain.city?.id && r.assignable && r.status === 'ACTIVE',
+      r.type === 'AREA' &&
+      r.parentId === chain.city?.id &&
+      r.assignable &&
+      r.status === 'ACTIVE' &&
+      r.slug !== null,
   )
 
   const slugOf = (id: string): string | null => byId.get(id)?.slug ?? null
@@ -70,6 +82,16 @@ export function RegionPicker({ regions, value, onChange, disabled }: RegionPicke
     (r): r is RegionNode => r !== undefined,
   )
 
+  // Dev-only: a renamed/removed quick-pick slug otherwise vanishes as a silent missing
+  // chip. Surface it so it's caught before shipping (review L1).
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    const missing = QUICK_PICK_SLUGS.filter((slug) => !bySlug.has(slug))
+    if (missing.length > 0) {
+      console.warn(`RegionPicker: quick-pick slug(s) not in taxonomy: ${missing.join(', ')}`)
+    }
+  }, [bySlug])
+
   const handleNearMe = () => {
     if (typeof navigator === 'undefined' || !navigator.geolocation) {
       onChange(null)
@@ -86,11 +108,12 @@ export function RegionPicker({ regions, value, onChange, disabled }: RegionPicke
         onChange(nearest?.slug ?? null)
       },
       () => {
-        // Denied / unavailable: a stale device point must never override a chosen area —
-        // fall back to the full list (§6).
+        // Denied / unavailable / timed out: a stale device point must never override a
+        // chosen area — fall back to the full list (§6).
         setLocating(false)
         onChange(null)
       },
+      { timeout: GEO_TIMEOUT_MS, maximumAge: GEO_MAX_AGE_MS },
     )
   }
 
@@ -99,51 +122,36 @@ export function RegionPicker({ regions, value, onChange, disabled }: RegionPicke
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
         <div>
           <Label htmlFor={`${ids}-prefecture`}>{t('prefecture')}</Label>
-          <NativeSelect
+          <LocationCombobox
             id={`${ids}-prefecture`}
+            regions={prefectures}
             value={chain.prefecture?.id ?? ''}
+            placeholder={t('anywhere')}
             disabled={disabled}
-            onChange={(e) => emit(e.target.value, null)}
-          >
-            <option value="">{t('anywhere')}</option>
-            {prefectures.map((r) => (
-              <option key={r.id} value={r.id}>
-                {nameOf(r, locale)}
-              </option>
-            ))}
-          </NativeSelect>
+            onChange={(id) => emit(id, null)}
+          />
         </div>
         <div>
           <Label htmlFor={`${ids}-city`}>{t('city')}</Label>
-          <NativeSelect
+          <LocationCombobox
             id={`${ids}-city`}
+            regions={cities}
             value={chain.city?.id ?? ''}
+            placeholder={t('allCities')}
             disabled={disabled || chain.prefecture === null}
-            onChange={(e) => emit(e.target.value, chain.prefecture)}
-          >
-            <option value="">{t('allCities')}</option>
-            {cities.map((r) => (
-              <option key={r.id} value={r.id}>
-                {nameOf(r, locale)}
-              </option>
-            ))}
-          </NativeSelect>
+            onChange={(id) => emit(id, chain.prefecture)}
+          />
         </div>
         <div>
           <Label htmlFor={`${ids}-area`}>{t('area')}</Label>
-          <NativeSelect
+          <LocationCombobox
             id={`${ids}-area`}
+            regions={areas}
             value={chain.area?.id ?? ''}
+            placeholder={t('allAreas')}
             disabled={disabled || chain.city === null}
-            onChange={(e) => emit(e.target.value, chain.city)}
-          >
-            <option value="">{t('allAreas')}</option>
-            {areas.map((r) => (
-              <option key={r.id} value={r.id}>
-                {nameOf(r, locale)}
-              </option>
-            ))}
-          </NativeSelect>
+            onChange={(id) => emit(id, chain.city)}
+          />
         </div>
       </div>
 
@@ -164,7 +172,7 @@ export function RegionPicker({ regions, value, onChange, disabled }: RegionPicke
                   : 'border-border bg-background text-foreground hover:bg-muted'
               }`}
             >
-              {nameOf(r, locale)}
+              {regionName(r, locale)}
             </button>
           )
         })}

--- a/packages/web/src/vite/regions/index.ts
+++ b/packages/web/src/vite/regions/index.ts
@@ -1,0 +1,6 @@
+// Public surface of the regions feature for cross-feature consumers. The shared
+// LocationCombobox (#1543) is also used by operator-locations; import it via
+// `@/vite/regions` rather than deep-importing the internal file, per the module-boundary
+// rule (docs/architecture/modules.md).
+export { LocationCombobox } from './LocationCombobox'
+export type { LocationComboboxProps } from './LocationCombobox'

--- a/packages/web/src/vite/regions/region-locale.test.ts
+++ b/packages/web/src/vite/regions/region-locale.test.ts
@@ -99,4 +99,10 @@ describe('regionMatchesQuery', () => {
   it('returns false when nothing matches', () => {
     expect(regionMatchesQuery(OSAKA, 'zzz', 'en')).toBe(false)
   })
+
+  it('does not fold Japanese dakuten in the display label (ぎ must not match き)', () => {
+    const gifu = makeRegion({ id: 'gifu', nameEn: 'Gifu', nameJa: 'ぎふ', nameZh: '岐阜' })
+    expect(regionMatchesQuery(gifu, 'ぎ', 'ja')).toBe(true)
+    expect(regionMatchesQuery(gifu, 'き', 'ja')).toBe(false)
+  })
 })

--- a/packages/web/src/vite/regions/region-locale.test.ts
+++ b/packages/web/src/vite/regions/region-locale.test.ts
@@ -1,0 +1,102 @@
+import type { RegionNode } from '@kuruma/shared/types/region'
+import { describe, expect, it } from 'vitest'
+import { orderRegionsForLocale, regionMatchesQuery, regionName } from './region-locale'
+
+function makeRegion(overrides: Pick<RegionNode, 'id'> & Partial<RegionNode>): RegionNode {
+  return {
+    parentId: null,
+    slug: null,
+    nameEn: 'Region',
+    nameJa: '地域',
+    nameZh: '地区',
+    type: 'PREFECTURE',
+    latitude: null,
+    longitude: null,
+    assignable: true,
+    status: 'ACTIVE',
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+// sortOrder ascending mirrors the API order (ORDER BY sortOrder, nameEn). The English
+// names are deliberately NOT alphabetical in this input so an en-sort is observable.
+const OSAKA = makeRegion({
+  id: 'osaka',
+  nameEn: 'Osaka',
+  nameJa: '大阪',
+  nameZh: '大阪',
+  sortOrder: 0,
+})
+const AICHI = makeRegion({
+  id: 'aichi',
+  nameEn: 'Aichi',
+  nameJa: '愛知',
+  nameZh: '爱知',
+  sortOrder: 1,
+})
+const KYOTO = makeRegion({
+  id: 'kyoto',
+  nameEn: 'Kyōto',
+  nameJa: '京都',
+  nameZh: '京都',
+  sortOrder: 2,
+})
+const INPUT = [OSAKA, AICHI, KYOTO] as const
+
+describe('regionName', () => {
+  it('returns the name for the active locale', () => {
+    expect(regionName(OSAKA, 'en')).toBe('Osaka')
+    expect(regionName(OSAKA, 'ja')).toBe('大阪')
+    expect(regionName(OSAKA, 'zh')).toBe('大阪')
+  })
+
+  it('falls back to the English name when the localized name is empty', () => {
+    const blankJa = makeRegion({ id: 'x', nameEn: 'Sakai', nameJa: '', nameZh: '' })
+    expect(regionName(blankJa, 'ja')).toBe('Sakai')
+    expect(regionName(blankJa, 'zh')).toBe('Sakai')
+  })
+})
+
+describe('orderRegionsForLocale', () => {
+  it('sorts English A-Z by the English name', () => {
+    expect(orderRegionsForLocale(INPUT, 'en').map((r) => r.id)).toEqual(['aichi', 'kyoto', 'osaka'])
+  })
+
+  it('preserves the API sortOrder for Japanese and Chinese', () => {
+    expect(orderRegionsForLocale(INPUT, 'ja').map((r) => r.id)).toEqual(['osaka', 'aichi', 'kyoto'])
+    expect(orderRegionsForLocale(INPUT, 'zh').map((r) => r.id)).toEqual(['osaka', 'aichi', 'kyoto'])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = [...INPUT]
+    orderRegionsForLocale(INPUT, 'en')
+    expect(INPUT).toEqual(copy)
+  })
+})
+
+describe('regionMatchesQuery', () => {
+  it('matches everything on an empty query', () => {
+    expect(regionMatchesQuery(OSAKA, '', 'ja')).toBe(true)
+    expect(regionMatchesQuery(OSAKA, '   ', 'ja')).toBe(true)
+  })
+
+  it('matches the active-locale name case-insensitively', () => {
+    expect(regionMatchesQuery(OSAKA, 'OSA', 'en')).toBe(true)
+    expect(regionMatchesQuery(OSAKA, '大阪', 'ja')).toBe(true)
+  })
+
+  it('matches a Japanese-labelled entry via its romanized English name', () => {
+    // A Japanese visitor sees 大阪, but an English typer should still find it by "osaka".
+    expect(regionMatchesQuery(OSAKA, 'osaka', 'ja')).toBe(true)
+  })
+
+  it('is accent-insensitive both ways', () => {
+    expect(regionMatchesQuery(KYOTO, 'kyoto', 'en')).toBe(true) // query plain, name "Kyōto"
+    expect(regionMatchesQuery(KYOTO, 'kyōto', 'ja')).toBe(true) // query accented
+  })
+
+  it('returns false when nothing matches', () => {
+    expect(regionMatchesQuery(OSAKA, 'zzz', 'en')).toBe(false)
+  })
+})

--- a/packages/web/src/vite/regions/region-locale.ts
+++ b/packages/web/src/vite/regions/region-locale.ts
@@ -1,0 +1,53 @@
+import type { RegionNode } from '@kuruma/shared/types/region'
+
+// The renter/operator UI is trilingual; the API returns all three names per node and the
+// client picks one by route locale. This module is the single source of truth for that
+// choice AND for the locale-aware ordering + search rules (#1543) — previously the
+// `nameOf` selector was copy-pasted across RegionPicker and RegionCascade.
+
+/** Display name for the active locale, falling back to English when a localized name is blank. */
+export function regionName(region: RegionNode, locale: string): string {
+  if (locale === 'ja') return region.nameJa || region.nameEn
+  if (locale === 'zh') return region.nameZh || region.nameEn
+  return region.nameEn
+}
+
+/**
+ * Order a level's options for display.
+ * - `en`: alphabetical by English name (easier to scan than the JP prefecture-code order).
+ * - `ja` / `zh`: keep the API's `sortOrder` sequence (the familiar Hokkaido→Okinawa order).
+ *
+ * Returns a new array; never mutates the input. The `en` sort is authoritative — the API
+ * orders by `(sortOrder, nameEn)`, so `nameEn` is only a within-group tiebreak there, not
+ * a global A-Z; we re-sort client-side rather than half-rely on server order.
+ */
+export function orderRegionsForLocale(
+  regions: readonly RegionNode[],
+  locale: string,
+): RegionNode[] {
+  if (locale === 'en') {
+    return [...regions].sort((a, b) => a.nameEn.localeCompare(b.nameEn, 'en'))
+  }
+  return [...regions]
+}
+
+// Case- and accent-insensitive fold: NFD splits accented letters into base + combining
+// mark, then we strip the marks so "Kyōto" and "kyoto" compare equal.
+function fold(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+}
+
+/**
+ * Whether a region matches a type-to-search query. Matches the active-locale display name
+ * OR the romanized (English) name, so an English typer can find a Japanese-labelled entry
+ * ("osaka" finds 大阪). Empty/whitespace query matches everything.
+ */
+export function regionMatchesQuery(region: RegionNode, query: string, locale: string): boolean {
+  const needle = fold(query)
+  if (needle === '') return true
+  return fold(regionName(region, locale)).includes(needle) || fold(region.nameEn).includes(needle)
+}

--- a/packages/web/src/vite/regions/region-locale.ts
+++ b/packages/web/src/vite/regions/region-locale.ts
@@ -31,9 +31,16 @@ export function orderRegionsForLocale(
   return [...regions]
 }
 
-// Case- and accent-insensitive fold: NFD splits accented letters into base + combining
-// mark, then we strip the marks so "Kyōto" and "kyoto" compare equal.
-function fold(value: string): string {
+// Case-only fold for CJK display labels: normalize + lowercase, but NEVER strip combining
+// marks. Japanese dakuten/handakuten (き vs ぎ, は vs ば/ぱ) are phonemic, not accents —
+// stripping them would make ぎ match き and ば match は.
+function foldLabel(value: string): string {
+  return value.normalize('NFC').toLowerCase().trim()
+}
+
+// Accent-insensitive fold for the romanized English name only: NFD splits accented
+// letters into base + combining mark, then we strip the marks so "Kyōto" matches "kyoto".
+function foldRomaji(value: string): string {
   return value
     .normalize('NFD')
     .replace(/\p{Diacritic}/gu, '')
@@ -43,11 +50,13 @@ function fold(value: string): string {
 
 /**
  * Whether a region matches a type-to-search query. Matches the active-locale display name
- * OR the romanized (English) name, so an English typer can find a Japanese-labelled entry
- * ("osaka" finds 大阪). Empty/whitespace query matches everything.
+ * (case-insensitive, diacritics preserved) OR the romanized English name (accent-insensitive),
+ * so an English typer can find a Japanese-labelled entry ("osaka" finds 大阪) without a
+ * kana search collapsing dakuten. Empty/whitespace query matches everything.
  */
 export function regionMatchesQuery(region: RegionNode, query: string, locale: string): boolean {
-  const needle = fold(query)
-  if (needle === '') return true
-  return fold(regionName(region, locale)).includes(needle) || fold(region.nameEn).includes(needle)
+  if (query.trim() === '') return true
+  const labelHit = foldLabel(regionName(region, locale)).includes(foldLabel(query))
+  const romajiHit = foldRomaji(region.nameEn).includes(foldRomaji(query))
+  return labelHit || romajiHit
 }

--- a/packages/web/tests/vite/operator-locations/LocationForm.test.tsx
+++ b/packages/web/tests/vite/operator-locations/LocationForm.test.tsx
@@ -1,10 +1,20 @@
 import { LocationForm } from '@/vite/operator-locations/LocationForm'
 import type { RegionNode } from '@kuruma/shared/types/region'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
+
+// Each cascade level is now a combobox; open it via its scoped trigger, then click an option.
+function openLevel(label: string) {
+  const group = screen.getByLabelText(label).closest('div')
+  if (group === null) throw new Error(`no group for ${label}`)
+  fireEvent.click(within(group).getByRole('button', { name: 'Open options' }))
+}
+function pickOption(name: string) {
+  fireEvent.click(screen.getByRole('option', { name }))
+}
 
 const node = (over: Partial<RegionNode> & Pick<RegionNode, 'id' | 'type'>): RegionNode => ({
   parentId: null,
@@ -49,9 +59,12 @@ describe('LocationForm region cascade (#651 Slice 2b)', () => {
 
     await user.type(screen.getByLabelText('Location name'), 'Namba Branch')
     await user.type(screen.getByLabelText('Address'), '1-2-3 Namba, Chuo-ku')
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
-    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
-    await user.selectOptions(screen.getByLabelText('Area'), 'reg_namba')
+    openLevel('Prefecture')
+    pickOption('Osaka')
+    openLevel('City')
+    pickOption('Osaka City')
+    openLevel('Area')
+    pickOption('Namba')
     await user.click(screen.getByRole('button', { name: 'Save location' }))
 
     expect(onSubmit).toHaveBeenCalledTimes(1)
@@ -83,8 +96,8 @@ describe('LocationForm region cascade (#651 Slice 2b)', () => {
       </IntlProvider>,
     )
 
-    expect(screen.getByLabelText('Prefecture')).toHaveValue('reg_osaka')
-    expect(screen.getByLabelText('City')).toHaveValue('reg_osaka_city')
-    expect(screen.getByLabelText('Area')).toHaveValue('reg_namba')
+    expect(screen.getByLabelText('Prefecture')).toHaveValue('Osaka')
+    expect(screen.getByLabelText('City')).toHaveValue('Osaka City')
+    expect(screen.getByLabelText('Area')).toHaveValue('Namba')
   })
 })

--- a/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
+++ b/packages/web/tests/vite/operator-locations/RegionCascade.test.tsx
@@ -1,7 +1,6 @@
 import { RegionCascade } from '@/vite/operator-locations/RegionCascade'
 import type { RegionNode } from '@kuruma/shared/types/region'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { IntlProvider } from 'use-intl'
 import { describe, expect, it, vi } from 'vitest'
 import en from '../../../messages/en.json'
@@ -75,6 +74,16 @@ function setup(value: string | null = null) {
   return onChange
 }
 
+// Each level is a combobox; open it via its own scoped trigger, then click an option.
+function open(label: string) {
+  const group = screen.getByLabelText(label).closest('div')
+  if (group === null) throw new Error(`no group for ${label}`)
+  fireEvent.click(within(group).getByRole('button', { name: 'Open options' }))
+}
+function pick(name: string) {
+  fireEvent.click(screen.getByRole('option', { name }))
+}
+
 describe('RegionCascade (#651 Slice 2b, #1276 city-as-terminal)', () => {
   it('shows only prefecture enabled initially; city disabled, area not yet rendered', () => {
     setup()
@@ -83,41 +92,43 @@ describe('RegionCascade (#651 Slice 2b, #1276 city-as-terminal)', () => {
     expect(screen.queryByLabelText('Area')).not.toBeInTheDocument()
   })
 
-  it('emits the city id when an assignable city is selected (city is terminal)', async () => {
-    const user = userEvent.setup()
+  it('emits the city id when an assignable city is selected (city is terminal)', () => {
     const onChange = setup()
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
-    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
-
+    open('Prefecture')
+    pick('Osaka')
+    open('City')
+    pick('Osaka City')
     expect(onChange).toHaveBeenLastCalledWith('reg_osaka_city')
   })
 
-  it('renders no area dropdown for an assignable city with no area children', async () => {
-    const user = userEvent.setup()
+  it('renders no area dropdown for an assignable city with no area children', () => {
     const onChange = setup()
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_kyoto')
-    await user.selectOptions(screen.getByLabelText('City'), 'reg_kyoto_city')
-
+    open('Prefecture')
+    pick('Kyoto')
+    open('City')
+    pick('Kyoto City')
     expect(onChange).toHaveBeenLastCalledWith('reg_kyoto_city')
     expect(screen.queryByLabelText('Area')).not.toBeInTheDocument()
   })
 
-  it('lets an area refine an assignable city, overriding the city as the terminal', async () => {
-    const user = userEvent.setup()
+  it('lets an area refine an assignable city, overriding the city as the terminal', () => {
     const onChange = setup()
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
-    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
-    await user.selectOptions(screen.getByLabelText('Area'), 'reg_namba')
-
+    open('Prefecture')
+    pick('Osaka')
+    open('City')
+    pick('Osaka City')
+    open('Area')
+    pick('Namba')
     expect(onChange).toHaveBeenLastCalledWith('reg_namba')
   })
 
-  it('lists only assignable, ACTIVE areas (excludes INACTIVE + navigation-only)', async () => {
-    const user = userEvent.setup()
+  it('lists only assignable, ACTIVE areas (excludes INACTIVE + navigation-only)', () => {
     setup()
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_osaka')
-    await user.selectOptions(screen.getByLabelText('City'), 'reg_osaka_city')
-
+    open('Prefecture')
+    pick('Osaka')
+    open('City')
+    pick('Osaka City')
+    open('Area')
     expect(screen.getByRole('option', { name: 'Namba' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Umeda' })).toBeInTheDocument()
     expect(screen.queryByRole('option', { name: 'Retired' })).not.toBeInTheDocument()
@@ -126,35 +137,39 @@ describe('RegionCascade (#651 Slice 2b, #1276 city-as-terminal)', () => {
 
   it('prefills the prefecture -> city -> area chain from an existing AREA value', () => {
     setup('reg_namba')
-    expect(screen.getByLabelText('Prefecture')).toHaveValue('reg_osaka')
-    expect(screen.getByLabelText('City')).toHaveValue('reg_osaka_city')
-    expect(screen.getByLabelText('Area')).toHaveValue('reg_namba')
+    expect(screen.getByLabelText('Prefecture')).toHaveValue('Osaka')
+    expect(screen.getByLabelText('City')).toHaveValue('Osaka City')
+    expect(screen.getByLabelText('Area')).toHaveValue('Namba')
   })
 
   it('prefills the prefecture -> city chain from an existing CITY value', () => {
     setup('reg_osaka_city')
-    expect(screen.getByLabelText('Prefecture')).toHaveValue('reg_osaka')
-    expect(screen.getByLabelText('City')).toHaveValue('reg_osaka_city')
-    // The city is the terminal, so the (optional) area select stays on its placeholder.
-    expect(screen.getByLabelText('Area')).toHaveValue('')
+    expect(screen.getByLabelText('Prefecture')).toHaveValue('Osaka')
+    expect(screen.getByLabelText('City')).toHaveValue('Osaka City')
+    // The city is the terminal, so the (optional) area level stays on its default option.
+    expect(screen.getByLabelText('Area')).toHaveValue('Select...')
   })
 
-  it('clears the value to null and resets the city when the prefecture changes', async () => {
-    const user = userEvent.setup()
+  it('clears the value to null and resets the city when the prefecture changes', () => {
     const onChange = setup('reg_namba')
-    await user.selectOptions(screen.getByLabelText('Prefecture'), 'reg_kyoto')
+    open('Prefecture')
+    pick('Kyoto')
     expect(onChange).toHaveBeenLastCalledWith(null)
-    expect(screen.getByLabelText('City')).toHaveValue('')
+    expect(screen.getByLabelText('City')).toHaveValue('Select...')
   })
 
   it('keeps a now-unselectable assigned region visible (INACTIVE) instead of blanking', () => {
     setup('reg_retired')
-    expect(screen.getByLabelText('Area')).toHaveValue('reg_retired')
+    expect(screen.getByLabelText('Area')).toHaveValue('Retired')
+    open('Area')
     expect(screen.getByRole('option', { name: 'Retired' })).toBeInTheDocument()
   })
 
-  it('renders without crashing when the assigned region is unknown (since deleted)', () => {
-    setup('reg_gone')
-    expect(screen.getByLabelText('Area')).toHaveValue('reg_gone')
+  it('does not crash or silently blank an unknown (since-deleted) assigned region', () => {
+    const onChange = setup('reg_gone')
+    // No name to show, so the control falls back to its placeholder — but the controlled
+    // value is never emitted away, so a blind re-save keeps the id rather than nulling it.
+    expect(screen.getByLabelText('Area')).toHaveValue('Select...')
+    expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -113,7 +113,11 @@ const DEPRECATED_WEB_TREE_BASELINE = 170
 // 165 (#877 operator terms): routes/$locale/_business/manage/terms.tsx composes the
 // operator-terms feature view + api (two reach-ins) — the same sanctioned
 // routes-compose-a-vite-feature pattern as the siblings above.
-const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 165
+// 166 (#1543 location combobox): operator-locations/RegionCascade composes the shared
+// regions/LocationCombobox — the reusable type-to-search picker the issue mandates for
+// both the public cascade and the operator forms (same shape as the regions-api reach-ins
+// already made by Add/EditLocationDialog).
+const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 166
 
 export type DeprecatedTreeStatus = {
   count: number

--- a/scripts/lint-module-boundaries.ts
+++ b/scripts/lint-module-boundaries.ts
@@ -113,11 +113,7 @@ const DEPRECATED_WEB_TREE_BASELINE = 170
 // 165 (#877 operator terms): routes/$locale/_business/manage/terms.tsx composes the
 // operator-terms feature view + api (two reach-ins) — the same sanctioned
 // routes-compose-a-vite-feature pattern as the siblings above.
-// 166 (#1543 location combobox): operator-locations/RegionCascade composes the shared
-// regions/LocationCombobox — the reusable type-to-search picker the issue mandates for
-// both the public cascade and the operator forms (same shape as the regions-api reach-ins
-// already made by Add/EditLocationDialog).
-const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 166
+const VITE_CROSS_FEATURE_REACH_IN_BASELINE = 165
 
 export type DeprecatedTreeStatus = {
   count: number


### PR DESCRIPTION
Closes #1543.

## What
A reusable **type-to-search location picker** (`LocationCombobox`) replaces the native `<select>` dropdowns at every level of the region cascade, with **locale-aware ordering**:
- `en`: options sorted A-Z by English name.
- `ja` / `zh`: keep the familiar API `sortOrder` (prefecture-code) sequence.
- Filtering is case/accent-insensitive and matches the romanized (English) name, so an English typer finds a Japanese-labelled entry ("osaka" → 大阪).

Built on `@base-ui/react` Combobox (already a dependency; matches the `ui/select.tsx` styling/a11y). Drop-in for `NativeSelect` — the `value`/`onChange` contract stays the region **id** / `''`. Used in both the public `RegionPicker` (landing `SearchWidget` + `StorefrontSearchForm`) and the operator `RegionCascade`. No schema/API/seed change — trilingual names already exist in the DB.

## Layers
- `region-locale.ts` — single source of truth for the trilingual name selector + ordering + search (replaces a `nameOf` helper that was copy-pasted across both pickers).
- `LocationCombobox.tsx` — the shared control; pinned "Anywhere / All cities / All areas" default option, clearable, keyboard nav.
- `RegionPicker` / `RegionCascade` — swapped to the combobox; quick-picks + Near-me untouched.
- `locationCombobox` i18n keys added (en/ja/zh).

## Review findings addressed (pre-refactor review of the touched surface)
| ID | Finding | Fix |
|----|---------|-----|
| H1 | Operator cascade nav state desynced from `value` (mount-only seed) | resync effect keyed on `value` (regions via ref, self-change skip) |
| H2 | Selecting a slug-less node collapsed to "Anywhere" | exclude `slug === null` from public options |
| H3 | `nameOf` duplicated across both pickers | extracted to `region-locale` |
| M1 | Static label ids / no a11y forwarding | `useId()` in cascade; combobox forwards `aria-invalid`/`aria-describedby` |
| M2 | Clear-to-parent semantics | preserved + characterization test |
| M3 | INACTIVE/deleted assignment stays visible | preserved (folded into option list) + tests |
| M4 | `Near me` could hang | `getCurrentPosition` timeout `{ timeout: 10s, maximumAge: 5m }` |
| M5 | Server order isn't global A-Z | client `en` sort is authoritative |
| L1 / L2 | Silent quick-pick drop / blank localized name | dev warn / `nameEn` fallback |

## Test plan
- [x] `bunx vitest run` (packages/web): **2255/2255 pass**, incl. migrated `tests/vite` RegionCascade (10) + LocationForm (3) suites (ported from native-select to combobox).
- [x] New unit tests: `region-locale` (10), `LocationCombobox` (5), `RegionCascade` (5); RegionPicker suite extended to 13.
- [x] `tsc --noEmit` web: 0 errors. Biome + module-boundary ratchet pass.
- [ ] Manual: verify type-to-search + keyboard nav on landing search and operator location form across en/ja/zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
