### PR TITLE
refactor(#1564): operator application service ctor to a deps object

### DIFF
--- a/packages/api/src/composition/operator-application-service.ts
+++ b/packages/api/src/composition/operator-application-service.ts
@@ -12,11 +12,12 @@ import {
 import { resolveEmailConfig } from './services'
 
 /**
- * Collaborators for the sign-in-first onboarding service (#877). A deps object
- * rather than positional args — the constructor takes seven collaborators and a
- * positional call at the composition root is easy to mis-order.
+ * Composition-root wiring inputs for the onboarding service (#877). Distinct from
+ * the service's own `OperatorApplicationServiceDeps` (which carries a resolved
+ * `config`): this shape takes a flat `webBaseUrl`, and the builder folds in the
+ * shared email envelope (from/reply-to) to produce the service `config`.
  */
-export interface OperatorApplicationServiceDeps {
+export interface OperatorApplicationServiceWiring {
   repo: OperatorApplicationRepository
   recordAudit: RecordOperatorApplicationAudit
   runApproval: RunOperatorApproval
@@ -32,20 +33,20 @@ export interface OperatorApplicationServiceDeps {
  * cap. Mirrors buildReconcileIdentityResolver (composition/session-reconcile.ts).
  */
 export function buildOperatorApplicationService(
-  deps: OperatorApplicationServiceDeps,
+  wiring: OperatorApplicationServiceWiring,
 ): OperatorApplicationService {
   const emailConfig = resolveEmailConfig()
-  return new OperatorApplicationService(
-    deps.repo,
-    deps.recordAudit,
-    deps.runApproval,
-    {
-      webBaseUrl: deps.webBaseUrl,
+  return new OperatorApplicationService({
+    repo: wiring.repo,
+    recordAudit: wiring.recordAudit,
+    runApproval: wiring.runApproval,
+    config: {
+      webBaseUrl: wiring.webBaseUrl,
       fromAddress: emailConfig.emailFrom,
       ...(emailConfig.emailReplyTo ? { replyTo: emailConfig.emailReplyTo } : {}),
     },
-    deps.members,
-    deps.users,
-    deps.emailSender,
-  )
+    members: wiring.members,
+    users: wiring.users,
+    emailSender: wiring.emailSender,
+  })
 }

--- a/packages/api/src/services/operator-application.test.ts
+++ b/packages/api/src/services/operator-application.test.ts
@@ -253,15 +253,15 @@ describe('OperatorApplicationService.approve', () => {
       }
     }
 
-    const service = new OperatorApplicationService(
-      applications,
-      audit,
-      runOperatorApproval,
-      { webBaseUrl: 'https://app.example.com', fromAddress: 'noreply@test.io' },
-      memberships,
+    const service = new OperatorApplicationService({
+      repo: applications,
+      recordAudit: audit,
+      runApproval: runOperatorApproval,
+      config: { webBaseUrl: 'https://app.example.com', fromAddress: 'noreply@test.io' },
+      members: memberships,
       users,
-      noopEmailSender,
-    )
+      emailSender: noopEmailSender,
+    })
     return {
       service,
       repos: {
@@ -559,15 +559,15 @@ describe('OperatorApplicationService.approve', () => {
       })
     }
 
-    const service = new OperatorApplicationService(
-      applications,
-      vi.fn(),
+    const service = new OperatorApplicationService({
+      repo: applications,
+      recordAudit: vi.fn(),
       runApproval,
-      { webBaseUrl: 'https://app.example.com', fromAddress: 'noreply@test.io' },
-      membershipsRepo,
-      usersRepo,
-      opts.emailSender ?? noopEmailSender,
-    )
+      config: { webBaseUrl: 'https://app.example.com', fromAddress: 'noreply@test.io' },
+      members: membershipsRepo,
+      users: usersRepo,
+      emailSender: opts.emailSender ?? noopEmailSender,
+    })
     return { service, applicationId: app.id }
   }
 
@@ -636,13 +636,13 @@ function makeService(
   }
   const memberships = deps.memberships ?? new InMemoryOperatorMembershipRepository()
   const users = deps.users ?? new InMemoryUserRepository()
-  return new OperatorApplicationService(
+  return new OperatorApplicationService({
     repo,
     recordAudit,
-    stubRunApproval,
-    { webBaseUrl: '', fromAddress: 'noreply@test.io' },
-    memberships,
+    runApproval: stubRunApproval,
+    config: { webBaseUrl: '', fromAddress: 'noreply@test.io' },
+    members: memberships,
     users,
-    deps.emailSender ?? noopEmailSender,
-  )
+    emailSender: deps.emailSender ?? noopEmailSender,
+  })
 }

--- a/packages/api/src/services/operator-application.ts
+++ b/packages/api/src/services/operator-application.ts
@@ -65,6 +65,23 @@ export interface OperatorApplicationServiceConfig {
   readonly replyTo?: string
 }
 
+// Collaborators for the sign-in-first onboarding service (#1564). A single deps
+// object rather than seven positional args — the constructor is easy to mis-order,
+// and the repo convention is `constructor(private readonly deps: XDeps)` (see
+// NotificationRetryService / CancellationRefundReconciler).
+export interface OperatorApplicationServiceDeps {
+  readonly repo: OperatorApplicationRepository
+  readonly recordAudit: RecordOperatorApplicationAudit
+  readonly runApproval: RunOperatorApproval
+  readonly config: OperatorApplicationServiceConfig
+  // Sign-in-first (#877): the already-operator guard reads the membership ledger,
+  // and the authoritative applicant email is resolved from the users projection —
+  // never the token's display email. Narrowed to the two reads submit() needs.
+  readonly members: Pick<OperatorMembershipRepository, 'findActiveByUserId'>
+  readonly users: Pick<UserRepository, 'findById'>
+  readonly emailSender: EmailSender
+}
+
 // The honeypot/consent fields are validated + stripped at the route boundary; the
 // service persists only the domain fields. Sign-in-first (#877): contactEmail is no
 // longer a client field (already removed from the schema) — the service resolves the
@@ -103,25 +120,14 @@ async function assertEmailUnclaimed(repos: OperatorApprovalRepos, email: string)
 }
 
 export class OperatorApplicationService {
-  constructor(
-    private readonly repo: OperatorApplicationRepository,
-    private readonly recordAudit: RecordOperatorApplicationAudit,
-    private readonly runApproval: RunOperatorApproval,
-    private readonly config: OperatorApplicationServiceConfig,
-    // Sign-in-first (#877): the already-operator guard reads the membership ledger,
-    // and the authoritative applicant email is resolved from the users projection —
-    // never the token's display email. Narrowed to the two reads submit() needs.
-    private readonly members: Pick<OperatorMembershipRepository, 'findActiveByUserId'>,
-    private readonly users: Pick<UserRepository, 'findById'>,
-    private readonly emailSender: EmailSender,
-  ) {}
+  constructor(private readonly deps: OperatorApplicationServiceDeps) {}
 
   async list(params: OperatorApplicationListParams): Promise<OperatorApplication[]> {
-    return this.repo.list(params)
+    return this.deps.repo.list(params)
   }
 
   async findMine(userId: string): Promise<ApplicantApplicationView | undefined> {
-    const application = await this.repo.findByApplicantUserId(userId)
+    const application = await this.deps.repo.findByApplicantUserId(userId)
     if (!application) return undefined
     // Applicant self-read must not leak internal review metadata. Keep operatorId +
     // rejectionReason (the status UI shows the portal link + the rejection reason);
@@ -135,14 +141,14 @@ export class OperatorApplicationService {
     reviewerUserId: string,
     rejectionReason: string,
   ): Promise<OperatorApplication> {
-    const row = await this.repo.markRejectedIfPending(
+    const row = await this.deps.repo.markRejectedIfPending(
       id,
       reviewerUserId,
       new Date(),
       rejectionReason,
     )
     if (!row) throw new NotFoundError('no pending application with that id')
-    this.recordAudit({
+    this.deps.recordAudit({
       type: 'OPERATOR_APPLICATION_REJECTED',
       actorUserId: reviewerUserId,
       applicationId: id,
@@ -160,7 +166,7 @@ export class OperatorApplicationService {
     // The atomic markApprovedIfPending below is still the race fence for concurrent
     // approvals that both pass this read. Email/name are immutable once PENDING, so
     // reading here (outside the tx) is safe.
-    const application = await this.repo.findById(id)
+    const application = await this.deps.repo.findById(id)
     if (!application) throw new NotFoundError('no application with that id')
     if (application.status !== 'PENDING') {
       throw new ConflictError('application already reviewed')
@@ -171,7 +177,7 @@ export class OperatorApplicationService {
       throw new ConflictError('application is not linked to an account; use the manual invite')
     }
     const outcome = await this.provisionApproval(id, application, reviewerUserId)
-    for (const e of outcome.events) this.recordAudit(e)
+    for (const e of outcome.events) this.deps.recordAudit(e)
     await this.notifyApproved(application, outcome)
     return { operatorId: outcome.operatorId, operatorSlug: outcome.operatorSlug }
   }
@@ -187,7 +193,7 @@ export class OperatorApplicationService {
   ): Promise<ApprovalOutcome> {
     for (let attempt = 1; attempt <= SLUG_ATTEMPTS; attempt++) {
       try {
-        return await this.runApproval((repos) =>
+        return await this.deps.runApproval((repos) =>
           this.provision(repos, id, application, reviewerUserId),
         )
       } catch (err) {
@@ -261,15 +267,15 @@ export class OperatorApplicationService {
     _outcome: ApprovalOutcome,
   ): Promise<void> {
     try {
-      const welcomeUrl = `${this.config.webBaseUrl}/${application.submittedLocale}/operator/welcome`
+      const welcomeUrl = `${this.deps.config.webBaseUrl}/${application.submittedLocale}/operator/welcome`
       const email = renderOperatorApplicationApproved(
         { businessName: application.businessName, welcomeUrl },
         application.submittedLocale,
       )
-      await this.emailSender.send({
+      await this.deps.emailSender.send({
         to: application.contactEmail,
-        from: this.config.fromAddress,
-        ...(this.config.replyTo ? { replyTo: this.config.replyTo } : {}),
+        from: this.deps.config.fromAddress,
+        ...(this.deps.config.replyTo ? { replyTo: this.deps.config.replyTo } : {}),
         subject: email.subject,
         html: email.html,
         text: email.text,
@@ -290,10 +296,10 @@ export class OperatorApplicationService {
         { businessName: row.businessName, reason: row.rejectionReason ?? '' },
         row.submittedLocale,
       )
-      await this.emailSender.send({
+      await this.deps.emailSender.send({
         to: row.contactEmail,
-        from: this.config.fromAddress,
-        ...(this.config.replyTo ? { replyTo: this.config.replyTo } : {}),
+        from: this.deps.config.fromAddress,
+        ...(this.deps.config.replyTo ? { replyTo: this.deps.config.replyTo } : {}),
         subject: email.subject,
         html: email.html,
         text: email.text,
@@ -309,17 +315,17 @@ export class OperatorApplicationService {
     // Already-operator guard: a signed-in caller who already owns or staffs an
     // operator can't apply again (the ledger is the revocation-aware source of truth,
     // not the users.role projection).
-    if (await this.members.findActiveByUserId(input.applicantUserId)) {
+    if (await this.deps.members.findActiveByUserId(input.applicantUserId)) {
       throw new ConflictError('you already belong to an operator')
     }
     // Server-authoritative email: resolve the applicant's real account email from the
     // users repo. Never trust a client-supplied email or the token's display email.
-    const account = await this.users.findById(input.applicantUserId)
+    const account = await this.deps.users.findById(input.applicantUserId)
     if (!account?.email) {
       throw new ConflictError('your account has no email on file')
     }
     try {
-      const app = await this.repo.create({
+      const app = await this.deps.repo.create({
         businessName: input.businessName,
         contactName: input.contactName,
         contactEmail: account.email,

--- a/packages/api/tests/neon/operator-application-promotion-tx.test.ts
+++ b/packages/api/tests/neon/operator-application-promotion-tx.test.ts
@@ -134,15 +134,15 @@ describe.skipIf(!NEON_URL)('operator approval promotion transaction atomicity (T
     })
     seededAppIds.push(app.id)
 
-    const service = new OperatorApplicationService(
+    const service = new OperatorApplicationService({
       repo,
-      noopAudit,
-      createDrizzleOperatorApproval(runTx),
-      { webBaseUrl: WEB_BASE_URL, fromAddress: 'noreply@test.io' },
-      new DrizzleOperatorMembershipRepository(db),
-      new DrizzleUserRepository(db),
-      { send: async () => ({ providerMessageId: 'noop' }) },
-    )
+      recordAudit: noopAudit,
+      runApproval: createDrizzleOperatorApproval(runTx),
+      config: { webBaseUrl: WEB_BASE_URL, fromAddress: 'noreply@test.io' },
+      members: new DrizzleOperatorMembershipRepository(db),
+      users: new DrizzleUserRepository(db),
+      emailSender: { send: async () => ({ providerMessageId: 'noop' }) },
+    })
     const result = await service.approve(app.id, reviewerId)
 
     // Operator row committed.
@@ -226,15 +226,15 @@ describe.skipIf(!NEON_URL)('operator approval promotion transaction atomicity (T
         }),
       )
 
-    const service = new OperatorApplicationService(
+    const service = new OperatorApplicationService({
       repo,
-      noopAudit,
-      failingFenceRun,
-      { webBaseUrl: WEB_BASE_URL, fromAddress: 'noreply@test.io' },
-      new DrizzleOperatorMembershipRepository(db),
-      new DrizzleUserRepository(db),
-      { send: async () => ({ providerMessageId: 'noop' }) },
-    )
+      recordAudit: noopAudit,
+      runApproval: failingFenceRun,
+      config: { webBaseUrl: WEB_BASE_URL, fromAddress: 'noreply@test.io' },
+      members: new DrizzleOperatorMembershipRepository(db),
+      users: new DrizzleUserRepository(db),
+      emailSender: { send: async () => ({ providerMessageId: 'noop' }) },
+    })
     await expect(service.approve(app.id, reviewerId)).rejects.toThrow('already reviewed')
 
     // The projection write genuinely executed inside the tx (visible on the tx connection


### PR DESCRIPTION
## What

`OperatorApplicationService` took **seven positional constructor args** — easy to mis-order at the call site. This converts the constructor to a single `readonly` deps object, matching the repo convention `constructor(private readonly deps: XDeps)` already used by `NotificationRetryService` and `CancellationRefundReconciler`.

The composition helper's input interface is renamed `OperatorApplicationServiceDeps` → `OperatorApplicationServiceWiring` to free the `Deps` name for the service's ctor-deps interface. The two shapes intentionally differ: the **wiring** carries a flat `webBaseUrl`, the **service** a resolved `config` (the builder folds in the shared email envelope).

All six construction sites updated to the named form:
- `composition/operator-application-service.ts` (composition root)
- `services/operator-application.test.ts` (×3)
- `tests/neon/operator-application-promotion-tx.test.ts` (×2)

**Pure tidy-up — no behavior change.**

## Verification

- `bun run --filter @kuruma/api typecheck` → exit 0 (distinct collaborator shapes mean a swapped/missing field fails the compiler)
- Full API unit suite: **3047 passed**
- `bun run lint` → exit 0; `lint:boundaries` OK
- code-reviewer agent: ship-ready, all 6 mappings traced field-by-field, no missed sites, no dangling refs

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)