### PR TITLE
Fail loud when the email service is half-configured

### DIFF
--- a/docs/plans/2026-07-11-go-live-checklist.md
+++ b/docs/plans/2026-07-11-go-live-checklist.md
@@ -57,6 +57,13 @@ not exist yet — this checklist builds it.
       `STRIPE_SECRET_KEY/WEBHOOK_SECRET` (live), `SENTRY_DSN`, `CONSENT_SIGNING_KEY(_ID)`,
       `GOOGLE_TRANSLATE_API_KEY`. Optional (fail closed if unset): `STATS_API_KEY` (the
       `/stats` dashboard), `PARTNER_API_KEY` (Trip.com partner API).
+  - [ ] **Email `from` is a var, not a secret (#1561)** — `EMAIL_FROM` already ships as a
+        `[vars]` value in `wrangler.toml` (beta + `[env.production.vars]`, both
+        `noreply@mail.jack-li.dev`), so there's nothing to `secret put`. It must stay
+        non-empty and on the Resend-verified sending domain: with `RESEND_API_KEY` set but
+        `EMAIL_FROM` empty, `resolveEmailSender` now returns a throwing sentinel — every
+        approval/rejection + booking + compliance email fails loud instead of silently
+        4xx-ing. `RESEND_API_KEY` is the only email secret.
   - [ ] **Do NOT reuse the beta secret `PROD_DATABASE_URL`** — it holds the **beta** DB
         connection string (feeds beta's `DATABASE_URL` + migrations). Create a NEW,
         distinctly-named GitHub secret (e.g. `PRODUCTION_LIVE_DATABASE_URL`) = the
@@ -77,8 +84,13 @@ not exist yet — this checklist builds it.
 - [ ] **Prod web Pages deploy** — `deploy.yml` is beta-only; add a `kuruma-web-production`
       deploy path once that Pages project exists.
 - [ ] **Prod secret rotation** — a `rotate-secrets.yml` variant that targets `--env production`.
-- [ ] **`deploy.yml` presence check** — add Stripe / Sentry / Consent / Translate to the
-      required-secret gate once prod genuinely depends on them.
+- [ ] **`deploy.yml` presence check** — add Stripe / Sentry / Consent / Translate /
+      **`RESEND_API_KEY` (#1561)** to the required-secret gate once prod genuinely depends
+      on them. Deferred until then on purpose: the gate reads `wrangler secret list` and
+      hard-fails the deploy for any listed-but-unset secret, so adding a not-yet-provisioned
+      key would block beta (same reason Stripe is still out). NOTE: `EMAIL_FROM` is a
+      `[vars]` value (ships with code), NOT a secret — it can't appear in `secret list`, so
+      it's validated by living in `wrangler.toml`, not by this gate.
 
 ---
 

--- a/packages/api/src/composition/services.test.ts
+++ b/packages/api/src/composition/services.test.ts
@@ -114,11 +114,29 @@ describe('resolveEmailSender', () => {
     await expect(sender.send({} as never)).rejects.toThrow('RESEND_API_KEY not configured')
   })
 
+  test('production with a key but no EMAIL_FROM yields a sentinel naming the missing from (#1561)', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.RESEND_API_KEY = 're_test'
+    // EMAIL_FROM unset: Resend would reject every send with an opaque 4xx that the
+    // best-effort callers swallow, so fail loud with a clear reason instead.
+    const sender = resolveEmailSender()
+    expect(sender).not.toBeInstanceOf(ResendEmailSender)
+    await expect(sender.send({} as never)).rejects.toThrow('EMAIL_FROM not configured')
+  })
+
   test('dev without a key yields a console stub returning the dev id', async () => {
     process.env.NODE_ENV = 'test'
     await expect(resolveEmailSender().send({} as never)).resolves.toEqual({
       providerMessageId: 'dev',
     })
+  })
+
+  test('dev with a key but no EMAIL_FROM falls to the dev stub, not a broken Resend sender (#1561)', async () => {
+    process.env.NODE_ENV = 'test'
+    process.env.RESEND_API_KEY = 're_test'
+    const sender = resolveEmailSender()
+    expect(sender).not.toBeInstanceOf(ResendEmailSender)
+    await expect(sender.send({} as never)).resolves.toEqual({ providerMessageId: 'dev' })
   })
 })
 

--- a/packages/api/src/composition/services.ts
+++ b/packages/api/src/composition/services.ts
@@ -65,19 +65,31 @@ export function resolveGoogleOAuthConfig(): GoogleOAuthConfig | undefined {
 
 /**
  * Resolve the outbound email port (#916 DRY): an injected override wins (tests),
- * else real Resend when RESEND_API_KEY is set, else a throwing sentinel in
- * production and a console stub in dev — so flows work end-to-end without a
- * vendor account. Shared by createApp's dispatcher and buildComplianceDigestService.
+ * else real Resend when BOTH RESEND_API_KEY and EMAIL_FROM are set, else a
+ * throwing sentinel in production and a console stub in dev — so flows work
+ * end-to-end without a vendor account. Shared by createApp's dispatcher and
+ * buildComplianceDigestService.
+ *
+ * #1561: a key WITHOUT EMAIL_FROM is a misconfiguration, not a working sender —
+ * every EmailMessage.from is sourced from EMAIL_FROM (notification-dispatcher,
+ * compliance-digest, operator-application), so an empty from makes Resend reject
+ * every send with an opaque 4xx that the best-effort callers swallow, silently
+ * dropping applicant mail. Treat it like a missing key: fail loud with a clear
+ * reason instead of shipping a sender that can never succeed. Mirrors
+ * resolvePaymentGateway's both-secrets-or-sentinel policy.
  */
 export function resolveEmailSender(overrides?: AppOverrides): EmailSender {
   if (overrides?.emailSender) return overrides.emailSender
   const key = process.env.RESEND_API_KEY
   const from = process.env.EMAIL_FROM ?? ''
-  if (key) return new ResendEmailSender(key, from)
+  if (key && from) return new ResendEmailSender(key, from)
   if (process.env.NODE_ENV === 'production') {
+    const reason = key
+      ? 'EMAIL_FROM not configured (RESEND_API_KEY is set)'
+      : 'RESEND_API_KEY not configured'
     return {
       send: async () => {
-        throw new Error('RESEND_API_KEY not configured')
+        throw new Error(reason)
       },
     }
   }


### PR DESCRIPTION
Refs #1561 (NOT Closes — the go-live provisioning half stays tracked until prod secrets are set).

## Problem
`resolveEmailSender` returned a real `ResendEmailSender` whenever `RESEND_API_KEY` was set, even if `EMAIL_FROM` was empty. Every `EmailMessage.from` is sourced from `EMAIL_FROM` (notification-dispatcher, compliance-digest, operator-application), so an empty from makes Resend 4xx-reject every send — and the best-effort callers swallow it, so approval/rejection + booking + compliance emails silently vanish.

## Fix
- Require **both** `RESEND_API_KEY` and `EMAIL_FROM` before returning the real sender; otherwise fall to the prod sentinel (now naming which piece is missing) or the dev stub. Mirrors `resolvePaymentGateway`'s both-secrets-or-sentinel policy in the same file.
- The real deployed config is **unchanged** — `EMAIL_FROM` ships as a `wrangler.toml` `[vars]` value (beta + prod, `noreply@mail.jack-li.dev`), so `key && from` stays truthy. This is defense-in-depth for a cleared/fresh/misconfigured env.
- Go-live checklist corrected: `EMAIL_FROM` is a **var, not a secret** (nothing to `secret put`; can't join the `wrangler secret list` presence gate) — only `RESEND_API_KEY` is the email secret.

## Deliberately out of scope (per #1561)
- Runtime Sentry escalation of the swallowed send failures (broader — 3 shared callers).
- Actually adding `RESEND_API_KEY` to `deploy.yml`'s presence gate (couples to go-live; adding a not-yet-live secret hard-fails beta deploys, same as Stripe).

## Test plan
- New unit tests for the misconfig path (prod → clear sentinel; dev → stub), mutation-resistant (assert reason string + `not.toBeInstanceOf`).
- api tsc clean, full api unit **3047** passing, lint:boundaries OK. code-reviewer: SHIP.