### PR TITLE
test(e2e): compute remaining real-db booking windows relative to now

### DIFF
--- a/e2e/real-db/booking-extras-consent.auth.spec.ts
+++ b/e2e/real-db/booking-extras-consent.auth.spec.ts
@@ -24,11 +24,21 @@ const ADD_ON_NAME = 'Child seat'
 const ADD_ON_PRICE_JPY = 1100
 const INSURANCE_NAME = 'Normal'
 
-// A far-future window distinct from the happy-path's 2026-07 window, so the two
-// specs never contend for KIX's 4 vehicles in the same window. `datetime-local`
-// wall-clock (parsed as JST).
-const FROM = '2026-09-10T10:00'
-const TO = '2026-09-12T10:00'
+// A window 5 months out, computed relative to today so it can never rot into the
+// past and 4xx the booking POST - the class of failure fixed for region-search in
+// #1567. The +5mo offset keeps this window distinct from every other real-DB spec's
+// so parallel specs never contend for KIX's 4 vehicles, and clear of the demo-
+// relative seed (~-5..+7d). `datetime-local` wall-clock (parsed as JST). MONTH_FLOOR
+// (1st of the booking month) also bounds the date-window cleanup below.
+const pad = (n: number) => String(n).padStart(2, '0')
+const isoDate = (d: Date) =>
+  `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+const NOW = new Date()
+// Date.UTC normalises a month index past 11 into the next year, so +N stays year-safe.
+const BOOK_MONTH = NOW.getUTCMonth() + 5
+const FROM = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 10)))}T10:00`
+const TO = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 12)))}T10:00`
+const MONTH_FLOOR = isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 1)))
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
@@ -208,7 +218,7 @@ async function cleanupFutureSarahBookings(): Promise<void> {
     const ids = await sql<{ id: string }[]>`
       SELECT b.id FROM bookings b
       JOIN users u ON u.id = b."renterId"
-      WHERE u.email = ${RENTER_EMAIL} AND b."startAt" >= '2026-09-01'
+      WHERE u.email = ${RENTER_EMAIL} AND b."startAt" >= ${MONTH_FLOOR}
     `
     if (ids.length === 0) return
     const bookingIds = ids.map((r) => r.id)

--- a/e2e/real-db/booking-extras-consent.auth.spec.ts
+++ b/e2e/real-db/booking-extras-consent.auth.spec.ts
@@ -29,7 +29,8 @@ const INSURANCE_NAME = 'Normal'
 // #1567. The +5mo offset keeps this window distinct from every other real-DB spec's
 // so parallel specs never contend for KIX's 4 vehicles, and clear of the demo-
 // relative seed (~-5..+7d). `datetime-local` wall-clock (parsed as JST). MONTH_FLOOR
-// (1st of the booking month) also bounds the date-window cleanup below.
+// and NEXT_MONTH_FLOOR (1st of this/next month) bracket the date-window cleanup below
+// so it deletes exactly this spec's month, never a further-future shared-renter row.
 const pad = (n: number) => String(n).padStart(2, '0')
 const isoDate = (d: Date) =>
   `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
@@ -39,6 +40,7 @@ const BOOK_MONTH = NOW.getUTCMonth() + 5
 const FROM = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 10)))}T10:00`
 const TO = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 12)))}T10:00`
 const MONTH_FLOOR = isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 1)))
+const NEXT_MONTH_FLOOR = isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH + 1, 1)))
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
@@ -218,7 +220,8 @@ async function cleanupFutureSarahBookings(): Promise<void> {
     const ids = await sql<{ id: string }[]>`
       SELECT b.id FROM bookings b
       JOIN users u ON u.id = b."renterId"
-      WHERE u.email = ${RENTER_EMAIL} AND b."startAt" >= ${MONTH_FLOOR}
+      WHERE u.email = ${RENTER_EMAIL}
+        AND b."startAt" >= ${MONTH_FLOOR} AND b."startAt" < ${NEXT_MONTH_FLOOR}
     `
     if (ids.length === 0) return
     const bookingIds = ids.map((r) => r.id)

--- a/e2e/real-db/mobile-happy-path.auth.spec.ts
+++ b/e2e/real-db/mobile-happy-path.auth.spec.ts
@@ -34,13 +34,24 @@ const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 const STOREFRONT_NAME = 'Kansai Airport (KIX)'
 const OPERATOR_NAME = 'Best Car Rental'
 
-// An AUGUST window — distinct from the desktop spec's July window so the two
-// never contend for the same KIX vehicle and each cleans up only its own rows.
-// `datetime-local` wall-clock (parsed as JST).
-const FROM = '2026-08-15T10:00'
-const TO = '2026-08-17T10:00'
-const WINDOW_START = '2026-08-01'
-const WINDOW_END = '2026-09-01'
+// A window 4 months out, computed relative to today so it can never rot into the
+// past and 4xx the booking POST - a hardcoded '2026-08-15' would once wall-clock
+// passed it (the class of failure fixed for region-search in #1567). The +4mo
+// offset keeps this window distinct from every other real-DB spec's (region +1mo,
+// marketplace +2mo, messaging +3mo, booking-extras +5mo, operator-books +6mo) so
+// parallel specs never contend for the same KIX vehicle, and clear of the demo-
+// relative seed (~-5..+7d). `datetime-local` wall-clock (parsed as JST).
+const pad = (n: number) => String(n).padStart(2, '0')
+const isoDate = (d: Date) =>
+  `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+const NOW = new Date()
+// Date.UTC normalises a month index past 11 into the next year, so +N stays year-safe.
+const BOOK_MONTH = NOW.getUTCMonth() + 4
+const FROM = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 15)))}T10:00`
+const TO = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 17)))}T10:00`
+// Month bracket [1st .. next 1st) for the FK-ordered date-window cleanup below.
+const WINDOW_START = isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH, 1)))
+const WINDOW_END = isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), BOOK_MONTH + 1, 1)))
 
 const PHONE_VIEWPORT = { width: 390, height: 844 }
 

--- a/e2e/real-db/operator-books-e2e.auth.spec.ts
+++ b/e2e/real-db/operator-books-e2e.auth.spec.ts
@@ -35,12 +35,23 @@ const LOCATION_NAME = `${MARKER} Namba depot`
 const VEHICLE_NAME = `${MARKER} Aqua`
 const LOCATION_ADDRESS = '2-1-1 Namba, Chuo-ku, Osaka'
 
-// Far-future window, clear of the seed's demo-relative (~-5..+7d) and every other
-// real-DB spec's window (Jul/Aug 2026, Aug 2027). The vehicle we mint carries far-
-// future compliance dates (below) so it is road-legal through this window.
-const FROM = '2027-03-16T10:00'
-const TO = '2027-03-18T10:00'
-const OPERATOR_MONTH = '2027-03-16'
+// A window 6 months out, computed relative to today so it can never rot into the
+// past and 4xx the booking POST - the class of failure fixed for region-search in
+// #1567. The +6mo offset keeps this window distinct from every other real-DB spec's
+// so parallel specs never contend for the same KIX vehicle, and clear of the demo-
+// relative seed (~-5..+7d). The vehicle we mint carries far-future compliance dates
+// (below) so it is road-legal through this window. `datetime-local` wall-clock
+// (parsed as JST); OPERATOR_MONTH must match FROM's date so the operator calendar
+// lands on the booking's month.
+const pad = (n: number) => String(n).padStart(2, '0')
+const isoDate = (d: Date) =>
+  `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+const NOW = new Date()
+// Date.UTC normalises a month index past 11 into the next year, so +6 stays year-safe.
+const BOOK_DAY = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 6, 16))
+const FROM = `${isoDate(BOOK_DAY)}T10:00`
+const TO = `${isoDate(new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 6, 18)))}T10:00`
+const OPERATOR_MONTH = isoDate(BOOK_DAY)
 
 // Compliance dates must be future-dated at create time (createVehicleSchema, #916)
 // and stay valid through the booking window — a fixed far-future date satisfies both.


### PR DESCRIPTION
## Summary

Follow-up to #1567. Three real-db specs still hardcoded their booking windows and were latent copies of the same time-bomb that just took down every PR's `e2e-real-db` lane: once the wall clock passes a static `FROM` date, the booking POST 4xxes on a past start date and the spec fails.

- `mobile-happy-path` — was Aug 2026 -> now +4 months, relative
- `booking-extras-consent` — was Sep 2026 -> now +5 months, relative (cleanup floor tracks the window)
- `operator-books-e2e` — was Mar 2027 -> now +6 months, relative (`OPERATOR_MONTH` tracks `FROM`)

Each offset is distinct (+4/+5/+6mo) so parallel specs never contend for the same KIX vehicle, and each clears the demo-relative seed window (~-5..+7d). Semantics preserved per spec (month-bracket cleanup, relative cleanup floor, calendar-month anchor). Mirrors the existing relative-window pattern already used by marketplace/messaging/renter-combo specs.

## Test plan
- [x] biome + tsc (pre-commit) green
- [ ] CI `e2e-real-db` runs all three specs end to end

Refs #1567