### PR TITLE
Fix e2e booking test that breaks itself once its hardcoded date passes

### DIFF
--- a/e2e/real-db/region-search.auth.spec.ts
+++ b/e2e/real-db/region-search.auth.spec.ts
@@ -23,9 +23,17 @@ const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 // Far-future window, clear of the demo-relative seeded bookings (~-5..+7d): every
 // store keeps a free fleet, so the region filter — not availability — drives the
-// result set. `datetime-local` wall-clock (parsed as JST).
-const FROM = '2026-07-15T10:00'
-const TO = '2026-07-17T10:00'
+// result set. `datetime-local` wall-clock (parsed as JST). Computed relative to
+// today (not a fixed date) so the window can never drift into the past and make
+// the real booking POST 4xx — a hardcoded '2026-07-15' silently rotted here once
+// wall-clock passed it, failing every PR's e2e-real-db lane.
+const bookingDay = (offsetDays: number): string => {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + offsetDays)
+  return d.toISOString().slice(0, 10) // YYYY-MM-DD
+}
+const FROM = `${bookingDay(30)}T10:00`
+const TO = `${bookingDay(32)}T10:00`
 
 // The KIX area (slug `kix`) is a leaf: its subtree is one store, Best Car Rental's
 // "Kansai Airport (KIX)". Its region centre == that store's coords, so the store


### PR DESCRIPTION
## Problem
`e2e/real-db/region-search.auth.spec.ts` hardcoded its booking window as `FROM = '2026-07-15T10:00'`. Once wall-clock passed that date, the booking **start** became the past, the real API rejected the POST, and the renter flow never reached `/bookings/confirmation`. Result: **`e2e-real-db` fails on every PR from 2026-07-15 onward** — a silent time-bomb, unrelated to any code change (it passed when last merged on 2026-07-13).

## Fix
Compute the window relative to today (`today+30 .. +32d`) so it stays far-future and clear of the demo-relative seeded bookings (`~-5..+7d`). Format unchanged (`YYYY-MM-DDT10:00`, datetime-local wall-clock).

## Heads-up (follow-up, not in this PR)
The same hardcoded-future-date pattern still lurks in two specs that haven't rotted yet:
- `mobile-happy-path.auth.spec.ts` — `2026-08-15`
- `booking-extras-consent.auth.spec.ts` — `2026-09-10`

They'll break the same way on those dates. Filing a follow-up to give them the same relative-window treatment (and consider a shared helper / a guard against hardcoded past dates in real-db specs).

## Test plan
- CI `e2e-real-db` is the exact reproduction env; region-search should now pass. Date computation verified locally (today 2026-07-16 → window 2026-08-15..08-17, correct format, future).